### PR TITLE
Added logits processor API to sampling params

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -47,6 +47,8 @@ class Sampler(nn.Module):
         logits = _get_logits(hidden_states, embedding, embedding_bias,
                              self.vocab_size)
 
+        # Apply logits processors (if any).
+        logits = _apply_logits_processors(logits, input_metadata)
         # Apply presence and frequency penalties.
         output_tokens = _get_output_tokens(input_metadata)
         assert len(output_tokens) == logits.shape[0]
@@ -168,6 +170,26 @@ def _get_output_tokens(input_metadata: InputMetadata) -> List[List[int]]:
             seq_data = input_metadata.seq_data[seq_id]
             output_tokens.append(seq_data.output_token_ids)
     return output_tokens
+
+
+def _apply_logits_processors(logits: torch.Tensor,
+                             input_metadata: InputMetadata) -> torch.Tensor:
+    logits_row_idx = 0
+    found_logits_processors = False
+    for seq_ids, sampling_params in input_metadata.seq_groups:
+        logits_processors = sampling_params.logits_processors
+        for seq_id in seq_ids:
+            if logits_processors:
+                found_logits_processors = True
+                logits_row = logits[logits_row_idx]
+                token_ids = input_metadata.seq_data[seq_id].output_token_ids
+                for logits_processor in logits_processors:
+                    logits_row = logits_processor(token_ids, logits_row)
+                logits[logits_row_idx] = logits_row
+            logits_row_idx += 1
+    if found_logits_processors:
+        assert logits_row_idx == logits.shape[0]
+    return logits
 
 
 def _apply_penalties(

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -164,8 +164,8 @@ def _apply_logits_processors(logits: torch.Tensor,
     for seq_ids, sampling_params in input_metadata.seq_groups:
         logits_processors = sampling_params.logits_processors
         if logits_processors:
+            found_logits_processors = True
             for seq_id in seq_ids:
-                found_logits_processors = True
                 logits_row = logits[logits_row_idx]
                 token_ids = input_metadata.seq_data[seq_id].output_token_ids
                 for logits_processor in logits_processors:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -163,8 +163,8 @@ def _apply_logits_processors(logits: torch.Tensor,
     found_logits_processors = False
     for seq_ids, sampling_params in input_metadata.seq_groups:
         logits_processors = sampling_params.logits_processors
-        for seq_id in seq_ids:
-            if logits_processors:
+        if logits_processors:
+            for seq_id in seq_ids:
                 found_logits_processors = True
                 logits_row = logits[logits_row_idx]
                 token_ids = input_metadata.seq_data[seq_id].output_token_ids
@@ -172,6 +172,8 @@ def _apply_logits_processors(logits: torch.Tensor,
                     logits_row = logits_processor(token_ids, logits_row)
                 logits[logits_row_idx] = logits_row
             logits_row_idx += 1
+        else:
+            logits_row_idx += len(seq_ids)
     if found_logits_processors:
         assert logits_row_idx == logits.shape[0]
     return logits

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -171,7 +171,7 @@ def _apply_logits_processors(logits: torch.Tensor,
                 for logits_processor in logits_processors:
                     logits_row = logits_processor(token_ids, logits_row)
                 logits[logits_row_idx] = logits_row
-            logits_row_idx += 1
+                logits_row_idx += 1
         else:
             logits_row_idx += len(seq_ids)
     if found_logits_processors:

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,7 +1,8 @@
 """Sampling parameters for text generation."""
 from enum import IntEnum
 from functools import cached_property
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
+import torch
 
 _SAMPLING_EPS = 1e-5
 
@@ -10,6 +11,12 @@ class SamplingType(IntEnum):
     GREEDY = 0
     RANDOM = 1
     BEAM = 2
+
+
+LogitsProcessor = Callable[[List[int], torch.Tensor], torch.Tensor]
+"""LogitsProcessor is a function that takes a list of previously generated
+tokens and a tensor of the logits for the next token, and returns a modified
+tensor of logits to sample from."""
 
 
 class SamplingParams:
@@ -67,6 +74,8 @@ class SamplingParams:
             `logprobs+1` elements in the response.
         prompt_logprobs: Number of log probabilities to return per prompt token.
         skip_special_tokens: Whether to skip special tokens in the output.
+        logits_processors: List of functions that modify logits based on
+            previously generated tokens.
     """
 
     def __init__(
@@ -88,6 +97,7 @@ class SamplingParams:
         logprobs: Optional[int] = None,
         prompt_logprobs: Optional[int] = None,
         skip_special_tokens: bool = True,
+        logits_processors: Optional[List[LogitsProcessor]] = None,
     ) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
@@ -114,6 +124,7 @@ class SamplingParams:
         self.logprobs = logprobs
         self.prompt_logprobs = prompt_logprobs
         self.skip_special_tokens = skip_special_tokens
+        self.logits_processors = logits_processors
 
         self._verify_args()
         if self.use_beam_search:

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -135,7 +135,6 @@ class SamplingParams:
         self.skip_special_tokens = skip_special_tokens
         self.spaces_between_special_tokens = spaces_between_special_tokens
         self.logits_processors = logits_processors
-        
         self._verify_args()
         if self.use_beam_search:
             self._verify_beam_search()


### PR DESCRIPTION
This PR adds a new optional parameter ```logits_processors``` to SamplingParams.

The idea (which exists in huggingface transformers, llama.cpp and other inference engines) allows custom code to modify the logits scores after they are generated by the model, before they are sampled from.

This opens integration possibilities with a lot of solutions, such as [LM Format Enforcer](https://github.com/noamgat/lm-format-enforcer) (my library), Guidance, JsonFormer and Outlines.

For example, this allows limiting vLLM to only generate outputs that conform to a specific JSON Schema or regular expression.

The design principles behind this PR were to have as little impact as possible on vLLM itself (so no extra dependencies, no runtime penalty if the option is not used) and to be as consistent as possible with other inference engines.

LM Format Enforcer already has an [example notebook](https://github.com/noamgat/lm-format-enforcer/blob/main/samples/colab_vllm_integration.ipynb) on integrating with vLLM, showing the benefits, however it uses monkey patching due to the lack of API, which makes it less robust for production use.

I added a test to check the integration, and format.sh did not add any new remarks.