### PR TITLE
Remove redundant code in ColumnParallelLinear

### DIFF
--- a/cacheflow/model_executor/parallel_utils/tensor_parallel/layers.py
+++ b/cacheflow/model_executor/parallel_utils/tensor_parallel/layers.py
@@ -305,10 +305,7 @@ class ColumnParallelLinear(torch.nn.Module):
         """
         bias = self.bias if not self.skip_bias_add else None
 
-        if get_tensor_model_parallel_world_size() == 1:
-            input_parallel = input_
-        else:
-            input_parallel = copy_to_tensor_model_parallel_region(input_)
+        input_parallel = input_
         # Matrix multiply.
         output_parallel = F.linear(input_parallel, self.weight, bias)
         if self.gather_output:

--- a/cacheflow/model_executor/parallel_utils/tensor_parallel/layers.py
+++ b/cacheflow/model_executor/parallel_utils/tensor_parallel/layers.py
@@ -305,7 +305,10 @@ class ColumnParallelLinear(torch.nn.Module):
         """
         bias = self.bias if not self.skip_bias_add else None
 
-        input_parallel = copy_to_tensor_model_parallel_region(input_)
+        if get_tensor_model_parallel_world_size() == 1:
+            input_parallel = input_
+        else:
+            input_parallel = copy_to_tensor_model_parallel_region(input_)
         # Matrix multiply.
         output_parallel = F.linear(input_parallel, self.weight, bias)
         if self.gather_output:


### PR DESCRIPTION
This PR deletes redundant code in `ColumnParallelLinear` to reduce CPU overhead.

Before:
```
$ python benchmarks/benchmark_latency.py --model facebook/opt-6.7b
Namespace(model='facebook/opt-6.7b', tensor_parallel_size=1, input_len=32, output_len=128, batch_size=8, n=1, use_beam_search=False, num_iters=3, profile=False)
INFO 06-11 02:01:10 llm_server.py:60] Initializing an LLM server with config: model='facebook/opt-6.7b', dtype=torch.float16, use_dummy_weights=False, download_dir=None, use_np_weights=False, tensor_parallel_size=1, seed=0)
INFO 06-11 02:01:22 llm_server.py:129] # GPU blocks: 2946, # CPU blocks: 512
SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, temperature=1.0, top_p=1.0, top_k=-1, use_beam_search=False, stop=[], ignore_eos=True, max_tokens=128, logprobs=None)
Warming up...
Profiling iterations: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:08<00:00,  2.68s/it]
Avg latency: 2.6759115854899087 seconds
```

After:
```
$ python benchmarks/benchmark_latency.py --model facebook/opt-6.7b
Namespace(model='facebook/opt-6.7b', tensor_parallel_size=1, input_len=32, output_len=128, batch_size=8, n=1, use_beam_search=False, num_iters=3, profile=False)
INFO 06-11 02:02:10 llm_server.py:60] Initializing an LLM server with config: model='facebook/opt-6.7b', dtype=torch.float16, use_dummy_weights=False, download_dir=None, use_np_weights=False, tensor_parallel_size=1, seed=0)
INFO 06-11 02:02:21 llm_server.py:129] # GPU blocks: 2946, # CPU blocks: 512
SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, temperature=1.0, top_p=1.0, top_k=-1, use_beam_search=False, stop=[], ignore_eos=True, max_tokens=128, logprobs=None)
Warming up...
Profiling iterations: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:07<00:00,  2.36s/it]
Avg latency: 2.363809108734131 seconds
```