### PR TITLE
Improve _prune_hidden_states micro-benchmark

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -100,8 +100,8 @@ def _prune_hidden_states(
         start_idx += prompt_len
     last_token_indicies.extend(
         range(start_idx, start_idx + input_metadata.num_generation_tokens))
-    return hidden_states.index_select(0,
-        torch.tensor(last_token_indicies, device=hidden_states.device))
+    return hidden_states.index_select(
+        0, torch.tensor(last_token_indicies, device=hidden_states.device))
 
 
 def _get_penalties(

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -100,7 +100,8 @@ def _prune_hidden_states(
         start_idx += prompt_len
     last_token_indicies.extend(
         range(start_idx, start_idx + input_metadata.num_generation_tokens))
-    return hidden_states[last_token_indicies]
+    return hidden_states.index_select(0,
+        torch.tensor(last_token_indicies, device=hidden_states.device))
 
 
 def _get_penalties(


### PR DESCRIPTION
I've been poking around the benchmarks for #485, and tried running benchmark_throughput.py and benchmark_latency.py with cProfile and line_profiler.

I noticed this stood out:

```
7201829 function calls (6535053 primitive calls) in 54976.552 seconds                                             
                                                                                                                           
   Ordered by: cumulative time                                                                                             
   List reduced from 2126 to 425 due to restriction <0.2>                                                                  
                                                                                                                           
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)                                                    
        1    0.500    0.500 54974.953 54974.953 benchmark_throughput.py:62(run_vllm)                                       
     1570    9.480    0.006 51565.625   32.844 llm_engine.py:455(_run_workers)                                             
        1   20.178   20.178 41678.349 41678.349 llm.py:142(_run_engine)                                                    
     1567   27.523    0.018 41637.036   26.571 llm_engine.py:291(step)                                                     
     1568   15.519    0.010 39502.196   25.193 _contextlib.py:112(decorate_context)                                        
559776/1568 1352.293    0.002 38986.309   24.864 module.py:1494(_call_impl)                                                
     1568   11.251    0.007 38976.032   24.857 llama.py:245(forward)                                                       
     1567    9.371    0.006 38577.718   24.619 worker.py:256(execute_model)                                                
     1568   47.306    0.030 22080.236   14.082 sampler.py:36(forward)                                                      
     1568 18806.380   11.994 18807.632   11.995 sampler.py:92(_prune_hidden_states)                                        
```

```
Total time: 10.298 s                                                                                                       
File: /mnt/ml/vllm/vllm/model_executor/layers/sampler.py                                                                   
Function: _prune_hidden_states at line 92                                                                                  
                                                                                                                           
Line #      Hits         Time  Per Hit   % Time  Line Contents                                                             
==============================================================                                                             
    92                                           @profile    
    93                                           def _prune_hidden_states(
    94                                               hidden_states: torch.Tensor,
    95                                               input_metadata: InputMetadata,                            
    96                                           ) -> torch.Tensor:                                            
    97      1025        308.2      0.3      0.0      start_idx = 0
    98      1025        281.7      0.3      0.0      last_token_indicies: List[int] = []
    99      1025        601.4      0.6      0.0      for prompt_len in input_metadata.prompt_lens:
   100        40         17.2      0.4      0.0          last_token_indicies.append(start_idx + prompt_len - 1)
   101        40          9.6      0.2      0.0          start_idx += prompt_len                               
   102      1025        901.9      0.9      0.0      last_token_indicies.extend(
   103      1025       1245.8      1.2      0.0          range(start_idx, start_idx + input_metadata.num_generation_tokens))
   104      1025   10294673.2  10043.6    100.0      return hidden_states[last_token_indicies]
```

I put together this micro-benchmark:

```python
from typing import List, Tuple
import torch

def _prune_idx_orig(states: torch.Tensor):
    start_idx = 0
    last_token_indicies: List[int] = []
    num_prompts = 256
    prompt_lens = [10] * num_prompts
    for prompt_len in prompt_lens:
        last_token_indicies.append(start_idx + prompt_len - 1)
        start_idx += prompt_len
    num_generation_tokens = 0
    last_token_indicies.extend(
        range(start_idx, start_idx + num_generation_tokens))
    return last_token_indicies

def _prune_orig(hidden_states: torch.Tensor) -> torch.Tensor:
    last_token_indicies = _prune_idx_orig(hidden_states)
    return hidden_states[last_token_indicies]

def _prune_index_select(hidden_states: torch.Tensor) -> torch.Tensor:
    last_token_indicies = _prune_idx_orig(hidden_states)
    return torch.index_select(hidden_states, 0, torch.tensor(last_token_indicies, device=hidden_states.device))

def test_compare():
    states = torch.randn(2560, 4096)
    orig = _prune_orig(states)
    iselect = _prune_index_select(states)
    assert orig.shape == iselect.shape
    assert torch.equal(orig, iselect)

def test_prune_orig(benchmark):
    states = torch.randn(2560, 4096)
    out = benchmark(_prune_orig, states)
    assert out.shape == torch.Size([256, 4096])

def test_prune_index_select(benchmark):
    states = torch.randn(2560, 4096)
    out = benchmark(_prune_index_select, states)
    assert out.shape == torch.Size([256, 4096])
```

and here were the results:

```
tests/test_sampler.py ...                                                                                           [100%] 
                                                                                                                           
                                                                                                                           
------------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------------                                               
Name (time in us)                Min                 Max                Mean             StdDev              Median                 IQR            Outliers  OPS (Kops/s)            Rounds  Iterations                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                               
test_prune_index_select     234.3490 (1.0)      315.7800 (1.0)      241.4404 (1.0)       5.0820 (1.0)      239.8520 (1.0)        4.1093 (1.0)       348;155        4.1418 (1.0)        2163           1                                               
test_prune_orig             239.8870 (1.02)     635.8810 (2.01)     322.2837 (1.33)     63.5578 (12.51)    362.2425 (1.51)     122.5505 (29.82)       649;3        3.1029 (0.75)       1392           1                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------                                               
                                                                                                                           
Legend:                                                                                                                    
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.              
  OPS: Operations Per Second, computed as 1 / Mean                                                                         
==================================================== 3 passed in 3.12s====================================================
```

based on that I made the same change here in this PR.

i'm relatively new to python and pytorch ecosystem, so let me know if i've made a mistake here or am overlooking something

cc https://stackoverflow.com/questions/59344751/is-there-any-diffrence-between-index-select-and-tensorsequence-in-pytorch
cc pytorch/pytorch#13420