### PR TITLE
Fix OPT weight loading

### DIFF
--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -331,6 +331,9 @@ class OPTForCausalLM(nn.Module):
                 model_name_or_path, cache_dir, load_format, revision):
             if "lm_head.weight" in name:
                 continue
+            if name.startswith("decoder."):
+                name = "model." + name
+
             for (param_name, weight_name, shard_id) in stacked_params_mapping:
                 if weight_name not in name:
                     continue


### PR DESCRIPTION
Fixes #1810

This PR adds `model.` prefix to OPT parameter names during weight loading. This renaming is necessary for some OPT models like OPT-6.7B but was deleted in #1622.