### PR TITLE
FIx vLLM cannot launch

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -81,7 +81,7 @@ class _AsyncLLMEngine(LLMEngine):
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
         )
 
-        return self._process_worker_outputs(output, scheduler_outputs)
+        return self._process_model_outputs(output, scheduler_outputs)
 
     async def _run_workers_async(
         self,


### PR DESCRIPTION
Because of a minor typo, the lastest code cannot work correctly and complains `AttributeError: '_AsyncLLMEngine' object has no attribute '_process_worker_outputs'`. This patch aims to fix this problem.