### PR TITLE
Allow setting fastapi root_path argument

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -74,12 +74,18 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)
     parser.add_argument("--ssl-certfile", type=str, default=None)
+    parser.add_argument(
+        "--root-path",
+        type=str,
+        default=None,
+        help="FastAPI root_path when app is behind a path based routing proxy")
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()
 
     engine_args = AsyncEngineArgs.from_cli_args(args)
     engine = AsyncLLMEngine.from_engine_args(engine_args)
 
+    app.root_path = args.root_path
     uvicorn.run(app,
                 host=args.host,
                 port=args.port,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -88,6 +88,11 @@ def parse_args():
                         type=str,
                         default=None,
                         help="The file path to the SSL cert file")
+    parser.add_argument(
+        "--root-path",
+        type=str,
+        default=None,
+        help="FastAPI root_path when app is behind a path based routing proxy")
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     return parser.parse_args()
@@ -748,6 +753,7 @@ if __name__ == "__main__":
     # Register labels for metrics
     add_global_metrics_labels(model_name=engine_args.model)
 
+    app.root_path = args.root_path
     uvicorn.run(app,
                 host=args.host,
                 port=args.port,


### PR DESCRIPTION
When FastAPI is run behind a path-based proxy the swagger fails to render because it is not aware of the path the application root is on
E.g. If the app is hosted on `https://example.com/vllm-svc/` then 
with `root_path=None` it will look for openapi.json at `https://example.com/openapi.json` and fail with 404
with `root_path="vllm-svc"` it will look for openapi.json at `https://example.com/vllm-svc/openapi.json` which works correctly

This change only affects the swagger at `/docs`
See: https://fastapi.tiangolo.com/advanced/behind-a-proxy/#proxy-with-a-stripped-path-prefix