### PR TITLE
[Minor] Fix a dtype bug

### DIFF
--- a/cacheflow/models/model_utils.py
+++ b/cacheflow/models/model_utils.py
@@ -37,7 +37,11 @@ _MEMORY_ANALYZERS = {
 
 
 def _get_dtype(config: PretrainedConfig, dtype: str) -> torch.dtype:
-    config_dtype: torch.dtype = getattr(config, 'torch_dtype', torch.float32)
+    # NOTE: getattr(config, 'torch_dtype', torch.float32) is not correct
+    # because config.torch_dtype can be None.
+    config_dtype = getattr(config, 'torch_dtype', None)
+    if config_dtype is None:
+        config_dtype = torch.float32
     if dtype == 'default':
         if config_dtype == torch.float32:
             # Following the common practice, we use float16 for float32 models.


### PR DESCRIPTION
This PR handles an exceptional case that `config.torch_dtype` is None (e.g., GPT-2). In this case, we interpret it as float32.