### PR TITLE
Fix PyTorch index URL in workflow

### DIFF
--- a/.github/workflows/scripts/pytorch-install.sh
+++ b/.github/workflows/scripts/pytorch-install.sh
@@ -6,7 +6,7 @@ cuda_version=$3
 
 # Install torch
 $python_executable -m pip install numpy pyyaml scipy ipython mkl mkl-include ninja cython typing pandas typing-extensions dataclasses setuptools && conda clean -ya
-$python_executable -m pip install torch==${pytorch_version}+cu${cuda_version//./} --index-url https://download.pytorch.org/whl/cu${cuda_version//./}
+$python_executable -m pip install torch==${pytorch_version}+cu${cuda_version//./} --extra-index-url https://download.pytorch.org/whl/cu${cuda_version//./}
 
 # Print version information
 $python_executable --version


### PR DESCRIPTION
This PR fixes the following error in building the package:
```
× pip subprocess to install build dependencies did not run successfully.
[189](https://github.com/WoosukKwon/vllm/actions/runs/6537760277/job/17752268755#step:6:190)
  │ exit code: 1
[190](https://github.com/WoosukKwon/vllm/actions/runs/6537760277/job/17752268755#step:6:191)
  ╰─> [6 lines of output]
[191](https://github.com/WoosukKwon/vllm/actions/runs/6537760277/job/17752268755#step:6:192)
      Looking in indexes: https://download.pytorch.org/whl/cu118
[192](https://github.com/WoosukKwon/vllm/actions/runs/6537760277/job/17752268755#step:6:193)
      ERROR: Could not find a version that satisfies the requirement setuptools>=40.8.0 (from versions: none)
[193](https://github.com/WoosukKwon/vllm/actions/runs/6537760277/job/17752268755#step:6:194)
      ERROR: No matching distribution found for setuptools>=40.8.0
```