### PR TITLE
[FIX] Don't initialize parameter by default

### DIFF
--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -5,15 +5,15 @@ Run `pytest tests/models/test_models.py --forked`.
 import pytest
 
 MODELS = [
-    "facebook/opt-125m",
+    # "facebook/opt-125m",
     "gpt2",
-    "bigcode/tiny_starcoder_py",
-    "EleutherAI/gpt-j-6b",
-    "EleutherAI/pythia-70m",
-    "bigscience/bloom-560m",
-    "mosaicml/mpt-7b",
-    "tiiuae/falcon-7b",
-    "meta-llama/Llama-2-7b-hf",
+    # "bigcode/tiny_starcoder_py",
+    # "EleutherAI/gpt-j-6b",
+    # "EleutherAI/pythia-70m",
+    # "bigscience/bloom-560m",
+    # "mosaicml/mpt-7b",
+    # "tiiuae/falcon-7b",
+    # "meta-llama/Llama-2-7b-hf",
 ]
 
 
@@ -39,7 +39,7 @@ def test_models(
     for i in range(len(example_prompts)):
         hf_output_ids, hf_output_str = hf_outputs[i]
         vllm_output_ids, vllm_output_str = vllm_outputs[i]
-        assert hf_output_str == vllm_output_str, (
-            f"Test{i}:\nHF: {hf_output_str!r}\nvLLM: {vllm_output_str!r}")
+        # assert hf_output_str == vllm_output_str, (
+        #     f"Test{i}:\nHF: {hf_output_str!r}\nvLLM: {vllm_output_str!r}")
         assert hf_output_ids == vllm_output_ids, (
             f"Test{i}:\nHF: {hf_output_ids}\nvLLM: {vllm_output_ids}")

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -5,15 +5,15 @@ Run `pytest tests/models/test_models.py --forked`.
 import pytest
 
 MODELS = [
-    # "facebook/opt-125m",
+    "facebook/opt-125m",
     "gpt2",
-    # "bigcode/tiny_starcoder_py",
-    # "EleutherAI/gpt-j-6b",
-    # "EleutherAI/pythia-70m",
-    # "bigscience/bloom-560m",
-    # "mosaicml/mpt-7b",
-    # "tiiuae/falcon-7b",
-    # "meta-llama/Llama-2-7b-hf",
+    "bigcode/tiny_starcoder_py",
+    "EleutherAI/gpt-j-6b",
+    "EleutherAI/pythia-70m",
+    "bigscience/bloom-560m",
+    "mosaicml/mpt-7b",
+    "tiiuae/falcon-7b",
+    "meta-llama/Llama-2-7b-hf",
 ]
 
 
@@ -39,7 +39,7 @@ def test_models(
     for i in range(len(example_prompts)):
         hf_output_ids, hf_output_str = hf_outputs[i]
         vllm_output_ids, vllm_output_str = vllm_outputs[i]
-        # assert hf_output_str == vllm_output_str, (
-        #     f"Test{i}:\nHF: {hf_output_str!r}\nvLLM: {vllm_output_str!r}")
+        assert hf_output_str == vllm_output_str, (
+            f"Test{i}:\nHF: {hf_output_str!r}\nvLLM: {vllm_output_str!r}")
         assert hf_output_ids == vllm_output_ids, (
             f"Test{i}:\nHF: {hf_output_ids}\nvLLM: {vllm_output_ids}")

--- a/vllm/model_executor/parallel_utils/tensor_parallel/layers.py
+++ b/vllm/model_executor/parallel_utils/tensor_parallel/layers.py
@@ -83,7 +83,7 @@ class VocabParallelEmbedding(torch.nn.Module):
                  init_method=init.xavier_normal_,
                  params_dtype: torch.dtype=None,
                  use_cpu_initialization: bool=False,
-                 perform_initialization: bool=True):
+                 perform_initialization: bool=False):
         super(VocabParallelEmbedding, self).__init__()
         assert not perform_initialization
         assert not use_cpu_initialization
@@ -113,7 +113,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         self.weight = Parameter(torch.empty(
             self.num_embeddings_per_partition, self.embedding_dim,
             device=torch.cuda.current_device(), dtype=params_dtype))
- 
+
     def forward(self, input_):
         if self.tensor_model_parallel_size > 1:
             # Build the mask.
@@ -172,7 +172,7 @@ class ColumnParallelLinear(torch.nn.Module):
                  skip_bias_add=False,
                  params_dtype=None,
                  use_cpu_initialization=False,
-                 perform_initialization=True,
+                 perform_initialization=False,
                  quant_config=None,
                  ):
         super(ColumnParallelLinear, self).__init__()
@@ -288,7 +288,7 @@ class RowParallelLinear(torch.nn.Module):
                  skip_bias_add=False,
                  params_dtype=None,
                  use_cpu_initialization=False,
-                 perform_initialization=True,
+                 perform_initialization=False,
                  reduce_results=True,
                  quant_config=None,
                  ):


### PR DESCRIPTION
Without this fix, many models cannot run. For example, `gpt2` will initialize the parameters for vocab and the following assert will immediately fail.