### PR TITLE
fix: ensure the full context window is allowed as input

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -129,14 +129,13 @@ async def check_length(
         input_ids = tokenizer(prompt).input_ids
     token_num = len(input_ids)
 
-    if token_num + request.max_tokens > max_model_len:
+    if token_num > max_model_len:
         return input_ids, create_error_response(
             HTTPStatus.BAD_REQUEST,
             f"This model's maximum context length is {max_model_len} tokens. "
-            f"However, you requested {request.max_tokens + token_num} tokens "
+            f"However, you requested {token_num} tokens "
             f"({token_num} in the messages, "
-            f"{request.max_tokens} in the completion). "
-            f"Please reduce the length of the messages or completion.",
+            f"Please reduce the length of the messages.",
         )
     else:
         return input_ids, None


### PR DESCRIPTION
The openai API has a `max_tokens` parameter geared at controlling the output tokens. 

vLLM is currently limiting the *input* context window according to the input tokens + the output `max_tokens`. Meanwhile, `max_model_len` is computed as the input context window. 

With the current code, a Llama2 model would run into something like this;

```
openai.error.APIError: Invalid response object from API: '{"object":"error","message":"This model\'s maximum context lengt
h is 4096 tokens. However, you requested 4726 tokens (3726 in the messages, 1000 in the completion). Please reduce the length of the messages or completio
n.","type":"invalid_request_error","param":null,"code":null}' (HTTP response code was 400) 
```

Which should clearly be ok since Llama2 context window is 4096, so 3726 fits fine.

Either we multiply `max_model_len` by two, as Llam2 can take 4096 tokens and generate 4096 tokens, or we only check for the input size here. The proposed PR goes with the latter since this appears to be an input validation.