### PR TITLE
Fix completion API echo and logprob combo

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -568,17 +568,22 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 i = output.index
                 delta_text = output.text[len(previous_texts[i]):]
                 token_ids = output.token_ids[previous_num_tokens[i]:]
-                top_logprobs = output.logprobs[previous_num_tokens[i]:]
+                if request.logprobs is not None:
+                    top_logprobs = output.logprobs[previous_num_tokens[i]:]
+                else:
+                    top_logprobs = None
                 offsets = len(previous_texts[i])
                 if request.echo and not has_echoed[i]:
                     if not echo_without_generation:
                         delta_text = res.prompt + delta_text
                         token_ids = res.prompt_token_ids + token_ids
-                        top_logprobs = res.prompt_logprobs + top_logprobs
-                    else:
+                        if top_logprobs:
+                            top_logprobs = res.prompt_logprobs + top_logprobs
+                    else: # only just return the prompt
                         delta_text = res.prompt
                         token_ids = res.prompt_token_ids
-                        top_logprobs = res.prompt_logprobs
+                        if top_logprobs:
+                            top_logprobs = res.prompt_logprobs
                     has_echoed[i] = True
                 if request.logprobs is not None:
                     logprobs = create_logprobs(

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -579,7 +579,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                         token_ids = res.prompt_token_ids + token_ids
                         if top_logprobs:
                             top_logprobs = res.prompt_logprobs + top_logprobs
-                    else: # only just return the prompt
+                    else:  # only just return the prompt
                         delta_text = res.prompt
                         token_ids = res.prompt_token_ids
                         if top_logprobs:


### PR DESCRIPTION
Closes #1967 

The bug comes down that somewhere in `echo` code path, `logprobs`'s conditional existence was not fully considered. 

I have tested the following four requests and all working:

```
curl http://localhost:8000/v1/completions  -H "Content-Type: application/json"      -d '{ "model": "facebook/opt-125m", "prompt":"Who won the world series in 2020?", "max_tokens": 20, "ignore_eos": true, "stream": true, "echo": false, "logprobs": false}' 
curl http://localhost:8000/v1/completions  -H "Content-Type: application/json"      -d '{ "model": "facebook/opt-125m", "prompt":"Who won the world series in 2020?", "max_tokens": 20, "ignore_eos": true, "stream": true, "echo": false, "logprobs": true}' 
curl http://localhost:8000/v1/completions  -H "Content-Type: application/json"      -d '{ "model": "facebook/opt-125m", "prompt":"Who won the world series in 2020?", "max_tokens": 20, "ignore_eos": true, "stream": true, "echo": true, "logprobs": true}' 
curl http://localhost:8000/v1/completions  -H "Content-Type: application/json"      -d '{ "model": "facebook/opt-125m", "prompt":"Who won the world series in 2020?", "max_tokens": 20, "ignore_eos": true, "stream": true, "echo": true, "logprobs": false}' 
````