### PR TITLE
Fix get_max_num_running_seqs for waiting seq groups

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -244,7 +244,7 @@ class SequenceGroup:
             # candidates running in the future.
             return self.sampling_params.best_of
         else:
-            if self.sampling_params.best_of > self.num_seqs():
+            if self.sampling_params.best_of >= self.num_seqs():
                 # At prompt stage, the sequence group is not yet filled up
                 # and only have one sequence running. However, in the
                 # generation stage, we will have `best_of` sequences running.


### PR DESCRIPTION
Currently, `get_max_num_running_seqs` will always return 0 for waiting sequences in the case of `best_of == self.num_seqs()`, leading to incorrect scheduler behavior of scheduling more requests than `max_num_seqs`.