### PR TITLE
Documentation about official docker image

### DIFF
--- a/docs/source/serving/deploying_with_docker.rst
+++ b/docs/source/serving/deploying_with_docker.rst
@@ -3,11 +3,25 @@
 Deploying with Docker
 ============================
 
+vLLM offers official docker image for deployment.
+The image can be used to run OpenAI compatible server.
+The image is available on Docker Hub as `vllm/vllm-openai <https://hub.docker.com/r/vllm/vllm-openai>`_.
+
+... code-block:: console
+
+    $ docker run --runtime nvidia --gpus all \
+        -v ~/.cache/huggingface:/root/.cache/huggingface \
+        -p 8000:8000 \
+        --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
+        vllm/vllm-openai \
+        --model mistralai/Mistral-7B-v0.1
+
+
 You can build and run vLLM from source via the provided dockerfile. To build vLLM:
 
 .. code-block:: console
 
-    $ DOCKER_BUILDKIT=1 docker build . --target vllm --tag vllm --build-arg max_jobs=8
+    $ DOCKER_BUILDKIT=1 docker build . --target vllm-openai --tag vllm/vllm-openai --build-arg max_jobs=8
 
 To run vLLM:
 
@@ -17,5 +31,5 @@ To run vLLM:
         -v ~/.cache/huggingface:/root/.cache/huggingface \
         -p 8000:8000 \
         --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
-        vllm <args...>
+        vllm/vllm-openai <args...>
 

--- a/docs/source/serving/deploying_with_docker.rst
+++ b/docs/source/serving/deploying_with_docker.rst
@@ -5,7 +5,7 @@ Deploying with Docker
 
 vLLM offers official docker image for deployment.
 The image can be used to run OpenAI compatible server.
-The image is available on Docker Hub as `vllm/vllm-openai <https://hub.docker.com/r/vllm/vllm-openai>`_.
+The image is available on Docker Hub as `vllm/vllm-openai <https://hub.docker.com/r/vllm/vllm-openai/tags>`_.
 
 ... code-block:: console
 
@@ -13,7 +13,7 @@ The image is available on Docker Hub as `vllm/vllm-openai <https://hub.docker.co
         -v ~/.cache/huggingface:/root/.cache/huggingface \
         -p 8000:8000 \
         --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
-        vllm/vllm-openai \
+        vllm/vllm-openai:latest \
         --model mistralai/Mistral-7B-v0.1
 
 


### PR DESCRIPTION
After the #1551, we should publish official docker image tagged with `latest` and `v0.2.2`. 

The way to push to docker image should be

```bash
docker login --username vllm
```

```bash
DOCKER_BUILDKIT=1 docker build . --target vllm-openai --tag vllm/vllm-openai --build-arg max_jobs=8
docker tag vllm/vllm-openai vllm/vllm-openai:latest
docker tag vllm/vllm-openai vllm/vllm-openai:v0.2.2
docker push vllm/vllm-openai:latest
docker push vllm/vllm-openai:v0.2.2
```