### PR TITLE
Abort when coroutine is cancelled

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -385,8 +385,8 @@ class AsyncLLMEngine:
 
             async for request_output in stream:
                 yield request_output
-        except Exception as e:
-            # If there is an exception, abort the request.
+        except (Exception, asyncio.CancelledError) as e:
+            # If there is an exception or coroutine is cancelled, abort the request.
             self._abort(request_id)
             raise e
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -386,7 +386,8 @@ class AsyncLLMEngine:
             async for request_output in stream:
                 yield request_output
         except (Exception, asyncio.CancelledError) as e:
-            # If there is an exception or coroutine is cancelled, abort the request.
+            # If there is an exception or coroutine is cancelled, abort the
+            # request.
             self._abort(request_id)
             raise e
 


### PR DESCRIPTION
There is a scene, while running `async for result in AsyncLLMEngine.generate(...)`，if caller cancel the coroutine at high level (ex. Sanic Framework cancel the coroutine which handling request when transport connection is disconnected), whether to need catching `asyncio.CancelledError ` and aborting  token generating in background?