### PR TITLE
Support LoRA adapter

### DIFF
--- a/vllm/model_executor/adapters/lora.py
+++ b/vllm/model_executor/adapters/lora.py
@@ -1,0 +1,114 @@
+from peft.tuners.lora import LoraLayer
+from peft import PeftConfig, LoraConfig, PEFT_TYPE_TO_CONFIG_MAPPING
+from peft.utils import WEIGHTS_NAME
+from huggingface_hub import hf_hub_download
+import torch
+from torch import nn
+from vllm.model_executor.models.opt import ColumnParallelLinear
+
+
+class VllmLoRA(LoraLayer, ColumnParallelLinear):
+    def __init__(
+        self,
+        input_size,
+        output_size,
+        *args,
+        r: int = 0,
+        lora_alpha: int = 1,
+        lora_dropout: float = 0.0,
+        adapter_name="default",
+        **kwargs
+    ):
+        init_lora_weights = kwargs.pop("init_lora_weights", True)
+
+        ColumnParallelLinear.__init__(self, input_size, output_size, *args, **kwargs)
+        LoraLayer.__init__(self, input_size, input_size)
+
+        nn.Linear.reset_parameters(self)
+        self.update_layer("q_proj", r, lora_alpha, lora_dropout, init_lora_weights)
+        self.update_layer("k_proj", r, lora_alpha, lora_dropout, init_lora_weights)
+        self.update_layer("v_proj", r, lora_alpha, lora_dropout, init_lora_weights)
+        self.active_adapter = adapter_name
+
+    def forward(self, input_):
+        result, bias = ColumnParallelLinear.forward(self, input_)
+
+        x = input_.to(self.lora_A["q_proj"].weight.dtype)
+
+        lora_results = [
+            self.lora_B[adapter](self.lora_A[adapter](self.lora_dropout[adapter](x)))
+            * self.scaling[adapter]
+            for adapter in ["q_proj", "k_proj", "v_proj"]
+        ]
+        result += torch.cat(lora_results, dim=-1)
+        return result, bias
+
+
+class LoRAModel:
+    @classmethod
+    def from_pretrained(cls, model, adapter_model_name: str, **kwargs):
+        config = PEFT_TYPE_TO_CONFIG_MAPPING[
+            PeftConfig.from_pretrained(
+                adapter_model_name, subfolder=kwargs.get("subfolder", None)
+            ).peft_type
+        ].from_pretrained(adapter_model_name, subfolder=kwargs.get("subfolder", None))
+        cls.load_adapter(model, config)
+        cls._update_weights(model, adapter_model_name, config)
+
+    @classmethod
+    def load_adapter(cls, model, config: LoraConfig):
+        for layer in model.model.decoder.layers:
+            qkv_proj = layer.self_attn.qkv_proj
+            new_model = VllmLoRA(
+                input_size=qkv_proj.input_size,
+                output_size=qkv_proj.output_size,
+                r=config.r,
+                lora_alpha=config.lora_alpha,
+            )
+            cls._replace_module(
+                layer.self_attn, "qkv_proj", new_model, layer.self_attn.qkv_proj
+            )
+
+        # incompatible_keys
+
+    @classmethod
+    def _replace_module(cls, parent_module, child_name, new_module, old_module):
+        setattr(parent_module, child_name, new_module)
+        new_module.weight = old_module.weight
+        if hasattr(old_module, "bias"):
+            if old_module.bias is not None:
+                new_module.bias = old_module.bias
+
+        if getattr(old_module, "state", None) is not None:
+            new_module.state = old_module.state
+            new_module.to(old_module.weight.device)
+
+        # dispatch to correct device
+        for name, module in new_module.named_modules():
+            if "lora_" in name:
+                module.to(old_module.weight.device)
+
+    @classmethod
+    def _update_weights(cls, model, adapter_model_name, config):
+        filename = hf_hub_download(adapter_model_name, WEIGHTS_NAME)
+        adapters_weights = torch.load(
+            filename,
+            map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        )
+
+        peft_model_state_dict = {}
+        # base_model.model.model.decoder.layers.0.self_attn.q_proj.lora_A.weight
+        #    ↓ ↓ ↓
+        # model.decoder.layers.0.self_attn.qkv_proj.lora_A.q_proj.weight 
+        prefix = list(adapters_weights.keys())[0].split('layers')[0]
+        for i in range(len(model.model.decoder.layers)):
+            for lora in ['lora_A', 'lora_B']:
+                for target in config.target_modules:
+                    proj_key = f"{prefix}layers.{i}.self_attn.{target}.{lora}.weight"
+                    proj_weight = adapters_weights.get(proj_key)
+
+                    to_key = f"model.decoder.layers.{i}.self_attn.qkv_proj.{lora}.{target}.weight"
+                    peft_model_state_dict[to_key] = proj_weight
+
+        incompatible_keys = model.load_state_dict(peft_model_state_dict, strict=False)
+        return incompatible_keys

