### PR TITLE
Add support for batched completion (offline) with OpenAI server

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1,6 +1,10 @@
 # Adapted from
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/serve/openai_api_server.py
 
+# Support for batched offline completion
+# Copyright (C) 2023 NVIDIA
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import asyncio
 import codecs

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1,7 +1,6 @@
 # Adapted from
 # https://github.com/lm-sys/FastChat/blob/168ccc29d3f7edc50823016105c024fe2282732a/fastchat/serve/openai_api_server.py
 
-# Support for batched offline completion
 # Copyright (C) 2023 NVIDIA
 # SPDX-License-Identifier: Apache-2.0
 
@@ -570,7 +569,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         results_cache = []
 
         if use_token_ids:
-            for pidx, token_id_list in enumerate(token_ids):
+            for pidx, _ in enumerate(token_ids):
                 sub_request_id = request_id + f"_{pidx + 1}"
                 results_generator = engine.add_request(sub_request_id, None, sampling_params, token_ids[pidx])
                 results_cache.append(results_generator)
@@ -861,7 +860,7 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
                 # return a streaming response with a single event.
                 response_json = response.json(ensure_ascii=False)
 
-                async def fake_stream_generator() -> AsyncGenerator[str, None]:
+                async def fake_stream_generator(response_json=response_json) -> AsyncGenerator[str, None]:
                     yield f"data: {response_json}\n\n"
                     yield "data: [DONE]\n\n"
 


### PR DESCRIPTION
# Scope
Adds the support for passing a batch of prompts (as a list) in the request, so as to process and enqueue all generations at once, improving throughput. 

It only supports offline generation. Streaming + batching has too many edge cases to consider, chief among them what happens when some streams end earlier than others. Not in scope for this PR.

## Changelog
The primary changes are to the api_server.py inside entrypoints/openai/. 
Overall, it simply detects if its a single prompt request or a batched prompt request.
If single prompt, it falls back to the current logic in main branch, otherwise it loops through the prompts and adds all of them to the AsyncEngine then awaits their completion.

Note: I'd like to add tests but there's no actual running test for the server, so I'd suggest the reviewers to pull the branch and test it locally before merge. I have done so, and results seem correct. 

## Sidenote
I'd prefer to merge this PR soon (as realistically possible). The changes are not trivial, and the rebasing this PR requires careful checking of every line of the diff so as not to miss any of the branch cases. It would be great to have this part of vLLM by default.

I do realize there was a comment about the API server not having to be feature complete, but since OpenAI library does support batched prompts, it would be very nice to support it in vLLM too.

cc @WoosukKwon @Yard1 @zhuohan123 