### PR TITLE
Add livez and readyz endpoints

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -17,12 +17,12 @@ app = FastAPI()
 engine = None
 
 
-@app.post("/livez")
+@app.get("/livez")
 def livez():
     return ""
 
 
-@app.post("/readyz")
+@app.get("/readyz")
 def readyz():
     return ""
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -18,13 +18,14 @@ engine = None
 
 
 @app.get("/livez")
-def livez():
-    return ""
+def livez() -> Response:
+    return Response()
 
 
 @app.get("/readyz")
-def readyz():
-    return ""
+def readyz() -> Response:
+    return Response()
+
 
 @app.post("/generate")
 async def generate(request: Request) -> Response:

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -17,6 +17,15 @@ app = FastAPI()
 engine = None
 
 
+@app.post("/livez")
+def livez():
+    return ""
+
+
+@app.post("/readyz")
+def readyz():
+    return ""
+
 @app.post("/generate")
 async def generate(request: Request) -> Response:
     """Generate completion for the request.


### PR DESCRIPTION
Update `api_server` to include `livez` and `readyz` endpoints. These endpoints are helpful for Kubernetes deployment: https://kubernetes.io/docs/reference/using-api/health-checks/