### PR TITLE
[Minor] Fix type annotation in Mixtral

### DIFF
--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -251,7 +251,7 @@ class BlockSparseMoE(nn.Module):
         return column_indices_t, offsets_t, block_offsets_t
 
     def topology(self, x: torch.Tensor,
-                 padded_bins: torch.Tensor) -> stk.Matrix:
+                 padded_bins: torch.Tensor) -> "stk.Matrix":
         padded_tokens, _ = x.size()
         assert padded_tokens % self.blocking == 0
         assert self.ffn_dim_per_partition % self.blocking == 0


### PR DESCRIPTION
The following error is raised for users who didn't install `megablocks`.
```
  File "/home/gcpuser/vllm/vllm/model_executor/models/mixtral.py", line 254, in BlockSparseMoE
    padded_bins: torch.Tensor) -> stk.Matrix:
NameError: name 'stk' is not defined
```
This PR removes this misleading error so that users can see the warning messages on the import statement.

@infwinston