### PR TITLE
[WIP] Prefix memory sharing

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, List, Tuple, Optional
 
 import torch
 from transformers import PretrainedConfig
@@ -303,6 +303,19 @@ class SchedulerConfig:
                 f"max_num_batched_tokens ({self.max_num_batched_tokens}) must "
                 "be greater than or equal to max_num_seqs "
                 f"({self.max_num_seqs}).")
+
+
+class PrefixConfig:
+    """
+        prefix configuration
+    """
+    def __init__(self,
+                 prefix_strings: Optional[List[str]]):
+        self.prefix_strings = prefix_strings
+
+    def encode(self, tokenizer):
+        if self.prefix_strings != None:
+            self.prefix_tokens = [tokenizer.encode(x) for x in self.prefix_strings]
 
 
 _STR_DTYPE_TO_TORCH_DTYPE = {

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -127,7 +127,7 @@ class BlockSpaceManager:
         block_table = BlockTable = []
         for logical_idx in range(len(prefix.logical_token_blocks)):
             block = self.gpu_allocator.allocate()
-            block.ref_count = 10000
+            block.ref_count = 100000
             block_table.append(block)
         self.prefix_block_tables[prefix.prefix_id] = block_table.copy()
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -8,6 +8,7 @@ from vllm.core.policy import PolicyFactory
 from vllm.logger import init_logger
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceStatus)
+from vllm.prefix import Prefix
 
 logger = init_logger(__name__)
 
@@ -266,6 +267,10 @@ class Scheduler:
         )
         return scheduler_outputs
 
+    def get_prefix_block_table(self, prefix: Prefix) -> List[int]:
+        return self.block_manager.get_block_table_prefix(prefix)
+
+
     def schedule(self) -> Tuple[List[SequenceGroupMetadata], SchedulerOutputs]:
         # Schedule sequence groups.
         # This function call changes the internal states of the scheduler
@@ -308,6 +313,9 @@ class Scheduler:
         self.block_manager.allocate(seq_group)
         for seq in seq_group.get_seqs():
             seq.status = SequenceStatus.RUNNING
+
+    def prefix_allocate(self, prefix) -> None:
+        self.block_manager.prefix_allocate(prefix)
 
     def _append_slot(
         self,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -287,12 +287,21 @@ class Scheduler:
                 seq_data[seq_id] = seq.data
                 block_tables[seq_id] = self.block_manager.get_block_table(seq)
 
+            if seq_group.prefix is not None:
+                prefix = seq_group.prefix
+                prefix_block_table = self.get_prefix_block_table(seq_group.prefix)
+            else:
+                prefix = None
+                prefix_block_table = None
+
             seq_group_metadata = SequenceGroupMetadata(
                 request_id=seq_group.request_id,
                 is_prompt=scheduler_outputs.prompt_run,
                 seq_data=seq_data,
                 sampling_params=seq_group.sampling_params,
                 block_tables=block_tables,
+                prefix=prefix,
+                prefix_block_table=prefix_block_table
             )
             seq_group_metadata_list.append(seq_group_metadata)
         return seq_group_metadata_list, scheduler_outputs

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -32,6 +32,7 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
+    prefixes_json: Optional[str] = None
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -171,6 +172,10 @@ class EngineArgs:
                             choices=['awq', None],
                             default=None,
                             help='Method used to quantize the weights')
+        parser.add_argument('--prefixes-json',
+                            type=str,
+                            default=None,
+                            help='path containing prefix json file')
         return parser
 
     @classmethod
@@ -200,11 +205,13 @@ class EngineArgs:
                                            self.max_num_seqs,
                                            model_config.max_model_len,
                                            self.max_paddings)
-        prefix_config = PrefixConfig(
-            [
-                '''You are given a long korean text (delimited by triple quotes) and a question. Read the text and answer the question at the end in Korean.\n"""\n\n   ''',
-             ]
-        )
+        if self.prefixes_json is not None:
+            import json
+            with open(self.prefixes_json) as f:
+                json_data = json.load(f)
+                prefix_config = PrefixConfig(json_data['prefix'])
+        else:
+            prefix_config = PrefixConfig([])
         return model_config, cache_config, parallel_config, scheduler_config, prefix_config
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
-                         SchedulerConfig)
+                         SchedulerConfig, PrefixConfig)
 
 
 @dataclass
