### PR TITLE
Load Baichuan2-7B-Chat with BaiChuan2ForCausalLM (rotery) instead of Baichuan2ForCausalLM (alibi)

### DIFF
--- a/examples/offline_inference_baichuan.py
+++ b/examples/offline_inference_baichuan.py
@@ -81,7 +81,8 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.3,
                                  top_k=5,
                                  top_p=0.85,
-                                 max_tokens=2048
+                                 max_tokens=2048,
+                                 stop=[".</s>"]
                                  # repetition_penalty=1.05
                                  )
 

--- a/examples/offline_inference_baichuan.py
+++ b/examples/offline_inference_baichuan.py
@@ -1,0 +1,144 @@
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+from typing import List
+
+import torch
+
+
+def build_chat_input(tokenizer,
+                     messages: List[dict],
+                     max_new_tokens: int = 2048,
+                     model_max_length: int = 4096,
+                     user_token_id: int = 195,
+                     assistant_token_id: int = 196):
+
+    def _parse_messages(messages, split_role="user"):
+        system, rounds = "", []
+        round = []
+        for i, message in enumerate(messages):
+            if message["role"] == "system":
+                assert i == 0
+                system = message["content"]
+                continue
+            if message["role"] == split_role and round:
+                rounds.append(round)
+                round = []
+            round.append(message)
+        if round:
+            rounds.append(round)
+        return system, rounds
+
+    max_new_tokens = max_new_tokens
+    max_input_tokens = model_max_length - max_new_tokens
+    system, rounds = _parse_messages(messages, split_role="user")
+    system_tokens = tokenizer.encode(system)
+    max_history_tokens = max_input_tokens - len(system_tokens)
+
+    history_tokens = []
+    for round in rounds[::-1]:
+        round_tokens = []
+        for message in round:
+            if message["role"] == "user":
+                round_tokens.append(user_token_id)
+            else:
+                round_tokens.append(assistant_token_id)
+            round_tokens.extend(tokenizer.encode(message["content"]))
+        if len(history_tokens) == 0 or len(history_tokens) + len(
+                round_tokens) <= max_history_tokens:
+            history_tokens = round_tokens + history_tokens  # concat left
+            if len(history_tokens) < max_history_tokens:
+                continue
+        break
+
+    input_tokens = system_tokens + history_tokens
+    if messages[-1]["role"] != "assistant":
+        input_tokens.append(assistant_token_id)
+    input_tokens = input_tokens[-max_input_tokens:]  # truncate left
+    return input_tokens
+
+
+# Sample prompts.
+prompts = [
+    [{
+        "role": "user",
+        "content": "Hello, my name is"
+    }],
+    [{
+        "role": "user",
+        "content": "The president of the United States is"
+    }],
+    [{
+        "role": "user",
+        "content": "The capital of France is"
+    }],
+    [{
+        "role": "user",
+        "content": "The future of AI is"
+    }],
+]
+
+# Taken from generation_config.
+sampling_params = SamplingParams(temperature=0.3,
+                                 top_k=5,
+                                 top_p=0.85,
+                                 max_tokens=2048
+                                 # repetition_penalty=1.05
+                                 )
+
+# Create an LLM.
+llm = LLM(model="baichuan-inc/Baichuan2-13B-Chat",
+          trust_remote_code=True,
+          tensor_parallel_size=2,
+          tokenizer_mode='slow')
+tokenizer = AutoTokenizer.from_pretrained("baichuan-inc/Baichuan2-13B-Chat",
+                                          use_fast=False,
+                                          trust_remote_code=True)
+# bypass chat format issue with explicit tokenization
+prompt_token_ids = [
+    build_chat_input(tokenizer, prompt, max_new_tokens=2048)
+    for prompt in prompts
+]
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompt_token_ids=prompt_token_ids,
+                       sampling_params=sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r},\n Generated text: {generated_text!r}")
+"""
+Sample output
+Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:13<00:00,  1.93s/it]
+Prompt: None,
+ Generated text: 'Hello, my name is [your name]. Nice to meet you!'
+Prompt: None,
+ Generated text: 'The current president of the United States is Joe Biden, who was sworn into office on January 20, 2021.'
+>>>>>> Baichuan2-13B-Chat 8Bit Demo: 
+"the President of the United States is currently Joe Biden, who was sworn into office on January 20, 2021. He succeeded former president Donald Trump. The next presidential election will be held in November 2024."
+>>>>>>
+Prompt: None,
+ Generated text: 'The capital of France is Paris.'
+Prompt: None,
+ Generated text: "The future of AI is promising and full of potential. It is expected to revolutionize various industries, including healthcare, finance, transportation, and manufacturing. AI will also play a significant role in solving complex problems, such as climate change, disease, and poverty.\n\nSome of the key trends in AI include:\n\n1. Autonomous vehicles: AI-powered self-driving cars and trucks are expected to become a reality in the near future, reducing traffic accidents, improving fuel efficiency, and transforming transportation as we know it.\n\n2. Personalized healthcare: AI will help analyze vast amounts of medical data, enabling doctors to make more accurate diagnoses and develop personalized treatment plans for patients.\n\n3. Virtual assistants: AI-powered virtual assistants will become more advanced, capable of understanding natural language, predicting user needs, and providing personalized recommendations.\n\n4. Manufacturing efficiency: AI will help optimize manufacturing processes, reducing waste, improving product quality, and lowering production costs.\n\n5. Financial services: AI will transform the financial industry by automating trading, fraud detection, and risk management, as well as providing personalized financial advice to consumers.\n\n6. Education: AI will help create personalized learning experiences, identifying students' strengths and weaknesses and providing targeted support to help them succeed.\n\n7. Smart cities: AI will play a crucial role in making cities more efficient and sustainable by optimizing energy consumption, traffic management, and public services.\n\n8. Language translation: AI-powered translation tools will become more accurate and natural, breaking down language barriers and facilitating global communication.\n\n9. Creative industries: AI will help drive innovation in the creative industries, such as music, art, and film, by collaborating with humans to create new works and improve existing ones.\n\n10. Ethical considerations: As AI becomes more integrated into our lives, ethical questions and concerns about privacy, security, and job displacement will need to be addressed.\n\nIn conclusion, the future of AI is full of possibilities and potential, but it also comes with challenges that need to be addressed. By embracing AI and working towards its responsible development, we can unlock its potential to improve our lives and create a better future for all."
+ 
+>>>>>> Baichuan2-13B-Chat 8Bit Demo:
+The future of AI is promising and full of potential. It is expected to revolutionize various industries, including healthcare, finance, transportation, manufacturing, and education. Some of the key areas where AI is expected to make a significant impact include:
+
+1. Healthcare: AI will play a crucial role in improving diagnostics, treatment planning, and personalized medicine. Machine learning algorithms can analyze medical images, patient records, and genetic data to identify patterns and make accurate predictions. This will help in early detection of diseases, better treatment options, and improved patient outcomes.
+
+2. Finance: AI will transform the financial industry by automating processes, enhancing risk management, and improving customer service. AI-powered algorithms can analyze vast amounts of financial data to detect fraud, assess credit risk, and optimize investment strategies.
+
+3. Transportation: Autonomous vehicles are expected to become a reality in the near future, thanks to advancements in AI and machine learning. Self-driving cars have the potential to reduce traffic accidents, improve fuel efficiency, and revolutionize urban transportation systems.
+
+4. Manufacturing: AI will enhance productivity and efficiency in the manufacturing sector by automating repetitive tasks, optimizing supply chains, and predicting equipment failures. This will enable companies to produce higher-quality products at a lower cost.
+
+5. Education: AI will transform the way we learn and teach by providing personalized learning experiences, identifying students' strengths and weaknesses, and offering targeted support. AI-powered tools can also help educators in managing classrooms, tracking student progress, and identifying learning gaps.
+
+6. Customer Service: AI-powered chatbots and virtual assistants will improve customer service by handling routine inquiries, providing personalized recommendations, and assisting human agents in resolving complex issues.
+
+7. Environment and Sustainability: AI can help monitor and predict environmental changes, optimize resource usage, and develop sustainable solutions for climate change and pollution control.
+
+However, the future of AI also comes with its challenges, such as job displacement, privacy concerns, and ethical considerations. As AI continues to advance, it is essential to address these challenges and ensure that its benefits are accessible to everyone.
+>>>>>
+ """

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -15,8 +15,8 @@ _MODEL_REGISTRY = {
     "AquilaModel": AquilaForCausalLM,
     "BaiChuanForCausalLM": BaiChuanForCausalLM,  # baichuan-7b
     "BaichuanForCausalLM": BaichuanForCausalLM,  # baichuan-13b
-    "BaiChuan2ForCausalLM": BaiChuan2ForCausalLM,  # baichuan-7b
-    "Baichuan2ForCausalLM": Baichuan2ForCausalLM,  # baichuan-13b
+    "BaiChuan2ForCausalLM": BaiChuan2ForCausalLM,  # baichuan2-rope
+    "Baichuan2ForCausalLM": Baichuan2ForCausalLM,  # baichuan2-alibi
     "BloomForCausalLM": BloomForCausalLM,
     "FalconForCausalLM": FalconForCausalLM,
     "GPT2LMHeadModel": GPT2LMHeadModel,
@@ -46,6 +46,10 @@ def _get_model_architecture(config: PretrainedConfig) -> Type[nn.Module]:
     architectures = getattr(config, "architectures", [])
     for arch in architectures:
         if arch in _MODEL_REGISTRY:
+            # baichuan 2 has different vocab size
+            if ("baichuan" in arch.lower()) and (getattr(config, "vocab_size")
+                                                 == 125696):
+                return Baichuan2ForCausalLM
             return _MODEL_REGISTRY[arch]
     raise ValueError(
         f"Model architectures {architectures} are not supported for now. "

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -15,6 +15,8 @@ _MODEL_REGISTRY = {
     "AquilaModel": AquilaForCausalLM,
     "BaiChuanForCausalLM": BaiChuanForCausalLM,  # baichuan-7b
     "BaichuanForCausalLM": BaichuanForCausalLM,  # baichuan-13b
+    "BaiChuan2ForCausalLM": BaiChuan2ForCausalLM,  # baichuan-7b
+    "Baichuan2ForCausalLM": Baichuan2ForCausalLM,  # baichuan-13b
     "BloomForCausalLM": BloomForCausalLM,
     "FalconForCausalLM": FalconForCausalLM,
     "GPT2LMHeadModel": GPT2LMHeadModel,

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -55,7 +55,11 @@ def _get_model_architecture(config: PretrainedConfig) -> Type[nn.Module]:
             # baichuan 2 has different vocab size
             if ("baichuan" in arch.lower()) and (getattr(config, "vocab_size")
                                                  == 125696):
-                return Baichuan2ForCausalLM
+                # baichuan 2 7b and 13b have different intermediate size
+                if getattr(config, "intermediate_size") == 11008:
+                    return BaiChuan2ForCausalLM
+                elif getattr(config, "intermediate_size") == 13696:
+                    return Baichuan2ForCausalLM
             return _MODEL_REGISTRY[arch]
     raise ValueError(
         f"Model architectures {architectures} are not supported for now. "

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -1,6 +1,8 @@
 from vllm.model_executor.models.aquila import AquilaForCausalLM
 from vllm.model_executor.models.baichuan import (BaiChuanForCausalLM,
                                                  BaichuanForCausalLM)
+from vllm.model_executor.models.baichuan2 import (BaiChuan2ForCausalLM,
+                                                 Baichuan2ForCausalLM)
 from vllm.model_executor.models.bloom import BloomForCausalLM
 from vllm.model_executor.models.falcon import FalconForCausalLM
 from vllm.model_executor.models.gpt2 import GPT2LMHeadModel
@@ -17,6 +19,8 @@ __all__ = [
     "AquilaForCausalLM",
     "BaiChuanForCausalLM",
     "BaichuanForCausalLM",
+    "BaiChuan2ForCausalLM",
+    "Baichuan2ForCausalLM",
     "BloomForCausalLM",
     "FalconForCausalLM",
     "GPT2LMHeadModel",

--- a/vllm/model_executor/models/baichuan2.py
+++ b/vllm/model_executor/models/baichuan2.py
@@ -1,0 +1,447 @@
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only BaiChuan model compatible with HuggingFace weights.
+
+The input of the model is flattened to a 1D tensor of tokens. The model uses
+InputMetadata to extract the original 2D shape of the input.
+"""
+import math
+from typing import List, Optional, Tuple
+from threading import Thread
+from typing import List, Optional, Tuple, Union
+from contextlib import contextmanager
+
+import torch
+from torch import nn
+from torch.nn import CrossEntropyLoss
+from transformers import PreTrainedModel
+from transformers.activations import ACT2FN
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.utils import logging
+from transformers.generation.utils import GenerationConfig
+
+from vllm.model_executor.input_metadata import InputMetadata
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.attention import (
+    PagedAttentionWithRoPE,
+    PagedAttentionWithALiBi,
+)
+from vllm.model_executor.layers.sampler import Sampler
+from vllm.model_executor.weight_utils import (
+    convert_pyslice_to_tensor,
+    hf_model_weights_iterator,
+    load_padded_tensor_parallel_vocab,
+    load_tensor_parallel_weights,
+)
+from vllm.model_executor.parallel_utils.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.model_executor.parallel_utils.tensor_parallel import (
+    VocabParallelEmbedding,
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from vllm.sequence import SamplerOutput
+from vllm.transformers_utils.configs.baichuan2 import BaiChuan2Config as BaiChuanConfig
+
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+# try:
+#     from xformers import ops as xops
+# except ImportError:
+#     xops = None
+#     print(
+#         "Xformers is not installed correctly. If you want to use memory_efficient_attention to accelerate training use the following command to install Xformers\npip install xformers."
+#     )
+
+
+def _get_interleave(n):
+    def _get_interleave_power_of_2(n):
+        start = 2 ** (-(2 ** -(math.log2(n) - 3)))
+        ratio = start
+        return [start * ratio**i for i in range(n)]
+
+    if math.log2(n).is_integer():
+        return _get_interleave_power_of_2(n)
+    else:
+        closest_power_of_2 = 2 ** math.floor(math.log2(n))
+        return (
+            _get_interleave_power_of_2(closest_power_of_2)
+            + _get_interleave(2 * closest_power_of_2)[0::2][: n - closest_power_of_2]
+        )
+
+
+def _fill_with_neg_inf(t):
+    """FP16-compatible function that fills a tensor with -inf."""
+    return t.float().fill_(float("-inf")).type_as(t)
+
+
+def _gen_alibi_mask(tensor, n_head, max_pos):
+    slopes = torch.Tensor(_get_interleave(n_head))
+    position_point = torch.arange(max_pos) - max_pos + 1
+    position_point = position_point.unsqueeze(0).unsqueeze(0).expand(n_head, -1, -1)
+    diag = torch.diag(position_point[0])
+    position_point = position_point - diag.unsqueeze(0).unsqueeze(0).transpose(-1, -2)
+    alibi = slopes.unsqueeze(1).unsqueeze(1) * position_point
+    alibi = alibi.view(n_head, 1, max_pos)
+    alibi_mask = torch.triu(_fill_with_neg_inf(torch.zeros([max_pos, max_pos])), 1)
+    alibi_mask = alibi_mask.unsqueeze(0) + alibi
+    return alibi_mask
+
+
+def _get_alibi_slopes(total_num_heads: int) -> torch.Tensor:
+    closest_power_of_2 = 2 ** math.floor(math.log2(total_num_heads))
+    base = torch.tensor(
+        2 ** (-(2 ** -(math.log2(closest_power_of_2) - 3))),
+        dtype=torch.float32,
+    )
+    powers = torch.arange(1, 1 + closest_power_of_2, dtype=torch.int32)
+    slopes = torch.pow(base, powers)
+
+    if closest_power_of_2 != total_num_heads:
+        extra_base = torch.tensor(
+            2 ** (-(2 ** -(math.log2(2 * closest_power_of_2) - 3))),
+            dtype=torch.float32,
+        )
+        num_remaining_heads = min(
+            closest_power_of_2, total_num_heads - closest_power_of_2
+        )
+        extra_powers = torch.arange(
+            start=1, end=1 + 2 * num_remaining_heads, step=2, dtype=torch.int32
+        )
+        slopes = torch.cat([slopes, torch.pow(extra_base, extra_powers)], dim=0)
+    return slopes
+
+
+def _buffered_future_mask(tensor, maxpos, alibi, attn_heads):
+    _future_mask = torch.triu(_fill_with_neg_inf(torch.zeros([maxpos, maxpos])), 1)
+    _future_mask = _future_mask.unsqueeze(0) + alibi
+    new_future_mask = _future_mask.to(tensor)
+    return new_future_mask[: tensor.shape[0] * attn_heads, :maxpos, :maxpos]
+
+
+class MLP(torch.nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+    ):
+        super().__init__()
+        self.gate_up_proj = ColumnParallelLinear(
+            hidden_size,
+            2 * intermediate_size,
+            bias=False,
+            gather_output=False,
+            perform_initialization=False,
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            perform_initialization=False,
+        )
+        self.act_fn = ACT2FN[hidden_act]
+
+    def forward(self, x):
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x, _ = self.down_proj(x)
+        return x
+
+
+class BaichuanAttention(torch.nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        position_embedding: str,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        tensor_model_parallel_world_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tensor_model_parallel_world_size == 0
+        self.num_heads = self.total_num_heads // tensor_model_parallel_world_size
+        self.head_dim = hidden_size // self.total_num_heads
+        self.postion_embedding = position_embedding
+
+        # pylint: disable=invalid-name
+        self.W_pack = ColumnParallelLinear(
+            hidden_size,
+            3 * hidden_size,
+            bias=False,
+            gather_output=False,
+            perform_initialization=False,
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            hidden_size,
+            bias=False,
+            input_is_parallel=True,
+            perform_initialization=False,
+        )
+        # Create the alibi slopes and slice them.
+        if self.postion_embedding == "ALIBI":
+            tp_rank = get_tensor_model_parallel_rank()
+            head_start = tp_rank * self.num_heads
+            head_end = (tp_rank + 1) * self.num_heads
+            alibi_slopes = _get_alibi_slopes(self.total_num_heads)
+            alibi_slopes = alibi_slopes[head_start:head_end].tolist()
+
+            scaling = self.head_dim**-0.5
+            self.attn = PagedAttentionWithALiBi(
+                self.num_heads, self.head_dim, scaling, alibi_slopes
+            )
+        else:
+            self.scaling = self.head_dim**-0.5
+            self.attn = PagedAttentionWithRoPE(
+                self.num_heads, self.head_dim, self.scaling, rotary_dim=self.head_dim
+            )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        qkv, _ = self.W_pack(hidden_states)
+        q, k, v = qkv.chunk(chunks=3, dim=-1)
+        k_cache, v_cache = kv_cache
+        if self.postion_embedding == "ALIBI":
+            attn_output = self.attn(
+                q, k, v, k_cache, v_cache, input_metadata, cache_event
+            )
+        else:
+            attn_output = self.attn(
+                positions, q, k, v, k_cache, v_cache, input_metadata, cache_event
+            )
+
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class BaichuanLayer(torch.nn.Module):
+    def __init__(self, config: BaiChuanConfig, position_embedding: str):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = BaichuanAttention(
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            position_embedding=position_embedding,
+        )
+        self.mlp = MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, epsilon=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, epsilon=config.rms_norm_eps
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        # Self Attention
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        # Self Attention
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+            kv_cache=kv_cache,
+            input_metadata=input_metadata,
+            cache_event=cache_event,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class BaichuanModel(nn.Module):
+    def __init__(self, config: BaiChuanConfig, position_embedding: str):
+        super().__init__(config)
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size, config.hidden_size, perform_initialization=False
+        )
+        self.layers = nn.ModuleList(
+            [
+                BaichuanLayer(config, position_embedding)
+                for _ in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = RMSNorm(config.hidden_size, epsilon=config.rms_norm_eps)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> torch.Tensor:
+        hidden_states = self.embed_tokens(input_ids)
+        for i in range(len(self.layers)):
+            if cache_events is None:
+                cache_event = None
+            else:
+                cache_event = cache_events[i]
+            layer = self.layers[i]
+            hidden_states = layer(
+                positions,
+                hidden_states,
+                kv_caches[i],
+                input_metadata,
+                cache_event,
+            )
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class BaiChuanBaseForCausalLM(nn.Module):
+    def __init__(self, config, position_embedding: str):
+        super().__init__()
+        self.config = config
+        self.model = BaichuanModel(config, position_embedding)
+        self.lm_head = ColumnParallelLinear(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            gather_output=False,
+            perform_initialization=False,
+        )
+        self.sampler = Sampler(config.vocab_size)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> SamplerOutput:
+        hidden_states = self.model(
+            input_ids, positions, kv_caches, input_metadata, cache_events
+        )
+        next_tokens = self.sampler(self.lm_head.weight, hidden_states, input_metadata)
+        return next_tokens
+
+    _column_parallel_weights = []
+    _row_parallel_weights = ["o_proj.weight", "down_proj.weight"]
+
+    def load_weights(
+        self,
+        model_name_or_path: str,
+        cache_dir: Optional[str] = None,
+        load_format: str = "auto",
+    ):
+        tp_world_size = get_tensor_model_parallel_world_size()
+        tp_rank = get_tensor_model_parallel_rank()
+        state_dict = self.state_dict()
+
+        for name, loaded_weight in hf_model_weights_iterator(
+            model_name_or_path, cache_dir, load_format
+        ):
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            loaded_weight = convert_pyslice_to_tensor(loaded_weight)
+
+            if "W_pack" in name:
+                total_num_heads = self.config.num_attention_heads
+                hidden_size = self.config.hidden_size
+                head_size = hidden_size // total_num_heads
+                num_heads = total_num_heads // tp_world_size
+                head_start = tp_rank * num_heads
+                head_end = (tp_rank + 1) * num_heads
+
+                loaded_weight = loaded_weight.view(
+                    3, total_num_heads, head_size, hidden_size
+                )
+                loaded_weight = loaded_weight[:, head_start:head_end, :, :]
+                loaded_weight = loaded_weight.reshape(-1, hidden_size)
+
+            is_gate_up_weight = False
+            for stride_id, weight_name in enumerate(["gate_proj", "up_proj"]):
+                if weight_name not in name:
+                    continue
+                param = state_dict[name.replace(weight_name, "gate_up_proj")]
+                shard_size = param.shape[0] // 2
+                loaded_weight = loaded_weight[
+                    shard_size * tp_rank : shard_size * (tp_rank + 1)
+                ]
+                param_slice = param.data[
+                    shard_size * stride_id : shard_size * (stride_id + 1)
+                ]
+                assert param_slice.shape == loaded_weight.shape
+                param_slice.copy_(loaded_weight)
+                is_gate_up_weight = True
+                break
+            if is_gate_up_weight:
+                continue
+
+            param = state_dict[name]
+
+            if "embed_tokens" in name or "lm_head" in name:
+                load_padded_tensor_parallel_vocab(param, loaded_weight, tp_rank)
+                continue
+
+            load_tensor_parallel_weights(
+                param,
+                loaded_weight,
+                name,
+                self._column_parallel_weights,
+                self._row_parallel_weights,
+                tp_rank,
+            )
+
+
+class Baichuan2ForCausalLM(BaiChuanBaseForCausalLM):  # baichuan 13b
+    def __init__(self, config):
+        super().__init__(config, "ALIBI")
+
+
+class BaiChuan2ForCausalLM(BaiChuanBaseForCausalLM):  # baichuan 7b
+    def __init__(self, config):
+        super().__init__(config, "ROPE")

--- a/vllm/model_executor/models/baichuan2.py
+++ b/vllm/model_executor/models/baichuan2.py
@@ -364,7 +364,10 @@ class BaiChuanBaseForCausalLM(nn.Module):
                 # print(
                 #     f"loading lm_head weight, norm: {loaded_weight.norm(2.0, 1, True).clamp_min(1e-12)}, shape: {loaded_weight.size()}"
                 # )
-                loaded_weight = torch.nn.functional.normalize(loaded_weight)
+                if loaded_weight.dtype == torch.float16 and loaded_weight.device == torch.device("cpu"):
+                    loaded_weight = torch.nn.functional.normalize(loaded_weight.float()).half()
+                else:
+                    loaded_weight = torch.nn.functional.normalize(loaded_weight)
                 # print(
                 #     f"after normalization, norm: {loaded_weight.norm(2.0, 1, True).clamp_min(1e-12)}, shape: {loaded_weight.size()}"
                 # )

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -5,6 +5,7 @@ from vllm.transformers_utils.configs import *  # pylint: disable=wildcard-import
 _CONFIG_REGISTRY = {
     "mpt": MPTConfig,
     "baichuan": BaiChuanConfig,
+    "baichuan2": BaiChuan2Config,
     "aquila": AquilaConfig,
     "qwen": QWenConfig,
     "RefinedWeb": RWConfig,  # For tiiuae/falcon-40b(-instruct)

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -1,5 +1,6 @@
 from vllm.transformers_utils.configs.mpt import MPTConfig
 from vllm.transformers_utils.configs.baichuan import BaiChuanConfig
+from vllm.transformers_utils.configs.baichuan2 import BaiChuan2Config
 from vllm.transformers_utils.configs.aquila import AquilaConfig
 from vllm.transformers_utils.configs.qwen import QWenConfig
 # RWConfig is for the original tiiuae/falcon-40b(-instruct) and
@@ -10,6 +11,7 @@ from vllm.transformers_utils.configs.falcon import RWConfig
 __all__ = [
     "MPTConfig",
     "BaiChuanConfig",
+    "BaiChuan2Config",
     "AquilaConfig",
     "QWenConfig",
     "RWConfig",

--- a/vllm/transformers_utils/configs/baichuan2.py
+++ b/vllm/transformers_utils/configs/baichuan2.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers.configuration_utils import PretrainedConfig
+
+        
+class BaiChuan2Config(PretrainedConfig):
+    model_type = "baichuan"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size=64000,
+        hidden_size=5120,
+        intermediate_size=13696,
+        num_hidden_layers=40,
+        num_attention_heads=40,
+        hidden_act="silu",
+        model_max_length=4096,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        gradient_checkpointing=False,
+        z_loss_weight=0,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.model_max_length = model_max_length
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.z_loss_weight = z_loss_weight
+        self.gradient_checkpointing = (gradient_checkpointing,)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )


### PR DESCRIPTION
### Description:
https://github.com/vllm-project/vllm/pull/1022 adds support for Baichuan2 models. However, for Baichuan2-Chat-7B based on rotary embeddings, Baichuan2ForCausalLM (alibi) is applied, leading to confusing generations of Baichuan2-Chat-7B. 

### Related Issue
Refer to https://github.com/vllm-project/vllm/issues/1085

### Changes
Modify the `_get_model_architecture` to apply BaiChuan2ForCausalLM for Baichuan2-7B-Chat by checking the intermediate_size.