### PR TITLE
Replace torch.cuda.DtypeTensor with torch.tensor

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -228,15 +228,25 @@ class Worker:
         input_positions = _pad_to_alignment(input_positions, multiple_of=8)
 
         # Convert to tensors.
-        tokens_tensor = torch.cuda.LongTensor(input_tokens)
-        positions_tensor = torch.cuda.LongTensor(input_positions)
-        slot_mapping_tensor = torch.cuda.IntTensor(slot_mapping)
-        context_lens_tensor = torch.cuda.IntTensor(context_lens)
+        tokens_tensor = torch.tensor(input_tokens,
+                                     dtype=torch.long,
+                                     device="cuda")
+        positions_tensor = torch.tensor(input_positions,
+                                        dtype=torch.long,
+                                        device="cuda")
+        slot_mapping_tensor = torch.tensor(slot_mapping,
+                                           dtype=torch.int,
+                                           device="cuda")
+        context_lens_tensor = torch.tensor(context_lens,
+                                           dtype=torch.int,
+                                           device="cuda")
         padded_block_tables = [
             _pad_to_max(block_table, max_num_blocks_per_seq)
             for block_table in generation_block_tables
         ]
-        block_tables_tensor = torch.cuda.IntTensor(padded_block_tables)
+        block_tables_tensor = torch.tensor(padded_block_tables,
+                                           dtype=torch.int,
+                                           device="cuda")
 
         seq_data: Dict[int, SequenceData] = {}
         for seq_group_metadata in seq_group_metadata_list:


### PR DESCRIPTION
PyTorch is deprecating `DtypeTensor` like `LongTensor`. I got a following error message when using the latest dev version of PyTorch:

> /usr/src/app/vllm/vllm/worker/worker.py:231: UserWarning: The torch.cuda.*DtypeTensor constructors are no longer recommended. It's best to use methods such as torch.tensor(data, dtype=*, device='cuda') to create tensors. (Triggered internally at ../torch/csrc/tensor/python_tensor.cpp:83.)

This PR fixes this in advance.