### PR TITLE
[Fix] Fix warning msg on quantization

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -137,9 +137,9 @@ class ModelConfig:
                 raise ValueError(
                     f"Unknown quantization method: {self.quantization}. Must "
                     f"be one of {supported_quantization}.")
-        logger.warning(f"{self.quantization} quantization is not fully "
-                       "optimized yet. The speed can be slower than "
-                       "non-quantized models.")
+            logger.warning(f"{self.quantization} quantization is not fully "
+                           "optimized yet. The speed can be slower than "
+                           "non-quantized models.")
 
     def verify_with_parallel_config(
         self,


### PR DESCRIPTION
This PR fixes a bug that the warning message on quantized model performance is printed for non-quantized models.