### PR TITLE
[DOCS] Add engine args documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -73,6 +73,7 @@ Documentation
 
    models/supported_models
    models/adding_model
+   models/engine_args
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -1,72 +1,114 @@
 .. _engine_args:
 
 Engine Arguments
-==================
+================
 
 Below, you can find an explanation of every engine argument for vLLM:
 
-* --model
+.. option:: --model <model_name_or_path>
+
     Name or path of the huggingface model to use.
-* --tokenizer
+
+.. option:: --tokenizer <tokenizer_name_or_path>
+
     Name or path of the huggingface tokenizer to use.
-* --revision
+
+.. option:: --revision <revision>
+
     The specific model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.
-* --tokenizer-revision
+
+.. option:: --tokenizer-revision <revision>
+
     The specific tokenizer version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.
-* --tokenizer-mode
-    {auto,slow} The tokenizer mode.
+
+.. option:: --tokenizer-mode {auto,slow}
+
+    The tokenizer mode.
     
-    * -- "auto" will use the fast tokenizer if available
-    * -- "slow" will always use the slow tokenizer.
-* --trust-remote-code
+    * "auto" will use the fast tokenizer if available.
+    * "slow" will always use the slow tokenizer.
+
+.. option:: --trust-remote-code
+
     Trust remote code from huggingface.
-* --download-dir
-    Directory to download and load the weights, default to the default cache dir of huggingface
-* --load-format
-    {auto,pt,safetensors,npcache,dummy} The format of the model weights to load. 
 
-    * -- "auto" will try to load the weights in the safetensors format and fall back to the pytorch bin format if safetensors format is not available. 
+.. option:: --download-dir <directory>
 
-    * -- "pt" will load the weights in the pytorch bin format. "safetensors" will load the weights in the safetensors format. 
+    Directory to download and load the weights, default to the default cache dir of huggingface.
 
-    * -- "npcache" will load the weights in pytorch format and store a numpy cache to speed up the loading. 
+.. option:: --load-format {auto,pt,safetensors,npcache,dummy}
 
-    * -- "dummy" will initialize the weights with random values, which is mainly for profiling.
-* --dtype
-    {auto,half,float16,bfloat16,float,float32} Data type for model weights and activations. 
+    The format of the model weights to load.
 
-    * -- The "auto" option will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models.
-    * -- Use "half" for FP16. It is recommended to use half for AWQ quantization.
-    * -- "float16" is the same as "half".
-    * -- "bfloat16" is similar to FP16, but is used for a better balance between precision and range.
-    * -- "float" is shorthand for FP32 precision.
-    * -- "float32" for FP32 precision.
+    * "auto" will try to load the weights in the safetensors format and fall back to the pytorch bin format if safetensors format is not available.
+    * "pt" will load the weights in the pytorch bin format.
+    * "safetensors" will load the weights in the safetensors format.
+    * "npcache" will load the weights in pytorch format and store a numpy cache to speed up the loading.
+    * "dummy" will initialize the weights with random values, mainly for profiling.
 
-* --max-model-len
+.. option:: --dtype {auto,half,float16,bfloat16,float,float32}
+
+    Data type for model weights and activations.
+
+    * "auto" will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models.
+    * "half" for FP16. Recommended for AWQ quantization.
+    * "float16" is the same as "half".
+    * "bfloat16" for a balance between precision and range.
+    * "float" is shorthand for FP32 precision.
+    * "float32" for FP32 precision.
+
+.. option:: --max-model-len <length>
+
     Model context length. If unspecified, will be automatically derived from the model config.
-* --worker-use-ray
+
+.. option:: --worker-use-ray
+
     Use Ray for distributed serving, will be automatically set when using more than 1 GPU.
-* --pipeline-parallel-size
-    (alias: -pp) Number of pipeline stages.
-* --tensor-parallel-size
-    (alias: -tp) Number of tensor parallel replicas.
-* --max-parallel-loading-workers
+
+.. option:: --pipeline-parallel-size (-pp) <size>
+
+    Number of pipeline stages.
+
+.. option:: --tensor-parallel-size (-tp) <size>
+
+    Number of tensor parallel replicas.
+
+.. option:: --max-parallel-loading-workers <workers>
+
     Load model sequentially in multiple batches, to avoid RAM OOM when using tensor parallel and large models.
-* --block-size 
-    {8,16,32} Token block size for contiguous chunks of tokens.
-* --seed
+
+.. option:: --block-size {8,16,32}
+
+    Token block size for contiguous chunks of tokens.
+
+.. option:: --seed <seed>
+
     Random seed for operations.
-* --swap-space
+
+.. option:: --swap-space <size>
+
     CPU swap space size (GiB) per GPU.
-* --gpu-memory-utilization
-    The percentage of GPU memory to be used forthe model executor.
-* --max-num-batched-tokens
+
+.. option:: --gpu-memory-utilization <percentage>
+
+    The percentage of GPU memory to be used for the model executor.
+
+.. option:: --max-num-batched-tokens <tokens>
+
     Maximum number of batched tokens per iteration.
-* --max-num-seqs
+
+.. option:: --max-num-seqs <sequences>
+
     Maximum number of sequences per iteration.
-* --max-paddings
+
+.. option:: --max-paddings <paddings>
+
     Maximum number of paddings in a batch.
-* --disable-log-stats
+
+.. option:: --disable-log-stats
+
     Disable logging statistics.
-* --quantization
-    (alias: -q) {awq,squeezellm,None} Method used to quantize the weights.
+
+.. option:: --quantization (-q) {awq,squeezellm,None}
+
+    Method used to quantize the weights.

