### PR TITLE
[Fix] Fix the condition of max_seq_len

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -190,7 +190,7 @@ class Scheduler:
                     break
 
                 num_prompt_tokens = seq_group.get_seqs()[0].get_len()
-                if num_prompt_tokens >= self.scheduler_config.max_seq_len:
+                if num_prompt_tokens > self.scheduler_config.max_seq_len:
                     logger.warning(
                         f"Input prompt ({num_prompt_tokens} tokens) is too long"
                         " and exceeds limit of "

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -300,7 +300,7 @@ class LLMEngine:
                     continue
 
                 # Check if the sequence has reached max_seq_len.
-                if (seq.get_len() >=
+                if (seq.get_len() >
                         self.scheduler.scheduler_config.max_seq_len):
                     self.scheduler.free_seq(
                         seq, SequenceStatus.FINISHED_LENGTH_CAPPED)


### PR DESCRIPTION
When the input length is exactly the same as the `max_seq_len`, the model can still run, because the generated new word will only be in the output.