### PR TITLE
Implement block copy kernel to optimize beam search

### DIFF
--- a/benchmark/benchmark_latency.py
+++ b/benchmark/benchmark_latency.py
@@ -50,14 +50,15 @@ def main(args: argparse.Namespace):
         block_size=args.block_size,
     )
     sampling_params_dict = {
-        'n': 1,
-        'temperature': 0.0,
+        'n': args.n,
+        'temperature': 0.0 if args.use_beam_search else 1.0,
         'top_p': 1.0,
-        'use_beam_search': False,
+        'use_beam_search': args.use_beam_search,
         'stop_token_ids': set(),
         'max_num_steps': args.output_len,
     }
     sampling_params = SamplingParams.from_dict(sampling_params_dict)
+    print(sampling_params)
     input_token_ids = [0] * args.input_len
 
     def profile_step(profile=False):
@@ -93,6 +94,8 @@ if __name__ == '__main__':
     parser.add_argument('--input-len', type=int, default=32)
     parser.add_argument('--output-len', type=int, default=128)
     parser.add_argument('--batch-size', type=int, default=8)
+    parser.add_argument('--n', type=int, default=1)
+    parser.add_argument('--use-beam-search', action='store_true')
     args = parser.parse_args()
     args.max_num_batched_tokens = max(
         args.max_num_batched_tokens, args.batch_size * args.input_len)

--- a/cacheflow/models/sample.py
+++ b/cacheflow/models/sample.py
@@ -185,9 +185,10 @@ def _sample_from_generation_tokens(
         vocab_size = logprobs.size(-1)
         beam_width = len(seq_ids)
         _, topk_ids = torch.topk(logprobs.flatten(), beam_width)
-        seq_idx = torch.div(topk_ids, vocab_size, rounding_mode='floor').tolist()
+        topk_ids = topk_ids.tolist()
+        seq_idx = [i // vocab_size for i in topk_ids]
         beam_seq_ids = [seq_ids[i] for i in seq_idx]
-        token_ids = (topk_ids % vocab_size).tolist()
+        token_ids = [i % vocab_size for i in topk_ids]
 
         beam_outputs: Dict[int, Tuple[int, int]] = {}
         outstanding_beams: List[Tuple[int, int]] = []

--- a/csrc/cache.cpp
+++ b/csrc/cache.cpp
@@ -9,8 +9,8 @@ void swap_blocks(
   const std::map<int64_t, int64_t>& block_mapping);
 
 void copy_blocks(
-  torch::Tensor& src,
-  torch::Tensor& dst,
+  std::vector<torch::Tensor>& key_caches,
+  std::vector<torch::Tensor>& value_caches,
   const std::map<int64_t, std::vector<int64_t>>& block_mapping);
 
 void reshape_and_cache(

--- a/tests/kernels/cache.py
+++ b/tests/kernels/cache.py
@@ -5,6 +5,61 @@ import torch
 from cacheflow import cache_ops
 
 
+def test_copy_blocks(
+    num_mappings: int,
+    num_layers: int,
+    num_heads: int,
+    head_size: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+) -> None:
+    # Generate random block mappings.
+    src_blocks = random.sample(range(num_blocks), num_mappings)
+    remainig_blocks = list(set(range(num_blocks)) - set(src_blocks))
+    dst_blocks = random.sample(remainig_blocks, num_mappings)
+    block_mapping = {src: [dst] for src, dst in zip(src_blocks, dst_blocks)}
+
+    # Create the KV cache.
+    x = 16 // torch.tensor([], dtype=dtype).element_size()
+    key_cache_shape = (num_blocks, num_heads, head_size // x, block_size, x)
+    key_caches = []
+    for _ in range(num_layers):
+        key_cache = torch.randn(
+            size=key_cache_shape, dtype=dtype, device='cuda')
+        key_caches.append(key_cache)
+    cloned_key_caches = []
+    for key_cache in key_caches:
+        cloned_key_caches.append(key_cache.clone())
+
+    value_cache_shape = (num_blocks, num_heads, head_size, block_size)
+    value_caches = []
+    for _ in range(num_layers):
+        value_cache = torch.randn(
+            size=value_cache_shape, dtype=dtype, device='cuda')
+        value_caches.append(value_cache)
+    cloned_value_caches = []
+    for value_cache in value_caches:
+        cloned_value_caches.append(value_cache.clone())
+
+    # Call the copy blocks kernel.
+    cache_ops.copy_blocks(key_caches, value_caches, block_mapping)
+
+    # Reference implementation.
+    for src, dsts in block_mapping.items():
+        for dst in dsts:
+            for key_cache, cloned_key_cache in zip(key_caches, cloned_key_caches):
+                cloned_key_cache[dst] = cloned_key_cache[src]
+            for value_cache, cloned_value_cache in zip(value_caches, cloned_value_caches):
+                cloned_value_cache[dst] = cloned_value_cache[src]
+
+    # Compare the results.
+    for key_cache, cloned_key_cache in zip(key_caches, cloned_key_caches):
+        assert torch.allclose(key_cache, cloned_key_cache)
+    for value_cache, cloned_value_cache in zip(value_caches, cloned_value_caches):
+        assert torch.allclose(value_cache, cloned_value_cache)
+
+
 def test_reshape_and_cache(
     num_tokens: int,
     num_heads: int,
@@ -46,6 +101,9 @@ def test_reshape_and_cache(
 
 @torch.inference_mode()
 def test_cache() -> None:
+    test_copy_blocks(
+        num_mappings=23, num_layers=7, num_heads=17, head_size=16,
+        block_size=8, num_blocks=1024, dtype=torch.half)
     test_reshape_and_cache(
         num_tokens=3, num_heads=2, head_size=16, block_size=8, num_blocks=2,
         dtype=torch.half)


### PR DESCRIPTION
This PR implements a block copy kernel. By using this kernel, we can reduce the number of kernel invocations from `2 * num_layers * num_copying_blocks` to 1.