### PR TITLE
Filter out unsupported arch list instead of error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def get_torch_arch_list() -> Set[str]:
 
     # List are separated by ; or space.
     arch_list = arch_list.replace(" ", ";").split(";")
-    filtered_arch_list = set(valid_arch_strs) - set(arch_list)
+    filtered_arch_list = set(valid_arch_strs).intersection(set(arch_list))
     return filtered_arch_list
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,8 @@ def get_torch_arch_list() -> Set[str]:
 
     # List are separated by ; or space.
     arch_list = arch_list.replace(" ", ";").split(";")
-    for arch in arch_list:
-        if arch not in valid_arch_strs:
-            raise ValueError(
-                f"Unsupported CUDA arch ({arch}). "
-                f"Valid CUDA arch strings are: {valid_arch_strs}.")
-    return set(arch_list)
+    filtered_arch_list = set(valid_arch_strs) - set(arch_list)
+    return filtered_arch_list
 
 
 # First, check the TORCH_CUDA_ARCH_LIST environment variable.


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/1225

it's unclear to me why we want to throw error rather than just filter out the unsupported architectures.