@@ -200,7 +200,13 @@ class EngineArgs:
                                            self.max_num_seqs,
                                            model_config.max_model_len,
                                            self.max_paddings)
-        return model_config, cache_config, parallel_config, scheduler_config
+        prefix_config = PrefixConfig(
+            [
+                "aaa bbb ccc ddd",
+                "김밥",
+             ]
+        )
+        return model_config, cache_config, parallel_config, scheduler_config, prefix_config
 
 
 @dataclass

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -202,8 +202,7 @@ class EngineArgs:
                                            self.max_paddings)
         prefix_config = PrefixConfig(
             [
-                "aaa bbb ccc ddd",
-                "김밥",
+                '''You are given a long korean text (delimited by triple quotes) and a question. Read the text and answer the question at the end in Korean.\n"""\n\n   ''',
              ]
         )
         return model_config, cache_config, parallel_config, scheduler_config, prefix_config

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -357,6 +357,7 @@ class AsyncLLMEngine:
         prompt: Optional[str],
         sampling_params: SamplingParams,
         prompt_token_ids: Optional[List[int]] = None,
+        prefix_id: Optional[int] = None,
         arrival_time: Optional[float] = None,
     ) -> AsyncStream:
         if self.log_requests:
@@ -388,6 +389,7 @@ class AsyncLLMEngine:
             prompt=prompt,
             sampling_params=sampling_params,
             prompt_token_ids=prompt_token_ids,
+            prefix_id=prefix_id,
             arrival_time=arrival_time)
 
         return stream
@@ -397,7 +399,8 @@ class AsyncLLMEngine:
             prompt: Optional[str],
             sampling_params: SamplingParams,
             request_id: str,
-            prompt_token_ids: Optional[List[int]] = None) -> RequestOutput:
+            prompt_token_ids: Optional[List[int]] = None,
+            prefix_id: Optional[int] = None) -> RequestOutput:
         """Generate outputs for a request.
 
         Generate outputs for a request. This method is a coroutine. It adds the
@@ -425,6 +428,7 @@ class AsyncLLMEngine:
                                             prompt,
                                             sampling_params,
                                             prompt_token_ids=prompt_token_ids,
+                                            prefix_id=prefix_id,
                                             arrival_time=arrival_time)
 
             async for request_output in stream:

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -29,10 +29,11 @@ async def generate(request: Request) -> Response:
     request_dict = await request.json()
     prompt = request_dict.pop("prompt")
     stream = request_dict.pop("stream", False)
+    prefix_id = request_dict.pop("prefix_id", None)
     sampling_params = SamplingParams(**request_dict)
     request_id = random_uuid()
 
-    results_generator = engine.generate(prompt, sampling_params, request_id)
+    results_generator = engine.generate(prompt, sampling_params, request_id, prefix_id=prefix_id)
 
     # Streaming case
     async def stream_results() -> AsyncGenerator[bytes, None]:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -108,6 +108,7 @@ class LLM:
         prompts: Optional[Union[str, List[str]]] = None,
         sampling_params: Optional[SamplingParams] = None,
         prompt_token_ids: Optional[List[List[int]]] = None,
+        prefix_id: Optional[int] = None,
         use_tqdm: bool = True,
     ) -> List[RequestOutput]:
         """Generates the completions for the input prompts.
@@ -153,7 +154,7 @@ class LLM:
                 token_ids = None
             else:
                 token_ids = prompt_token_ids[i]
-            self._add_request(prompt, sampling_params, token_ids)
+            self._add_request(prompt, sampling_params, token_ids, prefix_id)
         return self._run_engine(use_tqdm)
 
     def _add_request(
@@ -161,10 +162,11 @@ class LLM:
         prompt: Optional[str],
         sampling_params: SamplingParams,
         prompt_token_ids: Optional[List[int]],
+        prefix_id: Optional[int] = None
     ) -> None:
         request_id = str(next(self.request_counter))
         self.llm_engine.add_request(request_id, prompt, sampling_params,
-                                    prompt_token_ids)
+                                    prompt_token_ids, prefix_id)
 
     def _run_engine(self, use_tqdm: bool) -> List[RequestOutput]:
         # Initialize tqdm.

