### PR TITLE
[tokenizer][wip] decouple tokenizer from the main scheduling thread

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -7,7 +7,9 @@ import torch
 from tqdm import tqdm
 
 from vllm import LLM, SamplingParams
+import os
 
+os.environ["TRANSFORMERS_CACHE"] = '/mnt/local_storage/'
 
 def main(args: argparse.Namespace):
     print(args)
@@ -22,6 +24,7 @@ def main(args: argparse.Namespace):
         max_num_seqs=args.batch_size,
         max_num_batched_tokens=args.batch_size * args.input_len,
         trust_remote_code=args.trust_remote_code,
+        use_dummy_weights=True,
     )
 
     sampling_params = SamplingParams(

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -6,7 +6,6 @@ from vllm.config import CacheConfig, SchedulerConfig
 from vllm.core.block_manager import BlockSpaceManager
 from vllm.core.policy import PolicyFactory
 from vllm.logger import init_logger
-from vllm.sampling_params import SamplingParams
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceOutputs,
                            SequenceStatus)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -9,7 +9,6 @@ from vllm.logger import init_logger
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceOutputs,
                            SequenceStatus)
-from vllm.transformers_utils.tokenizer import  Detokenizer
 
 logger = init_logger(__name__)
 
@@ -61,7 +60,6 @@ class Scheduler:
         self,
         scheduler_config: SchedulerConfig,
         cache_config: CacheConfig,
-        detokenizer: Detokenizer,
     ) -> None:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
@@ -74,7 +72,6 @@ class Scheduler:
             num_gpu_blocks=self.cache_config.num_gpu_blocks,
             num_cpu_blocks=self.cache_config.num_cpu_blocks,
         )
-        self.detokenizer = detokenizer
 
         # Sequence groups in the WAITING state.
         self.waiting: List[SequenceGroup] = []
@@ -309,7 +306,6 @@ class Scheduler:
     def free_seq(self, seq: Sequence, finish_status: SequenceStatus) -> None:
         seq.status = finish_status
         self.block_manager.free(seq)
-        self.detokenizer.free_sequence(seq.seq_id)
 
     def free_finished_seq_groups(self) -> None:
         self.running = [

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,7 +24,7 @@ class EngineArgs:
     tensor_parallel_size: int = 1
     block_size: int = 16
     swap_space: int = 4  # GiB
-    gpu_memory_utilization: float = 0.90
+    gpu_memory_utilization: float = 0.30
     max_num_batched_tokens: int = 2560
     max_num_seqs: int = 256
     disable_log_stats: bool = False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,7 +24,7 @@ class EngineArgs:
     tensor_parallel_size: int = 1
     block_size: int = 16
     swap_space: int = 4  # GiB
-    gpu_memory_utilization: float = 0.30
+    gpu_memory_utilization: float = 0.90
     max_num_batched_tokens: int = 2560
     max_num_seqs: int = 256
     disable_log_stats: bool = False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -26,7 +26,7 @@ class EngineArgs:
     swap_space: int = 4  # GiB
     gpu_memory_utilization: float = 0.90
     max_num_batched_tokens: int = 2560
-    max_num_seqs: int = 256
+    max_num_seqs: int = 256 
     disable_log_stats: bool = False
 
     def __post_init__(self):

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -13,7 +13,9 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import Sequence, SequenceGroup, SequenceStatus
 from vllm.transformers_utils.tokenizer import (get_tokenizer,
-                                               Detokenizer)
+                                               Detokenizer,
+                                               DummyDetokenizer,
+                                               ThreadedDetokenizer)
 from vllm.utils import Counter
 
 if ray:
@@ -93,7 +95,7 @@ class LLMEngine:
             tokenizer_mode=model_config.tokenizer_mode,
             trust_remote_code=model_config.trust_remote_code)
 
-        self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -95,8 +95,9 @@ class LLMEngine:
             tokenizer_mode=model_config.tokenizer_mode,
             trust_remote_code=model_config.trust_remote_code)
 
