### PR TITLE
Pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ numpy
 torch == 2.0.1
 transformers >= 4.34.0  # Required for Mistral.
 xformers == 0.0.22  # Required for Mistral.
-fastapi==0.103.2
+fastapi
 uvicorn[standard]
-pydantic < 2  # Required for OpenAI server.
-typing-inspect==0.8.0
-typing_extensions==4.5.0
+pydantic == 1.10.13  # Required for OpenAI server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,8 @@ numpy
 torch == 2.0.1
 transformers >= 4.34.0  # Required for Mistral.
 xformers == 0.0.22  # Required for Mistral.
-fastapi
+fastapi==0.103.2
 uvicorn[standard]
 pydantic < 2  # Required for OpenAI server.
+typing-inspect==0.8.0
+typing_extensions==4.5.0


### PR DESCRIPTION
FastAPI released a new version last week that conflicts with typing-extensions and typing-inspect versions that are needed to run correctly on docker (at least for MPT models).

In order to make vLLM work properly I needed to create a dockerfile like this

```
FROM nvcr.io/nvidia/pytorch:22.12-py3

RUN pip uninstall torch -y
RUN pip install vllm

RUN pip install typing-inspect==0.8.0 typing_extensions==4.5.0 fastapi==0.103.2

```

I saw several issues reporting the same behavior so I decided to open this PR pinning the versions that we currently need to make everything work properly until we can make sure that the entire code works properly with the newest versions of typing extensions, typing inspect and fastapi.