### PR TITLE
Add max_seq_len in check_length of openai endpoint

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -107,6 +107,8 @@ async def check_length(request, prompt, model_config):
         context_len = model_config.hf_config.max_position_embeddings
     elif hasattr(model_config.hf_config, "seq_length"):
         context_len = model_config.hf_config.seq_length
+    elif hasattr(model_config.hf_config, "max_seq_len"):
+        context_len = model_config.hf_config.max_seq_len
     else:
         context_len = 2048
 


### PR DESCRIPTION
MPT models use max_seq_len for limiting the number of generated tokens.
This pull request adds max_seq_len in check_length of openai compatible api endpoint.