### PR TITLE
Align with huggingface Top K sampling

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -78,7 +78,7 @@ class Sampler(nn.Module):
         do_top_k = any(k != self.vocab_size for k in top_ks)
         if do_top_p or do_top_k:
             logits = _apply_top_p_top_k(logits, top_ps, top_ks)
-        
+
         # We use float32 for probabilities and log probabilities.
         # Compute the probabilities.
         probs = torch.softmax(logits, dim=-1, dtype=torch.float)
@@ -301,8 +301,7 @@ def _sample_from_prompt(
         # Random sampling.
         # Sample `best_of` tokens for the prompt.
         num_seqs = sampling_params.best_of
-        next_token_ids = torch.multinomial(prob,
-                                           num_samples=num_seqs)
+        next_token_ids = torch.multinomial(prob, num_samples=num_seqs)
         next_token_ids = next_token_ids.tolist()
     return next_token_ids
 

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -71,19 +71,19 @@ class Sampler(nn.Module):
             # Use in-place division to avoid creating a new tensor.
             logits.div_(t.unsqueeze(dim=1))
 
+        # Apply top-p and top-k truncation.
+        top_ps, top_ks = _get_top_p_top_k(input_metadata, self.vocab_size)
+        assert len(top_ps) == len(top_ks) == logits.shape[0]
+        do_top_p = any(p < 1.0 - _SAMPLING_EPS for p in top_ps)
+        do_top_k = any(k != self.vocab_size for k in top_ks)
+        if do_top_p or do_top_k:
+            logits = _apply_top_p_top_k(logits, top_ps, top_ks)
+        
         # We use float32 for probabilities and log probabilities.
         # Compute the probabilities.
         probs = torch.softmax(logits, dim=-1, dtype=torch.float)
         # Compute the log probabilities (before applying top-p and top-k).
         logprobs = torch.log(probs)
-
-        # Apply top-p and top-k truncation.
-        top_ps, top_ks = _get_top_p_top_k(input_metadata, self.vocab_size)
-        assert len(top_ps) == len(top_ks) == probs.shape[0]
-        do_top_p = any(p < 1.0 - _SAMPLING_EPS for p in top_ps)
-        do_top_k = any(k != self.vocab_size for k in top_ks)
-        if do_top_p or do_top_k:
-            probs = _apply_top_p_top_k(probs, top_ps, top_ks)
 
         # Sample the next tokens.
         return _sample(probs, logprobs, input_metadata)
@@ -244,16 +244,16 @@ def _apply_top_p_top_k(
     probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
 
     # Apply top-p.
-    probs_sum = torch.cumsum(probs_sort, dim=-1)
-    top_p_mask = (probs_sum - probs_sort) > p.unsqueeze(dim=1)
-    probs_sort[top_p_mask] = 0.0
+    probs_sum = probs_sort.softmax(dim=-1).cumsum(dim=-1)
+    top_p_mask = (probs_sum - probs_sort.softmax(dim=-1)) > p.unsqueeze(dim=1)
+    probs_sort[top_p_mask] = -float("Inf")
 
     # Apply top-k.
     # Create a mask for the top-k elements.
     top_k_mask = torch.arange(probs_idx.shape[-1], device=probs_idx.device)
     top_k_mask = top_k_mask.expand(probs_idx.shape[0], -1)
     top_k_mask = top_k_mask >= k.unsqueeze(dim=1)
-    probs_sort[top_k_mask] = 0.0
+    probs_sort[top_k_mask] = -float("Inf")
 
     # Re-sort the probabilities.
     probs = torch.gather(probs_sort,
@@ -302,8 +302,7 @@ def _sample_from_prompt(
         # Sample `best_of` tokens for the prompt.
         num_seqs = sampling_params.best_of
         next_token_ids = torch.multinomial(prob,
-                                           num_samples=num_seqs,
-                                           replacement=True)
+                                           num_samples=num_seqs)
         next_token_ids = next_token_ids.tolist()
     return next_token_ids
 


### PR DESCRIPTION
**main modifications**
all modifications are in vllm/model_executor/layers/sampler.py
1. Reverse the order of softmax and _apply_top_p_top_k function in forward function of class Sampler. So the _apply_top_p_top_k will use logits as input instead of probabilites.
2. In _apply_top_p_top_k function, it computes the temporary probabilities ( softmax of logits ) firstly for the top_p process to locate the indexes whose cumulative probability exceeds the probability p. ( ATTENTION: the output of _apply_top_p_top_k function is still logits instead of probabilities. This is the main difference from the original code. )
3. Change the top_p and top_k masked probability value from 0 to -float("Inf").
4. In _sample_from_prompt function, use torch.multinomial without parameter "replacement=True".

**tested result**
The input probabilites distribution of torch.multinomial for the first token is the same as for huggingface/transformers under the same weights and input sentence.

test code:
huggingface/transformers
```
PATH_TO_CONVERTED_WEIGHTS="/data/xutianci/llama_hf/"
PATH_TO_CONVERTED_TOKENIZER="/data/xutianci/vllm/llama-tokenizer/"

from transformers import AutoTokenizer,  AutoModelForCausalLM
import torch
import numpy as np

model = AutoModelForCausalLM.from_pretrained(PATH_TO_CONVERTED_WEIGHTS)
tokenizer = AutoTokenizer.from_pretrained(PATH_TO_CONVERTED_TOKENIZER)

prompt = "Hello, my name is"
inputs = tokenizer(prompt, return_tensors="pt")
print(f'inputs={inputs}')

# Generate
generate_ids = model.generate(inputs.input_ids, do_sample=True, max_new_tokens=1)
print(f'generate_ids={generate_ids}')
output = tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
print(f'output={output}')
```

vllm
```
from vllm import LLM, SamplingParams
import torch
import numpy as np

prompts = [
    "Hello, my name is",
]
sampling_params = SamplingParams(top_k=50, max_tokens=1)

llm = LLM(model="/data/xutianci/llama_hf/", tokenizer="/data/xutianci/vllm/llama-tokenizer/")

outputs = llm.generate(prompts, sampling_params)

# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```

**related issue**
[https://github.com/vllm-project/vllm/issues/718](url)