### PR TITLE
fix: Always initialize bias to zero for ColumnParallelLinear.

### DIFF
--- a/vllm/model_executor/parallel_utils/layers.py
+++ b/vllm/model_executor/parallel_utils/layers.py
@@ -142,6 +142,10 @@ class ColumnParallelLinear(torch.nn.Module):
                 torch.empty(self.output_size_per_partition,
                             device=torch.cuda.current_device(),
                             dtype=params_dtype))
+
+            # Always initialize bias to zero.
+            with torch.no_grad():
+                self.bias.zero_()
         else:
             self.register_parameter('bias', None)
 

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -81,10 +81,7 @@ def _convert_tokens_to_string_with_added_encoders(
     # even when the loop body is very simple.
     sub_texts = []
     current_sub_text = []
-    all_special_tokens = set(tokenizer.all_special_tokens)
     for token in output_tokens:
-        if skip_special_tokens and token in all_special_tokens:
-            continue
         if token in tokenizer.get_added_vocab():
             if current_sub_text:
                 sub_text = tokenizer.convert_tokens_to_string(current_sub_text)
@@ -120,7 +117,11 @@ def detokenize_incrementally(
         # tokenizers (bigger = more conservative).
         # Subtract 1 extra to account for the generated token.
         prefix_offset = max(len(output_tokens) - 6, 0)
-        read_offset = max(len(output_tokens) - 1, 0)
+        # If the first new token is a special token, we can't skip 1 extra token
+        if skip_special_tokens and new_token_id in tokenizer.all_special_ids:
+            read_offset = max(len(output_tokens), 0)
+        else:
+            read_offset = max(len(output_tokens) - 1, 0)
     else:
         # Put new_token_id in a list so skip_special_tokens is respected
         new_tokens = tokenizer.convert_ids_to_tokens(


### PR DESCRIPTION
This PR should fix the problem of #1411.

In #1181, @zhuohan123 refactor the codes of `ColumnParallelLinear`, and removed the `self.bias.zero_()` statement, which result in some unknow behaviors in the model init phase. vLLM will do a forward in`profile_num_available_blocks`, and `hidden_state` will include `nan` value when executing the second `DecodeLayer` forwarding.
To be more precise, some wired phenomenon happened to the `self.bias` of `ColumnParallelLinear`:
1. `self.bias` will include some large value from the second attention layer if we just init the whole model;
![image](https://github.com/vllm-project/vllm/assets/37237570/e62aef4b-a574-444d-ae0a-496124cf7e9a)
These larger value will result in some `nan` value in the `attn_output`.

2. If I add a breakpoint at this statement:
```python
        self.qkv_proj = ColumnParallelLinear(
            hidden_size,
            3 * self.total_num_heads * self.head_dim,
            bias=True,
            gather_output=False,
        )
```
step into its construct function, run the `__init__()` step by step, `self.bias` seems to be a zero tensor, but still bring in some accuracy error when forwarding, `qkv, _ = self.qkv_proj(hidden_states)` is different to the result in vLLM==0.2.0.
![image](https://github.com/vllm-project/vllm/assets/37237570/b7b6dda3-404a-4f04-8ce5-bcae32ee2195)
![image](https://github.com/vllm-project/vllm/assets/37237570/214cee34-0691-4999-92af-7afc66523db4)


I'm no a expert of Pytorch, and can't explain why these wired phenomenon  happened. But this PR could fix the bug.
