### PR TITLE
fix typo in getenv call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ for capability in compute_capabilities:
 
 # Use NVCC threads to parallelize the build.
 if nvcc_cuda_version >= Version("11.2"):
-    nvcc_threads = int(os.getenv("NVCC_THREADS"), 8)
+    nvcc_threads = int(os.getenv("NVCC_THREADS", 8))
     num_threads = min(os.cpu_count(), nvcc_threads)
     NVCC_FLAGS += ["--threads", str(num_threads)]
 


### PR DESCRIPTION
Otherwise the build fails with:

```
      Traceback (most recent call last):
        File "/mnt/workdisk/daya/vllm/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
          main()
        File "/mnt/workdisk/daya/vllm/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/mnt/workdisk/daya/vllm/venv/lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/mnt/workdisk/daya/vllm/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 174, in prepare_metadata_for_build_wheel
          self.run_setup()
        File "/mnt/workdisk/daya/vllm/venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 158, in run_setup
          exec(compile(code, __file__, 'exec'), locals())
        File "setup.py", line 141, in <module>
          nvcc_threads = int(os.getenv("NVCC_THREADS"), 8)
      ValueError: invalid literal for int() with base 8: '8'
```