### PR TITLE
Fix gibberish outputs of GPT-BigCode-based models

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -98,9 +98,11 @@ class ModelConfig:
         # Note: for falcon, when new_decoder_architecture is True, the
         # multi_query flag is ignored and we use n_head_kv for the number of
         # KV heads.
-        if (getattr(self.hf_config, "multi_query", False) and
-            (self.hf_config.model_type == "falcon" and
-             not getattr(self.hf_config, "new_decoder_architecture", False))):
+        new_decoder_arch_falcon = (
+            self.hf_config.model_type == "falcon"
+            and getattr(self.hf_config, "new_decoder_architecture", False))
+        if not new_decoder_arch_falcon and getattr(self.hf_config,
+                                                   "multi_query", False):
             # Multi-query attention, only one KV head.
             return 1
         # For Falcon:


### PR DESCRIPTION
As issue https://github.com/vllm-project/vllm/issues/675 mentioned, GPT-BigCode-based models will produce gibberish outputs.

This is caused by a minor mistake during calculating the number of attention heads. If we are not using a new decoder arch Falcon model and turns on the `multi_query` option, we should return `1` rather than the default `total_num_attention_heads // parallel_config.tensor_parallel_size`.

After applying this patch, I believe at least the following models will work normally (tested on A100 with CUDA 11.8):
- WizardLM/WizardCoder-15B-V1.0
- openchat/opencoderplus
- bigcode/starcoder