### PR TITLE
Move bfloat16 check to worker

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -340,15 +340,6 @@ def _get_and_verify_dtype(
             # Casting between float16 and bfloat16 is allowed with a warning.
             logger.warning(f"Casting {config_dtype} to {torch_dtype}.")
 
-    # Check if the GPU supports the dtype.
-    if torch_dtype == torch.bfloat16:
-        compute_capability = torch.cuda.get_device_capability()
-        if compute_capability[0] < 8:
-            gpu_name = torch.cuda.get_device_name()
-            raise ValueError(
-                "Bfloat16 is only supported on GPUs with compute capability "
-                f"of at least 8.0. Your {gpu_name} GPU has compute capability "
-                f"{compute_capability[0]}.{compute_capability[1]}.")
     return torch_dtype
 
 


### PR DESCRIPTION
The bfloat16 check requires CUDA initialization. If using Ray workers (eg. for tensor parallelism), this will lead to Ray being unable to set the correct environment variables, leading to exceptions later. Moving this check to the worker after it has been initialized solves the issue.