### PR TITLE
Add ninja to dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 pip install psutil numpy ray torch
 pip install git+https://github.com/huggingface/transformers  # Required for LLaMA.
 pip install sentencepiece  # Required for LlamaTokenizer.
-pip install flash-attn  # This may take up to 20 mins.
+pip install ninja  # To parallelize the compilation of flash-attn.
+pip install flash-attn  # This may take up to 10 mins.
 pip install -e .
 ```
 


### PR DESCRIPTION
The compilation time of flash-attn can be drastically reduced if ninja is installed. Related issue: https://github.com/HazyResearch/flash-attention/issues/150