### PR TITLE
change the timing of sorting logits

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -105,7 +105,7 @@ def _prune_hidden_states(
     last_token_indices = []
     start_idx = 0
     for i, seq_group in enumerate(input_metadata.seq_groups):
-        seq_ids, sampling_params = seq_group
+        seq_ids, _ = seq_group
         if i < input_metadata.num_prompts:
             assert len(seq_ids) == 1, "Prompt input should have only one seq."
             prompt_len = input_metadata.prompt_lens[i]

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -429,7 +429,6 @@ def _sample(
             range(start_idx, start_idx + num_seqs))
         start_idx += num_seqs
     seq_outputs_dict: Dict[int, List[SequenceOutputs]] = {}
-    category_start_idx = 0
     for sampling_type in SamplingType:
         seq_group_ids = categorized_seq_group_ids[sampling_type]
         seq_groups = [input_metadata.seq_groups[i] for i in seq_group_ids]
@@ -491,6 +490,5 @@ def _sample(
             sample_idx += num_parent_seqs
             result_idx += num_results
         assert sample_idx == num_tokens
-        category_start_idx += num_tokens
 
     return [seq_outputs_dict[i] for i in range(len(input_metadata.seq_groups))]


### PR DESCRIPTION
This PR fixes #1179 .

There is a bug in the way sampling parameters are applied to logits.
The logits are sorted before the parameters are applied, so there are in danger of using other input's parameters.

For example, assume that the following 4 inputs are in a batch, in this order : 
<greedy, frequency penalty = 0.0>, <random, frequency penalty = 0.0>, <greedy, frequency penalty = 1.0>, <random, frequency penalty = 1.0>

Before applies the frequency penalty, logits are sorted by sampling type, such as GREEDY, RANDOM, or BEAM
Logits : <**greedy**, frequency penalty = 0.0>, <**greedy**, frequency penalty = 1.0>, <**random**, frequency penalty = 0.0>, <**random**, frequency penalty = 1.0>

However, the sampling parameters do not change their order.
Parameters : <greedy, **frequency penalty = 0.0**>, <random, **frequency penalty = 0.0**>, <greedy, **frequency penalty = 1.0**>, <random, **frequency penalty = 1.0**>

Therefore, the frequency penalty is used in the wrong order, which changes the final result to something unexpected.
results : <**greedy**, **frequency penalty = 0.0**>, <**greedy**, **frequency penalty = 0.0**>, <**random**, **frequency penalty = 1.0**>, <**random**, **frequency penalty = 1.0**>

I change the timing of the sorting to just the beginning of the final sampling function(=_sample)

