### PR TITLE
Add half rmsnorm kernel

### DIFF
--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -2,140 +2,104 @@
 #include <c10/util/Half.h>
 #include <torch/extension.h>
 
+#include "attention/attention_utils.cuh"
 #include "reduction_utils.cuh"
 
 namespace vllm {
 
-// TODO(woosuk): Further optimize this kernel.
-template<typename scalar_t>
-__global__ void rms_norm_kernel_impl(
-  scalar_t* __restrict__ out,
-  const scalar_t* __restrict__ input,
-  const scalar_t* __restrict__ weight,
-  const float epsilon,
-  const int num_tokens,
-  const int hidden_size) {
+template <typename scalar_t, int pack_size>
+__global__ void rms_norm_kernel_impl(scalar_t *__restrict__ out,
+                                     const scalar_t *__restrict__ input,
+                                     const scalar_t *__restrict__ weight,
+                                     const float epsilon, const int num_tokens,
+                                     const int hidden_size) {
+  int thread_group_width = hidden_size / pack_size;
+
   __shared__ float s_variance;
   float variance = 0.0f;
+  const int vec_offset = blockIdx.x * hidden_size;
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    const float x = (float) input[blockIdx.x * hidden_size + idx];
-    variance += x * x;
+  using pack_vec = typename Vec<scalar_t, pack_size>::Type;
+  scalar_t *out_ptr = out + vec_offset;
+  const scalar_t *input_ptr = input + vec_offset;
+
+  for (int idx = threadIdx.x; idx < thread_group_width; idx += blockDim.x) {
+    pack_vec vec_input =
+        *reinterpret_cast<const pack_vec *>(input_ptr + idx * pack_size);
+    variance += dot(vec_input, vec_input);
   }
+
   variance = blockReduceSum<float>(variance);
+
   if (threadIdx.x == 0) {
     s_variance = rsqrtf(variance / hidden_size + epsilon);
   }
   __syncthreads();
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float x = (float) input[blockIdx.x * hidden_size + idx];
-    out[blockIdx.x * hidden_size + idx] = ((scalar_t) (x * s_variance)) * weight[idx];
+  for (int idx = threadIdx.x; idx < thread_group_width; idx += blockDim.x) {
+    const int offset = idx * pack_size;
+    pack_vec vec_input =
+        *reinterpret_cast<const pack_vec *>(input_ptr + offset);
+    pack_vec vec_weight = *reinterpret_cast<const pack_vec *>(weight + offset);
+    pack_vec *vec_out = reinterpret_cast<pack_vec *>(out_ptr + offset);
+    pack_vec hidden_states;
+    if constexpr (std::is_same<scalar_t, __nv_bfloat16>::value) {
+      hidden_states = mul<pack_vec, scalar_t, pack_vec>(
+          __float2bfloat16(s_variance), vec_input);
+    } else if constexpr (std::is_same<scalar_t, uint16_t>::value) {
+      hidden_states = mul<pack_vec, scalar_t, pack_vec>(
+          float_to_half(s_variance), vec_input);
+    } else if constexpr (std::is_same<scalar_t, float>::value) {
+      hidden_states = mul<pack_vec, scalar_t, pack_vec>(s_variance, vec_input);
+    }
+    *vec_out = mul<pack_vec>(hidden_states, vec_weight);
   }
 }
 
-__global__ void rms_norm_kernel_impl_half(
-  __half* __restrict__ out,
-  const __half* __restrict__ input,
-  const __half* __restrict__ weight,
-  const float epsilon,
-  const int num_tokens,
-  const int hidden_size)
-{
-  __shared__ float s_variance;
-  float variance = 0.0f;
+template <typename scalar_t>
+void rms_norm_kernel_launcher(torch::Tensor &out, torch::Tensor &input,
+                              torch::Tensor &weight, float epsilon) {
 
-  const float4 *input_float4 = reinterpret_cast<const float4 *>(input) + blockIdx.x * hidden_size;
-  float4 *out_float4 = reinterpret_cast<float4 *>(out)+ blockIdx.x * hidden_size;
+  int num_tokens = input.size(0);
+  int hidden_size = input.size(1);
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  constexpr int pack_size = 16 / sizeof(scalar_t);
 
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float4 val_f4 = input_float4[idx];
-    __half2 *val_h2 = (__half2 *)(&val_f4);
-    #pragma unroll
-    for (int i = 0; i < 4; i++) {
-      float2 val_f2 = __half22float2(val_h2[i]);
-      variance += val_f2.x * val_f2.x + val_f2.y * val_f2.y;
-    }
-  }
+  scalar_t *out_ptr = reinterpret_cast<scalar_t *>(out.data_ptr());
+  scalar_t *input_ptr = reinterpret_cast<scalar_t *>(input.data_ptr());
+  scalar_t *weight_ptr = reinterpret_cast<scalar_t *>(weight.data_ptr());
 
-  variance = blockReduceSum<float>(variance);
-  if (threadIdx.x == 0) {
-    s_variance = __frsqrt_rn(variance / (hidden_size * 8) + epsilon);
-  }
-  __syncthreads();
-  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
-    float4 weight_f4 = __ldg(reinterpret_cast<const float4 *>(weight) + idx);
-    __half2 *weight_h2 = reinterpret_cast<__half2 *>(&weight_f4);
-
-    float4 val_f4 = input_float4[idx];
-    __half2 *val_h2 = reinterpret_cast<__half2 *>(&val_f4);
-
-#pragma unroll
-    for (int i = 0; i < 4; i++) {
-      float2 weight_f2 = __half22float2(weight_h2[i]);
-    
-      float2 val_f2 = __half22float2(val_h2[i]);
-      val_f2.x = val_f2.x  * s_variance * weight_f2.x ;
-      val_f2.y = val_f2.y * s_variance * weight_f2.y;
-      val_h2[i] = __float22half2_rn(val_f2);
-    }
-    out_float4[idx] = val_f4;
-  }
-}
-template<typename scalar_t>
-void rms_norm_kernel(
-    scalar_t* __restrict__ out,
-    const scalar_t* __restrict__ input,
-    const scalar_t* __restrict__ weight,
-    const float epsilon,
-    const int num_tokens,
-    const int hidden_size)
-  {
+  if (hidden_size % pack_size == 0) {
     dim3 grid(num_tokens);
-    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    if  (std::is_same<scalar_t, at::Half>::value && hidden_size % 8 == 0) {
-      dim3 block(min(((hidden_size / 8 + 31) / 32) * 32, 1024));
-      rms_norm_kernel_impl_half<<<grid, block, 0, stream>>>(
-        reinterpret_cast<__half*>(out),
-        reinterpret_cast<const __half*>(input),
-        reinterpret_cast<const __half*>(weight),
-        epsilon,
-        num_tokens,
-        hidden_size / 8);
-    } else {
-      dim3 block(std::min(hidden_size, 1024));
-      rms_norm_kernel_impl<<<grid, block, 0, stream>>>(
-        out,
-        input,
-        weight,
-        epsilon,
-        num_tokens,
-        hidden_size);
-    }
+    dim3 block(min(((hidden_size / pack_size + 31) / 32) * 32, 1024));
+    vllm::rms_norm_kernel_impl<scalar_t, pack_size><<<grid, block, 0, stream>>>(
+        out_ptr, input_ptr, weight_ptr, epsilon, num_tokens, hidden_size);
+  } else {
+    dim3 grid(num_tokens);
+    dim3 block(min(((hidden_size / 1 + 31) / 32) * 32, 1024));
+    vllm::rms_norm_kernel_impl<scalar_t, 1><<<grid, block, 0, stream>>>(
+        out_ptr, input_ptr, weight_ptr, epsilon, num_tokens, hidden_size);
   }
-  
+}
 
 } // namespace vllm
 
