### PR TITLE
Not all stop sequences are created equal

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -338,10 +338,10 @@ class LLMEngine:
                 # Check if the sequence has generated a stop string.
                 stopped = False
                 for stop_str in sampling_params.stop:
-                    if seq.output_text.endswith(stop_str):
+                    if stop_str in seq.output_text:
                         # Truncate the output text so that the stop string is
                         # not included in the output.
-                        seq.output_text = seq.output_text[:-len(stop_str)]
+                        seq.output_text = seq.output_text[:seq.output_text.index(stop_str)]
                         self.scheduler.free_seq(
                             seq, SequenceStatus.FINISHED_STOPPED)
                         stopped = True


### PR DESCRIPTION
This PR fixes some stop sequences not being matched. When generating and decoding tokens, sometimes a single token will generate the stop sequence **plus additional characters**. This caused `if seq.output_text.endswith(stop_str):` not to behave as expected.

For example. If a stop sequence is defined as `",` and the model generates `","` as a single token, as is the case with `EleutherAI/gpt-neox-20b`, then the stop sequence will not be detected and generation will not stop.

This is a small PR that, instead of checking only the end of the generated sequence, checks the entire sequence for the stop sequence