### PR TITLE
Fix single_attn compilation bug when block_size = 256, scalar_t = float

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -225,7 +225,7 @@ __global__ void single_query_cached_kv_attention_kernel(
   using Float_L_vec = typename FloatVec<L_vec>::Type;
 
   constexpr int NUM_V_VECS_PER_ROW = BLOCK_SIZE / V_VEC_SIZE;
-  constexpr int NUM_ROWS_PER_ITER = WARP_SIZE / NUM_V_VECS_PER_ROW;
+  constexpr int NUM_ROWS_PER_ITER = MAX(WARP_SIZE / NUM_V_VECS_PER_ROW, 1);
   constexpr int NUM_ROWS_PER_THREAD = (HEAD_SIZE + NUM_ROWS_PER_ITER - 1) / NUM_ROWS_PER_ITER;
 
   // NOTE(woosuk): We use FP32 for the accumulator for better accuracy.


### PR DESCRIPTION
When I try to turn the block size to 256, I find that the compiled code will give an error as follows

```
vllm/csrc/attention/attention_kernels.cu (229): error: division by zero
          Detected during:
            Instantiation of "void vllm :: single_query_cached_kv_attention_kernel < scalar_t, HEAD_SIZE, BLOCK_SIZE, NUM_THREADS > (scalar_t *, const scalar_t *, const scalar_t *, const scalar_t *, float, const int *, const int *, int, int) [with scalar_t = float, HEAD_SIZE = 64, BLOCK_SIZE = 256, NUM_THREADS = 128]"
(379): here
            Instantiation of "void single_query_cached_kv_attention_launcher < T, BLOCK_SIZE, NUM_THREADS > (at :: T ensor &, at :: T ensor &, at :: T ensor &, at :: T ensor &, float, at :: T ensor &, at :: T ensor &, int) [with T = float, BLOCK_SIZE = 256, NUM_THREADS = 128]"
(463): here
```

It seems that because when `block size = 256, scalar_t = float, constexpr int NUM_ROWS_PER_ITER = WARP_SIZE/NUM_V_VECS_PER_ROW;` will be equal to 0, I try `MAX (WARP_SIZE/NUM_V_VECS_PER_ROW, 1)` to solve the bug, the compilation can pass.
But through the code, there is a doubt, theoretically the shape of the value_cache should be `32 * NUM_ROWS_PER_THREAD * V_VEC_SIZE`, when the above data is I think only 128 data will be calculated, not 256, why can the diff pass?