### PR TITLE
[Bugfix] Fix the non-blocking behavior of the sampler

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -58,7 +58,17 @@ class Sampler(nn.Module):
              do_min_p) = SamplingTensors.from_sampling_metadata(
                  sampling_metadata, vocab_size, logits.device, logits.dtype)
 
-        torch.cuda.current_stream().wait_stream(self._copy_stream)
+        current_stream = torch.cuda.current_stream()
+        current_stream.wait_stream(self._copy_stream)
+        sampling_tensors.temperatures.record_stream(current_stream)
+        sampling_tensors.top_ps.record_stream(current_stream)
+        sampling_tensors.top_ks.record_stream(current_stream)
+        sampling_tensors.min_ps.record_stream(current_stream)
+        sampling_tensors.presence_penalties.record_stream(current_stream)
+        sampling_tensors.frequency_penalties.record_stream(current_stream)
+        sampling_tensors.repetition_penalties.record_stream(current_stream)
+        sampling_tensors.prompt_tokens.record_stream(current_stream)
+        sampling_tensors.output_tokens.record_stream(current_stream)
 
         # Apply presence and frequency penalties.
         if do_penalties:


### PR DESCRIPTION
Cuda-Caching-Allocator in PyTorch relies on the ordering guarantee of the same stream for safe memory reuse (even if the computation is async), but there are no such guarantees for different stream. Note that the sampling tensors are created under `copy_stream` and used in `main_stream`, so `tensor.record_stream` should be called on those tensors for proper synchronization.

Reference:
https://pytorch.org/docs/stable/generated/torch.Tensor.record_stream.html
https://zdevito.github.io/2022/08/04/cuda-caching-allocator.html

cc @Yard1 @WoosukKwon @zhuohan123 