### PR TITLE
Return when there is at least one ignored request

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -162,7 +162,7 @@ class Scheduler:
                 num_batched_tokens += num_prompt_tokens
                 scheduled.append(seq_group)
 
-            if scheduled:
+            if scheduled or ignored_seq_groups:
                 scheduler_outputs = SchedulerOutputs(
                     scheduled_seq_groups=scheduled,
                     prompt_run=True,


### PR DESCRIPTION
This should prevent the server from getting stuck when a too-long prompt is sent
#286 

I am not sure, this change might not be needed after #867