### PR TITLE
Move the definition of BlockTable a few lines above so we could use it in BlockAllocator

### DIFF
--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -7,6 +7,10 @@ from vllm.sequence import Sequence, SequenceGroup, SequenceStatus
 from vllm.utils import Device
 
 
+# Mapping: logical block number -> physical block.
+BlockTable = List[PhysicalTokenBlock]
+
+
 class BlockAllocator:
     """Manages free physical token blocks for a device.
 
@@ -26,7 +30,7 @@ class BlockAllocator:
         self.num_blocks = num_blocks
 
         # Initialize the free blocks.
-        self.free_blocks: List[PhysicalTokenBlock] = []
+        self.free_blocks: BlockTable = []
         for i in range(num_blocks):
             block = PhysicalTokenBlock(device=device,
                                        block_number=i,
@@ -49,10 +53,6 @@ class BlockAllocator:
 
     def get_num_free_blocks(self) -> int:
         return len(self.free_blocks)
-
-
-# Mapping: logical block number -> physical block.
-BlockTable = List[PhysicalTokenBlock]
 
 
 class AllocStatus(enum.Enum):


### PR DESCRIPTION
The class `BlockAllocator` has a field

```python
self.free_blocks: List[PhysicalTokenBlock] = ...
```

However, right after the definition of `BlockAllocator`, there is

```python
BlockTable = List[PhysicalTokenBlock]
```

This pull request moves the definition of `BlockTable` before `BlockAllocator` and type hint `free_blocks` as `BlockTable`.
