### PR TITLE
Fix the typo in SamplingParams' docstring.

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -69,7 +69,7 @@ class SamplingParams:
             The returned output will not contain the stop strings.
         stop_token_ids: List of tokens that stop the generation when they are
             generated. The returned output will contain the stop tokens unless
-            the stop tokens are sepcial tokens.
+            the stop tokens are special tokens.
         ignore_eos: Whether to ignore the EOS token and continue generating
             tokens after the EOS token is generated.
         max_tokens: Maximum number of tokens to generate per output sequence.


### PR DESCRIPTION
To fix the typo of "special" in line 72:
https://github.com/vllm-project/vllm/blob/e5452ddfd6e9a08d5e15bd81a010934550b9b507/vllm/sampling_params.py#L72
Mentioned in this issue [#1872].