### PR TITLE
Fix baichuan doc style

### DIFF
--- a/docs/source/models/supported_models.rst
+++ b/docs/source/models/supported_models.rst
@@ -16,7 +16,7 @@ Alongside each architecture, we include some popular models that use it.
     - Example HuggingFace Models
   * - :code:`BaiChuanForCausalLM`
     - Baichuan
-    - :code:`baichuan-inc/Baichuan-7B`, `baichuan-inc/Baichuan-13B-Chat`, etc.
+    - :code:`baichuan-inc/Baichuan-7B`, :code:`baichuan-inc/Baichuan-13B-Chat`, etc.
   * - :code:`BloomForCausalLM`
     - BLOOM, BLOOMZ, BLOOMChat
     - :code:`bigscience/bloom`, :code:`bigscience/bloomz`, etc.


### PR DESCRIPTION
Fix the style issue of baichuan in the [supported models](https://vllm.readthedocs.io/en/latest/models/supported_models.html) page.