### PR TITLE
Fix rope cache key error

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -285,6 +285,9 @@ def get_rope(
 ) -> RotaryEmbedding:
     key = (head_size, rotary_dim, max_position, base, is_neox_style,
            rope_scaling)
+    if rope_scaling is not None:
+        key = (head_size, rotary_dim, max_position, base, is_neox_style,
+               tuple(rope_scaling.items()))
     if key in _ROPE_DICT:
         return _ROPE_DICT[key]
     if rope_scaling is None:

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -284,12 +284,10 @@ def get_rope(
     rope_scaling: Optional[Dict[str, Any]] = None,
 ) -> RotaryEmbedding:
     key = (head_size, rotary_dim, max_position, base, is_neox_style,
-           rope_scaling)
-    if rope_scaling is not None:
-        key = (head_size, rotary_dim, max_position, base, is_neox_style,
-               tuple(rope_scaling.items()))
+           tuple(rope_scaling.items()) if rope_scaling is not None else None)
     if key in _ROPE_DICT:
         return _ROPE_DICT[key]
+
     if rope_scaling is None:
         rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base,
                                      is_neox_style)


### PR DESCRIPTION
This error is introduced by #1828. When the model has `rope_scaling` config , the `key` cache used will throw error when initializing. Because Tuple's item shouldn't be mutable where rope_scaling is a mutable dict.
In my opinion, i think this rope cache seems not too much neccessary because it only takes effect at the init model phase.