### PR TITLE
expand coverage of gpt2 models

### DIFF
--- a/vllm/model_executor/models/gpt2.py
+++ b/vllm/model_executor/models/gpt2.py
@@ -228,11 +228,13 @@ class GPT2LMHeadModel(nn.Module):
                 # GPT-2 ties the weights of the embedding layer and the final
                 # linear layer.
                 continue
-            if ".attn.bias" in name:
+            if ".attn.bias" in name or ".attn.masked_bias" in name:
                 # Skip attention mask.
                 # NOTE: "c_attn.bias" should not be skipped.
                 continue
-            name = "transformer." + name
+
+            if not name.startswith("transformer."):
+                name = "transformer." + name
 
             # The HF's GPT-2 implementation uses Conv1D instead of Linear.
             # Because of this, we need to transpose the weights.


### PR DESCRIPTION
Thanks for the amazing project!
I noticed some gpt2 models have different naming of weights from https://huggingface.co/gpt2

For example, [DialoGPT-small](https://huggingface.co/microsoft/DialoGPT-small) and [mGPT](https://huggingface.co/ai-forever/mGPT) are saved in a way that `transformer.` prefix is already prepended and also masked_bias is saved.
```
transformer.wte.weight
transformer.wpe.weight
transformer.h.0.attn.c_attn.weight
transformer.h.0.attn.c_attn.bias
transformer.h.0.attn.bias
transformer.h.0.attn.masked_bias
...
```
Therefore, it causes errors such as`KeyError: 'transformer.transformer.wte.weight'`.
This PR fixes these errors in model loading by checking `transformer.` prefix and ignoring masked_bias.