### PR TITLE
Bump pydantic version from 1.10.13 to >= 1.9.0, < 3

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -11,5 +11,5 @@ tokenizers>=0.15.0
 transformers >= 4.36.0  # Required for Mixtral.
 fastapi
 uvicorn[standard]
-pydantic == 1.10.13  # Required for OpenAI server.
+pydantic >= 1.9.0, < 3  # Required for OpenAI server.
 aioprometheus[starlette]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ transformers >= 4.36.0  # Required for Mixtral.
 xformers == 0.0.23.post1  # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]
-pydantic == 1.10.13  # Required for OpenAI server.
+pydantic >= 1.9.0, < 3  # Required for OpenAI server.
 aioprometheus[starlette]

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -100,7 +100,7 @@ app.add_route("/metrics", metrics)  # Exposes HTTP metrics
 def create_error_response(status_code: HTTPStatus,
                           message: str) -> JSONResponse:
     return JSONResponse(ErrorResponse(message=message,
-                                      type="invalid_request_error").dict(),
+                                      type="invalid_request_error").model_dump(),
                         status_code=status_code.value)
 
 


### PR DESCRIPTION
Updating pydantic version from 1.10.13 to >= 1.9.0, < 3. The version was originally pinned due to a dependency on the OpenAI python library. OpenAI has since updated their version requirements for pydantic. See OpenAI docs for the version change: [pyproject.toml](https://github.com/openai/openai-python/blob/f1c7d714914e3321ca2e72839fe2d132a8646e7f/pyproject.toml#L12).
 
Pydantic V1 is no longer supported, and suggests migration to V2 ([Migration Guide](https://docs.pydantic.dev/latest/migration/)).