### PR TITLE
Add option in OpenAI API to disable special tokens when tokenizing

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -75,6 +75,10 @@ def parse_args():
                         help="The file path to the chat template, "
                         "or the template in single-line form "
                         "for the specified model")
+    parser.add_argument("--disable-special-tokens",
+                        action='store_true',
+                        help="Disable special tokens when tokenizing. "
+                        "Usefule for chat template with special tokens.")
     parser.add_argument("--response-role",
                         type=str,
                         default="assistant",
@@ -141,13 +145,14 @@ async def check_model(request) -> Optional[JSONResponse]:
 async def check_length(
     request: Union[ChatCompletionRequest, CompletionRequest],
     prompt: Optional[str] = None,
-    prompt_ids: Optional[List[int]] = None
+    prompt_ids: Optional[List[int]] = None,
+    add_special_tokens: bool = True
 ) -> Tuple[List[int], Optional[JSONResponse]]:
     assert (not (prompt is None and prompt_ids is None)
             and not (prompt is not None and prompt_ids is not None)
             ), "Either prompt or prompt_ids should be provided."
     input_ids = prompt_ids if prompt_ids is not None else tokenizer(
-        prompt).input_ids
+        prompt, add_special_tokens=add_special_tokens).input_ids
     token_num = len(input_ids)
 
     if request.max_tokens is None:
@@ -247,7 +252,9 @@ async def create_chat_completion(request: ChatCompletionRequest,
         logger.error(f"Error in applying chat template from request: {str(e)}")
         return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
-    token_ids, error_check_ret = await check_length(request, prompt=prompt)
+    add_special_tokens = not args.disable_special_tokens
+    token_ids, error_check_ret = await check_length(
+        request, prompt=prompt, add_special_tokens=add_special_tokens)
     if error_check_ret is not None:
         return error_check_ret
 


### PR DESCRIPTION
Follow the instruction in huggingface [doc](https://huggingface.co/docs/transformers/chat_templating), i use a llama style chat template for my own model

```python
template = (
    "{% if messages[0]['role'] == 'system' %}"
    "{% set loop_messages = messages[1:] %}"  # Extract system message if it's present
    "{% set system_message = messages[0]['content'] %}"
    "{% elif USE_DEFAULT_PROMPT == true and not '<<SYS>>' in messages[0]['content'] %}"
    "{% set loop_messages = messages %}"  # Or use the default system message if the flag is set
    "{% set system_message = 'DEFAULT_SYSTEM_MESSAGE' %}"
    "{% else %}"
    "{% set loop_messages = messages %}"
    "{% set system_message = false %}"
    "{% endif %}"
    "{% for message in loop_messages %}"  # Loop over all non-system messages
    "{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}"
    "{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}"
    "{% endif %}"
    "{% if loop.index0 == 0 and system_message != false %}"  # Embed system message in first message
    "{% set content = '<<SYS>>\\n' + system_message + '\\n<</SYS>>\\n\\n' + message['content'] %}"
    "{% else %}"
    "{% set content = message['content'] %}"
    "{% endif %}"
    "{% if message['role'] == 'user' %}"  # After all of that, handle messages/roles in a fairly normal way
    "{{ bos_token + '[INST] ' + content.strip() + ' [/INST]' }}"
    "{% elif message['role'] == 'system' %}"
    "{{ '<<SYS>>\\n' + content.strip() + '\\n<</SYS>>\\n\\n' }}"
    "{% elif message['role'] == 'assistant' %}"
    "{{ ' '  + content.strip() + ' ' + eos_token }}"
    "{% endif %}"
    "{% endfor %}"
)
```

There is already a bos_token in template, after tokenize in OpenAI API server, there are two bos at the start.

So i add an option to control the behavior of the tokenizer.

This may fix #2012 