-        self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
+        #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
         #self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -95,7 +95,8 @@ class LLMEngine:
             tokenizer_mode=model_config.tokenizer_mode,
             trust_remote_code=model_config.trust_remote_code)
 
-        self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
+        #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -15,7 +15,7 @@ from vllm.sequence import Sequence, SequenceGroup, SequenceStatus
 from vllm.transformers_utils.tokenizer import (get_tokenizer,
                                                Detokenizer,
                                                DummyDetokenizer,
-                                               ThreadedDetokenizer)
+                                               RayDetokenizer)
 from vllm.utils import Counter
 
 if ray:
@@ -95,8 +95,12 @@ class LLMEngine:
             tokenizer_mode=model_config.tokenizer_mode,
             trust_remote_code=model_config.trust_remote_code)
 
-        #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
-        self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = RayDetokenizer(
+            tokenizer_creator=lambda: get_tokenizer(
+                model_config.tokenizer,
+                tokenizer_mode=model_config.tokenizer_mode,
+                trust_remote_code=model_config.trust_remote_code))
+        #self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
         #self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -96,8 +96,8 @@ class LLMEngine:
             trust_remote_code=model_config.trust_remote_code)
 
         #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
-        self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
-        #self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
+        #self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -422,19 +422,19 @@ class LLMEngine:
             sampling_params = seq_group.sampling_params
             for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
                 # Check if the sequence has generated a stop string.
-                stopped = False
                 for stop_str in sampling_params.stop:
                     if seq.output_text.endswith(stop_str):
                         # Truncate the output text so that the stop string is
                         # not included in the output.
                         seq.output_text = seq.output_text[:-len(stop_str)]
-                        self.scheduler.free_seq(
-                            seq, SequenceStatus.FINISHED_STOPPED)
-                        stopped = True
+                        seq.stop_string_matched
                         break
-                if stopped:
-                    continue
 
+                # Check if the sequence has generated a stop string.
+                if seq.stop_string_matched:
+                    self.scheduler.free_seq(
+                        seq, SequenceStatus.FINISHED_STOPPED)
+                    continue
                 # Check if the sequence has reached max_model_len.
                 if seq.get_len() > self.scheduler_config.max_model_len:
                     self.scheduler.free_seq(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -95,8 +95,8 @@ class LLMEngine:
             tokenizer_mode=model_config.tokenizer_mode,
             trust_remote_code=model_config.trust_remote_code)
 
-        #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
-        self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
+        #self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -96,8 +96,8 @@ class LLMEngine:
             trust_remote_code=model_config.trust_remote_code)
 
         #self.detokenizer = ThreadedDetokenizer(tokenizer=self.tokenizer)
-        #self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
-        self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
+        self.detokenizer = DummyDetokenizer(tokenizer=self.tokenizer)
+        #self.detokenizer = Detokenizer(tokenizer=self.tokenizer)
         self.seq_counter = Counter()
 
         # Create the parallel GPU workers.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -409,7 +409,7 @@ class LLMEngine:
         """Decodes the sequence outputs."""
         for seq_group in seq_groups:
             for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
-                self.detokenizer.detokenize_last_token(seq, seq.get_last_token_id())
+                self.detokenizer.detokenize_last_token(seq.seq_id, seq.get_last_token_id())
 
     def _stop_sequences(self, seq_groups: List[SequenceGroup]) -> None:
         """Stop the finished sequences."""

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Optional
 
 from vllm.sequence import SequenceGroup, SequenceStatus
+from vllm.transformers_utils.tokenizer import Detokenizer
 
 
 class CompletionOutput:
@@ -71,7 +72,7 @@ class RequestOutput:
         self.finished = finished
 
     @classmethod
-    def from_seq_group(cls, seq_group: SequenceGroup) -> "RequestOutput":
+    def from_seq_group(cls, seq_group: SequenceGroup, detokenizer: Detokenizer) -> "RequestOutput":
         # Get the top-n sequences.
         n = seq_group.sampling_params.n
         seqs = seq_group.get_seqs()
