### PR TITLE
Implement preemption via recomputation & Refactor scheduling logic

### DIFF
--- a/cacheflow/http_frontend/fastapi_frontend.py
+++ b/cacheflow/http_frontend/fastapi_frontend.py
@@ -84,8 +84,9 @@ class FastAPIFrontend:
             seq = Sequence(seq_id, token_ids, block_size=self.block_size)
             seqs.append(seq)
 
+        arrival_time = time.time()
         group_id = next(self.seq_group_counter)
-        seq_group = SequenceGroup(group_id, seqs)
+        seq_group = SequenceGroup(group_id, seqs, arrival_time)
         group_event = asyncio.Event()
         self.sequence_group_events[group_id] = group_event
         await self.server.add_sequence_groups.remote([(seq_group, sampling_params)])

--- a/cacheflow/master/block_manager.py
+++ b/cacheflow/master/block_manager.py
@@ -60,11 +60,15 @@ class BlockSpaceManager:
         block_size: int,
         num_gpu_blocks: int,
         num_cpu_blocks: int,
+        watermark: float = 0.01,
     ) -> None:
         self.block_size = block_size
         self.num_total_gpu_blocks = num_gpu_blocks
         self.num_total_cpu_blocks = num_cpu_blocks
+        self.watermark = watermark
+        assert watermark >= 0.0
 
+        self.watermark_blocks = int(watermark * num_gpu_blocks)
         self.gpu_allocator = BlockAllocator(Device.GPU, block_size, num_gpu_blocks)
         self.cpu_allocator = BlockAllocator(Device.CPU, block_size, num_cpu_blocks)
 
@@ -72,11 +76,13 @@ class BlockSpaceManager:
         self.block_tables: Dict[int, BlockTable] = {}
 
     def can_allocate(self, seq_group: SequenceGroup) -> bool:
-        # NOTE: Here we assume that all sequences in the group have the same prompt.
+        # FIXME(woosuk): Here we assume that all sequences in the group share
+        # the same prompt. This is not true for preempted sequences.
         seq = seq_group.seqs[0]
         num_required_blocks = len(seq.logical_token_blocks)
         num_free_gpu_blocks = self.gpu_allocator.get_num_free_blocks()
-        return num_required_blocks <= num_free_gpu_blocks
+        # Use watermark to avoid thrashing.
+        return num_free_gpu_blocks - num_required_blocks >= self.watermark_blocks
 
     def allocate(self, seq_group: SequenceGroup) -> None:
         # NOTE: Here we assume that all sequences in the group have the same prompt.

--- a/cacheflow/master/block_manager.py
+++ b/cacheflow/master/block_manager.py
@@ -77,11 +77,11 @@ class BlockSpaceManager:
 
     def can_allocate(self, seq_group: SequenceGroup) -> bool:
         # FIXME(woosuk): Here we assume that all sequences in the group share
-        # the same prompt. This is not true for preempted sequences.
+        # the same prompt. This may not be true for preempted sequences.
         seq = seq_group.seqs[0]
         num_required_blocks = len(seq.logical_token_blocks)
         num_free_gpu_blocks = self.gpu_allocator.get_num_free_blocks()
-        # Use watermark to avoid thrashing.
+        # Use watermark to avoid frequent preemptions.
         return num_free_gpu_blocks - num_required_blocks >= self.watermark_blocks
 
     def allocate(self, seq_group: SequenceGroup) -> None:

--- a/cacheflow/master/block_manager.py
+++ b/cacheflow/master/block_manager.py
@@ -160,7 +160,8 @@ class BlockSpaceManager:
         # NOTE: Conservatively, we assume that every sequence will allocate
         # at least one free block right after the swap-in.
         # NOTE: This should match the logic in can_append().
-        return len(blocks) + num_swapped_seqs <= num_free_blocks
+        num_required_blocks = len(blocks) + num_swapped_seqs
+        return num_free_blocks - num_required_blocks >= self.watermark_blocks
 
     def swap_in(self, seq_group: SequenceGroup) -> Dict[int, int]:
         # CPU block -> GPU block.

