### PR TITLE
[WIP] Prefix  prompt cache 

### DIFF
--- a/vllm/model_executor/__init__.py
+++ b/vllm/model_executor/__init__.py
@@ -1,4 +1,4 @@
-from vllm.model_executor.input_metadata import InputMetadata
+from vllm.model_executor.input_metadata import InputMetadata, PrefixStatus
 from vllm.model_executor.model_loader import get_model
 from vllm.model_executor.utils import set_random_seed
 
@@ -6,4 +6,5 @@ __all__ = [
     "InputMetadata",
     "get_model",
     "set_random_seed",
+    "PrefixStatus",
 ]

--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -5,6 +5,13 @@ from xformers.ops import AttentionBias
 
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import SequenceData
+import enum
+
+
+class PrefixStatus(enum.Enum):
+    BLOCK_INIT = enum.auto()
+    PREFIX_INIT = enum.auto()
+    USE_PREFIX = enum.auto()
 
 
 class InputMetadata:
@@ -30,7 +37,10 @@ class InputMetadata:
         max_context_len: int,
         block_tables: torch.Tensor,
         sliding_window: Optional[int] = None,
+        use_prefix_cache: PrefixStatus = PrefixStatus.USE_PREFIX,
+        prefix_len: int = 0,
     ) -> None:
+        self.prefix_len = prefix_len
         self.seq_groups = seq_groups
         self.seq_data = seq_data
         self.prompt_lens = prompt_lens
@@ -70,6 +80,7 @@ class InputMetadata:
 
         # Set during the execution of the first attention op.
         self.attn_bias: List[AttentionBias] = []
+        self.use_prefix_cache = use_prefix_cache
 
     def __repr__(self) -> str:
         # Print only useful metadata.


### PR DESCRIPTION
I have implemented a rudimentary version of the prefix cache function, which shows significant performance improvement in specific scenarios. Do you require this feature? I can propose a detailed modification plan for us to discuss together.
Also, there are requests for this feature as shown in https://github.com/vllm-project/vllm/issues/227
#### This is for a performance test:

- Compared to the base limit, the prefix cache increases throughput by 29%. At a high QPS (15 QPS), the time consumption for the first token decreases, and the average latency per request decreases by more than 60%.
- The performance of the prefix cache is related to both the prefix length and the input length.

**For each request, the prefix length is 200, the input length is 30, and the output length is 50.**
**model : llama 13B ,  A100 80G**
<!DOCTYPE html>
Load (QPS) | Method | Requests/s | Average Latency per Req | First Token Time
-- | -- | -- | -- | --
10 QPS | Prefix Cache | 9.83 requests/s | 1.97 s | 0.29 s
10 QPS | Base | 9.80 requests/s | 2.87 s | 0.45 s
15 QPS | Prefix Cache | 14.30 requests/s | 2.98 s | 0.39 s
15 QPS | Base | 13.24 requests/s | 8.65 s | 1.02 s
25 QPS | Prefix Cache | 19.81 requests/s | 6.46 s | 0.84 s
25 QPS | Base | 14.08 requests/s | 13.67 s | 4.74 s

