### PR TITLE
Set replacement=True in torch.multinomial

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -302,7 +302,9 @@ def _sample_from_prompt(
         # Random sampling.
         # Sample `best_of` tokens for the prompt.
         num_seqs = sampling_params.best_of
-        next_token_ids = torch.multinomial(prob, num_samples=num_seqs)
+        next_token_ids = torch.multinomial(prob,
+                                           num_samples=num_seqs,
+                                           replacement=True)
         next_token_ids = next_token_ids.tolist()
     return next_token_ids
 


### PR DESCRIPTION
This PR sets `replacement=True` in `torch.multinomial`, which reverts back a change in #753. The change has affected the sampling quality when `n` is larger than 1. The fix aligns with HF [Transformers](https://github.com/huggingface/transformers/blob/f26099e7b5cf579f99a42bab6ddd371bf2c8d548/src/transformers/generation/utils.py#L2760), where the sequences are sampled independently. I've checked that the fix also aligns with the results from OpenAI API.