### PR TITLE
Feature : Support baichuan2 model and efficient multi-lora adapters in a single batch #182

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -40,15 +40,10 @@ def sample_requests(
     with open(dataset_path) as f:
         dataset = json.load(f)
     # Filter out the conversations with less than 2 turns.
-    dataset = [
-        data for data in dataset
-        if len(data["conversations"]) >= 2
-    ]
+    dataset = [data for data in dataset if len(data["conversations"]) >= 2]
     # Only keep the first two turns of each conversation.
-    dataset = [
-        (data["conversations"][0]["value"], data["conversations"][1]["value"])
-        for data in dataset
-    ]
+    dataset = [(data["conversations"][0]["value"],
+                data["conversations"][1]["value"]) for data in dataset]
 
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]
@@ -137,7 +132,8 @@ async def send_request(
     timeout = aiohttp.ClientTimeout(total=3 * 3600)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         while True:
-            async with session.post(api_url, headers=headers, json=pload) as response:
+            async with session.post(api_url, headers=headers,
+                                    json=pload) as response:
                 chunks = []
                 async for chunk, _ in response.content.iter_chunks():
                     chunks.append(chunk)
@@ -164,9 +160,9 @@ async def benchmark(
     tasks: List[asyncio.Task] = []
     async for request in get_request(input_requests, request_rate):
         prompt, prompt_len, output_len = request
-        task = asyncio.create_task(send_request(backend, api_url, prompt,
-                                                prompt_len, output_len,
-                                                best_of, use_beam_search))
+        task = asyncio.create_task(
+            send_request(backend, api_url, prompt, prompt_len, output_len,
+                         best_of, use_beam_search))
         tasks.append(task)
     await asyncio.gather(*tasks)
 
@@ -177,12 +173,14 @@ def main(args: argparse.Namespace):
     np.random.seed(args.seed)
 
     api_url = f"http://{args.host}:{args.port}/generate"
-    tokenizer = get_tokenizer(args.tokenizer, trust_remote_code=args.trust_remote_code)
+    tokenizer = get_tokenizer(args.tokenizer,
+                              trust_remote_code=args.trust_remote_code)
     input_requests = sample_requests(args.dataset, args.num_prompts, tokenizer)
 
     benchmark_start_time = time.perf_counter()
-    asyncio.run(benchmark(args.backend, api_url, input_requests, args.best_of,
-                          args.use_beam_search, args.request_rate))
+    asyncio.run(
+        benchmark(args.backend, api_url, input_requests, args.best_of,
+                  args.use_beam_search, args.request_rate))
     benchmark_end_time = time.perf_counter()
     benchmark_time = benchmark_end_time - benchmark_start_time
     print(f"Total time: {benchmark_time:.2f} s")
@@ -196,10 +194,8 @@ def main(args: argparse.Namespace):
         for prompt_len, output_len, latency in REQUEST_LATENCY
     ])
     print(f"Average latency per token: {avg_per_token_latency:.2f} s")
-    avg_per_output_token_latency = np.mean([
-        latency / output_len
-        for _, output_len, latency in REQUEST_LATENCY
-    ])
+    avg_per_output_token_latency = np.mean(
+        [latency / output_len for _, output_len, latency in REQUEST_LATENCY])
     print("Average latency per output token: "
           f"{avg_per_output_token_latency:.2f} s")
 
