### PR TITLE
Fix for KeyError on Loading LLaMA

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -322,6 +322,10 @@ class LlamaForCausalLM(nn.Module):
                 model_name_or_path, cache_dir, load_format, revision):
             if "rotary_emb.inv_freq" in name:
                 continue
+            if "rotary_emb.cos_cached" in name:
+                continue
+            if "rotary_emb.sin_cached" in name:
+                continue
             for (param_name, weight_name, shard_id) in stacked_params_mapping:
                 if weight_name not in name:
                     continue


### PR DESCRIPTION
This PR addresses the issue where loading LLaMA model parameters into vLLM results in a KeyError due to the presence of `rotary_emb.cos_cached` and `rotary_emb.sin_cached`. These cached values from LLaMA are not required or directly managed by vLLM, leading to compatibility issues. 

Related issue #1977 

Changes Made:
- Added conditional checks to ignore `rotary_emb.cos_cached` and `rotary_emb.sin_cached` during the loading process.
- Ensured that other necessary parameters are loaded correctly, without interfering with the rotary embeddings.
