### PR TITLE
Add float16 and float32 to dtype choices

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -93,7 +93,9 @@ class EngineArgs:
             '--dtype',
             type=str,
             default=EngineArgs.dtype,
-            choices=['auto', 'half', 'bfloat16', 'float'],
+            choices=[
+                'auto', 'half', 'float16', 'bfloat16', 'float', 'float32'
+            ],
             help='data type for model weights and activations. '
             'The "auto" option will use FP16 precision '
             'for FP32 and FP16 models, and BF16 precision '


### PR DESCRIPTION
As mentioned in #1114, it'd be nice to add `float16` and `float32` to our engine's `dtype` parameter.