### PR TITLE
Raise error for long prompt

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -170,17 +170,18 @@ class SchedulerConfig:
             a single iteration.
         max_num_seqs: Maximum number of sequences to be processed in a single
             iteration.
-        max_prompt_len: Maximum length of input prompt.
+        max_sequence_len: Maximum length of a sequence (including prompt
+            and generated text).
     """
     def __init__(
         self,
         max_num_batched_tokens: int,
         max_num_seqs: int,
-        max_prompt_len: int
+        max_sequence_len: int
     ) -> None:
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_num_seqs = max_num_seqs
-        self.max_prompt_len = max_prompt_len
+        self.max_sequence_len = max_sequence_len
 
 
 _STR_DTYPE_TO_TORCH_DTYPE = {

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -170,18 +170,18 @@ class SchedulerConfig:
             a single iteration.
         max_num_seqs: Maximum number of sequences to be processed in a single
             iteration.
-        max_sequence_len: Maximum length of a sequence (including prompt
+        max_seq_len: Maximum length of a sequence (including prompt
             and generated text).
     """
     def __init__(
         self,
         max_num_batched_tokens: int,
         max_num_seqs: int,
-        max_sequence_len: int
+        max_seq_len: int
     ) -> None:
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_num_seqs = max_num_seqs
-        self.max_sequence_len = max_sequence_len
+        self.max_seq_len = max_seq_len
 
 
 _STR_DTYPE_TO_TORCH_DTYPE = {

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -170,14 +170,17 @@ class SchedulerConfig:
             a single iteration.
         max_num_seqs: Maximum number of sequences to be processed in a single
             iteration.
+        max_prompt_len: Maximum length of input prompt.
     """
     def __init__(
         self,
         max_num_batched_tokens: int,
         max_num_seqs: int,
+        max_prompt_len: int
     ) -> None:
         self.max_num_batched_tokens = max_num_batched_tokens
         self.max_num_seqs = max_num_seqs
+        self.max_prompt_len = max_prompt_len
 
 
 _STR_DTYPE_TO_TORCH_DTYPE = {

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -190,11 +190,11 @@ class Scheduler:
                     break
 
                 num_prompt_tokens = seq_group.get_seqs()[0].get_len()
-                if num_prompt_tokens >= self.scheduler_config.max_sequence_len:
+                if num_prompt_tokens >= self.scheduler_config.max_seq_len:
                     logger.warn(
                         f"Input prompt ({num_prompt_tokens} tokens) is too long"
-                        f" and exceeds limit of "
-                        f"{self.scheduler_config.max_sequence_len}")
+                        " and exceeds limit of "
+                        f"{self.scheduler_config.max_seq_len}")
                     for seq in seq_group.get_seqs():
                         seq.status = SequenceStatus.FINISHED_IGNORED
                     ignored_seq_groups.append(seq_group)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -193,6 +193,8 @@ class Scheduler:
                 if num_prompt_tokens > self.scheduler_config.max_prompt_len:
                     logger.warn(
                         f"Input prompt ({num_prompt_tokens} tokens) is too long, exceeding limit of {self.scheduler_config.max_prompt_len}")
+                    for seq in seq_group.get_seqs():
+                        seq.status = SequenceStatus.IGNORED
                     ignored_seq_groups.append(seq_group)
                     self.waiting.pop(0)
                     break

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -102,11 +102,12 @@ class Scheduler:
     def get_num_unfinished_seq_groups(self) -> int:
         return len(self.waiting) + len(self.running) + len(self.swapped)
 
-    def _schedule(self) -> Tuple[SchedulerOutputs, List[str]]:
+    def _schedule(self) -> Tuple[SchedulerOutputs, List[str], List[SequenceGroup]]:
         # Blocks that need to be swaped or copied before model execution.
         blocks_to_swap_in: Dict[int, int] = {}
         blocks_to_swap_out: Dict[int, int] = {}
         blocks_to_copy: Dict[int, List[int]] = {}
+        ignored_seq_groups: List[SequenceGroup] = []
 
         # Fix the current time.
         now = time.time()
@@ -187,12 +188,20 @@ class Scheduler:
                 # If the sequence group has been preempted in this step, stop.
                 if seq_group in preempted:
                     break
+
+                num_prompt_tokens = seq_group.get_seqs()[0].get_len()
+                if num_prompt_tokens > self.scheduler_config.max_prompt_len:
+                    logger.warn(
+                        f"Input prompt ({num_prompt_tokens} tokens) is too long, exceeding limit of {self.scheduler_config.max_prompt_len}")
+                    ignored_seq_groups.append(seq_group)
+                    self.waiting.pop(0)
+                    break
+
                 # If the sequence group cannot be allocated, stop.
                 if not self.block_manager.can_allocate(seq_group):
                     break
 
                 # If the number of batched tokens exceeds the limit, stop.
-                num_prompt_tokens = seq_group.get_seqs()[0].get_len()
                 if (num_batched_tokens + num_prompt_tokens
                     > self.scheduler_config.max_num_batched_tokens):
                     break
@@ -218,7 +227,7 @@ class Scheduler:
             blocks_to_copy=blocks_to_copy,
         )
         if not self.log_stats:
-            return scheduler_outputs, prompt_group_ids
+            return scheduler_outputs, prompt_group_ids, ignored_seq_groups
 
         # TODO(woosuk): Move the below code to the engine.
         now = time.time()
@@ -258,13 +267,13 @@ class Scheduler:
                 f"Pending: {len(self.waiting)} reqs, "
                 f"GPU KV cache usage: {gpu_cache_usage * 100:.1f}%, "
                 f"CPU KV cache usage: {cpu_cache_usage * 100:.1f}%")
-        return scheduler_outputs, prompt_group_ids
+        return scheduler_outputs, prompt_group_ids, ignored_seq_groups
 
-    def schedule(self) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
+    def schedule(self) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs, List[SequenceGroup]]:
         # Schedule sequence groups.
         # This function call changes the internal states of the scheduler
         # such as self.running, self.swapped, and self.waiting.
-        scheduler_outputs, prompt_group_ids = self._schedule()
+        scheduler_outputs, prompt_group_ids, ignored_seq_groups = self._schedule()
 
         # Create input data structures.
         seq_group_metadata_list: List[SequenceGroupMetadata] = []
@@ -286,7 +295,7 @@ class Scheduler:
                 block_tables=block_tables,
             )
             seq_group_metadata_list.append(seq_group_metadata)
-        return seq_group_metadata_list, scheduler_outputs
+        return seq_group_metadata_list, scheduler_outputs, ignored_seq_groups
 
     def update(
         self,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -190,11 +190,13 @@ class Scheduler:
                     break
 
                 num_prompt_tokens = seq_group.get_seqs()[0].get_len()
-                if num_prompt_tokens > self.scheduler_config.max_prompt_len:
+                if num_prompt_tokens >= self.scheduler_config.max_sequence_len:
                     logger.warn(
-                        f"Input prompt ({num_prompt_tokens} tokens) is too long, exceeding limit of {self.scheduler_config.max_prompt_len}")
+                        f"Input prompt ({num_prompt_tokens} tokens) is too long"
+                        f" and exceeds limit of "
+                        f"{self.scheduler_config.max_sequence_len}")
                     for seq in seq_group.get_seqs():
-                        seq.status = SequenceStatus.IGNORED
+                        seq.status = SequenceStatus.FINISHED_IGNORED
                     ignored_seq_groups.append(seq_group)
                     self.waiting.pop(0)
                     break

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -193,6 +193,9 @@ class Scheduler:
 
                 # If the number of batched tokens exceeds the limit, stop.
                 num_prompt_tokens = seq_group.get_seqs()[0].get_len()
+                if num_prompt_tokens > self.scheduler_config.max_num_batched_tokens:
+                    raise ValueError(f"The input promot is too long. The current prompt is of length {num_prompt_tokens}, "
+                                     f"which exceeds the limit of {self.scheduler_config.max_num_batched_tokens}.")
                 if (num_batched_tokens + num_prompt_tokens
                     > self.scheduler_config.max_num_batched_tokens):
                     break

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -193,9 +193,6 @@ class Scheduler:
 
                 # If the number of batched tokens exceeds the limit, stop.
                 num_prompt_tokens = seq_group.get_seqs()[0].get_len()
-                if num_prompt_tokens > self.scheduler_config.max_num_batched_tokens:
-                    raise ValueError(f"The input promot is too long. The current prompt is of length {num_prompt_tokens}, "
-                                     f"which exceeds the limit of {self.scheduler_config.max_num_batched_tokens}.")
                 if (num_batched_tokens + num_prompt_tokens
                     > self.scheduler_config.max_num_batched_tokens):
                     break

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -111,12 +111,12 @@ class EngineArgs:
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray)
-        max_sequence_len = min(
+        max_seq_len = min(
             self.max_num_batched_tokens, 
             getattr(model_config.hf_config, "max_position_embeddings", 
                     float("inf")))
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
-                                           self.max_num_seqs, max_sequence_len)
+                                           self.max_num_seqs, max_seq_len)
         return model_config, cache_config, parallel_config, scheduler_config
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -111,8 +111,10 @@ class EngineArgs:
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray)
+        max_prompt_len = min(self.max_num_batched_tokens, model_config.hf_config.max_position_embeddings) if hasattr(
+            model_config.hf_config, "max_position_embeddings") else self.max_num_batched_tokens
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
-                                           self.max_num_seqs)
+                                           self.max_num_seqs, max_prompt_len)
         return model_config, cache_config, parallel_config, scheduler_config
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -111,10 +111,12 @@ class EngineArgs:
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray)
-        max_prompt_len = min(self.max_num_batched_tokens, model_config.hf_config.max_position_embeddings) if hasattr(
-            model_config.hf_config, "max_position_embeddings") else self.max_num_batched_tokens
+        max_sequence_len = min(
+            self.max_num_batched_tokens, 
+            getattr(model_config.hf_config, "max_position_embeddings", 
+                    float("inf")))
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
-                                           self.max_num_seqs, max_prompt_len)
+                                           self.max_num_seqs, max_sequence_len)
         return model_config, cache_config, parallel_config, scheduler_config
 
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -284,6 +284,12 @@ class LLMEngine:
                 if stopped:
                     continue
 
+                # Check if the sequence has reached max_sequence_len.
+                if seq.get_len() == \
+                    self.scheduler.scheduler_config.max_sequence_len:
+                    self.scheduler.free_seq(
+                        seq, SequenceStatus.FINISHED_LENGTH_CAPPED)
+                    continue
                 # Check if the sequence has reached max_tokens.
                 if seq.get_output_len() == sampling_params.max_tokens:
                     self.scheduler.free_seq(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -182,6 +182,15 @@ class LLMEngine:
             assert prompt is not None
             prompt_token_ids = self.tokenizer.encode(prompt)
 
+        # check if input prompt is too long
+        if hasattr(self.model_config.hf_config, "max_position_embeddings"):
+            limit = min(self.scheduler_config.max_num_batched_tokens, self.model_config.hf_config.max_position_embeddings)
+        else:
+            limit = self.scheduler_config.max_num_batched_tokens
+        if len(prompt_token_ids) > limit:
+            logger.warn(f"[Warning] input prompt has {len(prompt_token_ids)} tokens, exceeding the limit of {limit}, ignored.")
+            return
+
         # Create the sequences.
         block_size = self.cache_config.block_size
         seqs: List[Sequence] = []

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -223,13 +223,9 @@ class LLMEngine:
         the sequences and returns the newly generated results.
         """
         seq_group_metadata_list, scheduler_outputs, ignored_seq_groups = self.scheduler.schedule()
-
-        # Create the outputs.
-        request_outputs: List[RequestOutput] = []
-
         if (not seq_group_metadata_list) and scheduler_outputs.is_empty() and (not ignored_seq_groups):
             # Nothing to do.
-            return request_outputs
+            return []
 
         # Execute the model.
         output = self._run_workers(
@@ -249,6 +245,8 @@ class LLMEngine:
         # Free the finished sequence groups.
         self.scheduler.free_finished_seq_groups()
 
+        # Create the outputs.
+        request_outputs: List[RequestOutput] = []
         for seq_group in seq_groups + ignored_seq_groups:
             request_output = RequestOutput.from_seq_group(seq_group)
             request_outputs.append(request_output)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -284,9 +284,9 @@ class LLMEngine:
                 if stopped:
                     continue
 
-                # Check if the sequence has reached max_sequence_len.
-                if seq.get_len() == \
-                    self.scheduler.scheduler_config.max_sequence_len:
+                # Check if the sequence has reached max_seq_len.
+                if (seq.get_len() >=
+                    self.scheduler.scheduler_config.max_seq_len):
                     self.scheduler.free_seq(
                         seq, SequenceStatus.FINISHED_LENGTH_CAPPED)
                     continue

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -102,16 +102,6 @@ class RequestOutput:
         return cls(seq_group.request_id, prompt, prompt_token_ids, outputs,
                    finished)
 
-    @classmethod
-    def from_ignored_seq_group(cls, seq_group: SequenceGroup) -> "RequestOutput":
-        output = CompletionOutput(
-            0, "", [], -1, None, SequenceStatus.get_finished_reason(SequenceStatus.IGNORED))
-        seq = seq_group.get_seqs()[0]
-        prompt = seq.prompt
-        prompt_token_ids = seq.data.prompt_token_ids
-        finished = True
-        return cls(seq_group.request_id, prompt, prompt_token_ids, [output], finished)
-
     def __repr__(self) -> str:
         return (f"RequestOutput(request_id={self.request_id}, "
                 f"prompt={self.prompt!r}, "

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -102,6 +102,16 @@ class RequestOutput:
         return cls(seq_group.request_id, prompt, prompt_token_ids, outputs,
                    finished)
 
+    @classmethod
+    def from_ignored_seq_group(cls, seq_group: SequenceGroup) -> "RequestOutput":
+        output = CompletionOutput(
+            0, "", [], -1, None, SequenceStatus.get_finished_reason(SequenceStatus.IGNORED))
+        seq = seq_group.get_seqs()[0]
+        prompt = seq.prompt
+        prompt_token_ids = seq.data.prompt_token_ids
+        finished = True
+        return cls(seq_group.request_id, prompt, prompt_token_ids, [output], finished)
+
     def __repr__(self) -> str:
         return (f"RequestOutput(request_id={self.request_id}, "
                 f"prompt={self.prompt!r}, "

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -13,6 +13,7 @@ class SequenceStatus(enum.Enum):
     FINISHED_STOPPED = enum.auto()
     FINISHED_LENGTH_CAPPED = enum.auto()
     FINISHED_ABORTED = enum.auto()
+    IGNORED = enum.auto()
 
     @staticmethod
     def is_finished(status: "SequenceStatus") -> bool:
@@ -20,6 +21,7 @@ class SequenceStatus(enum.Enum):
             SequenceStatus.FINISHED_STOPPED,
             SequenceStatus.FINISHED_LENGTH_CAPPED,
             SequenceStatus.FINISHED_ABORTED,
+            SequenceStatus.IGNORED
         ]
 
     @staticmethod
@@ -30,6 +32,8 @@ class SequenceStatus(enum.Enum):
             finish_reason = "length"
         elif status == SequenceStatus.FINISHED_ABORTED:
             finish_reason = "abort"
+        elif status == SequenceStatus.IGNORED:
+            finish_reason = "ignored"
         else:
             finish_reason = None
         return finish_reason

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -13,7 +13,7 @@ class SequenceStatus(enum.Enum):
     FINISHED_STOPPED = enum.auto()
     FINISHED_LENGTH_CAPPED = enum.auto()
     FINISHED_ABORTED = enum.auto()
-    IGNORED = enum.auto()
+    FINISHED_IGNORED = enum.auto()
 
     @staticmethod
     def is_finished(status: "SequenceStatus") -> bool:
@@ -21,7 +21,7 @@ class SequenceStatus(enum.Enum):
             SequenceStatus.FINISHED_STOPPED,
             SequenceStatus.FINISHED_LENGTH_CAPPED,
             SequenceStatus.FINISHED_ABORTED,
-            SequenceStatus.IGNORED
+            SequenceStatus.FINISHED_IGNORED
         ]
 
     @staticmethod
@@ -32,8 +32,8 @@ class SequenceStatus(enum.Enum):
             finish_reason = "length"
         elif status == SequenceStatus.FINISHED_ABORTED:
             finish_reason = "abort"
-        elif status == SequenceStatus.IGNORED:
-            finish_reason = "ignored"
+        elif status == SequenceStatus.FINISHED_IGNORED:
+            finish_reason = "length"
         else:
             finish_reason = None
         return finish_reason


### PR DESCRIPTION
This is a fix for  #113. The program hangs when the input prompt is too long because [the check ](https://github.com/vllm-project/vllm/blob/43710e8d0965d616db51639ced76605dee1bde93/vllm/core/scheduler.py#L196) will always succeed and the request will always in the waiting queue and will never be added to the running queue. 
Add a check before the if statement, if the prompt length is too long, it will raise ValueError directly.