### PR TITLE
Scheduler policy to maximize throughput

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -219,7 +219,7 @@ def main(args: argparse.Namespace):
                                 args.trust_remote_code, args.dtype,
                                 args.max_model_len, args.enforce_eager,
                                 args.kv_cache_dtype, args.device,
-                                args.enable_prefix_caching,
+                                args.enable_prefix_caching, args.vllm_scheduler_policy,
                                 args.vllm_scheduler_reorder_window, args.swap_space,
                                 args.swap_space, args.gpu_memory_utilization)
     elif args.backend == "hf":

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -248,7 +248,9 @@ if __name__ == "__main__":
                         type=str,
                         choices=["fcfs", "reorder"],
                         default="fcfs")
-    parser.add_argument("--vllm-scheduler-reorder-window", type=float, default=0)
+    parser.add_argument("--vllm-scheduler-reorder-window",
+                        type=float,
+                        default=0)
     parser.add_argument("--dataset",
                         type=str,
                         default=None,

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -74,6 +74,9 @@ def run_vllm(
     kv_cache_dtype: str,
     device: str,
     enable_prefix_caching: bool,
+    scheduler_policy: str,
+    scheduler_reorder_window: float,
+    swap_space: int,
     gpu_memory_utilization: float = 0.9,
 ) -> float:
     from vllm import LLM, SamplingParams
@@ -91,9 +94,8 @@ def run_vllm(
               device=device,
               enable_prefix_caching=enable_prefix_caching,
               scheduler_policy=scheduler_policy,
-              scheduler_max_delay=scheduler_max_delay,
+              scheduler_reorder_window=scheduler_reorder_window,
               swap_space=swap_space)
-
     # Add the requests to the engine.
     for prompt, _, output_len in requests:
         sampling_params = SamplingParams(
@@ -218,9 +220,8 @@ def main(args: argparse.Namespace):
                                 args.max_model_len, args.enforce_eager,
                                 args.kv_cache_dtype, args.device,
                                 args.enable_prefix_caching,
-                                args.vllm_scheduler_policy,
-                                args.vllm_scheduler_max_delay, args.swap_space,
-                                 args.gpu_memory_utilization)
+                                args.vllm_scheduler_reorder_window, args.swap_space,
+                                args.swap_space, args.gpu_memory_utilization)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -245,9 +246,9 @@ if __name__ == "__main__":
                         default="vllm")
     parser.add_argument("--vllm-scheduler-policy",
                         type=str,
-                        choices=["fcfs", "throughput"],
+                        choices=["fcfs", "reorder"],
                         default="fcfs")
-    parser.add_argument("--vllm-scheduler-max-delay", type=float, default=0)
+    parser.add_argument("--vllm-scheduler-reorder-window", type=float, default=0)
     parser.add_argument("--dataset",
                         type=str,
                         default=None,

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -213,15 +213,14 @@ def main(args: argparse.Namespace):
                                    args.output_len)
 
     if args.backend == "vllm":
-        elapsed_time = run_vllm(requests, args.model, args.tokenizer,
-                                args.quantization, args.tensor_parallel_size,
-                                args.seed, args.n, args.use_beam_search,
-                                args.trust_remote_code, args.dtype,
-                                args.max_model_len, args.enforce_eager,
-                                args.kv_cache_dtype, args.device,
-                                args.enable_prefix_caching, args.vllm_scheduler_policy,
-                                args.vllm_scheduler_reorder_window, args.swap_space,
-                                args.swap_space, args.gpu_memory_utilization)
+        elapsed_time = run_vllm(
+            requests, args.model, args.tokenizer, args.quantization,
+            args.tensor_parallel_size, args.seed, args.n, args.use_beam_search,
+            args.trust_remote_code, args.dtype, args.max_model_len,
+            args.enforce_eager, args.kv_cache_dtype, args.device,
+            args.enable_prefix_caching, args.vllm_scheduler_policy,
+            args.vllm_scheduler_reorder_window, args.swap_space,
+            args.gpu_memory_utilization)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -457,6 +457,8 @@ class SchedulerConfig:
         max_model_len: Maximum length of a sequence (including prompt
             and generated text).
         max_paddings: Maximum number of paddings to be added to a batch.
