### PR TITLE
Fix quickstart.rst example

### DIFF
--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -129,7 +129,7 @@ By default, the server uses a predefined chat template stored in the tokenizer. 
 
    $ python -m vllm.entrypoints.openai.api_server \
    $     --model facebook/opt-125m \
-   $     --chat-template ./examples/template_chatml.json
+   $     --chat-template ./examples/template_chatml.jinja
 
 This server can be queried in the same format as OpenAI API. For example, list the models:
 


### PR DESCRIPTION
This confused me a bit, but I figured it's just a typo (was `.json` instead of `.jinja`)