### PR TITLE
feat: demonstrate using regex for suffix matching

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -649,13 +649,13 @@ class LLMEngine:
     def _check_stop(self, seq: Sequence,
                     sampling_params: SamplingParams) -> None:
         """Stop the finished sequences."""
-        for stop_str in sampling_params.stop:
-            if seq.output_text.endswith(stop_str):
-                # Truncate the output text so that the stop string is
-                # not included in the output.
-                seq.output_text = seq.output_text[:-len(stop_str)]
-                seq.status = SequenceStatus.FINISHED_STOPPED
-                return
+        reversed_output_text = seq.output_text[::-1]
+        matched = sampling_params.reverse_stop_regex.match(reversed_output_text)
+        if matched:
+            matched_len = len(matched.string)
+            seq.output_text = seq.output_text[:-matched_len]
+            seq.status = SequenceStatus.FINISHED_STOPPED
+
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
             seq.status = SequenceStatus.FINISHED_STOPPED
             return

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,4 +1,6 @@
 """Sampling parameters for text generation."""
+import re
+
 from enum import IntEnum
 from functools import cached_property
 from typing import List, Optional, Union
@@ -98,6 +100,17 @@ class SamplingParams:
             self.stop = [stop]
         else:
             self.stop = list(stop)
+
+        reverse_stop_regex_string =
+          # multi-line matching
+          "(?m)" +
+          # assert as start of the string
+          "\A" +
+          # Translate ["a", "b", "cde"] into "(a)|(b)|(edc)"
+          "(" + ")|(".join([x[::-1] for x in self.stop]) + ")"
+
+        self.reverse_stop_regex = re.compile(reverse_stop_regex_string)
+
         if stop_token_ids is None:
             self.stop_token_ids = []
         else:

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -107,7 +107,7 @@ class SamplingParams:
           # assert as start of the string
           "\A" +
           # Translate ["a", "b", "cde"] into "(a)|(b)|(edc)"
-          "(" + ")|(".join([x[::-1] for x in self.stop]) + ")"
+          "(" + ")|(".join([re.escape(x[::-1]) for x in self.stop]) + ")"
 
         self.reverse_stop_regex = re.compile(reverse_stop_regex_string)
 


### PR DESCRIPTION
Sending out a draft for the follow-up discussion from today's meetup to determine whether this should be merged or left as a modification in Tabby's fork.

Notes:
1. Trie libraries, such as pygtrie, can serve as efficient alternatives to regular expressions.
2. Compiling stop words on a per-request basis might prove to be too expensive, especially when dealing with a long stop words list (e.g., in Tabby, we likely have a stop words list of approximately 20). an LRU cache could help (if the # of unique stop words combination is finite)