### PR TITLE
fix: CUDA error when inferencing with Falcon-40B base model

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -114,8 +114,9 @@ class ModelConfig:
         # Note: for falcon, when new_decoder_architecture is True, the
         # multi_query flag is ignored and we use n_head_kv for the number of
         # KV heads.
+        falcon_model_types = ["falcon", "RefinedWeb", "RefinedWebModel"]
         new_decoder_arch_falcon = (
-            self.hf_config.to_dict().["model_type"] == "falcon"
+            self.hf_config.model_type in falcon_model_types
             and getattr(self.hf_config, "new_decoder_architecture", False))
         if not new_decoder_arch_falcon and getattr(self.hf_config,
                                                    "multi_query", False):

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -115,7 +115,7 @@ class ModelConfig:
         # multi_query flag is ignored and we use n_head_kv for the number of
         # KV heads.
         new_decoder_arch_falcon = (
-            self.hf_config.model_type == "falcon"
+            self.hf_config.to_dict().["model_type"] == "falcon"
             and getattr(self.hf_config, "new_decoder_architecture", False))
         if not new_decoder_arch_falcon and getattr(self.hf_config,
                                                    "multi_query", False):


### PR DESCRIPTION
This PR resolves #767. As described on https://github.com/vllm-project/vllm/issues/767#issuecomment-1699136748, referencing `model_type` instance variable results in wrongly determining model variant. Until there's some movement to fix this behavior on huggingface side, this patch will be a simple workaround to get rid of the CUDA error.