### PR TITLE
support ChatGLMForConditionalGeneration

### DIFF
--- a/vllm/model_executor/model_loader.py
+++ b/vllm/model_executor/model_loader.py
@@ -19,6 +19,7 @@ _MODEL_REGISTRY = {
     "BaichuanForCausalLM": BaichuanForCausalLM,  # baichuan-13b
     "BloomForCausalLM": BloomForCausalLM,
     "ChatGLMModel": ChatGLMForCausalLM,
+    "ChatGLMForConditionalGeneration": ChatGLMForCausalLM,
     "FalconForCausalLM": FalconForCausalLM,
     "GPT2LMHeadModel": GPT2LMHeadModel,
     "GPTBigCodeForCausalLM": GPTBigCodeForCausalLM,


### PR DESCRIPTION
Since the architectures in the config.json saved after chatglm2 training are ChatGLMForConditionalGeneration, model_loader.py needs to be compatible with ChatGLMForConditionalGeneration.