### PR TITLE
fix "tansformers_module" ModuleNotFoundError when load model with `trust_remote_code=True`

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -150,7 +150,7 @@ class LLMEngine:
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
                     placement_group=placement_group,
                     placement_group_capture_child_tasks=True),
-            )(RayWorker).remote()
+            )(RayWorker).remote(self.model_config.trust_remote_code)
             self.workers.append(worker)
 
         # Initialize torch distributed process group for the workers.

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -13,6 +13,7 @@ try:
 
         def __init__(self, init_cached_hf_modules=False) -> None:
             if init_cached_hf_modules:
+                # pylint: disable=import-outside-toplevel
                 from transformers.dynamic_module_utils import init_hf_modules
                 init_hf_modules()
             self.worker = None

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -11,7 +11,10 @@ try:
         """Ray wrapper for vllm.worker.Worker, allowing Worker to be
         lazliy initialized after Ray sets CUDA_VISIBLE_DEVICES."""
 
-        def __init__(self) -> None:
+        def __init__(self, init_cached_hf_modules=False) -> None:
+            if init_cached_hf_modules:
+                from transformers.dynamic_module_utils import init_hf_modules
+                init_hf_modules()
             self.worker = None
 
         def init_worker(self, worker_init_fn):


### PR DESCRIPTION
If we load a model with `trust_remote_code=True`, hf will download model code or load local model code and cache dynamic model modules in its cache directory (it's usually in `~/.cache/huggingface/modules/`).

When a ray worker starts, it will serialize some configs and send them to ray worker sub process. The model config contains dynamic modules imported from hf cache directory which is already added in sys.path by `init_hf_modules` function.

So ray workers have to `init_hf_modules` once they start in case of ModuleNotFoundError.