### PR TITLE
feat(api_server): add options for users to control output

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -78,9 +78,9 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--echo",
                         type=bool,
-                        action='store_true',
+                        action="store_true",
                         default=True,
-                        help='Whether to add prompt into outputs')
+                        help="Whether to add prompt into outputs")
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -36,9 +36,14 @@ async def generate(request: Request) -> Response:
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output in results_generator:
             prompt = request_output.prompt
-            text_outputs = [
-                prompt + output.text for output in request_output.outputs
-            ]
+            if args.echo:
+                text_outputs = [
+                    prompt + output.text for output in request_output.outputs
+                ]
+            else:
+                text_outputs = [
+                    output.text for output in request_output.outputs
+                ]
             ret = {"text": text_outputs}
             yield (json.dumps(ret) + "\0").encode("utf-8")
 
@@ -71,6 +76,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--echo",
+                        type=bool,
+                        action='store_true',
+                        default=True,
+                        help='Whether to add prompt into outputs')
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -36,14 +36,10 @@ async def generate(request: Request) -> Response:
     async def stream_results() -> AsyncGenerator[bytes, None]:
         async for request_output in results_generator:
             prompt = request_output.prompt
-            if args.echo:
-                text_outputs = [
-                    prompt + output.text for output in request_output.outputs
-                ]
-            else:
-                text_outputs = [
-                    output.text for output in request_output.outputs
-                ]
+            text_outputs = [
+                (prompt + output.text if args.echo else output.text)
+                for output in request_output.outputs
+            ]
             ret = {"text": text_outputs}
             yield (json.dumps(ret) + "\0").encode("utf-8")
 


### PR DESCRIPTION
cc @WoosukKwon when you have bandwidth. This allows users to have more fine tuned control on how the API server yield back the text. Default behaviour are still the same, but it will address #1612 

Signed-off-by: Aaron <29749331+aarnphm@users.noreply.github.com>
