### PR TITLE
ci: retry on build failure as well

### DIFF
--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -9,6 +9,10 @@ steps:
       - "docker push {{ docker_image }}"
     env:
       DOCKER_BUILDKIT: "1"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 5
   - wait
 
   {% for step in steps %}


### PR DESCRIPTION
as seen in https://buildkite.com/vllm/ci/builds/259#018d1365-3fa1-4f3b-9cb2-97106827129b, we need to perform retry because our docker builders are also on spot fleet. 