### PR TITLE
[BugFix] Fix NaN errors in paged attention kernel

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -262,21 +262,14 @@ __global__ void single_query_cached_kv_attention_kernel(
       const int row_idx = lane / NUM_V_VECS_PER_ROW + i * NUM_ROWS_PER_ITER;
       if (row_idx < HEAD_SIZE) {
         const int offset = row_idx * BLOCK_SIZE + physical_block_offset;
-        V_vec v_vec;
-        if (token_idx + V_VEC_SIZE <= context_len) {
-          // Common case: the V_VEC does not contain the tokens that are out of the context.
-          // We can compute the dot product without any special handling.
-          v_vec = *reinterpret_cast<const V_vec*>(v_ptr + offset);
-        } else {
-          // When the V_VEC contains the tokens that are out of the context, we should
-          // explicitly skip the computation for those tokens since they may contain NaNs.
-          // See https://github.com/vllm-project/vllm/issues/641#issuecomment-1682544472
-          scalar_t v_vec_arr[V_VEC_SIZE];
+        V_vec v_vec = *reinterpret_cast<const V_vec*>(v_ptr + offset);
+        // When the V_VEC contains the tokens that are out of the context, we
+        // should explicitly zero out those tokens since they may contain NaNs.
+        // See https://github.com/vllm-project/vllm/issues/641#issuecomment-1682544472
+        scalar_t* v_vec_ptr = reinterpret_cast<scalar_t*>(&v_vec);
 #pragma unroll
-          for (int j = 0; j < V_VEC_SIZE; j++) {
-            v_vec_arr[j] = token_idx + j < context_len ? v_ptr[offset + j] : zero_value;
-          }
-          v_vec = *reinterpret_cast<const V_vec*>(v_vec_arr);
+        for (int j = 0; j <= V_VEC_SIZE; j++) {
+          v_vec_ptr[j] = token_idx + j < context_len ? v_vec_ptr[j] : zero_value;
         }
         accs[i] += dot(logits_vec, v_vec);
       }

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -263,8 +263,8 @@ __global__ void single_query_cached_kv_attention_kernel(
       if (row_idx < HEAD_SIZE) {
         const int offset = row_idx * BLOCK_SIZE + physical_block_offset;
         V_vec v_vec = *reinterpret_cast<const V_vec*>(v_ptr + offset);
-        // When the V_VEC contains the tokens that are out of the context, we
-        // should explicitly zero out those tokens since they may contain NaNs.
+        // NOTE(woosuk): When v_vec contains the tokens that are out of the context,
+        // we should explicitly zero out the values since they may contain NaNs.
         // See https://github.com/vllm-project/vllm/issues/641#issuecomment-1682544472
         scalar_t* v_vec_ptr = reinterpret_cast<scalar_t*>(&v_vec);
 #pragma unroll

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -507,11 +507,11 @@ void single_query_cached_kv_attention(
   int max_context_len,
   const c10::optional<torch::Tensor>& alibi_slopes) {
   if (query.dtype() == at::ScalarType::Float) {
-    // CALL_KERNEL_LAUNCHER_BLOCK_SIZE(float);
+    CALL_KERNEL_LAUNCHER_BLOCK_SIZE(float);
   } else if (query.dtype() == at::ScalarType::Half) {
     CALL_KERNEL_LAUNCHER_BLOCK_SIZE(uint16_t);
   } else if (query.dtype() == at::ScalarType::BFloat16) {
-    // CALL_KERNEL_LAUNCHER_BLOCK_SIZE(__nv_bfloat16);
+    CALL_KERNEL_LAUNCHER_BLOCK_SIZE(__nv_bfloat16);
   } else {
     TORCH_CHECK(false, "Unsupported data type: ", query.dtype());
   }

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -276,7 +276,7 @@ __global__ void single_query_cached_kv_attention_kernel(
           for (int j = 0; j < V_VEC_SIZE; j++) {
             v_vec_arr[j] = token_idx + j < context_len ? v_ptr[offset + j] : zero_value;
           }
-          V_vec v_vec = *reinterpret_cast<const V_vec*>(v_vec_arr);
+          v_vec = *reinterpret_cast<const V_vec*>(v_vec_arr);
         }
         accs[i] += dot(logits_vec, v_vec);
       }

--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -246,6 +246,8 @@ __global__ void single_query_cached_kv_attention_kernel(
     accs[i] = 0.f;
   }
 
+  scalar_t zero_value;
+  zero(zero_value);
   for (int block_idx = warp_idx; block_idx < num_blocks; block_idx += NUM_WARPS) {
     const int physical_block_number = block_table[block_idx];
     const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
@@ -272,7 +274,7 @@ __global__ void single_query_cached_kv_attention_kernel(
           scalar_t v_vec_arr[V_VEC_SIZE];
 #pragma unroll
           for (int j = 0; j < V_VEC_SIZE; j++) {
-            v_vec_arr[j] = token_idx + j < context_len ? v_ptr[offset + j] : 0.f;
+            v_vec_arr[j] = token_idx + j < context_len ? v_ptr[offset + j] : zero_value;
           }
           V_vec v_vec = *reinterpret_cast<const V_vec*>(v_vec_arr);
         }

--- a/csrc/attention/dtype_bfloat16.cuh
+++ b/csrc/attention/dtype_bfloat16.cuh
@@ -420,4 +420,9 @@ inline __device__ void from_float(bf16_8_t& dst, Float8_ src) {
 #endif
 }
 
+// Zero-out a variable.
+inline __device__ void zero(__nv_bfloat16& dst) {
+  from_float(dst, 0.f);
+}
+
 } // namespace vllm

--- a/csrc/attention/dtype_bfloat16.cuh
+++ b/csrc/attention/dtype_bfloat16.cuh
@@ -422,7 +422,12 @@ inline __device__ void from_float(bf16_8_t& dst, Float8_ src) {
 
 // Zero-out a variable.
 inline __device__ void zero(__nv_bfloat16& dst) {
-  from_float(dst, 0.f);
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800
+  assert(false);
+#else
+  // Same as CUDART_ZERO_BF16 introduced in CUDA 12.2.
+  dst = __ushort_as_bfloat16((unsigned short)0x0000U);
+#endif
 }
 
 } // namespace vllm

--- a/csrc/attention/dtype_float16.cuh
+++ b/csrc/attention/dtype_float16.cuh
@@ -390,11 +390,6 @@ inline __device__ float sum(uint4 v) {
   return sum(c);
 }
 
-// Zero-out a vector.
-inline __device__ void zero(uint16_t& dst) {
-  dst = uint16_t(0);
-}
-
 // From float32 to float16.
 inline __device__ void from_float(uint16_t& dst, float src) {
   dst = float_to_half(src);
@@ -439,6 +434,11 @@ inline __device__ Float8_ to_float(uint4 u) {
   tmp.z = half2_to_float2(u.z);
   tmp.w = half2_to_float2(u.w);
   return tmp;
+}
+
+// Zero-out a variable.
+inline __device__ void zero(uint16_t& dst) {
+  dst = uint16_t(0);
 }
 
 } // namespace vllm

--- a/csrc/attention/dtype_float32.cuh
+++ b/csrc/attention/dtype_float32.cuh
@@ -267,7 +267,7 @@ inline __device__ Float8_ to_float(Float8_ u) {
 
 // Zero-out a variable.
 inline __device__ void zero(float& dst) {
-  dst = float(0.f);
+  dst = 0.f;
 }
 
 } // namespace vllm

--- a/csrc/attention/dtype_float32.cuh
+++ b/csrc/attention/dtype_float32.cuh
@@ -265,4 +265,9 @@ inline __device__ Float8_ to_float(Float8_ u) {
   return u;
 }
 
+// Zero-out a variable.
+inline __device__ void zero(float& dst) {
+  dst = float(0.f);
+}
+
 } // namespace vllm


### PR DESCRIPTION
Fixes #641 
This PR fixes the paged attention kernel. Currently, the kernel computes `attn_weight * value` for all tokens in a value block, even if some of them are not included in the context. It is generally acceptable since the `attn_weight` for those tokens is 0, but this causes errors when the tokens contain NaNs (since 0 * NaN is NaN). The PR solves this by explicitly setting the values of those tokens as 0.