### PR TITLE
Add `MptForCausalLM` key in model_loader

### DIFF
--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -27,6 +27,7 @@ _MODEL_REGISTRY = {
     "LlamaForCausalLM": LlamaForCausalLM,
     "LLaMAForCausalLM": LlamaForCausalLM,  # For decapoda-research/llama-*
     "MistralForCausalLM": MistralForCausalLM,
+    "MptForCausalLM": MPTForCausalLM,  # transformers's mpt class has lower case
     "MPTForCausalLM": MPTForCausalLM,
     "OPTForCausalLM": OPTForCausalLM,
     "QWenLMHeadModel": QWenLMHeadModel,

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -27,7 +27,8 @@ _MODEL_REGISTRY = {
     "LlamaForCausalLM": LlamaForCausalLM,
     "LLaMAForCausalLM": LlamaForCausalLM,  # For decapoda-research/llama-*
     "MistralForCausalLM": MistralForCausalLM,
-    "MptForCausalLM": MPTForCausalLM,  # transformers's mpt class has lower case
+    "MptForCausalLM":
+    MPTForCausalLM,  # transformers's mpt class has lower case
     "MPTForCausalLM": MPTForCausalLM,
     "OPTForCausalLM": OPTForCausalLM,
     "QWenLMHeadModel": QWenLMHeadModel,

--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -27,8 +27,8 @@ _MODEL_REGISTRY = {
     "LlamaForCausalLM": LlamaForCausalLM,
     "LLaMAForCausalLM": LlamaForCausalLM,  # For decapoda-research/llama-*
     "MistralForCausalLM": MistralForCausalLM,
-    "MptForCausalLM":
-    MPTForCausalLM,  # transformers's mpt class has lower case
+    # transformers's mpt class has lower case
+    "MptForCausalLM": MPTForCausalLM,
     "MPTForCausalLM": MPTForCausalLM,
     "OPTForCausalLM": OPTForCausalLM,
     "QWenLMHeadModel": QWenLMHeadModel,


### PR DESCRIPTION
vllm now throws `ValueError` when a MPT model is loaded without `trust_remote_code` and with newer `transformers` versions.
```
ValueError: Model architectures ['MptForCausalLM'] are not supported for now. Supported architectures: ['AquilaModel', 'AquilaForCausalLM', 'BaiChuanForCausalLM', 'BaichuanForCausalLM', 'BloomForCausalLM', 'FalconForCausalLM', 'GPT2LMHeadModel', 'GPTBigCodeForCausalLM', 'GPTJForCausalLM', 'GPTNeoXForCausalLM', 'InternLMForCausalLM', 'LlamaForCausalLM', 'LLaMAForCausalLM', 'MistralForCausalLM', 'MPTForCausalLM', 'OPTForCausalLM', 'QWenLMHeadModel', 'RWForCausalLM']
```

The cause is that the official MPT model class name in `transformers` is lower case ([MptForCausalLM](https://huggingface.co/docs/transformers/main/model_doc/mpt#transformers.MptForCausalLM)), which is different from the original `MPTForCausalLM` in mosciaml's own [implementation](https://huggingface.co/mosaicml/mpt-7b/blob/main/config.json#L3).

