### PR TITLE
faster startup of vLLM 

### DIFF
--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -247,8 +247,9 @@ class PagedAttentionWithRoPE(PagedAttention):
         super().__init__(num_heads, head_size, scale, num_kv_heads)
 
         # Create the cos and sin cache.
-        inv_freq = 1.0 / (base**(torch.arange(0, rotary_dim, 2) / rotary_dim))
-        t = torch.arange(max_position).float()
+        dev = torch.cuda.current_device()
+        inv_freq = 1.0 / (base**(torch.arange(0, rotary_dim, 2, device=dev) / rotary_dim))
+        t = torch.arange(max_position, device=dev).float()
         freqs = torch.einsum("i,j -> ij", t, inv_freq.float())
         cos = freqs.cos()
         sin = freqs.sin()

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -247,9 +247,9 @@ class PagedAttentionWithRoPE(PagedAttention):
         super().__init__(num_heads, head_size, scale, num_kv_heads)
 
         # Create the cos and sin cache.
-        dev = torch.cuda.current_device()
-        inv_freq = 1.0 / (base**(torch.arange(0, rotary_dim, 2, device=dev) / rotary_dim))
-        t = torch.arange(max_position, device=dev).float()
+        inv_freq = 1.0 / (base**(
+            torch.arange(0, rotary_dim, 2, device="cuda") / rotary_dim))
+        t = torch.arange(max_position, device="cuda").float()
         freqs = torch.einsum("i,j -> ij", t, inv_freq.float())
         cos = freqs.cos()
         sin = freqs.sin()


### PR DESCRIPTION
## issue ##

In production + using autoscaling the startup time of servers and vllm is very important to performance. Currently a lot of CPU work is being done on startup which can be done blazingly fast if done on the GPU instead

## metrics ##

2 CPU environment
defaultdict(<class 'int'>, {'rope': 143.8646891117096s})

4-8 CPU environment
~ 20-40s

20 CPU environment
~10s (not exact number)

on device
defaultdict(<class 'int'>, {'rope': 0.09561300277709961})