--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -287,12 +287,16 @@ class OPTForCausalLM(nn.Module):
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
         cache_events: Optional[List[torch.cuda.Event]],
+        sampling=True
     ) -> SamplerOutput:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    input_metadata, cache_events)
-        next_tokens = self.sampler(self.lm_head_weight, hidden_states,
-                                   input_metadata)
-        return next_tokens
+        if sampling:
+            next_tokens = self.sampler(self.lm_head_weight, hidden_states,
+                                    input_metadata)
+            return next_tokens
+        else:
+            return hidden_states
 
     _column_parallel_weights = [
         "embed_tokens.weight", "fc1.weight", "fc1.bias"

--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -286,17 +286,13 @@ class OPTForCausalLM(nn.Module):
         positions: torch.Tensor,
         kv_caches: List[KVCache],
         input_metadata: InputMetadata,
-        cache_events: Optional[List[torch.cuda.Event]],
-        sampling=True
+        cache_events: Optional[List[torch.cuda.Event]]
     ) -> SamplerOutput:
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    input_metadata, cache_events)
-        if sampling:
-            next_tokens = self.sampler(self.lm_head_weight, hidden_states,
-                                    input_metadata)
-            return next_tokens
-        else:
-            return hidden_states
+        next_tokens = self.sampler(self.lm_head_weight, hidden_states,
+                                input_metadata)
+        return next_tokens
 
     _column_parallel_weights = [
         "embed_tokens.weight", "fc1.weight", "fc1.bias"

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -65,6 +65,7 @@ class RequestOutput:
         prompt_logprobs: Optional[PromptLogprobs],
         outputs: List[CompletionOutput],
         finished: bool,
+        prefix: Optional[str] = None,
     ) -> None:
         self.request_id = request_id
         self.prompt = prompt
@@ -72,6 +73,7 @@ class RequestOutput:
         self.prompt_logprobs = prompt_logprobs
         self.outputs = outputs
         self.finished = finished
+        self.prefix = prefix
 
     @classmethod
     def from_seq_group(cls, seq_group: SequenceGroup) -> "RequestOutput":
@@ -107,13 +109,30 @@ class RequestOutput:
         prompt_token_ids = seq_group.prompt_token_ids
         prompt_logprobs = seq_group.prompt_logprobs
         finished = seq_group.is_finished()
-        return cls(seq_group.request_id, prompt, prompt_token_ids,
+        if seq_group.prefix is not None:
+            prefix = seq_group.prefix.prefix_string
+        else:
+            prefix = None
+        if prefix is not None:
+            return cls(seq_group.request_id, prompt, prompt_token_ids,
+                   prompt_logprobs, outputs, finished, prefix)
+        else:
+            return cls(seq_group.request_id, prompt, prompt_token_ids,
                    prompt_logprobs, outputs, finished)
 
     def __repr__(self) -> str:
-        return (f"RequestOutput(request_id={self.request_id}, "
-                f"prompt={self.prompt!r}, "
-                f"prompt_token_ids={self.prompt_token_ids}, "
-                f"prompt_logprobs={self.prompt_logprobs}, "
-                f"outputs={self.outputs}, "
-                f"finished={self.finished})")
+        if self.prefix is None:
+            return (f"RequestOutput(request_id={self.request_id}, "
+                    f"prompt={self.prompt!r}, "
+                    f"prompt_token_ids={self.prompt_token_ids}, "
+                    f"prompt_logprobs={self.prompt_logprobs}, "
+                    f"outputs={self.outputs}, "
+                    f"finished={self.finished})")
+        else:
+            return (f"RequestOutput(request_id={self.request_id}, "
+                    f"prompt={self.prompt!r}, "
+                    f"prefix={self.prefix!r}, "
+                    f"prompt_token_ids={self.prompt_token_ids}, "
+                    f"prompt_logprobs={self.prompt_logprobs}, "
+                    f"outputs={self.outputs}, "
+                    f"finished={self.finished})")

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -19,12 +19,12 @@ class Prefix:
     def __init__(
         self,
         prefix_id: int,
-        prefix_strings: str,
+        prefix_string: str,
         prefix_token_ids: List[int],
         block_size: int,
     ) -> None:
         self.prefix_id = prefix_id
-        self.prompt = prefix_strings
+        self.prefix_string = prefix_string
         self.block_size = block_size
 
         self.token_ids = prefix_token_ids
@@ -33,11 +33,8 @@ class Prefix:
         # Initialize the logical token blocks with the prompt token ids.
         self._append_tokens_to_blocks(prefix_token_ids)
 
-        # Used for incremental detokenization
-        self.prefix_offset = 0
-        self.read_offset = 0
-        # Input + output tokens
-        self.tokens: Optional[List[str]] = None
+    def get_prefix_offset(self):
+        return self.logical_token_blocks[-1].get_num_empty_slots()
 
     def _append_logical_block(self) -> None:
         block = LogicalTokenBlock(
@@ -62,24 +59,14 @@ class Prefix:
                                                num_empty_slots])
             cursor += num_empty_slots
 
