### PR TITLE
Fix hanging when prompt exceeds limit

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -175,7 +175,7 @@ class Scheduler:
                 num_curr_seqs += num_new_seqs
                 scheduled.append(seq_group)
 
-            if scheduled:
+            if scheduled or ignored_seq_groups:
                 scheduler_outputs = SchedulerOutputs(
                     scheduled_seq_groups=scheduled,
                     prompt_run=True,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -291,14 +291,12 @@ class LLMEngine:
     def _schedule(
         self
     ) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs,
-               Optional[List[RequestOutput]]]:
+               List[RequestOutput]]:
         seq_group_metadata_list, scheduler_outputs = self.scheduler.schedule()
-        if scheduler_outputs.is_empty():
-            return seq_group_metadata_list, scheduler_outputs, [
-                RequestOutput.from_seq_group(seq_group)
-                for seq_group in scheduler_outputs.ignored_seq_groups
-            ]
-        return seq_group_metadata_list, scheduler_outputs, None
+        return seq_group_metadata_list, scheduler_outputs, [
+            RequestOutput.from_seq_group(seq_group)
+            for seq_group in scheduler_outputs.ignored_seq_groups
+        ]
 
     def _check_beam_search_early_stopping(
         self,
@@ -542,10 +540,9 @@ class LLMEngine:
         and updates the scheduler with the model outputs. Finally, it decodes
         the sequences and returns the newly generated results.
         """
-        (seq_group_metadata_list, scheduler_outputs,
-         early_return) = self._schedule()
-        if early_return is not None:
-            return early_return
+        seq_group_metadata_list, scheduler_outputs, ignored = self._schedule()
+        if scheduler_outputs.is_empty():
+            return ignored
 
         # Execute the model.
         output = self._run_workers(
@@ -556,7 +553,7 @@ class LLMEngine:
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
         )
 
-        return self._process_model_outputs(output, scheduler_outputs)
+        return self._process_model_outputs(output, scheduler_outputs) + ignored
 
     def _log_system_stats(
         self,


### PR DESCRIPTION
I discovered that my API server with AsyncLLMEngine was blocked when a lengthy prompt was submitted to it. This problem shares similarities with issues #765 and #1026.

The scheduler is adding seq_groups that are larger than the prompt_limit:
```python
if num_prompt_tokens > self.prompt_limit:
    logger.warning(
        f"Input prompt ({num_prompt_tokens} tokens) is too long"
        f" and exceeds limit of {self.prompt_limit}")
    for seq in seq_group.get_seqs():
        seq.status = SequenceStatus.FINISHED_IGNORED
    ignored_seq_groups.append(seq_group)
    self.waiting.pop(0)
    continue
```
And it returns when the schedule is not empty:
```python
if scheduled:
    scheduler_outputs = SchedulerOutputs(
        scheduled_seq_groups=scheduled,
        prompt_run=True,
        num_batched_tokens=num_batched_tokens,
        blocks_to_swap_in=blocks_to_swap_in,
        blocks_to_swap_out=blocks_to_swap_out,
        blocks_to_copy=blocks_to_copy,
        ignored_seq_groups=ignored_seq_groups,
    )
    return scheduler_outputs
```

However, in `LLMEngine._schedule`, `ignored_seq_groups` is returned when `scheduler_outputs.is_empty()`. 
```python
def step(self) -> List[RequestOutput]:
    (seq_group_metadata_list, scheduler_outputs,
     early_return) = self._schedule()
    if early_return is not None:
        return early_return
```
The third value returned by `LLMEngine._schedule` will always be None, and the ignored seq groups are thus **LEAKED**.