### PR TITLE
Drop to float16 if bfloat16 is not supported

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -17,8 +17,10 @@ from vllm.worker.model_runner import ModelRunner
 from vllm.utils import get_gpu_memory
 
 # Configure basic logging
-logging.basicConfig(level=logging.WARNING, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.WARNING,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
 log = logging.getLogger(__name__)
+
 
 class Worker:
     """A worker class that executes (a partition of) the model on a GPU.
@@ -203,7 +205,7 @@ def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype) -> torch.dtype:
             log.warning(
                 "Bfloat16 is only supported on GPUs with compute capability "
                 "of at least 8.0. Your %s GPU has compute capability %d.%d. "
-                "Dropping to float16", gpu_name, compute_capability[0], compute_capability[1]
-            )
+                "Dropping to float16", gpu_name, compute_capability[0],
+                compute_capability[1])
             torch_dtype = torch.float16
     return torch_dtype

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -190,8 +190,4 @@ def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):
         compute_capability = torch.cuda.get_device_capability()
         if compute_capability[0] < 8:
             gpu_name = torch.cuda.get_device_name()
-            log.warning(
-                "Bfloat16 is only supported on GPUs with compute capability "
-                f"of at least 8.0. Your {gpu_name} GPU has compute capability "
-                f"{compute_capability[0]}.{compute_capability[1]}. Dropping to float16")
-            torch_dtype = torch.float16
+            

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -190,4 +190,8 @@ def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):
         compute_capability = torch.cuda.get_device_capability()
         if compute_capability[0] < 8:
             gpu_name = torch.cuda.get_device_name()
-            
+            log.warning(
+                "Bfloat16 is only supported on GPUs with compute capability "
+                f"of at least 8.0. Your {gpu_name} GPU has compute capability "
+                f"{compute_capability[0]}.{compute_capability[1]}. Dropping to float16")
+            torch_dtype = torch.float16

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -184,14 +184,26 @@ def _init_distributed_environment(
                               parallel_config.pipeline_parallel_size)
 
 
-def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):
-    # Check if the GPU supports the dtype.
+def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype) -> torch.dtype:
+    """Check if the GPU supports the specified data type.
+    
+    Args:
+        torch_dtype: The data type to check support for on the GPU.
+        
+    Returns:
+        The data type supported by the GPU. Falls back to float16 if bfloat16
+        is not supported.
+    """
     if torch_dtype == torch.bfloat16:
         compute_capability = torch.cuda.get_device_capability()
         if compute_capability[0] < 8:
             gpu_name = torch.cuda.get_device_name()
+            # Using old-style % formatting for logging is recommended for
+            # performance reasons. The variables are passed as arguments.
             log.warning(
                 "Bfloat16 is only supported on GPUs with compute capability "
-                f"of at least 8.0. Your {gpu_name} GPU has compute capability "
-                f"{compute_capability[0]}.{compute_capability[1]}. Dropping to float16")
+                "of at least 8.0. Your %s GPU has compute capability %d.%d. "
+                "Dropping to float16", gpu_name, compute_capability[0], compute_capability[1]
+            )
             torch_dtype = torch.float16
+    return torch_dtype


### PR DESCRIPTION
# Issue:- #1157 
Instead of throwing an error if the GPU compute capability is not supported for bfloat16, vLLM should throw a warning but use float16 instead. This helps in Colab notebooks where the compute of the T4 instance is set to 7.5 and not 8 so vLLM does not work trivially.