### PR TITLE
Fix all-reduce memory usage

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -54,7 +54,7 @@ class Worker:
         # this behavior.
         # Related issue:
         # https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573
-        os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = 1
+        os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
 
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -89,7 +89,6 @@ class Worker:
         # Profile the memory usage of the model and get the maximum number of
         # cache blocks that can be allocated with the remaining free memory.
         torch.cuda.empty_cache()
-        torch.cuda.memory._record_memory_history()
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -98,7 +97,6 @@ class Worker:
         # Calculate the number of blocks that can be allocated with the
         # profiled peak memory.
         torch.cuda.synchronize()
-        torch.cuda.memory._dump_snapshot("llama7b.pickle")
         free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info()
         peak_memory = total_gpu_memory - free_gpu_memory
 


### PR DESCRIPTION
Fixes #2150 

Related issue: https://discuss.pytorch.org/t/cuda-allocation-lifetime-for-inputs-to-distributed-all-reduce/191573

* Before:
<img width="3257" alt="Screenshot 2023-12-16 at 11 38 15 PM" src="https://github.com/vllm-project/vllm/assets/46394894/d3a6c58e-e6c2-4897-b206-f72f8c69c4b6">

* After:
<img width="3245" alt="Screenshot 2023-12-16 at 11 40 51 PM" src="https://github.com/vllm-project/vllm/assets/46394894/bae6ce42-4c9a-4302-b66c-248d868233b7">

The peak memory usage was reduced from 25.5 GiB to 19.5 GiB for Llama-70B with TP=8.