--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -1,0 +1,68 @@
+.. _engine_args:
+
+Engine Arguments
+==================
+
+Below, you can find an explanation of every engine argument for vLLM:
+
+* --model
+    Name or path of the huggingface model to use.
+* --tokenizer
+    Name or path of the huggingface tokenizer to use.
+* --revision
+    The specific model version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.
+* --tokenizer-revision
+    The specific tokenizer version to use. It can be a branch name, a tag name, or a commit id. If unspecified, will use the default version.
+* --tokenizer-mode
+    {auto,slow} The tokenizer mode.
+    
+    * -- "auto" will use the fast tokenizer if available
+    * -- "slow" will always use the slow tokenizer.
+* --trust-remote-code
+    Trust remote code from huggingface.
+* --download-dir
+    Directory to download and load the weights, default to the default cache dir of huggingface
+* --load-format
+    {auto,pt,safetensors,npcache,dummy} The format of the model weights to load. 
+
+    * -- "auto" will try to load the weights in the safetensors format and fall back to the pytorch bin format if safetensors format is not available. 
+
+    * -- "pt" will load the weights in the pytorch bin format. "safetensors" will load the weights in the safetensors format. 
+
+    * -- "npcache" will load the weights in pytorch format and store a numpy cache to speed up the loading. 
+
+    * -- "dummy" will initialize the weights with random values, which is mainly for profiling.
+* --dtype
+    {auto,half,float16,bfloat16,float,float32} Data type for model weights and activations. 
+
+    * -- The "auto" option will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models.
+    * -- Use "half" for AWQ quantization.
+
+* --max-model-len
+    Model context length. If unspecified, will be automatically derived from the model config.
+* --worker-use-ray
+    Use Ray for distributed serving, will be automatically set when using more than 1 GPU.
+* --pipeline-parallel-size
+    (-pp) Number of pipeline stages.
+* --tensor-parallel-size
+    (-tp) Number of tensor parallel replicas.
+* --max-parallel-loading-workers
+    Load model sequentially in multiple batches, to avoid RAM OOM when using tensor parallel and large models.
+* --block-size 
+    {8,16,32} Token block size.
+* --seed
+    Random seed for operations.
+* --swap-space
+    CPU swap space size (GiB) per GPU.
+* --gpu-memory-utilization
+    The percentage of GPU memory to be used forthe model executor.
+* --max-num-batched-tokens
+    Maximum number of batched tokens per iteration.
+* --max-num-seqs
+    Maximum number of sequences per iteration.
+* --max-paddings
+    Maximum number of paddings in a batch.
+* --disable-log-stats
+    Disable logging statistics.
+* --quantization
+    (-q) {awq,squeezellm,None} Method used to quantize the weights.

--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -36,20 +36,24 @@ Below, you can find an explanation of every engine argument for vLLM:
     {auto,half,float16,bfloat16,float,float32} Data type for model weights and activations. 
 
     * -- The "auto" option will use FP16 precision for FP32 and FP16 models, and BF16 precision for BF16 models.
-    * -- Use "half" for AWQ quantization.
+    * -- Use "half" for FP16. It is recommended to use half for AWQ quantization.
+    * -- "float16" is the same as "half".
+    * -- "bfloat16" is similar to FP16, but is used for a better balance between precision and range.
+    * -- "float" is shorthand for FP32 precision.
+    * -- "float32" for FP32 precision.
 
 * --max-model-len
     Model context length. If unspecified, will be automatically derived from the model config.
 * --worker-use-ray
     Use Ray for distributed serving, will be automatically set when using more than 1 GPU.
 * --pipeline-parallel-size
-    (-pp) Number of pipeline stages.
+    (alias: -pp) Number of pipeline stages.
 * --tensor-parallel-size
-    (-tp) Number of tensor parallel replicas.
+    (alias: -tp) Number of tensor parallel replicas.
 * --max-parallel-loading-workers
     Load model sequentially in multiple batches, to avoid RAM OOM when using tensor parallel and large models.
 * --block-size 
-    {8,16,32} Token block size.
+    {8,16,32} Token block size for contiguous chunks of tokens.
 * --seed
     Random seed for operations.
 * --swap-space
@@ -65,4 +69,4 @@ Below, you can find an explanation of every engine argument for vLLM:
 * --disable-log-stats
     Disable logging statistics.
 * --quantization
-    (-q) {awq,squeezellm,None} Method used to quantize the weights.
+    (alias: -q) {awq,squeezellm,None} Method used to quantize the weights.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -42,6 +42,9 @@ class EngineArgs:
     def add_cli_args(
             parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Shared CLI arguments for vLLM engine."""
+        # NOTE: If you update any of the arguments below, please also 
+        # make sure to update docs/source/models/engine_args.rst
+        
         # Model arguments
         parser.add_argument(
             '--model',

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -43,7 +43,7 @@ class EngineArgs:
             parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Shared CLI arguments for vLLM engine."""
 
-        # NOTE: If you update any of the arguments below, please also 
+        # NOTE: If you update any of the arguments below, please also
         # make sure to update docs/source/models/engine_args.rst
 
         # Model arguments

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -42,9 +42,10 @@ class EngineArgs:
     def add_cli_args(
             parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         """Shared CLI arguments for vLLM engine."""
+
         # NOTE: If you update any of the arguments below, please also 
         # make sure to update docs/source/models/engine_args.rst
-        
+
         # Model arguments
         parser.add_argument(
             '--model',


### PR DESCRIPTION
Engine arguments are largely undocumented which means users have to go and read the source-code to discover which arguments that exist and what they mean. This PR attempts to create a documentation page for the engine arguments that are nicely formatted and easy to expand in the future.

NOTE: All arguments do not fit into the screenshot.

![Screenshot 2023-11-21 at 12 51 14](https://github.com/vllm-project/vllm/assets/27340033/f8ac0cd9-9497-4e8c-9b27-7474cece8ca9)
