### PR TITLE
fix: add assertion when temperature applied logits are inf

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -71,6 +71,8 @@ class Sampler(nn.Module):
             # Use in-place division to avoid creating a new tensor.
             logits.div_(t.unsqueeze(dim=1))
 
+            assert not any(torch.any(torch.isinf(logits), 1))
+
         # Apply top-p and top-k truncation.
         top_ps, top_ks = _get_top_p_top_k(input_metadata, self.vocab_size)
         assert len(top_ps) == len(top_ks) == logits.shape[0]


### PR DESCRIPTION
If a number close to 0, such as _SAMPLING_EPS, is entered for temperature, the logits value to which temperature is applied may become an inf value.


```
### logits before applying temperature (1e-5)
tensor([[ 2.8750, 2.9551, 11.0625, ..., -2.4473, -1.5439, -1.9463]],
        device='cuda:0')

### logits after applying temperature (1e-5)
tensor([[ 28752., 29552., inf, ..., -24464., -15440., -19456.]],
        device='cuda:0')
```



In this case, passing softmax causes nan and causes errors in multinomial sampling.
```
### probs after softmax
tensor([[nan, nan, nan, ..., 0., 0., 0.]], device='cuda:0',
        dtype=torch.float32)

### error
../aten/src/ATen/native/cuda/MultinomialKernel.cu:109: binarySearchForMultinomial: block: [0,0,0], thread: [0,0,0] Assertion `cumdist[size - 1] > static_cast <scalar_t>(0)` failed.
```

The above cuda error results in engine blocking for all subsequent requests.

To solve this problem, I suggest adding assertion to check if there is an inf value in the logits where temperature is applied.