### PR TITLE
Incrementally decode output tokens

### DIFF
--- a/cacheflow/core/scheduler.py
+++ b/cacheflow/core/scheduler.py
@@ -291,7 +291,7 @@ class Scheduler:
             for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
                 # Append a new token to the sequence.
                 output = seq_outputs[seq.seq_id]
-                seq.append_token(output.output_token, output.logprobs)
+                seq.append_token_id(output.output_token, output.logprobs)
         return self.running.copy()
 
     def free_seq(self, seq: Sequence) -> None:

--- a/cacheflow/sequence.py
+++ b/cacheflow/sequence.py
@@ -24,7 +24,7 @@ class SequenceData:
         self.output_token_ids: List[int] = []
         self.cumulative_logprob = 0.0
 
-    def append_token(self, token_id: int, logprob: float) -> None:
+    def append_token_id(self, token_id: int, logprob: float) -> None:
         self.output_token_ids.append(token_id)
         self.cumulative_logprob += logprob
 
@@ -64,6 +64,7 @@ class Sequence:
 
         self.data = SequenceData(prompt_token_ids)
         self.output_logprobs: List[Dict[int, float]] = []
+        self.output_tokens: List[str] = []
         self.output_text = ""
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
@@ -92,11 +93,15 @@ class Sequence:
             last_block.append_tokens(token_ids[:num_empty_slots])
             token_ids = token_ids[num_empty_slots:]
 
-    def append_token(self, token_id: int, logprobs: Dict[int, float]) -> None:
+    def append_token_id(
+        self,
+        token_id: int,
+        logprobs: Dict[int, float],
+    ) -> None:
         assert token_id in logprobs
         self._append_tokens_to_blocks([token_id])
         self.output_logprobs.append(logprobs)
-        self.data.append_token(token_id, logprobs[token_id])
+        self.data.append_token_id(token_id, logprobs[token_id])
 
     def get_len(self) -> int:
         return self.data.get_len()

--- a/cacheflow/server/llm_server.py
+++ b/cacheflow/server/llm_server.py
@@ -185,7 +185,7 @@ class LLMServer:
         return request_outputs
 
     def _decode_sequences(self, seq_groups: List[SequenceGroup]) -> None:
