### PR TITLE
Fix detokenization leaving special tokens

### DIFF
--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -119,9 +119,9 @@ def detokenize_incrementally(
         prefix_offset = max(len(output_tokens) - 6, 0)
         read_offset = max(len(output_tokens) - 1, 0)
     else:
-        new_token = tokenizer.convert_ids_to_tokens(
-            new_token_id, skip_special_tokens=skip_special_tokens)
-        new_tokens = [new_token]
+        # Put new_token_id in a list so skip_special_tokens is respected
+        new_tokens = tokenizer.convert_ids_to_tokens(
+            [new_token_id], skip_special_tokens=skip_special_tokens)
         output_tokens = prev_tokens + new_tokens
 
     # The prefix text is necessary only to defeat cleanup algorithms in


### PR DESCRIPTION
Turns out `skip_special_tokens` is not respected if input to `convert_ids_to_tokens` is an int instead of a list.

@HermitSun this should fix the issue you mentioned [here](https://github.com/vllm-project/vllm/pull/984#issuecomment-1719071329)