+        policy: Policy of sequence scheduling(`fcfs` or `reorder`).
+        reorder_window: Allowed reorder window size(in sec) for `reorder` policy.
     """
 
     def __init__(
@@ -466,7 +468,7 @@ class SchedulerConfig:
         max_model_len: int,
         max_paddings: int,
         policy: str = 'fcfs',
-        max_delay: float = 0,
+        reorder_window: float = 0,
     ) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
@@ -478,7 +480,7 @@ class SchedulerConfig:
         self.max_model_len = max_model_len
         self.max_paddings = max_paddings
         self.policy = policy
-        self.max_delay = max_delay
+        self.reorder_window = reorder_window
         self._verify_args()
 
     def _verify_args(self) -> None:
@@ -495,6 +497,13 @@ class SchedulerConfig:
                 f"max_num_batched_tokens ({self.max_num_batched_tokens}) must "
                 "be greater than or equal to max_num_seqs "
                 f"({self.max_num_seqs}).")
+        if self.reorder_window < 0:
+            raise ValueError(
+                f"reorder_window ({self.reorder_window}) must "
+                "be not be negative.")
+        if self.reorder_window != 0 and self.policy == 'fcfs':
+            raise ValueError(
+                f"fcfs policy doesn't support reorder_window ({self.reorder_window}).")
 
 
 class DeviceConfig:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -465,6 +465,8 @@ class SchedulerConfig:
         max_num_seqs: int,
         max_model_len: int,
         max_paddings: int,
+        policy: str = 'fcfs',
+        max_delay: float = 0,
     ) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
@@ -475,6 +477,8 @@ class SchedulerConfig:
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len
         self.max_paddings = max_paddings
+        self.policy = policy
+        self.max_delay = max_delay
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -498,12 +498,12 @@ class SchedulerConfig:
                 "be greater than or equal to max_num_seqs "
                 f"({self.max_num_seqs}).")
         if self.reorder_window < 0:
-            raise ValueError(
-                f"reorder_window ({self.reorder_window}) must "
-                "be not be negative.")
+            raise ValueError(f"reorder_window ({self.reorder_window}) must "
+                             "be not be negative.")
         if self.reorder_window != 0 and self.policy == 'fcfs':
             raise ValueError(
-                f"fcfs policy doesn't support reorder_window ({self.reorder_window}).")
+                f"fcfs policy doesn't support reorder_window ({self.reorder_window})."
+            )
 
 
 class DeviceConfig:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -500,7 +500,7 @@ class SchedulerConfig:
         if self.reorder_window < 0:
             raise ValueError(f"reorder_window ({self.reorder_window}) must "
                              "be not be negative.")
-        if self.reorder_window != 0 and self.policy == 'fcfs':
+        if self.reorder_window != 0 and self.policy != 'reorder':
             raise ValueError(
                 f"fcfs policy doesn't support reorder_window ({self.reorder_window})."
             )

--- a/vllm/core/policy.py
+++ b/vllm/core/policy.py
@@ -1,45 +1,96 @@
 from collections import deque
 from typing import Deque
+import enum
+import bisect
 
 from vllm.sequence import SequenceGroup
 
 
-class Policy:
+class PreemptionMode(enum.Enum):
+    """Preemption modes.
 
