### PR TITLE
Add Mistral 7B to `test_models`

### DIFF
--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -6,14 +6,15 @@ import pytest
 
 MODELS = [
     "facebook/opt-125m",
+    "meta-llama/Llama-2-7b-hf",
+    "mistralai/Mistral-7B-v0.1",
+    "tiiuae/falcon-7b",
     "gpt2",
     "bigcode/tiny_starcoder_py",
     "EleutherAI/gpt-j-6b",
     "EleutherAI/pythia-70m",
     "bigscience/bloom-560m",
     "mosaicml/mpt-7b",
-    "tiiuae/falcon-7b",
-    "meta-llama/Llama-2-7b-hf",
 ]
 
 


### PR DESCRIPTION
This PR adds the mistral model to `test_models` and re-orders the models so that more important models come first.