### PR TITLE
[BUGFIX] Fix API server test

### DIFF
--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -51,10 +51,9 @@ def test_api_server(api_server):
                 for r in pool.map(_query_server, prompts):
                     result = r
                     break
-            except Exception as e:
-                print("fail", e)
+            except requests.exceptions.ConnectionError:
                 time.sleep(1)
-        print("Server is ready")
+
         # Actual tests start here
         # Try with 1 prompt
         for result in pool.map(_query_server, prompts):
@@ -72,7 +71,7 @@ def test_api_server(api_server):
         # Cancel requests
         prompts = ["canceled requests"] * 100
         pool.map_async(_query_server, prompts)
-        time.sleep(0.01)
+        time.sleep(0.001)
         pool.terminate()
         pool.join()
 

--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -44,15 +44,17 @@ def test_api_server(api_server):
     """
     with Pool(32) as pool:
         # Wait until the server is ready
-        prompts = ["Hello world"] * 1
+        prompts = ["warm up"] * 1
         result = None
         while not result:
             try:
-                for _ in pool.map(_query_server, prompts):
+                for r in pool.map(_query_server, prompts):
+                    result = r
                     break
-            except Exception:
+            except Exception as e:
+                print("fail", e)
                 time.sleep(1)
-
+        print("Server is ready")
         # Actual tests start here
         # Try with 1 prompt
         for result in pool.map(_query_server, prompts):
@@ -63,11 +65,12 @@ def test_api_server(api_server):
         assert num_aborted_requests == 0
 
         # Try with 100 prompts
-        prompts = ["Hello world"] * 100
+        prompts = ["test prompt"] * 100
         for result in pool.map(_query_server, prompts):
             assert result
 
         # Cancel requests
+        prompts = ["canceled requests"] * 100
         pool.map_async(_query_server, prompts)
         time.sleep(0.01)
         pool.terminate()
@@ -81,6 +84,6 @@ def test_api_server(api_server):
     # check that server still runs after cancellations
     with Pool(32) as pool:
         # Try with 100 prompts
-        prompts = ["Hello world"] * 100
+        prompts = ["test prompt after canceled"] * 100
         for result in pool.map(_query_server, prompts):
             assert result


### PR DESCRIPTION
Previously `tests/async_engine/test_api_server.py` would always be in a dead loop.