### PR TITLE
Fix #1474 - gptj AssertionError : assert param_slice.shape == loaded_weight.shape

### DIFF
--- a/vllm/model_executor/models/gpt_j.py
+++ b/vllm/model_executor/models/gpt_j.py
@@ -250,7 +250,7 @@ class GPTJForCausalLM(nn.Module):
                 if att_weight_name not in name:
                     continue
                 param = state_dict[name.replace(att_weight_name, "qkv_proj")]
-                shard_size = param.shape[1]
+                shard_size = param.shape[0] // 3
                 loaded_weight = loaded_weight[shard_size * tp_rank:shard_size *
                                               (tp_rank + 1)]
                 param_slice = param.data[shard_size * stride_id:shard_size *


### PR DESCRIPTION
Fix #1474
`python  ./entrypoints/api_server.py --model /home/server/models/gptj6b --tensor-parallel-size 2`

```
File "/usr/local/lib/python3.8/dist-packages/vllm/engine/ray_utils.py", line 29, in execute_method
    return executor(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/vllm/worker/worker.py", line 67, in init_model
    self.model = get_model(self.model_config)
  File "/usr/local/lib/python3.8/dist-packages/vllm/model_executor/model_loader.py", line 66, in get_model
    model.load_weights(model_config.model, model_config.download_dir,
  File "/usr/local/lib/python3.8/dist-packages/vllm/model_executor/models/gpt_j.py", line 245, in load_weights
    assert param_slice.shape == loaded_weight.shape
AssertionError
```