### PR TITLE
Add support for conversation-template argument for openai endpoint

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -95,7 +95,7 @@ Start the server:
     $ python -m vllm.entrypoints.openai.api_server \
     $     --model facebook/opt-125m
 
-By default, it starts the server at ``http://localhost:8000``. You can specify the address with ``--host`` and ``--port`` arguments. The server currently hosts one model at a time (OPT-125M in the above command) and implements `list models <https://platform.openai.com/docs/api-reference/models/list>`_ and `create completion <https://platform.openai.com/docs/api-reference/completions/create>`_ endpoints. We are actively adding support for more endpoints.
+By default, it starts the server at ``http://localhost:8000``. You can specify the address with ``--host`` and ``--port`` arguments. You can override the FastChat template by using the ``--conversation-template`` argument which points to a json file. The server currently hosts one model at a time (OPT-125M in the above command) and implements `list models <https://platform.openai.com/docs/api-reference/models/list>`_ and `create completion <https://platform.openai.com/docs/api-reference/completions/create>`_ endpoints. We are actively adding support for more endpoints.
 
 This server can be queried in the same format as OpenAI API. For example, list the models:
 

--- a/examples/conversation_template_example.json
+++ b/examples/conversation_template_example.json
@@ -1,0 +1,13 @@
+{
+  "name": "example",
+  "system_template": "{system_message}",
+  "system_message": "A chat between a user and an artificial intelligence assistant.",
+  "roles": ["USER", "ASSISTANT"],
+  "messages": [],
+  "offset": 0,
+  "sep_style": "ADD_COLON_TWO",
+  "sep": "\n",
+  "sep2": "</s>",
+  "stop_str": "",
+  "stop_token_ids": []
+}

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -98,19 +98,17 @@ async def get_gen_prompt(request) -> str:
         )
     else:
         template = conversation_template
-        conv = Conversation(
-            name=template['name'],
-            system_template=template['system_template'],
-            system_message=template.get('system_message', ""),
-            roles=tuple(template['roles']),
-            messages=template.get('messages', []),
-            offset=template.get('offset', 0),
-            sep_style=SeparatorStyle[template['sep_style']],
-            sep=template['sep'],
-            sep2=template.get('sep2', ""),
-            stop_str=template['stop_str'],
-            stop_token_ids=template.get('stop_token_ids', [])
-        )
+        conv = Conversation(name=template["name"],
+                            system_template=template["system_template"],
+                            system_message=template.get("system_message", ""),
+                            roles=tuple(template["roles"]),
+                            messages=template.get("messages", []),
+                            offset=template.get("offset", 0),
+                            sep_style=SeparatorStyle[template["sep_style"]],
+                            sep=template["sep"],
+                            sep2=template.get("sep2", ""),
+                            stop_str=template["stop_str"],
+                            stop_token_ids=template.get("stop_token_ids", []))
 
     if isinstance(request.messages, str):
         prompt = request.messages

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -101,15 +101,15 @@ async def get_gen_prompt(request) -> str:
         conv = Conversation(
             name=template['name'],
             system_template=template['system_template'],
-            system_message=template.get('system_message', ""),  # Use default if not provided
+            system_message=template.get('system_message', ""),
             roles=tuple(template['roles']),
-            messages=template.get('messages', []),  # Use default if not provided
-            offset=template.get('offset', 0),  # Use default if not provided
+            messages=template.get('messages', []),
+            offset=template.get('offset', 0),
             sep_style=SeparatorStyle[template['sep_style']],
             sep=template['sep'],
-            sep2=template.get('sep2', ""),  # Use default if not provided
+            sep2=template.get('sep2', ""),
             stop_str=template['stop_str'],
-            stop_token_ids=template.get('stop_token_ids', [])  # Use default if not provided
+            stop_token_ids=template.get('stop_token_ids', [])
         )
 
     if isinstance(request.messages, str):

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -609,7 +609,7 @@ if __name__ == "__main__":
                         type=str,
                         default=None,
                         help="The path to the conversation template to use "
-                             "with the specified model.")
+                        "with the specified model.")
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()


### PR DESCRIPTION
Here is a PR for support for conversation-templates setup as json files which can be specified for a model upon starting the api. Just create your template, and pass in the path with the --conversation-template my_template.json argument.

There was no where for me to add support for this in the vLLM api, so I only added it to the OpenAI api.

Added an example, and updated the quickstart part of the readme (the only place that talked about the other arguments)