-        # Batch-decode the sequence outputs.
+        # Decode the sequence outputs.
         for seq_group in seq_groups:
             for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
                 new_token, new_output_text = detokenize_incrementally(

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -54,8 +54,7 @@ def detokenize_incrementally(
     # Convert the tokens to a string.
     # Optimization: If the tokenizer does not have `added_tokens_encoder`,
     # then we can just use `convert_tokens_to_string`.
-    if not (hasattr(tokenizer, "added_tokens_encoder") and 
-            tokenizer.added_tokens_encoder):
+    if not getattr(tokenizer, "added_tokens_encoder", {}):
         output_text = tokenizer.convert_tokens_to_string(output_tokens)
         return new_token, output_text
 
@@ -66,8 +65,7 @@ def detokenize_incrementally(
     for token in output_tokens:
         if skip_special_tokens and token in tokenizer.all_special_ids:
             continue
-        if (hasattr(tokenizer, "added_tokens_encoder") and
-            token in tokenizer.added_tokens_encoder):
+        if token in tokenizer.added_tokens_encoder:
             if current_sub_text:
                 sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
                 sub_texts.append(sub_text)

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -40,23 +40,9 @@ def detokenize_incrementally(
     output_tokens = prev_output_tokens + [new_token]
 
     # Convert the tokens to a string.
-    # Adapted from https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
-    sub_texts = []
-    current_sub_text = []
-    for token in output_tokens:
-        if skip_special_tokens and token in tokenizer.all_special_ids:
-            continue
-        if (hasattr(tokenizer, "added_tokens_encoder") and
-            token in tokenizer.added_tokens_encoder):
-            if current_sub_text:
-                sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
-                sub_texts.append(sub_text)
-                current_sub_text = []
-            sub_texts.append(token)
-        else:
-            current_sub_text.append(token)
-    if current_sub_text:
-        sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
-        sub_texts.append(sub_text)
-    output_text = " ".join(sub_texts)
+    # We optimize tokenizer._decode() by assuming that the tokenizer does not
+    # have added_tokens_encoder.
+    if hasattr(tokenizer, "added_tokens_encoder"):
+        assert not tokenizer.added_tokens_encoder
+    output_text = tokenizer.convert_tokens_to_string(output_tokens)
     return new_token, output_text

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Tuple, Union
 
 from transformers import (AutoConfig, AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
@@ -19,3 +19,44 @@ def get_tokenizer(
     if config.model_type in _MODEL_TYPES_WITH_SLOW_TOKENIZER:
         kwargs["use_fast"] = False
     return AutoTokenizer.from_pretrained(model_name, *args, **kwargs)
+
+
+def detokenize_incrementally(
+    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    prev_output_tokens: List[str],
+    new_token_id: int,
+    skip_special_tokens: bool,
+) -> Tuple[str, str]:
+    """Detokenizes the new token in conjuction with the previous output tokens.
+
+    NOTE: This function does not update prev_output_tokens.
+
+    Returns:
+        new_token: The new token as a string.
+        output_text: The new output text as a string.
+    """
+    new_token = tokenizer.convert_ids_to_tokens(
+        new_token_id, skip_special_tokens=skip_special_tokens)
+    output_tokens = prev_output_tokens + [new_token]
+
+    # Convert the tokens to a string.
+    # Adapted from https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
+    sub_texts = []
+    current_sub_text = []
+    for token in output_tokens:
+        if skip_special_tokens and token in tokenizer.all_special_ids:
+            continue
+        if (hasattr(tokenizer, "added_tokens_encoder") and
+            token in tokenizer.added_tokens_encoder):
+            if current_sub_text:
+                sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+                sub_texts.append(sub_text)
+                current_sub_text = []
+            sub_texts.append(token)
+        else:
+            current_sub_text.append(token)
+    if current_sub_text:
+        sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+        sub_texts.append(sub_text)
+    output_text = " ".join(sub_texts)
+    return new_token, output_text

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -53,13 +53,14 @@ def detokenize_incrementally(
 
     # Convert the tokens to a string.
     # Optimization: If the tokenizer does not have `added_tokens_encoder`,
-    # then we can just use `convert_tokens_to_string`.
+    # then we can directly use `convert_tokens_to_string`.
     if not getattr(tokenizer, "added_tokens_encoder", {}):
         output_text = tokenizer.convert_tokens_to_string(output_tokens)
         return new_token, output_text
 
     # Adapted from https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
-    # NOTE(woosuk): The following code is slow.
+    # NOTE(woosuk): The following code is slow because it runs a for loop over
+    # the output_tokens.
     sub_texts = []
     current_sub_text = []
     for token in output_tokens:

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -60,7 +60,8 @@ def detokenize_incrementally(
 
     # Adapted from https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
     # NOTE(woosuk): The following code is slow because it runs a for loop over
-    # the output_tokens.
+    # the output_tokens. In Python, running a for loop over a list can be slow
+    # even when the loop body is very simple.
     sub_texts = []
     current_sub_text = []
     for token in output_tokens:

--- a/cacheflow/server/tokenizer_utils.py
+++ b/cacheflow/server/tokenizer_utils.py
@@ -40,9 +40,31 @@ def detokenize_incrementally(
     output_tokens = prev_output_tokens + [new_token]
 
     # Convert the tokens to a string.
-    # We optimize tokenizer._decode() by assuming that the tokenizer does not
-    # have added_tokens_encoder.
-    if hasattr(tokenizer, "added_tokens_encoder"):
-        assert not tokenizer.added_tokens_encoder
-    output_text = tokenizer.convert_tokens_to_string(output_tokens)
+    # Optimization: If the tokenizer does not have `added_tokens_encoder`,
+    # then we can just use `convert_tokens_to_string`.
+    if not (hasattr(tokenizer, "added_tokens_encoder") and 
+            tokenizer.added_tokens_encoder):
+        output_text = tokenizer.convert_tokens_to_string(output_tokens)
+        return new_token, output_text
+
+    # Adapted from https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
+    # NOTE(woosuk): The following code is slow.
+    sub_texts = []
+    current_sub_text = []
+    for token in output_tokens:
+        if skip_special_tokens and token in tokenizer.all_special_ids:
+            continue
+        if (hasattr(tokenizer, "added_tokens_encoder") and
+            token in tokenizer.added_tokens_encoder):
+            if current_sub_text:
+                sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+                sub_texts.append(sub_text)
+                current_sub_text = []
+            sub_texts.append(token)
+        else:
+            current_sub_text.append(token)
+    if current_sub_text:
+        sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+        sub_texts.append(sub_text)
+    output_text = " ".join(sub_texts)
     return new_token, output_text


### PR DESCRIPTION
Fixes #119 

This PR reduces the overhead of the tokenizer by incrementally decoding the output tokens at every step. Specifically, the detokenization process is split into two stages:
1. Convert token ids to token strings (i.e., `List[int] -> List[str]`)
2. Concatenate the token strings to the output text (i.e., `List[str] -> str`)

In the new method introduced by this PR, the first stage is performed incrementally: the new token id is decoded into a string token and is appended to the list of previous string output tokens. Meanwhile, this PR does not change the second stage: the tokenizer will transform the whole output tokens into the output text at every step. IIUC, this stage cannot be performed incrementally.

```
# opt-13b inference latency (bs 8, input 32, output 128)
# Main
Avg latency: 3.57 seconds
Tokenizer (fast): 0.14 seconds
# This PR
Avg latency: 3.47 seconds
Tokenizer (fast): 0.03 seconds

# llama-13b inference latency (bs 8, input 32, output 128)
# Main
Avg latency: 5.28 seconds
Tokenizer (slow): 1.97 seconds
# This PR
Avg latency: 3.77 seconds
Tokenizer: 0.48 seconds
```

Note that there are still some overheads from the tokenizer in case of LLaMA.