### PR TITLE
Make `max_model_len` configurable

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -66,15 +66,14 @@ class ModelConfig:
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self._verify_load_format()
         self._verify_tokenizer_mode()
-        if max_model_len:
+        if max_model_len is not None:
             derived_max_model_len = self.get_max_model_len()
             if max_model_len > derived_max_model_len:
                 logger.warning(
                     f"User-specified max_model_len ({max_model_len}) is "
                     f"greater than the derived max_model_len "
                     f"({derived_max_model_len}). Make sure the value is "
-                    "correct and within the model context size."
-                )
+                    "correct and within the model context size.")
         self.max_model_len = max_model_len
 
     def _verify_load_format(self) -> None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -61,12 +61,21 @@ class ModelConfig:
         self.download_dir = download_dir
         self.load_format = load_format
         self.seed = seed
-        self.max_model_len = max_model_len
 
         self.hf_config = get_config(model, trust_remote_code)
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self._verify_load_format()
         self._verify_tokenizer_mode()
+        if max_model_len:
+            derived_max_model_len = self.get_max_model_len()
+            if max_model_len > derived_max_model_len:
+                logger.warning(
+                    f"User-specified max_model_len ({max_model_len}) is "
+                    f"greater than the derived max_model_len "
+                    f"({derived_max_model_len}). Make sure the value is "
+                    "correct and within the model context size."
+                )
+        self.max_model_len = max_model_len
 
     def _verify_load_format(self) -> None:
         load_format = self.load_format.lower()

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -31,6 +31,8 @@ class ModelConfig:
             will use FP16 precision for FP32 and FP16 models, and BF16 precision
             for BF16 models.
         seed: Random seed for reproducibility.
+        max_model_len: Maximum length of a sequence (including prompt and
+            output). If None, will be derived from the model.
     """
 
     def __init__(
@@ -44,6 +46,7 @@ class ModelConfig:
         use_dummy_weights: bool,
         dtype: str,
         seed: int,
+        max_model_len: Optional[int] = None,
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
@@ -53,6 +56,7 @@ class ModelConfig:
         self.use_np_weights = use_np_weights
         self.use_dummy_weights = use_dummy_weights
         self.seed = seed
+        self.max_model_len = max_model_len
 
         self.hf_config = get_config(model, trust_remote_code)
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
@@ -117,6 +121,8 @@ class ModelConfig:
         return total_num_attention_heads // parallel_config.tensor_parallel_size
 
     def get_max_model_len(self) -> int:
+        if self.max_model_len is not None:
+            return self.max_model_len
         max_model_len = float("inf")
         possible_keys = [
             # OPT

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -66,6 +66,7 @@ class ModelConfig:
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self._verify_load_format()
         self._verify_tokenizer_mode()
+        self.max_model_len = None
         if max_model_len is not None:
             derived_max_model_len = self.get_max_model_len()
             if max_model_len > derived_max_model_len:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -19,6 +19,7 @@ class EngineArgs:
     use_dummy_weights: bool = False
     dtype: str = 'auto'
     seed: int = 0
+    max_model_len: Optional[int] = None
     worker_use_ray: bool = False
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
@@ -73,6 +74,11 @@ class EngineArgs:
         parser.add_argument('--use-dummy-weights',
                             action='store_true',
                             help='use dummy values for model weights')
+        parser.add_argument('--max-model-len',
+                            type=int,
+                            default=None,
+                            help='model context length. If unspecified, '
+                            'will be automatically derived from the model.')
         # TODO(woosuk): Support FP32.
         parser.add_argument(
             '--dtype',
@@ -148,7 +154,7 @@ class EngineArgs:
                                    self.tokenizer_mode, self.trust_remote_code,
                                    self.download_dir, self.use_np_weights,
                                    self.use_dummy_weights, self.dtype,
-                                   self.seed)
+                                   self.seed, self.max_model_len)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space)


### PR DESCRIPTION
Allows the user to override derived `max_model_len` if they so desire.

We can also warn the user if the `max_model_len` is set above what vLLM has derived - lmk if you think that's a good idea!