### PR TITLE
Force paged attention v2 for long contexts

### DIFF
--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -32,7 +32,6 @@ class InputMetadata:
         selected_token_indices: torch.Tensor,
         categorized_sample_indices: Dict[SamplingType, torch.Tensor],
         sliding_window: Optional[int] = None,
-        force_paged_attention_v2: bool = False,
     ) -> None:
         self.seq_groups = seq_groups
         self.seq_data = seq_data
@@ -43,7 +42,6 @@ class InputMetadata:
         self.block_tables = block_tables
         self.selected_token_indices = selected_token_indices
         self.categorized_sample_indices = categorized_sample_indices
-        self.force_paged_attention_v2 = force_paged_attention_v2
 
         self.max_prompt_len = max(prompt_lens) if prompt_lens else 0
         self.to_cache = None

--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -32,6 +32,7 @@ class InputMetadata:
         selected_token_indices: torch.Tensor,
         categorized_sample_indices: Dict[SamplingType, torch.Tensor],
         sliding_window: Optional[int] = None,
+        force_paged_attention_v2: bool = False,
     ) -> None:
         self.seq_groups = seq_groups
         self.seq_data = seq_data
@@ -42,6 +43,7 @@ class InputMetadata:
         self.block_tables = block_tables
         self.selected_token_indices = selected_token_indices
         self.categorized_sample_indices = categorized_sample_indices
+        self.force_paged_attention_v2 = force_paged_attention_v2
 
         self.max_prompt_len = max(prompt_lens) if prompt_lens else 0
         self.to_cache = None

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -156,7 +156,8 @@ class PagedAttention(nn.Module):
         # sequences or heads is large, we use V1 since there is enough work
         # to parallelize.
         # TODO(woosuk): Tune this heuristic.
-        use_v1 = max_num_partitions == 1 or num_seqs * num_heads > 512
+        use_v1 = not input_metadata.force_paged_attention_v2 and (
+            max_num_partitions == 1 or num_seqs * num_heads > 512)
         if use_v1:
             # Run PagedAttention V1.
             attention_ops.paged_attention_v1(

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -156,7 +156,7 @@ class PagedAttention(nn.Module):
         # sequences or heads is large, we use V1 since there is enough work
         # to parallelize.
         # TODO(woosuk): Tune this heuristic.
-        use_v1 = not input_metadata.force_paged_attention_v2 and (
+        use_v1 = input_metadata.max_context_len <= 8192 and (
             max_num_partitions == 1 or num_seqs * num_heads > 512)
         if use_v1:
             # Run PagedAttention V1.

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -156,6 +156,7 @@ class PagedAttention(nn.Module):
         # sequences or heads is large, we use V1 since there is enough work
         # to parallelize.
         # TODO(woosuk): Tune this heuristic.
+        # For context len > 8192, use V2 kernel to avoid shared memory shortage.
         use_v1 = input_metadata.max_context_len <= 8192 and (
             max_num_partitions == 1 or num_seqs * num_heads > 512)
         if use_v1:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -13,7 +13,7 @@ from vllm.model_executor.parallel_utils.parallel_state import (
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from vllm.worker.cache_engine import CacheEngine
-from vllm.utils import get_gpu_memory, get_max_shared_memory_bytes
+from vllm.utils import get_gpu_memory
 
 
 class Worker:
@@ -140,12 +140,6 @@ class Worker:
         self.cache_config = cache_config
         self.block_size = cache_config.block_size
         self.sliding_window = cache_config.sliding_window
-
-        if self.sliding_window is None:
-            max_seq_len = self.scheduler_config.max_model_len
-        else:
-            max_seq_len = min(self.scheduler_config.max_model_len,
-                              self.sliding_window)
 
         self.cache_engine = CacheEngine(self.cache_config, self.model_config,
                                         self.parallel_config)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -47,8 +47,6 @@ class Worker:
         self.cache_events = None
         self.gpu_cache = None
 
-        self.force_paged_attention_v2 = False
-
     def init_model(self):
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -148,8 +146,6 @@ class Worker:
         else:
             max_seq_len = min(self.scheduler_config.max_model_len,
                               self.sliding_window)
-        self.force_paged_attention_v2 = _should_force_paged_attention_v2(
-            max_seq_len, self.block_size)
 
         self.cache_engine = CacheEngine(self.cache_config, self.model_config,
                                         self.parallel_config)
@@ -335,7 +331,6 @@ class Worker:
             selected_token_indices=selected_token_indices,
             categorized_sample_indices=categorized_sample_indices,
             sliding_window=self.sliding_window,
-            force_paged_attention_v2=self.force_paged_attention_v2,
         )
         return tokens_tensor, positions_tensor, input_metadata
 
@@ -423,19 +418,6 @@ def _pad_to_alignment(x: List[int], multiple_of: int, pad: int) -> List[int]:
 
 def _pad_to_max(x: List[int], max_len: int, pad: int) -> List[int]:
     return x + [pad] * (max_len - len(x))
-
-
-def _should_force_paged_attention_v2(max_seq_len: int,
-                                     block_size: int) -> bool:
-    # Follows the logic in
-    # attention_kernels.cu::paged_attention_kernel
-    max_shared_mem = get_max_shared_memory_bytes()
-    float32_bytes = torch.finfo(torch.float).bits // 8
-    padded_max_seq_len = (
-        (max_seq_len + block_size - 1) / block_size) * block_size
-    # padded_max_seq_len + extra buffer
-    required_shared_mem = (padded_max_seq_len + 512) * float32_bytes
-    return required_shared_mem > max_shared_mem
 
 
 def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):


### PR DESCRIPTION
Removes the hard limit on context length that was tied to paged attention v1 limitations and instead forces v2 to be used if the context cannot fit in shared memory.