### PR TITLE
Specify python package dependencies in requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CacheFlow
 
-## Installation
+## Build from source
 
 ```bash
-pip install ninja psutil numpy sentencepiece ray torch transformers xformers
-pip install -e .
+pip install -r requirements.txt
+pip install -e .  # This may take several minutes.
 ```
 
 ## Test simple server

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ python simple_server.py --help
 
 ## FastAPI server
 
-Install the following additional dependencies:
-```bash
-pip install fastapi uvicorn
-```
-
 To start the server:
 ```bash
 ray start --head

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ numpy
 torch >= 2.0.0
 transformers >= 4.28.0  # Required for LLaMA.
 xformers >= 0.0.19
+fastapi
+uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+ninja  # For faster builds.
+psutil
+ray
+sentencepiece  # Required for LLaMA tokenizer.
+numpy
+torch >= 2.0.0
+transformers >= 4.28.0  # Required for LLaMA.
+xformers >= 0.0.19

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from torch.utils.cpp_extension import CUDA_HOME
 
 # Build custom operators.
 CXX_FLAGS = ["-g"]
+# TODO(woosuk): Should we use -O3?
 NVCC_FLAGS = ["-O2"]
 
 if not torch.cuda.is_available():

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import setuptools
 import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
@@ -64,8 +66,17 @@ activation_extension = CUDAExtension(
 )
 ext_modules.append(activation_extension)
 
+
+def get_requirements() -> List[str]:
+    """Get Python package dependencies from requirements.txt."""
+    with open("requirements.txt") as f:
+        requirements = f.read().strip().split("\n")
+    return requirements
+
+
 setuptools.setup(
     name="cacheflow",
+    install_requires=get_requirements(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension},
 )

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ from torch.utils.cpp_extension import CUDA_HOME
 
 
 # Build custom operators.
-CXX_FLAGS = ['-g']
-NVCC_FLAGS = ['-O2']
+CXX_FLAGS = ["-g"]
+NVCC_FLAGS = ["-O2"]
 
 if not torch.cuda.is_available():
     raise RuntimeError(
-        f'Cannot find CUDA at CUDA_HOME: {CUDA_HOME}. '
-        'CUDA must be available in order to build the package.')
+        f"Cannot find CUDA at CUDA_HOME: {CUDA_HOME}. "
+        "CUDA must be available in order to build the package.")
 
 # FIXME(woosuk): Consider the case where the machine has multiple GPUs with
 # different compute capabilities.
@@ -19,52 +19,52 @@ compute_capability = torch.cuda.get_device_capability()
 major, minor = compute_capability
 # Enable bfloat16 support if the compute capability is >= 8.0.
 if major >= 8:
-    NVCC_FLAGS.append('-DENABLE_BF16')
+    NVCC_FLAGS.append("-DENABLE_BF16")
 
 ext_modules = []
 
 # Cache operations.
 cache_extension = CUDAExtension(
-    name='cacheflow.cache_ops',
-    sources=['csrc/cache.cpp', 'csrc/cache_kernels.cu'],
-    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+    name="cacheflow.cache_ops",
+    sources=["csrc/cache.cpp", "csrc/cache_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 )
 ext_modules.append(cache_extension)
 
 # Attention kernels.
 attention_extension = CUDAExtension(
-    name='cacheflow.attention_ops',
-    sources=['csrc/attention.cpp', 'csrc/attention/attention_kernels.cu'],
-    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+    name="cacheflow.attention_ops",
+    sources=["csrc/attention.cpp", "csrc/attention/attention_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 )
 ext_modules.append(attention_extension)
 
 # Positional encoding kernels.
 positional_encoding_extension = CUDAExtension(
-    name='cacheflow.pos_encoding_ops',
-    sources=['csrc/pos_encoding.cpp', 'csrc/pos_encoding_kernels.cu'],
-    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+    name="cacheflow.pos_encoding_ops",
+    sources=["csrc/pos_encoding.cpp", "csrc/pos_encoding_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 )
 ext_modules.append(positional_encoding_extension)
 
 # Layer normalization kernels.
 layernorm_extension = CUDAExtension(
-    name='cacheflow.layernorm_ops',
-    sources=['csrc/layernorm.cpp', 'csrc/layernorm_kernels.cu'],
-    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+    name="cacheflow.layernorm_ops",
+    sources=["csrc/layernorm.cpp", "csrc/layernorm_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 )
 ext_modules.append(layernorm_extension)
 
 # Activation kernels.
 activation_extension = CUDAExtension(
-    name='cacheflow.activation_ops',
-    sources=['csrc/activation.cpp', 'csrc/activation_kernels.cu'],
-    extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
+    name="cacheflow.activation_ops",
+    sources=["csrc/activation.cpp", "csrc/activation_kernels.cu"],
+    extra_compile_args={"cxx": CXX_FLAGS, "nvcc": NVCC_FLAGS},
 )
 ext_modules.append(activation_extension)
 
 setuptools.setup(
-    name='cacheflow',
+    name="cacheflow",
     ext_modules=ext_modules,
-    cmdclass={'build_ext': BuildExtension},
+    cmdclass={"build_ext": BuildExtension},
 )

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ def get_requirements() -> List[str]:
 
 setuptools.setup(
     name="cacheflow",
+    python_requires=">=3.8",
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension},

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 import setuptools
 import torch
-from torch.utils import cpp_extension
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+from torch.utils.cpp_extension import CUDA_HOME
 
+
+# Build custom operators.
 CXX_FLAGS = ['-g']
 NVCC_FLAGS = ['-O2']
 
 if not torch.cuda.is_available():
     raise RuntimeError(
-        f'Cannot find CUDA at CUDA_HOME: {cpp_extension.CUDA_HOME}. '
+        f'Cannot find CUDA at CUDA_HOME: {CUDA_HOME}. '
         'CUDA must be available in order to build the package.')
 
 # FIXME(woosuk): Consider the case where the machine has multiple GPUs with
@@ -21,7 +24,7 @@ if major >= 8:
 ext_modules = []
 
 # Cache operations.
-cache_extension = cpp_extension.CUDAExtension(
+cache_extension = CUDAExtension(
     name='cacheflow.cache_ops',
     sources=['csrc/cache.cpp', 'csrc/cache_kernels.cu'],
     extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
@@ -29,7 +32,7 @@ cache_extension = cpp_extension.CUDAExtension(
 ext_modules.append(cache_extension)
 
 # Attention kernels.
-attention_extension = cpp_extension.CUDAExtension(
+attention_extension = CUDAExtension(
     name='cacheflow.attention_ops',
     sources=['csrc/attention.cpp', 'csrc/attention/attention_kernels.cu'],
     extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
@@ -37,7 +40,7 @@ attention_extension = cpp_extension.CUDAExtension(
 ext_modules.append(attention_extension)
 
 # Positional encoding kernels.
-positional_encoding_extension = cpp_extension.CUDAExtension(
+positional_encoding_extension = CUDAExtension(
     name='cacheflow.pos_encoding_ops',
     sources=['csrc/pos_encoding.cpp', 'csrc/pos_encoding_kernels.cu'],
     extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
@@ -45,7 +48,7 @@ positional_encoding_extension = cpp_extension.CUDAExtension(
 ext_modules.append(positional_encoding_extension)
 
 # Layer normalization kernels.
-layernorm_extension = cpp_extension.CUDAExtension(
+layernorm_extension = CUDAExtension(
     name='cacheflow.layernorm_ops',
     sources=['csrc/layernorm.cpp', 'csrc/layernorm_kernels.cu'],
     extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
@@ -53,7 +56,7 @@ layernorm_extension = cpp_extension.CUDAExtension(
 ext_modules.append(layernorm_extension)
 
 # Activation kernels.
-activation_extension = cpp_extension.CUDAExtension(
+activation_extension = CUDAExtension(
     name='cacheflow.activation_ops',
     sources=['csrc/activation.cpp', 'csrc/activation_kernels.cu'],
     extra_compile_args={'cxx': CXX_FLAGS, 'nvcc': NVCC_FLAGS},
@@ -63,5 +66,5 @@ ext_modules.append(activation_extension)
 setuptools.setup(
     name='cacheflow',
     ext_modules=ext_modules,
-    cmdclass={'build_ext': cpp_extension.BuildExtension},
+    cmdclass={'build_ext': BuildExtension},
 )


### PR DESCRIPTION
Closes #56 

This PR specifies the python package dependencies in `requirements.txt`. The file will be parsed by `setup.py`.

### Why not directly specify them in `setup.py`?

For those who build CacheFlow from source, the dependencies (or at least pytorch) should be installed BEFORE executing `pip install .`. This is because we use pytorch (and ninja) to build our custom operators. Having `requirements.txt` allows those people to easily install the dependencies before build.