### PR TITLE
Update config.py for models which use_dynamic_ntk

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -399,11 +399,6 @@ def _get_and_verify_max_len(
         scaling_factor = rope_scaling["factor"]
         derived_max_model_len *= scaling_factor
 
-    # consifer use_dynamic_ntk case
-    use_dynamic_ntk = getattr(hf_config, "use_dynamic_ntk", None)
-    if use_dynamic_ntk is not None:
-        derived_max_model_len = 16384
-
     if max_model_len is None:
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -77,13 +77,10 @@ class ModelConfig:
         self.quantization = quantization
 
         self.hf_config = get_config(model, trust_remote_code, revision)
-
-        # add following lines to support fschat to load model which uses dynamic ntk (e.g Qwen)
-        # https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/vllm_worker.py#L59C65-L59C87
+        # support fschat to load model which uses dynamic ntk (e.g Qwen)
         use_dynamic_ntk = getattr(self.hf_config, "use_dynamic_ntk", None)
         if use_dynamic_ntk is not None:
             self.hf_config.max_sequence_length = 16384
-        
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self.max_model_len = _get_and_verify_max_len(self.hf_config,
                                                      max_model_len)


### PR DESCRIPTION
Hi there, 

for those models use ntk (like Qwen), fastchat will use hf_config to determine the context_length when applying vllm_worker

see link: https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/vllm_worker.py#L59C65-L59C87

Which makes those models have a relatively short context length. For Qwen case, it only has 2048 context length. 

For Qwen, if we start a model worker without vllm, the way the fastchat applied is to add a ’max_sequence_length‘ on config

see link: https://github.com/lm-sys/FastChat/blob/main/fastchat/model/model_adapter.py#L1421

Therefore, I made this PR for supporting model which applies ntk.

Thanks