### PR TITLE
Call destory_model_parallel from tests/samplers/*.py

### DIFF
--- a/tests/samplers/test_beam_search.py
+++ b/tests/samplers/test_beam_search.py
@@ -3,6 +3,7 @@
 Run `pytest tests/samplers/test_beam_search.py --forked`.
 """
 import pytest
+from vllm.model_executor.parallel_utils.parallel_state import destroy_model_parallel
 
 # FIXME(zhuohan): The test can not pass if we:
 #   1. Increase max_tokens to 256.
@@ -35,6 +36,7 @@ def test_beam_search_single_input(
     vllm_outputs = vllm_model.generate_beam_search(example_prompts, beam_width,
                                                    max_tokens)
     del vllm_model
+    destroy_model_parallel()
 
     for i in range(len(example_prompts)):
         hf_output_ids, _ = hf_outputs[i]

--- a/tests/samplers/test_logprobs.py
+++ b/tests/samplers/test_logprobs.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from vllm import SamplingParams
+from vllm.model_executor.parallel_utils.parallel_state import destroy_model_parallel
 
 MODELS = ["facebook/opt-125m"]
 
@@ -30,6 +31,8 @@ def test_get_prompt_logprobs(
                                           temperature=0.0)
     vllm_results = vllm_model.model.generate(
         example_prompts, sampling_params=vllm_sampling_params)
+    del vllm_model
+    destroy_model_parallel()
 
     # Test whether logprobs are included in the results.
     for result in vllm_results:


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/2005

Test Plan:

On an H100 computer, `pytest tests/samplers/` will no longer make `AssertionError: tensor model parallel group is already initialized`.