### PR TITLE
fix(ray_utils): ignore re-init error

### DIFF
--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -38,7 +38,7 @@ def initialize_cluster(
                 "Ray is not installed. Please install Ray to use distributed "
                 "serving.")
         # Connect to a ray cluster.
-        ray.init(address=ray_address)
+        ray.init(address=ray_address, ignore_reinit_error=True)
 
     if not parallel_config.worker_use_ray:
         # Initialize cluster locally.


### PR DESCRIPTION
Hi,
this simple PR aims at solving this annoying error raised by `ray` when creating multiple `vllm.LLM` objects

```
Exception: Perhaps you called ray.init twice by accident?
```