### PR TITLE
Use TGI-like incremental detokenization

### DIFF
--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -42,8 +42,8 @@ def _run_incremental_decode(llama_tokenizer, all_input_ids):
 
 @pytest.mark.parametrize("TRUTH_AND_INPUT_PAIRS", TRUTH_AND_INPUT_PAIRS)
 def test_decode_streaming_english_spaces(llama_tokenizer,
-                                         TRUTH_AND_INPUT_PAIRS):
-    truth, all_input_ids = TRUTH_AND_INPUT_PAIRS
+                                         truth_and_input_pairs):
+    truth, all_input_ids = truth_and_input_pairs
     assert (all_input_ids == llama_tokenizer(
         truth, add_special_tokens=False)["input_ids"])
 

--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -4,34 +4,38 @@ from transformers import AutoTokenizer
 
 from vllm.transformers_utils.tokenizer import detokenize_incrementally
 
-
-@pytest.fixture(scope="module")
-def llama_tokenizer():
-    return AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
-
-
-TRUTH_AND_INPUT_PAIRS = [
-    ("Hello here, this is a simple test",
-     [15043, 1244, 29892, 445, 338, 263, 2560, 1243]),
-    ("<s> vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",
-     [
-         1, 325, 2208, 29924, 338, 263, 1880, 29899, 20678, 649, 322, 3370,
-         29899, 8462, 27262, 322, 16330, 6012, 363, 365, 26369, 29879, 29889,
-         739, 338, 8688, 304, 367, 1304, 297, 5802, 23136, 29892, 988, 27262,
-         322, 16330
-     ])
+TRUTH = [
+    "Hello here, this is a simple test",
+    "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",
+    "我很感谢你的热情"
+]
+TOKENIZERS = [
+    "facebook/opt-125m",
+    "gpt2",
+    "bigcode/tiny_starcoder_py",
+    "EleutherAI/gpt-j-6b",
+    "EleutherAI/pythia-70m",
+    "bigscience/bloom-560m",
+    "mosaicml/mpt-7b",
+    "tiiuae/falcon-7b",
+    "meta-llama/Llama-2-7b-hf",
+    "codellama/CodeLlama-7b-hf",
 ]
 
 
-def _run_incremental_decode(llama_tokenizer, all_input_ids):
+def _run_incremental_decode(tokenizer, all_input_ids):
     decoded_text = ""
     offset = 0
     token_offset = 0
     prev_output_tokens = None
     for i in range(len(all_input_ids)):
         new_tokens, text, offset, token_offset = detokenize_incrementally(
-            llama_tokenizer, all_input_ids[:i + 1], prev_output_tokens, offset,
-            token_offset)
+            tokenizer,
+            all_input_ids[:i + 1],
+            prev_output_tokens,
+            offset,
+            token_offset,
+            skip_special_tokens=False)
         decoded_text += text
         if prev_output_tokens is None:
             prev_output_tokens = new_tokens
@@ -40,25 +44,12 @@ def _run_incremental_decode(llama_tokenizer, all_input_ids):
     return decoded_text
 
 
-@pytest.mark.parametrize("TRUTH_AND_INPUT_PAIRS", TRUTH_AND_INPUT_PAIRS)
-def test_decode_streaming_english_spaces(llama_tokenizer,
-                                         truth_and_input_pairs):
-    truth, all_input_ids = truth_and_input_pairs
-    assert (all_input_ids == llama_tokenizer(
-        truth, add_special_tokens=False)["input_ids"])
+@pytest.mark.parametrize("truth", TRUTH)
+@pytest.mark.parametrize("tokenizer_id", TOKENIZERS)
+def test_decode_streaming(tokenizer_id, truth):
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
+    all_input_ids = tokenizer(truth, add_special_tokens=False)["input_ids"]
 
-    decoded_text = _run_incremental_decode(llama_tokenizer, all_input_ids)
-
-    assert decoded_text == truth
-
-
-def test_decode_streaming_chinese_utf8(llama_tokenizer):
-    truth = "我很感谢你的热情"
-    all_input_ids = [
-        30672, 232, 193, 139, 233, 135, 162, 235, 179, 165, 30919, 30210, 234,
-        134, 176, 30993
-    ]
-
-    decoded_text = _run_incremental_decode(llama_tokenizer, all_input_ids)
+    decoded_text = _run_incremental_decode(tokenizer, all_input_ids)
 
     assert decoded_text == truth

