### PR TITLE
Make _prepare_sample non blocking and pin memory of CPU input buffers

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -10,6 +10,7 @@ from vllm.logger import init_logger
 from vllm.model_executor import get_model, InputMetadata, SamplingMetadata
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
+from vllm.utils import in_wsl
 
 logger = init_logger(__name__)
 
@@ -52,6 +53,8 @@ class ModelRunner:
         # The shape of the cached block table will be
         # (max batch size to capture, max context len to capture / block size).
         self.graph_block_tables = None  # Set after initial profiling.
+        # cache in_wsl result
+        self.in_wsl = in_wsl()
 
     def load_model(self) -> None:
         self.model = get_model(self.model_config)
@@ -203,25 +206,29 @@ class ModelRunner:
         # When using CUDA graph, we don't need to make the tensors on the GPU
         # because they will be eventually copied to the designated GPU buffer.
         device = "cpu" if use_captured_graph else "cuda"
+        pin_memory = use_captured_graph and not self.in_wsl
         input_tokens = _make_tensor_with_pad(input_tokens,
                                              max_len=1,
                                              pad=0,
                                              dtype=torch.long,
-                                             device=device)
+                                             device=device,
+                                             pin_memory=pin_memory)
         input_positions = _make_tensor_with_pad(input_positions,
                                                 max_len=1,
                                                 pad=0,
                                                 dtype=torch.long,
-                                                device=device)
+                                                device=device,
+                                                pin_memory=pin_memory)
         slot_mapping = _make_tensor_with_pad(slot_mapping,
                                              max_len=1,
                                              pad=_PAD_SLOT_ID,
                                              dtype=torch.long,
-                                             device=device)
+                                             device=device,
+                                             pin_memory=pin_memory)
         context_lens = torch.tensor(context_lens,
                                     dtype=torch.int,
                                     device=device,
-                                    pin_memory=use_captured_graph)
+                                    pin_memory=pin_memory)
 
         if use_captured_graph:
             # The shape of graph_block_tables is
@@ -298,16 +305,13 @@ class ModelRunner:
                               categorized_sample_indices_start_idx + num_seqs))
                 categorized_sample_indices_start_idx += num_seqs
 
-        def async_h2d(data: list, dtype):
-            t = torch.tensor(data, dtype=dtype, pin_memory=True)
-            return t.to(device="cuda", non_blocking=True)
-
         selected_token_indices = async_h2d(
             selected_token_indices,
             dtype=torch.long,
+            pin_memory=not self.in_wsl
         )
         categorized_sample_indices = {
-            t: async_h2d(seq_ids, dtype=torch.int)
+            t: async_h2d(seq_ids, dtype=torch.int, pin_memory=not self.in_wsl)
             for t, seq_ids in categorized_sample_indices.items()
         }
 
@@ -539,12 +543,13 @@ def _make_tensor_with_pad(
     pad: int,
     dtype: torch.dtype,
     device: Union[str, torch.device] = "cuda",
+    pin_memory=False
 ) -> torch.Tensor:
     padded_x = [_pad_to_max(x_i, max_len, pad) for x_i in x]
     return torch.tensor(padded_x,
                         dtype=dtype,
                         device=device,
-                        pin_memory=device == 'cpu')
+                        pin_memory=pin_memory)
 
 
 def _get_graph_batch_size(batch_size: int) -> int:
@@ -554,3 +559,8 @@ def _get_graph_batch_size(batch_size: int) -> int:
         return 4
     else:
         return (batch_size + 7) // 8 * 8
+
+
+def async_h2d(data: list, dtype, pin_memory):
+    t = torch.tensor(data, dtype=dtype, pin_memory=pin_memory)
+    return t.to(device="cuda", non_blocking=True)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -545,7 +545,7 @@ def _make_tensor_with_pad(x: List[List[int]],
     return torch.tensor(padded_x,
                         dtype=dtype,
                         device=device,
-                        pin_memory=pin_memory)
+                        pin_memory=pin_memory and str(device) == "cpu")
 
 
 def _get_graph_batch_size(batch_size: int) -> int:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -559,6 +559,6 @@ def _get_graph_batch_size(batch_size: int) -> int:
         return (batch_size + 7) // 8 * 8
 
 
