### PR TITLE
Fix the code block's format in deploying_with_docker page

### DIFF
--- a/docs/source/serving/deploying_with_docker.rst
+++ b/docs/source/serving/deploying_with_docker.rst
@@ -7,7 +7,7 @@ vLLM offers official docker image for deployment.
 The image can be used to run OpenAI compatible server.
 The image is available on Docker Hub as `vllm/vllm-openai <https://hub.docker.com/r/vllm/vllm-openai/tags>`_.
 
-... code-block:: console
+.. code-block:: console
 
     $ docker run --runtime nvidia --gpus all \
         -v ~/.cache/huggingface:/root/.cache/huggingface \


### PR DESCRIPTION
After this patch, the deploying_with_docker page will be rendered as expected: https://vllm.readthedocs.io/en/latest/serving/deploying_with_docker.html