--- a/cacheflow/master/frontend.py
+++ b/cacheflow/master/frontend.py
@@ -1,3 +1,4 @@
+import time
 from typing import List, Optional, Set, Tuple
 
 from transformers import AutoTokenizer
@@ -54,6 +55,7 @@ class Frontend:
         token_ids: List[int],
         sampling_params: SamplingParams,
     ) -> None:
+        arrival_time = time.time()
         seqs: List[Sequence] = []
         for _ in range(sampling_params.n):
             seq_id = next(self.seq_counter)
@@ -61,7 +63,7 @@ class Frontend:
             seqs.append(seq)
 
         group_id = next(self.seq_group_counter)
-        seq_group = SequenceGroup(group_id, seqs)
+        seq_group = SequenceGroup(group_id, seqs, arrival_time)
         self.inputs.append((seq_group, sampling_params))
 
     def get_inputs(self) -> List[Tuple[SequenceGroup, SamplingParams]]:

--- a/cacheflow/master/policy.py
+++ b/cacheflow/master/policy.py
@@ -24,17 +24,6 @@ class Policy:
         )
 
 
-class PolicyFactory:
-
-    def __init__(self) -> None:
-        self.policies = {
-            'fcfs': FCFS,
-        }
-
-    def get_policy(self, policy_name: str, **kwargs) -> Policy:
-        return self.policies[policy_name](**kwargs)
-
-
 class FCFS(Policy):
 
     def get_priority(
@@ -43,3 +32,14 @@ class FCFS(Policy):
         seq_group: SequenceGroup,
     ) -> float:
         return now - seq_group.arrival_time
+
+
+class PolicyFactory:
+
+    _POLICY_REGISTRY = {
+        'fcfs': FCFS,
+    }
+
+    @classmethod
+    def get_policy(cls, policy_name: str, **kwargs) -> Policy:
+        return cls._POLICY_REGISTRY[policy_name](**kwargs)

--- a/cacheflow/master/policy.py
+++ b/cacheflow/master/policy.py
@@ -1,0 +1,45 @@
+from typing import List
+
+from cacheflow.sequence import SequenceGroup
+
+
+class Policy:
+
+    def get_priority(
+        self,
+        now: float,
+        seq_group: SequenceGroup,
+    ) -> float:
+        raise NotImplementedError
+
+    def sort_by_priority(
+        self,
+        now: float,
+        seq_groups: List[SequenceGroup],
+    ) -> List[SequenceGroup]:
+        return sorted(
+            seq_groups,
+            key=lambda seq_group: self.get_priority(now, seq_group),
+            reverse=True,
+        )
+
+
+class PolicyFactory:
+
+    def __init__(self) -> None:
+        self.policies = {
+            'fcfs': FCFS,
+        }
+
+    def get_policy(self, policy_name: str, **kwargs) -> Policy:
+        return self.policies[policy_name](**kwargs)
+
+
+class FCFS(Policy):
+
+    def get_priority(
+        self,
+        now: float,
+        seq_group: SequenceGroup,
+    ) -> float:
+        return now - seq_group.arrival_time

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -28,7 +28,7 @@ class Scheduler:
         self.max_num_batched_tokens = max_num_batched_tokens
 
         # Instantiate the scheduling policy.