--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -1,0 +1,105 @@
+import pytest
+
+from transformers import AutoTokenizer
+
+from vllm.transformers_utils.tokenizer import detokenize_incrementally
+
+
+@pytest.fixture(scope="module")
+def llama_tokenizer():
+    return AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
+
+
+truth_and_input_ids = [
+    ("Hello here, this is a simple test",
+     [15043, 1244, 29892, 445, 338, 263, 2560, 1243]),
+    ("<s> vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",
+     [
+         1,
+         325,
+         2208,
+         29924,
+         338,
+         263,
+         1880,
+         29899,
+         20678,
+         649,
+         322,
+         3370,
+         29899,
+         8462,
+         27262,
+         322,
+         16330,
+         6012,
+         363,
+         365,
+         26369,
+         29879,
+         29889,
+         739,
+         338,
+         8688,
+         304,
+         367,
+         1304,
+         297,
+         5802,
+         23136,
+         29892,
+         988,
+         27262,
+         322,
+         16330,
+     ])
+]
+
+
+@pytest.mark.parametrize("truth_and_input_ids", truth_and_input_ids)
+def test_decode_streaming_english_spaces(llama_tokenizer, truth_and_input_ids):
+    truth, all_input_ids = truth_and_input_ids
+    assert (all_input_ids == llama_tokenizer(
+        truth, add_special_tokens=False)["input_ids"])
+
+    decoded_text = ""
+    offset = 0
+    token_offset = 0
+    for i in range(len(all_input_ids)):
+        text, offset, token_offset = detokenize_incrementally(
+            llama_tokenizer, all_input_ids[:i + 1], offset, token_offset)
+        decoded_text += text
+
+    assert decoded_text == truth
+
+
+def test_decode_streaming_chinese_utf8(llama_tokenizer):
+    truth = "我很感谢你的热情"
+    all_input_ids = [
+        30672,
+        232,
+        193,
+        139,
+        233,
+        135,
+        162,
+        235,
+        179,
+        165,
+        30919,
+        30210,
+        234,
+        134,
+        176,
+        30993,
+    ]
+
+    decoded_text = ""
+    offset = 0
+    token_offset = 0
+    for i in range(len(all_input_ids)):
+        text, offset, token_offset = detokenize_incrementally(
+            llama_tokenizer, all_input_ids[:i + 1], offset, token_offset)
+        decoded_text += text
+
+    assert decoded_text == truth

--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -27,10 +27,16 @@ def _run_incremental_decode(llama_tokenizer, all_input_ids):
     decoded_text = ""
     offset = 0
     token_offset = 0
+    prev_output_tokens = None
     for i in range(len(all_input_ids)):
-        text, offset, token_offset = detokenize_incrementally(
-            llama_tokenizer, all_input_ids[:i + 1], offset, token_offset)
+        new_tokens, text, offset, token_offset = detokenize_incrementally(
+            llama_tokenizer, all_input_ids[:i + 1], prev_output_tokens, offset,
+            token_offset)
         decoded_text += text
+        if prev_output_tokens is None:
+            prev_output_tokens = new_tokens
+        else:
+            prev_output_tokens += new_tokens
     return decoded_text
 
 

--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -10,58 +10,20 @@ def llama_tokenizer():
     return AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
 
 
