### PR TITLE
Fix loading error when safetensors contains empty tensor

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -261,6 +261,8 @@ def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
         try:
             x = x[:]
         except IndexError:
+            # IndexError happens when the tensor is empty.
+            # e.g. transformer.h.0.attn.masked_bias is empty in some gpt2 models.
             return torch.Tensor()
     return x
 

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -262,7 +262,7 @@ def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
             x = x[:]
         except IndexError:
             # IndexError happens when the tensor is empty.
-            # e.g. transformer.h.0.attn.masked_bias is empty in some gpt2 models.
+            # transformer.h.0.attn.masked_bias is empty in some gpt2 models.
             return torch.Tensor()
     return x
 

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -258,7 +258,10 @@ def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
     tensor first.
     """
     if not isinstance(x, torch.Tensor):
-        x = x[:]
+        try:
+            x = x[:]
+        except IndexError:
+            return torch.Tensor()
     return x
 
 


### PR DESCRIPTION
Hi, I found subtle edge case in the latest main branch causing loading error when safetensors model contains empty tensor.
It's reproducible with https://huggingface.co/flax-community/gpt-2-spanish for example.
```
root@06b574a5ef0f:~# python3 -m vllm.entrypoints.api_server --model flax-community/gpt-2-spanish
INFO 11-16 17:51:29 llm_engine.py:72] Initializing an LLM engine with config: model='flax-community/gpt-2-spanish', tokenizer='flax-community/gpt-2-spanish', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=1024, download_dir=None, load_format=auto, tensor_parallel_size=1, quantization=None, seed=0)
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/api_server.py", line 80, in <module>
    engine = AsyncLLMEngine.from_engine_args(engine_args)
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 486, in from_engine_args
    engine = cls(parallel_config.worker_use_ray,
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 269, in __init__
    self.engine = self._init_engine(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 305, in _init_engine
    return engine_class(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 110, in __init__
    self._init_workers(distributed_init_method)
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 142, in _init_workers
    self._run_workers(
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 700, in _run_workers
    output = executor(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 70, in init_model
    self.model = get_model(self.model_config)
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader.py", line 96, in get_model
    model.load_weights(model_config.model, model_config.download_dir,
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/gpt2.py", line 253, in load_weights
    for name, loaded_weight in hf_model_weights_iterator(
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/weight_utils.py", line 240, in hf_model_weights_iterator
    yield name, convert_pyslice_to_tensor(param)
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/weight_utils.py", line 261, in convert_pyslice_to_tensor
    x = x[:]
IndexError: too many indices for tensor of dimension 0
```
This PR fixes it by catching IndexError because I'm not sure I can assume `x` is always PySafeSlice.