-    def append_token_id(
-        self,
-        token_id: int,
-        logprobs: Dict[int, float],
-    ) -> None:
-        assert token_id in logprobs
-        self._append_tokens_to_blocks([token_id])
-        self.output_logprobs.append(logprobs)
-        self.data.append_token_id(token_id, logprobs[token_id])
-
     def get_len(self) -> int:
-        return len(self.data)
+        return len(self.token_ids)
 
     def get_token_ids(self) -> List[int]:
-        return self.data
+        return self.token_ids
 
     def get_last_token_id(self) -> int:
-        return self.data[-1]
+        return self.token_ids[-1]
 
 class PrefixMetaData:
     def __init__(

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -1,0 +1,90 @@
+"""Prefix and its related classes."""
+import copy
+import enum
+from typing import Dict, List, Optional, Union
+
+from vllm.block import LogicalTokenBlock
+
+class Prefix:
+    """Stores the data, status, and block information of a prefix.
+
+    Args:
+        prefix_id: The ID of the prefix.
+        prompt: The prompt of the prefix.
+        prompt_token_ids: The token IDs of the prompt.
+        block_size: The block size of the prefix. Should be the same as the
+            block size used by the block manager and cache engine.
+    """
+
+    def __init__(
+        self,
+        prefix_id: int,
+        prefix_strings: str,
+        prefix_token_ids: List[int],
+        block_size: int,
+    ) -> None:
+        self.prefix_id = prefix_id
+        self.prompt = prefix_strings
+        self.block_size = block_size
+
+        self.token_ids = prefix_token_ids
+
+        self.logical_token_blocks: List[LogicalTokenBlock] = []
+        # Initialize the logical token blocks with the prompt token ids.
+        self._append_tokens_to_blocks(prefix_token_ids)
+
+        # Used for incremental detokenization
+        self.prefix_offset = 0
+        self.read_offset = 0
+        # Input + output tokens
+        self.tokens: Optional[List[str]] = None
+
+    def _append_logical_block(self) -> None:
+        block = LogicalTokenBlock(
+            block_number=len(self.logical_token_blocks),
+            block_size=self.block_size,
+        )
+        self.logical_token_blocks.append(block)
+
+    def _append_tokens_to_blocks(self, token_ids: List[int]) -> None:
+        cursor = 0
+        while cursor < len(token_ids):
+            if not self.logical_token_blocks:
+                self._append_logical_block()
+
+            last_block = self.logical_token_blocks[-1]
+            if last_block.is_full():
+                self._append_logical_block()
+                last_block = self.logical_token_blocks[-1]
+
+            num_empty_slots = last_block.get_num_empty_slots()
+            last_block.append_tokens(token_ids[cursor:cursor +
+                                               num_empty_slots])
+            cursor += num_empty_slots
+
+    def append_token_id(
+        self,
+        token_id: int,
+        logprobs: Dict[int, float],
+    ) -> None:
+        assert token_id in logprobs
+        self._append_tokens_to_blocks([token_id])
+        self.output_logprobs.append(logprobs)
+        self.data.append_token_id(token_id, logprobs[token_id])
+
+    def get_len(self) -> int:
+        return len(self.data)
+
+    def get_token_ids(self) -> List[int]:
+        return self.data
+
+    def get_last_token_id(self) -> int:
+        return self.data[-1]
+
+class PrefixMetaData:
+    def __init__(
+            self,
+            prefix_data: Dict[int, Prefix],
+            block_tables: Dict[int, List[int]]) -> None:
+        self.prefix_data = prefix_data
+        self.block_tables = block_tables

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Union
 
 from vllm.block import LogicalTokenBlock
 from vllm.sampling_params import SamplingParams
-
+from vllm.prefix import Prefix
 PromptLogprobs = List[Optional[Dict[int, float]]]
 SampleLogprobs = List[Dict[int, float]]
 
@@ -236,10 +236,12 @@ class SequenceGroup:
         seqs: List[Sequence],
         sampling_params: SamplingParams,
         arrival_time: float,
+        prefix: Optional[Prefix] = None
     ) -> None:
         self.request_id = request_id
         self.seqs_dict = {seq.seq_id: seq for seq in seqs}
         self.sampling_params = sampling_params
