### PR TITLE
aquila model add rope_scaling

### DIFF
--- a/vllm/model_executor/models/aquila.py
+++ b/vllm/model_executor/models/aquila.py
@@ -103,13 +103,15 @@ class AquilaRMSNorm(nn.Module):
 
 class AquilaAttention(nn.Module):
 
-    def __init__(self,
-                 hidden_size: int,
-                 num_heads: int,
-                 num_kv_heads: int,
-                 rope_theta: float = 10000,
-                 max_position_embeddings: int = 8192,
-                 rope_scaling: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_theta: float = 10000,
+        max_position_embeddings: int = 8192,
+        rope_scaling: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__()
         self.hidden_size = hidden_size
         tp_size = get_tensor_model_parallel_world_size()

--- a/vllm/model_executor/models/aquila.py
+++ b/vllm/model_executor/models/aquila.py
@@ -25,7 +25,7 @@
 The input of the model is flattened to a 1D tensor of tokens. The model uses
 InputMetadata to extract the original 2D shape of the input.
 """
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -103,14 +103,13 @@ class AquilaRMSNorm(nn.Module):
 
 class AquilaAttention(nn.Module):
 
-    def __init__(
-        self,
-        hidden_size: int,
-        num_heads: int,
-        num_kv_heads: int,
-        rope_theta: float = 10000,
-        max_position_embeddings: int = 8192,
-    ):
+    def __init__(self,
+                 hidden_size: int,
+                 num_heads: int,
+                 num_kv_heads: int,
+                 rope_theta: float = 10000,
+                 max_position_embeddings: int = 8192,
+                 rope_scaling: Optional[Dict[str, Any]] = None):
         super().__init__()
         self.hidden_size = hidden_size
         tp_size = get_tensor_model_parallel_world_size()
@@ -148,6 +147,7 @@ class AquilaAttention(nn.Module):
             base=self.rope_theta,
             max_position=self.max_position_embeddings,
             num_kv_heads=self.num_kv_heads,
+            rope_scaling=rope_scaling,
         )
 
     def forward(
@@ -173,6 +173,7 @@ class AquilaDecoderLayer(nn.Module):
         super().__init__()
         self.hidden_size = config.hidden_size
         rope_theta = getattr(config, "rope_theta", 10000)
+        rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings",
                                           8192)
         self.self_attn = AquilaAttention(
@@ -181,6 +182,7 @@ class AquilaDecoderLayer(nn.Module):
             num_kv_heads=config.num_key_value_heads,
             rope_theta=rope_theta,
             max_position_embeddings=max_position_embeddings,
+            rope_scaling=rope_scaling,
         )
         self.mlp = AquilaMLP(
             hidden_size=self.hidden_size,


### PR DESCRIPTION
Aquila model add rope_scaling, it's required for `BAAI/AquilaChat2-34B-16K` model, fix: https://github.com/vllm-project/vllm/issues/1436#issuecomment-1776572759