### PR TITLE
Fix Gradio example: remove deprecated parameter `concurrency_count`

### DIFF
--- a/examples/gradio_webserver.py
+++ b/examples/gradio_webserver.py
@@ -47,6 +47,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     demo = build_demo()
-    demo.queue(concurrency_count=100).launch(server_name=args.host,
-                                             server_port=args.port,
-                                             share=True)
+    demo.queue().launch(server_name=args.host,
+                        server_port=args.port,
+                        share=True)


### PR DESCRIPTION


Running the gradio example with the latest `gradio` package (version 4.12.0) results in the following error:
```
    raise DeprecationWarning(
DeprecationWarning: concurrency_count has been deprecated. Set the concurrency_limit directly on event listeners e.g. btn.click(fn, ..., concurrency_limit=10) or gr.Interface(concurrency_limit=10). If necessary, the total number of workers can be configured via `max_threads` in launch().
```

It appears that passing `concurrency_count` to `Blocks.queue()` has been deprecated. Removing it resolves the issue.