### PR TITLE
Fast GELU CUDA kernel

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -1,32 +1,63 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
 
-namespace vllm {
+namespace vllm
+{
 
-template<typename T>
-__device__ __forceinline__ T silu(const T& x) {
-  // x * sigmoid(x)
-  return (T) (((float) x) / (1.0f + expf((float) -x)));
-}
-
-template<typename scalar_t>
-__global__ void silu_and_mul_kernel(
-  scalar_t* __restrict__ out,               // [num_tokens, d]
-  const scalar_t* __restrict__ input,       // [num_tokens, 2, d]
-  const int d) {
-  const int token_idx = blockIdx.x;
-  for (int idx = threadIdx.x; idx < d; idx += blockDim.x) {
-    const scalar_t x = __ldg(&input[token_idx * 2 * d + idx]);
-    const scalar_t y = __ldg(&input[token_idx * 2 * d + d + idx]);
-    out[token_idx * d + idx] = silu(x) * y;
+  template <typename T>
+  __device__ __forceinline__ T silu(const T &x)
+  {
+    // x * sigmoid(x)
+    return (T)(((float)x) / (1.0f + expf((float)-x)));
   }
-}
+
+  template <typename T>
+  __device__ __forceinline__ T fast_tanh(cosnt T &x)
+  {
+    // 1 - (2 * (1 / (1 + exp(x*2))))
+    return (T)(1.0f - (2.0f * (1.0f / (1.0f + expf((float)x * 2.0f)))));
+  }
+
+  template <typename scalar_t>
+  __global__ void silu_and_mul_kernel(
+      scalar_t *__restrict__ out,         // [num_tokens, d]
+      const scalar_t *__restrict__ input, // [num_tokens, 2, d]
+      const int d)
+  {
+    const int token_idx = blockIdx.x;
+    for (int idx = threadIdx.x; idx < d; idx += blockDim.x)
+    {
+      const scalar_t x = __ldg(&input[token_idx * 2 * d + idx]);
+      const scalar_t y = __ldg(&input[token_idx * 2 * d + d + idx]);
+      out[token_idx * d + idx] = silu(x) * y;
+    }
+  }
+
+  template <typename scalar_t>
+  __global__ void fast_gelu(
+      scalar_t *__restrict__ out,
+      const scalar_t *__restrict__ input,
+      const int d)
+  {
+    const int token_idx = blockIdx.x;
+    const int chunk = blockDim.x;
+
+    for (int idx = threadIdx.x; idx < d; i += chunk)
+    {
+      const scalar_t tensor = __ldg(&input[token_idx * 2 * d + idx]);
+
+      // scale = sqrt(2/pi)
+      //  6 decimal precision for scale
+      scalar_t cdf = 0.5f * (1.0f + fast_tanh(0.797885f * (tensor + 0.044715f * (tensor * tensor * tensor))));
+      out[token_idx * d + idx] = tensor * cdf;
+    }
+  }
 
 } // namespace vllm
 
 void silu_and_mul(
-  torch::Tensor& out,      // [num_tokens, d]
-  torch::Tensor& input)    // [num_tokens, 2 * d]
+    torch::Tensor &out,   // [num_tokens, d]
+    torch::Tensor &input) // [num_tokens, 2 * d]
 {
   int num_tokens = input.size(0);
   int d = input.size(1) / 2;
@@ -35,14 +66,39 @@ void silu_and_mul(
   dim3 block(std::min(d, 1024));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   AT_DISPATCH_FLOATING_TYPES_AND2(
-    at::ScalarType::Half,
-    at::ScalarType::BFloat16,
-    input.scalar_type(),
-    "silu_and_mul_kernel",
-    [&] {
-      vllm::silu_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
-        out.data_ptr<scalar_t>(),
-        input.data_ptr<scalar_t>(),
-        d);
-    });
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      input.scalar_type(),
+      "silu_and_mul_kernel",
+      [&]
+      {
+        vllm::silu_and_mul_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            out.data_ptr<scalar_t>(),
+            input.data_ptr<scalar_t>(),
+            d);
+      });
+}
+
+void fast_gelu(
+    torch::Tensor &out,
+    torch::Tensor &input)
+{
+  int num_tokens = input.size(0);
+  int d = input.size(1) / 2;
+
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      input.scalar_type(),
+      "fast_gelu_kernel",
+      [&]
+      {
+        vllm::fast_gelu<scalar_t><<<grid, block, 0, stream>>>(
+            out.data_ptr<scalar_t>(),
+            input.data_ptr<scalar_t>(),
+            d);
+      });
 }

--- a/tests/kernels/test_activation.py
+++ b/tests/kernels/test_activation.py
@@ -8,6 +8,10 @@ def ref_silu_and_mul(x: torch.Tensor) -> torch.Tensor:
     x1, x2 = x.chunk(chunks=2, dim=1)
     return F.silu(x1) * x2
 
+def ref_gelu(x: torch.Tensor) -> torch.Tensor:
+    x1 = x.chunk(chunks=2, dim=1)
+    return F.gelu(x1, approximate='tanh')
+
 
 @torch.inference_mode()
 def run_silu_and_mul(
@@ -22,9 +26,30 @@ def run_silu_and_mul(
     assert torch.allclose(out, ref_out, atol=1e-5, rtol=1e-5)
 
 
+@torch.inference_mode()
+def run_fast_gelu(
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+) -> None:
+    x = torch.randn(num_tokens, 2 * d, dtype=dtype, device='cuda')
+    out = torch.empty(num_tokens, d, dtype=dtype, device='cuda')
+    activation_ops.fast_gelu(out, x)
+    ref_out = ref_gelu(x)
+    assert torch.allclose(out, ref_out, atol=1e-5, rtol=1e-5)
+
+
 def test_silu_and_mul() -> None:
     for dtype in [torch.half, torch.bfloat16, torch.float]:
         for num_tokens in [7, 83, 2048]:
             for d in [512, 4096, 5120, 13824]:
                 print(f'Testing dtype={dtype}, num_tokens={num_tokens}, d={d}')
                 run_silu_and_mul(num_tokens, d, dtype)
+
+
+def test_fast_gelu() -> None:
+    for dtype in [torch.half, torch.bfloat16, torch.float]:
+        for num_tokens in [7, 83, 2048]:
+            for d in [512, 4096, 5120, 13824]:
+                print(f'Testing dtype={dtype}, num_tokens={num_tokens}, d={d}')
+                run_fast_gelu(num_tokens, d, dtype)

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -38,3 +38,21 @@ class SiluAndMul(nn.Module):
         out = torch.empty(num_tokens, d, dtype=x.dtype, device=x.device)
         activation_ops.silu_and_mul(out, x)
         return out
+    
+
+class FastGelu(nn.Module):
+    """An activation function for GELU using approximated tanh for performance
+
+    The function computes x -> 0.5 * (1 + tanh(0.797885 * (x + 0.044715 * (x * x * x)))) where d = x.shape[1] // 2;
+
+    Shapes:
+        x: (num_tokens, 2 * d)
+        return: (num_tokens, d)
+    """
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        num_tokens = x.shape[0]
+        d = x.shape[1] // 2
+        out = torch.empty(num_tokens, d, dtype=x.dtype, device=x.device)
+        activation_ops.fast_gelu(out, x)
+        return out


### PR DESCRIPTION
Changes:
- GELU with tanh as approximation
- using faster approximated tanh for improved speed

Ideas: 
- give user option to run faster gelu for less accuracy? Currently torch.nn.GELU() is being dispatched and all other variations in the activation registry are unused

Todos:
- run tests on different input sizes and benchmark performance trade-off