### PR TITLE
Add repetition_penalty aligned with huggingface

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -26,6 +26,9 @@ class SamplingParams:
             frequency in the generated text so far. Values > 0 encourage the
             model to use new tokens, while values < 0 encourage the model to
             repeat tokens.
+        repetition_penalty: The parameter for repetition penalty. 1.0 means no
+            penalty. See [this paper](https://arxiv.org/pdf/1909.05858.pdf) for
+            more details.
         temperature: Float that controls the randomness of the sampling. Lower
             values make the model more deterministic, while higher values make
             the model more random. Zero means greedy sampling.
@@ -48,6 +51,7 @@ class SamplingParams:
         best_of: Optional[int] = None,
         presence_penalty: float = 0.0,
         frequency_penalty: float = 0.0,
+        repetition_penalty: float = 1.0,
         temperature: float = 1.0,
         top_p: float = 1.0,
         top_k: int = -1,
@@ -61,6 +65,7 @@ class SamplingParams:
         self.best_of = best_of if best_of is not None else n
         self.presence_penalty = presence_penalty
         self.frequency_penalty = frequency_penalty
+        self.repetition_penalty = repetition_penalty
         self.temperature = temperature
         self.top_p = top_p
         self.top_k = top_k
@@ -94,6 +99,9 @@ class SamplingParams:
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError("frequency_penalty must be in [-2, 2], got "
                              f"{self.frequency_penalty}.")
+        if self.repetition_penalty <= 0.0:
+            raise ValueError("repetition_penalty must be a strictly positive "
+                             f"float, got {self.repetition_penalty}.")
         if self.temperature < 0.0:
             raise ValueError(
                 f"temperature must be non-negative, got {self.temperature}.")
@@ -134,6 +142,7 @@ class SamplingParams:
                 f"best_of={self.best_of}, "
                 f"presence_penalty={self.presence_penalty}, "
                 f"frequency_penalty={self.frequency_penalty}, "
+                f"repetition_penalty={self.repetition_penalty}, "
                 f"temperature={self.temperature}, "
                 f"top_p={self.top_p}, "
                 f"top_k={self.top_k}, "

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -102,6 +102,15 @@ class SamplingParams:
         if self.repetition_penalty <= 0.0:
             raise ValueError("repetition_penalty must be a strictly positive "
                              f"float, got {self.repetition_penalty}.")
+        if self.repetition_penalty != 1.0 and (
+                abs(self.frequency_penalty) > _SAMPLING_EPS
+                or abs(self.presence_penalty) > _SAMPLING_EPS):
+            raise ValueError(
+                f"repetition_penalty cannot be used with "
+                f"frequency_penalty and presence_penalty."
+                f"got repetition_penalty={self.repetition_penalty}, "
+                f"frequency_penalty={self.frequency_penalty}, "
+                f"presence_penalty={self.presence_penalty}")
         if self.temperature < 0.0:
             raise ValueError(
                 f"temperature must be non-negative, got {self.temperature}.")


### PR DESCRIPTION
In huggingface/transformers generate method: 
https://github.com/huggingface/transformers/blob/ae320fa53f74cc4dfa0e4fc3c95b6129a86b0512/src/transformers/generation/utils.py#L1295
1. it prepares a logits_processor from generation_config
https://github.com/huggingface/transformers/blob/ae320fa53f74cc4dfa0e4fc3c95b6129a86b0512/src/transformers/generation/utils.py#L1540
2. it does logits pre-process by logits_processor in greedy_search/sample/beam_search
https://github.com/huggingface/transformers/blob/ae320fa53f74cc4dfa0e4fc3c95b6129a86b0512/src/transformers/generation/utils.py#L2457

Specificaly, **repetition penalty** is a frequently used pre-process method in logits_processor. It prevents repetitions through a penalty. This penalized sampling works by discounting the scores of previously generated tokens. (https://arxiv.org/pdf/1909.05858.pdf)

I introduced the the repetition penalty pre-process to sampler.py aligned with huggingface implementation:
https://github.com/huggingface/transformers/blob/ae320fa53f74cc4dfa0e4fc3c95b6129a86b0512/src/transformers/generation/logits_process.py#L328