-        self.policy = PolicyFactory.get_policy('fcfs')
+        self.policy = PolicyFactory.get_policy(policy_name='fcfs')
         # Create the block space manager.
         self.block_manager = BlockSpaceManager(
             block_size=block_size,

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -182,6 +182,7 @@ class Scheduler:
 
         # Execute the first stage of the pipeline.
         if input_seq_groups or blocks_to_swap_in or blocks_to_swap_out:
+            # Swap in and swap out should never happen at the same time.
             assert not (blocks_to_swap_in and blocks_to_swap_out)
             self.controllers[0].execute_stage(
                 input_seq_groups,
@@ -285,6 +286,11 @@ class Scheduler:
         # sequences, we only support swapping.
         # TODO(woosuk): Support recomputation for sequence groups with multiple
         # sequences.
+
+        # FIXME(woosuk): This makes our scheduling policy a bit bizarre.
+        # Because swapped sequences are prioritized over waiting sequences,
+        # sequence groups with multiple sequences are implicitly prioritized
+        # over sequence groups with a single sequence.
         seqs = seq_group.get_seqs(status=SequenceStatus.RUNNING)
         if len(seqs) == 1:
             # Recomputation.

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -232,7 +232,7 @@ class Scheduler:
         seq_group: SequenceGroup,
         blocks_to_copy: Dict[int, List[int]],
     ) -> None:
-        for seq in seq_group.seqs(status=SequenceStatus.RUNNING):
+        for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
             ret = self.block_manager.append(seq)
             if ret is not None:
                 src_block, dst_block = ret

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -102,6 +102,7 @@ class Scheduler:
         )
 
         # Join new sequences if possible.
+        prompt_group_ids: List[int] = []
         self.waiting = self.policy.sort_by_priority(now, self.waiting)
         # FIXME(woosuk): This does not work if sequence groups have more than
         # one sequence.
@@ -121,14 +122,13 @@ class Scheduler:
             self._allocate(seq_group)
             self.running.append(seq_group)
             num_batched_tokens += num_prompt_tokens
+            prompt_group_ids.append(seq_group.group_id)
 
         # Create input data structures.
         input_seq_groups: List[SequenceGroupInputs] = []
         for seq_group in self.running:
             group_id = seq_group.group_id
-            num_steps = self.num_steps[group_id]
-
-            is_prompt = num_steps == 0
+            is_prompt = group_id in prompt_group_ids
 
             input_tokens: Dict[int, List[int]] = {}
             seq_logprobs: Dict[int, float] = {}

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -126,7 +126,6 @@ class Scheduler:
 
             while self.waiting:
                 seq_group = self.waiting[0]
-                assert seq_group.num_seqs() == 1
                 # If the sequence group cannot be allocated, stop.
                 if not self.block_manager.can_allocate(seq_group):
                     break

--- a/cacheflow/master/scheduler.py
+++ b/cacheflow/master/scheduler.py
@@ -51,12 +51,12 @@ class Scheduler:
         self,
         seq_groups: List[Tuple[SequenceGroup, SamplingParams]],
     ) -> None:
-        # Add sequence groups to the pending queue.
+        # Add sequence groups to the waiting queue.
         for seq_group, sampling_params in seq_groups:
-            self.pending.append(seq_group)
+            self.waiting.append(seq_group)
             self.sampling_params[seq_group.group_id] = sampling_params
 
-    def step(self) -> None:
+    def step(self) -> List[SequenceGroup]:
         # Blocks that need to be swaped or copied before model execution.
         blocks_to_swap_in: Dict[int, int] = {}
         blocks_to_swap_out: Dict[int, int] = {}
@@ -303,7 +303,7 @@ class Scheduler:
         seq.status = SequenceStatus.FINISHED
         self.block_manager.free(seq)
 
-    def _return(self, seq_group: SequenceGroup) -> None:
+    def _free_seq_group(self, seq_group: SequenceGroup) -> None:
         group_id = seq_group.group_id
         del self.num_steps[group_id]
         del self.sampling_params[group_id]

--- a/cacheflow/master/server.py
+++ b/cacheflow/master/server.py
@@ -92,7 +92,7 @@ class Server:
         return self.scheduler.step()
 
     def has_unfinished_requests(self):
