### PR TITLE
[Small] Formatter only checks lints in changed files

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -93,9 +93,43 @@ echo 'vLLM yapf: Done'
 # echo 'vLLM mypy:'
 # mypy
 
+# Lint specified files
+lint() {
+    pylint "$@"
+}
+
+# Lint files that differ from main branch. Ignores dirs that are not slated
+# for autolint yet.
+lint_changed() {
+    # The `if` guard ensures that the list of filenames is not empty, which
+    # could cause pylint to receive 0 positional arguments, making it hang
+    # waiting for STDIN.
+    #
+    # `diff-filter=ACM` and $MERGEBASE is to ensure we only lint files that
+    # exist on both branches.
+    MERGEBASE="$(git merge-base origin/main HEAD)"
+
+    if ! git diff --diff-filter=ACM --quiet --exit-code "$MERGEBASE" -- '*.py' '*.pyi' &>/dev/null; then
+        git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.py' '*.pyi' | xargs \
+             pylint
+    fi
+
+}
+
 # Run Pylint
 echo 'vLLM Pylint:'
-pylint vllm tests
+## This flag lints individual files. --files *must* be the first command line
+## arg to use this option.
+if [[ "$1" == '--files' ]]; then
+   lint "${@:2}"
+   # If `--all` is passed, then any further arguments are ignored and the
+   # entire python directory is linted.
+elif [[ "$1" == '--all' ]]; then
+   lint vllm tests
+else
+   # Format only the files that changed in last commit.
+   lint_changed
+fi
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted files. Please review and stage the changes.'


### PR DESCRIPTION
There are many lint failures which makes new ones easy to miss. This PR makes the linter by default only check changed files using the same logic as used for yapf.

### Testing
```
$ ./format.sh --files vllm/block.py
vLLM yapf: Done
vLLM Pylint:

------------------------------------
Your code has been rated at 10.00/10
```

```
$ echo '# long line------------------------------------------------------------------------' >> vllm/block.py
$ ./format.sh
vLLM yapf: Done
vLLM Pylint:
************* Module vllm.block
vllm/block.py:71:0: C0301: Line too long (83/80) (line-too-long)

-----------------------------------
Your code has been rated at 9.70/10
```

```
$ ./format.sh --all
vLLM yapf: Done
vLLM Pylint:
************* Module vllm.model_executor.models.internlm
vllm/model_executor/models/internlm.py:265:24: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
vllm/model_executor/models/internlm.py:275:24: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
vllm/model_executor/models/internlm.py:293:24: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
vllm/model_executor/models/internlm.py:307:20: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
************* Module vllm.model_executor.models.qwen
vllm/model_executor/models/qwen.py:296:24: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
vllm/model_executor/models/qwen.py:309:20: E1136: Value 'state_dict' is unsubscriptable (unsubscriptable-object)
[rest omitted]
```