### PR TITLE
Remove dependency to Ray AIR

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 ninja  # For faster builds.
 psutil
 ray >= 2.5.1
-pandas  # Required for Ray data.
-pyarrow  # Required for Ray data.
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 torch >= 2.0.0

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -8,9 +8,8 @@ logger = init_logger(__name__)
 
 try:
     import ray
-    from ray.air.util.torch_dist import TorchDistributedWorker
 
-    class RayWorker(TorchDistributedWorker):
+    class RayWorker:
         """Ray wrapper for vllm.worker.Worker, allowing Worker to be
         lazliy initialized after Ray sets CUDA_VISIBLE_DEVICES."""
 

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -33,7 +33,7 @@ try:
 except ImportError as e:
     logger.warning(f"Failed to import Ray with {e!r}. "
                    "For distributed inference, please install Ray with "
-                   "`pip install ray pandas pyarrow`.")
+                   "`pip install ray`.")
     ray = None
     TorchDistributedWorker = None
     RayWorker = None  # pylint: disable=invalid-name

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -35,7 +35,6 @@ except ImportError as e:
                    "For distributed inference, please install Ray with "
                    "`pip install ray`.")
     ray = None
-    TorchDistributedWorker = None
     RayWorker = None  # pylint: disable=invalid-name
 
 if TYPE_CHECKING:


### PR DESCRIPTION
As discussed offline with @Yard1, it seems there's no reason for `RayWorker` to inherit `TorchDistributedWorker` from Ray.