### PR TITLE
feat: flag to specify chat prompt template for openai api server

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -104,7 +104,7 @@ async def get_gen_prompt(request) -> str:
         prompt = request.messages
     else:
         for message in request.messages:
-            msg_role = message["role"]
+            msg_role = message["role"].lower()
             if msg_role == "system":
                 conv.system_message = message["content"]
             elif msg_role == "user":


### PR DESCRIPTION
example usage:

```
python -m vllm.entrypoints.openai.api_server --served-model-name "gpt-4" --conv-template "vicuna_v1.1"  --model TheBlok
e/WizardLM-13B-V1.2-AWQ --quantization awq
```