### PR TITLE
Temporarily enforce eager mode for GPTQ models

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -185,6 +185,12 @@ class ModelConfig:
             self.max_context_len_to_capture = self.max_model_len
         self.max_context_len_to_capture = min(self.max_context_len_to_capture,
                                               self.max_model_len)
+        if self.quantization == "gptq":
+            # GPTQ does not support CUDA graph yet.
+            # Related issue: https://github.com/vllm-project/vllm/issues/2147
+            logger.warning("GPTQ does not support CUDA graph yet. Disabling "
+                           "CUDA graph.")
+            self.enforce_eager = True
 
     def verify_with_parallel_config(
         self,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -185,7 +185,7 @@ class ModelConfig:
             self.max_context_len_to_capture = self.max_model_len
         self.max_context_len_to_capture = min(self.max_context_len_to_capture,
                                               self.max_model_len)
-        if self.quantization == "gptq":
+        if self.quantization == "gptq" and not self.enforce_eager:
             # GPTQ does not support CUDA graph yet.
             # Related issue: https://github.com/vllm-project/vllm/issues/2147
             logger.warning("GPTQ does not support CUDA graph yet. Disabling "

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -186,7 +186,6 @@ class ModelConfig:
         self.max_context_len_to_capture = min(self.max_context_len_to_capture,
                                               self.max_model_len)
         if self.quantization == "gptq" and not self.enforce_eager:
-            # GPTQ does not support CUDA graph yet.
             # Related issue: https://github.com/vllm-project/vllm/issues/2147
             logger.warning("GPTQ does not support CUDA graph yet. Disabling "
                            "CUDA graph.")


### PR DESCRIPTION
Related to #2147

This PR temporarily forbid using CUDA graph for GPTQ models.