### PR TITLE
remove useless statements

### DIFF
--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -66,7 +66,6 @@ class InputMetadata:
         else:
             self.max_num_blocks_per_seq = 0
         assert block_tables.shape[0] == self.num_generation_tokens
-        assert context_lens.shape[0] == self.num_generation_tokens
 
         # Set during the execution of the first attention op.
         self.attn_bias: Optional[AttentionBias] = None


### PR DESCRIPTION
Because `self.num_generation_tokens = context_lens.shape[0]`, the removed statement is useless.