@@ -91,7 +92,7 @@ class RequestOutput:
                 # logprobs are not requested.
                 logprobs = {}
             finshed_reason = SequenceStatus.get_finished_reason(seq.status)
-            output = CompletionOutput(seqs.index(seq), seq.output_text,
+            output = CompletionOutput(seqs.index(seq), detokenizer.get_output_text(seq),
                                       seq.get_output_token_ids(),
                                       seq.get_cumulative_logprob(), logprobs,
                                       finshed_reason)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -92,7 +92,7 @@ class RequestOutput:
                 # logprobs are not requested.
                 logprobs = {}
             finshed_reason = SequenceStatus.get_finished_reason(seq.status)
-            output = CompletionOutput(seqs.index(seq), detokenizer.get_output_text(seq),
+            output = CompletionOutput(seqs.index(seq), detokenizer.get_output_text(seq.seq_id),
                                       seq.get_output_token_ids(),
                                       seq.get_cumulative_logprob(), logprobs,
                                       finshed_reason)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -112,8 +112,6 @@ class Sequence:
         self.data = SequenceData(prompt_token_ids)
         self.output_logprobs: List[Dict[int, float]] = []
         self.output_tokens: List[str] = []
-        self.output_text = ""
-        self.stop_string_matched = False
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
         # Initialize the logical token blocks with the prompt token ids.

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -113,6 +113,7 @@ class Sequence:
         self.output_logprobs: List[Dict[int, float]] = []
         self.output_tokens: List[str] = []
         self.output_text = ""
+        self.stop_string_matched = False
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
         # Initialize the logical token blocks with the prompt token ids.

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,9 +1,11 @@
-from typing import List, Tuple, Union
+from dataclasses import dataclass
+from typing import List, Tuple, Union, Dict
 
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
 
 from vllm.logger import init_logger
+from vllm.sampling_params import SamplingParams
 
 logger = init_logger(__name__)
 
@@ -116,3 +118,55 @@ def detokenize_incrementally(
         sub_texts.append(sub_text)
     output_text = " ".join(sub_texts)
     return new_token, output_text
+
+
+class SequenceDetokenizeState:
+    def __init__(self, seq_id: int, stop_strings: List[str]) -> None:
+        self.seq_id: int = seq_id
+        self.stop_strings: List[str] = stop_strings
+        self.output_text: str = ""
+        self.output_tokens; List[str] = []
+        self.stop_string_matched = False
+
+
+class Detokenizer:
+    def __init__(
+        self, 
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.decoding_sequences: Dict[int, SequenceDetokenizeState] = dict()
+
+    def add_sequence(self, seq_id: int, stop_strings: List[str]) -> None:
+        self.decoding_sequences[seq_id] = SequenceDetokenizeState(seq_id, stop_strings) 
+
+    def detokenize_last_token(self, seq_id: int, last_token_id: int):
+        assert seq_id in self.decoding_sequences
+        state = self.decoding_sequences[self.seq_id]
+
+        new_token, new_output_text = detokenize_incrementally(
+            self.tokenizer,
+            state.output_tokens,
+            last_token_id,
+            skip_special_tokens=True,
+        )
+        if new_token is None:
+            return
+        for stop_str in state.stop_strings:
+            if new_output_text.endswith(stop_str):
+                # Truncate the output text so that the stop string is
+                # not included in the output.
+                new_output_text = new_output_text[:-len(stop_str)]
+                state.stop_string_matched = True
+                break
+
+        state.output_tokens.append(new_token)
+        state.output_text = new_output_text
+
+    def get_output_text(self, seq_id: int):
+        assert seq_id in self.decoding_sequences
+        return self.decoding_sequences[seq_id].output_text
+
+    def remove_sequence(self, seq_id: int):
+        if seq_id in self.decoding_sequences:
+            del self.decoding_sequences[seq_id]

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import List, Tuple, Union, Dict
 
 from transformers import (AutoTokenizer, PreTrainedTokenizer,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -125,7 +125,7 @@ class SequenceDetokenizeState:
         self.seq_id: int = seq_id
         self.stop_strings: List[str] = stop_strings
         self.output_text: str = ""
-        self.output_tokens; List[str] = []
+        self.output_tokens: List[str] = []
         self.stop_string_matched = False
 
 
@@ -141,8 +141,8 @@ class Detokenizer:
         self.decoding_sequences[seq_id] = SequenceDetokenizeState(seq_id, stop_strings) 
 
     def detokenize_last_token(self, seq_id: int, last_token_id: int) -> None:
-        assert seq_id in self.decoding_sequences
-        state = self.decoding_sequences[self.seq_id]
+        assert seq_id in self.decoding_sequences, f"{self.decoding_sequences.keys()}"
+        state = self.decoding_sequences[seq_id]
 
         new_token, new_output_text = detokenize_incrementally(
             self.tokenizer,
@@ -165,8 +165,9 @@ class Detokenizer:
         state.output_text = new_output_text
 
     def get_output_text(self, seq_id: int) -> str:
-        assert seq_id in self.decoding_sequences
-        return self.decoding_sequences[seq_id].output_text
+        if seq_id in self.decoding_sequences:
+            return self.decoding_sequences[seq_id].output_text
+        return ""
 
     def free_sequence(self, seq_id: int) -> None:
         self.decoding_sequences.pop(seq_id)

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -140,7 +140,7 @@ class Detokenizer:
     def add_sequence(self, seq_id: int, stop_strings: List[str]) -> None:
         self.decoding_sequences[seq_id] = SequenceDetokenizeState(seq_id, stop_strings) 
 
-    def detokenize_last_token(self, seq_id: int, last_token_id: int):
+    def detokenize_last_token(self, seq_id: int, last_token_id: int) -> None:
         assert seq_id in self.decoding_sequences
         state = self.decoding_sequences[self.seq_id]
 
@@ -157,16 +157,20 @@ class Detokenizer:
                 # Truncate the output text so that the stop string is
                 # not included in the output.
                 new_output_text = new_output_text[:-len(stop_str)]
+                # TODO: propogate stop_string_matched state
                 state.stop_string_matched = True
                 break
 
         state.output_tokens.append(new_token)
         state.output_text = new_output_text
 
-    def get_output_text(self, seq_id: int):
+    def get_output_text(self, seq_id: int) -> str:
         assert seq_id in self.decoding_sequences
         return self.decoding_sequences[seq_id].output_text
 
-    def remove_sequence(self, seq_id: int):
-        if seq_id in self.decoding_sequences:
-            del self.decoding_sequences[seq_id]
+    def free_sequence(self, seq_id: int) -> None:
+        self.decoding_sequences.pop(seq_id)
+
+    def stop_string_matched(self, seq_id: int) -> bool:
+        assert seq_id in self.decoding_sequences
+        return self.decoding_sequences[seq_id].stop_string_matched

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -185,8 +185,7 @@ class DummyDetokenizer:
         self, 
         tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
     ) -> None:
-        self.tokenizer = tokenizer
-        self.decoding_sequences: Dict[int, SequenceDetokenizeState] = dict()
+        pass
 
     def add_sequence(self, seq_id: int, stop_strings: List[str]) -> None:
         pass
@@ -252,7 +251,7 @@ class ThreadedDetokenizer:
         return self.state[seq_id].get_output_text()
 
     def free_sequence(self, seq_id: int) -> None:
-        # TODO: actually we need to free the request
+        # TODO: we need to free the request
         self.executor.submit(self.delegate_detokenizer.free_sequence, seq_id)
 
     def stop_string_matched(self, seq_id: int) -> bool:


### PR DESCRIPTION
This PR tries to remove detokenization off the critical path of engine execution. We achieve so by create an abstraction of Detokenizer, which provides functionality of detokenizing output token_ids into text. 