### PR TITLE
Add logits processors to enable logit_bias in OpenAI server

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -187,7 +187,9 @@ async def create_chat_completion(raw_request: Request):
     if not request.logit_bias:
         logit_processors = []
     else:
-        biases = dict(map(lambda bias: (int(bias[0]), bias[1]), request.logit_bias.items()))
+        biases = dict(
+            map(lambda bias: (int(bias[0]), bias[1]),
+                request.logit_bias.items()))
         logit_processors = [BiasLogitsProcessor(biases)]
 
     model_name = request.model
@@ -206,8 +208,7 @@ async def create_chat_completion(raw_request: Request):
             top_k=request.top_k,
             ignore_eos=request.ignore_eos,
             use_beam_search=request.use_beam_search,
-            logit_processors=logit_processors
-        )
+            logits_processors=logit_processors)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
@@ -366,7 +367,9 @@ async def create_completion(raw_request: Request):
     if not request.logit_bias:
         logit_processors = []
     else:
-        logit_bias = dict(map(lambda logit: (int(logit[0]), logit[1]), request.logit_bias.items()))
+        logit_bias = dict(
+            map(lambda logit: (int(logit[0]), logit[1]),
+                request.logit_bias.items()))
         logit_processors = [BiasLogitsProcessor(logit_bias)]
 
     model_name = request.model
@@ -398,8 +401,7 @@ async def create_completion(raw_request: Request):
             max_tokens=request.max_tokens,
             logprobs=request.logprobs,
             use_beam_search=request.use_beam_search,
-            logits_processors=logit_processors
-        )
+            logits_processors=logit_processors)
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 

--- a/vllm/logits_processors.py
+++ b/vllm/logits_processors.py
@@ -2,37 +2,45 @@ from abc import ABC, abstractmethod
 import torch
 from typing import Dict
 
+
 class LogitsProcessor(ABC):
-  @abstractmethod
-  def __call__(self, logits: torch.tensor) -> torch.tensor:
-    pass
+
+    @abstractmethod
+    def __call__(self, logits: torch.tensor) -> torch.tensor:
+        pass
+
 
 class BiasLogitsProcessor(LogitsProcessor):
-  """This is to enable logit_bias in the OpenAI server.
+    """This is to enable logit_bias in the OpenAI server.
 
-  biases is a dict where each value is -100 to 100 according to the OpenAI API docs.
+    biases is a dict where each value is -100 to 100
+      according to the OpenAI API docs.
 
-  Args:
-    biases: Dict ov values from -100 to 100 to scale the probability of a token being generated.
-      Each key of the dict coresponds to the the token id.
-  """
-  def __init__(self, biases: Dict[int, float]):
-    self.biases = biases
+    Args:
+      biases: Dict ov values from -100 to 100 to scale the
+        probability of a token being generated.
+        Each key of the dict coresponds to the the token id.
+    """
 
-    if not biases:
-      return
+    def __init__(self, biases: Dict[int, float]):
+        self.biases = biases
 
-    self.keys = torch.tensor(list(self.biases.keys()), dtype=torch.long)
-    self.values = torch.tensor(list(self.biases.values()), dtype=torch.long)
+        if not biases:
+            return
 
-  def __call__(self, logits):
-    if not self.biases:
-      return logits
+        self.keys = torch.tensor(list(self.biases.keys()), dtype=torch.long)
+        self.values = torch.tensor(list(self.biases.values()),
+                                   dtype=torch.long)
 
-    values = self.values.to(logits.device)
-    keys = self.keys.to(logits.device)
+    def __call__(self, logits):
+        if not self.biases:
+            return logits
 
-    update_factors = torch.where(values >= 0, 1 + (values / 100), 1 / (1 - (values / 100)))
-    logits[0, keys] *= update_factors
+        values = self.values.to(logits.device)
+        keys = self.keys.to(logits.device)
 
-    return logits
+        update_factors = torch.where(values >= 0, 1 + (values / 100),
+                                     1 / (1 - (values / 100)))
+        logits[0, keys] *= update_factors
+
+        return logits

