### PR TITLE
Minor fix for gpu-memory-utilization description

### DIFF
--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -89,9 +89,11 @@ Below, you can find an explanation of every engine argument for vLLM:
 
     CPU swap space size (GiB) per GPU.
 
-.. option:: --gpu-memory-utilization <percentage>
+.. option:: --gpu-memory-utilization <fraction>
 
-    The percentage of GPU memory to be used for the model executor.
+    The fraction of GPU memory to be used for the model executor, which can range from 0 to 1. 
+    For example, a value of 0.5 would imply 50% GPU memory utilization.
+    If unspecified, will use the default value of 0.9.
 
 .. option:: --max-num-batched-tokens <tokens>
 


### PR DESCRIPTION
This minor update revises the input description for the `--gpu-memory-utilization` option. 

Changes include:

- Changing the input description from `<percentage>` to `<fraction>` to more accurately reflect the actual expected input range of 0 to 1.
- Specifying the default value of 0.9 in the documentation to provide clearer guidance when the option is not explicitly set.