### PR TITLE
add vllm output log for debug, reduce ray log to slow down memory inc…

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -97,7 +97,8 @@ class RequestTracker:
         self._request_streams[request_id].put(request_output)
         if request_output.finished:
             if verbose:
-                logger.info(f"Finished request {request_id}.")
+                output_text = request_output.outputs[0].text if request_output.outputs else ""
+                logger.info(f"Finished request {request_id}: {output_text}")
             self.abort_request(request_id)
 
     def add_request(self, request_id: str,

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -69,7 +69,7 @@ def initialize_cluster(
                 "Ray is not installed. Please install Ray to use distributed "
                 "serving.")
         # Connect to a ray cluster.
-        ray.init(address=ray_address, ignore_reinit_error=True)
+        ray.init(address=ray_address, ignore_reinit_error=True, logging_level="error")
 
     if not parallel_config.worker_use_ray:
         # Initialize cluster locally.


### PR DESCRIPTION
Some change about log:
1. add vllm output log for debug
2. set ray log level to error, to slow down  ray memory increase. https://github.com/ray-project/ray/issues/31688#issuecomment-1405973526