### PR TITLE
fix: bug fix when penalties are negative

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -157,7 +157,7 @@ def _apply_penalties(
             continue
         p = presence_penalties[i]
         f = frequency_penalties[i]
-        if p < _SAMPLING_EPS and f < _SAMPLING_EPS:
+        if abs(p) < _SAMPLING_EPS and abs(f) < _SAMPLING_EPS:
             continue
         indices.append(i)
 


### PR DESCRIPTION
I discovered that when penalties are negative, they are skipped.

According to openAI's definition of penalties, it seems that negative penalties are also being considered, although their use may be rare.
- https://platform.openai.com/docs/api-reference/chat/create#presence_penalty
- https://platform.openai.com/docs/api-reference/chat/create#frequency_penalty