### PR TITLE
fix: Always initialize bias to zero for ColumnParallelLinear.

### DIFF
--- a/vllm/model_executor/parallel_utils/layers.py
+++ b/vllm/model_executor/parallel_utils/layers.py
@@ -142,6 +142,10 @@ class ColumnParallelLinear(torch.nn.Module):
                 torch.empty(self.output_size_per_partition,
                             device=torch.cuda.current_device(),
                             dtype=params_dtype))
+
+            # Always initialize bias to zero.
+            with torch.no_grad():
+                self.bias.zero_()
         else:
             self.register_parameter('bias', None)
 


### PR DESCRIPTION
This PR should fix the problem of https://github.com/vllm-project/vllm/issues/1411.

In https://github.com/vllm-project/vllm/pull/1181, @zhuohan123 refactor the codes of ColumnParallelLinear, and removed the self.bias.zero_() statement, which result in some unknow behaviors in the model init phase. vLLM will do a forward inprofile_num_available_blocks, and hidden_state will include nan value when executing the second DecodeLayer forwarding.
To be more precise, some wired phenomenon happened to the self.bias of ColumnParallelLinear:

1.self.bias will include some large value from the second attention layer if we just init the whole model;
![image](https://github.com/vllm-project/vllm/assets/37237570/6e7b54dd-baf3-427a-b527-3f63253d266c)
These larger value will result in some nan value in the attn_output.

2.If I add a breakpoint at this statement:

        self.qkv_proj = ColumnParallelLinear(
            hidden_size,
            3 * self.total_num_heads * self.head_dim,
            bias=True,
            gather_output=False,
        )
step into its construct function, run the __init__() step by step, self.bias seems to be a zero tensor, but still bring in some accuracy error when forwarding, qkv, _ = self.qkv_proj(hidden_states) is different to the result in vLLM==0.2.0.
![image](https://github.com/vllm-project/vllm/assets/37237570/6e7b54dd-baf3-427a-b527-3f63253d266c)
![image](https://github.com/vllm-project/vllm/assets/37237570/10d0b280-59fd-4c2c-aa16-7fa1a56a7dd1)

I'm no a expert of Pytorch, and can't explain why these wired phenomenon happened. But this PR could fix the bug.