### PR TITLE
Enable request body OpenAPI spec for OpenAI endpoints

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -178,7 +178,8 @@ def create_logprobs(token_ids: List[int],
 
 
 @app.post("/v1/chat/completions")
-async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
+async def create_chat_completion(request: ChatCompletionRequest,
+                                 raw_request: Request):
     """Completion API similar to OpenAI's API.
 
     See  https://platform.openai.com/docs/api-reference/chat/create

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -178,7 +178,7 @@ def create_logprobs(token_ids: List[int],
 
 
 @app.post("/v1/chat/completions")
-async def create_chat_completion(raw_request: Request):
+async def create_chat_completion(request: ChatCompletionRequest, raw_request: Request):
     """Completion API similar to OpenAI's API.
 
     See  https://platform.openai.com/docs/api-reference/chat/create
@@ -188,7 +188,6 @@ async def create_chat_completion(raw_request: Request):
         - function_call (Users should implement this by themselves)
         - logit_bias (to be supported by vLLM engine)
     """
-    request = ChatCompletionRequest(**await raw_request.json())
     logger.info(f"Received chat completion request: {request}")
 
     error_check_ret = await check_model(request)
@@ -348,7 +347,7 @@ async def create_chat_completion(raw_request: Request):
 
 
 @app.post("/v1/completions")
-async def create_completion(raw_request: Request):
+async def create_completion(request: CompletionRequest, raw_request: Request):
     """Completion API similar to OpenAI's API.
 
     See https://platform.openai.com/docs/api-reference/completions/create
@@ -361,7 +360,6 @@ async def create_completion(raw_request: Request):
           suffix)
         - logit_bias (to be supported by vLLM engine)
     """
-    request = CompletionRequest(**await raw_request.json())
     logger.info(f"Received completion request: {request}")
 
     error_check_ret = await check_model(request)


### PR DESCRIPTION
# What & Why
FastAPI by default supports OpenAPI spec https://fastapi.tiangolo.com/tutorial/body/#automatic-docs which will be used to generate docs (e.g., Swagger UI). The way to enable request body documentation for post based endpoint is to include the custom data model into the function signature.

The way we use now `request = ChatCompletionRequest(**await raw_request.json())`, per https://fastapi.tiangolo.com/tutorial/body/#results , is essentially the same as defining as `request: ChatCompletionRequest` in the function signature. And the raw request usage won't be impacted per https://fastapi.tiangolo.com/advanced/using-request-directly/ 

The benefit of this change is to enable an interactive Swagger UI "Try it out" experience.

Without this change, the Swagger UI (the `/docs` endpoint of the server) shows no request body for the openai endpoint thus can't `Try it out` (Thus the Swagger UI is basically unusable)
<img width="1370" alt="Screenshot 2023-08-24 at 9 49 12 PM" src="https://github.com/vllm-project/vllm/assets/11920339/29440cc4-16b8-4525-abf9-226ad20e88a8">

With this change, the Swagger UI will show the request body and we can `Try it out` through the UI directly to hit the server.
<img width="1426" alt="Screenshot 2023-08-24 at 9 19 23 PM" src="https://github.com/vllm-project/vllm/assets/11920339/0d1a8da7-4efd-4fea-baa1-759148662412">

This may help with many live demo use cases through the Swagger UI.
