### PR TITLE
explicitly del state

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -76,6 +76,8 @@ def hf_model_weights_iterator(
             state = torch.load(bin_file, map_location="cpu")
             for name, param in state.items():
                 yield name, param
+            del state
+            torch.cuda.empty_cache()
 
 
 def load_tensor_parallel_weights(


### PR DESCRIPTION
improvement to the memory management on machines with low CPU memory. Previously, the state variable was not explicitly deleted after its use, potentially leading to killed when you loading a big model in low cpu mem meachine.