--- a/vllm/model_executor/adapters/lora.py
+++ b/vllm/model_executor/adapters/lora.py
@@ -5,6 +5,9 @@ from huggingface_hub import hf_hub_download
 import torch
 from torch import nn
 from vllm.model_executor.models.opt import ColumnParallelLinear
+from .mapping import MODEL_LAYER_MAPPING
+from operator import attrgetter
+import os
 
 
 class VllmLoRA(LoraLayer, ColumnParallelLinear):
@@ -17,7 +20,7 @@ class VllmLoRA(LoraLayer, ColumnParallelLinear):
         lora_alpha: int = 1,
         lora_dropout: float = 0.0,
         adapter_name="default",
-        **kwargs
+        **kwargs,
     ):
         init_lora_weights = kwargs.pop("init_lora_weights", True)
 
@@ -52,24 +55,30 @@ class LoRAModel:
                 adapter_model_name, subfolder=kwargs.get("subfolder", None)
             ).peft_type
         ].from_pretrained(adapter_model_name, subfolder=kwargs.get("subfolder", None))
-        cls.load_adapter(model, config)
-        cls._update_weights(model, adapter_model_name, config)
+
+        cls_name = attrgetter("__class__.__name__")(model)
+        layers = attrgetter(MODEL_LAYER_MAPPING[cls_name])(model)
+
+        cls.load_adapter(layers, config)
+        cls._update_weights(model, adapter_model_name, config, layers)
 
     @classmethod
-    def load_adapter(cls, model, config: LoraConfig):
-        for layer in model.model.decoder.layers:
+    def load_adapter(cls, layers, config: LoraConfig):
+        for layer in layers:
             qkv_proj = layer.self_attn.qkv_proj
+            use_bias = qkv_proj.bias is not None
             new_model = VllmLoRA(
                 input_size=qkv_proj.input_size,
                 output_size=qkv_proj.output_size,
                 r=config.r,
                 lora_alpha=config.lora_alpha,
+                bias=use_bias,
+                gather_output=qkv_proj.gather_output,
+                perform_initialization=False,
             )
             cls._replace_module(
                 layer.self_attn, "qkv_proj", new_model, layer.self_attn.qkv_proj
             )
-
-        # incompatible_keys
 
     @classmethod
     def _replace_module(cls, parent_module, child_name, new_module, old_module):
@@ -89,8 +98,18 @@ class LoRAModel:
                 module.to(old_module.weight.device)
 
     @classmethod
