### PR TITLE
Remove Sampler copy stream

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -30,7 +30,6 @@ class Sampler(nn.Module):
     def __init__(self, vocab_size: int) -> None:
         super().__init__()
         self.vocab_size = vocab_size
-        self._copy_stream: torch.cuda.Stream = torch.cuda.Stream()
 
     def forward(
         self,
@@ -51,14 +50,11 @@ class Sampler(nn.Module):
         # Apply logits processors (if any).
         logits = _apply_logits_processors(logits, sampling_metadata)
 
-        # Prepare sampling tensors in another stream to overlap
-        # CPU<->GPU data transfer with GPU computation in forward pass.
-        with torch.cuda.stream(self._copy_stream):
-            (sampling_tensors, do_penalties, do_top_p_top_k,
-             do_min_p) = SamplingTensors.from_sampling_metadata(
-                 sampling_metadata, vocab_size, logits.device, logits.dtype)
-
-        torch.cuda.current_stream().wait_stream(self._copy_stream)
+        # Prepare sampling tensors with pinned memory to avoid
+        # blocking.
+        (sampling_tensors, do_penalties, do_top_p_top_k,
+            do_min_p) = SamplingTensors.from_sampling_metadata(
+                sampling_metadata, vocab_size, logits.device, logits.dtype)
 
         # Apply presence and frequency penalties.
         if do_penalties:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -53,8 +53,8 @@ class Sampler(nn.Module):
         # Prepare sampling tensors with pinned memory to avoid
         # blocking.
         (sampling_tensors, do_penalties, do_top_p_top_k,
-            do_min_p) = SamplingTensors.from_sampling_metadata(
-                sampling_metadata, vocab_size, logits.device, logits.dtype)
+         do_min_p) = SamplingTensors.from_sampling_metadata(
+             sampling_metadata, vocab_size, logits.device, logits.dtype)
 
         # Apply presence and frequency penalties.
         if do_penalties:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -50,8 +50,7 @@ class Sampler(nn.Module):
         # Apply logits processors (if any).
         logits = _apply_logits_processors(logits, sampling_metadata)
 
-        # Prepare sampling tensors with pinned memory to avoid
-        # blocking.
+        # Prepare sampling tensors with pinned memory to avoid blocking.
         (sampling_tensors, do_penalties, do_top_p_top_k,
          do_min_p) = SamplingTensors.from_sampling_metadata(
              sampling_metadata, vocab_size, logits.device, logits.dtype)


### PR DESCRIPTION
We don't really need an extra stream in sampler to still benefit from non-blocking execution. This will add 5-10 microseconds of overhead, which I think is an acceptable tradeoff for stronger consistency guarantees.

Supersedes https://github.com/vllm-project/vllm/pull/2190 and https://github.com/vllm-project/vllm/pull/2177

cc @esmeetu @ZiyueHuang