### PR TITLE
OpenAI-Server: Only fail if logit_bias has actual values

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -196,7 +196,7 @@ async def create_chat_completion(request: ChatCompletionRequest,
     if error_check_ret is not None:
         return error_check_ret
 
-    if request.logit_bias is not None:
+    if request.logit_bias is not None and len(request.logit_bias) > 0:
         # TODO: support logit_bias in vLLM engine.
         return create_error_response(HTTPStatus.BAD_REQUEST,
                                      "logit_bias is not currently supported")
@@ -379,7 +379,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         return create_error_response(HTTPStatus.BAD_REQUEST,
                                      "suffix is not currently supported")
 
-    if request.logit_bias is not None:
+    if request.logit_bias is not None and len(request.logit_bias) > 0:
         # TODO: support logit_bias in vLLM engine.
         return create_error_response(HTTPStatus.BAD_REQUEST,
                                      "logit_bias is not currently supported")


### PR DESCRIPTION
Many OpenAI wrappers of popular libraries such as `langchain` or `haystack` will always append an empty dictionary as a `logit_bias` value to their requests. Currently the server will return an error in these cases. I think the server should only error out if `logit_bias` actually contains any values and process the request otherwise. This enables user to simply use their vLLM servers via `langchain`.  