### PR TITLE
[BugFix] Fix a bug in loading safetensors

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -240,7 +240,7 @@ def hf_model_weights_iterator(
     elif use_safetensors:
         for st_file in hf_weights_files:
             with safe_open(st_file, framework="pt") as f:
-                for name in f.keys(): # noqa: SIM118
+                for name in f.keys():  # noqa: SIM118
                     param = f.get_tensor(name)
                     yield name, param
     else:

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -240,7 +240,7 @@ def hf_model_weights_iterator(
     elif use_safetensors:
         for st_file in hf_weights_files:
             with safe_open(st_file, framework="pt") as f:
-                for name in f:
+                for name in f.keys():
                     param = f.get_tensor(name)
                     yield name, param
     else:

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -240,7 +240,7 @@ def hf_model_weights_iterator(
     elif use_safetensors:
         for st_file in hf_weights_files:
             with safe_open(st_file, framework="pt") as f:
-                for name in f.keys():
+                for name in f.keys(): # noqa: SIM118
                     param = f.get_tensor(name)
                     yield name, param
     else:


### PR DESCRIPTION
This PR fixes a bug introduced in #1688 

The fix is necessary because otherwise we get the following error:
```
  File "/workspace/vllm/vllm/model_executor/weight_utils.py", line 243, in hf_model_weights_iterator
    for name in f:
TypeError: 'builtins.safe_open' object is not iterable
```