### PR TITLE
CI: make sure benchmark script exit on error

### DIFF
--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -7,8 +7,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # run benchmarks and upload the result to buildkite
 python3 benchmarks/benchmark_latency.py 2>&1 | tee benchmark_latency.txt
+bench_latency_exit_code=$?
 
 python3 benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 2>&1 | tee benchmark_throughput.txt
+bench_throughput_exit_code=$?
 
 # write the results into a markdown file
 echo "### Latency Benchmarks" >> benchmark_results.md
@@ -22,3 +24,12 @@ sed -n '$p' benchmark_throughput.txt >> benchmark_results.md
 
 # upload the results to buildkite
 /workspace/buildkite-agent annotate --style "info" --context "benchmark-results" < benchmark_results.md
+
+# exit with the exit code of the benchmarks
+if [ $bench_latency_exit_code -ne 0 ]; then
+    exit $bench_latency_exit_code
+fi
+
+if [ $bench_throughput_exit_code -ne 0 ]; then
+    exit $bench_throughput_exit_code
+fi


### PR DESCRIPTION
Seen in https://buildkite.com/vllm/ci/builds/239#018d1090-bac5-4167-a34a-46c351a52ee0, if the benchmark script fails, the test suite should fail as well. This is not the case currently. 