### PR TITLE
Keep special sampling params

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -387,7 +387,7 @@ class LLMEngine:
             child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:
-            self._decode_sequence(seq)
+            self._decode_sequence(seq, seq_group.sampling_params)
             self._check_stop(seq, seq_group.sampling_params)
 
         # Non-beam search case
@@ -621,7 +621,8 @@ class LLMEngine:
                     f"CPU KV cache usage: {cpu_cache_usage * 100:.1f}%")
         self.last_logging_time = now
 
-    def _decode_sequence(self, seq: Sequence) -> None:
+    def _decode_sequence(self, seq: Sequence,
+                         sampling_params: SamplingParams) -> None:
         """Decodes the new token for a sequence."""
         (new_tokens, new_output_text, prefix_offset,
          read_offset) = detokenize_incrementally(
@@ -630,7 +631,7 @@ class LLMEngine:
              prev_tokens=seq.tokens,
              prefix_offset=seq.prefix_offset,
              read_offset=seq.read_offset,
-             skip_special_tokens=True,
+             skip_special_tokens=not sampling_params.keep_special_tokens,
          )
         if seq.tokens is None:
             seq.tokens = new_tokens

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -631,7 +631,7 @@ class LLMEngine:
              prev_tokens=seq.tokens,
              prefix_offset=seq.prefix_offset,
              read_offset=seq.read_offset,
-             skip_special_tokens=not sampling_params.keep_special_tokens,
+             skip_special_tokens=sampling_params.skip_special_tokens,
          )
         if seq.tokens is None:
             seq.tokens = new_tokens

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -225,6 +225,7 @@ async def create_chat_completion(request: ChatCompletionRequest,
             top_k=request.top_k,
             ignore_eos=request.ignore_eos,
             use_beam_search=request.use_beam_search,
+            keep_special_tokens=request.keep_special_tokens,
         )
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -426,6 +427,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             max_tokens=request.max_tokens,
             logprobs=request.logprobs,
             use_beam_search=request.use_beam_search,
+            keep_special_tokens=request.keep_special_tokens,
         )
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -225,7 +225,7 @@ async def create_chat_completion(request: ChatCompletionRequest,
             top_k=request.top_k,
             ignore_eos=request.ignore_eos,
             use_beam_search=request.use_beam_search,
-            keep_special_tokens=request.keep_special_tokens,
+            skip_special_tokens=request.skip_special_tokens,
         )
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
@@ -427,7 +427,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
             max_tokens=request.max_tokens,
             logprobs=request.logprobs,
             use_beam_search=request.use_beam_search,
-            keep_special_tokens=request.keep_special_tokens,
+            skip_special_tokens=request.skip_special_tokens,
         )
     except ValueError as e:
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -71,6 +71,7 @@ class ChatCompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     use_beam_search: Optional[bool] = False
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
+    keep_special_tokens: Optional[bool] = False
 
 
 class CompletionRequest(BaseModel):
@@ -96,6 +97,7 @@ class CompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     use_beam_search: Optional[bool] = False
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
+    keep_special_tokens: Optional[bool] = False
 
 
 class LogProbs(BaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -71,7 +71,7 @@ class ChatCompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     use_beam_search: Optional[bool] = False
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
-    keep_special_tokens: Optional[bool] = False
+    skip_special_tokens: Optional[bool] = True
 
 
 class CompletionRequest(BaseModel):
@@ -97,7 +97,7 @@ class CompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     use_beam_search: Optional[bool] = False
     stop_token_ids: Optional[List[int]] = Field(default_factory=list)
-    keep_special_tokens: Optional[bool] = False
+    skip_special_tokens: Optional[bool] = True
 
 
 class LogProbs(BaseModel):

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -60,6 +60,7 @@ class SamplingParams:
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.
         logprobs: Number of log probabilities to return per output token.
+        keep_special_tokens: Whether to keep special tokens in the output
     """
 
     def __init__(
@@ -79,6 +80,7 @@ class SamplingParams:
         ignore_eos: bool = False,
         max_tokens: int = 16,
         logprobs: Optional[int] = None,
+        keep_special_tokens: bool = False,
     ) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
@@ -103,6 +105,7 @@ class SamplingParams:
         self.ignore_eos = ignore_eos
         self.max_tokens = max_tokens
         self.logprobs = logprobs
+        self.keep_special_tokens = keep_special_tokens
 
         self._verify_args()
         if self.use_beam_search:
@@ -196,4 +199,5 @@ class SamplingParams:
                 f"stop={self.stop}, "
                 f"ignore_eos={self.ignore_eos}, "
                 f"max_tokens={self.max_tokens}, "
-                f"logprobs={self.logprobs})")
+                f"logprobs={self.logprobs}, "
+                f"keep_special_tokens={self.keep_special_tokens})")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -60,7 +60,8 @@ class SamplingParams:
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.
         logprobs: Number of log probabilities to return per output token.
-        skip_special_tokens: Whether to skip special tokens in the output.  Defaults to true.
+        skip_special_tokens: Whether to skip special tokens in the output.
+            Defaults to true.
     """
 
     def __init__(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -60,7 +60,7 @@ class SamplingParams:
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.
         logprobs: Number of log probabilities to return per output token.
-        keep_special_tokens: Whether to keep special tokens in the output
+        skip_special_tokens: Whether to skip special tokens in the output.  Defaults to true.
     """
 
     def __init__(
@@ -80,7 +80,7 @@ class SamplingParams:
         ignore_eos: bool = False,
         max_tokens: int = 16,
         logprobs: Optional[int] = None,
-        keep_special_tokens: bool = False,
+        skip_special_tokens: bool = True,
     ) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
@@ -105,7 +105,7 @@ class SamplingParams:
         self.ignore_eos = ignore_eos
         self.max_tokens = max_tokens
         self.logprobs = logprobs
-        self.keep_special_tokens = keep_special_tokens
+        self.skip_special_tokens = skip_special_tokens
 
         self._verify_args()
         if self.use_beam_search:
@@ -200,4 +200,4 @@ class SamplingParams:
                 f"ignore_eos={self.ignore_eos}, "
                 f"max_tokens={self.max_tokens}, "
                 f"logprobs={self.logprobs}, "
-                f"keep_special_tokens={self.keep_special_tokens})")
+                f"skip_special_tokens={self.skip_special_tokens})")


### PR DESCRIPTION
See the discussion on #970 

I have a model that generates special tokens with important meaning to generation tasks. At present there is no way to get these special tokens back in the generated text because of the hardcoded input to detokenize_incrementally in llm_engine.

This PR adds an optional parameter to `SamplingParams`