### PR TITLE
Fix the `KeyError` when loading bloom-based models

### DIFF
--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -285,7 +285,7 @@ class BloomForCausalLM(nn.Module):
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, use_np_cache):
             if name == "lm_head.weight":
-                # Since hidden_states are parallelized, we need to 
+                # Since hidden_states are parallelized, we need to
                 # load lm_head.weight in parallel.
                 self._column_parallel_weights.append(name)
                 # If lm_head is provided, use it instead.

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -284,8 +284,11 @@ class BloomForCausalLM(nn.Module):
         state_dict = self.state_dict()
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, use_np_cache):
-            if not name.startswith("transformer."):
-                name = "transformer." + name
+            if name == "lm_head.weight":
+                name = "lm_head_weight"
+            else:
+                if not name.startswith("transformer."):
+                    name = "transformer." + name
 
             param = state_dict[name]
             if "query_key_value" in name:

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -25,7 +25,6 @@ from typing import Dict, List, Optional, Tuple
 
 import torch
 from torch import nn
-from torch.nn.parameter import Parameter
 from transformers import BloomConfig
 
 from vllm.model_executor.input_metadata import InputMetadata
@@ -287,7 +286,7 @@ class BloomForCausalLM(nn.Module):
                 model_name_or_path, cache_dir, use_np_cache):
             # If lm_head is provided in weights, use it instead.
             if name == "lm_head.weight":
-                self.lm_head_weight = Parameter(state_dict["lm_head_weight"])
+                self.lm_head_weight.data.copy_(state_dict["lm_head_weight"])
                 continue
 
             if not name.startswith("transformer."):

--- a/vllm/model_executor/models/bloom.py
+++ b/vllm/model_executor/models/bloom.py
@@ -284,12 +284,12 @@ class BloomForCausalLM(nn.Module):
         state_dict = self.state_dict()
         for name, loaded_weight in hf_model_weights_iterator(
                 model_name_or_path, cache_dir, use_np_cache):
-            # If lm_head is provided in weights, use it instead.
             if name == "lm_head.weight":
                 # Since hidden_states are parallelized, we need to 
                 # load lm_head.weight in parallel.
                 self._column_parallel_weights.append(name)
-                param = state_dict["lm_head_weight"]
+                # If lm_head is provided, use it instead.
+                param = self.lm_head_weight
             else:
                 if not name.startswith("transformer."):
                     name = "transformer." + name


### PR DESCRIPTION
As the issue https://github.com/vllm-project/vllm/issues/413 mentioned, a `KeyError` will be raised when loading **some** bloom-based models. This is because those bloom-based models provide their `lm_head` in pretrained weights, which is slightly different from the behavior of original bloom models.

After applying this patch, the following bloom-based models can be accelerated by vllm (tested on A100 with CUDA 11.8):
1. TigerResearch/tigerbot-7b-sft
2. sambanovasystems/BLOOMChat-176B-v1

And I believe TigerResearch/tigerbot-180b-research can also be supported after solving some minor problems (issue https://github.com/vllm-project/vllm/issues/440). 