### PR TITLE
long text (8k) support for Qwen

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -447,7 +447,9 @@ def _get_and_verify_max_len(
             derived_max_model_len = rope_scaling[
                 "original_max_position_embeddings"]
         derived_max_model_len *= scaling_factor
-
+    if getattr(hf_config, "model_type", "") == "qwen":
+        derived_max_model_len = getattr(hf_config, "max_position_embeddings",
+                                        8192)
     if max_model_len is None:
         max_model_len = derived_max_model_len
     elif max_model_len > derived_max_model_len:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -381,6 +381,7 @@ class AsyncLLMEngine:
                     "inspect the output to find the stacktrace of the "
                     "error that caused the background loop to stop "
                     "(AsyncEngineDeadError).")
+        sampling_params.prompt_token_length = len(prompt_token_ids)
 
         stream = self._request_tracker.add_request(
             request_id,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -280,6 +280,7 @@ class LLMEngine:
         block_size = self.cache_config.block_size
         seq_id = next(self.seq_counter)
         seq = Sequence(seq_id, prompt, prompt_token_ids, block_size)
+        sampling_params.prompt_token_length = len(prompt_token_ids)
 
         # Create the sequence group.
         seq_group = SequenceGroup(request_id, [seq], sampling_params,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -107,6 +107,7 @@ class Worker:
 
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seqs)
+        sampling_params.prompt_token_length = len(input_tokens)
 
         # Execute the model.
         num_layers = self.model_config.get_num_layers(self.parallel_config)
@@ -364,7 +365,6 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
-
         # Execute the model.
         output = self.model(
             input_ids=input_tokens,


### PR DESCRIPTION
This modification resolves #1683, resolves #1466, resolves #1323, resolves #1604,

Fix the bug "using vllm for reasoning with long prompts yields poor results".

The qwen-14b model will generate wrong or nonsense response in vllm-accelerated inference. Specifically, this phenomenon occurs when the input prompt is more than 3k context (token). However, Qwen-14b should support 8k long context reasoning according to qwen's official document.

This bug is fixed in this pull request.

Hope this can help! Thank you. Please merge this request! 