### PR TITLE
Bump up transformers version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ray >= 2.5.1
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 torch >= 2.0.0
-transformers >= 4.31.0  # Required for LLaMA-2.
+transformers >= 4.33.1  # Required for Code Llama.
 xformers >= 0.0.21
 fastapi
 uvicorn


### PR DESCRIPTION
The new version of transformers is required for Code LLaMA and recent models.