### PR TITLE
[Setup] Check CUDA_HOME instead of cuda.is_available() in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,9 @@ ABI = 1 if torch._C._GLIBCXX_USE_CXX11_ABI else 0
 CXX_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
 NVCC_FLAGS += [f"-D_GLIBCXX_USE_CXX11_ABI={ABI}"]
 
-if not torch.cuda.is_available():
+if CUDA_HOME is None:
     raise RuntimeError(
-        f"Cannot find CUDA at CUDA_HOME: {CUDA_HOME}. "
-        "CUDA must be available in order to build the package.")
+        f"Cannot find CUDA_HOME. CUDA must be available in order to build the package.")
 
 
 def get_nvcc_cuda_version(cuda_dir: str) -> Version:


### PR DESCRIPTION
This is to solve #177

The issue is when building a docker image, `torch.cuda.is_available()` always shows False even `CUDA_HOME` is available. This seems normal to me because you don't need GPUs but just CUDA (or nvcc).

With this change, I could use the following Dockerfile to build an image:

```
FROM nvcr.io/nvidia/pytorch:22.12-py3
RUN apt update
RUN pip uninstall -y torch

RUN git clone https://github.com/comaniac/vllm.git /vllm; \
    cd /vllm; git checkout -b comaniac-patch-1; origin/comaniac-patch-1; \
    pip install -e .
ENV PYTHONPATH "/vllm:${PYTHONPATH}"
```

using
```
docker build -t vllm .
```

cc @WoosukKwon 