### PR TITLE
Optimize data movement

### DIFF
--- a/cacheflow/models/activation.py
+++ b/cacheflow/models/activation.py
@@ -1,0 +1,20 @@
+import torch
+import torch.nn as nn
+
+from cacheflow import activation_ops
+
+
+class SiluAndMul(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(
+        self,
+        x: torch.Tensor,        # (num_tokens, 2 * d)
+    ) -> torch.Tensor:          # (num_tokens, d)
+        num_tokens = x.shape[0]
+        d = x.shape[1] // 2
+        out = torch.empty(num_tokens, d, dtype=x.dtype, device=x.device)
+        activation_ops.silu_and_mul(out, x)
+        return out

--- a/cacheflow/models/attention.py
+++ b/cacheflow/models/attention.py
@@ -1,6 +1,6 @@
-from typing import List, Optional
+from typing import Optional
 
-from flash_attn.flash_attention import FlashAttention
+from flash_attn.flash_attn_interface import _flash_attn_forward
 import torch
 import torch.nn as nn
 
@@ -16,40 +16,41 @@ class GPTCacheFlowAttention(nn.Module):
         super().__init__()
         self.scale = float(scale)
 
-        self.flash_attn = FlashAttention(softmax_scale=self.scale)
-
     def multi_query_kv_attention(
         self,
-        output: torch.Tensor,       # [num_prompt_tokens, num_heads, head_size]
-        query: torch.Tensor,        # [num_prompt_tokens, num_heads, head_size]
-        key: torch.Tensor,          # [num_prompt_tokens, num_heads, head_size]
-        value: torch.Tensor,        # [num_prompt_tokens, num_heads, head_size]
-        prompt_lens: List[int],
+        output: torch.Tensor,                   # [num_prompt_tokens, num_heads, head_size]
+        query: torch.Tensor,                    # [num_prompt_tokens, num_heads, head_size]
+        key: torch.Tensor,                      # [num_prompt_tokens, num_heads, head_size]
+        value: torch.Tensor,                    # [num_prompt_tokens, num_heads, head_size]
+        cumulative_prompt_lens: torch.Tensor,   # [num_prompts + 1]
+        max_prompt_len: int,
     ) -> None:
+        # NOTE: Each of the query, key, and value tensors is not contiguous
+        # in memory. This is because the tensors are sliced from a qkv tensor
+        # of shape [num_prompt_tokens, 3 * num_heads * head_size].
         if query.dtype == torch.float:
             raise ValueError('The float data type is not supported by '
                              'FlashAttention. Use the half data type instead.')
-        head_size = query.shape[2]
+        head_size = query.shape[-1]
         if head_size > 128:
             raise ValueError('FlashAttention does not support head_size > 128.')
 
-        device = query.device
-        prefix_sum = [0]
-        for prompt_len in prompt_lens:
-            prefix_sum.append(prefix_sum[-1] + prompt_len)
-        prefix_sum = torch.tensor(prefix_sum, dtype=torch.int, device=device)
-        max_prompt_len = max(prompt_lens)
-
-        # FIXME(woosuk): Unnecessary copy. Optimize this.
-        qkv = torch.stack([query, key, value], dim=1)
-        out = self.flash_attn(
-            qkv,
-            cu_seqlens=prefix_sum,
-            max_s=max_prompt_len,
+        # Directly call FlashAttention's internal function to avoid allocating
+        # a new tensor for the output.
+        _flash_attn_forward(
+            query,
+            key,
+            value,
+            output,
+            cumulative_prompt_lens,
+            cumulative_prompt_lens,
+            max_prompt_len,
+            max_prompt_len,
+            dropout_p=0.0,
+            softmax_scale=self.scale,
             causal=True,
-        )[0]
-        # FIXME(woosuk): Unnecessary copy. Optimize this.
-        output.copy_(out, non_blocking=True)
+            return_softmax=False,
+        )
 
     def single_query_cached_kv_attention(
         self,
@@ -82,29 +83,27 @@ class GPTCacheFlowAttention(nn.Module):
 
     def forward(
         self,
-        query: torch.Tensor,                    # [num_tokens, num_heads * head_size]
-        key: torch.Tensor,                      # [num_tokens, num_heads * head_size]
-        value: torch.Tensor,                    # [num_tokens, num_heads * head_size]
+        qkv: torch.Tensor,                      # [num_tokens, 3 * num_heads * head_size]
         key_cache: torch.Tensor,                # [num_blocks, num_heads, head_size/x, block_size, x]
         value_cache: torch.Tensor,              # [num_blocks, num_heads, head_size, block_size]
         input_metadata: InputMetadata,
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:                          # [num_tokens, num_heads * head_size]
-        # Pre-allocate the output tensor.
-        output = torch.empty_like(query)
-
-        # Prune out paddings if any.
-        query = query[:input_metadata.num_valid_tokens]
-        key = key[:input_metadata.num_valid_tokens]
-        value = value[:input_metadata.num_valid_tokens]
-
-        # Reshape the input tensors.
+        num_tokens = qkv.shape[0]
         num_heads = value_cache.shape[1]
         head_size = value_cache.shape[2]
-        query = query.view(-1, num_heads, head_size)
-        key = key.view(-1, num_heads, head_size)
-        value = value.view(-1, num_heads, head_size)
-        output = output.view(-1, num_heads, head_size)
+
+        # Pre-allocate the output tensor.
+        output = torch.empty(
+            num_tokens,
+            num_heads,
+            head_size,
+            dtype=qkv.dtype,
+            device=qkv.device,
+        )
+        # Reshape and split the qkv tensor.
+        qkv = qkv.view(-1, 3, num_heads, head_size)
+        query, key, value = qkv.unbind(dim=1)
 
         # Compute the attention op for prompts.
         num_prompt_tokens = input_metadata.num_prompt_tokens
@@ -114,7 +113,8 @@ class GPTCacheFlowAttention(nn.Module):
                 query[:num_prompt_tokens],
                 key[:num_prompt_tokens],
                 value[:num_prompt_tokens],
-                input_metadata.prompt_lens,
+                input_metadata.cumulative_prompt_lens,
+                input_metadata.max_prompt_len,
             )
 
         # Wait until the cache op is done.
@@ -122,14 +122,22 @@ class GPTCacheFlowAttention(nn.Module):
             cache_event.wait()
 
         # Reshape the keys and values and store them in the cache.
-        cache_ops.reshape_and_cache(
-            key, value, key_cache, value_cache, input_metadata.slot_mapping)
+        num_valid_tokens = input_metadata.num_valid_tokens
+        if num_valid_tokens > 0:
+            # The stride is 3 because the key and value are sliced from qkv.
+            cache_ops.reshape_and_cache(
+                key[:num_valid_tokens],
+                value[:num_valid_tokens],
+                key_cache,
+                value_cache,
+                input_metadata.slot_mapping,
+            )
 
         if input_metadata.num_generation_tokens > 0:
             # Compute the attention op for generation tokens.
             self.single_query_cached_kv_attention(
-                output[num_prompt_tokens:],
-                query[num_prompt_tokens:],
+                output[num_prompt_tokens:num_valid_tokens],
+                query[num_prompt_tokens:num_valid_tokens],
                 key_cache,
                 value_cache,
                 input_metadata)

--- a/cacheflow/models/attention.py
+++ b/cacheflow/models/attention.py
@@ -90,7 +90,7 @@ class OPTCacheFlowAttention(nn.Module):
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:                          # [num_tokens, num_heads * head_size]
         # Pre-allocate the output tensor.
-        output = torch.zeros_like(query)
+        output = torch.empty_like(query)
 
         # Prune out paddings if any.
         query = query[:input_metadata.num_valid_tokens]

--- a/cacheflow/models/attention.py
+++ b/cacheflow/models/attention.py
@@ -90,7 +90,7 @@ class OPTCacheFlowAttention(nn.Module):
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:                          # [num_tokens, num_heads * head_size]
         # Pre-allocate the output tensor.
-        output = torch.empty_like(query)
+        output = torch.zeros_like(query)
 
         # Prune out paddings if any.
         query = query[:input_metadata.num_valid_tokens]

--- a/cacheflow/models/input_metadata.py
+++ b/cacheflow/models/input_metadata.py
@@ -12,6 +12,7 @@ class InputMetadata:
         seq_groups: List[Tuple[List[int], SamplingParams]],
         seq_logprobs: Dict[int, float],                         # Seq id -> cumulative logprobs.
         prompt_lens: List[int],
+        cumulative_prompt_lens: torch.Tensor,
         slot_mapping: torch.Tensor,
         context_lens: torch.Tensor,
         max_context_len: int,
@@ -20,6 +21,7 @@ class InputMetadata:
         self.seq_groups = seq_groups
         self.seq_logprobs = seq_logprobs
         self.prompt_lens = prompt_lens
+        self.cumulative_prompt_lens = cumulative_prompt_lens
         self.slot_mapping = slot_mapping
         self.context_lens = context_lens
         self.max_context_len = max_context_len
@@ -27,6 +29,7 @@ class InputMetadata:
 
         self.num_prompts = len(prompt_lens)
         self.num_prompt_tokens = sum(prompt_lens)
+        self.max_prompt_len = max(prompt_lens) if prompt_lens else 0
         self.num_generation_tokens = context_lens.shape[0]
         self.num_valid_tokens = slot_mapping.shape[0]
         if block_tables.numel() > 0:
@@ -40,11 +43,13 @@ class InputMetadata:
         return (f'InputMetadata('
                 f'num_prompts={self.num_prompts}, '
                 f'num_prompt_tokens={self.num_prompt_tokens}, '
+                f'max_prompt_len={self.max_prompt_len}, '
                 f'num_generation_tokens={self.num_generation_tokens}, '
                 f'num_valid_tokens={self.num_valid_tokens}, '
                 f'max_num_blocks_per_seq={self.max_num_blocks_per_seq}, '
                 f'max_context_len={self.max_context_len}), '
                 f'prompt_lens={self.prompt_lens}, '
+                f'cumulative_prompt_lens={self.cumulative_prompt_lens}, '
                 f'slot_mapping={self.slot_mapping}, '
                 f'context_lens={self.context_lens}, '
                 f'block_tables={self.block_tables})')

--- a/cacheflow/models/llama.py
+++ b/cacheflow/models/llama.py
@@ -93,11 +93,7 @@ class LlamaAttention(nn.Module):
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        qkv = qkv.reshape(qkv.shape[:-1] + (3, -1))
-        q, k, v = torch.split(qkv, 1, dim=-2)
-        q = q.squeeze(dim=-2).contiguous()
-        k = k.squeeze(dim=-2).contiguous()
-        v = v.squeeze(dim=-2).contiguous()
+        q, k, v = qkv.chunk(chunks=3, dim=-1)
         k_cache, v_cache = kv_cache
         attn_output = self.attn(
             positions, q, k, v, k_cache, v_cache, input_metadata, cache_event)

--- a/cacheflow/models/llama.py
+++ b/cacheflow/models/llama.py
@@ -90,22 +90,21 @@ class LlamaMLP(nn.Module):
         hidden_act: str,
     ):
         super().__init__()
-        # TODO: Merge the gate and down linear layers.
-        self.gate_proj = ColumnParallelLinear(hidden_size, intermediate_size,
-                                              bias=False, gather_output=False,
-                                              perform_initialization=False)
+        self.gate_up_proj = ColumnParallelLinear(hidden_size, 2 * intermediate_size,
+                                                 bias=False, gather_output=False,
+                                                 perform_initialization=False)
         self.down_proj = RowParallelLinear(intermediate_size, hidden_size,
                                            bias=False, input_is_parallel=True,
                                            perform_initialization=False)
-        self.up_proj = ColumnParallelLinear(hidden_size, intermediate_size,
-                                            bias=False, gather_output=False,
-                                            perform_initialization=False)
         assert hidden_act == 'silu'
         self.act_fn = nn.SiLU()
 
     def forward(self, x):
-        gate, _ = self.gate_proj(x)
-        up, _ = self.up_proj(x)
+        gate_up, _ = self.gate_up_proj(x)
+        gate_up = gate_up.reshape(gate_up.shape[:-1] + (-1, 2))
+        gate, up = torch.split(gate_up, 1, dim=-1)
+        gate = gate.squeeze(dim=-1).contiguous()
+        up = up.squeeze(dim=-1).contiguous()
         x = self.act_fn(gate) * up
         x, _ = self.down_proj(x)
         return x
@@ -127,24 +126,9 @@ class LlamaAttention(nn.Module):
         self.head_dim = hidden_size // self.total_num_heads
         self.scaling = self.head_dim ** -0.5
 
-        # TODO: Merge the QKV linear layers.
-        self.q_proj = ColumnParallelLinear(
+        self.qkv_proj = ColumnParallelLinear(
             hidden_size,
-            self.total_num_heads * self.head_dim,
-            bias=False,
-            gather_output=False,
-            perform_initialization=False,
-        )
-        self.k_proj = ColumnParallelLinear(
-            hidden_size,
-            self.total_num_heads * self.head_dim,
-            bias=False,
-            gather_output=False,
-            perform_initialization=False,
-        )
-        self.v_proj = ColumnParallelLinear(
-            hidden_size,
-            self.total_num_heads * self.head_dim,
+            3 * self.total_num_heads * self.head_dim,
             bias=False,
             gather_output=False,
             perform_initialization=False,
@@ -168,9 +152,12 @@ class LlamaAttention(nn.Module):
         input_metadata: InputMetadata,
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:
-        q, _ = self.q_proj(hidden_states)
-        k, _ = self.k_proj(hidden_states)
-        v, _ = self.v_proj(hidden_states)
+        qkv, _ = self.qkv_proj(hidden_states)
+        qkv = qkv.reshape(qkv.shape[:-1] + (-1, 3))
+        q, k, v = torch.split(qkv, 1, dim=-1)
+        q = q.squeeze(dim=-1).contiguous()
+        k = k.squeeze(dim=-1).contiguous()
+        v = v.squeeze(dim=-1).contiguous()
 
         # Apply rotrary embedding.
         # TODO: Optimize.
@@ -299,8 +286,7 @@ class LlamaForCausalLM(nn.Module):
         return next_tokens
 
     _column_parallel_weights = ["embed_tokens.weight", "lm_head.weight",
-                                "q_proj.weight", "k_proj.weight",
-                                "v_proj.weight", "gate_proj.weight",
+                                "qkv_proj.weight", "gate_proj.weight",
                                 "up_proj.weight"]
     _row_parallel_weights = ["o_proj.weight", "down_proj.weight"]
 
@@ -308,8 +294,19 @@ class LlamaForCausalLM(nn.Module):
         tensor_model_parallel_rank = get_tensor_model_parallel_rank()
         state_dict = self.state_dict()
         for name, param in state_dict.items():
-            loaded_weight = torch.from_numpy(np.load(os.path.join(weights_path,
-                                                                  name)))
+            if "qkv_proj.weight" in name:
+                q_weight = np.load(os.path.join(weights_path, name.replace("qkv_proj", "q_proj")))
+                k_weight = np.load(os.path.join(weights_path, name.replace("qkv_proj", "k_proj")))
+                v_weight = np.load(os.path.join(weights_path, name.replace("qkv_proj", "v_proj")))
+                loaded_weight = np.stack([q_weight, k_weight, v_weight]).transpose(1, 0, 2)
+                loaded_weight = torch.from_numpy(loaded_weight.reshape(-1, loaded_weight.shape[-1]))
+            elif "gate_up_proj.weight" in name:
+                gate_weight = np.load(os.path.join(weights_path, name.replace("gate_up_proj", "gate_proj")))
+                up_weight = np.load(os.path.join(weights_path, name.replace("gate_up_proj", "up_proj")))
+                loaded_weight = np.stack([gate_weight, up_weight]).transpose(1, 0, 2)
+                loaded_weight = torch.from_numpy(loaded_weight.reshape(-1, loaded_weight.shape[-1]))
+            else:
+                loaded_weight = torch.from_numpy(np.load(os.path.join(weights_path, name)))
             for p in self._column_parallel_weights:
                 if p in name:
                     shard_size = param.shape[0]

--- a/cacheflow/models/llama.py
+++ b/cacheflow/models/llama.py
@@ -11,6 +11,7 @@ from torch import nn
 from transformers import LlamaConfig
 
 from cacheflow.models import InputMetadata
+from cacheflow.models.activation import SiluAndMul
 from cacheflow.models.attention import LlamaCacheFlowAttention
 from cacheflow.models.layernorm import RMSNorm
 from cacheflow.models.sample import Sampler
@@ -39,16 +40,14 @@ class LlamaMLP(nn.Module):
         self.down_proj = RowParallelLinear(intermediate_size, hidden_size,
                                            bias=False, input_is_parallel=True,
                                            perform_initialization=False)
-        assert hidden_act == 'silu'
-        self.act_fn = nn.SiLU()
+        if hidden_act != 'silu':
+            raise ValueError(f'Unsupported activation: {hidden_act}. '
+                             'Only silu is supported for now.')
+        self.act_fn = SiluAndMul()
 
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
-        gate_up = gate_up.reshape(gate_up.shape[:-1] + (2, -1))
-        gate, up = torch.split(gate_up, 1, dim=-2)
-        gate = gate.squeeze(dim=-2).contiguous()
-        up = up.squeeze(dim=-2).contiguous()
-        x = self.act_fn(gate) * up
+        x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x
 

--- a/cacheflow/models/opt.py
+++ b/cacheflow/models/opt.py
@@ -69,14 +69,9 @@ class OPTAttention(nn.Module):
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
-        qkv = qkv.reshape(qkv.shape[:-1] + (3, -1))
-        q, k, v = torch.split(qkv, 1, dim=-2)
-        q = q.squeeze(dim=-2).contiguous()
-        k = k.squeeze(dim=-2).contiguous()
-        v = v.squeeze(dim=-2).contiguous()
         key_cache, value_cache = kv_cache
         attn_output = self.attn(
-            q, k, v, key_cache, value_cache, input_metadata, cache_event)
+            qkv, key_cache, value_cache, input_metadata, cache_event)
         output, _ = self.out_proj(attn_output)
         return output
 

--- a/cacheflow/models/opt.py
+++ b/cacheflow/models/opt.py
@@ -282,8 +282,7 @@ class OPTForCausalLM(nn.Module):
                 loaded_weight = np.stack([q_bias, k_bias, v_bias]).transpose(1, 0)
                 loaded_weight = torch.from_numpy(loaded_weight.reshape(-1))
             else:
-                loaded_weight = torch.from_numpy(np.load(os.path.join(weights_path,
-                                                                    name)))
+                loaded_weight = torch.from_numpy(np.load(os.path.join(weights_path, name)))
 
             for p in (self._column_parallel_weights
                       + self._column_parallel_biases):

--- a/cacheflow/models/opt.py
+++ b/cacheflow/models/opt.py
@@ -69,9 +69,10 @@ class OPTAttention(nn.Module):
         cache_event: Optional[torch.cuda.Event],
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.chunk(chunks=3, dim=-1)
         key_cache, value_cache = kv_cache
         attn_output = self.attn(
-            qkv, key_cache, value_cache, input_metadata, cache_event)
+            q, k, v, key_cache, value_cache, input_metadata, cache_event)
         output, _ = self.out_proj(attn_output)
         return output
 

--- a/cacheflow/worker/worker.py
+++ b/cacheflow/worker/worker.py
@@ -128,6 +128,11 @@ class Worker:
                 slot = block_number * self.block_size + block_offset
                 slot_mapping.append(slot)
 
+        cumulative_prompt_lens: List[int] = [0]
+        for prompt_len in prompt_lens:
+            cumulative_prompt_lens.append(
+                cumulative_prompt_lens[-1] + prompt_len)
+
         # Add generation tokens.
         max_context_len = 0
         max_num_blocks_per_seq = 0
@@ -183,11 +188,14 @@ class Worker:
             for block_table in generation_block_tables]
         block_tables_tensor = torch.tensor(
             padded_block_tables, dtype=torch.int, device='cuda')
