### PR TITLE
Add stop_token_ids in SamplingParams.__repr__

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -241,6 +241,7 @@ class SamplingParams:
                 f"length_penalty={self.length_penalty}, "
                 f"early_stopping={self.early_stopping}, "
                 f"stop={self.stop}, "
+                f"stop_token_ids={self.stop_token_ids}, "
                 f"ignore_eos={self.ignore_eos}, "
                 f"max_tokens={self.max_tokens}, "
                 f"logprobs={self.logprobs}, "


### PR DESCRIPTION
The stop_token_ids is missing in the ``__repr__`` method.