+        self.prefix = prefix
         self.arrival_time = arrival_time
         self.prompt_logprobs: Optional[PromptLogprobs] = None
 
@@ -344,12 +346,16 @@ class SequenceGroupMetadata:
         seq_data: Dict[int, SequenceData],
         sampling_params: SamplingParams,
         block_tables: Dict[int, List[int]],
+        prefix: Optional[Prefix] = None,
+        prefix_block_table: Optional[List[int]] = None
     ) -> None:
         self.request_id = request_id
         self.is_prompt = is_prompt
         self.seq_data = seq_data
         self.sampling_params = sampling_params
         self.block_tables = block_tables
+        self.prefix = prefix
+        self.prefix_block_table = prefix_block_table
 
 
 class SequenceOutputs:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -222,9 +222,6 @@ class Worker:
         slot_mapping_tensor = torch.tensor(padded_slot_mapping, dtype=torch.int, device="cuda")
         context_lens_tensor = torch.tensor(context_lens, dtype=torch.int, device="cuda")
         block_tables_tensor = torch.tensor(padded_block_tables, dtype=torch.int, device="cuda")
-        print("tokens_tensors shape", tokens_tensor.shape)
-        print("context_lens_tensor shape", context_lens_tensor.shape)
-        print("block_tables_tensor shape", block_tables_tensor.shape)
 
         # Create dummy sequences
         seq_groups = [([0], SamplingParams())]
@@ -239,7 +236,6 @@ class Worker:
             block_tables=block_tables_tensor,
             sliding_window=None
         )
-        print("input_metadata", input_metadata)
         return tokens_tensor, positions_tensor, input_metadata
 
 


### PR DESCRIPTION
Supports memory sharing of query prompts sharing same prefixes.

Remains
- [ ] support prefixes not multiple of `block_size`
- [ ] add tests
------

Usually queries share common prefix(instructions). 
For example, in this prompt,
```
[INST]  You are given a long korean text (delimited by triple quotes) and a question. 
Read the text and answer the question at the end in Korean.\n\"\"\"\n 
브라질 국적의 제수스는 2015년 SE 파우메리아스에서 프로 무대에 데뷔했다. 
제수스는 2022년 여름 이적시장을 통해 맨시티를 떠나 아스널로 새롭게 둥지를 틀었다. 
제수스는 곧바로 팀 공격의 핵심으로 떠올랐다. \n\"\"\"\nQuestion: 제수스의 데뷔 작품은 무엇인가요? [/INST]
```

Prefix part
```
[INST]  You are given a long korean text (delimited by triple quotes) and a question. 
Read the text and answer the question at the end in Korean.\n\"\"\"\n
```
is shared with other similar prompts.

require additional prefix.json file like
```json
{
    "prefix": [
            "[INST]  You are given a long korean text (delimited by triple quotes) and a question. Read the text and answer the question at the end in Korean.\n\"\"\""
        ]
}
```

I think this PR is not complete since only memory of prefixes are shared  and computation is done for each query yet, memory sharing itself gives improvements in throughput.