+        cumulative_prompt_lens_tensor = torch.tensor(
+            cumulative_prompt_lens, dtype=torch.int, device='cuda')
 
         input_metadata = InputMetadata(
             seq_groups=seq_groups,
             seq_logprobs=seq_logprobs,
             prompt_lens=prompt_lens,
+            cumulative_prompt_lens=cumulative_prompt_lens_tensor,
             slot_mapping=slot_mapping_tensor,
             context_lens=context_lens_tensor,
             max_context_len=max_context_len,

--- a/csrc/activation.cpp
+++ b/csrc/activation.cpp
@@ -1,0 +1,12 @@
+#include <torch/extension.h>
+
+void silu_and_mul(
+  torch::Tensor& out,
+  torch::Tensor& input);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def(
+    "silu_and_mul",
+    &silu_and_mul,
+    "Activation function used in SwiGLU.");
+}

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -1,0 +1,67 @@
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+namespace cacheflow {
+
+template<typename T>
+__device__ __forceinline__ T silu(const T& x) {
+  // x * sigmoid(x)
+  return (T) (((float) x) / (1.0f + expf((float) -x)));
+}
+
+template<typename scalar_t>
+__global__ void silu_and_mul_kernel(
+  scalar_t* __restrict__ out,               // [num_tokens, d]
+  const scalar_t* __restrict__ input,       // [num_tokens, 2, d]
+  const int d) {
+  const int token_idx = blockIdx.x;
+  for (int idx = threadIdx.x; idx < d; idx += blockDim.x) {
+    const scalar_t x = __ldg(&input[token_idx * 2 * d + idx]);
+    const scalar_t y = __ldg(&input[token_idx * 2 * d + d + idx]);
+    out[token_idx * d + idx] = silu(x) * y;
+  }
+}
+
+} // namespace cacheflow
+
+void silu_and_mul(
+  torch::Tensor& out,      // [num_tokens, d]
+  torch::Tensor& input)    // [num_tokens, 2 * d]
+{
+  int num_tokens = input.size(0);
+  int d = input.size(1) / 2;
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(
+    input.scalar_type(),
+    "silu_and_mul_kernel",
+    [&] {
+      cacheflow::silu_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        out.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(),
+        d);
+    });
+}
+
+namespace cacheflow {
+
+// template<typename T>
+// __global__ void in_place_add_bias_gelu(
+//     T* out,
+//     const T* __restrict__ bias,
+//     int m, int n)
+// {
+//     for (int id = blockIdx.x * blockDim.x + threadIdx.x; id < m * n; id += blockDim.x * gridDim.x) {
+//         T val = out[id];
+//         if (bias != nullptr) {
+//             T reg_bias = __ldg(&bias[id % n]);
+//             val = val + reg_bias;
+//         }
+//         out[id] = (T)(gelu(val));
+//     }
+// }
+
+
+} // namespace cacheflow

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -44,24 +44,3 @@ void silu_and_mul(
         d);
     });
 }
