### PR TITLE
Fix Ray node resources error

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -87,7 +87,7 @@ class LLMEngine:
                 worker_cls = ray.remote(
                     num_cpus=0,
                     num_gpus=1,
-                    resources={node_resource: 1e-5},
+                    resources={node_resource: 1e-3},
                 )(worker_cls).remote
 
             worker = worker_cls(


### PR DESCRIPTION
The latest Ray limits the smallest fraction of node resources. Modify it to a larger number.

Fix #173.