### PR TITLE
Offload port selection to OS

### DIFF
--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -1,5 +1,4 @@
 import socket
-import random
 from typing import List, Optional, Tuple
 
 try:
@@ -12,10 +11,12 @@ from vllm.config import ParallelConfig
 # rank, node resource (node IP), device id
 DeviceID = Tuple[int, Optional[str], int]
 
+
 def get_open_port():
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("",0))
+        s.bind(("", 0))
         return s.getsockname()[1]
+
 
 def initialize_cluster(
     parallel_config: ParallelConfig,

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -1,3 +1,4 @@
+import socket
 import random
 from typing import List, Optional, Tuple
 
@@ -11,6 +12,10 @@ from vllm.config import ParallelConfig
 # rank, node resource (node IP), device id
 DeviceID = Tuple[int, Optional[str], int]
 
+def get_open_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("",0))
+        return s.getsockname()[1]
 
 def initialize_cluster(
     parallel_config: ParallelConfig,
@@ -42,7 +47,7 @@ def initialize_cluster(
 
     if not parallel_config.worker_use_ray:
         # Initialize cluster locally.
-        port = random.randint(10000, 20000)
+        port = get_open_port()
         # We need to setup the distributed init method to make sure
         # the distributed megatron code (e.g., get world size) works correctly.
         distributed_init_method = f"tcp://localhost:{port}"
@@ -96,7 +101,7 @@ def initialize_cluster(
             stage_devices.append((rank, node_resource, current_device_id))
             if distributed_init_method is None:
                 ip = node_resource.split("node:")[-1]
-                port = random.randint(10000, 20000)
+                port = get_open_port()
                 distributed_init_method = f"tcp://{ip}:{port}"
             rank += 1
             current_device_id += 1


### PR DESCRIPTION
In machine learning, it is a common workflow to run two programs that make the sequence of random choices with the same random seed on the same machine at the same time. For example, this happens when you run the same eval suite on two different language models. 

Currently, the doing the above won't work because vllm uses Python's random module to select TCP ports, resulting in a port collision when running two instances at the same time with the same seed. 

The solution is to offload port selection to the OS. In particular, if one instructs the Python `socket` API to bind to port 0, Python will instruct the OS to choose a suitable free port number. The code I added using this mechanism to choose a port. 