-
-namespace cacheflow {
-
-// template<typename T>
-// __global__ void in_place_add_bias_gelu(
-//     T* out,
-//     const T* __restrict__ bias,
-//     int m, int n)
-// {
-//     for (int id = blockIdx.x * blockDim.x + threadIdx.x; id < m * n; id += blockDim.x * gridDim.x) {
-//         T val = out[id];
-//         if (bias != nullptr) {
-//             T reg_bias = __ldg(&bias[id % n]);
-//             val = val + reg_bias;
-//         }
-//         out[id] = (T)(gelu(val));
-//     }
-// }
-
-
-} // namespace cacheflow

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -81,6 +81,8 @@ __global__ void reshape_and_cache_kernel(
   scalar_t* __restrict__ key_cache,     // [num_blocks, num_heads, head_size/x, block_size, x]
   scalar_t* __restrict__ value_cache,   // [num_blocks, num_heads, head_size, block_size]
   const int* __restrict__ slot_mapping, // [num_tokens]
+  const int key_stride,
+  const int value_stride,
   const int num_heads,
   const int head_size,
   const int block_size,
@@ -92,7 +94,8 @@ __global__ void reshape_and_cache_kernel(
 
   const int n = num_heads * head_size;
   for (int i = threadIdx.x; i < n; i += blockDim.x) {
-    const int src_idx = token_idx * n + i;
+    const int src_key_idx = token_idx * key_stride + i;
+    const int src_value_idx = token_idx * value_stride + i;
 
     const int head_idx = i / head_size;
     const int head_offset = i % head_size;
@@ -108,24 +111,28 @@ __global__ void reshape_and_cache_kernel(
                               + head_idx * head_size * block_size
                               + head_offset * block_size
                               + block_offset;
-    key_cache[tgt_key_idx] = __ldg(&key[src_idx]);
-    value_cache[tgt_value_idx] = __ldg(&value[src_idx]);
+    key_cache[tgt_key_idx] = __ldg(&key[src_key_idx]);
+    value_cache[tgt_value_idx] = __ldg(&value[src_value_idx]);
   }
 }
 
 } // namespace cacheflow
 
 void reshape_and_cache(
-  torch::Tensor& key,
-  torch::Tensor& value,
-  torch::Tensor& key_cache,
-  torch::Tensor& value_cache,
-  torch::Tensor& slot_mapping) {
+  torch::Tensor& key,           // [num_tokens, num_heads, head_size]
+  torch::Tensor& value,         // [num_tokens, num_heads, head_size]
+  torch::Tensor& key_cache,     // [num_blocks, num_heads, head_size/x, block_size, x]
+  torch::Tensor& value_cache,   // [num_blocks, num_heads, head_size, block_size]
+  torch::Tensor& slot_mapping)  // [num_tokens]
+{
   int num_tokens = key.size(0);
   int num_heads = key.size(1);
   int head_size = key.size(2);
   int block_size = key_cache.size(3);
   int x = key_cache.size(4);
+
+  int key_stride = key.stride(0);
+  int value_stride = value.stride(0);
 
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * head_size, 512));
@@ -140,6 +147,8 @@ void reshape_and_cache(
         key_cache.data_ptr<scalar_t>(),
         value_cache.data_ptr<scalar_t>(),
         slot_mapping.data_ptr<int>(),
+        key_stride,
+        value_stride,
         num_heads,
         head_size,
         block_size,

--- a/csrc/pos_encoding.cpp
+++ b/csrc/pos_encoding.cpp
@@ -1,8 +1,6 @@
 #include <torch/extension.h>
 
 void rotary_embedding_neox(
-  torch::Tensor& out_query,
-  torch::Tensor& out_key,
   torch::Tensor& positions,
   torch::Tensor& query,
   torch::Tensor& key,

--- a/csrc/pos_encoding_kernels.cu
+++ b/csrc/pos_encoding_kernels.cu
@@ -60,7 +60,7 @@ void rotary_embedding_neox(
   TORCH_CHECK(stride == key.stride(0));
 
   dim3 grid(num_tokens);
-  dim3 block(std::min(num_heads * head_size, 512));
+  dim3 block(std::min(num_heads * head_size / 2, 512));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
     query.scalar_type(),

--- a/csrc/pos_encoding_kernels.cu
+++ b/csrc/pos_encoding_kernels.cu
@@ -5,12 +5,11 @@ namespace cacheflow {
 
 template<typename scalar_t>
 __global__ void rotary_embedding_neox_kernel(
-  scalar_t* __restrict__ out_query,             // [num_tokens, num_heads, head_size]
-  scalar_t* __restrict__ out_key,               // [num_tokens, num_heads, head_size]
   const int64_t* __restrict__ positions,        // [num_tokens]
-  const scalar_t* __restrict__ query,           // [num_tokens, num_heads, head_size]
-  const scalar_t* __restrict__ key,             // [num_tokens, num_heads, head_size]
+  scalar_t* __restrict__ query,                 // [num_tokens, num_heads, head_size]
+  scalar_t* __restrict__ key,                   // [num_tokens, num_heads, head_size]
   const scalar_t* __restrict__ cos_sin_cache,   // [max_position, 2, head_size // 2]
+  const int stride,
   const int num_heads,
   const int head_size) {
   // Each thread block is responsible for one token.
@@ -19,41 +18,36 @@ __global__ void rotary_embedding_neox_kernel(
   const scalar_t* cache_ptr = cos_sin_cache + pos * head_size;
 
   const int embed_dim = head_size / 2;
-  const int n = num_heads * head_size;
+  const int n = num_heads * embed_dim;
   for (int i = threadIdx.x; i < n; i += blockDim.x) {
-    const int idx = token_idx * n + i;
+    const int head_idx = i / embed_dim;
+    const int token_head = token_idx * stride + head_idx * head_size;
 
-    const int head_idx = i / head_size;
-    const int head_offset = i % head_size;
-    const int token_head = token_idx * n + head_idx * head_size;
-
-    const bool is_first_half = head_offset < embed_dim;
-    const int rot_offset = head_offset % embed_dim;
+    const int rot_offset = i % embed_dim;
     const int x_index = rot_offset;
     const int y_index = embed_dim + rot_offset;
+
+    const int out_x = token_idx * stride + head_idx * head_size + x_index;
+    const int out_y = token_idx * stride + head_idx * head_size + y_index;
 
     const scalar_t cos = __ldg(cache_ptr + x_index);
     const scalar_t sin = __ldg(cache_ptr + y_index);
 
-    const scalar_t q_x = __ldg(query + token_head + x_index);
-    const scalar_t q_y = __ldg(query + token_head + y_index);
-    const scalar_t q_cos = is_first_half ? q_x : q_y;
-    const scalar_t q_sin = is_first_half ? -q_y : q_x;
-    out_query[idx] = q_cos * cos + q_sin * sin;
+    const scalar_t q_x = query[token_head + x_index];
+    const scalar_t q_y = query[token_head + y_index];
+    query[out_x] = q_x * cos - q_y * sin;
+    query[out_y] = q_y * cos + q_x * sin;
 
-    const scalar_t k_x = __ldg(key + token_head + x_index);
-    const scalar_t k_y = __ldg(key + token_head + y_index);
-    const scalar_t k_cos = is_first_half ? k_x : k_y;
-    const scalar_t k_sin = is_first_half ? -k_y : k_x;
-    out_key[idx] = k_cos * cos + k_sin * sin;
+    const scalar_t k_x = key[token_head + x_index];
+    const scalar_t k_y = key[token_head + y_index];
+    key[out_x] = k_x * cos - k_y * sin;
+    key[out_y] = k_y * cos + k_x * sin;
   }
 }
 
 } // namespace cacheflow
 
 void rotary_embedding_neox(
-  torch::Tensor& out_query,         // [num_tokens, num_heads * head_size]
-  torch::Tensor& out_key,           // [num_tokens, num_heads * head_size]
   torch::Tensor& positions,         // [num_tokens]
   torch::Tensor& query,             // [num_tokens, num_heads * head_size]
   torch::Tensor& key,               // [num_tokens, num_heads * head_size]
@@ -62,6 +56,8 @@ void rotary_embedding_neox(
   int num_tokens = query.size(0);
   int head_size = cos_sin_cache.size(1);
   int num_heads = query.size(1) / head_size;
+  int stride = query.stride(0);
+  TORCH_CHECK(stride == key.stride(0));
 
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * head_size, 512));
@@ -71,12 +67,11 @@ void rotary_embedding_neox(
     "rotary_embedding_neox",
     [&] {
       cacheflow::rotary_embedding_neox_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        out_query.data_ptr<scalar_t>(),
-        out_key.data_ptr<scalar_t>(),
         positions.data_ptr<int64_t>(),
         query.data_ptr<scalar_t>(),
         key.data_ptr<scalar_t>(),
         cos_sin_cache.data_ptr<scalar_t>(),
+        stride,
         num_heads,
         head_size);
     });

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,13 @@ layernorm_extension = cpp_extension.CUDAExtension(
 )
 ext_modules.append(layernorm_extension)
 
+activation_extension = cpp_extension.CUDAExtension(
+    name='cacheflow.activation_ops',
+    sources=['csrc/activation.cpp', 'csrc/activation_kernels.cu'],
+    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+)
+ext_modules.append(activation_extension)
+
 setuptools.setup(
     name='cacheflow',
     ext_modules=ext_modules,

--- a/tests/kernels/activation.py
+++ b/tests/kernels/activation.py
@@ -1,0 +1,30 @@
+import torch
+import torch.nn.functional as F
+
+from cacheflow import activation_ops
+
+
+def ref_silu_and_mul(x: torch.Tensor) -> torch.Tensor:
+    x1, x2 = x.chunk(chunks=2, dim=1)
+    return F.silu(x1) * x2
+
+
+@torch.inference_mode()
+def test_silu_and_mul(
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+) -> None:
+    x = torch.randn(num_tokens, 2 * d, dtype=dtype, device='cuda')
+    out = torch.empty(num_tokens, d, dtype=dtype, device='cuda')
+    activation_ops.silu_and_mul(out, x)
+    ref_out = ref_silu_and_mul(x)
+    assert torch.allclose(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
+if __name__ == '__main__':
+    for dtype in [torch.half, torch.float]:
+        for num_tokens in [7, 83, 2048]:
+            for d in [512, 4096, 13824]:
+                print(f'Testing dtype={dtype}, num_tokens={num_tokens}, d={d}')
+                test_silu_and_mul(num_tokens, d, dtype)

--- a/tests/kernels/pos_encoding.py
+++ b/tests/kernels/pos_encoding.py
@@ -85,15 +85,13 @@ def test_rotary_embedding_neox(
     cos_sin_cache = torch.cat((cos, sin), dim=-1)
     cos_sin_cache = cos_sin_cache.to(dtype=dtype, device='cuda')
 
-    # Run the kernel.
-    out_query = torch.empty_like(query)
-    out_key = torch.empty_like(key)
+    # Run the kernel. The kernel is in-place, so we need to clone the inputs.
+    out_query = query.clone()
+    out_key = key.clone()
     pos_encoding_ops.rotary_embedding_neox(
+        positions,
         out_query,
         out_key,
-        positions,
-        query,
-        key,
         cos_sin_cache,
     )
 


### PR DESCRIPTION
Should be merged after #15 .

The changes in this PR eliminate the need for redundant data movements such as `torch.cat`, `torch.stack`, and `torch.contiguous`, which were previously used to align input and output shapes. The PR modifies existing kernels and adds new kernels to accommodate non-contiguous tensors, making these data movement operators unnecessary.