### PR TITLE
[WIP] Qwen-style dynamic-NTK ROPE kernel for long sequence support

### DIFF
--- a/csrc/pos_encoding.cpp
+++ b/csrc/pos_encoding.cpp
@@ -2,6 +2,7 @@
 
 void rotary_embedding(
   torch::Tensor& positions,
+  torch::Tensor& input_true_seq_len,
   torch::Tensor& query,
   torch::Tensor& key,
   int head_size,

--- a/csrc/pos_encoding_kernels.cu
+++ b/csrc/pos_encoding_kernels.cu
@@ -8,26 +8,31 @@ namespace vllm {
 template<typename scalar_t, bool IS_NEOX>
 inline __device__ void apply_rotary_embedding(
   scalar_t* __restrict__ arr,
-  const scalar_t* __restrict__ cos_ptr,
-  const scalar_t* __restrict__ sin_ptr,
+  float pos,
+  float base,
   int rot_offset,
-  int embed_dim)
+  int embed_dim,
+  int rot_dim)
 {
-  int x_index, y_index;
-  scalar_t cos, sin;
+  const float inv_freq = pos / powf(base, rot_offset*2 / (float)rot_dim);
+  scalar_t cos = static_cast<scalar_t>(cosf(inv_freq));
+  scalar_t sin = static_cast<scalar_t>(sinf(inv_freq));
   if (IS_NEOX) {
     // GPT-NeoX style rotary embedding.
-    x_index = rot_offset;
-    y_index = embed_dim + rot_offset;
-    cos = __ldg(cos_ptr + x_index);
-    sin = __ldg(sin_ptr + x_index);
+    // x_index = rot_offset;
+    // y_index = embed_dim + rot_offset;
+    // cos = __ldg(cos_ptr + x_index);
+    // sin = __ldg(sin_ptr + x_index);
   } else {
     // GPT-J style rotary embedding.
-    x_index = 2 * rot_offset;
-    y_index = 2 * rot_offset + 1;
-    cos = __ldg(cos_ptr + x_index / 2);
-    sin = __ldg(sin_ptr + x_index / 2);
+    // x_index = 2 * rot_offset;
+    // y_index = 2 * rot_offset + 1;
+    // cos = __ldg(cos_ptr + x_index / 2);
+    // sin = __ldg(sin_ptr + x_index / 2);
   }
+
+  int x_index = rot_offset;
+  int y_index = embed_dim + rot_offset;
 
   const scalar_t x = arr[x_index];
   const scalar_t y = arr[y_index];
@@ -35,9 +40,23 @@ inline __device__ void apply_rotary_embedding(
   arr[y_index] = y * cos + x * sin;
 }
 
+inline __device__ float rotary_embedding_get_base(
+  float true_seq_len,
+  int seq_len,
+  float rot_dim,
+  float base) {
+  if (true_seq_len <= seq_len) {
+    return base;
+  }
+  float ntk_alpha = max(exp2f(ceilf(log2f(true_seq_len / seq_len) + 1.f)) - 1.f, 1.f);
+  base *= powf(ntk_alpha, rot_dim / (rot_dim - 2.f));
+  return base;
+}
+
 template<typename scalar_t, bool IS_NEOX>
 __global__ void rotary_embedding_kernel(
   const int64_t* __restrict__ positions,        // [batch_size, seq_len] or [num_tokens]
+  const int64_t* __restrict__ input_true_seq_len,
   scalar_t* __restrict__ query,                 // [batch_size, seq_len, num_heads, head_size] or [num_tokens, num_heads, head_size]
   scalar_t* __restrict__ key,                   // [batch_size, seq_len, num_kv_heads, head_size] or [num_tokens, num_kv_heads, head_size]
   const scalar_t* __restrict__ cos_sin_cache,   // [max_position, 2, rot_dim // 2]
@@ -46,11 +65,14 @@ __global__ void rotary_embedding_kernel(
   const int key_stride,
   const int num_heads,
   const int num_kv_heads,
-  const int head_size) {
+  const int head_size,
+  const int seq_len) {
   // Each thread block is responsible for one token.
   const int token_idx = blockIdx.x;
   int64_t pos = positions[token_idx];
   const scalar_t* cache_ptr = cos_sin_cache + pos * rot_dim;
+
+  float base = rotary_embedding_get_base(input_true_seq_len[token_idx/seq_len], 2048, rot_dim, 10000);
 
   const int embed_dim = rot_dim / 2;
   const scalar_t* cos_ptr = cache_ptr;
@@ -61,8 +83,8 @@ __global__ void rotary_embedding_kernel(
     const int head_idx = i / embed_dim;
     const int token_head = token_idx * query_stride + head_idx * head_size;
     const int rot_offset = i % embed_dim;
-    apply_rotary_embedding<scalar_t, IS_NEOX>(query + token_head, cos_ptr,
-                                              sin_ptr, rot_offset, embed_dim);
+    apply_rotary_embedding<scalar_t, IS_NEOX>(query + token_head, pos,
+                                              base, rot_offset, embed_dim, rot_dim);
   }
 
   const int nk = num_kv_heads * embed_dim;
@@ -70,8 +92,8 @@ __global__ void rotary_embedding_kernel(
     const int head_idx = i / embed_dim;
     const int token_head = token_idx * key_stride + head_idx * head_size;
     const int rot_offset = i % embed_dim;
-    apply_rotary_embedding<scalar_t, IS_NEOX>(key + token_head, cos_ptr,
-                                              sin_ptr, rot_offset, embed_dim);
+    apply_rotary_embedding<scalar_t, IS_NEOX>(key + token_head, pos,
+                                              base, rot_offset, embed_dim, rot_dim);
   }
 }
 
@@ -79,6 +101,7 @@ __global__ void rotary_embedding_kernel(
 
 void rotary_embedding(
   torch::Tensor& positions,         // [batch_size, seq_len] or [num_tokens]
+  torch::Tensor& input_true_seq_len,
   torch::Tensor& query,             // [batch_size, seq_len, num_heads * head_size] or [num_tokens, num_heads * head_size]
   torch::Tensor& key,               // [batch_size, seq_len, num_kv_heads * head_size] or [num_tokens, num_kv_heads * head_size]
   int head_size,
@@ -91,6 +114,11 @@ void rotary_embedding(
   int query_stride = query.stride(-2);
   int key_stride = key.stride(-2);
 
+  int seq_len = query.size(1);
+
+  assert(input_true_seq_len.size(0) == query.size(0));
+  assert(query.size(1) * query.size(0) == num_tokens);
+
   dim3 grid(num_tokens);
   dim3 block(std::min(num_heads * rot_dim / 2, 512));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
@@ -101,6 +129,7 @@ void rotary_embedding(
       if (is_neox) {
         vllm::rotary_embedding_kernel<scalar_t, true><<<grid, block, 0, stream>>>(
           positions.data_ptr<int64_t>(),
+          input_true_seq_len.data_ptr<int64_t>(),
           query.data_ptr<scalar_t>(),
           key.data_ptr<scalar_t>(),
           cos_sin_cache.data_ptr<scalar_t>(),
@@ -109,10 +138,12 @@ void rotary_embedding(
           key_stride,
           num_heads,
           num_kv_heads,
-          head_size);
+          head_size,
+          seq_len);
       } else {
         vllm::rotary_embedding_kernel<scalar_t, false><<<grid, block, 0, stream>>>(
           positions.data_ptr<int64_t>(),
+          input_true_seq_len.data_ptr<int64_t>(),
           query.data_ptr<scalar_t>(),
           key.data_ptr<scalar_t>(),
           cos_sin_cache.data_ptr<scalar_t>(),
@@ -121,7 +152,8 @@ void rotary_embedding(
           key_stride,
           num_heads,
           num_kv_heads,
-          head_size);
+          head_size,
+          seq_len);
       }
     });
 }

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -383,6 +383,8 @@ class AsyncLLMEngine:
                     "error that caused the background loop to stop "
                     "(AsyncEngineDeadError).")
 
+        sampling_params.prompt_token_length = len(prompt_token_ids)
+
         stream = self._request_tracker.add_request(
             request_id,
             prompt=prompt,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -264,6 +264,8 @@ class LLMEngine:
             assert prompt is not None
             prompt_token_ids = self.tokenizer.encode(prompt)
 
+        sampling_params.prompt_token_length = len(prompt_token_ids)
+
         # Create the sequences.
         block_size = self.cache_config.block_size
         seq_id = next(self.seq_counter)

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -167,3 +167,20 @@ class DynamicNTKScalingRotaryEmbedding(RotaryEmbedding):
         sin = freqs.sin()
         cache = torch.cat((cos, sin), dim=-1)
         return cache
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        input_true_seq_len: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # pos_encoding_ops.rotary_embedding() is an in-place operation that
+        # updates the query and key tensors.
+        #print('input_true_seq_len ', input_true_seq_len, input_true_seq_len.dtype, input_true_seq_len.shape)
+        #print('positions ', positions.dtype, positions.shape)
+        #print('query ', query.dtype, query.shape)
+        pos_encoding_ops.rotary_embedding(positions, input_true_seq_len, query, key,
+                                          self.head_size, self.cos_sin_cache,
+                                          self.is_neox_style)
+        return query, key


### PR DESCRIPTION
Implement Qwen-style dynamic-NTK ROPE kernel (official code [here](https://huggingface.co/Qwen/Qwen-14B-Chat/blob/main/modeling_qwen.py#L737)), which calculates the NTK-alpha depending on the prompt length, which varies between 1 and 8192, and the training sequence length, which is 2048.

I have tried some workarounds, like `"rope_scaling": { "type": "dynamic", "factor": 2.0 / 3.0 }`, but there is a noticeable quality degradation (even gibberish) in the generated text for prompts of different lengths (1 ~ 8k). For example, when `factor=2.0`, the model outputs gibberish for a prompt of length ~6k. Qwen is a quite powerful LLM with amazing performance especially in the scenario of tool usage (function call), and in this case the REACT prompts maybe lengthy. Also, there are many requests for this feature as shown in https://github.com/vllm-project/vllm/issues/1683, https://github.com/vllm-project/vllm/issues/1466, https://github.com/vllm-project/vllm/issues/1323, https://github.com/vllm-project/vllm/issues/1604.

I did the test by:

- `pip install -e .` in this branch (https://github.com/ZiyueHuang/vllm/tree/qwen-dynamic-ntk), with environment `V100-32GB CUDA 11.7`, `PyTorch==2.0.1`, `python-3.8`.

- `python -m vllm.entrypoints.openai.api_server --model /path/to/Qwen-14B-Chat  --host 0.0.0.0 --port PORT --trust-remote-code -tp 2 --served-model-name Qwen-14B --max-num-seqs 8 --max-log-len 32 --max-model-len 8192`

- Then I concurrently send three requests with different length prompts (tens of tokens, ~3k tokens, ~6k tokens), and the results look much better than the workarounds `"rope_scaling": { "type": "dynamic", "factor": 2.0 / 3.0 }`.

In this PR, an additional field `input_true_seq_len_tensor` is returned from `_prepare_inputs`, which incurs only a small overhead (only `batch-size` elements).

cc @LiuXiaoxuanPKU @simon-mo @zhuohan123 @WoosukKwon 

P.S.-1: I didn't post the log-N attention mechanism in this PR, because I found it may hurt performance in our use cases.

P.S.-2: Attaching prompt length onto the sampling_params is inspired from https://github.com/vllm-project/vllm/pull/1746.
