### PR TITLE
follow up of #1687 when safetensors model contains 0-rank tensors

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -236,8 +236,8 @@ def hf_model_weights_iterator(
         for st_file in hf_weights_files:
             with safe_open(st_file, framework="pt") as f:
                 for name in f.keys():
-                    param = f.get_slice(name)
-                    yield name, convert_pyslice_to_tensor(param)
+                    param = f.get_tensor(name)
+                    yield name, param
     else:
         for bin_file in hf_weights_files:
             state = torch.load(bin_file, map_location="cpu")
@@ -258,12 +258,7 @@ def convert_pyslice_to_tensor(x: Any) -> torch.Tensor:
     tensor first.
     """
     if not isinstance(x, torch.Tensor):
-        try:
-            x = x[:]
-        except IndexError:
-            # IndexError happens when the tensor is empty.
-            # transformer.h.0.attn.masked_bias is empty in some gpt2 models.
-            return torch.Tensor()
+        x = x[:]
     return x
 
 


### PR DESCRIPTION
I have misunderstood regarding fix of #1687.
After digging carefully, the tensor with shape [] is actually a scalar. 

> 0-rank Tensors (tensors with shape []) are allowed, they are merely a scalar.
https://github.com/huggingface/safetensors#format

However, it seems we can't retrieve a scalar from PySafeSlice currently.
- https://github.com/huggingface/safetensors/issues/380

As a result of recent refactoring, all params are converted pyslice to tensor in hf_model_weights_iterator.
Therefore, is it feasible to use get_tensor directly to retrieve torch.Tensor?