### PR TITLE
Avoid re-initialize parallel groups

### DIFF
--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -43,6 +43,9 @@ def initialize_model_parallel(
     ranks 8 to 15 belong to the second box.
     """
     # Get world size and rank. Ensure some consistencies.
+    if model_parallel_is_initialized():
+        return
+
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
 

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -42,10 +42,10 @@ def initialize_model_parallel(
     with a total of 16 GPUs, rank 0 to 7 belong to the first box and
     ranks 8 to 15 belong to the second box.
     """
-    # Get world size and rank. Ensure some consistencies.
     if model_parallel_is_initialized():
         return
 
+    # Get world size and rank. Ensure some consistencies.
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
 


### PR DESCRIPTION
With current code base, if one initializes two LLM instance in a single py script (even without actual model/tensor parallel), the model will raise error showing that model parallel is already initialized. 

Is it good to avoid re-initialize model parallel with this modification?