### PR TITLE
Fix logging issues

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -48,4 +48,8 @@ _setup_logger()
 
 
 def init_logger(name: str):
-    return logging.getLogger(name)
+    # Use the same settings as above for root logger
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(_default_handler)
+    return logger


### PR DESCRIPTION
Currently, info logs are not actually being logged.

For example the args log in the OpenAI api_server:
```
logger.info(f"args: {args}")
```
doesn't actually print anything when you start the server.

This pull request fixes that.