### PR TITLE
Fix warning message on LLaMA FastTokenizer

### DIFF
--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -32,7 +32,6 @@ def get_tokenizer(
             "take a long time. To reduce the initialization time, consider "
             f"using '{_FAST_LLAMA_TOKENIZER}' instead of the original "
             "tokenizer.")
-
     try:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -25,13 +25,6 @@ def get_tokenizer(
                 "Cannot use the fast tokenizer in slow tokenizer mode.")
         kwargs["use_fast"] = False
 
-    if ("llama" in tokenizer_name.lower() and kwargs.get("use_fast", True)
-            and tokenizer_name != _FAST_LLAMA_TOKENIZER):
-        logger.info(
-            "For some LLaMA-based models, initializing the fast tokenizer may "
-            "take a long time. To eliminate the initialization time, consider "
-            f"using '{_FAST_LLAMA_TOKENIZER}' instead of the original "
-            "tokenizer.")
     try:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -25,6 +25,14 @@ def get_tokenizer(
                 "Cannot use the fast tokenizer in slow tokenizer mode.")
         kwargs["use_fast"] = False
 
+    if ("llama" in tokenizer_name.lower() and kwargs.get("use_fast", True)
+             and tokenizer_name != _FAST_LLAMA_TOKENIZER):
+         logger.info(
+             "For some LLaMA V1 models, initializing the fast tokenizer may "
+             "take a long time. To eliminate the initialization time, "
+             f"consider using '{_FAST_LLAMA_TOKENIZER}' instead of the "
+             "original tokenizer.")
+
     try:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name,
@@ -34,9 +42,9 @@ def get_tokenizer(
     except TypeError as e:
         # The LLaMA tokenizer causes a protobuf error in some environments.
         err_msg = (
-            "Failed to load the tokenizer. If you are using a LLaMA-based "
-            f"model, use '{_FAST_LLAMA_TOKENIZER}' instead of the original "
-            "tokenizer.")
+            "Failed to load the tokenizer. If you are using a LLaMA V1 model "
+            f"consider using '{_FAST_LLAMA_TOKENIZER}' instead of the "
+            "original tokenizer.")
         raise RuntimeError(err_msg) from e
     except ValueError as e:
         # If the error pertains to the tokenizer class not existing or not

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -26,12 +26,12 @@ def get_tokenizer(
         kwargs["use_fast"] = False
 
     if ("llama" in tokenizer_name.lower() and kwargs.get("use_fast", True)
-             and tokenizer_name != _FAST_LLAMA_TOKENIZER):
-         logger.info(
-             "For some LLaMA V1 models, initializing the fast tokenizer may "
-             "take a long time. To eliminate the initialization time, "
-             f"consider using '{_FAST_LLAMA_TOKENIZER}' instead of the "
-             "original tokenizer.")
+            and tokenizer_name != _FAST_LLAMA_TOKENIZER):
+        logger.info(
+            "For some LLaMA V1 models, initializing the fast tokenizer may "
+            "take a long time. To reduce the initialization time, consider "
+            f"using '{_FAST_LLAMA_TOKENIZER}' instead of the original "
+            "tokenizer.")
 
     try:
         tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
The warning message is for the LLaMA V1 model, and does not hold for all LLaMA variants. The PR clarifies that it is for LLaMA V1.