### PR TITLE
Use standard extras for `uvicorn`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ torch >= 2.0.0
 transformers >= 4.33.1  # Required for Code Llama.
 xformers >= 0.0.21
 fastapi
-uvicorn
+uvicorn[standard]
 pydantic < 2  # Required for OpenAI server.


### PR DESCRIPTION
By adding the standard, Uvicorn will install and use some recommended extra dependencies.

That including uvloop, the high-performance drop-in replacement for asyncio.
uvloop is not supported on Windows. Uvicorn will fallback to asyncio on Windows.