### PR TITLE
Compute logits*V in FP32 in attention kernel to improve numerical accuracy

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -281,6 +281,7 @@ __device__ void paged_attention_kernel(
   // Each thread will fetch 16 bytes from the value cache at a time.
   constexpr int V_VEC_SIZE = MIN(16 / sizeof(scalar_t), BLOCK_SIZE);
   using V_vec = typename Vec<scalar_t, V_VEC_SIZE>::Type;
+  using Float_V_vec = typename FloatVec<V_vec>::Type;
   using L_vec = typename Vec<scalar_t, V_VEC_SIZE>::Type;
   using Float_L_vec = typename FloatVec<L_vec>::Type;
 
@@ -304,8 +305,7 @@ __device__ void paged_attention_kernel(
     const int64_t physical_block_number = static_cast<int64_t>(block_table[block_idx]);
     const int physical_block_offset = (lane % NUM_V_VECS_PER_ROW) * V_VEC_SIZE;
     const int token_idx = block_idx * BLOCK_SIZE + physical_block_offset;
-    L_vec logits_vec;
-    from_float(logits_vec, *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx));
+    Float_L_vec logits_vec_float = *reinterpret_cast<Float_L_vec*>(logits + token_idx - start_token_idx);
 
     const scalar_t* v_ptr = v_cache + physical_block_number * kv_block_stride
                                     + kv_head_idx * kv_head_stride;
@@ -325,7 +325,8 @@ __device__ void paged_attention_kernel(
             v_vec_ptr[j] = token_idx + j < context_len ? v_vec_ptr[j] : zero_value;
           }
         }
-        accs[i] += dot(logits_vec, v_vec);
+        Float_V_vec v_vec_float = to_float(v_vec);
+        accs[i] += dot(logits_vec_float, v_vec_float);
       }
     }
   }

--- a/csrc/attention/dtype_bfloat16.cuh
+++ b/csrc/attention/dtype_bfloat16.cuh
@@ -438,6 +438,26 @@ inline __device__ float to_float(__nv_bfloat16 u) {
   return __bfloat162float(u);
 }
 
+inline __device__ float2 to_float(__nv_bfloat162 u) {
+  return __bfloat1622float2(u);
+}
+
+inline __device__ Float4_ to_float(bf16_4_t u) {
+  Float4_ tmp;
+  tmp.x = __bfloat1622float2(u.x);
+  tmp.y = __bfloat1622float2(u.y);
+  return tmp;
+}
+
+inline __device__ Float8_ to_float(bf16_8_t u) {
+  Float8_ tmp;
+  tmp.x = __bfloat1622float2(u.x);
+  tmp.y = __bfloat1622float2(u.y);
+  tmp.z = __bfloat1622float2(u.z);
+  tmp.w = __bfloat1622float2(u.w);
+  return tmp;
+}
+
 // Zero-out a variable.
 inline __device__ void zero(__nv_bfloat16& dst) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 800


### PR DESCRIPTION
Before this PR: Cast `logits` from FP32 to BF16/FP16, then compute `dot(logits, V)`.
After this PR: Cast `V` from BF16/FP16 to FP32, then compute `dot(logits, V)`.