### PR TITLE
Supports tokens and arrays of tokens as inputs to the OpenAI completion API

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -397,7 +397,7 @@ async def create_completion(raw_request: Request):
         if isinstance(first_element, int):
             use_token_ids = True
             prompt = request.prompt
-        elif isinstance(first_element, str) or isinstance(first_element, list):
+        elif isinstance(first_element, (str, list)):
             # TODO: handles multiple prompt case in list[list[int]]
             if len(request.prompt) > 1:
                 return create_error_response(
@@ -409,9 +409,13 @@ async def create_completion(raw_request: Request):
         prompt = request.prompt
 
     if use_token_ids:
-        token_ids, error_check_ret = await check_length(request, prompt_ids=prompt)
+        token_ids, error_check_ret = await check_length(
+            request, prompt_ids=prompt
+        )
     else:
-        token_ids, error_check_ret = await check_length(request, prompt=prompt)
+        token_ids, error_check_ret = await check_length(
+            request, prompt=prompt
+        )
     if error_check_ret is not None:
         return error_check_ret
 
@@ -435,7 +439,9 @@ async def create_completion(raw_request: Request):
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
     if use_token_ids:
-        result_generator = engine.generate(None, sampling_params, request_id, prompt_token_ids=prompt)
+        result_generator = engine.generate(
+            None, sampling_params, request_id, prompt_token_ids=prompt
+        )
     else:
         result_generator = engine.generate(prompt, sampling_params, request_id)
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -409,7 +409,7 @@ async def create_completion(raw_request: Request):
         prompt = request.prompt
 
     if use_token_ids:
-        token_ids, error_check_ret = await check_length(
+        _, error_check_ret = await check_length(
             request, prompt_ids=prompt
         )
     else:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -116,14 +116,13 @@ async def get_gen_prompt(request) -> str:
 
 
 async def check_length(
-        request: Union[ChatCompletionRequest, CompletionRequest],
-        prompt: Optional[str] = None,
-        prompt_ids: Optional[List[int]] = None
+    request: Union[ChatCompletionRequest, CompletionRequest],
+    prompt: Optional[str] = None,
+    prompt_ids: Optional[List[int]] = None
 ) -> Tuple[List[int], Optional[JSONResponse]]:
-    assert (
-        not (prompt is None and prompt_ids is None)
-        and not (prompt is not None and prompt_ids is not None)
-    ), "Either prompt or prompt_ids should be provided."
+    assert (not (prompt is None and prompt_ids is None)
+            and not (prompt is not None and prompt_ids is not None)
+            ), "Either prompt or prompt_ids should be provided."
     if prompt_ids is not None:
         input_ids = prompt_ids
     else:
@@ -409,13 +408,9 @@ async def create_completion(raw_request: Request):
         prompt = request.prompt
 
     if use_token_ids:
-        _, error_check_ret = await check_length(
-            request, prompt_ids=prompt
-        )
+        _, error_check_ret = await check_length(request, prompt_ids=prompt)
     else:
-        token_ids, error_check_ret = await check_length(
-            request, prompt=prompt
-        )
+        token_ids, error_check_ret = await check_length(request, prompt=prompt)
     if error_check_ret is not None:
         return error_check_ret
 
@@ -439,11 +434,13 @@ async def create_completion(raw_request: Request):
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
     if use_token_ids:
-        result_generator = engine.generate(
-            None, sampling_params, request_id, prompt_token_ids=prompt
-        )
+        result_generator = engine.generate(None,
+                                           sampling_params,
+                                           request_id,
+                                           prompt_token_ids=prompt)
     else:
-        result_generator = engine.generate(prompt, sampling_params, request_id)
+        result_generator = engine.generate(prompt, sampling_params, request_id,
+                                           token_ids)
 
     # Similar to the OpenAI API, when n != best_of, we do not stream the
     # results. In addition, we do not stream the results when use beam search.

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -100,7 +100,8 @@ class LogProbs(BaseModel):
     text_offset: List[int] = Field(default_factory=list)
     token_logprobs: List[Optional[float]] = Field(default_factory=list)
     tokens: List[str] = Field(default_factory=list)
-    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str,
+                                     float]]] = Field(default_factory=list)
 
 
 class CompletionResponseChoice(BaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -74,7 +74,8 @@ class ChatCompletionRequest(BaseModel):
 
 class CompletionRequest(BaseModel):
     model: str
-    prompt: Union[str, List[str]]
+    # a string, array of strings, array of tokens, or array of token arrays
+    prompt: Union[List[int], List[List[int]], str, List[str]]
     suffix: Optional[str] = None
     max_tokens: Optional[int] = 16
     temperature: Optional[float] = 1.0
@@ -99,8 +100,7 @@ class LogProbs(BaseModel):
     text_offset: List[int] = Field(default_factory=list)
     token_logprobs: List[Optional[float]] = Field(default_factory=list)
     tokens: List[str] = Field(default_factory=list)
-    top_logprobs: List[Optional[Dict[str,
-                                     float]]] = Field(default_factory=list)
+    top_logprobs: List[Optional[Dict[str, float]]] = Field(default_factory=list)
 
 
 class CompletionResponseChoice(BaseModel):


### PR DESCRIPTION
According to [the completion API doc](https://platform.openai.com/docs/api-reference/completions/create), the API supports **a string, array of strings, array of tokens, or array of token arrays**. At the moment, the API only supports `str | list[str]`. 

In this PR, I made the following modifications:
- extended the model protocol to support deserializing all these types in `CompletionRequest`
- changed the completion API to detect the input type and respond accordingly

The PR has been rebased on the latest main, reformatted, and passed all tests.