-void rms_norm(
-  torch::Tensor& out,      // [num_tokens, hidden_size]
-  torch::Tensor& input,    // [num_tokens, hidden_size]
-  torch::Tensor& weight,   // [hidden_size]
-  float epsilon) {
-  AT_DISPATCH_FLOATING_TYPES_AND2(
-    at::ScalarType::Half,
-    at::ScalarType::BFloat16,
-    input.scalar_type(),
-    "rms_norm_kernel",
-    [&] {
-       vllm::rms_norm_kernel(
-          out.data_ptr<scalar_t>(),
-          input.data_ptr<scalar_t>(),
-          weight.data_ptr<scalar_t>(),
-          epsilon,
-          input.size(0),
-          input.size(1));
-  }
-  );
-}
+// TODO(sleepcoo): opt use shared memory.
+#define CALL_RMSNORM_LAUNCHER_BY_TYPE(scalar_t)                                \
+  vllm::rms_norm_kernel_launcher<scalar_t>(out, input, weight, epsilon);
 
+void rms_norm(torch::Tensor &out,    // [num_tokens, hidden_size]
+              torch::Tensor &input,  // [num_tokens, hidden_size]
+              torch::Tensor &weight, // [hidden_size]
+              float epsilon) {
+
+  if (input.dtype() == at::ScalarType::Float) {
+    CALL_RMSNORM_LAUNCHER_BY_TYPE(float);
+  } else if (input.dtype() == at::ScalarType::Half) {
+    CALL_RMSNORM_LAUNCHER_BY_TYPE(uint16_t);
+  } else if (input.dtype() == at::ScalarType::BFloat16) {
+    CALL_RMSNORM_LAUNCHER_BY_TYPE(__nv_bfloat16);
+  } else {
+    TORCH_CHECK(false, "Unsupported data type: ", input.dtype());
+  }
+}

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -1,8 +1,9 @@
-#include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
 
 #include "reduction_utils.cuh"
 #include <c10/util/Half.h>