-def async_h2d(data: list, dtype, pin_memory):
+def _async_h2d(data: list, dtype, pin_memory):
     t = torch.tensor(data, dtype=dtype, pin_memory=pin_memory)
     return t.to(device="cuda", non_blocking=True)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -305,11 +305,9 @@ class ModelRunner:
                               categorized_sample_indices_start_idx + num_seqs))
                 categorized_sample_indices_start_idx += num_seqs
 
-        selected_token_indices = async_h2d(
-            selected_token_indices,
-            dtype=torch.long,
-            pin_memory=not self.in_wsl
-        )
+        selected_token_indices = async_h2d(selected_token_indices,
+                                           dtype=torch.long,
+                                           pin_memory=not self.in_wsl)
         categorized_sample_indices = {
             t: async_h2d(seq_ids, dtype=torch.int, pin_memory=not self.in_wsl)
             for t, seq_ids in categorized_sample_indices.items()
@@ -537,14 +535,12 @@ def _pad_to_max(x: List[int], max_len: int, pad: int) -> List[int]:
     return x + [pad] * (max_len - len(x))
 
 
-def _make_tensor_with_pad(
-    x: List[List[int]],
-    max_len: int,
-    pad: int,
-    dtype: torch.dtype,
-    device: Union[str, torch.device] = "cuda",
-    pin_memory=False
-) -> torch.Tensor:
+def _make_tensor_with_pad(x: List[List[int]],
+                          max_len: int,
+                          pad: int,
+                          dtype: torch.dtype,
+                          device: Union[str, torch.device] = "cuda",
+                          pin_memory=False) -> torch.Tensor:
     padded_x = [_pad_to_max(x_i, max_len, pad) for x_i in x]
     return torch.tensor(padded_x,
                         dtype=dtype,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -305,11 +305,11 @@ class ModelRunner:
                               categorized_sample_indices_start_idx + num_seqs))
                 categorized_sample_indices_start_idx += num_seqs
 
-        selected_token_indices = async_h2d(selected_token_indices,
+        selected_token_indices = _async_h2d(selected_token_indices,
                                            dtype=torch.long,
                                            pin_memory=not self.in_wsl)
         categorized_sample_indices = {
-            t: async_h2d(seq_ids, dtype=torch.int, pin_memory=not self.in_wsl)
+            t: _async_h2d(seq_ids, dtype=torch.int, pin_memory=not self.in_wsl)
             for t, seq_ids in categorized_sample_indices.items()
         }
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -535,12 +535,14 @@ def _pad_to_max(x: List[int], max_len: int, pad: int) -> List[int]:
     return x + [pad] * (max_len - len(x))
 
 
-def _make_tensor_with_pad(x: List[List[int]],
-                          max_len: int,
-                          pad: int,
-                          dtype: torch.dtype,
-                          device: Union[str, torch.device] = "cuda",
-                          pin_memory=False) -> torch.Tensor:
+def _make_tensor_with_pad(
+    x: List[List[int]],
+    max_len: int,
+    pad: int,
+    dtype: torch.dtype,
+    device: Union[str, torch.device] = "cuda",
+    pin_memory=False,
+) -> torch.Tensor:
     padded_x = [_pad_to_max(x_i, max_len, pad) for x_i in x]
     return torch.tensor(padded_x,
                         dtype=dtype,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -306,8 +306,8 @@ class ModelRunner:
                 categorized_sample_indices_start_idx += num_seqs
 
         selected_token_indices = _async_h2d(selected_token_indices,
-                                           dtype=torch.long,
-                                           pin_memory=not self.in_wsl)
+                                            dtype=torch.long,
+                                            pin_memory=not self.in_wsl)
         categorized_sample_indices = {
             t: _async_h2d(seq_ids, dtype=torch.int, pin_memory=not self.in_wsl)
             for t, seq_ids in categorized_sample_indices.items()

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -541,7 +541,7 @@ def _make_tensor_with_pad(
     pad: int,
     dtype: torch.dtype,
     device: Union[str, torch.device] = "cuda",
-    pin_memory=False,
+    pin_memory: bool = False,
 ) -> torch.Tensor:
     padded_x = [_pad_to_max(x_i, max_len, pad) for x_i in x]
     return torch.tensor(padded_x,


### PR DESCRIPTION
Hide `_prepare_sample` latency with model execution since it looks like it doesn't depend on model forward. 

We can use a copy stream for h2ds in `_prepare_sample`, but we probably don't really need to because these h2ds are very short. 

cc @Yard1 