### PR TITLE
Add support GPT-NeoX Models without attention biases

### DIFF
--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -54,8 +54,7 @@ class GPTNeoXAttention(nn.Module):
         self.total_num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
         self.head_size = self.hidden_size // self.total_num_heads
-        self.bias = "True" if not hasattr(
-            config, "attention_bias") else config.attention_bias
+        self.bias = getattr(config, "attention_bias", True)
 
         tensor_model_parallel_world_size = (
             get_tensor_model_parallel_world_size())

--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -54,6 +54,7 @@ class GPTNeoXAttention(nn.Module):
         self.total_num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
         self.head_size = self.hidden_size // self.total_num_heads
+        self.bias = "True" if not hasattr(config, "attention_bias") else config.attention_bias
 
         tensor_model_parallel_world_size = (
             get_tensor_model_parallel_world_size())
@@ -65,11 +66,13 @@ class GPTNeoXAttention(nn.Module):
             config.hidden_size,
             self.head_size,
             self.total_num_heads,
+            bias=self.bias,
             linear_method=linear_method,
         )
         self.dense = RowParallelLinear(
             config.hidden_size,
             config.hidden_size,
+            bias=self.bias,
             linear_method=linear_method,
         )
         scaling = self.head_size**-0.5

--- a/vllm/model_executor/models/gpt_neox.py
+++ b/vllm/model_executor/models/gpt_neox.py
@@ -54,7 +54,8 @@ class GPTNeoXAttention(nn.Module):
         self.total_num_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
         self.head_size = self.hidden_size // self.total_num_heads
-        self.bias = "True" if not hasattr(config, "attention_bias") else config.attention_bias
+        self.bias = "True" if not hasattr(
+            config, "attention_bias") else config.attention_bias
 
         tensor_model_parallel_world_size = (
             get_tensor_model_parallel_world_size())


### PR DESCRIPTION
This PR enables support for GPT-NeoX models without attention bias. 

All models with the currently released GPT-NeoX architecture use attention bias by default, but the next version of huggingface transformers will support models without attention bias (merged PR - https://github.com/huggingface/transformers/pull/28126), and we want to modify the code to properly initialize these models in vLLM as well.

In previous versions of the transformers, there was no attention_bias argument in GPTNeoXConfig, so we used hasattr() to apply a default value to avoid compatibility issues with version differences.