+
 namespace vllm {
 
 // TODO(woosuk): Further optimize this kernel.
@@ -98,7 +99,7 @@ void rms_norm_kernel(
 
     
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    if  (std::is_same<scalar_t, at::Half>::value) {
+    if  (std::is_same<scalar_t, at::Half>::value && hidden_size % 8 == 0) {
       dim3 block(min(((hidden_size / 8 + 31) / 32) * 32, 1024));
       rms_norm_kernel_impl_half<<<grid, block, 0, stream>>>(
         reinterpret_cast<__half*>(out),

--- a/csrc/layernorm_kernels.cu
+++ b/csrc/layernorm_kernels.cu
@@ -2,15 +2,15 @@
 #include <ATen/cuda/CUDAContext.h>
 
 #include "reduction_utils.cuh"
-
+#include <c10/util/Half.h>
 namespace vllm {
 
 // TODO(woosuk): Further optimize this kernel.
 template<typename scalar_t>
-__global__ void rms_norm_kernel(
-  scalar_t* __restrict__ out,             // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ input,     // [num_tokens, hidden_size]
-  const scalar_t* __restrict__ weight,    // [hidden_size]
+__global__ void rms_norm_kernel_impl_float(
+  scalar_t* __restrict__ out,
+  const scalar_t* __restrict__ input,
+  const scalar_t* __restrict__ weight,
   const float epsilon,
   const int num_tokens,
   const int hidden_size) {
@@ -32,6 +32,93 @@ __global__ void rms_norm_kernel(
     out[blockIdx.x * hidden_size + idx] = ((scalar_t) (x * s_variance)) * weight[idx];
   }
 }
+  
+
+__global__ void rms_norm_kernel_impl_half(
+  __half* __restrict__ out,
+  const __half* __restrict__ input,
+  const __half* __restrict__ weight,
+  const float epsilon,
+  const int num_tokens,
+  const int hidden_size)
+{
+  __shared__ float s_variance;
+  float variance = 0.0f;
+
+  const float4 *input_float4 = reinterpret_cast<const float4 *>(input) + blockIdx.x * hidden_size;
+  float4 *out_float4 = reinterpret_cast<float4 *>(out)+ blockIdx.x * hidden_size;;
+
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float4 val_f4 = input_float4[idx];
+    __half2 *val_h2 = (__half2 *)(&val_f4);
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+      float2 val_f2 = __half22float2(val_h2[i]);
+      variance += val_f2.x * val_f2.x + val_f2.y * val_f2.y;
+    }
+  }
+
+  variance = blockReduceSum<float>(variance);
+  if (threadIdx.x == 0) {
+    s_variance = __frsqrt_rn(variance / (hidden_size * 8) + epsilon);
+  }
+  __syncthreads();
+  for (int idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    float4 weight_f4 = __ldg(reinterpret_cast<const float4 *>(weight) + idx);
+    __half2 *weight_h2 = reinterpret_cast<__half2 *>(&weight_f4);
+
+    float4 val_f4 = input_float4[idx];
+    __half2 *val_h2 = reinterpret_cast<__half2 *>(&val_f4);
+
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      float2 weight_f2 = __half22float2(weight_h2[i]);
+    
+      float2 val_f2 = __half22float2(val_h2[i]);
+      val_f2.x = val_f2.x  * s_variance * weight_f2.x ;
+      val_f2.y = val_f2.y * s_variance * weight_f2.y;
+      val_h2[i] = __float22half2_rn(val_f2);
+    }
+    out_float4[idx] = val_f4;
+  }
+}
+
+
+
+template<typename scalar_t>
+void rms_norm_kernel(
+    scalar_t* __restrict__ out,
+    const scalar_t* __restrict__ input,
+    const scalar_t* __restrict__ weight,
+    const float epsilon,
+    const int num_tokens,
+    const int hidden_size)
+  {
+    dim3 grid(num_tokens);
+
+    
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    if  (std::is_same<scalar_t, at::Half>::value) {
+      dim3 block(min(((hidden_size / 8 + 31) / 32) * 32, 1024));
+      rms_norm_kernel_impl_half<<<grid, block, 0, stream>>>(
+        reinterpret_cast<__half*>(out),
+        reinterpret_cast<const __half*>(input),
+        reinterpret_cast<const __half*>(weight),
+        epsilon,
+        num_tokens,
+        hidden_size / 8);
+    } else {
+      dim3 block(std::min(hidden_size, 1024));
+      rms_norm_kernel_impl_float<<<grid, block, 0, stream>>>(
+        out,
+        input,
+        weight,
+        epsilon,
+        num_tokens,
+        hidden_size);
+    }
+  }
+  
 
 } // namespace vllm
 
@@ -40,24 +127,20 @@ void rms_norm(
   torch::Tensor& input,    // [num_tokens, hidden_size]
   torch::Tensor& weight,   // [hidden_size]
   float epsilon) {
-  int num_tokens = input.size(0);
-  int hidden_size = input.size(1);
-
-  dim3 grid(num_tokens);
-  dim3 block(std::min(hidden_size, 1024));
-  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND2(
     at::ScalarType::Half,
     at::ScalarType::BFloat16,
     input.scalar_type(),
     "rms_norm_kernel",
     [&] {
-      vllm::rms_norm_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        out.data_ptr<scalar_t>(),
-        input.data_ptr<scalar_t>(),
-        weight.data_ptr<scalar_t>(),
-        epsilon,
-        num_tokens,
-        hidden_size);
-    });
+       vllm::rms_norm_kernel(
+          out.data_ptr<scalar_t>(),
+          input.data_ptr<scalar_t>(),
+          weight.data_ptr<scalar_t>(),
+          epsilon,
+          input.size(0),
+          input.size(1));
+  }
+  );
 }
