### PR TITLE
Add support for chatglm2

### DIFF
--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -22,6 +22,7 @@ _MODEL_REGISTRY = {
     "LLaMAForCausalLM": LlamaForCausalLM,  # For decapoda-research/llama-*
     "MPTForCausalLM": MPTForCausalLM,
     "OPTForCausalLM": OPTForCausalLM,
+    "ChatGLMModel": ChatGLMModel,
 }
 
 

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -7,6 +7,7 @@ from vllm.model_executor.models.gpt_neox import GPTNeoXForCausalLM
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.model_executor.models.mpt import MPTForCausalLM
 from vllm.model_executor.models.opt import OPTForCausalLM
+from vllm.model_executor.models.chatglm import ChatGLMModel
 
 __all__ = [
     "BaiChuanForCausalLM",
@@ -19,4 +20,5 @@ __all__ = [
     "LlamaForCausalLM",
     "MPTForCausalLM",
     "OPTForCausalLM",
+    "ChatGLMModel",
 ]

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -1,0 +1,552 @@
+# coding=utf-8
+# Adapted from
+# https://huggingface.co/THUDM/chatglm2-6b/blob/main/modeling_chatglm.py
+
+"""Inference-only ChatGLM model compatible with HuggingFace weights.
+
+The input of the model is flattened to a 1D tensor of tokens. The model uses
+InputMetadata to extract the original 2D shape of the input.
+"""
+
+import math
+import copy
+import warnings
+import re
+import sys
+
+import torch
+import torch.utils.checkpoint
+import torch.nn.functional as F
+from torch import nn
+from torch.nn import CrossEntropyLoss, LayerNorm
+from torch.nn.utils import skip_init
+from typing import Optional, Tuple, Union, List, Callable, Dict, Any
+
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+from transformers.generation.logits_process import LogitsProcessor
+from transformers.generation.utils import LogitsProcessorList, StoppingCriteriaList, GenerationConfig, ModelOutput
+
+
+# vllm
+from vllm.model_executor.input_metadata import InputMetadata
+from vllm.model_executor.layers.attention import PagedAttention
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.sampler import Sampler
+from vllm.model_executor.weight_utils import (hf_model_weights_iterator,
+                                              load_tensor_parallel_weights)
+from vllm.model_executor.parallel_utils.parallel_state import (
+    get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
+from vllm.model_executor.parallel_utils.tensor_parallel import (
+    VocabParallelEmbedding, ColumnParallelLinear, RowParallelLinear)
+from vllm.sequence import SequenceOutputs
+
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+# flags required to enable jit fusion kernels
+
+if sys.platform != 'darwin':
+    torch._C._jit_set_profiling_mode(False)
+    torch._C._jit_set_profiling_executor(False)
+    torch._C._jit_override_can_fuse_on_cpu(True)
+    torch._C._jit_override_can_fuse_on_gpu(True)
+
+logger = logging.get_logger(__name__)
+
+
+CHATGLM_6B_PRETRAINED_MODEL_ARCHIVE_LIST = [
+    "THUDM/chatglm2-6b",
+    # See all ChatGLM models at https://huggingface.co/models?filter=chatglm
+]
+
+    
+def build_rotary_pos(seq_len, n_elem, dtype, device, base: int = 10000):
+    theta = 1.0 / (base ** (torch.arange(0, n_elem, 2, dtype=dtype, device=device) / n_elem))
+
+    # Create position indexes `[0, 1, ..., seq_len - 1]`
+    seq_idx = torch.arange(seq_len, dtype=dtype, device=device)
+
+    # Calculate the product of position index and $\theta_i$
+    idx_theta = torch.outer(seq_idx, theta).float()
+
+    cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
+
+    # this is to mimic the behaviour of complex32, else we will get different results
+    if dtype in (torch.float16, torch.bfloat16, torch.int8):
+        cache = cache.bfloat16() if dtype == torch.bfloat16 else cache.half()
+    return cache
+
+@torch.jit.script
+def apply_rotary_pos_emb(x: torch.Tensor, rope_cache: torch.Tensor) -> torch.Tensor:
+    # x: [sq, np, hn]
+    x = x.unsqueeze(1)
+    sq, b, np, hn = x.size(0), x.size(1), x.size(2), x.size(3)
+    rot_dim = rope_cache.shape[-2] * 2
+    x, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+    # truncate to support variable sizes
+    rope_cache = rope_cache[:sq]
+    xshaped = x.reshape(sq, -1, np, rot_dim // 2, 2)
+    rope_cache = rope_cache.view(sq, -1, 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * rope_cache[..., 0] - xshaped[..., 1] * rope_cache[..., 1],
+            xshaped[..., 1] * rope_cache[..., 0] + xshaped[..., 0] * rope_cache[..., 1],
+        ],
+        -1,
+    )
+    x_out2 = x_out2.flatten(3)
+    return torch.cat((x_out2, x_pass), dim=-1)
+
+class MLP(torch.nn.Module):
+    """MLP.
+
+    MLP will take the input with h hidden state, project it to 4*h
+    hidden dimension, perform nonlinear transformation, and project the
+    state back into h hidden dimension.
+    """
+
+    def __init__(self, config):
+        super(MLP, self).__init__()
+
+        self.add_bias = config.add_bias_linear
+
+        # Project to 4h. If using swiglu double the output width, see https://arxiv.org/pdf/2002.05202.pdf
+        self.dense_h_to_4h = ColumnParallelLinear(config.hidden_size,
+                                                 config.ffn_hidden_size * 2,
+                                                 bias=self.add_bias,
+                                                 gather_output=False,
+                                                 perform_initialization=False,
+                                                 params_dtype=config.torch_dtype)
+
+        
+        def swiglu(x):
+            x = torch.chunk(x, 2, dim=-1)
+            return F.silu(x[0]) * x[1]
+
+        self.activation_func = swiglu
+
+        # Project back to h.
+        self.dense_4h_to_h = RowParallelLinear(config.ffn_hidden_size,
+                                                config.hidden_size,
+                                                bias=self.add_bias,
+                                                input_is_parallel=True,
+                                                perform_initialization=False,
+                                                params_dtype=config.torch_dtype)
+
+
+    def forward(self, hidden_states):
+        # [s, b, 4hp]
+        intermediate_parallel, _ = self.dense_h_to_4h(hidden_states)
+        intermediate_parallel = self.activation_func(intermediate_parallel)
+        # [s, b, h]
+        output, _ = self.dense_4h_to_h(intermediate_parallel)
+        return output
+    
+
+def default_init(cls, *args, **kwargs):
+    return cls(*args, **kwargs)
+
+
+
+def split_tensor_along_last_dim(
+        tensor: torch.Tensor,
+        num_partitions: int,
+        contiguous_split_chunks: bool = False,
+) -> List[torch.Tensor]:
+    """Split a tensor along its last dimension.
+
+    Arguments:
+        tensor: input tensor.
+        num_partitions: number of partitions to split the tensor
+        contiguous_split_chunks: If True, make each chunk contiguous
+                                 in memory.
+
+    Returns:
+        A list of Tensors
+    """
+    # Get the size and dimension.
+    last_dim = tensor.dim() - 1
+    last_dim_size = tensor.size()[last_dim] // num_partitions
+    # Split.
+    tensor_list = torch.split(tensor, last_dim_size, dim=last_dim)
+    # Note: torch.split does not create contiguous tensors by default.
+    if contiguous_split_chunks:
+        return tuple(chunk.contiguous() for chunk in tensor_list)
+
+    return tensor_list
+
+
+
+class SelfAttention(torch.nn.Module):
+    """Parallel self-attention layer abstract class.
+
+    Self-attention layer takes input with size [s, b, h]
+    and returns output of the same size.
+    """
+
+    def __init__(self, config, layer_number):
+        super(SelfAttention, self).__init__()
+        self.layer_number = max(1, layer_number)
+
+        self.projection_size = config.kv_channels * config.num_attention_heads
+
+        # Per attention head and per partition values.
+        self.hidden_size_per_attention_head = self.projection_size // config.num_attention_heads
+        self.num_attention_heads_per_partition = config.num_attention_heads
+
+        self.norm_factor = self.hidden_size_per_attention_head ** -0.5
+
+        self.multi_query_attention = config.multi_query_attention
+        self.seq_length = config.seq_length
+        self.rotary_dim = (
+            config.hidden_size // config.num_attention_heads if config.kv_channels is None else config.kv_channels
+        )
+
+        self.qkv_hidden_size = 3 * self.projection_size
+        if self.multi_query_attention:
+            self.num_multi_query_groups_per_partition = config.multi_query_group_num
+            self.qkv_hidden_size = (
+                    self.projection_size + 2 * self.hidden_size_per_attention_head * config.multi_query_group_num
+            )
+    
+        self.query_key_value = ColumnParallelLinear(
+                                config.hidden_size,
+                                self.qkv_hidden_size,
+                                bias=config.add_bias_linear or config.add_qkv_bias,
+                                gather_output=False,
+                                perform_initialization=False,
+                                params_dtype=config.torch_dtype
+                            )
+        # rotary_dim=self.hidden_size_per_attention_head
+        self.atten = PagedAttention(config.num_attention_heads, 
+                                            self.hidden_size_per_attention_head, 
+                                            self.norm_factor)
+        # Output.
+        self.dense = RowParallelLinear(
+                        self.projection_size,
+                        config.hidden_size,
+                        bias=config.add_bias_linear,
+                        input_is_parallel=True,
+                        perform_initialization=False,
+                        params_dtype=config.torch_dtype
+                    )
+        # debug
+        # self.core_attention = CoreAttention(config, self.layer_number)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        # hidden_states: [sq, b, h]
+
+        # =================================================
+        # Pre-allocate memory for key-values for inference.
+        # =================================================
+        # =====================
+        # Query, Key, and Value
+        # =====================
+
+        # Attention heads [sq, b, h] --> [sq, b, (np * 3 * hn)]
+        mixed_x_layer, _ = self.query_key_value(hidden_states)
+
+        if self.multi_query_attention:
+            (query_layer, key_layer, value_layer) = mixed_x_layer.split(
+                [
+                    self.num_attention_heads_per_partition * self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition * self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition * self.hidden_size_per_attention_head,
+                ],
+                dim=-1,
+            )
+            query_layer = query_layer.contiguous().view(
+                query_layer.size()[:-1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+            )
+            key_layer = key_layer.contiguous().view(
+                key_layer.size()[:-1] + (self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
+            )
+            value_layer = value_layer.contiguous().view(
+                value_layer.size()[:-1]
+                + (self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
+            )
+        else:
+            new_tensor_shape = mixed_x_layer.size()[:-1] + \
+                               (self.num_attention_heads_per_partition,
+                                3 * self.hidden_size_per_attention_head)
+            mixed_x_layer = mixed_x_layer.contiguous().view(*new_tensor_shape)
+
+            # [sq, b, np, 3 * hn] --> 3 [sq, b, np, hn]
+            (query_layer, key_layer, value_layer) = split_tensor_along_last_dim(mixed_x_layer, 3)
+
+        k_cache, v_cache = kv_cache
+        rotary_pos = build_rotary_pos(self.seq_length, self.rotary_dim // 2, dtype=query_layer.dtype, device=query_layer.device)
+        if positions is not None:
+            rotary_pos = rotary_pos[positions]
+        else:
+            rotary_pos = rotary_pos[:query_layer.shape[0]]
+
+        rotary_pos = rotary_pos.unsqueeze(0).transpose(0, 1).contiguous()
+
+        query_layer = apply_rotary_pos_emb(query_layer, rotary_pos).reshape(-1, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+        key_layer = apply_rotary_pos_emb(key_layer, rotary_pos).reshape(-1, self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
+        
+
+        if self.multi_query_attention:
+            key_layer = key_layer.unsqueeze(-2)
+            key_layer = key_layer.expand(
+                -1, -1, self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition, -1
+            )
+            key_layer = key_layer.contiguous().view(
+                key_layer.size()[:1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+            )
+            value_layer = value_layer.unsqueeze(-2)
+            value_layer = value_layer.expand(
+                -1, -1, self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition, -1
+            )
+            value_layer = value_layer.contiguous().view(
+                value_layer.size()[:1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
+            )
+
+        # ==================================
+        # core attention computation
+        # ==================================
+        
+        query_layer = query_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
+        key_layer = key_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
+        value_layer = value_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
+
+        context_layer = self.atten(query_layer, key_layer, value_layer, k_cache, v_cache, input_metadata, cache_event)
+        # =================
+        # Output. [sq, h]
+        # =================
+        output, _ = self.dense(context_layer)
+
+        return output
+
+
+
+class GLMBlock(torch.nn.Module):
+    """A single transformer layer.
+
+    Transformer layer takes input with size [s, b, h] and returns an
+    output of the same size.
+    """
+
+    def __init__(self, config, layer_number):
+        super(GLMBlock, self).__init__()
+        self.layer_number = layer_number
+
+        self.apply_residual_connection_post_layernorm = config.apply_residual_connection_post_layernorm
+
+        LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
+        # Layernorm on the input data.
+        self.input_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
+
+        # Self attention.
+        self.self_attention = SelfAttention(config, layer_number)
+        self.hidden_dropout = config.hidden_dropout
+
+        # Layernorm on the attention output
+        self.post_attention_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
+
+        # MLP
+        self.mlp = MLP(config)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        # hidden_states: [s, b, h]
+        # Layer norm at the beginning of the transformer layer.
+        layernorm_output = self.input_layernorm(hidden_states)
+        # Residual connection.
+        if self.apply_residual_connection_post_layernorm:
+            residual = layernorm_output
+        else:
+            residual = hidden_states
+        # Self attention.
+        hidden_states = self.self_attention(
+            positions=positions,
+            hidden_states=layernorm_output,
+            kv_cache=kv_cache,
+            input_metadata=input_metadata,
+            cache_event=cache_event,
+        )
+
+        layernorm_input = residual + hidden_states
+
+        # Layer norm post the self attention.
+        layernorm_output = self.post_attention_layernorm(layernorm_input)
+
+        # MLP.
+        mlp_output = self.mlp(layernorm_output)
+
+        # Second residual connection.
+        if self.apply_residual_connection_post_layernorm:
+            residual = layernorm_output
+        else:
+            residual = layernorm_input
+
+        output = residual + mlp_output
+
+        return output
+
+
+class GLMTransformer(torch.nn.Module):
+    """Transformer class."""
+
+    def __init__(self, config):
+        super(GLMTransformer, self).__init__()
+
+        self.fp32_residual_connection = config.fp32_residual_connection
+        self.post_layer_norm = config.post_layer_norm
+
+        # Number of layers.
+        self.num_layers = config.num_layers
+
+        # Transformer layers.
+        def build_layer(layer_number):
+            return GLMBlock(config, layer_number)
+
+        self.layers = torch.nn.ModuleList([build_layer(i + 1) for i in range(self.num_layers)])
+
+        if self.post_layer_norm:
+            LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
+            # Final layer norm before output.
+            self.final_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
+
+
+    def _get_layer(self, layer_number):
+        return self.layers[layer_number]
+
+    def forward(
+            self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> torch.Tensor:
+        
+        for index in range(self.num_layers):
+            if cache_events is None:
+                cache_event = None
+            else:
+                cache_event = cache_events[index]
+            layer = self._get_layer(index)
+            hidden_states = layer(
+                positions,
+                hidden_states,
+                kv_caches[index],
+                input_metadata,
+                cache_event
+            )
+
+        # Final layer norm.
+        if self.post_layer_norm:
+            hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states
+
+
+
+class ChatGLMModel(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        vocab_size = 0
+        for k, v in config.to_dict().items():
+            if 'vocab_size' in k:
+                vocab_size = v
+                break
+
+        config.vocab_size = vocab_size
+        self.config = config
+        self.embedding = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+        
+
+        self.num_layers = config.num_layers
+        self.multi_query_group_num = config.multi_query_group_num
+        self.kv_channels = config.kv_channels
+        self.fp32_residual_connection = config.fp32_residual_connection
+
+        # Rotary positional embeddings
+        self.seq_length = config.seq_length
+
+        self.encoder = GLMTransformer(config)
+
+        self.output_layer = ColumnParallelLinear(config.hidden_size,
+                                            config.vocab_size,
+                                            bias=False,
+                                            gather_output=False,
+                                            perform_initialization=False,
+                                            params_dtype=config.torch_dtype)
+        
+        self.sampler = Sampler(config.vocab_size)
+
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> Dict[int, SequenceOutputs]:
+
+        inputs_embeds = self.embedding(input_ids)
+        # If the input flag for fp32 residual connection is set, convert for float.
+        if self.fp32_residual_connection:
+            inputs_embeds = inputs_embeds.float()
+        # Run encoder.
+        hidden_states = self.encoder(
+            positions, inputs_embeds, kv_caches,
+            input_metadata, cache_events)
+        
+        next_tokens = self.sampler(self.output_layer.weight, hidden_states, input_metadata)
+        
+        return next_tokens
+
+    _column_parallel_weights = [
+        "dense_h_to_4h.weight", "query_key_value.weight", "output_layer.weight",
+        "embedding.weight"
+    ]
+    _row_parallel_weights = ["dense_4h_to_h.weight", "dense.weight"]
+
+    def load_weights(self,
+                     model_name_or_path: str,
+                     cache_dir: Optional[str] = None,
+                     use_np_cache: bool = False):
+        
+        tensor_model_parallel_rank = get_tensor_model_parallel_rank()
+        state_dict = self.state_dict()
+
+        for name, loaded_weight in hf_model_weights_iterator(
+                model_name_or_path, cache_dir, use_np_cache):
+            if "rotary_pos_emb.inv_freq" in name:
+                continue
+            
+            name = name.replace("transformer.", "")
+
+            if name.startswith("embedding"):
+                name = name.replace(".word_embeddings", "")
+            
+
+            param = state_dict[name]
+            load_tensor_parallel_weights(param, loaded_weight, name,
+                                         self._column_parallel_weights,
+                                         self._row_parallel_weights,
+                                         tensor_model_parallel_rank)

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -8,28 +8,15 @@ InputMetadata to extract the original 2D shape of the input.
 
 """
 
-import math
-import copy
-import warnings
-import re
 import sys
 
 import torch
 import torch.utils.checkpoint
 import torch.nn.functional as F
-from torch import nn
-from torch.nn import CrossEntropyLoss, LayerNorm
-from torch.nn.utils import skip_init
-from typing import Optional, Tuple, Union, List, Callable, Dict, Any
+from torch.nn import LayerNorm
+from typing import Optional, Tuple, List, Dict
 
-from transformers.modeling_outputs import (
-    BaseModelOutputWithPast,
-    CausalLMOutputWithPast,
-)
-from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import logging
-from transformers.generation.logits_process import LogitsProcessor
-from transformers.generation.utils import LogitsProcessorList, StoppingCriteriaList, GenerationConfig, ModelOutput
 
 # vllm
 from vllm.model_executor.input_metadata import InputMetadata
@@ -39,7 +26,7 @@ from vllm.model_executor.layers.sampler import Sampler
 from vllm.model_executor.weight_utils import (hf_model_weights_iterator,
                                               load_tensor_parallel_weights)
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
+    get_tensor_model_parallel_rank)
 from vllm.model_executor.parallel_utils.tensor_parallel import (
     VocabParallelEmbedding, ColumnParallelLinear, RowParallelLinear)
 from vllm.sequence import SequenceOutputs
@@ -48,7 +35,7 @@ KVCache = Tuple[torch.Tensor, torch.Tensor]
 
 # flags required to enable jit fusion kernels
 
-if sys.platform != 'darwin':
+if sys.platform != "darwin":
     torch._C._jit_set_profiling_mode(False)
     torch._C._jit_set_profiling_executor(False)
     torch._C._jit_override_can_fuse_on_cpu(True)
@@ -61,7 +48,13 @@ CHATGLM_6B_PRETRAINED_MODEL_ARCHIVE_LIST = [
     # See all ChatGLM models at https://huggingface.co/models?filter=chatglm
 ]
 
-def build_rotary_pos(seq_len, n_elem, dtype, device, base: int = 10000, rope_ratio: int=1):
+
+def build_rotary_pos(seq_len,
+                     n_elem,
+                     dtype,
+                     device,
+                     base: int = 10000,
+                     rope_ratio: int = 1):
     theta = 1.0 / (base**(
         torch.arange(0, n_elem, 2, dtype=dtype, device=device) / n_elem))
 
@@ -73,18 +66,19 @@ def build_rotary_pos(seq_len, n_elem, dtype, device, base: int = 10000, rope_rat
 
     cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
 
-    # this is to mimic the behaviour of complex32, else we will get different results
+    # this is to mimic the behaviour of complex32, else we will
+    # get different results
     if dtype in (torch.float16, torch.bfloat16, torch.int8):
         cache = cache.bfloat16() if dtype == torch.bfloat16 else cache.half()
     return cache
 
 
 @torch.jit.script
-def apply_rotary_pos_emb(x: torch.Tensor, 
+def apply_rotary_pos_emb(x: torch.Tensor,
                          rope_cache: torch.Tensor) -> torch.Tensor:
     # x: [sq, np, hn]
     x = x.unsqueeze(1)
-    sq, b, np, hn = x.size(0), x.size(1), x.size(2), x.size(3)
+    sq, _, np, _ = x.size(0), x.size(1), x.size(2), x.size(3)
     rot_dim = rope_cache.shape[-2] * 2
     x, x_pass = x[..., :rot_dim], x[..., rot_dim:]
     # truncate to support variable sizes
@@ -93,9 +87,9 @@ def apply_rotary_pos_emb(x: torch.Tensor,
     rope_cache = rope_cache.view(sq, -1, 1, xshaped.size(3), 2)
     x_out2 = torch.stack(
         [
-            xshaped[..., 0] * rope_cache[..., 0] - 
+            xshaped[..., 0] * rope_cache[..., 0] -
             xshaped[..., 1] * rope_cache[..., 1],
-            xshaped[..., 1] * rope_cache[..., 0] + 
+            xshaped[..., 1] * rope_cache[..., 0] +
             xshaped[..., 0] * rope_cache[..., 1],
         ],
         -1,
@@ -113,11 +107,12 @@ class MLP(torch.nn.Module):
     """
 
     def __init__(self, config):
-        super(MLP, self).__init__()
+        super().__init__()
 
         self.add_bias = config.add_bias_linear
 
-        # Project to 4h. If using swiglu double the output width, see https://arxiv.org/pdf/2002.05202.pdf
+        # Project to 4h. If using swiglu double the output width,
+        #  see https://arxiv.org/pdf/2002.05202.pdf
         self.dense_h_to_4h = ColumnParallelLinear(
             config.hidden_size,
             config.ffn_hidden_size * 2,
@@ -126,7 +121,6 @@ class MLP(torch.nn.Module):
             perform_initialization=False,
             params_dtype=config.torch_dtype)
 
-        
         def swiglu(x):
             x = torch.chunk(x, 2, dim=-1)
             return F.silu(x[0]) * x[1]
@@ -135,12 +129,11 @@ class MLP(torch.nn.Module):
 
         # Project back to h.
         self.dense_4h_to_h = RowParallelLinear(config.ffn_hidden_size,
-                                                config.hidden_size,
-                                                bias=self.add_bias,
-                                                input_is_parallel=True,
-                                                perform_initialization=False,
-                                                params_dtype=config.torch_dtype)
-
+                                               config.hidden_size,
+                                               bias=self.add_bias,
+                                               input_is_parallel=True,
+                                               perform_initialization=False,
+                                               params_dtype=config.torch_dtype)
 
     def forward(self, hidden_states):
         # [s, b, 4hp]
@@ -149,17 +142,16 @@ class MLP(torch.nn.Module):
         # [s, b, h]
         output, _ = self.dense_4h_to_h(intermediate_parallel)
         return output
-    
+
 
 def default_init(cls, *args, **kwargs):
     return cls(*args, **kwargs)
 
 
-
 def split_tensor_along_last_dim(
-        tensor: torch.Tensor,
-        num_partitions: int,
-        contiguous_split_chunks: bool = False,
+    tensor: torch.Tensor,
+    num_partitions: int,
+    contiguous_split_chunks: bool = False,
 ) -> List[torch.Tensor]:
     """Split a tensor along its last dimension.
 
@@ -184,7 +176,6 @@ def split_tensor_along_last_dim(
     return tensor_list
 
 
-
 class SelfAttention(torch.nn.Module):
     """Parallel self-attention layer abstract class.
 
@@ -193,54 +184,54 @@ class SelfAttention(torch.nn.Module):
     """
 
     def __init__(self, config, layer_number):
-        super(SelfAttention, self).__init__()
+        super().__init__()
         self.layer_number = max(1, layer_number)
 
-        self.projection_size = config.kv_channels * config.num_attention_heads
+        self.projection_size = (config.kv_channels *
+                                config.num_attention_heads)
 
         # Per attention head and per partition values.
-        self.hidden_size_per_attention_head = self.projection_size // config.num_attention_heads
+        self.hidden_size_per_attention_head = (self.projection_size //
+                                               config.num_attention_heads)
         self.num_attention_heads_per_partition = config.num_attention_heads
 
-        self.norm_factor = self.hidden_size_per_attention_head ** -0.5
+        self.norm_factor = self.hidden_size_per_attention_head**-0.5
 
-        self.rope_ratio = 1 if ('rope_ratio' not in config.to_dict()) else config.rope_ratio
+        self.rope_ratio = 1 if ("rope_ratio"
+                                not in config.to_dict()) else config.rope_ratio
         self.multi_query_attention = config.multi_query_attention
+
         self.seq_length = config.seq_length
-        self.rotary_dim = (
-            config.hidden_size // config.num_attention_heads if config.kv_channels is None else config.kv_channels
-        )
+        self.rotary_dim = (config.hidden_size // config.num_attention_heads if
+                           config.kv_channels is None else config.kv_channels)
 
         self.qkv_hidden_size = 3 * self.projection_size
         if self.multi_query_attention:
-            self.num_multi_query_groups_per_partition = config.multi_query_group_num
-            self.qkv_hidden_size = (
-                    self.projection_size + 2 * self.hidden_size_per_attention_head * config.multi_query_group_num
-            )
-    
+            self.num_multi_query_groups_per_partition = (
+                config.multi_query_group_num)
+            self.qkv_hidden_size = (self.projection_size +
+                                    2 * self.hidden_size_per_attention_head *
+                                    config.multi_query_group_num)
         self.query_key_value = ColumnParallelLinear(
-                                config.hidden_size,
-                                self.qkv_hidden_size,
-                                bias=config.add_bias_linear or config.add_qkv_bias,
-                                gather_output=False,
-                                perform_initialization=False,
-                                params_dtype=config.torch_dtype
-                            )
-        # rotary_dim=self.hidden_size_per_attention_head
-        self.atten = PagedAttention(config.num_attention_heads, 
-                                            self.hidden_size_per_attention_head, 
-                                            self.norm_factor)
+            config.hidden_size,
+            self.qkv_hidden_size,
+            bias=config.add_bias_linear or config.add_qkv_bias,
+            gather_output=False,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+
+        # num_kv_heads=self.num_multi_query_groups_per_partition
+        # if self.multi_query_attention else config.num_attention_heads
+        self.atten = PagedAttention(config.num_attention_heads,
+                                    self.hidden_size_per_attention_head,
+                                    self.norm_factor)
         # Output.
-        self.dense = RowParallelLinear(
-                        self.projection_size,
-                        config.hidden_size,
-                        bias=config.add_bias_linear,
-                        input_is_parallel=True,
-                        perform_initialization=False,
-                        params_dtype=config.torch_dtype
-                    )
-        # debug
-        # self.core_attention = CoreAttention(config, self.layer_number)
+        self.dense = RowParallelLinear(self.projection_size,
+                                       config.hidden_size,
+                                       bias=config.add_bias_linear,
+                                       input_is_parallel=True,
+                                       perform_initialization=False,
+                                       params_dtype=config.torch_dtype)
 
     def forward(
         self,
@@ -265,33 +256,42 @@ class SelfAttention(torch.nn.Module):
         if self.multi_query_attention:
             (query_layer, key_layer, value_layer) = mixed_x_layer.split(
                 [
-                    self.num_attention_heads_per_partition * self.hidden_size_per_attention_head,
-                    self.num_multi_query_groups_per_partition * self.hidden_size_per_attention_head,
-                    self.num_multi_query_groups_per_partition * self.hidden_size_per_attention_head,
+                    self.num_attention_heads_per_partition *
+                    self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition *
+                    self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition *
+                    self.hidden_size_per_attention_head,
                 ],
                 dim=-1,
             )
             query_layer = query_layer.contiguous().view(
-                query_layer.size()[:-1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
-            )
-            key_layer = key_layer.contiguous().view(
-                key_layer.size()[:-1] + (self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
-            )
+                query_layer.size()[:-1] +
+                (self.num_attention_heads_per_partition,
+                 self.hidden_size_per_attention_head))
+            key_layer = key_layer.contiguous().view(key_layer.size()[:-1] + (
+                self.num_multi_query_groups_per_partition,
+                self.hidden_size_per_attention_head))
             value_layer = value_layer.contiguous().view(
-                value_layer.size()[:-1]
-                + (self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
-            )
+                value_layer.size()[:-1] +
+                (self.num_multi_query_groups_per_partition,
+                 self.hidden_size_per_attention_head))
         else:
-            new_tensor_shape = mixed_x_layer.size()[:-1] + \
-                               (self.num_attention_heads_per_partition,
-                                3 * self.hidden_size_per_attention_head)
+            new_tensor_shape = (mixed_x_layer.size()[:-1] +
+                                (self.num_attention_heads_per_partition,
+                                 3 * self.hidden_size_per_attention_head))
             mixed_x_layer = mixed_x_layer.contiguous().view(*new_tensor_shape)
 
             # [sq, b, np, 3 * hn] --> 3 [sq, b, np, hn]
-            (query_layer, key_layer, value_layer) = split_tensor_along_last_dim(mixed_x_layer, 3)
+            (query_layer, key_layer,
+             value_layer) = split_tensor_along_last_dim(mixed_x_layer, 3)
 
         k_cache, v_cache = kv_cache
-        rotary_pos = build_rotary_pos(self.seq_length, self.rotary_dim // 2, dtype=query_layer.dtype, device=query_layer.device, rope_ratio=self.rope_ratio)
+        rotary_pos = build_rotary_pos(self.seq_length,
+                                      self.rotary_dim // 2,
+                                      dtype=query_layer.dtype,
+                                      device=query_layer.device,
+                                      rope_ratio=self.rope_ratio)
         if positions is not None:
             rotary_pos = rotary_pos[positions]
         else:
@@ -299,42 +299,48 @@ class SelfAttention(torch.nn.Module):
 
         rotary_pos = rotary_pos.unsqueeze(0).transpose(0, 1).contiguous()
 
-        query_layer = apply_rotary_pos_emb(query_layer, rotary_pos).reshape(-1, self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
-        key_layer = apply_rotary_pos_emb(key_layer, rotary_pos).reshape(-1, self.num_multi_query_groups_per_partition, self.hidden_size_per_attention_head)
-        
+        query_layer = apply_rotary_pos_emb(query_layer, rotary_pos).reshape(
+            -1, self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head)
+        key_layer = apply_rotary_pos_emb(key_layer, rotary_pos).reshape(
+            -1, self.num_multi_query_groups_per_partition,
+            self.hidden_size_per_attention_head)
 
         if self.multi_query_attention:
-            key_layer = key_layer.unsqueeze(-2)
-            key_layer = key_layer.expand(
-                -1, -1, self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition, -1
-            )
-            key_layer = key_layer.contiguous().view(
-                key_layer.size()[:1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
-            )
-            value_layer = value_layer.unsqueeze(-2)
-            value_layer = value_layer.expand(
-                -1, -1, self.num_attention_heads_per_partition // self.num_multi_query_groups_per_partition, -1
-            )
-            value_layer = value_layer.contiguous().view(
-                value_layer.size()[:1] + (self.num_attention_heads_per_partition, self.hidden_size_per_attention_head)
-            )
+            key_layer = torch.repeat_interleave(
+                key_layer,
+                self.num_attention_heads_per_partition //
+                self.num_multi_query_groups_per_partition,
+                dim=1)
+            value_layer = torch.repeat_interleave(
+                value_layer,
+                self.num_attention_heads_per_partition //
+                self.num_multi_query_groups_per_partition,
+                dim=1)
 
         # ==================================
         # core attention computation
         # ==================================
-        
-        query_layer = query_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
-        key_layer = key_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
-        value_layer = value_layer.reshape(-1, self.num_attention_heads_per_partition * self.hidden_size_per_attention_head)
 
-        context_layer = self.atten(query_layer, key_layer, value_layer, k_cache, v_cache, input_metadata, cache_event)
+        query_layer = query_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)
+        key_layer = key_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)
+        value_layer = value_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)
+
+        context_layer = self.atten(query_layer, key_layer, value_layer,
+                                   k_cache, v_cache, input_metadata,
+                                   cache_event)
         # =================
         # Output. [sq, h]
         # =================
         output, _ = self.dense(context_layer)
 
         return output
-
 
 
 class GLMBlock(torch.nn.Module):
@@ -345,21 +351,24 @@ class GLMBlock(torch.nn.Module):
     """
 
     def __init__(self, config, layer_number):
-        super(GLMBlock, self).__init__()
+        super().__init__()
         self.layer_number = layer_number
 
-        self.apply_residual_connection_post_layernorm = config.apply_residual_connection_post_layernorm
+        self.apply_residual_connection_post_layernorm = (
+            config.apply_residual_connection_post_layernorm)
 
         LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
         # Layernorm on the input data.
-        self.input_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
+        self.input_layernorm = LayerNormFunc(config.hidden_size,
+                                             eps=config.layernorm_epsilon)
 
         # Self attention.
         self.self_attention = SelfAttention(config, layer_number)
         self.hidden_dropout = config.hidden_dropout
 
         # Layernorm on the attention output
-        self.post_attention_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
+        self.post_attention_layernorm = LayerNormFunc(
+            config.hidden_size, eps=config.layernorm_epsilon)
 
         # MLP
         self.mlp = MLP(config)
@@ -412,7 +421,7 @@ class GLMTransformer(torch.nn.Module):
     """Transformer class."""
 
     def __init__(self, config):
-        super(GLMTransformer, self).__init__()
+        super().__init__()
 
         self.fp32_residual_connection = config.fp32_residual_connection
         self.post_layer_norm = config.post_layer_norm
@@ -424,39 +433,35 @@ class GLMTransformer(torch.nn.Module):
         def build_layer(layer_number):
             return GLMBlock(config, layer_number)
 
-        self.layers = torch.nn.ModuleList([build_layer(i + 1) for i in range(self.num_layers)])
+        self.layers = torch.nn.ModuleList(
+            [build_layer(i + 1) for i in range(self.num_layers)])
 
         if self.post_layer_norm:
             LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
             # Final layer norm before output.
-            self.final_layernorm = LayerNormFunc(config.hidden_size, eps=config.layernorm_epsilon)
-
+            self.final_layernorm = LayerNormFunc(config.hidden_size,
+                                                 eps=config.layernorm_epsilon)
 
     def _get_layer(self, layer_number):
         return self.layers[layer_number]
 
     def forward(
-            self,
+        self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
         cache_events: Optional[List[torch.cuda.Event]],
     ) -> torch.Tensor:
-        
+
         for index in range(self.num_layers):
             if cache_events is None:
                 cache_event = None
             else:
                 cache_event = cache_events[index]
             layer = self._get_layer(index)
-            hidden_states = layer(
-                positions,
-                hidden_states,
-                kv_caches[index],
-                input_metadata,
-                cache_event
-            )
+            hidden_states = layer(positions, hidden_states, kv_caches[index],
+                                  input_metadata, cache_event)
 
         # Final layer norm.
         if self.post_layer_norm:
@@ -464,24 +469,17 @@ class GLMTransformer(torch.nn.Module):
         return hidden_states
 
 
-
 class ChatGLMModel(torch.nn.Module):
+
     def __init__(self, config):
         super().__init__()
-        vocab_size = 0
-        for k, v in config.to_dict().items():
-            if 'vocab_size' in k:
-                vocab_size = v
-                break
 
-        config.vocab_size = vocab_size
         self.config = config
         self.embedding = VocabParallelEmbedding(
             config.vocab_size,
             config.hidden_size,
             perform_initialization=False,
             params_dtype=config.torch_dtype)
-        
 
         self.num_layers = config.num_layers
         self.multi_query_group_num = config.multi_query_group_num
@@ -493,15 +491,15 @@ class ChatGLMModel(torch.nn.Module):
 
         self.encoder = GLMTransformer(config)
 
-        self.output_layer = ColumnParallelLinear(config.hidden_size,
-                                            config.vocab_size,
-                                            bias=False,
-                                            gather_output=False,
-                                            perform_initialization=False,
-                                            params_dtype=config.torch_dtype)
-        
-        self.sampler = Sampler(config.vocab_size)
+        self.output_layer = ColumnParallelLinear(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            gather_output=False,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
 
+        self.sampler = Sampler(config.vocab_size)
 
     def forward(
         self,
@@ -513,21 +511,22 @@ class ChatGLMModel(torch.nn.Module):
     ) -> Dict[int, SequenceOutputs]:
 
         inputs_embeds = self.embedding(input_ids)
-        # If the input flag for fp32 residual connection is set, convert for float.
+        # If the input flag for fp32 residual connection is set,
+        # convert for float.
         if self.fp32_residual_connection:
             inputs_embeds = inputs_embeds.float()
         # Run encoder.
-        hidden_states = self.encoder(
-            positions, inputs_embeds, kv_caches,
-            input_metadata, cache_events)
-        
-        next_tokens = self.sampler(self.output_layer.weight, hidden_states, input_metadata)
-        
+        hidden_states = self.encoder(positions, inputs_embeds, kv_caches,
+                                     input_metadata, cache_events)
+
+        next_tokens = self.sampler(self.output_layer.weight, hidden_states,
+                                   input_metadata)
+
         return next_tokens
 
     _column_parallel_weights = [
-        "dense_h_to_4h.weight", "query_key_value.weight", "output_layer.weight",
-        "embedding.weight"
+        "dense_h_to_4h.weight", "query_key_value.weight",
+        "output_layer.weight", "embedding.weight"
     ]
     _row_parallel_weights = ["dense_4h_to_h.weight", "dense.weight"]
 
@@ -535,7 +534,7 @@ class ChatGLMModel(torch.nn.Module):
                      model_name_or_path: str,
                      cache_dir: Optional[str] = None,
                      use_np_cache: bool = False):
-        
+
         tensor_model_parallel_rank = get_tensor_model_parallel_rank()
         state_dict = self.state_dict()
 
@@ -543,12 +542,11 @@ class ChatGLMModel(torch.nn.Module):
                 model_name_or_path, cache_dir, use_np_cache):
             if "rotary_pos_emb.inv_freq" in name:
                 continue
-            
+
             name = name.replace("transformer.", "")
 
             if name.startswith("embedding"):
                 name = name.replace(".word_embeddings", "")
-            
 
             param = state_dict[name]
             load_tensor_parallel_weights(param, loaded_weight, name,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -26,4 +26,6 @@ def get_config(model: str, trust_remote_code: bool) -> PretrainedConfig:
     if config.model_type in _CONFIG_REGISTRY:
         config_class = _CONFIG_REGISTRY[config.model_type]
         config = config_class.from_pretrained(model)
+    if 'chatglm' in config.model_type:
+        config.num_hidden_layers = config.num_layers
     return config

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -8,6 +8,7 @@ _CONFIG_REGISTRY = {
     "qwen": QWenConfig,
     "RefinedWeb": RWConfig,  # For tiiuae/falcon-40b(-instruct)
     "RefinedWebModel": RWConfig,  # For tiiuae/falcon-7b(-instruct)
+    "chatglm": ChatGLMConfig,
 }
 
 
@@ -29,6 +30,4 @@ def get_config(model: str, trust_remote_code: bool) -> PretrainedConfig:
     if config.model_type in _CONFIG_REGISTRY:
         config_class = _CONFIG_REGISTRY[config.model_type]
         config = config_class.from_pretrained(model)
-    if 'chatglm' in config.model_type:
-        config.num_hidden_layers = config.num_layers
     return config

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -5,10 +5,8 @@ from vllm.transformers_utils.configs.qwen import QWenConfig
 # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
 # `FalconConfig` class from the official HuggingFace transformers library.
 from vllm.transformers_utils.configs.falcon import RWConfig
+from vllm.transformers_utils.configs.chatglm import ChatGLMConfig
 
 __all__ = [
-    "MPTConfig",
-    "BaiChuanConfig",
-    "QWenConfig",
-    "RWConfig",
+    "MPTConfig", "BaiChuanConfig", "QWenConfig", "RWConfig", "ChatGLMConfig"
 ]

--- a/vllm/transformers_utils/configs/chatglm.py
+++ b/vllm/transformers_utils/configs/chatglm.py
@@ -1,0 +1,63 @@
+from transformers import PretrainedConfig
+
+
+class ChatGLMConfig(PretrainedConfig):
+    attribute_map = {
+        "num_hidden_layers": "num_layers",
+    }
+
+    def __init__(
+        self,
+        num_layers=28,
+        padded_vocab_size=65024,
+        hidden_size=4096,
+        ffn_hidden_size=13696,
+        kv_channels=128,
+        num_attention_heads=32,
+        seq_length=2048,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        layernorm_epsilon=1e-5,
+        rmsnorm=True,
+        apply_residual_connection_post_layernorm=False,
+        post_layer_norm=True,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        bias_dropout_fusion=True,
+        multi_query_attention=False,
+        multi_query_group_num=1,
+        apply_query_key_layer_scaling=True,
+        attention_softmax_in_fp32=True,
+        fp32_residual_connection=False,
+        quantization_bit=0,
+        pre_seq_len=None,
+        prefix_projection=False,
+        **kwargs
+    ):
+        self.num_layers = num_layers
+        self.vocab_size = padded_vocab_size
+        self.padded_vocab_size = padded_vocab_size
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.kv_channels = kv_channels
+        self.num_attention_heads = num_attention_heads
+        self.seq_length = seq_length
+        self.hidden_dropout = hidden_dropout
+        self.attention_dropout = attention_dropout
+        self.layernorm_epsilon = layernorm_epsilon
+        self.rmsnorm = rmsnorm
+        self.apply_residual_connection_post_layernorm = (
+            apply_residual_connection_post_layernorm)
+        self.post_layer_norm = post_layer_norm
+        self.add_bias_linear = add_bias_linear
+        self.add_qkv_bias = add_qkv_bias
+        self.bias_dropout_fusion = bias_dropout_fusion
+        self.multi_query_attention = multi_query_attention
+        self.multi_query_group_num = multi_query_group_num
+        self.apply_query_key_layer_scaling = apply_query_key_layer_scaling
+        self.attention_softmax_in_fp32 = attention_softmax_in_fp32
+        self.fp32_residual_connection = fp32_residual_connection
+        self.quantization_bit = quantization_bit
+        self.pre_seq_len = pre_seq_len
+        self.prefix_projection = prefix_projection
+        super().__init__(**kwargs)


### PR DESCRIPTION
Hi repository maintainers! Thanks for your excited work, and I have implemented chatglm2 support for vllm. Here is something you should notice:
-  I register the class as ''ChatGLMModel".
-  I implement the rope and multi-query attention in `chatglm.py` and use the standard `PagedAttention`.

I provide a quick evaluation script as follows:
```
from vllm import LLM, SamplingParams
  
def build_prompt(prompt):
    return "[Round 1]\n\n问：{}\n\n答：".format(prompt)

content = "你好"
prompts = [
    content,
    "晚上睡不着应该怎么办"
]
prompts = [build_prompt(item) for item in prompts]
# edit this model_url
model_url = 'model/chatglm2-6b'

sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=8192)
llm = LLM(model=model_url, gpu_memory_utilization=0.98, dtype="float16", trust_remote_code=True)
outputs = llm.generate(prompts, sampling_params)

# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

You should see the results:
```
Prompt: '[Round 1]\n\n问：你好\n\n答：', Generated text: '你好👋！我是人工智能助手 ChatGLM2-6B，很高兴见到你，欢迎问我任何问题。'
Prompt: '[Round 1]\n\n问：晚上睡不着应该怎么办\n\n答：', Generated text: '以下是一些有助于晚上睡觉的技巧:\n\n1. 建立一个固定的睡眠时间表:每天在相同的时间上床和起床可以帮助身体形成固定的生物钟。\n\n2. 创建一个舒适的睡眠环境:保持房间安静、黑暗、凉爽和舒适可以帮助睡眠。\n\n3. 避免使用电子设备:在睡觉前一小时避免使用电子设备,如手机、电脑、平板等,因为它们可能会干扰睡眠。\n\n4. 放松身心:在睡觉前进行一些放松身心的活动,如泡个热水澡、听轻柔的音乐或进行冥想,有助于缓解压力和焦虑。\n\n5. 限制咖啡因和酒精:避免在睡觉前摄入咖啡因和酒精,因为它们可能会影响睡眠。\n\n6. 远离刺激:避免在睡觉前进行刺激性的活动,如激烈的运动或紧张的任务。\n\n7. 远离躺在床上翻来覆去:如果躺在床上超过20分钟还不能入睡,不要躺在床上翻来覆去,而是起床去做一些平静的活动,如阅读或听轻柔的音乐,直到感到困倦再返回床上。\n\n8. 考虑使用睡眠辅助工具:如果以上方法不能解决问题,可以考虑使用睡眠辅助工具,如睡眠面具、耳塞或鼻塞,但请在使用前咨询医生或专业人士的意见。'
```
They are the same as the original version.
Additionally, I have tested the speed between`chatglm2_vllm` and `chatglm2_original` on A10. For ShareGPT dataset,  `chatglm2_original` achieves 119.3 tokens per second and `chatglm2_vllm` achieves 1015.1 tokens per second. For Chinese dataset(abstractive summarization), `chatglm2_original` achieves 737.3 tokens per second and `chatglm2_vllm` achieves 3317.6 tokens per second. We can see vllm speeds up 8.5x for English and 4.5x for Chinese. The 'tokens' means the sum of 'prompt tokens' and 'output length'.

I also tested the api server speed for Chinese.  `chatglm2_original` achieves 28 generated tokens per second and `chatglm2_vllm` achieves 487 generated tokens per second, which means 17.4x speeds up.

Hi  @zhuohan123 @WoosukKwon, could you please have a quick check? Let me know if there is any problem.

