### PR TITLE
fix RAM OOM when load large models in tensor parallel mode.

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -242,12 +242,12 @@ class ParallelConfig:
         pipeline_parallel_size: int,
         tensor_parallel_size: int,
         worker_use_ray: bool,
-        model_load_batch_size: Optional[int] = None,
+        max_parallel_loading_workers: Optional[int] = None,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size
         self.worker_use_ray = worker_use_ray
-        self.model_load_batch_size = model_load_batch_size
+        self.max_parallel_loading_workers = max_parallel_loading_workers
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
         if self.world_size > 1:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -242,10 +242,12 @@ class ParallelConfig:
         pipeline_parallel_size: int,
         tensor_parallel_size: int,
         worker_use_ray: bool,
+        model_load_batch_size: Optional[int] = None,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size
         self.worker_use_ray = worker_use_ray
+        self.model_load_batch_size = model_load_batch_size
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
         if self.world_size > 1:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -22,7 +22,7 @@ class EngineArgs:
     worker_use_ray: bool = False
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
-    tensor_parallel_model_load_batch_size: Optional[int] = None
+    max_parallel_loading_workers: Optional[int] = None
     block_size: int = 16
     swap_space: int = 4  # GiB
     gpu_memory_utilization: float = 0.90
@@ -130,7 +130,7 @@ class EngineArgs:
                             default=EngineArgs.tensor_parallel_size,
                             help='number of tensor parallel replicas')
         parser.add_argument(
-            '--tensor-parallel-model-load-batch-size',
+            '--max-parallel-loading-workers',
             type=int,
             help='load model sequentially in multiple batches, '
             'to avoid RAM OOM when using tensor '
@@ -200,9 +200,10 @@ class EngineArgs:
         cache_config = CacheConfig(
             self.block_size, self.gpu_memory_utilization, self.swap_space,
             getattr(model_config.hf_config, 'sliding_window', None))
-        parallel_config = ParallelConfig(
-            self.pipeline_parallel_size, self.tensor_parallel_size,
-            self.worker_use_ray, self.tensor_parallel_model_load_batch_size)
+        parallel_config = ParallelConfig(self.pipeline_parallel_size,
+                                         self.tensor_parallel_size,
+                                         self.worker_use_ray,
+                                         self.max_parallel_loading_workers)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -146,7 +146,8 @@ class LLMEngine:
         self._run_workers(
             "load_model",
             get_all_outputs=True,
-            batch_size=self.parallel_config.model_load_batch_size,
+            max_concurrent_workers=self.parallel_config.
+            max_parallel_loading_workers,
         )
 
     def _init_workers_ray(self, placement_group: "PlacementGroup",
@@ -190,7 +191,8 @@ class LLMEngine:
         self._run_workers(
             "load_model",
             get_all_outputs=True,
-            batch_size=self.parallel_config.model_load_batch_size,
+            max_concurrent_workers=self.parallel_config.
+            max_parallel_loading_workers,
         )
 
     def _verify_args(self) -> None:
@@ -717,15 +719,15 @@ class LLMEngine:
         method: str,
         *args,
         get_all_outputs: bool = False,
-        batch_size: Optional[int] = None,
+        max_concurrent_workers: Optional[int] = None,
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
         all_outputs = []
-        if batch_size:
+        if max_concurrent_workers:
             work_groups = [
-                self.workers[i:i + batch_size]
-                for i in range(0, len(self.workers), batch_size)
+                self.workers[i:i + max_concurrent_workers]
+                for i in range(0, len(self.workers), max_concurrent_workers)
             ]
         else:
             work_groups = [self.workers]

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -67,6 +67,8 @@ class Worker:
 
         # Initialize the model.
         set_random_seed(self.model_config.seed)
+
+    def load_model(self):
         self.model = get_model(self.model_config)
 
     @torch.inference_mode()


### PR DESCRIPTION
fix bug: #322 #872 

## Test log：
```
(vllm-boydfd) root:~/projects# python -m vllm.entrypoints.api_server --model /root/WizardLM--WizardCoder-15B-V1.0/ --tensor-parallel-size 8
2023-10-17 19:13:33,431 INFO worker.py:1642 -- Started a local Ray instance.
INFO 10-17 19:13:34 llm_engine.py:72] Initializing an LLM engine with config: model='/root/WizardLM--WizardCoder-15B-V1.0/', tokenizer='/root/WizardLM--WizardCoder-15B-V1.0/', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=8192, download_dir=None, load_format=auto, tensor_parallel_size=8, quantization=None, seed=0)
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
Traceback (most recent call last):
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/entrypoints/api_server.py", line 74, in <module>
    engine = AsyncLLMEngine.from_engine_args(engine_args)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 487, in from_engine_args
    engine = cls(engine_args.worker_use_ray,
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 270, in __init__
    self.engine = self._init_engine(*args, **kwargs)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 306, in _init_engine
    return engine_class(*args, **kwargs)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 108, in __init__
    self._init_workers_ray(placement_group)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 190, in _init_workers_ray
    self._run_workers(
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 730, in _run_workers
    all_outputs.extend(self._run_workers_in_batch(workers, method, *args, **kwargs))
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 711, in _run_workers_in_batch
    all_outputs = ray.get(all_outputs)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/ray/_private/auto_init_hook.py", line 24, in auto_init_wrapper
    return fn(*args, **kwargs)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
  File "/workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/ray/_private/worker.py", line 2549, in get
    raise value
ray.exceptions.OutOfMemoryError: Task was killed due to the node running low on memory.
Memory on the node (IP: xxxxxxxxx, ID: xxxxxx) where the task (actor ID: xxxxx, name=RayWorker.__init__, pid=1080909, memory used=29.64GB) was running was 242.20GB / 251.71GB (0.962216), which exceeds the memory usage threshold of 0.95. Ray killed this worker (ID: xxxxx) because it was the most recently scheduled task; to see more information about memory usage on this node, use `ray logs raylet.out -ip xxxxxx`. To see the logs of the worker, use `ray logs worker-xxxxx*out -ip xxxxxx. Top 10 memory users:
PID     MEM(GB) COMMAND
1080909 29.64   ray::RayWorker.execute_method
1080908 29.61   ray::RayWorker.execute_method
1080907 29.57   ray::RayWorker.execute_method
1080906 29.53   ray::RayWorker.execute_method
1080905 29.50   ray::RayWorker.execute_method
1080904 29.47   ray::RayWorker.execute_method
1080903 29.43   ray::RayWorker.execute_method
1080902 29.40   ray::RayWorker.execute_method
1078425 0.27    /workspace/miniconda/envs/vllm-boydfd/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server -...
1078324 0.25    python -m vllm.entrypoints.api_server --model /root/WizardLM--WizardCoder-15B-V1.0/ --tensor-paralle...
Refer to the documentation on how to address the out of memory issue: https://docs.ray.io/en/latest/ray-core/scheduling/ray-oom-prevention.html. Consider provisioning more memory on this node or reducing task parallelism by requesting more CPUs per task. Set max_restarts and max_task_retries to enable retry when the task crashes due to OOM. To adjust the kill threshold, set the environment variable `RAY_memory_usage_threshold` when starting Ray. To disable worker killing, set the environment variable `RAY_memory_monitor_refresh_ms` to zero.
^C
(vllm-boydfd) root:~/projects# python -m vllm.entrypoints.api_server --model /root/WizardLM--WizardCoder-15B-V1.0/ --tensor-parallel-size 8 --tensor-parallel-model-load-batch-size 2
2023-10-17 19:16:32,655 INFO worker.py:1642 -- Started a local Ray instance.
INFO 10-17 19:16:33 llm_engine.py:72] Initializing an LLM engine with config: model='/root/WizardLM--WizardCoder-15B-V1.0/', tokenizer='/root/WizardLM--WizardCoder-15B-V1.0/', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=8192, download_dir=None, load_format=auto, tensor_parallel_size=8, quantization=None, seed=0)
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
INFO 10-17 19:21:29 llm_engine.py:218] # GPU blocks: 31424, # CPU blocks: 13107
INFO:     Started server process [1082377]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
```
## Memory usage in model loading

![image](https://github.com/vllm-project/vllm/assets/12119051/3dc3a440-37a2-4063-831d-28d77aa76d3e)

