### PR TITLE
Enable LLaMA fast tokenizer

### DIFF
--- a/cacheflow/sampling_params.py
+++ b/cacheflow/sampling_params.py
@@ -129,7 +129,7 @@ class SamplingParams:
                 f"frequency_penalty={self.frequency_penalty}, "
                 f"temperature={self.temperature}, "
                 f"top_p={self.top_p}, "
-                f"top_k={self.top_k},"
+                f"top_k={self.top_k}, "
                 f"use_beam_search={self.use_beam_search}, "
                 f"stop={self.stop}, "
                 f"ignore_eos={self.ignore_eos}, "


### PR DESCRIPTION
Fixes #80 

I found that the llama fast tokenizer in https://huggingface.co/hf-internal-testing/llama-tokenizer does not cause the protobuf errors. This PR uses this tokenizer to eliminate the tokenizer overhead in LLaMA.

```
# Before this PR
llama-13b latency (bs 8, input len 32, output len 128): 3.75 ms

# After this PR
llama-13b latency (bs 8, input len 32, output len 128): 3.37 ms
```