### PR TITLE
GPTJConfig has no attribute rotary. 

### DIFF
--- a/vllm/model_executor/models/gpt_j.py
+++ b/vllm/model_executor/models/gpt_j.py
@@ -65,6 +65,7 @@ class GPTJAttention(nn.Module):
         self.num_heads = self.total_num_heads // tp_world_size
 
         scaling = self.head_size**-0.5
+        assert getattr(config, "rotary", True)
         assert config.rotary_dim % 2 == 0
         self.attn = PagedAttentionWithRoPE(self.num_heads, self.head_size,
                                            scaling, config.rotary_dim)

--- a/vllm/model_executor/models/gpt_j.py
+++ b/vllm/model_executor/models/gpt_j.py
@@ -65,7 +65,6 @@ class GPTJAttention(nn.Module):
         self.num_heads = self.total_num_heads // tp_world_size
 
         scaling = self.head_size**-0.5
-        assert config.rotary
         assert config.rotary_dim % 2 == 0
         self.attn = PagedAttentionWithRoPE(self.num_heads, self.head_size,
                                            scaling, config.rotary_dim)


### PR DESCRIPTION
GPTJConfig has no attribute rotary. Remove this line to skip runtime error when using gpt-j model.