### PR TITLE
Use FP32 in RoPE initialization

### DIFF
--- a/csrc/pos_encoding_kernels.cu
+++ b/csrc/pos_encoding_kernels.cu
@@ -29,10 +29,10 @@ inline __device__ void apply_rotary_embedding(
     sin = __ldg(sin_ptr + x_index / 2);
   }
 
-  const scalar_t x = arr[x_index];
-  const scalar_t y = arr[y_index];
-  arr[x_index] = x * cos - y * sin;
-  arr[y_index] = y * cos + x * sin;
+  const float x = static_cast<float>(arr[x_index]);
+  const float y = static_cast<float>(arr[y_index]);
+  arr[x_index] = static_cast<scalar_t>(x * cos - y * sin);
+  arr[y_index] = static_cast<scalar_t>(y * cos + x * sin);
 }
 
 template<typename scalar_t, bool IS_NEOX>

--- a/tests/kernels/test_pos_encoding.py
+++ b/tests/kernels/test_pos_encoding.py
@@ -133,9 +133,10 @@ def test_rotary_embedding(
                       device="cuda")
 
     # Create the rotary embedding.
-    inv_freq = 1.0 / (base**(torch.arange(0, rotary_dim, 2) / rotary_dim))
+    inv_freq = 1.0 / (base**(
+        torch.arange(0, rotary_dim, 2, dtype=torch.float) / rotary_dim))
     t = torch.arange(max_position).float()
-    freqs = torch.einsum("i,j -> ij", t, inv_freq.float())
+    freqs = torch.einsum("i,j -> ij", t, inv_freq)
     cos = freqs.cos()
     sin = freqs.sin()
     cos_sin_cache = torch.cat((cos, sin), dim=-1)

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -264,10 +264,10 @@ class PagedAttentionWithRoPE(PagedAttention):
         self.is_neox_style = is_neox_style
 
         # Create the cos and sin cache.
-        inv_freq = 1.0 / (base**(
-            torch.arange(0, rotary_dim, 2, device="cuda") / rotary_dim))
+        inv_freq = 1.0 / (base**(torch.arange(
+            0, rotary_dim, 2, device="cuda", dtype=torch.float) / rotary_dim))
         t = torch.arange(max_position, device="cuda").float()
-        freqs = torch.einsum("i,j -> ij", t, inv_freq.float())
+        freqs = torch.einsum("i,j -> ij", t, inv_freq)
         cos = freqs.cos()
         sin = freqs.sin()
         cache = torch.cat((cos, sin), dim=-1)


### PR DESCRIPTION
Fixes #883

This PR uses FP32 for initializing the cos and sin cache in RoPE. This resolves the precision issues when using a large `base` like 1000000 with FP16.

NOTE: This change is aligned with the [RoPE definition](https://github.com/huggingface/transformers/blob/95b374952dc27d8511541d6f5a4e22c9ec11fb24/src/transformers/models/llama/modeling_llama.py#L99) in HuggingFace. However, as mentioned in #863, this may not align with the original definition of Meta's LLaMA. In the original implementation, FP32 is not only used for initialization, but is also used for calculating RoPE. The original implementation can be supported by slightly modifying the kernel.