-    def _update_weights(cls, model, adapter_model_name, config):
-        filename = hf_hub_download(adapter_model_name, WEIGHTS_NAME)
+    def _update_weights(cls, model, adapter_model_name, config, layers):
+        if os.path.exists(os.path.join(adapter_model_name, WEIGHTS_NAME)):
+            filename = os.path.join(adapter_model_name, WEIGHTS_NAME)
+        else:
+            try:
+                filename = hf_hub_download(adapter_model_name, WEIGHTS_NAME)
+            except:  # noqa
+                raise ValueError(
+                    f"Can't find weights for {adapter_model_name} in {adapter_model_name} or in the Hugging Face Hub. "
+                    f"Please check that the file {WEIGHTS_NAME} is present at {adapter_model_name}."
+                )
+
         adapters_weights = torch.load(
             filename,
             map_location=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
@@ -99,15 +118,24 @@ class LoRAModel:
         peft_model_state_dict = {}
         # base_model.model.model.decoder.layers.0.self_attn.q_proj.lora_A.weight
         #    ↓ ↓ ↓
-        # model.decoder.layers.0.self_attn.qkv_proj.lora_A.q_proj.weight 
-        prefix = list(adapters_weights.keys())[0].split('layers')[0]
-        for i in range(len(model.model.decoder.layers)):
-            for lora in ['lora_A', 'lora_B']:
+        # model.decoder.layers.0.self_attn.qkv_proj.lora_A.q_proj.weight
+        peft_prefix = list(adapters_weights.keys())[0].split("layers")[0]
+        vllm_prefix = ""
+        for k, _ in model.named_parameters():
+            if "lora_" in k:
+                vllm_prefix = k.split("layers")[0]
+        if not vllm_prefix:
+            raise ValueError("Can't find vllm_prefix.")
+
+        for i in range(len(layers)):
+            for lora in ["lora_A", "lora_B"]:
                 for target in config.target_modules:
-                    proj_key = f"{prefix}layers.{i}.self_attn.{target}.{lora}.weight"
+                    proj_key = (
+                        f"{peft_prefix}layers.{i}.self_attn.{target}.{lora}.weight"
+                    )
                     proj_weight = adapters_weights.get(proj_key)
 
-                    to_key = f"model.decoder.layers.{i}.self_attn.qkv_proj.{lora}.{target}.weight"
+                    to_key = f"{vllm_prefix}layers.{i}.self_attn.qkv_proj.{lora}.{target}.weight"
                     peft_model_state_dict[to_key] = proj_weight
 
         incompatible_keys = model.load_state_dict(peft_model_state_dict, strict=False)

--- a/vllm/model_executor/adapters/mapping.py
+++ b/vllm/model_executor/adapters/mapping.py
@@ -1,0 +1,3 @@
+ADAPTER_MAPPING = {
+    "LORA": "",
+}

--- a/vllm/model_executor/adapters/mapping.py
+++ b/vllm/model_executor/adapters/mapping.py
@@ -1,3 +1,9 @@
+
 ADAPTER_MAPPING = {
     "LORA": "",
+}
+
+MODEL_LAYER_MAPPING ={
+    "OPTForCausalLM": "model.decoder.layers",
+    "LlamaForCausalLM": "model.layers",
 }


### PR DESCRIPTION
hi guys, 
We found that infer with vllm can greatly improve performance! But we need to use LoRA(`peft`) in inference.
We also found that the community has a strong demand for lora. https://github.com/vllm-project/vllm/issues/182
After reading the model implementation of vllm, we found there are some differences from huggingface's transformer, so we cannot directly use peft to add LoRA with vllm.

So we added an extra to add LoRA weights to `qkv`. The following is an example of use:
```python
from vllm import LLM, SamplingParams
from vllm.model_executor.adapters import lora

# Create an LLM.
llm = LLM(model="facebook/opt-125m", gpu_memory_utilization=0.05)

# Add LoRA adapter
lora.LoRAModel.from_pretrained(llm.llm_engine.workers[0].model, "edbeeching/opt-125m-imdb-lora")

prompts = [
    "Hello, my name is",
    "The capital of France is",
    "The future of AI is",
]

sampling_params = SamplingParams(temperature=0, top_k=-1)

outputs = llm.generate(prompts, sampling_params)

for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```


Currently only supports the lora model with `["q_proj", "v_proj"]` target modules, like `opt`, `llama`.

And, it's not yet supported to use LoRA in the case of using parallel