### PR TITLE
Added support for inference of chatglm2 on multiple GPUs, which inherits from #649

### DIFF
--- a/README-glm.md
+++ b/README-glm.md
@@ -1,17 +1,17 @@
 # vllm 自定义项目
 
-该项目fork自[vllm-project/vllm](https://github.com/vllm-project),  目前主要实现了对chatglm2的多卡支持
-注意：由于glm2的GQA的group_num=2, 所以目前多卡只支持2卡。
+	该项目fork自[vllm-project/vllm](https://github.com/vllm-project),  目前主要实现了对chatglm2的多卡支持
+	注意：由于glm2的GQA的group_num=2, 所以目前多卡只支持2卡。
 
 ## 安装
 
-- git clone https://github.com/David-webb/vllm-custom.git
-- cd vllm-custom
+- git clone https://github.com/David-webb/vllm.git -b vllm4chatglm
+- cd vllm
 - pip install -e .
 
 ## 使用
 
-custom_launch_scripts/目录下:
+vllm/custom_launch_scripts/目录下:
 
 - vllm_launch.sh   用于启动服务
 - try_vllm.py    提供了vllm的访问接口模板（流式/非流式）

--- a/README-glm.md
+++ b/README-glm.md
@@ -1,0 +1,24 @@
+# vllm 自定义项目
+
+该项目fork自[vllm-project/vllm](https://github.com/vllm-project),  目前主要实现了对chatglm2的多卡支持
+注意：由于glm2的GQA的group_num=2, 所以目前多卡只支持2卡。
+
+## 安装
+
+- git clone https://github.com/David-webb/vllm-custom.git
+- cd vllm-custom
+- pip install -e .
+
+## 使用
+
+custom_launch_scripts/目录下:
+
+- vllm_launch.sh   用于启动服务
+- try_vllm.py    提供了vllm的访问接口模板（流式/非流式）
+- Dockerfile   提供了构建vllm运行环境的docker镜像
+
+## todo
+
+- chatglm2的多卡突破GQA限制
+- vllm上实现对ntk的支持
+- vllm上实现flash-attention的集成（非xformer方法）

--- a/custom_launch_scripts/Dockerfile
+++ b/custom_launch_scripts/Dockerfile
@@ -1,0 +1,11 @@
+FROM nvcr.io/nvidia/pytorch:22.12-py3
+RUN pip uninstall torch -y && \
+    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple && \
+    python -m pip install --upgrade pip
+RUN pip install accelerate==0.21.0 bitsandbytes==0.40.2 gradio==3.37.0 protobuf==3.20.3 typing-inspect==0.8.0 typing_extensions==4.5.0 ray==2.5.1  transformers==4.33.1 scipy sentencepiece torch
+COPY ./ /home/focusgpt/
+WORKDIR /home/focusgpt/
+RUN cd /home/focusgpt/vllm_src/vllm/ && pip install -e .
+RUN cd /home/focusgpt/ && chmod +x /home/focusgpt/new_vllm_launch.sh
+ENTRYPOINT ["./vllm_launch.sh"]
+EXPOSE 8080

--- a/custom_launch_scripts/api_server.py
+++ b/custom_launch_scripts/api_server.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+from typing import AsyncGenerator
+
+from fastapi import BackgroundTasks, FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+import uvicorn
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.sampling_params import SamplingParams
+from vllm.utils import random_uuid
+
+TIMEOUT_KEEP_ALIVE = 5  # seconds.
+TIMEOUT_TO_PREVENT_DEADLOCK = 1  # seconds.
+app = FastAPI()
+engine = None
+
+
+@app.post("/generate")
+async def generate(request: Request) -> Response:
+    """Generate completion for the request.
+
+    The request should be a JSON object with the following fields:
+    - prompt: the prompt to use for the generation.
+    - stream: whether to stream the results or not.
+    - other fields: the sampling parameters (See `SamplingParams` for details).
+    """
+    request_dict = await request.json()
+    prompt = request_dict.pop("prompt")
+    stream = request_dict.pop("stream", False)
+    sampling_params = SamplingParams(**request_dict)
+    request_id = random_uuid()
+
+    results_generator = engine.generate(prompt, sampling_params, request_id)
+
+    # Streaming case
+    async def stream_results() -> AsyncGenerator[bytes, None]:
+        async for request_output in results_generator:
+            prompt = request_output.prompt
+            text_outputs = [
+                prompt + output.text for output in request_output.outputs
+            ]
+            ret = {"text": text_outputs}
+            yield (json.dumps(ret) + "\0").encode("utf-8")
+
+    async def abort_request() -> None:
+        await engine.abort(request_id)
+
+    if stream:
+        background_tasks = BackgroundTasks()
+        # Abort the request if the client disconnects.
+        background_tasks.add_task(abort_request)
+        return StreamingResponse(stream_results(), background=background_tasks)
+
+    # Non-streaming case
+    final_output = None
+    async for request_output in results_generator:
+        if await request.is_disconnected():
+            # Abort the request if the client disconnects.
+            await engine.abort(request_id)
+            return Response(status_code=499)
+        final_output = request_output
+
+    assert final_output is not None
+    prompt = final_output.prompt
+    text_outputs = [prompt + output.text for output in final_output.outputs]
+    ret = {"text": text_outputs}
+    return JSONResponse(ret)
+
+def get_model_type(model_dir):
+    import os
+    model_config = os.path.join(model_dir, "config.json")
+    with open(model_config, "r")as rd:
+        cfg = json.loads(rd.read())
+    return cfg["architectures"][0]
+    pass
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser = AsyncEngineArgs.add_cli_args(parser)
+    args = parser.parse_args()
+
+    engine_args = AsyncEngineArgs.from_cli_args(args)
+    arch = get_model_type(engine_args.model)
+    if "baichuan" in arch.lower() or "chatglm" in arch.lower():
+        # print(engine_args.model)
+        print("当前架构是:", arch)
+        print("set trust_remote_code True......")
+        engine_args.trust_remote_code = True
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+
+    uvicorn.run(app,
+                host=args.host,
+                port=args.port,
+                log_level="debug",
+                timeout_keep_alive=TIMEOUT_KEEP_ALIVE)

--- a/custom_launch_scripts/try_vllm.py
+++ b/custom_launch_scripts/try_vllm.py
@@ -1,0 +1,94 @@
+# 声明使用utf8编码
+# -*- coding: utf-8 -*-
+import json
+import requests
+from vllm import LLM, SamplingParams
+
+
+def clear_line(n: int = 1) -> None:
+    LINE_UP = '\033[1A'
+    LINE_CLEAR = '\x1b[2K'
+    for _ in range(n):
+        print(LINE_UP, end=LINE_CLEAR, flush=True)
+
+
+def vllm_request_template(url, prompt, temperature, max_tokens=4096, use_beam_search=False, num_of_seqencens=1, top_k=1, top_p=0.95, stream=True, stop="$$"):
+    """vllms部署llama2访问接口模板(完整版)
+    """
+
+    def get_stream_res(response):
+        for chunk in response.iter_lines(chunk_size=8192,decode_unicode=False,delimiter=b"\0"):
+            if chunk:
+                data = json.loads(chunk.decode("utf-8"))
+                output = data["text"]
+                yield output 
+
+    data = {
+        "prompt": prompt,
+        "use_beam_search": use_beam_search,
+        "n": num_of_seqencens,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "top_k": top_k,
+        "top_p": top_p,
+        "stop": stop,
+        "stream": stream 
+    }
+    # data = json.dumps(data)
+    if stream:
+        headers = {"User-Agent": "stream test client"}
+    else:
+        headers = {'Content-Type': 'application/json'}
+
+    res = requests.post(url, headers=headers, json=data, stream=stream)
+
+    if stream:
+        num_printed_lines = 0
+        for h in get_stream_res(res):
+            clear_line(num_printed_lines)
+            num_printed_lines = 0
+            is_end = False
+            tmp_s = ""
+            for i, line in enumerate(h):
+                num_printed_lines += 1
+                if line.endswith("$$"):     # 检测到padding符号，终止
+                    line = line.replace("$$", "").strip()
+                    is_end = True
+                tmp_s += line
+                print(f"Beam candidate {i}: {line!r}", flush=True)
+                if is_end:
+                    print("最终额输出是:", tmp_s)
+                    return 
+                print("临时输出:", tmp_s)
+    else:
+        # ans = json.loads(res.text)["text"][0].strip().split("### Response:")[1].strip()
+        try:
+            res_flag = "### Response:"
+            ans = json.loads(res.text)["text"][0].strip()
+            if res_flag in ans: 
+                ans = ans.split(res_flag)[1].strip()
+        except Exception as e:
+            print("检测到异常的返回，res.text: ", res.text)
+            print(e)
+            ans = ""
+        return ans 
+    pass
+
+def normal_api_main():
+    url = "http://ip:port/generate"
+    prompt = "你好，今天天气不错，我想出去玩，请给我推荐一些户外运动？" 
+    # prompt = "你好，帮我写一篇500字关于北京的近代史的文章"
+    prompt_input_template = (
+        "Below is an instruction that describes a task. "
+        "Write a response that appropriately completes the request.\n\n"
+        "### Instruction:\n\n {instruction} \n\n### Response:\n\n"
+    )
+    inp_prompt = prompt_input_template.format(instruction=prompt)
+    temperature = 0.1
+    stream = True 
+    stop = "$$"
+    print(vllm_request_template(url, inp_prompt, temperature, max_tokens=4096, use_beam_search=False, num_of_seqencens=1, top_k=-1, top_p=1.0, stream=stream, stop=stop))
+
+if __name__ == "__main__":
+    normal_api_main()
+    pass

--- a/custom_launch_scripts/vllm_launch.sh
+++ b/custom_launch_scripts/vllm_launch.sh
@@ -1,0 +1,2 @@
+export NCCL_IGNORE_DISABLED_P2P=1
+CUDA_VISIBLE_DEVICES=YOUR_GPU_LIST python api_server.py --model /PATH/TO/chatglm2-6b --port 23889 --gpu-memory-utilization=0.95  --host YOUR_IP --max-num-batched-tokens=4096 --tensor-parallel-size=2 

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -29,6 +29,7 @@ _MODEL_REGISTRY = {
     "OPTForCausalLM": OPTForCausalLM,
     "QWenLMHeadModel": QWenLMHeadModel,
     "RWForCausalLM": FalconForCausalLM,
+    "ChatGLMModel": ChatGLMHeadModel,
 }
 
 # FIXME(woosuk): Remove this once all models support quantization.

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -12,6 +12,7 @@ from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.model_executor.models.mpt import MPTForCausalLM
 from vllm.model_executor.models.opt import OPTForCausalLM
 from vllm.model_executor.models.qwen import QWenLMHeadModel
+from vllm.model_executor.models.chatglm import ChatGLMHeadModel
 
 __all__ = [
     "AquilaForCausalLM",
@@ -28,4 +29,5 @@ __all__ = [
     "MPTForCausalLM",
     "OPTForCausalLM",
     "QWenLMHeadModel",
+    "ChatGLMHeadModel",
 ]

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -567,7 +567,8 @@ class ChatGLMHeadModel(torch.nn.Module):
     def load_weights(self,
                      model_name_or_path: str,
                      cache_dir: Optional[str] = None,
-                     load_format: str = "auto"):
+                     load_format: str = "auto",
+                     revision: Optional[str] = None):
 
         offset = tensor_model_parallel_rank = get_tensor_model_parallel_rank()
         tp_size = get_tensor_model_parallel_world_size()

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -1,0 +1,773 @@
+# coding=utf-8
+# Adapted from
+# https://huggingface.co/THUDM/chatglm2-6b/blob/main/modeling_chatglm.py
+"""Inference-only ChatGLM model compatible with HuggingFace weights.
+
+The input of the model is flattened to a 1D tensor of tokens. The model uses
+InputMetadata to extract the original 2D shape of the input.
+
+"""
+import sys
+import torch
+import torch.utils.checkpoint
+# import torch.nn.functional as F
+from torch.nn import LayerNorm
+from typing import Optional, Tuple, List  # , Dict
+from transformers.utils import logging
+# vllm
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.input_metadata import InputMetadata
+from vllm.model_executor.layers.attention import PagedAttentionWithRoPE  # PagedAttention,
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.sampler import Sampler
+from vllm.model_executor.weight_utils import (
+    hf_model_weights_iterator,
+    load_tensor_parallel_weights,
+    load_padded_tensor_parallel_vocab,
+)
+from vllm.model_executor.parallel_utils.parallel_state import (
+    get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)
+from vllm.model_executor.parallel_utils.tensor_parallel import (
+    VocabParallelEmbedding, ColumnParallelLinear, RowParallelLinear)
+from vllm.sequence import SamplerOutput  # SequenceOutputs,
+from vllm.transformers_utils.configs.chatglm import ChatGLMConfig
+
+KVCache = Tuple[torch.Tensor, torch.Tensor]
+
+# flags required to enable jit fusion kernels
+
+if sys.platform != "darwin":
+    torch._C._jit_set_profiling_mode(False)
+    torch._C._jit_set_profiling_executor(False)
+    torch._C._jit_override_can_fuse_on_cpu(True)
+    torch._C._jit_override_can_fuse_on_gpu(True)
+
+logger = logging.get_logger(__name__)
+
+CHATGLM_6B_PRETRAINED_MODEL_ARCHIVE_LIST = [
+    "THUDM/chatglm2-6b",
+    # See all ChatGLM models at https://huggingface.co/models?filter=chatglm
+]
+
+
+def build_rotary_pos(seq_len,
+                     n_elem,
+                     dtype,
+                     device,
+                     base: int = 10000,
+                     rope_ratio: int = 1):
+    theta = 1.0 / (base**(
+        torch.arange(0, n_elem, 2, dtype=dtype, device=device) / n_elem))
+
+    # Create position indexes `[0, 1, ..., seq_len - 1]`
+    seq_idx = torch.arange(seq_len, dtype=dtype, device=device) / rope_ratio
+
+    # Calculate the product of position index and $\theta_i$
+    idx_theta = torch.outer(seq_idx, theta).float()
+
+    cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
+
+    # this is to mimic the behaviour of complex32, else we will
+    # get different results
+    if dtype in (torch.float16, torch.bfloat16, torch.int8):
+        cache = cache.bfloat16() if dtype == torch.bfloat16 else cache.half()
+    return cache
+
+
+@torch.jit.script
+def apply_rotary_pos_emb(x: torch.Tensor,
+                         rope_cache: torch.Tensor) -> torch.Tensor:
+    # x: [sq, np, hn]
+    x = x.unsqueeze(1)
+    sq, _, np, _ = x.size(0), x.size(1), x.size(2), x.size(3)
+    rot_dim = rope_cache.shape[-2] * 2
+    x, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+    # truncate to support variable sizes
+    rope_cache = rope_cache[:sq]
+    xshaped = x.reshape(sq, -1, np, rot_dim // 2, 2)
+    rope_cache = rope_cache.view(sq, -1, 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * rope_cache[..., 0] -
+            xshaped[..., 1] * rope_cache[..., 1],
+            xshaped[..., 1] * rope_cache[..., 0] +
+            xshaped[..., 0] * rope_cache[..., 1],
+        ],
+        -1,
+    )
+    x_out2 = x_out2.flatten(3)
+    return torch.cat((x_out2, x_pass), dim=-1)
+
+
+class MLP(torch.nn.Module):
+    """MLP.
+
+    MLP will take the input with h hidden state, project it to 4*h
+    hidden dimension, perform nonlinear transformation, and project the
+    state back into h hidden dimension.
+    """
+
+    def __init__(self, config):
+        super().__init__()
+
+        self.add_bias = config.add_bias_linear
+
+        # Project to 4h. If using swiglu double the output width,
+        #  see https://arxiv.org/pdf/2002.05202.pdf
+        self.dense_h_to_4h = ColumnParallelLinear(
+            config.hidden_size,
+            config.ffn_hidden_size * 2,
+            bias=self.add_bias,
+            gather_output=False,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+
+        # def swiglu(x):
+        # x = torch.chunk(x, 2, dim=-1)
+        # return F.silu(x[0]) * x[1]
+
+        # self.activation_func = swiglu
+        self.activation_func = SiluAndMul()
+
+        # Project back to h.
+        self.dense_4h_to_h = RowParallelLinear(config.ffn_hidden_size,
+                                               config.hidden_size,
+                                               bias=self.add_bias,
+                                               input_is_parallel=True,
+                                               perform_initialization=False,
+                                               params_dtype=config.torch_dtype)
+
+    def forward(self, hidden_states):
+        # [s, b, 4hp]
+        intermediate_parallel, _ = self.dense_h_to_4h(hidden_states)
+        intermediate_parallel = self.activation_func(intermediate_parallel)
+        # [s, b, h]
+        output, _ = self.dense_4h_to_h(intermediate_parallel)
+        return output
+
+
+def default_init(cls, *args, **kwargs):
+    return cls(*args, **kwargs)
+
+
+def split_tensor_along_last_dim(
+    tensor: torch.Tensor,
+    num_partitions: int,
+    contiguous_split_chunks: bool = False,
+) -> List[torch.Tensor]:
+    """Split a tensor along its last dimension.
+
+    Arguments:
+        tensor: input tensor.
+        num_partitions: number of partitions to split the tensor
+        contiguous_split_chunks: If True, make each chunk contiguous
+                                 in memory.
+
+    Returns:
+        A list of Tensors
+    """
+    # Get the size and dimension.
+    last_dim = tensor.dim() - 1
+    last_dim_size = tensor.size()[last_dim] // num_partitions
+    # Split.
+    tensor_list = torch.split(tensor, last_dim_size, dim=last_dim)
+    # Note: torch.split does not create contiguous tensors by default.
+    if contiguous_split_chunks:
+        return tuple(chunk.contiguous() for chunk in tensor_list)
+
+    return tensor_list
+
+
+class SelfAttention(torch.nn.Module):
+    """Parallel self-attention layer abstract class.
+
+    Self-attention layer takes input with size [s, b, h]
+    and returns output of the same size.
+    """
+
+    def __init__(self, config, layer_number):
+        super().__init__()
+        self.layer_number = max(1, layer_number)
+        # 添加tp的计算
+        tp_size = get_tensor_model_parallel_world_size()
+        self.projection_size = (config.kv_channels *
+                                config.num_attention_heads)
+
+        # Per attention head and per partition values.
+        # self.hidden_size_per_attention_head = (self.projection_size //
+        # config.num_attention_heads)
+        self.hidden_size_per_attention_head = config.kv_channels
+
+        self.num_attention_heads_per_partition = config.num_attention_heads // tp_size
+
+        self.norm_factor = self.hidden_size_per_attention_head**-0.5
+
+        self.rope_theta = getattr(config, "rope_theta", 10000)
+        self.rope_ratio = 1 if ("rope_ratio"
+                                not in config.to_dict()) else config.rope_ratio
+        self.multi_query_attention = config.multi_query_attention
+
+        self.seq_length = config.seq_length
+        self.rotary_dim = (config.hidden_size // config.num_attention_heads if
+                           config.kv_channels is None else config.kv_channels)
+
+        self.qkv_hidden_size = 3 * self.projection_size
+        # if self.multi_query_attention:
+        # self.num_multi_query_groups_per_partition = (
+        # config.multi_query_group_num) // tp_size
+        # self.qkv_hidden_size = ( (config.num_attention_heads +
+        # 2 * config.multi_query_group_num) * self.hidden_size_per_attention_head)
+
+        # 如果tp_size 超过了 group_num，但满足 num_attention_heads%tp_size == 0 and tp_size % group_num == 0, 则直接将group_num_per_partition提升到tp_size
+        if self.multi_query_attention:
+            group_num = config.multi_query_group_num
+            if tp_size <= group_num:
+                self.num_multi_query_groups_per_partition = group_num // tp_size
+            else:
+                assert config.num_attention_heads % tp_size == 0 and tp_size % group_num == 0, "Wrong tensor_parallel, must mod num_attention_heads and be mod by group_num when it bigger than group_num! "
+                self.num_multi_query_groups_per_partition = 1  # 每个张量并行的分支都有1个group_head
+            self.qkv_hidden_size = (
+                (config.num_attention_heads +
+                 2 * tp_size * self.num_multi_query_groups_per_partition) *
+                self.hidden_size_per_attention_head)
+            pass
+        # else:
+        self.query_key_value = ColumnParallelLinear(
+            config.hidden_size,
+            self.qkv_hidden_size,
+            bias=config.add_bias_linear or config.add_qkv_bias,
+            gather_output=False,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+
+        # num_kv_heads=self.num_multi_query_groups_per_partition
+        # if self.multi_query_attention else config.num_attention_heads
+        # self.atten = PagedAttention(config.num_attention_heads ,
+        # self.atten = PagedAttention(self.num_attention_heads_per_partition,
+        # self.hidden_size_per_attention_head,
+        # self.norm_factor)
+
+        #  ================= PagedAttentionWithRoPE =========================
+        self.atten = PagedAttentionWithRoPE(
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+            self.norm_factor,
+            base=self.rope_theta,
+            max_position=config.seq_length,
+            rotary_dim=self.hidden_size_per_attention_head // 2,
+            is_neox_style=False,
+            num_kv_heads=self.num_attention_heads_per_partition)
+        # num_kv_heads=self.num_multi_query_groups_per_partition,
+        # Output.
+        self.dense = RowParallelLinear(self.projection_size,
+                                       config.hidden_size,
+                                       bias=config.add_bias_linear,
+                                       input_is_parallel=True,
+                                       perform_initialization=False,
+                                       params_dtype=config.torch_dtype)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        # hidden_states: [sq, b, h]
+
+        # =================================================
+        # Pre-allocate memory for key-values for inference.
+        # =================================================
+        # =====================
+        # Query, Key, and Value
+        # =====================
+
+        # Attention heads [sq, b, h] --> [sq, b, (np * 3 * hn)]
+        mixed_x_layer, _ = self.query_key_value(hidden_states)
+
+        if self.multi_query_attention:
+            (query_layer, key_layer, value_layer) = mixed_x_layer.split(
+                [
+                    self.num_attention_heads_per_partition *
+                    self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition *
+                    self.hidden_size_per_attention_head,
+                    self.num_multi_query_groups_per_partition *
+                    self.hidden_size_per_attention_head,
+                ],
+                dim=-1,
+            )
+            # print(query_layer.shape, key_layer.shape)
+            query_layer = query_layer.contiguous().view(
+                query_layer.size()[:-1] +
+                (self.num_attention_heads_per_partition,
+                 self.hidden_size_per_attention_head))  # (sq*b, 16, 128)
+            key_layer = key_layer.contiguous().view(
+                key_layer.size()[:-1] +
+                (self.num_multi_query_groups_per_partition,
+                 self.hidden_size_per_attention_head))  # (sq*b, 1, 128)
+            value_layer = value_layer.contiguous().view(
+                value_layer.size()[:-1] +
+                (self.num_multi_query_groups_per_partition,
+                 self.hidden_size_per_attention_head))  # (sq*b, 1, 128)
+            # print(query_layer.shape, key_layer.shape, value_layer.shape)
+        else:
+            new_tensor_shape = (mixed_x_layer.size()[:-1] +
+                                (self.num_attention_heads_per_partition,
+                                 3 * self.hidden_size_per_attention_head))
+            mixed_x_layer = mixed_x_layer.contiguous().view(*new_tensor_shape)
+
+            # [sq, b, np, 3 * hn] --> 3 [sq, b, np, hn]
+            (query_layer, key_layer,
+             value_layer) = split_tensor_along_last_dim(mixed_x_layer, 3)
+
+        k_cache, v_cache = kv_cache
+        # ============= deprecated ====================
+        # rotary_pos = build_rotary_pos(self.seq_length, # 32k
+        # self.rotary_dim // 2, # 128 // 2 == 64
+        # dtype=query_layer.dtype,
+        # device=query_layer.device,
+        # rope_ratio=self.rope_ratio) # rope_ratio=1
+        # if positions is not None:
+        # # print("got positions!")
+        # # print("positions的数值", positions, positions.shape)
+        # rotary_pos = rotary_pos[positions]
+        # else:
+        # rotary_pos = rotary_pos[:query_layer.shape[0]]
+        # # print("rotary_pos的shape为：", rotary_pos.size()) # (s, )
+
+        # rotary_pos = rotary_pos.unsqueeze(0).transpose(0, 1).contiguous()
+
+        # query_layer = apply_rotary_pos_emb(query_layer, rotary_pos).reshape(
+        # -1, self.num_attention_heads_per_partition,
+        # self.hidden_size_per_attention_head) # (sq*b, 16, 128)
+        # key_layer = apply_rotary_pos_emb(key_layer, rotary_pos).reshape(
+        # -1, self.num_multi_query_groups_per_partition,
+        # self.hidden_size_per_attention_head) # (sq*b, 1, 128)
+        # ==================================================
+        if self.multi_query_attention:
+            # print("key_layer.shape 是:", key_layer.shape)
+            # print("repeat_interleave之前：", key_layer.shape, key_layer[...,:2])
+            key_layer = torch.repeat_interleave(
+                key_layer,
+                self.num_attention_heads_per_partition //
+                self.num_multi_query_groups_per_partition,
+                dim=1)
+            value_layer = torch.repeat_interleave(
+                value_layer,
+                self.num_attention_heads_per_partition //
+                self.num_multi_query_groups_per_partition,
+                dim=1)
+            # print(key_layer.shape, key_layer[...,:2])
+
+        # ==================================
+        # core attention computation
+        # ==================================
+
+        query_layer = query_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)  # (sq*b, 16*128)
+        key_layer = key_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)  # (sq*b, 16*128)
+        value_layer = value_layer.reshape(
+            -1, self.num_attention_heads_per_partition *
+            self.hidden_size_per_attention_head)
+
+        # ============= pagedAttentionWithRoPE ===============
+        # key_layer = key_layer.reshape(
+        # -1, self.num_multi_query_groups_per_partition*
+        # self.hidden_size_per_attention_head) # (sq*b, 16*128)
+        # value_layer = value_layer.reshape(
+        # -1, self.num_multi_query_groups_per_partition *
+        # self.hidden_size_per_attention_head)
+
+        # ==================== make place with PagedAttentionWithRoPE ====================
+        # context_layer = self.atten(query_layer, key_layer, value_layer,
+        # k_cache, v_cache, input_metadata,
+        # cache_event)
+        context_layer = self.atten(positions, query_layer, key_layer,
+                                   value_layer, k_cache, v_cache,
+                                   input_metadata, cache_event)
+        # =================
+        # Output. [sq, h]
+        # =================
+        # print("context layer shape is:", context_layer.shape)
+        output, _ = self.dense(context_layer)
+
+        return output
+
+
+class GLMBlock(torch.nn.Module):
+    """A single transformer layer.
+
+    Transformer layer takes input with size [s, b, h] and returns an
+    output of the same size.
+    """
+
+    def __init__(self, config, layer_number):
+        super().__init__()
+        self.layer_number = layer_number
+
+        self.apply_residual_connection_post_layernorm = (
+            config.apply_residual_connection_post_layernorm)
+
+        LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
+        # Layernorm on the input data.
+        self.input_layernorm = LayerNormFunc(config.hidden_size,
+                                             eps=config.layernorm_epsilon)
+
+        # Self attention.
+        self.self_attention = SelfAttention(config, layer_number)
+        self.hidden_dropout = config.hidden_dropout
+
+        # Layernorm on the attention output
+        self.post_attention_layernorm = LayerNormFunc(
+            config.hidden_size, eps=config.layernorm_epsilon)
+
+        # MLP
+        self.mlp = MLP(config)
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_cache: KVCache,
+        input_metadata: InputMetadata,
+        cache_event: Optional[torch.cuda.Event],
+    ) -> torch.Tensor:
+        # hidden_states: [s, b, h]
+        # Layer norm at the beginning of the transformer layer.
+        layernorm_output = self.input_layernorm(hidden_states)
+        # Residual connection.
+        if self.apply_residual_connection_post_layernorm:  # False
+            residual = layernorm_output
+        else:
+            residual = hidden_states
+        # Self attention.
+        hidden_states = self.self_attention(
+            positions=positions,
+            hidden_states=layernorm_output,
+            kv_cache=kv_cache,
+            input_metadata=input_metadata,
+            cache_event=cache_event,
+        )
+
+        layernorm_input = residual + hidden_states
+
+        # Layer norm post the self attention.
+        layernorm_output = self.post_attention_layernorm(layernorm_input)
+
+        # MLP.
+        mlp_output = self.mlp(layernorm_output)
+
+        # Second residual connection.
+        if self.apply_residual_connection_post_layernorm:
+            residual = layernorm_output
+        else:
+            residual = layernorm_input
+
+        output = residual + mlp_output
+
+        return output
+
+
+class GLMTransformer(torch.nn.Module):
+    """Transformer class."""
+
+    def __init__(self, config):
+        super().__init__()
+
+        self.fp32_residual_connection = config.fp32_residual_connection
+        self.post_layer_norm = config.post_layer_norm
+
+        # Number of layers.
+        self.num_layers = config.num_layers
+
+        # Transformer layers.
+        def build_layer(layer_number):
+            return GLMBlock(config, layer_number)
+
+        self.layers = torch.nn.ModuleList(
+            [build_layer(i + 1) for i in range(self.num_layers)])
+
+        if self.post_layer_norm:
+            LayerNormFunc = RMSNorm if config.rmsnorm else LayerNorm
+            # Final layer norm before output.
+            self.final_layernorm = LayerNormFunc(config.hidden_size,
+                                                 eps=config.layernorm_epsilon)
+
+    def _get_layer(self, layer_number):
+        return self.layers[layer_number]
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> torch.Tensor:
+
+        for index in range(self.num_layers):
+            if cache_events is None:
+                cache_event = None
+            else:
+                cache_event = cache_events[index]
+            layer = self._get_layer(index)
+            hidden_states = layer(positions, hidden_states, kv_caches[index],
+                                  input_metadata, cache_event)
+
+        # Final layer norm.
+        if self.post_layer_norm:
+            hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states
+
+
+class ChatGLMHeadModel(torch.nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.model = ChatGLMModel(config)
+        vocab_size = ((config.vocab_size + 63) // 64) * 64
+        self.output_layer = ColumnParallelLinear(
+            config.hidden_size,
+            vocab_size,
+            bias=False,
+            gather_output=False,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+        self.sampler = Sampler(config.vocab_size)
+
+    pass
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> SamplerOutput:  # -> Dict[int, SequenceOutputs]:
+        hidden_states = self.model(input_ids, positions, kv_caches,
+                                   input_metadata, cache_events)
+        next_tokens = self.sampler(self.output_layer.weight, hidden_states,
+                                   input_metadata)
+        return next_tokens
+        pass
+
+    _column_parallel_weights = [
+        "dense_h_to_4h.weight",  # "query_key_value.weight", "query_key_value.bias",
+        # "output_layer.weight", "embedding.weight"
+    ]  # "query_key_value.bias"
+    _row_parallel_weights = ["dense_4h_to_h.weight", "dense.weight"]
+
+    def load_weights(self,
+                     model_name_or_path: str,
+                     cache_dir: Optional[str] = None,
+                     load_format: str = "auto"):
+
+        offset = tensor_model_parallel_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
+        g_num = self.config.multi_query_group_num
+        hdim = self.config.hidden_size
+        hn, hd = self.config.num_attention_heads, self.config.kv_channels
+        q_end = hd * hn
+        q_proj_shard_size = (q_end // tp_size)
+        # kv_proj_shard_size = (hd * g_num // tp_size)
+        kv_proj_shard_size = (hd * g_num //
+                              tp_size) if g_num >= tp_size else hd * 1
+        kv_range = g_num * hd  # kv_proj_shard_size * tp_size
+        state_dict = self.state_dict()
+
+        for name, loaded_weight in hf_model_weights_iterator(
+                model_name_or_path, cache_dir, load_format):
+            if "rotary_pos_emb.inv_freq" in name:
+                print("旋转编码相关的的参数:", name)
+                continue
+
+            # name = name.replace("transformer.", "")
+            if "output_layer" in name:
+                name = name.replace("transformer.", "")
+            else:
+                name = name.replace("transformer.", "model.")
+
+            # if name.startswith("embedding"):
+            if name.startswith("model.embedding"):
+                # print(name)
+                name = name.replace(".word_embeddings", "")
+
+            param = state_dict[name]
+
+            if "embedding.weight" in name or "output_layer.weight" in name:
+                # print("当前rank是%d, 调用load_padded_tensor_parallel_vocab: %s"% (offset, name))
+                load_padded_tensor_parallel_vocab(param, loaded_weight,
+                                                  tensor_model_parallel_rank)
+                continue
+
+            # ============== 添加对qkv的参数切分代码: 即：当前rank的qkv怎么从原始的qkv中抽取参数 ===================
+            if "query_key_value.weight" in name:
+                # loaded_weight 的shape为(qH+kH+vH, h)
+                # 按照group聚合重排query.weight, 注意qk相乘时，q的元素和group分组的对应关系是[0,1,0,1,0,1...]
+                # q_weight_loaded = loaded_weight[offset:q_end:tp] # 每个rank上q-linear的shape (hd*hn//tp, h)
+                # q_param = q_weight_loaded.view((hn, hd, hdim))[offset:hn:tp_size]
+                q_weight_loaded = loaded_weight[:q_end]  # (hd*hn, h)
+                q_param = q_weight_loaded[offset *
+                                          q_proj_shard_size:(offset + 1) *
+                                          q_proj_shard_size]
+                # print(q_param.shape, hdim,offset, hn, tp_size)
+                # .contiguous() #, conti会增加额外的显存开销，虽然只是加载阶段
+                q_param = q_param.reshape((-1, hdim))
+                q_param_slice = param.data[:q_proj_shard_size]
+                # print(q_param.shape, q_param_slice.shape)
+                assert q_param.shape == q_param_slice.shape
+                q_param_slice.copy_(q_param)
+
+                # 重新计算offset 支持tp_size >= g_num的情况
+                offset_proj = offset if tp_size <= g_num else offset % (
+                    tp_size // g_num)
+                # print("加载qkv_weight, 当前rank是：",offset_proj)
+                # 抽取k的参数
+                # k_weight_loaded = loaded_weight[q_end:q_end+kv_range].view((g_num, hd, hdim))
+                # k_weight_loaded = k_weight_loaded[offset:g_num:tp_size].view((-1, hdim)).contiguous()
+                k_weight_loaded = loaded_weight[q_end:q_end + kv_range]
+                # k_weight_loaded = k_weight_loaded[offset*kv_proj_shard_size:(offset+1)*kv_proj_shard_size] #.contiguous()
+                k_weight_loaded = k_weight_loaded[
+                    offset_proj * kv_proj_shard_size:(offset_proj + 1) *
+                    kv_proj_shard_size]  # .contiguous()
+                k_param_slice = param.data[
+                    q_proj_shard_size:q_proj_shard_size + kv_proj_shard_size]
+                assert k_param_slice.shape == k_weight_loaded.shape
+                k_param_slice.copy_(k_weight_loaded)
+
+                # 抽取k的参数
+                # v_weight_loaded = loaded_weight[q_end+kv_range:].view((g_num, hd, hdim))
+                # v_weight_loaded = v_weight_loaded[offset:g_num:tp_size].view((-1, hdim)).contiguous()
+                v_weight_loaded = loaded_weight[q_end + kv_range:]
+                # v_weight_loaded = v_weight_loaded[offset*kv_proj_shard_size:(offset+1)*kv_proj_shard_size] #.contiguous()
+                v_weight_loaded = v_weight_loaded[
+                    offset_proj * kv_proj_shard_size:(offset_proj + 1) *
+                    kv_proj_shard_size]  # .contiguous()
+                v_param_slice = param.data[q_proj_shard_size +
+                                           kv_proj_shard_size:]
+                assert v_param_slice.shape == v_weight_loaded.shape
+                v_param_slice.copy_(v_weight_loaded)
+
+                # print("当前rank是%d, qkv_proj 参数加载成功！" % offset)
+                # 跳过load_tensor_parallel_weights
+                continue
+
+            if "query_key_value.bias" in name:
+                # 重新计算offset 支持tp_size >= g_num的情况
+                offset_proj = offset if tp_size <= g_num else offset % (
+                    tp_size // g_num)
+
+                # q_bias
+                # q_weight_loaded = loaded_weight[:q_end].view((hn,hd))[offset:hn:tp_size].reshape((-1)) # (hn,hd)
+                q_weight_loaded = loaded_weight[:q_end][
+                    offset * q_proj_shard_size:(offset + 1) *
+                    q_proj_shard_size].reshape((-1))  # (hn,hd)
+                q_param_slice = param.data[:q_proj_shard_size]
+                q_param_slice.copy_(q_weight_loaded)
+
+                # k_bias
+                # k_weight_loaded = loaded_weight[q_end:q_end+kv_range].view((g_num, hd))
+                # k_weight_loaded = k_weight_loaded[offset:g_num:tp_size].view((-1)).contiguous()
+                k_weight_loaded = loaded_weight[q_end:q_end + kv_range]
+                # k_weight_loaded = k_weight_loaded[offset*kv_proj_shard_size:(offset+1)*kv_proj_shard_size] # .contiguous()
+                k_weight_loaded = k_weight_loaded[
+                    offset_proj * kv_proj_shard_size:(offset_proj + 1) *
+                    kv_proj_shard_size]  # .contiguous()
+                k_param_slice = param.data[
+                    q_proj_shard_size:q_proj_shard_size + kv_proj_shard_size]
+                k_param_slice.copy_(k_weight_loaded)
+
+                # print("加载qkv_bias, 当前rank是：",offset_proj)
+                # v_bias
+                # v_weight_loaded = loaded_weight[q_end+kv_range:].view((g_num, hd))
+                # v_weight_loaded = v_weight_loaded[offset:g_num:tp_size].view((-1)).contiguous()
+                v_weight_loaded = loaded_weight[q_end + kv_range:]
+                # v_weight_loaded = v_weight_loaded[offset*kv_proj_shard_size:(offset+1)*kv_proj_shard_size] #.contiguous()
+                v_weight_loaded = v_weight_loaded[
+                    offset_proj * kv_proj_shard_size:(offset_proj + 1) *
+                    kv_proj_shard_size]  # .contiguous()
+                v_param_slice = param.data[q_proj_shard_size +
+                                           kv_proj_shard_size:]
+                v_param_slice.copy_(v_weight_loaded)
+
+                # print("当前rank是%d,bias赋值成功" % offset)
+                # 跳过load_tensor_parallel_weights
+                continue
+
+            if "dense_h_to_4h.weight" in name:
+                # name: model.encoder.layers.21.mlp.dense_h_to_4h.weight
+                # param.weight(tp=2):  torch.Size([13696, 4096])
+                # loaded_weight:  torch.Size([27392, 4096])
+
+                # print(name, param.shape, loaded_weight.shape)
+                shard_size = param.shape[0] // 2
+                gate_up_loaded_weight = loaded_weight[shard_size *
+                                                      offset:shard_size *
+                                                      (offset + 1)]
+                param_slice_1 = param.data[:shard_size]
+                param_slice_1.copy_(gate_up_loaded_weight)
+
+                gap = loaded_weight.shape[0] // 2
+                gate_up_loaded_weight = loaded_weight[shard_size * offset +
+                                                      gap:shard_size *
+                                                      (offset + 1) + gap]
+                param_slice_2 = param.data[shard_size:]
+                param_slice_2.copy_(gate_up_loaded_weight)
+
+                continue
+
+            load_tensor_parallel_weights(param, loaded_weight, name,
+                                         self._column_parallel_weights,
+                                         self._row_parallel_weights,
+                                         tensor_model_parallel_rank)
+
+
+class ChatGLMModel(torch.nn.Module):
+
+    def __init__(self, config: ChatGLMConfig):
+        super().__init__()
+
+        self.config = config
+        vocab_size = ((config.vocab_size + 63) // 64) * 64
+        self.embedding = VocabParallelEmbedding(
+            vocab_size,
+            config.hidden_size,
+            perform_initialization=False,
+            params_dtype=config.torch_dtype)
+
+        self.num_layers = config.num_layers
+        self.multi_query_group_num = config.multi_query_group_num
+        self.kv_channels = config.kv_channels
+        self.fp32_residual_connection = config.fp32_residual_connection
+
+        # Rotary positional embeddings
+        self.seq_length = config.seq_length
+
+        self.encoder = GLMTransformer(config)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[KVCache],
+        input_metadata: InputMetadata,
+        cache_events: Optional[List[torch.cuda.Event]],
+    ) -> torch.Tensor:  # -> Dict[int, SequenceOutputs]:
+
+        inputs_embeds = self.embedding(input_ids)
+        # If the input flag for fp32 residual connection is set,
+        # convert for float.
+        if self.fp32_residual_connection:
+            inputs_embeds = inputs_embeds.float()
+        # Run encoder.
+        hidden_states = self.encoder(positions, inputs_embeds, kv_caches,
+                                     input_metadata, cache_events)
+
+        return hidden_states

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -11,6 +11,7 @@ _CONFIG_REGISTRY = {
     "qwen": QWenConfig,
     "RefinedWeb": RWConfig,  # For tiiuae/falcon-40b(-instruct)
     "RefinedWebModel": RWConfig,  # For tiiuae/falcon-7b(-instruct)
+    "chatglm": ChatGLMConfig,
 }
 
 

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -6,6 +6,7 @@ from vllm.transformers_utils.configs.qwen import QWenConfig
 # tiiuae/falcon-7b(-instruct) models. Newer Falcon models will use the
 # `FalconConfig` class from the official HuggingFace transformers library.
 from vllm.transformers_utils.configs.falcon import RWConfig
+from vllm.transformers_utils.configs.chatglm import ChatGLMConfig
 
 __all__ = [
     "MPTConfig",
@@ -13,4 +14,5 @@ __all__ = [
     "AquilaConfig",
     "QWenConfig",
     "RWConfig",
+    "ChatGLMConfig",
 ]

--- a/vllm/transformers_utils/configs/chatglm.py
+++ b/vllm/transformers_utils/configs/chatglm.py
@@ -1,0 +1,63 @@
+from transformers import PretrainedConfig
+
+
+class ChatGLMConfig(PretrainedConfig):
+    attribute_map = {
+        "num_hidden_layers": "num_layers",
+    }
+
+    def __init__(
+        self,
+        num_layers=28,
+        padded_vocab_size=65024,
+        hidden_size=4096,
+        ffn_hidden_size=13696,
+        kv_channels=128,
+        num_attention_heads=32,
+        seq_length=2048,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        layernorm_epsilon=1e-5,
+        rmsnorm=True,
+        apply_residual_connection_post_layernorm=False,
+        post_layer_norm=True,
+        add_bias_linear=False,
+        add_qkv_bias=False,
+        bias_dropout_fusion=True,
+        multi_query_attention=False,
+        multi_query_group_num=1,
+        apply_query_key_layer_scaling=True,
+        attention_softmax_in_fp32=True,
+        fp32_residual_connection=False,
+        quantization_bit=0,
+        pre_seq_len=None,
+        prefix_projection=False,
+        **kwargs
+    ):
+        self.num_layers = num_layers
+        self.vocab_size = padded_vocab_size
+        self.padded_vocab_size = padded_vocab_size
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.kv_channels = kv_channels
+        self.num_attention_heads = num_attention_heads
+        self.seq_length = seq_length
+        self.hidden_dropout = hidden_dropout
+        self.attention_dropout = attention_dropout
+        self.layernorm_epsilon = layernorm_epsilon
+        self.rmsnorm = rmsnorm
+        self.apply_residual_connection_post_layernorm = (
+            apply_residual_connection_post_layernorm)
+        self.post_layer_norm = post_layer_norm
+        self.add_bias_linear = add_bias_linear
+        self.add_qkv_bias = add_qkv_bias
+        self.bias_dropout_fusion = bias_dropout_fusion
+        self.multi_query_attention = multi_query_attention
+        self.multi_query_group_num = multi_query_group_num
+        self.apply_query_key_layer_scaling = apply_query_key_layer_scaling
+        self.attention_softmax_in_fp32 = attention_softmax_in_fp32
+        self.fp32_residual_connection = fp32_residual_connection
+        self.quantization_bit = quantization_bit
+        self.pre_seq_len = pre_seq_len
+        self.prefix_projection = prefix_projection
+        super().__init__(**kwargs)

--- a/vllm/transformers_utils/configs/config.py
+++ b/vllm/transformers_utils/configs/config.py
@@ -1,0 +1,38 @@
+from typing import Optional
+
+from transformers import AutoConfig, PretrainedConfig
+
+from vllm.transformers_utils.configs import *  # pylint: disable=wildcard-import
+
+_CONFIG_REGISTRY = {
+    "mpt": MPTConfig,
+    "baichuan": BaiChuanConfig,
+    "aquila": AquilaConfig,
+    "qwen": QWenConfig,
+    "RefinedWeb": RWConfig,  # For tiiuae/falcon-40b(-instruct)
+    "RefinedWebModel": RWConfig,  # For tiiuae/falcon-7b(-instruct)
+    "chatglm": ChatGLMConfig,
+}
+
+
+def get_config(model: str,
+               trust_remote_code: bool,
+               revision: Optional[str] = None) -> PretrainedConfig:
+    try:
+        config = AutoConfig.from_pretrained(
+            model, trust_remote_code=trust_remote_code, revision=revision)
+    except ValueError as e:
+        if (not trust_remote_code and
+                "requires you to execute the configuration file" in str(e)):
+            err_msg = (
+                "Failed to load the model config. If the model is a custom "
+                "model not yet available in the HuggingFace transformers "
+                "library, consider setting `trust_remote_code=True` in LLM "
+                "or using the `--trust-remote-code` flag in the CLI.")
+            raise RuntimeError(err_msg) from e
+        else:
+            raise e
+    if config.model_type in _CONFIG_REGISTRY:
+        config_class = _CONFIG_REGISTRY[config.model_type]
+        config = config_class.from_pretrained(model, revision=revision)
+    return config


### PR DESCRIPTION
Updated the load_weights function following the principles of tensor parallelism for #649. However, due to limitations in GQA（group_nums=2）,inference with more than 2 GPUs is not supported. Even though more GPUs (provided they are divisible by num_attention_heads) can be utilized, the results are incorrect. and i tested it, the inference results with 2 GPUs are consistent with single GPU inference.