### PR TITLE
support prefix-tunning

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -39,6 +39,7 @@ class ModelConfig:
         tokenizer: str,
         tokenizer_mode: str,
         trust_remote_code: bool,
+        adpater_model_and_path,
         download_dir: Optional[str],
         use_np_weights: bool,
         use_dummy_weights: bool,
@@ -49,6 +50,7 @@ class ModelConfig:
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode
         self.trust_remote_code = trust_remote_code
+        self.adpater_model_and_path = adpater_model_and_path
         self.download_dir = download_dir
         self.use_np_weights = use_np_weights
         self.use_dummy_weights = use_dummy_weights
@@ -165,6 +167,7 @@ class CacheConfig:
         # Will be set after profiling.
         self.num_gpu_blocks = None
         self.num_cpu_blocks = None
+        self.cache_engine = None
 
     def _verify_args(self) -> None:
         if self.gpu_memory_utilization > 1.0:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -13,6 +13,7 @@ class EngineArgs:
     model: str
     tokenizer: Optional[str] = None
     tokenizer_mode: str = 'auto'
+    adapter_model_and_path = None
     trust_remote_code: bool = False
     download_dir: Optional[str] = None
     use_np_weights: bool = False
@@ -146,6 +147,7 @@ class EngineArgs:
         # Initialize the configs.
         model_config = ModelConfig(self.model, self.tokenizer,
                                    self.tokenizer_mode, self.trust_remote_code,
+                                   self.adapter_model_and_path,
                                    self.download_dir, self.use_np_weights,
                                    self.use_dummy_weights, self.dtype,
                                    self.seed)

--- a/vllm/model_executor/__init__.py
+++ b/vllm/model_executor/__init__.py
@@ -1,9 +1,14 @@
 from vllm.model_executor.input_metadata import InputMetadata
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.utils import set_random_seed
+from vllm.model_executor.adapters import PrefixEncoder, set_prefix_encoder,get_prefix_encoder,get_prefix_tuning_encoder
 
 __all__ = [
     "InputMetadata",
     "get_model",
     "set_random_seed",
+    "PrefixEncoder",
+    "set_prefix_encoder",
+    "get_prefix_encoder",
+    "get_prefix_tuning_encoder",
 ]