-    def get_priority(
-        self,
-        now: float,
-        seq_group: SequenceGroup,
-    ) -> float:
-        raise NotImplementedError
+    1. Swapping: Swap out the blocks of the preempted sequences to CPU memory
+    and swap them back in when the sequences are resumed.
+    2. Recomputation: Discard the blocks of the preempted sequences and
+    recompute them when the sequences are resumed, treating the sequences as
+    new prompts.
+    """
+    SWAP = enum.auto()
+    RECOMPUTE = enum.auto()
+
+
+class Policy:
+    """Base class policy"""
 
     def sort_by_priority(
         self,
-        now: float,
         seq_groups: Deque[SequenceGroup],
     ) -> Deque[SequenceGroup]:
-        return deque(
-            sorted(
-                seq_groups,
-                key=lambda seq_group: self.get_priority(now, seq_group),
-                reverse=True,
-            ))
+        raise NotImplementedError
+
+    def get_preemption_mode(self, seq_group: SequenceGroup) -> PreemptionMode:
+        raise NotImplementedError
 
 
 class FCFS(Policy):
+    """Default FIFO Policy"""
 
-    def get_priority(
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+
+    def sort_by_priority(
         self,
-        now: float,
-        seq_group: SequenceGroup,
-    ) -> float:
-        return now - seq_group.metrics.arrival_time
+        seq_groups: Deque[SequenceGroup],
+    ) -> Deque[SequenceGroup]:
+        """We can just sort `Deque[SequenceGroup]` by `arrival_time`"""
+        return deque(sorted(seq_groups, key=lambda x: x.metrics.arrival_time))
+
+    def get_preemption_mode(self, seq_group: SequenceGroup) -> PreemptionMode:
+        #Copa-pasted from previous implementation
+        if seq_group.get_max_num_running_seqs() == 1:
+            return PreemptionMode.RECOMPUTE
+        else:
+            return PreemptionMode.SWAP
+
+
+class MaxThroughput(Policy):
+    """MaxThroughput tries to maximize throughput by reordering incoming requests.
+    
+    Args:
+        max_delay: maximum acceptable delay in sec while reorder `List[SequenceGroup]`. 0 means FIFO behavior. 
+    """
+
+    def __init__(self, max_delay: float = 0, **kwargs) -> None:
+        super().__init__()
+        self.max_delay = max_delay
+
+    def sort_by_priority(
+        self,
+        seq_groups: Deque[SequenceGroup],
+    ) -> Deque[SequenceGroup]:
+        """Sort head withing `max_delay` of the `seq_groups` by length. It reduces padding computation overhead."""
+        if len(seq_groups) == 0:
+            return seq_groups
+        arrival_time_sorted = sorted(seq_groups, key=lambda x: x.metrics.arrival_time)
+        pos = bisect.bisect_left(arrival_time_sorted,
+                                 arrival_time_sorted[0].metrics.arrival_time +
+                                 self.max_delay,
+                                 key=lambda x: x.metrics.arrival_time)
+        return deque(
+            sorted(arrival_time_sorted[:pos],
+                   key=lambda x: x.get_seqs()[0].get_len()) +
+            arrival_time_sorted[pos:])
+
+    def get_preemption_mode(self, seq_group: SequenceGroup) -> PreemptionMode:
+        """Always use SWAP"""
+        return PreemptionMode.SWAP
 
 
 class PolicyFactory:
 
     _POLICY_REGISTRY = {
         'fcfs': FCFS,
+        'throughput': MaxThroughput,
     }
 
     @classmethod

--- a/vllm/core/policy.py
+++ b/vllm/core/policy.py
@@ -66,10 +66,11 @@ class ReorderPolicy(Policy):
         self,
         seq_groups: Deque[SequenceGroup],
     ) -> Deque[SequenceGroup]:
-        """Sort head withing `reorder_window` of the `seq_groups` by length. It reduces padding computation overhead."""
+        """Sort head within `reorder_window` of the `seq_groups` by length. It reduces padding computation overhead."""
         if len(seq_groups) == 0:
             return seq_groups
-        arrival_time_sorted = sorted(seq_groups, key=lambda x: x.metrics.arrival_time)
+        arrival_time_sorted = sorted(seq_groups,
+                                     key=lambda x: x.metrics.arrival_time)
         pos = bisect.bisect_left(arrival_time_sorted,
                                  arrival_time_sorted[0].metrics.arrival_time +
                                  self.reorder_window,

--- a/vllm/core/policy.py
+++ b/vllm/core/policy.py
@@ -80,7 +80,7 @@ class ReorderPolicy(Policy):
             arrival_time_sorted[pos:])
 
     def get_preemption_mode(self, seq_group: SequenceGroup) -> PreemptionMode:
-        """Always use SWAP"""
+        """Always use SWAP, as it is faster than `RECOMPUTE` for heavy models like llama."""
         return PreemptionMode.SWAP
 
 

--- a/vllm/core/policy.py
+++ b/vllm/core/policy.py
@@ -33,6 +33,7 @@ class Policy:
 
 
 class FCFS(Policy):
+
     def __init__(self, **kwargs) -> None:
         super().__init__()
 
@@ -65,7 +66,7 @@ class ReorderPolicy(Policy):
         self,
         seq_groups: Deque[SequenceGroup],
     ) -> Deque[SequenceGroup]:
-        """Sort head withing `max_delay` of the `seq_groups` by length. It reduces padding computation overhead."""
+        """Sort head withing `reorder_window` of the `seq_groups` by length. It reduces padding computation overhead."""
         if len(seq_groups) == 0:
             return seq_groups
         arrival_time_sorted = sorted(seq_groups, key=lambda x: x.metrics.arrival_time)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -167,7 +167,7 @@ class Scheduler:
             # sequence groups are added to the front and the new sequence groups
             # are added to the back.
             leftover_waiting_sequences = deque()
-            if type(self.policy) is not FCFS:
+            if not isinstance(self.policy, FCFS):
                 self.waiting = self.policy.sort(self.waiting)
             while self.waiting:
                 seq_group = self.waiting[0]

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1,6 +1,4 @@
 from collections import deque
-import enum
-import time
 from typing import Deque, Dict, Iterable, List, Optional, Tuple, Union, Set
 
 from vllm.config import CacheConfig, LoRAConfig, SchedulerConfig
@@ -10,6 +8,7 @@ from vllm.core.policy import PolicyFactory, PreemptionMode, FCFS
 from vllm.logger import init_logger
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceStatus)
+import time
 
 logger = init_logger(__name__)
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -163,7 +163,7 @@ class Scheduler:
                 for seq_group in self.running) if self.lora_enabled else None
             seq_lens: List[int] = []
 
-            # Optimization: We do not sort the waiting queue when use FCFS policy since the preempted
+            # Optimization: We do not sort the waiting queue when using FCFS policy since the preempted
             # sequence groups are added to the front and the new sequence groups
             # are added to the back.
             leftover_waiting_sequences = deque()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -226,7 +226,7 @@ class EngineArgs:
                             default=EngineArgs.scheduler_policy,
                             choices=['fcfs', 'reorder'],
                             help='scheduler policy')
-        parser.add_argument('--scheduler_reorder_window',
+        parser.add_argument('--scheduler-reorder-window',
                             type=float,
                             default=EngineArgs.scheduler_reorder_window,
                             help='allowed sequences reorder window(in sec)')

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -336,7 +336,7 @@ class EngineArgs:
                                            model_config.max_model_len,
                                            self.max_paddings,
                                            self.scheduler_policy,
-                                           self.scheduler_max_delay)
+                                           self.scheduler_reorder_window)
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -32,6 +32,8 @@ class EngineArgs:
     max_num_seqs: int = 256
     max_paddings: int = 256
     max_logprobs: int = 5  # OpenAI default value
+    scheduler_policy: str = 'fcfs'
+    scheduler_max_delay: float = 0
     disable_log_stats: bool = False
     revision: Optional[str] = None
     code_revision: Optional[str] = None
@@ -219,6 +221,15 @@ class EngineArgs:
             default=EngineArgs.max_logprobs,
             help=('max number of log probs to return logprobs is specified in'
                   ' SamplingParams'))
+        parser.add_argument('--scheduler-policy',
+                            type=str,
+                            default=EngineArgs.scheduler_policy,
+                            choices=['fcfs', 'throughput'],
+                            help='scheduler policy')
+        parser.add_argument('--scheduler_max_delay',
+                            type=float,
+                            default=EngineArgs.scheduler_max_delay,
+                            help='scheduler max delay')
         parser.add_argument('--disable-log-stats',
                             action='store_true',
                             help='disable logging statistics')
@@ -323,7 +334,9 @@ class EngineArgs:
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,
-                                           self.max_paddings)
+                                           self.max_paddings,
+                                           self.scheduler_policy,
+                                           self.scheduler_max_delay)
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -33,7 +33,7 @@ class EngineArgs:
     max_paddings: int = 256
     max_logprobs: int = 5  # OpenAI default value
     scheduler_policy: str = 'fcfs'
-    scheduler_max_delay: float = 0
+    scheduler_reorder_window: float = 0
     disable_log_stats: bool = False
     revision: Optional[str] = None
     code_revision: Optional[str] = None
@@ -224,12 +224,12 @@ class EngineArgs:
         parser.add_argument('--scheduler-policy',
                             type=str,
                             default=EngineArgs.scheduler_policy,
-                            choices=['fcfs', 'throughput'],
+                            choices=['fcfs', 'reorder'],
                             help='scheduler policy')
-        parser.add_argument('--scheduler_max_delay',
+        parser.add_argument('--scheduler_reorder_window',
                             type=float,
-                            default=EngineArgs.scheduler_max_delay,
-                            help='scheduler max delay')
+                            default=EngineArgs.scheduler_reorder_window,
+                            help='allowed sequences reorder window(in sec)')
         parser.add_argument('--disable-log-stats',
                             action='store_true',
                             help='disable logging statistics')


### PR DESCRIPTION
I noticed that handling Sequences sorted by length gives some performance improvements as we have less percentage of padding tokens. So this PR adds one more policy that makes scheduling less fair by sorting Sequences within acceptable delay. The worst-case scenario is that a seq will not be processed immediately(compared to FIFO), but until all seq in the delay are processed. 
Setting this parameter to 0.1-0.2 may give some thruput improvements when running a web server. And a larger value makes more sense for batch processing. 

All benchmarks are performed on RTX 3090.

fcfs 4aaafdd289f57a82513a7742155e4f1b796c8bdc
```
python benchmarks/benchmark_throughput.py --output-len 64 --num-prompts 1000 --model h2oai/h2ogpt-40
96-llama2-7b-chat --dataset ShareGPT_V3_unfiltered_cleaned_split.json
Namespace(backend='vllm', vllm_scheduler_policy='fcfs', vllm_scheduler_max_delay=0, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', input_len=None, output_len=64, model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', quantization=None, tensor_parallel_size=1, n=1, use_beam_search=False, num_prompts=1000, seed=0, hf_max_batch_size=None, trust_remote_code=False, max_model_len=None, dtype='auto', enforce_eager=False, swap_space=16)
INFO 01-05 13:17:44 llm_engine.py:73] Initializing an LLM engine with config: model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, quantization=None, enforce_eager=False, seed=0)
INFO 01-05 13:17:48 llm_engine.py:227] # GPU blocks: 1011, # CPU blocks: 2048
INFO 01-05 13:17:53 model_runner.py:403] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
INFO 01-05 13:17:53 model_runner.py:407] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode.
INFO 01-05 13:17:56 model_runner.py:449] Graph capturing finished in 4 secs.
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [02:14<00:00,  7.42it/s]
Throughput: 7.42 requests/s, 2438.76 tokens/s
```

```
python benchmarks/benchmark_throughput.py --output-len 64 --num-prompts 1000 --model h2oai/h2ogpt-4096-llama2-7b-chat --dataset ShareGPT_V3_unfiltered_cleaned_split.json --vllm-scheduler-policy throughput --vllm-scheduler-max-delay 0.1
Namespace(backend='vllm', vllm_scheduler_policy='throughput', vllm_scheduler_max_delay=0.1, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', input_len=None, output_len=64, model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', quantization=None, tensor_parallel_size=1, n=1, use_beam_search=False, num_prompts=1000, seed=0, hf_max_batch_size=None, trust_remote_code=False, max_model_len=None, dtype='auto', enforce_eager=False, swap_space=16)
INFO 01-05 13:27:41 llm_engine.py:73] Initializing an LLM engine with config: model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, quantization=None, enforce_eager=False, seed=0)
INFO 01-05 13:27:45 llm_engine.py:227] # GPU blocks: 1011, # CPU blocks: 2048
INFO 01-05 13:27:49 model_runner.py:403] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
INFO 01-05 13:27:49 model_runner.py:407] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode.
INFO 01-05 13:27:53 model_runner.py:449] Graph capturing finished in 4 secs.
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [01:53<00:00,  8.83it/s]
Throughput: 8.83 requests/s, 2904.79 tokens/s
```

Setting the delay to `0` means no reordering, but enable SWAP. 
```
python benchmarks/benchmark_throughput.py --output-len 64 --num-prompts 1000 --model h2oai/h2ogpt-4096-llama2-7b-chat --dataset ShareGPT_V3_unfiltered_cleaned_split.json --vllm-scheduler-policy throughput --vllm-scheduler-max-delay 0
Namespace(backend='vllm', vllm_scheduler_policy='throughput', vllm_scheduler_max_delay=0.0, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', input_len=None, output_len=64, model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', quantization=None, tensor_parallel_size=1, n=1, use_beam_search=False, num_prompts=1000, seed=0, hf_max_batch_size=None, trust_remote_code=False, max_model_len=None, dtype='auto', enforce_eager=False, swap_space=16)
INFO 01-05 13:34:37 llm_engine.py:73] Initializing an LLM engine with config: model='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer='h2oai/h2ogpt-4096-llama2-7b-chat', tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=auto, tensor_parallel_size=1, quantization=None, enforce_eager=False, seed=0)
INFO 01-05 13:34:42 llm_engine.py:227] # GPU blocks: 1011, # CPU blocks: 2048
INFO 01-05 13:34:46 model_runner.py:403] Capturing the model for CUDA graphs. This may lead to unexpected consequences if the model is not static. To run the model in eager mode, set 'enforce_eager=True' or use '--enforce-eager' in the CLI.
INFO 01-05 13:34:46 model_runner.py:407] CUDA graphs can take additional 1~3 GiB memory per GPU. If you are running out of memory, consider decreasing `gpu_memory_utilization` or enforcing eager mode.
INFO 01-05 13:34:50 model_runner.py:449] Graph capturing finished in 4 secs.
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████| 1000/1000 [02:06<00:00,  7.91it/s]
Throughput: 7.91 requests/s, 2601.37 tokens/s
```

A more realistic scenario of handling web requests.
fcfs
```
# python -m vllm.entrypoints.api_server --model h2oai/h2ogpt-4096-llama2-7b-chat --swap-space 16 --disable-log-requests
python benchmarks/benchmark_serving.py --dataset ShareGPT_V3_unfiltered_cleaned_split.json --backend vllm --tokenizer hf-internal-testing/llama-tokenizer --request-rate 100
Namespace(backend='vllm', host='localhost', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', tokenizer='hf-internal-testing/llama-tokenizer', best_of=1, use_beam_search=False, num_prompts=1000, request_rate=100.0, seed=0, trust_remote_code=False)
Token indices sequence length is longer than the specified maximum sequence length for this model (3152 > 2048). Running this sequence through the model will result in indexing errors
Total time: 366.12 s
Throughput: 2.73 requests/s
Average latency: 173.05 s
Average latency per token: 0.67 s
Average tokens/s: 1306.1809333710682
Average latency per output token: 4.33 s
Average output tokens/s: 669.5195394394392
```
```
# python -m vllm.entrypoints.api_server --model h2oai/h2ogpt-4096-llama2-7b-chat --swap-space 16 --disable-log-requests --scheduler-policy throughput --scheduler_max_delay 0.0
python benchmarks/benchmark_serving.py --dataset ShareGPT_V3_unfiltered_cleaned_split.json --backend vllm --tokenizer hf-internal-testing/llama-tokenizer --request-rate 100
Namespace(backend='vllm', host='localhost', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', tokenizer='hf-internal-testing/llama-tokenizer', best_of=1, use_beam_search=False, num_prompts=1000, request_rate=100.0, seed=0, trust_remote_code=False)
Token indices sequence length is longer than the specified maximum sequence length for this model (3152 > 2048). Running this sequence through the model will result in indexing errors
Total time: 337.67 s
Throughput: 2.96 requests/s
Average latency: 157.70 s
Average latency per token: 0.61 s
Average tokens/s: 1416.2474011598774
Average latency per output token: 3.94 s
Average output tokens/s: 725.937183380621
```

```
# python -m vllm.entrypoints.api_server --model h2oai/h2ogpt-4096-llama2-7b-chat --swap-space 16 --disable-log-requests --scheduler-policy throughput --scheduler_max_delay 0.1
python benchmarks/benchmark_serving.py --dataset ShareGPT_V3_unfiltered_cleaned_split.json --backend vllm --tokenizer hf-internal-testing/llama-tokenizer --request-rate 100
Namespace(backend='vllm', host='localhost', port=8000, dataset='ShareGPT_V3_unfiltered_cleaned_split.json', tokenizer='hf-internal-testing/llama-tokenizer', best_of=1, use_beam_search=False, num_prompts=1000, request_rate=100.0, seed=0, trust_remote_code=False)
Token indices sequence length is longer than the specified maximum sequence length for this model (3152 > 2048). Running this sequence through the model will result in indexing errors
Total time: 333.97 s
Throughput: 2.99 requests/s
Average latency: 155.62 s
Average latency per token: 0.60 s
Average tokens/s: 1431.9384763210942
Average latency per output token: 3.91 s
Average output tokens/s: 733.9800824513756
```

`python benchmarks/benchmark_throughput.py --output-len 64 --num-prompts 1000 --model h2oai/h2ogpt-40
96-llama2-7b-chat --dataset ShareGPT_V3_unfiltered_cleaned_split.json`
| Policy | Throughput, tokens/s |
| ----------- | ----------- |
| fcfs | 2438  |
| throughput(delay=0) | 2601 | 
| throughput(delay=0.1) | 2904 |

`python benchmarks/benchmark_serving.py --dataset ShareGPT_V3_unfiltered_cleaned_split.json --backend vllm --tokenizer hf-internal-testing/llama-tokenizer --request-rate 100`
| Policy | Average output tokens/s|
| ----------- | ----------- |
| fcfs | 669  |
| throughput(delay=0) | 725 | 
| throughput(delay=0.1) | 733 |  

