### PR TITLE
avoid python list copy in sequence initialization

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -127,7 +127,8 @@ class Sequence:
         self.logical_token_blocks.append(block)
 
     def _append_tokens_to_blocks(self, token_ids: List[int]) -> None:
-        while token_ids:
+        cursor = 0
+        while cursor < len(token_ids):
             if not self.logical_token_blocks:
                 self._append_logical_block()
 
@@ -137,8 +138,9 @@ class Sequence:
                 last_block = self.logical_token_blocks[-1]
 
             num_empty_slots = last_block.get_num_empty_slots()
-            last_block.append_tokens(token_ids[:num_empty_slots])
-            token_ids = token_ids[num_empty_slots:]
+            last_block.append_tokens(token_ids[cursor:cursor +
+                                               num_empty_slots])
+            cursor += num_empty_slots
 
     def append_token_id(
         self,


### PR DESCRIPTION
The pr tries to fix [this](https://github.com/vllm-project/vllm/commit/dafd924c1f165b4478a9d7a3c915d2ecc2e148e2#commitcomment-120855647). 

Before the fix, vllm will be stuck for a while when the input is very long before returning to the user. This is because we have an expensive python list copy in the _append_tokens_to_blocks function used by sequence initialization [here](https://github.com/vllm-project/vllm/blob/a945fcc2aec97d5fd85f5a7264814de04bbf5154/vllm/sequence.py#L141). (For the Shakespeare example, it takes 226s for this line). 

After this fix, the sequence initialization function returns instantly (<1e-5 s).
