### PR TITLE
Add pandas to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 ninja  # For faster builds.
 psutil
 ray >= 2.5.1
+pandas  # Required for Ray AIR.
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 torch >= 2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ninja  # For faster builds.
 psutil
 ray >= 2.5.1
-pandas  # Required for Ray AIR.
+pandas  # Required for Ray data.
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 torch >= 2.0.0


### PR DESCRIPTION
Closes #754 

When I tried inference with TP, I got a message like:
```
ValueError: Ray is not installed. Please install Ray to use distributed serving.
```
although I've already installed Ray.

This turned out be due to the following error in importing Ray data:
```
 File "/home/wskwon/anaconda3/envs/test-ray/lib/python3.9/site-packages/ray/air/__init__.py", line 2, in <module>
    from ray.air.config import (
  File "/home/wskwon/anaconda3/envs/test-ray/lib/python3.9/site-packages/ray/air/config.py", line 25, in <module>
    from ray.data.preprocessor import Preprocessor
  File "/home/wskwon/anaconda3/envs/test-ray/lib/python3.9/site-packages/ray/data/__init__.py", line 3, in <module>
    import pandas  # noqa
ModuleNotFoundError: No module named 'pandas'
```