+

--- a/tests/kernels/test_layernorm.py
+++ b/tests/kernels/test_layernorm.py
@@ -1,8 +1,9 @@
+import time
+
 import torch
 import torch.nn as nn
-import time
-from vllm import layernorm_ops
 
+from vllm import layernorm_ops
 
 class RefRMSNorm(nn.Module):
 


### PR DESCRIPTION
I found that there is a kenel for writing subsequent optimizations in rmsnorm, and I tried to write a half-precision kernel for rms.
Below is the comparison data, I tested it on A100 80G, range 10000

### benchmark
num_tokens | hidden_size | Elapsed time (base) | Elapsed time (opt)
-- | -- | -- | --
2048 | 64 | 1.470 seconds | 1.594 seconds
2048 | 768 | 0.163 seconds | 0.066 seconds
2048 | 1024 | 0.171 seconds | 0.076 seconds
2048 | 5120 | 0.531 seconds | 0.280 seconds
4096 | 64 | 0.116 seconds | 0.090 seconds
4096 | 768 | 0.256 seconds | 0.073 seconds
4096 | 1024 | 0.311 seconds | 0.084 seconds
4096 | 5120 | 0.991 seconds | 0.497 seconds
10192 | 64 | 0.208 seconds | 0.158 seconds
10192 | 768 | 0.707 seconds | 0.178 seconds
10192 | 1024 | 0.851 seconds | 0.278 seconds
10192 | 5120 | 2.383 seconds | 1.164 seconds
### analyze
Except token=2048&&hidden=64 in the case, there can be a good speedup ratio, because in some cases the time is too small, and there may be fluctuations when you reproduce. The worse in the case of token=2048&&hidden=64 should be due to the fact that the number of threads started at this time is too small, but this situation should not exist in the real scene.





Since I used pytorch to register the kernel for the first time, the current method of registering the kernel may not be elegant. Doing benchmark can only comment out the half-precision kernel, and then recompile to test the time-consuming. If you have a better method, you can tell me I will modify it.