### PR TITLE
Support FP32

### DIFF
--- a/cacheflow/config.py
+++ b/cacheflow/config.py
@@ -184,9 +184,8 @@ def _get_and_verify_dtype(
             # Downcasting from float32 to float16 or bfloat16 is allowed.
             pass
         else:
-            # Casting between float16 and bfloat16 is not allowed.
-            raise ValueError(
-                f"Cannot use {torch_dtype} for {config_dtype} model.")
+            # Casting between float16 and bfloat16 is allowed with a warning.
+            logger.warn(f"Casting {config_dtype} to {torch_dtype}.")
 
     # Check if the GPU supports the dtype.
     if torch_dtype == torch.bfloat16:

--- a/cacheflow/config.py
+++ b/cacheflow/config.py
@@ -164,7 +164,7 @@ def _get_and_verify_dtype(
         config_dtype = torch.float32
 
     dtype = dtype.lower()
-    if dtype == "default":
+    if dtype == "auto":
         if config_dtype == torch.float32:
             # Following the common practice, we use float16 for float32 models.
             torch_dtype = torch.float16

--- a/cacheflow/entrypoints/llm.py
+++ b/cacheflow/entrypoints/llm.py
@@ -28,7 +28,7 @@ class LLM:
         tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
         dtype: The data type for the model weights and activations. Currently,
-            we support `float16` and `bfloat16`. If `default`, we use the
+            we support `float16` and `bfloat16`. If `auto`, we use the
             `torch_dtype` attribute of the model config. If the `torch_dtype`
             is `float32`, we use `float16` instead.
         seed: The seed to initialize the random number generator for sampling.
@@ -38,7 +38,7 @@ class LLM:
         self,
         model: str,
         tensor_parallel_size: int = 1,
-        dtype: str = "default",
+        dtype: str = "auto",
         seed: int = 0,
         **kwargs,
     ) -> None:

--- a/cacheflow/entrypoints/llm.py
+++ b/cacheflow/entrypoints/llm.py
@@ -29,8 +29,9 @@ class LLM:
             execution with tensor parallelism.
         dtype: The data type for the model weights and activations. Currently,
             we support `float32`, `float16`, and `bfloat16`. If `auto`, we use
-            the `torch_dtype` attribute of the model config. If `torch_dtype`
-            is `float32`, we use `float16` instead.
+            the `torch_dtype` attribute specified in the model config file.
+            However, if the `torch_dtype` in the config is `float32`, we will
+            use `float16` instead.
         seed: The seed to initialize the random number generator for sampling.
     """
 

--- a/cacheflow/entrypoints/llm.py
+++ b/cacheflow/entrypoints/llm.py
@@ -28,8 +28,8 @@ class LLM:
         tensor_parallel_size: The number of GPUs to use for distributed
             execution with tensor parallelism.
         dtype: The data type for the model weights and activations. Currently,
-            we support `float16` and `bfloat16`. If `auto`, we use the
-            `torch_dtype` attribute of the model config. If the `torch_dtype`
+            we support `float32`, `float16`, and `bfloat16`. If `auto`, we use
+            the `torch_dtype` attribute of the model config. If `torch_dtype`
             is `float32`, we use `float16` instead.
         seed: The seed to initialize the random number generator for sampling.
     """

--- a/cacheflow/model_executor/layers/attention.py
+++ b/cacheflow/model_executor/layers/attention.py
@@ -10,7 +10,7 @@ from cacheflow import cache_ops
 from cacheflow import pos_encoding_ops
 from cacheflow.model_executor.input_metadata import InputMetadata
 
-_SUPPORTED_HEAD_SIZES = [32, 64, 80, 96, 128, 160, 192, 256]
+_SUPPORTED_HEAD_SIZES = [64, 80, 96, 128]
 
 
 class GPTCacheFlowAttention(nn.Module):
@@ -49,10 +49,8 @@ class GPTCacheFlowAttention(nn.Module):
         self.attn_op = xops.fmha.cutlass.FwOp()
 
         if self.head_size not in _SUPPORTED_HEAD_SIZES:
-            raise ValueError(f'head_size ({self.head_size}) is not supported by '
-                             'the single_query_cached_kv_attention kernel. '
-                             'Use one of the following head sizes: '
-                             f'{_SUPPORTED_HEAD_SIZES}.')
+            raise ValueError(f"head_size ({self.head_size}) is not supported. "
+                             f"Supported head sizes: {_SUPPORTED_HEAD_SIZES}.")
 
     def multi_query_kv_attention(
         self,

--- a/cacheflow/server/arg_utils.py
+++ b/cacheflow/server/arg_utils.py
@@ -67,7 +67,7 @@ class ServerArgs:
         # KV cache arguments
         parser.add_argument('--block-size', type=int,
                             default=ServerArgs.block_size,
-                            choices=[1, 2, 4, 8, 16, 32, 64, 128, 256],
+                            choices=[8, 16, 32, 64],
                             help='token block size')
         # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
         parser.add_argument('--seed', type=int, default=ServerArgs.seed,

--- a/cacheflow/server/arg_utils.py
+++ b/cacheflow/server/arg_utils.py
@@ -49,7 +49,7 @@ class ServerArgs:
                             help='use dummy values for model weights')
         # TODO(woosuk): Support FP32.
         parser.add_argument('--dtype', type=str, default=ServerArgs.dtype,
-                            choices=['default', 'half', 'bfloat16'],
+                            choices=['default', 'half', 'bfloat16', 'float'],
                             help='data type for model weights and activations. '
                                  'The "default" option will use FP16 precision '
                                  'for FP32 and FP16 models, and BF16 precision '

--- a/cacheflow/server/arg_utils.py
+++ b/cacheflow/server/arg_utils.py
@@ -13,7 +13,7 @@ class ServerArgs:
     download_dir: Optional[str] = None
     use_np_weights: bool = False
     use_dummy_weights: bool = False
-    dtype: str = "default"
+    dtype: str = "auto"
     seed: int = 0
     worker_use_ray: bool = False
     pipeline_parallel_size: int = 1
@@ -49,9 +49,9 @@ class ServerArgs:
                             help='use dummy values for model weights')
         # TODO(woosuk): Support FP32.
         parser.add_argument('--dtype', type=str, default=ServerArgs.dtype,
-                            choices=['default', 'half', 'bfloat16'],
+                            choices=['auto', 'half', 'bfloat16'],
                             help='data type for model weights and activations. '
-                                 'The "default" option will use FP16 precision '
+                                 'The "auto" option will use FP16 precision '
                                  'for FP32 and FP16 models, and BF16 precision '
                                  'for BF16 models.')
         # Parallel arguments

--- a/cacheflow/server/arg_utils.py
+++ b/cacheflow/server/arg_utils.py
@@ -67,7 +67,7 @@ class ServerArgs:
         # KV cache arguments
         parser.add_argument('--block-size', type=int,
                             default=ServerArgs.block_size,
-                            choices=[8, 16, 32, 64],
+                            choices=[8, 16, 32],
                             help='token block size')
         # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
         parser.add_argument('--seed', type=int, default=ServerArgs.seed,

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -417,6 +417,15 @@ void single_query_cached_kv_attention_launcher(
 // 1, 2, 4, 64, 128, 256.
 #define CALL_KERNEL_LAUNCHER_BLOCK_SIZE(T)                          \
   switch (block_size) {                                             \
+    /* case 1:                         */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 1);   */                           \
+    /*   break;                        */                           \
+    /* case 2:                         */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 2);   */                           \
+    /*   break;                        */                           \
+    /* case 4:                         */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 4);   */                           \
+    /*   break;                        */                           \
     case 8:                                                         \
       CALL_KERNEL_LAUNCHER(T, 8);                                   \
       break;                                                        \
@@ -426,6 +435,15 @@ void single_query_cached_kv_attention_launcher(
     case 32:                                                        \
       CALL_KERNEL_LAUNCHER(T, 32);                                  \
       break;                                                        \
+    /* case 64:                        */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 64);  */                           \
+    /*   break;                        */                           \
+    /* case 128:                       */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 128); */                           \
+    /*   break;                        */                           \
+    /* case 256:                       */                           \
+    /*   CALL_KERNEL_LAUNCHER(T, 256); */                           \
+    /*   break;                        */                           \
     default:                                                        \
       TORCH_CHECK(false, "Unsupported block size: ", block_size);   \
       break;                                                        \

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -414,7 +414,7 @@ void single_query_cached_kv_attention_launcher(
     max_context_len);
 
 // NOTE(woosuk): To reduce the compilation time, we omitted block sizes
-// 1, 2, 4, 128, 256.
+// 1, 2, 4, 64, 128, 256.
 #define CALL_KERNEL_LAUNCHER_BLOCK_SIZE(T)                          \
   switch (block_size) {                                             \
     case 8:                                                         \
@@ -425,9 +425,6 @@ void single_query_cached_kv_attention_launcher(
       break;                                                        \
     case 32:                                                        \
       CALL_KERNEL_LAUNCHER(T, 32);                                  \
-      break;                                                        \
-    case 64:                                                        \
-      CALL_KERNEL_LAUNCHER(T, 64);                                  \
       break;                                                        \
     default:                                                        \
       TORCH_CHECK(false, "Unsupported block size: ", block_size);   \

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -370,9 +370,11 @@ void single_query_cached_kv_attention_launcher(
   dim3 block(NUM_THREADS);
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   switch (head_size) {
-    case 32:
-      LAUNCH_ATTENTION_KERNEL(T, 32, BLOCK_SIZE, NUM_THREADS);
-      break;
+    // NOTE(woosuk): To reduce the compilation time, we omitted head sizes
+    // 32, 160, 192, 256.
+    // case 32:
+    //   LAUNCH_ATTENTION_KERNEL(T, 32, BLOCK_SIZE, NUM_THREADS);
+    //   break;
     case 64:
       LAUNCH_ATTENTION_KERNEL(T, 64, BLOCK_SIZE, NUM_THREADS);
       break;
@@ -385,15 +387,15 @@ void single_query_cached_kv_attention_launcher(
     case 128:
       LAUNCH_ATTENTION_KERNEL(T, 128, BLOCK_SIZE, NUM_THREADS);
       break;
-    case 160:
-      LAUNCH_ATTENTION_KERNEL(T, 160, BLOCK_SIZE, NUM_THREADS);
-      break;
-    case 192:
-      LAUNCH_ATTENTION_KERNEL(T, 192, BLOCK_SIZE, NUM_THREADS);
-      break;
-    case 256:
-      LAUNCH_ATTENTION_KERNEL(T, 256, BLOCK_SIZE, NUM_THREADS);
-      break;
+    // case 160:
+    //   LAUNCH_ATTENTION_KERNEL(T, 160, BLOCK_SIZE, NUM_THREADS);
+    //   break;
+    // case 192:
+    //   LAUNCH_ATTENTION_KERNEL(T, 192, BLOCK_SIZE, NUM_THREADS);
+    //   break;
+    // case 256:
+    //   LAUNCH_ATTENTION_KERNEL(T, 256, BLOCK_SIZE, NUM_THREADS);
+    //   break;
     default:
       TORCH_CHECK(false, "Unsupported head size: ", head_size);
       break;
@@ -411,17 +413,10 @@ void single_query_cached_kv_attention_launcher(
     context_lens,                                                   \
     max_context_len);
 
+// NOTE(woosuk): To reduce the compilation time, we omitted block sizes
+// 1, 2, 4, 128, 256.
 #define CALL_KERNEL_LAUNCHER_BLOCK_SIZE(T)                          \
   switch (block_size) {                                             \
-    case 1:                                                         \
-      CALL_KERNEL_LAUNCHER(T, 1);                                   \
-      break;                                                        \
-    case 2:                                                         \
-      CALL_KERNEL_LAUNCHER(T, 2);                                   \
-      break;                                                        \
-    case 4:                                                         \
-      CALL_KERNEL_LAUNCHER(T, 4);                                   \
-      break;                                                        \
     case 8:                                                         \
       CALL_KERNEL_LAUNCHER(T, 8);                                   \
       break;                                                        \
@@ -433,12 +428,6 @@ void single_query_cached_kv_attention_launcher(
       break;                                                        \
     case 64:                                                        \
       CALL_KERNEL_LAUNCHER(T, 64);                                  \
-      break;                                                        \
-    case 128:                                                       \
-      CALL_KERNEL_LAUNCHER(T, 128);                                 \
-      break;                                                        \
-    case 256:                                                       \
-      CALL_KERNEL_LAUNCHER(T, 256);                                 \
       break;                                                        \
     default:                                                        \
       TORCH_CHECK(false, "Unsupported block size: ", block_size);   \

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -441,8 +441,9 @@ void single_query_cached_kv_attention(
   torch::Tensor& context_lens,    // [num_seqs]
   int block_size,
   int max_context_len) {
-  // TODO(woosuk): Support FP32.
-  if (query.dtype() == at::ScalarType::Half) {
+  if (query.dtype() == at::ScalarType::Float) {
+    CALL_KERNEL_LAUNCHER_BLOCK_SIZE(float);
+  } else if (query.dtype() == at::ScalarType::Half) {
     CALL_KERNEL_LAUNCHER_BLOCK_SIZE(uint16_t);
   } else if (query.dtype() == at::ScalarType::BFloat16) {
     CALL_KERNEL_LAUNCHER_BLOCK_SIZE(__nv_bfloat16);

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -18,7 +18,10 @@ CacheFlow can run on systems that meet the following requirements:
 
     .. code-block:: console
 
+        $ # Pull the Docker image with CUDA 11.8.
         $ docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/pytorch:22.12-py3
+
+    Inside the Docker container, please execute :code:`pip uninstall torch` before installing CacheFlow.
 
 Install with pip
 ----------------

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -32,7 +32,7 @@ You can install CacheFlow using pip:
     $ conda activate myenv
 
     $ # Install CacheFlow.
-    $ pip install cacheflow
+    $ pip install cacheflow  # This may take 2-3 minutes.
 
 
 .. _build_from_source:

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -47,4 +47,4 @@ You can also build and install CacheFlow from source.
     $ git clone https://github.com/WoosukKwon/cacheflow.git
     $ cd cacheflow
     $ pip install -r requirements.txt
-    $ pip install -e .  # This may take 5-10 minutes.
+    $ pip install -e .  # This may take 2-3 minutes.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -35,7 +35,7 @@ You can install CacheFlow using pip:
     $ conda activate myenv
 
     $ # Install CacheFlow.
-    $ pip install cacheflow  # This may take 2-3 minutes.
+    $ pip install cacheflow  # This may take 5-10 minutes.
 
 
 .. _build_from_source:
@@ -49,4 +49,4 @@ You can also build and install CacheFlow from source.
 
     $ git clone https://github.com/WoosukKwon/cacheflow.git
     $ cd cacheflow
-    $ pip install -e .  # This may take 2-3 minutes.
+    $ pip install -e .  # This may take 5-10 minutes.

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,11 @@ if 90 in compute_capabilities and nvcc_cuda_version < Version("11.8"):
     raise RuntimeError(
         "CUDA 11.8 or higher is required for GPUs with compute capability 9.0.")
 
+# Use NVCC threads to parallelize the build.
+if nvcc_cuda_version >= Version("11.2"):
+    num_threads = min(os.cpu_count(), 8)
+    NVCC_FLAGS += ["--threads", str(num_threads)]
+
 ext_modules = []
 
 # Cache operations.

--- a/tests/kernels/test_attention.py
+++ b/tests/kernels/test_attention.py
@@ -270,7 +270,7 @@ def run_multi_query_kv_attention(
 def test_single_query_cached_kv_attention() -> None:
     torch.random.manual_seed(TEST_SEED)
     torch.cuda.manual_seed(TEST_SEED)
-    for dtype in [torch.half, torch.bfloat16]:
+    for dtype in [torch.half, torch.bfloat16, torch.float]:
         for block_size in [8, 16, 32]:
             for head_size in [64, 80, 96, 128]:
                 print(f'Testing single_query_cached_kv_attention with '

--- a/tests/kernels/test_attention.py
+++ b/tests/kernels/test_attention.py
@@ -289,8 +289,8 @@ def test_single_query_cached_kv_attention() -> None:
 def test_multi_query_kv_attention() -> None:
     torch.random.manual_seed(TEST_SEED)
     torch.cuda.manual_seed(TEST_SEED)
-    for dtype in [torch.half, torch.bfloat16]:
-        for head_size in [32, 64, 80, 96, 128, 160, 192, 256]:
+    for dtype in [torch.half, torch.bfloat16, torch.float]:
+        for head_size in [64, 80, 96, 128]:
             print(f'Testing multi_query_kv_attention with dtype={dtype}, '
                   f'head_size={head_size}')
             run_multi_query_kv_attention(

--- a/tests/kernels/test_attention.py
+++ b/tests/kernels/test_attention.py
@@ -271,8 +271,8 @@ def test_single_query_cached_kv_attention() -> None:
     torch.random.manual_seed(TEST_SEED)
     torch.cuda.manual_seed(TEST_SEED)
     for dtype in [torch.half, torch.bfloat16]:
-        for block_size in [8, 16, 32, 64]:
-            for head_size in [32, 64, 80, 96, 128, 160, 192, 256]:
+        for block_size in [8, 16, 32]:
+            for head_size in [64, 80, 96, 128]:
                 print(f'Testing single_query_cached_kv_attention with '
                       f'dtype={dtype}, block_size={block_size}, '
                       f'head_size={head_size}')


### PR DESCRIPTION
Closes #72 

~~This PR removes the support for some head and block sizes to enhance the compilation speed. The removed sizes are not used for the models we currently support. In addition, removing them allows us to support FP32. On my machine, the compilation time got reduced **from 7.5 mins to 1.5 mins** even though FP32 is now added.~~

This PR removes the support for some head and block sizes to enable FP32. Besides, the PR changes the `default` dtype option to `auto`, to make its meaning clearer.