### PR TITLE
Allow send list of str for the Prompt on openai demo endpoint /v1/completions

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -124,7 +124,7 @@ async def create_completion(raw_request: Request):
 
     model_name = request.model
     request_id = f"cmpl-{random_uuid()}"
-    prompt = request.prompt
+    prompt = request.prompt if type(request.prompt) != list else ' '.join(request.prompt)
     created_time = int(time.time())
     try:
         sampling_params = SamplingParams(

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -124,7 +124,11 @@ async def create_completion(raw_request: Request):
 
     model_name = request.model
     request_id = f"cmpl-{random_uuid()}"
-    prompt = request.prompt if type(request.prompt) != list else ' '.join(request.prompt)
+    if isinstance(request.prompt, list):
+        assert len(request.prompt) == 1
+        prompt = request.prompt[0]
+    else:
+        prompt = request.prompt
     created_time = int(time.time())
     try:
         sampling_params = SamplingParams(

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -67,7 +67,7 @@ class ChatCompletionRequest(BaseModel):
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: str
+    prompt: Union[str, List[str]]
     suffix: Optional[str] = None
     max_tokens: Optional[int] = 16
     temperature: Optional[float] = 1.0


### PR DESCRIPTION
The langchain implementation sends the prompt as an array of strings to the /v1/completions endpoint.

With this change, it is possible to use a simple string or an array of strings to send the prompt.

If the prompt is an array, then we concatenate all strings to one string. And the following engine will work with both prompt data types.

This is a solution for #186 