-        return (self.scheduler.pending or self.scheduler.running or
+        return (self.scheduler.waiting or self.scheduler.running or
                 self.scheduler.swapped)
 
 

--- a/cacheflow/sequence.py
+++ b/cacheflow/sequence.py
@@ -7,7 +7,7 @@ from cacheflow.sampling_params import SamplingParams
 
 
 class SequenceStatus(enum.Enum):
-    PENDING = enum.auto()
+    WAITING = enum.auto()
     RUNNING = enum.auto()
     SWAPPED = enum.auto()
     FINISHED = enum.auto()
@@ -28,7 +28,7 @@ class Sequence:
         # Initialize the logical token blocks with the given token ids.
         self.add(token_ids)
 
-        self.status = SequenceStatus.PENDING
+        self.status = SequenceStatus.WAITING
         self.output_logprobs: List[Dict[int, float]] = []
         self.cumulative_logprobs = 0.0
 
@@ -88,9 +88,11 @@ class SequenceGroup:
         self,
         group_id: int,
         seqs: List[Sequence],
+        arrival_time: float,
     ) -> None:
         self.group_id = group_id
         self.seqs = seqs
+        self.arrival_time = arrival_time
 
     def get_seqs(
         self,

--- a/server.py
+++ b/server.py
@@ -99,9 +99,6 @@ def main(args: argparse.Namespace):
         max_num_batched_tokens=args.max_batch_size)
     num_cpu_blocks = memory_analyzer.get_max_num_cpu_blocks(
         swap_space=args.swap_space)
-    if num_cpu_blocks > 0:
-        raise ValueError(
-            'CPU blocks are not used. Please set --swap-space to 0.')
     print(f'# GPU blocks: {num_gpu_blocks}, # CPU blocks: {num_cpu_blocks}')
 
     # Create a controller for each pipeline stage.
@@ -174,7 +171,7 @@ if __name__ == '__main__':
     parser.add_argument('--dtype', type=str, default='half', choices=['half', 'float'], help='data type')
     # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
     parser.add_argument('--seed', type=int, default=0, help='random seed')
-    parser.add_argument('--swap-space', type=int, default=0, help='CPU swap space size (GiB) per GPU')
+    parser.add_argument('--swap-space', type=int, default=20, help='CPU swap space size (GiB) per GPU')
     parser.add_argument('--max-batch-size', type=int, default=2560, help='maximum number of batched tokens')
     args = parser.parse_args()
 

--- a/server.py
+++ b/server.py
@@ -99,6 +99,9 @@ def main(args: argparse.Namespace):
         max_num_batched_tokens=args.max_batch_size)
     num_cpu_blocks = memory_analyzer.get_max_num_cpu_blocks(
         swap_space=args.swap_space)
+    if num_cpu_blocks > 0:
+        raise ValueError(
+            'CPU blocks are not used. Please set --swap-space to 0.')
     print(f'# GPU blocks: {num_gpu_blocks}, # CPU blocks: {num_cpu_blocks}')
 
     # Create a controller for each pipeline stage.
@@ -152,7 +155,7 @@ def main(args: argparse.Namespace):
             text, sampling_params = test_inputs.pop(0)
             frontend.query(text, **sampling_params)
         scheduler.step()
-        if not (scheduler.pending or scheduler.running or test_inputs):
+        if not (scheduler.waiting or scheduler.running or test_inputs):
             break
 
 
@@ -171,7 +174,7 @@ if __name__ == '__main__':
     parser.add_argument('--dtype', type=str, default='half', choices=['half', 'float'], help='data type')
     # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
     parser.add_argument('--seed', type=int, default=0, help='random seed')
-    parser.add_argument('--swap-space', type=int, default=20, help='CPU swap space size (GiB) per GPU')
+    parser.add_argument('--swap-space', type=int, default=0, help='CPU swap space size (GiB) per GPU')
     parser.add_argument('--max-batch-size', type=int, default=2560, help='maximum number of batched tokens')
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR implements a new preemption (eviction) mechanism "recomputation". In our benchmark results, recomputation is more efficient than swapping, because swapping incurs significant overheads due to numerous small data transfers between CPU and GPU. Thus, we use recomputation for our default preemption mechanism.

However, currently we do not support recomputation for sequence groups with multiple sequences. This is because when token blocks are shared, the recomputation logic becomes very complex and we do not have CUDA kernels to efficiently support it. We will use swapping for this case despite its overheads.

Besides, this PR also refactors the scheduling logic to be easier to understand.