### PR TITLE
Add half rmsnorm kernel

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -2,15 +2,15 @@
 #include <ATen/cuda/CUDAContext.h>
 
 #include "reduction_utils.cuh"
-
+#include <c10/util/Half.h>
 namespace vllm {
 
 // TODO(woosuk): Further optimize this kernel.
 template<typename scalar_t>
-__global__ void rms_norm_kernel(
-  scalar_t* __restrict__ out,             // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ input,     // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ weight,    // [hidden_size]
+__global__ void rms_norm_kernel_impl_float(
+  scalar_t* __restrict__ out,
+  const scalar_t* __restrict__ input,
+  const scalar_t* __restrict__ weight,
   const float epsilon,
   const int num_tokens,
   const int hidden_size) {
@@ -32,6 +32,93 @@ __global__ void rms_norm_kernel(
     out[blockIdx.x * hidden_size + idx] = ((scalar_t) (x * s_variance)) * weight[idx];
   }
 }
+  
+
+__global__ void rms_norm_kernel_impl_half(
+  __half* __restrict__ out,
+  const __half* __restrict__ input,
+  const __half* __restrict__ weight,
+  const float epsilon,
+  const int num_tokens,
+  const int hidden_size)
+{
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  const float4 *input_float4 = reinterpret_cast<const float4 *>(input) + blockIdx.x * hidden_size;
+  float4 *out_float4 = reinterpret_cast<float4 *>(out)+ blockIdx.x * hidden_size;;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float4 val_f4 = input_float4[idx];
+    __half2 *val_h2 = (__half2 *)(&val_f4);
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+      float2 val_f2 = __half22float2(val_h2[i]);
+      variance += val_f2.x * val_f2.x + val_f2.y * val_f2.y;
+    }
+  }
+
+  variance = blockReduceSum<float>(variance);
+  if (threadIdx.x == 0) {
+    s_variance = __frsqrt_rn(variance / (hidden_size * 8) + epsilon);
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float4 weight_f4 = __ldg(reinterpret_cast<const float4 *>(weight) + idx);
+    __half2 *weight_h2 = reinterpret_cast<__half2 *>(&weight_f4);
+
+    float4 val_f4 = input_float4[idx];
+    __half2 *val_h2 = reinterpret_cast<__half2 *>(&val_f4);
+
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      float2 weight_f2 = __half22float2(weight_h2[i]);
+    
+      float2 val_f2 = __half22float2(val_h2[i]);
+      val_f2.x = val_f2.x  * s_variance * weight_f2.x ;
+      val_f2.y = val_f2.y * s_variance * weight_f2.y;
+      val_h2[i] = __float22half2_rn(val_f2);
+    }
+    out_float4[idx] = val_f4;
+  }
+}
+
+
+
+template<typename scalar_t>
+void rms_norm_kernel(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    const float epsilon,
+    const int num_tokens,
+    const int hidden_size)
+  {
+    dim3 grid(num_tokens);
+
+    
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    if  (std::is_same<scalar_t, at::Half>::value) {
+      dim3 block(min(((hidden_size / 8 + 31) / 32) * 32, 32));
+      rms_norm_kernel_impl_half<<<grid, block, 0, stream>>>(
+        reinterpret_cast<__half*>(out),
+        reinterpret_cast<const __half*>(input),
+        reinterpret_cast<const __half*>(weight),
+        epsilon,
+        num_tokens,
+        hidden_size/8 );
+    } else {
+      dim3 block(min(((hidden_size + 31) / 32) * 32, 32));
+      rms_norm_kernel_impl_float<<<grid, block, 0, stream>>>(
+        out,
+        input,
+        weight,
+        epsilon,
+        num_tokens,
+        hidden_size);
+    }
+  }
+  
 
 } // namespace vllm
 
@@ -40,24 +127,21 @@ void rms_norm(
   torch::Tensor& input,    // [num_tokens, hidden_size]
   torch::Tensor& weight,   // [hidden_size]
   float epsilon) {
-  int num_tokens = input.size(0);
-  int hidden_size = input.size(1);
-
-  dim3 grid(num_tokens);
-  dim3 block(std::min(hidden_size, 1024));
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND2(
     at::ScalarType::Half,
     at::ScalarType::BFloat16,
     input.scalar_type(),
     "rms_norm_kernel",
     [&] {
-      vllm::rms_norm_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        out.data_ptr<scalar_t>(),
-        input.data_ptr<scalar_t>(),
-        weight.data_ptr<scalar_t>(),
-        epsilon,
-        num_tokens,
-        hidden_size);
-    });
+       vllm::rms_norm_kernel(
+          out.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          weight.data_ptr<scalar_t>(),
+          epsilon,
+          input.size(0),
+          input.size(1));
+     
+  }
+  );
 }
+

--- a/tests/kernels/test_layernorm.py
+++ b/tests/kernels/test_layernorm.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-
+import time
 from vllm import layernorm_ops
 
 
@@ -52,3 +52,24 @@ def test_rms_norm() -> None:
                     hidden_size=hidden_size,
                     dtype=dtype,
                 )
+                
+def test_rms_norm_performence() -> None:
+    dtype=torch.half
+    for num_tokens in [2048,5096,10192]:
+        for hidden_size in [64, 768, 1024, 5120]:
+            start_time=time.time()
+            x = torch.randn(num_tokens, hidden_size, dtype=dtype, device='cuda')
+            ref = RefRMSNorm(hidden_size).to(dtype).cuda()
+            out = torch.empty_like(x)
+            for i in range(100):
+                layernorm_ops.rms_norm(
+                    out,
+                    x,
+                    ref.weight.data,
+                    ref.variance_epsilon,
+                )
+            elapsed_time =time.time()-start_time
+            print(f'Testing RMS kernel with dtype={dtype}, num_tokens='
+                      f'{num_tokens}, hidden_size={hidden_size} Elapsed time: {elapsed_time} seconds')
+                
+test_rms_norm_performence()


### PR DESCRIPTION
I found that there is a kenel for writing subsequent optimizations in rmsnorm, and I tried to write a half-precision kernel for rms.
Below is the comparison data, I tested it on 3070ti, range 10000

 base: num_tokens=10192, hidden_size=768 Elapsed time: 1.2 seconds
 new:  num_tokens=10192, hidden_size=768 Elapsed time: 0.64 seconds
 base: num_tokens=2048, hidden_size=768 Elapsed time: 0.28 seconds
 new:  num_tokens=2048, hidden_size=768 Elapsed time: 0.14 seconds

Since I used pytorch to register the kernel for the first time, the current method of registering the kernel may not be elegant. Doing benchmark can only comment out the half-precision kernel, and then recompile to test the time-consuming. If you have a better method, you can tell me I will modify it.