--- a/vllm/model_executor/adapters/prefix_encoder.py
+++ b/vllm/model_executor/adapters/prefix_encoder.py
@@ -1,0 +1,169 @@
+# coding=utf-8
+import os
+import torch
+from safetensors.torch import load_file as safe_load_file
+from peft import (
+    PeftType,
+    PeftConfig,
+    PromptLearningConfig,
+    mapping,
+    utils,
+)
+from vllm import cache_ops
+from vllm.model_executor.parallel_utils.parallel_state import (
+    get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
+
+def set_prefix_encoder(adpater_model_and_path):
+    global prefix_encoder
+    try:
+        if prefix_encoder is not None:
+            pass
+    except Exception as e:
+        if isinstance(adpater_model_and_path,str):
+            prefix_encoder = PrefixEncoder(adpater_model_and_path)
+        elif isinstance(adpater_model_and_path, PrefixEncoder):
+            prefix_encoder = adpater_model_and_path
+
+def get_prefix_encoder():
+    try:
+        return prefix_encoder
+    except Exception as e:
+        return None
+    
+def get_prefix_tuning_encoder():
+    try:
+        if prefix_encoder.prefix_tunning:
+            return prefix_encoder
+        else:
+            return None
+    except Exception as e:
+        return None
+    
+    
+
+class PrefixEncoder(object):
+    def __init__(self, adpater_model_and_path = None) -> None:
+        if adpater_model_and_path and os.path.isfile(os.path.join(adpater_model_and_path, "adapter_config.json")):
+            self.init_with_peft_format(adpater_model_and_path)
+        self.kv_cache = None
+    
+    def custom_init(self, prompt_embedding,                 
+                        num_virtual_tokens, num_layers,
+                        num_attention_heads, prefix_tunning):
+        self.prompt_embedding = prompt_embedding.half().cuda()
+        self.num_virtual_tokens = num_virtual_tokens
+        self.num_layers = num_layers
+        self.num_attention_heads = num_attention_heads
+        self.prefix_tunning = prefix_tunning
+
+    def init_with_peft_format(self,peft_model_id):
+        self.peft_config = mapping.PEFT_TYPE_TO_CONFIG_MAPPING[
+                PeftConfig._get_peft_type(
+                    peft_model_id,
+                )
+            ].from_pretrained(
+                peft_model_id,
+            )
+        assert isinstance(self.peft_config, PromptLearningConfig)
+        self.num_virtual_tokens = self.peft_config.num_virtual_tokens
+        self.num_layers = self.peft_config.num_layers
+        self.num_attention_heads = self.peft_config.num_attention_heads
+        self.prefix_tunning = self.peft_config.peft_type == PeftType.PREFIX_TUNING
+        torch_device = "cuda" if torch.cuda.is_available() else "cpu"
+        if os.path.exists(os.path.join(peft_model_id, utils.SAFETENSORS_WEIGHTS_NAME)):
+            filename = os.path.join(peft_model_id, utils.SAFETENSORS_WEIGHTS_NAME)
+            use_safetensors = True
+        elif os.path.exists(os.path.join(peft_model_id, utils.WEIGHTS_NAME)):
+            filename = os.path.join(peft_model_id, utils.WEIGHTS_NAME)
+            use_safetensors = False
+        if use_safetensors:
+            adapters_weights = safe_load_file(filename, device=torch_device)
+        else:
+            adapters_weights = torch.load(filename, map_location=torch.device(torch_device))
+        self.prompt_embedding = adapters_weights["prompt_embeddings"].half()
+        
+    @property
+    def num_virtual_token_blocks(self):
+        return (self.num_virtual_tokens + self.block_size -1) // self.block_size
+    
+    def write_prompt_embedding_into_kvcache(self,gpu_allocator, gpu_cache, block_size):
+        assert self.prefix_tunning,"only prefix embedding need write_prompt_embedding_into_kvcache."
+        self.block_size = block_size
+        prompt_embedding_table = []
+        for _ in range(self.num_virtual_tokens_blocks):
+            block = gpu_allocator.allocate()
+            prompt_embedding_table.append(block)
+                
+        slot_mapping = []
+        for i in range(self.num_virtual_tokens):
+            block_number = prompt_embedding_table[i // self.block_size].block_number
+            block_offset = i % self.block_size
+            slot = block_number * self.block_size + block_offset
+            slot_mapping.append(slot)
+        slot_mapping = torch.cuda.IntTensor(slot_mapping)
+        
+        for layer_index,(key_cache, value_cache) in enumerate(gpu_cache):
+            cache_k, cache_v = self.kv_cache[layer_index][:,0],self.kv_cache[layer_index][:,1]
+            cache_ops.reshape_and_cache(
+                cache_k,
+                cache_v,
+                key_cache,
+                value_cache,
+                slot_mapping,
+            )
+        return prompt_embedding_table
+
+    
+    def cat_prompt_embedding_with_input_embedding(self, inputs_embeds, prompt_lens):
+        if not self.prefix_tunning:
+            new_inputs_embeds = torch.empty(inputs_embeds.shape[0]+self.num_virtual_tokens*len(prompt_lens), *inputs_embeds.shape[1:])
+            start,end = 0,0
+            new_start,new_end = 0,0
+            for prompt_len in prompt_lens:
+                end += prompt_len
+                new_end += prompt_len + self.num_virtual_tokens
+                index = torch.range(new_start,new_start+ self.num_virtual_tokens-1, 
+                                    device = inputs_embeds.device, dtype=torch.long)
+            
+                #get_tensor_model_parallel_rank 取对应的num_heads
+                new_inputs_embeds.index_copy_(0,index,self.prompt_embedding)
+                index = torch.range(new_start + self.num_virtual_tokens, new_end -1, 
+                                    device = inputs_embeds.device, dtype=torch.long)
+                new_inputs_embeds.index_copy_(0,index ,inputs_embeds[start:end])
+                start += prompt_len
+                new_start = start + self.num_virtual_tokens
+            return new_inputs_embeds
+        
+    def cat_prompt_with_key_value(self, layer_index, prompt_lens, key, value):
+        if self.prefix_tunning:
+            if self.kv_cache is None:
+                self.prompt_embedding = self.prompt_embedding.view(self.num_virtual_tokens, 2*self.num_layers, self.num_attention_heads, -1)
+                self.kv_cache = self.prompt_embedding.split(2,dim=1)
+            new_key = torch.empty(size=(key.shape[0]+self.num_virtual_tokens * len(prompt_lens),
+                                        *key.shape[1:]),
+                                dtype = key.dtype,
+                                device = key.device)
+            new_value = torch.empty(size=(value.shape[0]+self.num_virtual_tokens * len(prompt_lens),
+                                        *value.shape[1:]),
+                                dtype = value.dtype,
+                                device = value.device)
+            start,end = 0,0
+            new_start,new_end = 0,0
+            cache_k, cache_v = self.kv_cache[layer_index][:,0],self.kv_cache[layer_index][:,1]
+            for prompt_len in prompt_lens:
+                end += prompt_len
+                new_end += prompt_len + self.num_virtual_tokens
+                index = torch.range(new_start,new_start+ self.num_virtual_tokens-1, 
+                                    device = key.device, dtype=torch.long)
+                new_start += self.num_virtual_tokens
+                #get_tensor_model_parallel_rank 取对应的num_heads
+                new_key.index_copy_(0,index,cache_k)
+                new_value.index_copy_(0,index,cache_v)
+                index = torch.range(new_start, new_end -1, 
+                                    device = key.device, dtype=torch.long)
+                new_key.index_copy_(0,index ,key[start:end])
+                new_value.index_copy_(0,index,value[start:end])
+                
+                start += prompt_len
+                new_start += prompt_len
+            return new_key,new_value

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -56,4 +56,4 @@ def get_model(model_config: ModelConfig) -> nn.Module:
         model.load_weights(model_config.model, model_config.download_dir,
                            model_config.use_np_weights)
         model = model.cuda()
-    return model.eval()
+    return model.eval(),set_adapter_model(model.adaper_model_and_path)


### PR DESCRIPTION
hi guys,
We found that infer with vllm can greatly improve performance! But we need to use p-tunning prefix-tunning prompt-tunning for peft model or custom prefix encoder in inference.
We also found that the community has a strong demand for prefixtuning. https://github.com/vllm-project/vllm/issues/660


So we added an prefix-tunning for opt. The following is an example of use:
```
from vllm import LLM, SamplingParams
from vllm.model_executor.adapters import lora

# Create an LLM.
llm = LLM(model="facebook/opt-125m", adpater_model_and_path='your pet_model_id')

prompts = [
    "Hello, my name is",
    "The capital of France is",
    "The future of AI is",
]

sampling_params = SamplingParams(temperature=0, top_k=-1)

outputs = llm.generate(prompts, sampling_params)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```
Currently supports  ptunning prefixtunning prompttunning for peft model or custom prefix encoder， but only support  the  opt model