### PR TITLE
Bump up the version to v0.1.6

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
This is an emergency release to revert a breaking API change that can make many existing codes using `AsyncLLMServer` not work.