### PR TITLE
Update a more user-friendly error message, offering more considerate advice for beginners, when using V100 GPU #1901

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -231,4 +231,6 @@ def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):
             raise ValueError(
                 "Bfloat16 is only supported on GPUs with compute capability "
                 f"of at least 8.0. Your {gpu_name} GPU has compute capability "
-                f"{compute_capability[0]}.{compute_capability[1]}.")
+                f"{compute_capability[0]}.{compute_capability[1]}."
+                f" You can explicitly specify the data type by using the --dtype option, for example: --dtype=half."
+            )


### PR DESCRIPTION
For the sake of future beginners, it is suggested to provide guidance in the error message, suggesting users to add --dtype="half" to specify the data type.
in issue #1901