### PR TITLE
Remove python 3.10 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install vLLM with pip or [from source](https://vllm.readthedocs.io/en/latest/get
 ```bash
 pip install vllm
 ```
-**NOTE:** The Mixtral model additionally requires `megablocks` which can be installed with pip or [from source](https://github.com/stanford-futuredata/megablocks) on **Python 3.10**:
+**NOTE:** The Mixtral model additionally requires `megablocks` which can be installed with pip or [from source](https://github.com/stanford-futuredata/megablocks):
 ```bash
 pip install megablocks
 ```

--- a/vllm/model_executor/models/mixtral.py
+++ b/vllm/model_executor/models/mixtral.py
@@ -35,9 +35,7 @@ try:
     import megablocks.ops as ops
 except ImportError:
     print(
-        "MegaBlocks not found. Please install it by `pip install megablocks`. "
-        "Note that MegaBlocks depends on mosaicml-turbo, which only supports "
-        "Python 3.10 for now.")
+        "MegaBlocks not found. Please install it by `pip install megablocks`.")
 try:
     import stk
 except ImportError:


### PR DESCRIPTION
A couple of hours ago, MegaBlocks cleaned up its dependencies. Now it does not require Python 3.10.