### PR TITLE
Fix OpenAI ChatCompletion Ignore stop from FastChat Conv Template 

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -179,6 +179,7 @@ def create_logprobs(token_ids: List[int],
         })
     return logprobs
 
+
 def _add_to_set(s, new_stop):
     if not s:
         return
@@ -186,6 +187,7 @@ def _add_to_set(s, new_stop):
         new_stop.add(s)
     else:
         new_stop.update(s)
+
 
 @app.post("/v1/chat/completions")
 async def create_chat_completion(request: ChatCompletionRequest,
@@ -213,7 +215,10 @@ async def create_chat_completion(request: ChatCompletionRequest,
     prompt, conv = await get_gen_prompt_and_conv(request)
 
     # Merge stop token from the conversation template.
-    stop_token_ids = list(request.stop_token_ids) if request.stop_token_ids is not None else []
+    if request.stop_token_ids is not None:
+        stop_token_ids = list(request.stop_token_ids)
+    else:
+        stop_token_ids = []
     if conv.stop_token_ids is not None:
         stop_token_ids = set(stop_token_ids)
         _add_to_set(conv.stop_token_ids, stop_token_ids)


### PR DESCRIPTION
When using vLLM's OpenAI API server to serve models, I find that the ChatCompletion request by default does not honor the `stop_token_ids` and `stop_str` set by FastChat conversation templates. It will cause issues (model keep generating irrelevant stuff) when using vLLM served OpenAI API as an OpenAI compatible server for [Gradio interface of FastChat](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/gradio_web_server.py).

This PR add a check in OpenAI ChatCompletion request to make sure the `stop_token_ids` and `stop_str` are merged with the request before send it to generation, similar to the implementation of [FastChat `vllm_worker`](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/openai_api_server.py#L297-L301).