### PR TITLE
Align `max_tokens` behavior with openai

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -129,8 +129,9 @@ async def check_length(
         input_ids = tokenizer(prompt).input_ids
     token_num = len(input_ids)
 
-    unlimited_tokens = request.max_tokens == max_model_len
-    if not unlimited_tokens and token_num + request.max_tokens > max_model_len:
+    if request.max_tokens is None:
+        request.max_tokens = max_model_len - token_num
+    if token_num + request.max_tokens > max_model_len:
         return input_ids, create_error_response(
             HTTPStatus.BAD_REQUEST,
             f"This model's maximum context length is {max_model_len} tokens. "
@@ -190,8 +191,6 @@ async def create_chat_completion(request: ChatCompletionRequest,
         - function_call (Users should implement this by themselves)
         - logit_bias (to be supported by vLLM engine)
     """
-    if request.max_tokens is None:
-        request.max_tokens = max_model_len
     logger.info(f"Received chat completion request: {request}")
 
     error_check_ret = await check_model(request)

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -58,7 +58,7 @@ class ChatCompletionRequest(BaseModel):
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1
-    max_tokens: Optional[int] = 16
+    max_tokens: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
     presence_penalty: Optional[float] = 0.0
@@ -77,7 +77,7 @@ class CompletionRequest(BaseModel):
     # a string, array of strings, array of tokens, or array of token arrays
     prompt: Union[List[int], List[List[int]], str, List[str]]
     suffix: Optional[str] = None
-    max_tokens: Optional[int] = 16
+    max_tokens: Optional[int] = None
     temperature: Optional[float] = 1.0
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -77,7 +77,7 @@ class CompletionRequest(BaseModel):
     # a string, array of strings, array of tokens, or array of token arrays
     prompt: Union[List[int], List[List[int]], str, List[str]]
     suffix: Optional[str] = None
-    max_tokens: Optional[int] = None
+    max_tokens: Optional[int] = 16
     temperature: Optional[float] = 1.0
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1


### PR DESCRIPTION
As [OpenAI's API doc](https://platform.openai.com/docs/api-reference/chat/create#max_tokens) says, `max_tokens` is an optional int param which defaults to inf. And since there is no official int inf in Python, we have two ways to trigger this param's default behavior:
1. Simply not pass this param when requests, and `pydantic` will set it to `16` for us.
https://github.com/vllm-project/vllm/blob/75c0ca9d432199d336e0bc6ae854aa1d35ba35ce/vllm/entrypoints/openai/protocol.py#L55-L61
2. Explicitly pass a `None`. This indicates we want to use the default value, [as `langchain` does](https://github.com/langchain-ai/langchain/blob/b048236c1a01d2bbcdb5c5c689246a69f13e51a9/libs/langchain/langchain/chat_models/openai.py#L164-L165). And the official OpenAI APIs support passing `max_tokens=None` to `openai.ChatCompletion.create`.

However, vLLM's OpenAI-compatible server will complain when passing `max_tokens=None`.

This pr try to align this behavior with openai. If `max_tokens=None` is passed, we can set it to model's max_length and skip the length check.