### PR TITLE
fix stream problem in Sampler

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -51,15 +51,12 @@ class Sampler(nn.Module):
         # Apply logits processors (if any).
         logits = _apply_logits_processors(logits, sampling_metadata)
 
-        self._copy_stream.wait_stream(torch.cuda.current_stream())
         # Prepare sampling tensors in another stream to overlap
         # CPU<->GPU data transfer with GPU computation in forward pass.
         with torch.cuda.stream(self._copy_stream):
             (sampling_tensors, do_penalties, do_top_p_top_k,
              do_min_p) = SamplingTensors.from_sampling_metadata(
                  sampling_metadata, vocab_size, logits.device, logits.dtype)
-
-        torch.cuda.current_stream().wait_stream(self._copy_stream)
 
         # Apply presence and frequency penalties.
         if do_penalties:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -51,6 +51,7 @@ class Sampler(nn.Module):
         # Apply logits processors (if any).
         logits = _apply_logits_processors(logits, sampling_metadata)
 
+        self._copy_stream.wait_stream(torch.cuda.current_stream())
         # Prepare sampling tensors in another stream to overlap
         # CPU<->GPU data transfer with GPU computation in forward pass.
         with torch.cuda.stream(self._copy_stream):


### PR DESCRIPTION
Problem description:
When serving a 34B model(like https://huggingface.co/TheBloke/WizardCoder-Python-34B-V1.0-AWQ) with TP4, the first generation is right, but the second generation will raise RuntimeError. What is weird is that https://huggingface.co/TheBloke/WizardCoder-Python-7B-V1.0-AWQ is fine using TP4 and I don't know why sampler is not working with bigger model.
Moreover, this not only have issues with the AWQ model but also with the GPTQ model.

And i found this error is introduced by PR: #1889 and the reason is that the sampler outputs nan logprops which trigger assert error between the 4 workers's output.
I believe there may be a stream conflict issue when employing tensor parallelism. While I am not skillful at PyTorch streams and made several modifications, I discovered that allowing `self._copy_stream` to wait for the current stream resolves the issue. Another effective fix involves adding a `print` statement in the `from_sampling_metadata` method of ` SamplingTesors`.

In conclusion, this is an experimental fix that requires further discussion. 
I am hopeful for a thorough explanation of this matter since I am uncertain about the effectiveness of this fix.