-truth_and_input_ids = [
+TRUTH_AND_INPUT_PAIRS = [
     ("Hello here, this is a simple test",
      [15043, 1244, 29892, 445, 338, 263, 2560, 1243]),
     ("<s> vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",
      [
-         1,
-         325,
-         2208,
-         29924,
-         338,
-         263,
-         1880,
-         29899,
-         20678,
-         649,
-         322,
-         3370,
-         29899,
-         8462,
-         27262,
-         322,
-         16330,
-         6012,
-         363,
-         365,
-         26369,
-         29879,
-         29889,
-         739,
-         338,
-         8688,
-         304,
-         367,
-         1304,
-         297,
-         5802,
-         23136,
-         29892,
-         988,
-         27262,
-         322,
-         16330,
+         1, 325, 2208, 29924, 338, 263, 1880, 29899, 20678, 649, 322, 3370,
+         29899, 8462, 27262, 322, 16330, 6012, 363, 365, 26369, 29879, 29889,
+         739, 338, 8688, 304, 367, 1304, 297, 5802, 23136, 29892, 988, 27262,
+         322, 16330
      ])
 ]
 
 
-@pytest.mark.parametrize("truth_and_input_ids", truth_and_input_ids)
-def test_decode_streaming_english_spaces(llama_tokenizer, truth_and_input_ids):
-    truth, all_input_ids = truth_and_input_ids
-    assert (all_input_ids == llama_tokenizer(
-        truth, add_special_tokens=False)["input_ids"])
-
+def _run_incremental_decode(llama_tokenizer, all_input_ids):
     decoded_text = ""
     offset = 0
     token_offset = 0
@@ -69,6 +31,17 @@ def test_decode_streaming_english_spaces(llama_tokenizer, truth_and_input_ids):
         text, offset, token_offset = detokenize_incrementally(
             llama_tokenizer, all_input_ids[:i + 1], offset, token_offset)
         decoded_text += text
+    return decoded_text
+
+
+@pytest.mark.parametrize("TRUTH_AND_INPUT_PAIRS", TRUTH_AND_INPUT_PAIRS)
+def test_decode_streaming_english_spaces(llama_tokenizer,
+                                         TRUTH_AND_INPUT_PAIRS):
+    truth, all_input_ids = TRUTH_AND_INPUT_PAIRS
+    assert (all_input_ids == llama_tokenizer(
+        truth, add_special_tokens=False)["input_ids"])
+
+    decoded_text = _run_incremental_decode(llama_tokenizer, all_input_ids)
 
     assert decoded_text == truth
 
@@ -76,30 +49,10 @@ def test_decode_streaming_english_spaces(llama_tokenizer, truth_and_input_ids):
 def test_decode_streaming_chinese_utf8(llama_tokenizer):
     truth = "我很感谢你的热情"
     all_input_ids = [
-        30672,
-        232,
-        193,
-        139,
-        233,
-        135,
-        162,
-        235,
-        179,
-        165,
-        30919,
-        30210,
-        234,
-        134,
-        176,
-        30993,
+        30672, 232, 193, 139, 233, 135, 162, 235, 179, 165, 30919, 30210, 234,
+        134, 176, 30993
     ]
 
-    decoded_text = ""
-    offset = 0
-    token_offset = 0
-    for i in range(len(all_input_ids)):
-        text, offset, token_offset = detokenize_incrementally(
-            llama_tokenizer, all_input_ids[:i + 1], offset, token_offset)
-        decoded_text += text
+    decoded_text = _run_incremental_decode(llama_tokenizer, all_input_ids)
 
     assert decoded_text == truth

--- a/tests/engine/test_detokenize.py
+++ b/tests/engine/test_detokenize.py
@@ -27,20 +27,20 @@ def _run_incremental_decode(tokenizer, all_input_ids):
     decoded_text = ""
     offset = 0
     token_offset = 0
-    prev_output_tokens = None
+    prev_tokens = None
     for i in range(len(all_input_ids)):
         new_tokens, text, offset, token_offset = detokenize_incrementally(
             tokenizer,
             all_input_ids[:i + 1],
-            prev_output_tokens,
+            prev_tokens,
             offset,
             token_offset,
             skip_special_tokens=False)
         decoded_text += text
-        if prev_output_tokens is None:
-            prev_output_tokens = new_tokens
+        if prev_tokens is None:
+            prev_tokens = new_tokens
         else:
-            prev_output_tokens += new_tokens
+            prev_tokens += new_tokens
     return decoded_text
 
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -623,17 +623,22 @@ class LLMEngine:
 
     def _decode_sequence(self, seq: Sequence) -> None:
         """Decodes the new token for a sequence."""
-        new_token_text, prefix_offset, read_offset = detokenize_incrementally(
-            self.tokenizer,
-            seq.get_token_ids(),
-            prefix_offset=seq.prefix_offset,
-            read_offset=seq.read_offset,
-            skip_special_tokens=True,
-        )
+        (new_tokens, new_output_text, prefix_offset,
+         read_offset) = detokenize_incrementally(
+             self.tokenizer,
+             all_input_ids=seq.get_token_ids(),
+             prev_output_tokens=seq.output_tokens,
+             prefix_offset=seq.prefix_offset,
+             read_offset=seq.read_offset,
+             skip_special_tokens=True,
+         )
+        if seq.output_tokens is None:
+            seq.output_tokens = new_tokens
+        else:
+            seq.output_tokens.extend(new_tokens)
         seq.prefix_offset = prefix_offset
         seq.read_offset = read_offset
-        seq.output_tokens.append(new_token_text)
-        seq.output_text += new_token_text
+        seq.output_text += new_output_text
 
     def _check_stop(self, seq: Sequence,
                     sampling_params: SamplingParams) -> None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -623,15 +623,17 @@ class LLMEngine:
 
     def _decode_sequence(self, seq: Sequence) -> None:
         """Decodes the new token for a sequence."""
-        new_token, new_output_text = detokenize_incrementally(
+        new_token_text, prefix_offset, read_offset = detokenize_incrementally(
             self.tokenizer,
-            seq.output_tokens,
-            seq.get_last_token_id(),
+            seq.get_token_ids(),
+            prefix_offset=seq.prefix_offset,
+            read_offset=seq.read_offset,
             skip_special_tokens=True,
         )
-        if new_token is not None:
-            seq.output_tokens.append(new_token)
-            seq.output_text = new_output_text
+        seq.prefix_offset = prefix_offset
+        seq.read_offset = read_offset
+        seq.output_tokens.append(new_token_text)
+        seq.output_text += new_token_text
 
     def _check_stop(self, seq: Sequence,
                     sampling_params: SamplingParams) -> None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -627,15 +627,15 @@ class LLMEngine:
          read_offset) = detokenize_incrementally(
              self.tokenizer,
              all_input_ids=seq.get_token_ids(),
-             prev_output_tokens=seq.output_tokens,
+             prev_tokens=seq.tokens,
              prefix_offset=seq.prefix_offset,
              read_offset=seq.read_offset,
              skip_special_tokens=True,
          )
-        if seq.output_tokens is None:
-            seq.output_tokens = new_tokens
+        if seq.tokens is None:
+            seq.tokens = new_tokens
         else:
-            seq.output_tokens.extend(new_tokens)
+            seq.tokens.extend(new_tokens)
         seq.prefix_offset = prefix_offset
         seq.read_offset = read_offset
         seq.output_text += new_output_text

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -121,6 +121,9 @@ class Sequence:
         # Initialize the logical token blocks with the prompt token ids.
         self._append_tokens_to_blocks(prompt_token_ids)
         self.status = SequenceStatus.WAITING
+        # Used for incremental detokenization
+        self.prefix_offset = len(prompt_token_ids) - 5
+        self.read_offset = len(prompt_token_ids)
 
     def _append_logical_block(self) -> None:
         block = LogicalTokenBlock(

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -122,6 +122,8 @@ class Sequence:
         self._append_tokens_to_blocks(prompt_token_ids)
         self.status = SequenceStatus.WAITING
         # Used for incremental detokenization
+        # 5 is an arbitrary value that should work for all
+        # tokenizers (bigger = more conservative).
         self.prefix_offset = len(prompt_token_ids) - 5
         self.read_offset = len(prompt_token_ids)
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -114,18 +114,17 @@ class Sequence:
 
         self.data = SequenceData(prompt_token_ids)
         self.output_logprobs: List[Dict[int, float]] = []
-        self.output_tokens: List[str] = []
+        self.output_tokens: Optional[List[str]] = None
         self.output_text = ""
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
         # Initialize the logical token blocks with the prompt token ids.
         self._append_tokens_to_blocks(prompt_token_ids)
         self.status = SequenceStatus.WAITING
+
         # Used for incremental detokenization
-        # 5 is an arbitrary value that should work for all
-        # tokenizers (bigger = more conservative).
-        self.prefix_offset = len(prompt_token_ids) - 5
-        self.read_offset = len(prompt_token_ids)
+        self.prefix_offset = 0
+        self.read_offset = 0
 
     def _append_logical_block(self) -> None:
         block = LogicalTokenBlock(

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -114,7 +114,6 @@ class Sequence:
 
         self.data = SequenceData(prompt_token_ids)
         self.output_logprobs: List[Dict[int, float]] = []
-        self.output_tokens: Optional[List[str]] = None
         self.output_text = ""
 
         self.logical_token_blocks: List[LogicalTokenBlock] = []
@@ -125,6 +124,8 @@ class Sequence:
         # Used for incremental detokenization
         self.prefix_offset = 0
         self.read_offset = 0
+        # Input + output tokens
+        self.tokens: Optional[List[str]] = None
 
     def _append_logical_block(self) -> None:
         block = LogicalTokenBlock(

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union, Optional
+from typing import List, Optional, Tuple, Union
 
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
@@ -68,9 +68,10 @@ def get_tokenizer(
 
 
 def _convert_tokens_to_string_with_added_encoders(
-        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
-        output_tokens: List[str],
-        skip_special_tokens: bool = False):
+    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    output_tokens: List[str],
+    skip_special_tokens: bool,
+) -> str:
     # Adapted from
     # https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
     # NOTE(woosuk): The following code is slow because it runs a for loop over
@@ -95,8 +96,8 @@ def _convert_tokens_to_string_with_added_encoders(
     return " ".join(sub_texts)
 
 
-# Based on https://github.com/huggingface/text-generation-inference/\
-# blob/v0.9.4/server/text_generation_server/models/model.py#L62C9-L62C15
+# Based on 
+# https://github.com/huggingface/text-generation-inference/blob/v0.9.4/server/text_generation_server/models/model.py#L62C9-L62C15
 # under Apache 2.0 license
 def detokenize_incrementally(
     tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
@@ -105,7 +106,7 @@ def detokenize_incrementally(
     prefix_offset: int = 0,
     read_offset: int = 0,
     skip_special_tokens: bool = False,
-) -> Tuple[str, str, int, int]:
+) -> Tuple[List[str], str, int, int]:
     new_token_id = all_input_ids[-1]
     # This is the first iteration for this sequence
     if prev_output_tokens is None:

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -67,8 +67,8 @@ def get_tokenizer(
     return tokenizer
 
 
-# Based on huggingface/text-generation-inference/blob/v0.9.4/\
-# server/text_generation_server/models/model.py#L62C9-L62C15
+# Based on https://github.com/huggingface/text-generation-inference/\
+# blob/v0.9.4/server/text_generation_server/models/model.py#L62C9-L62C15
 # under Apache 2.0 license
 def detokenize_incrementally(
     tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -96,7 +96,7 @@ def _convert_tokens_to_string_with_added_encoders(
     return " ".join(sub_texts)
 
 
-# Based on 
+# Based on
 # https://github.com/huggingface/text-generation-inference/blob/v0.9.4/server/text_generation_server/models/model.py#L62C9-L62C15
 # under Apache 2.0 license
 def detokenize_incrementally(

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -102,14 +102,14 @@ def _convert_tokens_to_string_with_added_encoders(
 def detokenize_incrementally(
     tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
     all_input_ids: List[int],
-    prev_output_tokens: Optional[List[str]],
+    prev_tokens: Optional[List[str]],
     prefix_offset: int = 0,
     read_offset: int = 0,
     skip_special_tokens: bool = False,
 ) -> Tuple[List[str], str, int, int]:
     new_token_id = all_input_ids[-1]
     # This is the first iteration for this sequence
-    if prev_output_tokens is None:
+    if prev_tokens is None:
         new_tokens = tokenizer.convert_ids_to_tokens(
             all_input_ids, skip_special_tokens=skip_special_tokens)
         output_tokens = new_tokens
@@ -122,7 +122,7 @@ def detokenize_incrementally(
         new_token = tokenizer.convert_ids_to_tokens(
             new_token_id, skip_special_tokens=skip_special_tokens)
         new_tokens = [new_token]
-        output_tokens = prev_output_tokens + new_tokens
+        output_tokens = prev_tokens + new_tokens
 
     # The prefix text is necessary only to defeat cleanup algorithms in
     # the decode which decide to add a space or not depending on the

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
                           PreTrainedTokenizerFast)
@@ -67,23 +67,79 @@ def get_tokenizer(
     return tokenizer
 
 
+def _convert_tokens_to_string_with_added_encoders(
+        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        output_tokens: List[str],
+        skip_special_tokens: bool = False):
+    # Adapted from
+    # https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/tokenization_utils.py#L921
+    # NOTE(woosuk): The following code is slow because it runs a for loop over
+    # the output_tokens. In Python, running a for loop over a list can be slow
+    # even when the loop body is very simple.
+    sub_texts = []
+    current_sub_text = []
+    for token in output_tokens:
+        if skip_special_tokens and token in tokenizer.all_special_tokens:
+            continue
+        if token in tokenizer.added_tokens_encoder:
+            if current_sub_text:
+                sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+                sub_texts.append(sub_text)
+                current_sub_text = []
+            sub_texts.append(token)
+        else:
+            current_sub_text.append(token)
+    if current_sub_text:
+        sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
+        sub_texts.append(sub_text)
+    return " ".join(sub_texts)
+
+
 # Based on https://github.com/huggingface/text-generation-inference/\
 # blob/v0.9.4/server/text_generation_server/models/model.py#L62C9-L62C15
 # under Apache 2.0 license
 def detokenize_incrementally(
     tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
     all_input_ids: List[int],
+    prev_output_tokens: Optional[List[str]],
     prefix_offset: int = 0,
     read_offset: int = 0,
     skip_special_tokens: bool = False,
-) -> Tuple[str, int, int]:
+) -> Tuple[str, str, int, int]:
+    new_token_id = all_input_ids[-1]
+    # This is the first iteration for this sequence
+    if prev_output_tokens is None:
+        new_tokens = tokenizer.convert_ids_to_tokens(
+            all_input_ids, skip_special_tokens=skip_special_tokens)
+        output_tokens = new_tokens
+        # 5 is an arbitrary value that should work for all
+        # tokenizers (bigger = more conservative).
+        # Subtract 1 extra to account for the generated token.
+        prefix_offset = max(len(output_tokens) - 6, 0)
+        read_offset = max(len(output_tokens) - 1, 0)
+    else:
+        new_token = tokenizer.convert_ids_to_tokens(
+            new_token_id, skip_special_tokens=skip_special_tokens)
+        new_tokens = [new_token]
+        output_tokens = prev_output_tokens + new_tokens
+
     # The prefix text is necessary only to defeat cleanup algorithms in
     # the decode which decide to add a space or not depending on the
     # surrounding ids.
-    prefix_text = tokenizer.decode(all_input_ids[prefix_offset:read_offset],
-                                   skip_special_tokens=skip_special_tokens)
-    new_text = tokenizer.decode(all_input_ids[prefix_offset:],
-                                skip_special_tokens=skip_special_tokens)
+    if not getattr(tokenizer, "added_tokens_encoder", {}):
+        prefix_text = tokenizer.convert_tokens_to_string(
+            output_tokens[prefix_offset:read_offset])
+        new_text = tokenizer.convert_tokens_to_string(
+            output_tokens[prefix_offset:])
+    else:
+        prefix_text = _convert_tokens_to_string_with_added_encoders(
+            tokenizer,
+            output_tokens[prefix_offset:read_offset],
+            skip_special_tokens=skip_special_tokens)
+        new_text = _convert_tokens_to_string_with_added_encoders(
+            tokenizer,
+            output_tokens[prefix_offset:],
+            skip_special_tokens=skip_special_tokens)
 
     if len(new_text) > len(prefix_text) and not new_text.endswith("�"):
         # utf-8 char at the end means it's a potential unfinished byte sequence
@@ -91,6 +147,6 @@ def detokenize_incrementally(
         # If it's in the middle, it's probably a real invalid id generated
         # by the model
         new_text = new_text[len(prefix_text):]
-        return new_text, read_offset, len(all_input_ids)
+        return new_tokens, new_text, read_offset, len(output_tokens)
     else:
-        return "", prefix_offset, read_offset
+        return new_tokens, "", prefix_offset, read_offset


### PR DESCRIPTION
Allows us to simplify the code and ensure that the incremental decoding is correct. Notably, when the `tests/models/test_models.py` is ran for meta-llama/Llama-2-7b-hf, this change fixes one of the different outputs between vLLM and HF.

vLLM before:
`vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs.It is designed to be used in production`

vLLM with this PR:
`vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production`

Notice the space after the dot.