### PR TITLE
[Minor] Fix duplication of ignored seq group in engine step

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,27 @@
+"""Containing tests that check for regressions in vLLM's behavior.
+
+It should include tests that are reported by users and making sure they
+will never happen again.
+
+"""
+from vllm import LLM, SamplingParams
+
+
+def test_duplicated_ignored_sequence_group():
+    """https://github.com/vllm-project/vllm/issues/1655"""
+
+    sampling_params = SamplingParams(temperature=0.01,
+                                     top_p=0.1,
+                                     max_tokens=256)
+    llm = LLM(model="meta-llama/Llama-2-7b-hf",
+              max_num_batched_tokens=4096,
+              tensor_parallel_size=1)
+    prompts = ["This is a short prompt", "This is a very long prompt " * 1000]
+    outputs = llm.generate(prompts, sampling_params=sampling_params)
+
+    assert len(prompts) == len(outputs)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -13,7 +13,7 @@ def test_duplicated_ignored_sequence_group():
     sampling_params = SamplingParams(temperature=0.01,
                                      top_p=0.1,
                                      max_tokens=256)
-    llm = LLM(model="meta-llama/Llama-2-7b-hf",
+    llm = LLM(model="facebook/opt-125m",
               max_num_batched_tokens=4096,
               tensor_parallel_size=1)
     prompts = ["This is a short prompt", "This is a very long prompt " * 1000]

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -567,7 +567,7 @@ class LLMEngine:
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
         )
 
-        return self._process_model_outputs(output, scheduler_outputs) + ignored
+        return self._process_model_outputs(output, scheduler_outputs)
 
     def _log_system_stats(
         self,


### PR DESCRIPTION
Closes #1655

The ignored sequence group is already included in `_process_model_outputs` so there's no need to append it to the list.

https://github.com/vllm-project/vllm/blob/660a7fcfa40d62305ecba6bc6352c4026d56d680/vllm/engine/llm_engine.py#L537-L540 