### PR TITLE
Remove unused const TIMEOUT_TO_PREVENT_DEADLOCK

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -12,7 +12,6 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
-TIMEOUT_TO_PREVENT_DEADLOCK = 1  # seconds.
 app = FastAPI()
 engine = None
 


### PR DESCRIPTION
It appears that the following constant is not used anywhere, so I believe it can be safely removed.
https://github.com/vllm-project/vllm/blob/4934d492744d14104353b8236ef8a0405edf1622/vllm/entrypoints/api_server.py#L15

