### PR TITLE
Compatible with Decapoda Research llama hf version

### DIFF
--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -16,6 +16,7 @@ _MODEL_REGISTRY = {
     "GPTBigCodeForCausalLM": GPTBigCodeForCausalLM,
     "GPTNeoXForCausalLM": GPTNeoXForCausalLM,
     "LlamaForCausalLM": LlamaForCausalLM,
+    "LLaMAForCausalLM": LlamaForCausalLM,
     "OPTForCausalLM": OPTForCausalLM,
 }
 


### PR DESCRIPTION
For the Decapoda Research llama hf version:
Model's config.json:
    "architectures": ["LLaMAForCausalLM"]
This may be seen as the Llama alias