@@ -207,27 +203,40 @@ def main(args: argparse.Namespace):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Benchmark the online serving throughput.")
-    parser.add_argument("--backend", type=str, default="vllm",
+    parser.add_argument("--backend",
+                        type=str,
+                        default="vllm",
                         choices=["vllm", "tgi"])
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--dataset", type=str, required=True,
+    parser.add_argument("--dataset",
+                        type=str,
+                        required=True,
                         help="Path to the dataset.")
-    parser.add_argument("--tokenizer", type=str, required=True,
+    parser.add_argument("--tokenizer",
+                        type=str,
+                        required=True,
                         help="Name or path of the tokenizer.")
-    parser.add_argument("--best-of", type=int, default=1,
+    parser.add_argument("--best-of",
+                        type=int,
+                        default=1,
                         help="Generates `best_of` sequences per prompt and "
-                             "returns the best one.")
+                        "returns the best one.")
     parser.add_argument("--use-beam-search", action="store_true")
-    parser.add_argument("--num-prompts", type=int, default=1000,
+    parser.add_argument("--num-prompts",
+                        type=int,
+                        default=1000,
                         help="Number of prompts to process.")
-    parser.add_argument("--request-rate", type=float, default=float("inf"),
+    parser.add_argument("--request-rate",
+                        type=float,
+                        default=float("inf"),
                         help="Number of requests per second. If this is inf, "
-                             "then all the requests are sent at time 0. "
-                             "Otherwise, we use Poisson process to synthesize "
-                             "the request arrival times.")
+                        "then all the requests are sent at time 0. "
+                        "Otherwise, we use Poisson process to synthesize "
+                        "the request arrival times.")
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument('--trust-remote-code', action='store_true',
+    parser.add_argument('--trust-remote-code',
+                        action='store_true',
                         help='trust remote code from huggingface')
     args = parser.parse_args()
     main(args)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,13 +14,11 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-
 # -- Project information -----------------------------------------------------
 
 project = 'vLLM'
 copyright = '2023, vLLM Team'
 author = 'the vLLM Team'
-
 
 # -- General configuration ---------------------------------------------------
 

--- a/examples/baichuan_lora.py
+++ b/examples/baichuan_lora.py
@@ -6,14 +6,33 @@ if __name__ == "__main__":
     path = "./baichuan2-13b"
     lora_path = "./baichuan2-13b-20231013174626"
     lora_path_2 = "./baichuan2-13b-20231013192059"
-    llm = LLM(model=path, trust_remote_code=True, lora_paths=[lora_path, lora_path_2], adapter_names=["adapter_1", "adapter_2"])
+    llm = LLM(model=path,
+              trust_remote_code=True,
+              lora_paths=[lora_path, lora_path_2],
+              adapter_names=["adapter_1", "adapter_2"])
 
     print(llm.llm_engine.workers[0].model)
 
-    sampling_params = SamplingParams(temperature=0, top_p=1, best_of=2, top_k=-1, max_tokens=100, use_beam_search=True, lora_id="adapter_1")
-    llm._add_request(prompt=prompt, prompt_token_ids=None, sampling_params=sampling_params)
-    sampling_params = SamplingParams(temperature=0, top_p=1, best_of=2, top_k=-1, max_tokens=100, use_beam_search=True, lora_id = "adapter_2")
-    llm._add_request(prompt=prompt, prompt_token_ids=None, sampling_params=sampling_params)
+    sampling_params = SamplingParams(temperature=0,
+                                     top_p=1,
+                                     best_of=2,
+                                     top_k=-1,
+                                     max_tokens=100,
+                                     use_beam_search=True,
+                                     lora_id="adapter_1")
+    llm._add_request(prompt=prompt,
+                     prompt_token_ids=None,
+                     sampling_params=sampling_params)
+    sampling_params = SamplingParams(temperature=0,
+                                     top_p=1,
+                                     best_of=2,
+                                     top_k=-1,
+                                     max_tokens=100,
+                                     use_beam_search=True,
+                                     lora_id="adapter_2")
+    llm._add_request(prompt=prompt,
+                     prompt_token_ids=None,
+                     sampling_params=sampling_params)
     start = time.time()
     outputs = llm._run_engine(use_tqdm=True)
     end = time.time()

--- a/examples/baichuan_lora.py
+++ b/examples/baichuan_lora.py
@@ -1,0 +1,25 @@
+from vllm import LLM, SamplingParams
+import time
+if __name__ == "__main__":
+    prompt = "Hello and welcome, "
+    prompts = [prompt]
+    path = "./baichuan2-13b"
+    lora_path = "./baichuan2-13b-20231013174626"
+    lora_path_2 = "./baichuan2-13b-20231013192059"
+    llm = LLM(model=path, trust_remote_code=True, lora_paths=[lora_path, lora_path_2], adapter_names=["adapter_1", "adapter_2"])
+
+    print(llm.llm_engine.workers[0].model)
+
+    sampling_params = SamplingParams(temperature=0, top_p=1, best_of=2, top_k=-1, max_tokens=100, use_beam_search=True, lora_id="adapter_1")
+    llm._add_request(prompt=prompt, prompt_token_ids=None, sampling_params=sampling_params)
+    sampling_params = SamplingParams(temperature=0, top_p=1, best_of=2, top_k=-1, max_tokens=100, use_beam_search=True, lora_id = "adapter_2")
+    llm._add_request(prompt=prompt, prompt_token_ids=None, sampling_params=sampling_params)
+    start = time.time()
+    outputs = llm._run_engine(use_tqdm=True)
+    end = time.time()
+    print(f"cost: {end - start}")
+    # Print the outputs.
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/examples/baichuan_lora_api.py
+++ b/examples/baichuan_lora_api.py
@@ -73,7 +73,7 @@ async def generate(request: Request) -> Response:
 
     assert final_output is not None
     #prompt = final_output.prompt
-    text_outputs = [ output.text for output in final_output.outputs]
+    text_outputs = [output.text for output in final_output.outputs]
     ret = {"text": text_outputs}
     return JSONResponse(ret)
 

--- a/examples/baichuan_lora_api.py
+++ b/examples/baichuan_lora_api.py
@@ -1,0 +1,98 @@
+import argparse
+import json
+from typing import AsyncGenerator
+
+from fastapi import BackgroundTasks, FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+import uvicorn
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.sampling_params import SamplingParams
+from vllm.utils import random_uuid
+# from vllm.model_executor.lora_utils import add_lora_adapter
+
+TIMEOUT_KEEP_ALIVE = 5  # seconds.
+TIMEOUT_TO_PREVENT_DEADLOCK = 1  # seconds.
+app = FastAPI()
+engine = None
+sampling_params = SamplingParams(temperature=0,
+                                 top_p=1,
+                                 best_of=2,
+                                 top_k=-1,
+                                 max_tokens=100,
+                                 use_beam_search=True)
+
+
+@app.post("/generate")
+async def generate(request: Request) -> Response:
+    """Generate completion for the request with specific lora.
+
+    The request should be a JSON object with the following fields:
+    - prompt: the prompt to use for the generation.
+    - stream: whether to stream the results or not.
+    - other fields: the sampling parameters (See `SamplingParams` for details).
+    """
+    request_dict = await request.json()
+    prompt = request_dict.pop("prompt")
+    stream = request_dict.pop("stream", False)
+    task = request_dict.pop("task", "adapter_1")
+    #sampling_params = SamplingParams(**request_dict)
+    request_id = random_uuid()
+    sampling_params.lora_id = task
+    #prepare_batch(["table_rank"], engine.engine.workers[0].model)
+    results_generator = engine.generate(prompt, sampling_params, request_id)
+
+    # Streaming case
+    async def stream_results() -> AsyncGenerator[bytes, None]:
+        async for request_output in results_generator:
+            prompt = request_output.prompt
+            text_outputs = [
+                prompt + output.text for output in request_output.outputs
+            ]
+            ret = {"text": text_outputs}
+            yield (json.dumps(ret) + "\0").encode("utf-8")
+
+    async def abort_request() -> None:
+        await engine.abort(request_id)
+
+    if stream:
+        background_tasks = BackgroundTasks()
+        # Abort the request if the client disconnects.
+        background_tasks.add_task(abort_request)
+        return StreamingResponse(stream_results(), background=background_tasks)
+
+    # Non-streaming case
+    final_output = None
+    async for request_output in results_generator:
+        if await request.is_disconnected():
+            # Abort the request if the client disconnects.
+            await engine.abort(request_id)
+            return Response(status_code=499)
+        final_output = request_output
+
+    assert final_output is not None
+    #prompt = final_output.prompt
+    text_outputs = [ output.text for output in final_output.outputs]
+    ret = {"text": text_outputs}
+    return JSONResponse(ret)
+
+
+if __name__ == "__main__":
+    """
+    run command:
+       python3 baichuan_lora_api.py --model [model path] --lora-paths ./baichuan2-13b-adapter1 ./baichuan2-13b-adapter2 --adapter-names adapter1 adapter2 --trust-remote-code [--tensor-parallel-size 2]
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    parser = AsyncEngineArgs.add_cli_args(parser)
+    args = parser.parse_args()
+
+    engine_args = AsyncEngineArgs.from_cli_args(args)
+    engine = AsyncLLMEngine.from_engine_args(engine_args)
+    uvicorn.run(app,
+                host=args.host,
+                port=args.port,
+                log_level="debug",
+                timeout_keep_alive=TIMEOUT_KEEP_ALIVE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ xformers == 0.0.22  # Required for Mistral.
 fastapi
 uvicorn[standard]
 pydantic == 1.10.13  # Required for OpenAI server.
+peft == 0.4.0

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -3,6 +3,16 @@ from typing import List, Tuple
 import pytest
 import torch
 
+import torch.distributed as dist
+import os
+from vllm.model_executor.parallel_utils.parallel_state import initialize_model_parallel
+
+os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+os.environ.setdefault("MASTER_PORT", "8000")
+dist.init_process_group(rank=0, world_size=1)
+initialize_model_parallel()
+torch.cuda.init()
+
 
 def create_kv_caches(
     num_blocks: int,

--- a/tests/kernels/test_blora.py
+++ b/tests/kernels/test_blora.py
@@ -1,0 +1,245 @@
+import pytest
+from vllm.model_executor.parallel_utils.layers import BLoraColumnParallelLinear, BLoraRowParallelLinear
+from peft.utils.other import transpose
+from peft.tuners.lora import Linear
+import torch
+import torch.nn.functional as F
+
+
+
+LORA_DROP_OUTS = [0.0, 0.5]
+INPUT_SIZE = [8, 16, 16]
+OUTPUT_SIZE = [16, 16, 32]
+ADAPTER_NAMES = [["lora1", "lora2"], ["lora1", "lora2", "lora3"]]
+LORA_ALPHA = [4, 6, 8, 10]
+BIAS = [True, False]
+SEEDS = [0]
+R = [1, 2, 4, 8]
+
+REDUCE_RESULTS = [True, False]
+
+IS_INPUT_PARALLEL = [True, False]
+
+class RefBLinear(Linear):
+    def forward(self, x: torch.Tensor):
+        previous_dtype = x.dtype
+        if self.active_adapter not in self.lora_A.keys():
+            return F.linear(
+                x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias
+            )
+        if self.disable_adapters:
+            if self.r[self.active_adapter] > 0 and self.merged:
+                self.unmerge()
+            result = F.linear(
+                x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias
+            )
+        elif self.r[self.active_adapter] > 0 and not self.merged:
+            result = F.linear(
+                x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias
+            )
+            x = x.to(self.lora_A[self.active_adapter].weight.dtype)
+
+            assert x.size(0) == len(self.batch_lora_ids)
+
+            batch = list(zip(x, self.batch_lora_ids))
+            # rewrite as for loop
+            lora_out = torch.zeros_like(result)
+            for i, (xi, lora_id) in enumerate(batch):
+                if lora_id in self.lora_A.keys():
+                    lora_out[i] = self.scaling[lora_id] * self.lora_B[lora_id](
+                        self.lora_A[lora_id](self.lora_dropout[lora_id](xi))
+                    )
+            result += lora_out
+
+        else:
+            result = F.linear(
+                x, transpose(self.weight, self.fan_in_fan_out), bias=self.bias
+            )
+
+        result = result.to(previous_dtype)
+        return result, self.bias
+
+
+@pytest.mark.parametrize("adapter_names", ADAPTER_NAMES)
+@pytest.mark.parametrize("output_size", OUTPUT_SIZE)
+@pytest.mark.parametrize("input_size", INPUT_SIZE)
+@pytest.mark.parametrize("bias", BIAS)
+@pytest.mark.parametrize("r", R)
+@pytest.mark.parametrize("lora_alpha", LORA_ALPHA)
+@pytest.mark.parametrize("lora_drop_out", LORA_DROP_OUTS)
+@pytest.mark.parametrize("seed", SEEDS)
+@torch.inference_mode()
+def test_column_blora(
+    adapter_names: list[str],
+    input_size: int,
+    output_size: int,
+    bias: bool,
+    r: int,
+    lora_alpha: int,
+    lora_drop_out: float,
+    seed: int,
+    init_lora_weights = True,
+):
+    ref_blinear = None
+    column_blora = None
+    skip_bias = not bias
+    # create model
+    for i in range(len(adapter_names)):
+        adapter_name = adapter_names[i]
+        if i == 0:
+            ref_blinear = RefBLinear(adapter_name=adapter_name,
+                                     in_features=input_size,
+                                     out_features=output_size,
+                                     r=r,
+                                     lora_alpha=lora_alpha,
+                                     bias=bias)
+            column_blora = BLoraColumnParallelLinear(input_size=input_size,
+                                                     output_size=output_size,
+                                                     adapter_name=adapter_name,
+                                                     bias=bias,
+                                                     skip_bias_add=skip_bias,
+                                                     r=r,
+                                                     lora_alpha=lora_alpha,
+                                                     lora_dropout=lora_drop_out)
+        else:
+            ref_blinear.update_layer(adapter_name=adapter_name,
+                                     r=r,
+                                     lora_alpha=lora_alpha,
+                                     lora_dropout=lora_drop_out,
+                                     init_lora_weights=init_lora_weights)
+            column_blora.update_layer(adapter_name=adapter_name,
+                                      r=r,
+                                      lora_alpha=lora_alpha,
+                                      lora_dropout=lora_drop_out,
+                                      init_lora_weights=init_lora_weights)
+    ref_blinear.cuda()
+    column_blora.cuda()
+    # prepare inputs
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    scale = float(input_size**-0.5)
+    x = torch.empty(len(adapter_names), input_size, device="cuda")
+    x.uniform_(-scale, scale)
+    setattr(ref_blinear, "batch_lora_ids", adapter_names)
+    setattr(column_blora, "batch_lora_ids", adapter_names)
+    batch_token_length = []
+    for i in range(len(adapter_names)):
+        batch_token_length.append(1)
+    setattr(column_blora, "batch_token_lengths", batch_token_length)
+
+    # align weights
+    column_blora.weight.copy_(ref_blinear.weight)
+    assert torch.allclose(column_blora.weight,
+                          ref_blinear.weight,
+                          atol=1e-8, rtol=1e-8)
+    if column_blora.bias is not None:
+        column_blora.bias.copy_(ref_blinear.bias)
+        assert torch.allclose(column_blora.bias, ref_blinear.bias,
+                              atol=1e-8, rtol=1e-8)
+
+    for lora_id, adapter in column_blora.lora_A.items():
+        adapter.weight.copy_(ref_blinear.lora_A[lora_id].weight)
+        assert torch.allclose(adapter.weight,
+                              ref_blinear.lora_A[lora_id].weight,
+                              atol=1e-8,
+                              rtol=1e-8)
+
+    #test inputs
+    ref_output, _ = ref_blinear.forward(x)
+    col_output, _ = column_blora.forward(x)
+
+    assert torch.allclose(ref_output, col_output, atol=1e-8, rtol=1e-8)
+
+
+@pytest.mark.parametrize("adapter_names", ADAPTER_NAMES)
+@pytest.mark.parametrize("output_size", OUTPUT_SIZE)
+@pytest.mark.parametrize("input_size", INPUT_SIZE)
+@pytest.mark.parametrize("reduce_results", REDUCE_RESULTS)
+@pytest.mark.parametrize("r", R)
+@pytest.mark.parametrize("lora_alpha", LORA_ALPHA)
+@pytest.mark.parametrize("lora_drop_out", LORA_DROP_OUTS)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("input_parallel", IS_INPUT_PARALLEL)
+@torch.inference_mode()
+def test_row_blora(
+    adapter_names: list[str],
+    input_size: int,
+    output_size: int,
+    reduce_results: bool,
+    r: int,
+    lora_alpha: int,
+    lora_drop_out: float,
+    seed: int,
+    input_parallel: bool,
+    init_lora_weights = True,
+):
+    ref_blinear = None
+    row_blora = None
+    bias = reduce_results
+    skip_bias = not bias
+
+    # create model
+    for i in range(len(adapter_names)):
+        adapter_name = adapter_names[i]
+        if i == 0:
+            ref_blinear = RefBLinear(adapter_name=adapter_name,
+                                     in_features=input_size,
+                                     out_features=output_size,
+                                     r=r,
+                                     lora_alpha=lora_alpha,
+                                     bias=bias)
+            row_blora = BLoraRowParallelLinear(input_size=input_size,
+                                               output_size=output_size,
+                                               adapter_name=adapter_name,
+                                               bias=bias,
+                                               skip_bias_add=skip_bias,
+                                               r=r,
+                                               lora_alpha=lora_alpha,
+                                               lora_dropout=lora_drop_out,
+                                               is_input_parallel=input_parallel,
+                                               reduce_results=reduce_results)
+        else:
+            ref_blinear.update_layer(adapter_name=adapter_name,
+                                     r=r,
+                                     lora_alpha=lora_alpha,
+                                     lora_dropout=lora_drop_out,
+                                     init_lora_weights=init_lora_weights)
+            row_blora.update_layer(adapter_name=adapter_name,
+                                   r=r,
+                                   lora_alpha=lora_alpha,
+                                   lora_dropout=lora_drop_out,
+                                   init_lora_weights=init_lora_weights)
+    ref_blinear.cuda()
+    row_blora.cuda()
+    # prepare inputs
+    torch.random.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    scale = float(input_size**-0.5)
+    x = torch.empty(len(adapter_names), input_size, device="cuda")
+    x.uniform_(-scale, scale)
+    setattr(ref_blinear, "batch_lora_ids", adapter_names)
+    setattr(row_blora, "batch_lora_ids", adapter_names)
+    batch_token_length = []
+    for i in range(len(adapter_names)):
+        batch_token_length.append(1)
+    setattr(row_blora, "batch_token_lengths", batch_token_length)
+
+    # align weights
+    row_blora.weight.copy_(ref_blinear.weight)
+    assert torch.allclose(row_blora.weight, ref_blinear.weight,
+                           atol=1e-8, rtol=1e-8)
+    if row_blora.bias is not None:
+        row_blora.bias.copy_(ref_blinear.bias)
+        assert torch.allclose(row_blora.bias, ref_blinear.bias
+                              , atol=1e-8, rtol=1e-8)
+    for lora_id, adapter in row_blora.lora_A.items():
+        adapter.weight.copy_(ref_blinear.lora_A[lora_id].weight)
+        adapter_weight = adapter.weight
+        ref_weight = ref_blinear.lora_A[lora_id].weight
+        assert torch.allclose(adapter_weight, ref_weight, atol=1e-8, rtol=1e-8)
+
+    #test inputs
+    ref_output, _ = ref_blinear.forward(x)
+    row_output, _ = row_blora.forward(x)
+
+    assert torch.allclose(ref_output, row_output, atol=1e-8, rtol=1e-8)

--- a/tests/kernels/test_normhead.py
+++ b/tests/kernels/test_normhead.py
@@ -1,0 +1,62 @@
+import pytest
+import torch
+import torch.nn as nn
+import math
+from vllm.model_executor.models.baichuan import NormHead as vllm_NormHead
+
+
+class NormHead(nn.Module):
+    def __init__(self, hidden_size, vocab_size):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty((vocab_size, hidden_size)))
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        self.first_flag = True
+
+    def forward(self, hidden_states):
+        if self.training:
+            norm_weight = nn.functional.normalize(self.weight)
+            self.first_flag = True
+        elif self.first_flag:
+            self.first_flag = False
+            self.weight = nn.Parameter(nn.functional.normalize(self.weight))
+            norm_weight = self.weight
+        else:
+            norm_weight = self.weight
+        return nn.functional.linear(hidden_states, norm_weight)
+
+
+@pytest.mark.parametrize("hidden_size", [512, 1024])
+@pytest.mark.parametrize("vocab_size", [256, 1256])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16, torch.float])
+@torch.inference_mode()
+def test_column_blora(
+    hidden_size: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+):
+    hf_normhead = NormHead(hidden_size, vocab_size)
+    hf_normhead.eval().cuda()
+    vllm_normhead = vllm_NormHead(hidden_size, vocab_size, bias=False)
+
+    # align weights
+    hf_normhead.weight.data = hf_normhead.weight.to(dtype)
+    vllm_normhead.weight.data = vllm_normhead.weight.to(dtype)
+    vllm_normhead.weight.copy_(hf_normhead.weight)
+    assert torch.allclose(vllm_normhead.weight, hf_normhead.weight, atol=1e-8)
+
+    #prepare inputs
+    x = torch.randn(1, hidden_size, device="cuda", dtype=dtype)
+
+    hf_first_output = hf_normhead.forward(x)
+    vllm_first_output, _ = vllm_normhead.forward(x)
+    assert torch.allclose(hf_first_output, vllm_first_output, atol=1e-8)
+
+    hf_first_output_mul = torch.matmul(x, hf_normhead.weight.t())
+    vllm_first_output_mul = torch.matmul(x, vllm_normhead.weight.t())
+    assert torch.allclose(hf_first_output, hf_first_output_mul)
+    assert torch.allclose(hf_first_output_mul, vllm_first_output_mul)
+
+    hf_second_output = hf_normhead.forward(x)
+    vllm_second_output, _ = vllm_normhead.forward(x)
+    assert torch.allclose(hf_second_output, vllm_second_output, atol=1e-8)
+    assert torch.allclose(hf_first_output_mul, hf_second_output, atol=1e-8)

--- a/tests/kernels/test_normhead.py
+++ b/tests/kernels/test_normhead.py
@@ -6,6 +6,7 @@ from vllm.model_executor.models.baichuan import NormHead as vllm_NormHead
 
 
 class NormHead(nn.Module):
+
     def __init__(self, hidden_size, vocab_size):
         super().__init__()
         self.weight = nn.Parameter(torch.empty((vocab_size, hidden_size)))

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -174,7 +174,7 @@ class EngineArgs:
                             default=None,
                             help='Method used to quantize the weights')
         parser.add_argument('--lora-paths',
-                            metavar="path",
+                            metavar='path',
                             type=str,
                             default=None,
                             nargs='+',
@@ -183,7 +183,7 @@ class EngineArgs:
 
         parser.add_argument(
             '--adapter-names',
-            metavar="adapter_name",
+            metavar='adapter_name',
             type=str,
             default=None,
             nargs='+',

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -32,6 +32,8 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
+    lora_paths: Optional[list[str]] = None
+    adapter_names: Optional[list[str]] = None
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -171,6 +173,23 @@ class EngineArgs:
                             choices=['awq', 'squeezellm', None],
                             default=None,
                             help='Method used to quantize the weights')
+        parser.add_argument('--lora-paths',
+                            metavar="path",
+                            type=str,
+                            default=None,
+                            nargs='+',
+                            help='the paths of lora model you want to load:' +
+                            '[lora_path1 lora_path2 ...]')
+
+        parser.add_argument(
+            '--adapter-names',
+            metavar="adapter_name",
+            type=str,
+            default=None,
+            nargs='+',
+            help='the adapter names of lora model you want to load, each name'
+            + ' should be unique and needs to correspond to the path ' +
+            'one-to-one: [name1 name2 ...]')
         return parser
 
     @classmethod

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -483,6 +483,17 @@ class AsyncLLMEngine:
         # Initialize the cluster.
         distributed_init_method, placement_group = initialize_cluster(
             parallel_config, engine_args.engine_use_ray)
+
+        lora_paths: list = engine_args.lora_paths
+        adapter_names: list = engine_args.adapter_names
+        lora_configs = None
+        if lora_paths is not None and adapter_names is not None:
+            assert len(lora_paths) == len(adapter_names), (len(lora_paths),
+                                                           len(adapter_names))
+            lora_configs = []
+            for lora_path, adapter_name in zip(lora_paths, adapter_names):
+                lora_configs.append((lora_path, adapter_name))
+
         # Create the async LLM engine.
         engine = cls(parallel_config.worker_use_ray,
                      engine_args.engine_use_ray,
@@ -492,5 +503,6 @@ class AsyncLLMEngine:
                      log_requests=not engine_args.disable_log_requests,
                      log_stats=not engine_args.disable_log_stats,
                      max_log_len=engine_args.max_log_len,
-                     start_engine_loop=start_engine_loop)
+                     start_engine_loop=start_engine_loop,
+                     lora_configs=lora_configs)
         return engine

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -137,6 +137,7 @@ class LLMEngine:
             self.scheduler_config,
             0,
             distributed_init_method,
+            self.lora_configs,
         )
         self.workers.append(worker)
         self._run_workers(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -71,6 +71,8 @@ class LLM:
         seed: int = 0,
         gpu_memory_utilization: float = 0.9,
         swap_space: int = 4,
+        lora_paths: List[str] = None,
+        adapter_names: List[str] = None,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -88,6 +90,8 @@ class LLM:
             seed=seed,
             gpu_memory_utilization=gpu_memory_utilization,
             swap_space=swap_space,
+            lora_paths=lora_paths,
+            adapter_names=adapter_names,
             **kwargs,
         )
         self.llm_engine = LLMEngine.from_engine_args(engine_args)

--- a/vllm/model_executor/lora_utils.py
+++ b/vllm/model_executor/lora_utils.py
@@ -1,0 +1,116 @@
+from vllm.model_executor.parallel_utils.layers import BLoraColumnParallelLinear, BLoraRowParallelLinear, ColumnParallelLinear, RowParallelLinear
+from peft.tuners.lora import LoraLayer
+from peft import LoraConfig
+import re
+import torch
+
+
+WEIGHTS_NAME = "adapter_model.bin"
+PREFIX = "base_model.model."
+PARAMETER_PREFIX = "lora_"
+
+def _get_submodules(model, key):
+    parent = model.get_submodule(".".join(key.split(".")[:-1]))
+    target_name = key.split(".")[-1]
+    target = model.get_submodule(key)
+    return parent, target, target_name
+
+
+def _create_new_module(lora_config, adapter_name, target):
+    lora_alpha = lora_config.lora_alpha
+    r = lora_config.r
+    lora_dropout = lora_config.lora_dropout
+    if isinstance(target, ColumnParallelLinear):
+        new_module = BLoraColumnParallelLinear(input_size=target.input_size,
+                                               output_size=target.output_size_per_partition,
+                                               adapter_name=adapter_name,bias=target.bias,
+                                                gather_output=target.gather_output,
+                                                skip_bias_add=target.skip_bias_add,
+                                                quant_config=target.quant_config,
+                                                lora_alpha=lora_alpha,
+                                                r=r,lora_dropout=lora_dropout)
+        return new_module
+    if isinstance(target, RowParallelLinear):
+        new_module = BLoraRowParallelLinear(input_size=target.input_size_per_partition,
+                                            output_size=target.output_size,
+                                            adapter_name=adapter_name,
+                                            bias=target.bias,
+                                            input_is_parallel=target.input_is_parallel,
+                                            reduce_results=target.reduce_results,
+                                            skip_bias_add=target.skip_bias_add,
+                                            quant_config=target.quant_config,
+                                            lora_alpha=lora_alpha,
+                                            r=r,
+                                            lora_dropout=lora_dropout)
+        return new_module
+
+
+def _replace_module(parent, child_name, new_module, child):
+    setattr(parent, child_name, new_module)
+    new_module.weight = child.weight
+    if getattr(child, "state", None) is not None:
+        new_module.state = child.state
+        new_module.to(child.weight.device)
+    # dispatch to correct device
+        for name, module in new_module.named_modules():
+            if "lora_" in name:
+                module.to(child.weight.device)
+
+def _create_and_replace(lora_config, adapter_name, target, target_name, parent):
+    if (isinstance(target, (ColumnParallelLinear, RowParallelLinear))
+        and not isinstance(target, LoraLayer)):
+        new_module = _create_new_module(lora_config, adapter_name, target)
+        _replace_module(parent, target_name, new_module, target)
+    elif isinstance(target, LoraLayer):
+        target.update_layer(adapter_name,
+                            lora_config.r,
+                            lora_config.lora_alpha,
+                            lora_config.lora_dropout,
+                            lora_config.init_lora_weights)
+
+
+def add_lora_adapter(model: torch.nn.Module, lora_path: str, adapter_name: str):
+    lora_config = LoraConfig.from_pretrained(lora_path,
+                                             revision=None,
+                                             use_auth_token=None)
+    key_list = [key for key, _ in model.named_modules()]
+    for key in key_list:
+        # find target module
+        target_module_found = any(
+                    re.match(f".*\\.{target_key}$", key) for target_key in lora_config.target_modules
+                ) or any(target_key == key for target_key in lora_config.target_modules)
+        if not target_module_found:
+            continue
+        parent, target, target_name = _get_submodules(model, key)
+
+        # create and replace
+        _create_and_replace(lora_config,
+                            adapter_name,
+                            target,
+                            target_name,
+                            parent)
+
+    adapters_weights = torch.load(f"{lora_path}/{WEIGHTS_NAME}")
+
+    processed_adapter_state_dict = {}
+    for key, value in adapters_weights.items():
+        if key.startswith(PREFIX):
+            new_key = key[len(PREFIX) :]
+        else:
+            new_key = key
+        processed_adapter_state_dict[new_key] = value
+
+    state_dict = {}
+    for k, v in processed_adapter_state_dict.items():
+        if PARAMETER_PREFIX in k:
+            suffix = k.split(PARAMETER_PREFIX)[1]
+            if "." in suffix:
+                to_replace = ".".join(suffix.split(".")[1:])
+                k = k.replace(to_replace,
+                              f"{adapter_name}.{to_replace}")
+            else:
+                k = f"{k}.{adapter_name}"
+        state_dict[k] = v
+
+    model.load_lora_weights_parallel(state_dict)
+    model.cuda()

--- a/vllm/model_executor/lora_utils.py
+++ b/vllm/model_executor/lora_utils.py
@@ -4,10 +4,10 @@ from peft import LoraConfig
 import re
 import torch
 
-
 WEIGHTS_NAME = "adapter_model.bin"
 PREFIX = "base_model.model."
 PARAMETER_PREFIX = "lora_"
+
 
 def _get_submodules(model, key):
     parent = model.get_submodule(".".join(key.split(".")[:-1]))
@@ -21,27 +21,31 @@ def _create_new_module(lora_config, adapter_name, target):
     r = lora_config.r
     lora_dropout = lora_config.lora_dropout
     if isinstance(target, ColumnParallelLinear):
-        new_module = BLoraColumnParallelLinear(input_size=target.input_size,
-                                               output_size=target.output_size_per_partition,
-                                               adapter_name=adapter_name,bias=target.bias,
-                                                gather_output=target.gather_output,
-                                                skip_bias_add=target.skip_bias_add,
-                                                quant_config=target.quant_config,
-                                                lora_alpha=lora_alpha,
-                                                r=r,lora_dropout=lora_dropout)
+        new_module = BLoraColumnParallelLinear(
+            input_size=target.input_size,
+            output_size=target.output_size_per_partition,
+            adapter_name=adapter_name,
+            bias=target.bias,
+            gather_output=target.gather_output,
+            skip_bias_add=target.skip_bias_add,
+            quant_config=target.quant_config,
+            lora_alpha=lora_alpha,
+            r=r,
+            lora_dropout=lora_dropout)
         return new_module
     if isinstance(target, RowParallelLinear):
-        new_module = BLoraRowParallelLinear(input_size=target.input_size_per_partition,
-                                            output_size=target.output_size,
-                                            adapter_name=adapter_name,
-                                            bias=target.bias,
-                                            input_is_parallel=target.input_is_parallel,
-                                            reduce_results=target.reduce_results,
-                                            skip_bias_add=target.skip_bias_add,
-                                            quant_config=target.quant_config,
-                                            lora_alpha=lora_alpha,
-                                            r=r,
-                                            lora_dropout=lora_dropout)
+        new_module = BLoraRowParallelLinear(
+            input_size=target.input_size_per_partition,
+            output_size=target.output_size,
+            adapter_name=adapter_name,
+            bias=target.bias,
+            input_is_parallel=target.input_is_parallel,
+            reduce_results=target.reduce_results,
+            skip_bias_add=target.skip_bias_add,
+            quant_config=target.quant_config,
+            lora_alpha=lora_alpha,
+            r=r,
+            lora_dropout=lora_dropout)
         return new_module
 
 
@@ -51,25 +55,26 @@ def _replace_module(parent, child_name, new_module, child):
     if getattr(child, "state", None) is not None:
         new_module.state = child.state
         new_module.to(child.weight.device)
-    # dispatch to correct device
+        # dispatch to correct device
         for name, module in new_module.named_modules():
             if "lora_" in name:
                 module.to(child.weight.device)
 
-def _create_and_replace(lora_config, adapter_name, target, target_name, parent):
+
+def _create_and_replace(lora_config, adapter_name, target, target_name,
+                        parent):
     if (isinstance(target, (ColumnParallelLinear, RowParallelLinear))
-        and not isinstance(target, LoraLayer)):
+            and not isinstance(target, LoraLayer)):
         new_module = _create_new_module(lora_config, adapter_name, target)
         _replace_module(parent, target_name, new_module, target)
     elif isinstance(target, LoraLayer):
-        target.update_layer(adapter_name,
-                            lora_config.r,
-                            lora_config.lora_alpha,
-                            lora_config.lora_dropout,
+        target.update_layer(adapter_name, lora_config.r,
+                            lora_config.lora_alpha, lora_config.lora_dropout,
                             lora_config.init_lora_weights)
 
 
-def add_lora_adapter(model: torch.nn.Module, lora_path: str, adapter_name: str):
+def add_lora_adapter(model: torch.nn.Module, lora_path: str,
+                     adapter_name: str):
     lora_config = LoraConfig.from_pretrained(lora_path,
                                              revision=None,
                                              use_auth_token=None)
@@ -77,17 +82,15 @@ def add_lora_adapter(model: torch.nn.Module, lora_path: str, adapter_name: str):
     for key in key_list:
         # find target module
         target_module_found = any(
-                    re.match(f".*\\.{target_key}$", key) for target_key in lora_config.target_modules
-                ) or any(target_key == key for target_key in lora_config.target_modules)
+            re.match(f".*\\.{target_key}$", key)
+            for target_key in lora_config.target_modules) or any(
+                target_key == key for target_key in lora_config.target_modules)
         if not target_module_found:
             continue
         parent, target, target_name = _get_submodules(model, key)
 
         # create and replace
-        _create_and_replace(lora_config,
-                            adapter_name,
-                            target,
-                            target_name,
+        _create_and_replace(lora_config, adapter_name, target, target_name,
                             parent)
 
     adapters_weights = torch.load(f"{lora_path}/{WEIGHTS_NAME}")
@@ -95,7 +98,7 @@ def add_lora_adapter(model: torch.nn.Module, lora_path: str, adapter_name: str):
     processed_adapter_state_dict = {}
     for key, value in adapters_weights.items():
         if key.startswith(PREFIX):
-            new_key = key[len(PREFIX) :]
+            new_key = key[len(PREFIX):]
         else:
             new_key = key
         processed_adapter_state_dict[new_key] = value
@@ -106,8 +109,7 @@ def add_lora_adapter(model: torch.nn.Module, lora_path: str, adapter_name: str):
             suffix = k.split(PARAMETER_PREFIX)[1]
             if "." in suffix:
                 to_replace = ".".join(suffix.split(".")[1:])
-                k = k.replace(to_replace,
-                              f"{adapter_name}.{to_replace}")
+                k = k.replace(to_replace, f"{adapter_name}.{to_replace}")
             else:
                 k = f"{k}.{adapter_name}"
         state_dict[k] = v

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -1,6 +1,8 @@
 from vllm.model_executor.models.aquila import AquilaForCausalLM
 from vllm.model_executor.models.baichuan import (BaiChuanForCausalLM,
-                                                 BaichuanForCausalLM)
+                                                 BaichuanForCausalLM,
+                                                 Baichuan2ForCausalLM,
+                                                 BaiChuan2ForCausalLM)
 from vllm.model_executor.models.bloom import BloomForCausalLM
 from vllm.model_executor.models.falcon import FalconForCausalLM
 from vllm.model_executor.models.gpt2 import GPT2LMHeadModel
@@ -18,6 +20,8 @@ __all__ = [
     "AquilaForCausalLM",
     "BaiChuanForCausalLM",
     "BaichuanForCausalLM",
+    "Baichuan2ForCausalLM",
+    "BaiChuan2ForCausalLM",
     "BloomForCausalLM",
     "FalconForCausalLM",
     "GPT2LMHeadModel",

--- a/vllm/model_executor/parallel_utils/layers.py
+++ b/vllm/model_executor/parallel_utils/layers.py
@@ -346,7 +346,7 @@ class BLoraColumnParallelLinear(ColumnParallelLinear, LoraLayer):
         lora_dropout: float = 0.0,
         **kwargs,
     ):
-        init_lora_weights = kwargs.pop("init_lora_weights", True)
+        init_lora_weights = kwargs.pop('init_lora_weights', True)
 
         ColumnParallelLinear.__init__(self, input_size, output_size, bias,
                                       gather_output, skip_bias_add,
@@ -403,7 +403,7 @@ class BLoraRowParallelLinear(RowParallelLinear, LoraLayer):
         lora_dropout: float = 0.0,
         **kwargs,
     ):
-        init_lora_weights = kwargs.pop("init_lora_weights", True)
+        init_lora_weights = kwargs.pop('init_lora_weights', True)
 
         RowParallelLinear.__init__(self, input_size, output_size, bias,
                                    input_is_parallel, skip_bias_add,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -106,6 +106,7 @@ class SamplingParams:
         skip_special_tokens: bool = True,
         spaces_between_special_tokens: bool = True,
         logits_processors: Optional[List[LogitsProcessor]] = None,
+        lora_id: str = None,
     ) -> None:
         self.n = n
         self.best_of = best_of if best_of is not None else n
@@ -118,6 +119,7 @@ class SamplingParams:
         self.use_beam_search = use_beam_search
         self.length_penalty = length_penalty
         self.early_stopping = early_stopping
+        self.lora_id = lora_id
         if stop is None:
             self.stop = []
         elif isinstance(stop, str):

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -24,20 +24,19 @@ class Worker:
     distributed inference, each worker is assigned a partition of the model.
     """
 
-    def __init__(
-        self,
-        model_config: ModelConfig,
-        parallel_config: ParallelConfig,
-        scheduler_config: SchedulerConfig,
-        rank: Optional[int] = None,
-        distributed_init_method: Optional[str] = None,
-    ) -> None:
+    def __init__(self,
+                 model_config: ModelConfig,
+                 parallel_config: ParallelConfig,
+                 scheduler_config: SchedulerConfig,
+                 rank: Optional[int] = None,
+                 distributed_init_method: Optional[str] = None,
+                 lora_configs: List[Tuple[str, str]] = None) -> None:
         self.model_config = model_config
         self.parallel_config = parallel_config
         self.scheduler_config = scheduler_config
         self.rank = rank
         self.distributed_init_method = distributed_init_method
-
+        self.lora_configs = lora_configs
         # Uninitialized cache engine. Will be initialized by
         # self.init_cache_engine().
         self.cache_config = None
@@ -67,7 +66,7 @@ class Worker:
 
         # Initialize the model.
         set_random_seed(self.model_config.seed)
-        self.model = get_model(self.model_config)
+        self.model = get_model(self.model_config, self.lora_configs)
 
     @torch.inference_mode()
     def profile_num_available_blocks(


### PR DESCRIPTION
Feature #182
    (A more efficient version for #1533 )
    Because I need to use baichuan2-13B with more than one lora adapters at the same time, I tried to implement these features by myself. It can work well for my situation now. And this feature was mentioned in #182. Welcome to give me some comments, and I'll try my best to modify them.

### Add Features

- Support Baichuan2-13B
- Support multi-lora adapters in a single batch inference

    I use peft to implement multi-lora adapters. And in this situation, because we want to use more than one lora adapters, we can't merge the lora weights into the base model. So there will be some extra computation which will increase the latency. If there is only one lora adapter that you want to use, just do not use this feature. 

    I also tested the benchmark of my modification by using the baichuan2-13B, running on one A100 GPU . The results are like this：

### benchmark_latency.py
**origin vllm**: 
    ` python3 benchmark_latency.py --model $MODEL --trust-remote-code --input-len 512`
    result : 

> Avg latency: 4.033462169269721 seconds

    

**vllm with lora**:
    `python3 benchmark_latency.py --model $MODEL --trust-remote-code --input-len 512 --lora-paths $LORA_PATH --adapter-names adapter1`
    result: 

> Avg latency: 4.7929534030457335 seconds

### benchmark_throughput.py
**origin vllm**: 
   `python benchmark_throughput.py --backend vllm --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --model $MODEL --trust-remote-code`
  result: 

> Throughput: 2.56 requests/s, 1224.07 tokens/s

 **vllm with lora**:
  `python3 benchmark_throughput.py  --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --model $MODEL --trust-remote-code --lora-paths $LORA_PATH --adapter-names adapter1`
 result: 

> Throughput: 1.87 requests/s, 895.59 tokens/s

### benchmark_serving.py
**origin vllm**: 
`python3 benchmark_serving.py --backend vllm --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --request-rate 1 --tokenizer $MODEL --trust-remote-code --num_prompts=100`
result: 

> Total time: 93.24 s
> Throughput: 1.07 requests/s
> Average latency: 4.80 s
> Average latency per token: 0.02 s
> Average latency per output token: 0.10 s

 **vllm with lora**:
result:

> Total time: 93.66 s
> Throughput: 1.07 requests/s
> Average latency: 3.64 s
> Average latency per token: 0.02 s
> Average latency per output token: 0.09 s

The performance decreased a little bit because of the extra computation. I'm still wokring on an more efficient version.

Now I just implemented the method of loading lora weights for Baichuan model while the target modules of adapter are limited to W_pack and o_proj which we used in our situation.
    If this feature is accepted, I'm willing to support more models for lora adapter.

### Changes of files

- requirements.txt

Add peft for lora adapters

- tests/kernels/test_blora.py

Test scripts for multi-lora computation

- tests/kernels/test_normhead.py

Test scripts for NormHead layer which is used in baichuan2-13B

- vllm/engine/arg_utils.py

Add two args which are used to initialize lora adapters when load the model

- vllm/engine/async_llm_engine.py

Check the lora config args are valid.

- vllm/engine/llm_engine.py

Check the lora config args are valid. And pass the lora config to workers.

- vllm/entrypoints/llm.py

Add lora config parameters and pass them to llm_engine

- vllm/model_executor/lora_utils.py

Create lora adapters and replace the target module in the base model

- vllm/model_executor/model_loader.py

Support baichuan2 and add lora adapters when initialize model.

- vllm/model_executor/models/init.py

Support baichuan2

- vllm/model_executor/models/baichuan.py

Support baichuan2 and schedule the lora information after each iteration according to the metadata.
Impelement the method to load lora weights in parallel.

- vllm/model_executor/parallel_utils/layers.py

Implement the lora module with ColumnParallelLinear and Row ParallelLinear

- vllm/sampling_params.py

Add lora_id parameter to specify the lora adapter you want to use for this prompt.

- vllm/worker/worker.py

pass the lora config to initialize the model

- examples/baichuan_lora.py

example for use multi-lora adapters in baichuan model with offline inference.

- examples/baichuan_lora_api.py

example for use multi-lora adapters in baichuan model with online serving.

Thanks and looking forward to your comments!