### PR TITLE
Option to change the temporary storage location for Ray logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Easy, fast, and cheap LLM serving for everyone
 </p>
 
 ---
-## DiscoLM implementation for Mixtral MoE is available on the DiscoLM branch 
 
 *Latest News* 🔥
 - [2023/12] Added ROCm support to vLLM.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Easy, fast, and cheap LLM serving for everyone
 </p>
 
 ---
+## DiscoLM implementation for Mixtral MoE is available on the DiscoLM branch 
 
 *Latest News* 🔥
 - [2023/12] Added ROCm support to vLLM.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -323,11 +323,13 @@ class ParallelConfig:
         tensor_parallel_size: int,
         worker_use_ray: bool,
         max_parallel_loading_workers: Optional[int] = None,
+        ray_temp_dir: Optional[str] = "/tmp/ray",
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size
         self.worker_use_ray = worker_use_ray
         self.max_parallel_loading_workers = max_parallel_loading_workers
+        self.ray_temp_dir = ray_temp_dir
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
         if self.world_size > 1:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -7,6 +7,7 @@ from transformers import PretrainedConfig
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_config
 from vllm.utils import get_cpu_memory, is_hip
+from ray._private.utils import get_ray_temp_dir
 
 logger = init_logger(__name__)
 
@@ -323,7 +324,7 @@ class ParallelConfig:
         tensor_parallel_size: int,
         worker_use_ray: bool,
         max_parallel_loading_workers: Optional[int] = None,
-        ray_temp_dir: Optional[str] = "/tmp",
+        ray_temp_dir: Optional[str] = get_ray_temp_dir(),
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -323,7 +323,7 @@ class ParallelConfig:
         tensor_parallel_size: int,
         worker_use_ray: bool,
         max_parallel_loading_workers: Optional[int] = None,
-        ray_temp_dir: Optional[str] = "/tmp/ray",
+        ray_temp_dir: Optional[str] = "/tmp",
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -5,6 +5,7 @@ from typing import Optional, Tuple
 
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig)
+from ray._private.utils import get_ray_temp_dir
 
 
 @dataclass
@@ -33,7 +34,7 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
-    ray_temp_dir: Optional[str] = "/tmp"
+    ray_temp_dir: Optional[str] = get_ray_temp_dir()
 
     def __post_init__(self):
         if self.tokenizer is None:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -33,7 +33,7 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
-    ray_temp_dir: Optional[str] = "/tmp/ray"
+    ray_temp_dir: Optional[str] = "/tmp"
 
     def __post_init__(self):
         if self.tokenizer is None:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -33,6 +33,7 @@ class EngineArgs:
     revision: Optional[str] = None
     tokenizer_revision: Optional[str] = None
     quantization: Optional[str] = None
+    ray_temp_dir: Optional[str] = "/tmp/ray"
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -175,6 +176,11 @@ class EngineArgs:
         parser.add_argument('--disable-log-stats',
                             action='store_true',
                             help='disable logging statistics')
+        # Change ray temp storage dir
+        parser.add_argument('--ray-temp-dir',
+                            type=str,
+                            default=EngineArgs.ray_temp_dir,
+                            help='temp storage dir for ray session')
         # Quantization settings.
         parser.add_argument('--quantization',
                             '-q',
@@ -208,7 +214,8 @@ class EngineArgs:
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,
-                                         self.max_parallel_loading_workers)
+                                         self.max_parallel_loading_workers,
+                                         self.ray_temp_dir)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,

--- a/vllm/engine/ray_utils.py
+++ b/vllm/engine/ray_utils.py
@@ -77,9 +77,10 @@ def initialize_cluster(
         if is_hip():
             ray.init(address=ray_address,
                      ignore_reinit_error=True,
-                     num_gpus=parallel_config.world_size)
+                     num_gpus=parallel_config.world_size,
+                     _temp_dir=parallel_config.ray_temp_dir)
         else:
-            ray.init(address=ray_address, ignore_reinit_error=True)
+            ray.init(address=ray_address, ignore_reinit_error=True, _temp_dir=parallel_config.ray_temp_dir)
 
     if not parallel_config.worker_use_ray:
         # Initialize cluster locally.


### PR DESCRIPTION
Issue : Sometimes when running vllm on sagemaker the ray logs fill up the /tmp folder quite fast. 

This change allows user to select a different folder to store ray logs and temp files. It can be used with a cli argument like `--ray-temp-dir <location>` 