--- a/vllm/logits_processors.py
+++ b/vllm/logits_processors.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+import torch
+from typing import Dict
+
+class LogitsProcessor(ABC):
+  @abstractmethod
+  def __call__(self, logits: torch.tensor) -> torch.tensor:
+    pass
+
+class BiasLogitsProcessor(LogitsProcessor):
+  """This is to enable logit_bias in the OpenAI server.
+
+  biases is a dict where each value is -100 to 100 according to the OpenAI API docs.
+
+  Args:
+    biases: Dict ov values from -100 to 100 to scale the probability of a token being generated.
+      Each key of the dict coresponds to the the token id.
+  """
+  def __init__(self, biases: Dict[int, float]):
+    self.biases = biases
+
+    if not biases:
+      return
+
+    self.keys = torch.tensor(list(self.biases.keys()), dtype=torch.long)
+    self.values = torch.tensor(list(self.biases.values()), dtype=torch.long)
+
+  def __call__(self, logits):
+    if not self.biases:
+      return logits
+
+    values = self.values.to(logits.device)
+    keys = self.keys.to(logits.device)
+
+    update_factors = torch.where(values >= 0, 1 + (values / 100), 1 / (1 - (values / 100)))
+    logits[0, keys] *= update_factors
+
+    return logits

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -145,6 +145,7 @@ def _get_output_tokens(input_metadata: InputMetadata) -> List[List[int]]:
                 output_tokens.append(seq_data.output_token_ids)
     return output_tokens
 
+
 def _apply_logits_processors(
     input_metadata: InputMetadata,
     logits: torch.Tensor,
@@ -153,10 +154,12 @@ def _apply_logits_processors(
         _, sampling_params = seq_group
         logits_processors = sampling_params.logits_processors
 
-        for logits_processor in logits_processors:
-            logits = logits_processor(logits)
-    
+        if logits_processors is not None:
+            for logits_processor in logits_processors:
+                logits = logits_processor(logits)
+
     return logits
+
 
 def _apply_penalties(
     logits: torch.Tensor,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -41,26 +41,24 @@ class SamplingParams:
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.
         logprobs: Number of log probabilities to return per output token.
-        logits_processors: List of LogitsProcessors to change the probability 
+        logits_processors: List of LogitsProcessors to change the probability
             of token prediction at runtime.
     """
 
-    def __init__(
-        self,
-        n: int = 1,
-        best_of: Optional[int] = None,
-        presence_penalty: float = 0.0,
-        frequency_penalty: float = 0.0,
-        temperature: float = 1.0,
-        top_p: float = 1.0,
-        top_k: int = -1,
-        use_beam_search: bool = False,
-        stop: Union[None, str, List[str]] = None,
-        ignore_eos: bool = False,
-        max_tokens: int = 16,
-        logprobs: Optional[int] = None,
-        logits_processors: List[LogitsProcessor] = []
-    ) -> None:
+    def __init__(self,
+                 n: int = 1,
+                 best_of: Optional[int] = None,
+                 presence_penalty: float = 0.0,
+                 frequency_penalty: float = 0.0,
+                 temperature: float = 1.0,
+                 top_p: float = 1.0,
+                 top_k: int = -1,
+                 use_beam_search: bool = False,
+                 stop: Union[None, str, List[str]] = None,
+                 ignore_eos: bool = False,
+                 max_tokens: int = 16,
+                 logprobs: Optional[int] = None,
+                 logits_processors: List[LogitsProcessor] = None) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
         self.presence_penalty = presence_penalty

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,5 +1,6 @@
 """Sampling parameters for text generation."""
 from typing import List, Optional, Union
+from vllm.logits_processors import LogitsProcessor
 
 _SAMPLING_EPS = 1e-5
 
@@ -40,6 +41,8 @@ class SamplingParams:
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.
         logprobs: Number of log probabilities to return per output token.
+        logits_processors: List of LogitsProcessors to change the probability 
+            of token prediction at runtime.
     """
 
     def __init__(
@@ -56,6 +59,7 @@ class SamplingParams:
         ignore_eos: bool = False,
         max_tokens: int = 16,
         logprobs: Optional[int] = None,
+        logits_processors: List[LogitsProcessor] = []
     ) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
@@ -74,6 +78,7 @@ class SamplingParams:
         self.ignore_eos = ignore_eos
         self.max_tokens = max_tokens
         self.logprobs = logprobs
+        self.logits_processors = logits_processors
 
         self._verify_args()
         if self.use_beam_search:


### PR DESCRIPTION
This PR makes it possible to define custom logits processors to alter the probability of token generation based on user defined code. This allows for the vLLM OpenAI server to accept requests with `logit_bias` too.

The BiasLogitsProcessor is included specifically for the OpenAI server to handle requests with `logit_bias`.