### PR TITLE
Use `--ipc=host` in `docker run` for distributed inference

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -46,4 +46,5 @@ You can also build and install vLLM from source:
     .. code-block:: console
 
         $ # Pull the Docker image with CUDA 11.8.
-        $ docker run --gpus all -it --rm --shm-size=8g nvcr.io/nvidia/pytorch:22.12-py3
+        $ # Use `--ipc=host` to make sure the shared memory is large enough.
+        $ docker run --gpus all -it --rm --ipc=host nvcr.io/nvidia/pytorch:22.12-py3


### PR DESCRIPTION
When the shared memory allocated for a docker container is too small and when TP is used, vLLM can hang or perform bad. While users can manually increase `shm-size`, `--ipc=host` can be a simple solution to this.

Reference: https://github.com/pytorch/pytorch/issues/1158#issuecomment-290771026