### PR TITLE
Don't try to load training_args.bin

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -39,7 +39,10 @@ def hf_model_weights_iterator(
     else:
         hf_folder = model_name_or_path
 
-    hf_bin_files = glob.glob(os.path.join(hf_folder, "*.bin"))
+    hf_bin_files = [
+        x for x in glob.glob(os.path.join(hf_folder, "*.bin"))
+        if not x.endswith("training_args.bin")
+    ]
 
     if use_np_cache:
         # Convert the model weights from torch tensors to numpy arrays for


### PR DESCRIPTION
While trying to load a fine-tuned model, I was getting this exception:
```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/venv/lib/python3.10/site-packages/vllm/entrypoints/api_server.py", line 82, in <module>
    engine = AsyncLLMEngine.from_engine_args(engine_args)
  File "/opt/venv/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 212, in from_engine_args
    engine = cls(engine_args.worker_use_ray,
  File "/opt/venv/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 49, in __init__
    self.engine = engine_class(*args, **kwargs)
  File "/opt/venv/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 97, in __init__
    worker = worker_cls(
  File "/opt/venv/lib/python3.10/site-packages/vllm/worker/worker.py", line 45, in __init__
    self.model = get_model(model_config)
  File "/opt/venv/lib/python3.10/site-packages/vllm/model_executor/model_loader.py", line 49, in get_model
    model.load_weights(
  File "/opt/venv/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 248, in load_weights
    for name, loaded_weight in hf_model_weights_iterator(
  File "/opt/venv/lib/python3.10/site-packages/vllm/model_executor/weight_utils.py", line 74, in hf_model_weights_iterator
    state = torch.load(bin_file, map_location="cpu")
  File "/opt/venv/lib/python3.10/site-packages/torch/serialization.py", line 809, in load
    return _load(opened_zipfile, map_location, pickle_module, **pickle_load_args)
  File "/opt/venv/lib/python3.10/site-packages/torch/serialization.py", line 1172, in _load
    result = unpickler.load()
  File "/opt/venv/lib/python3.10/site-packages/torch/serialization.py", line 1165, in find_class
    return super().find_class(mod_name, name)
AttributeError: Can't get attribute 'TrainingArguments' on <module 'vllm.entrypoints.api_server' from '/opt/venv/lib/python3.10/site-packages/vllm/entrypoints/api_server.py'>
```