### PR TITLE
relax pydantic version to '>=1.9.0,<3'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ transformers >= 4.36.0  # Required for Mixtral.
 xformers == 0.0.23.post1  # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]
-pydantic == 1.10.13  # Required for OpenAI server.
+pydantic >= 1.9.0, < 3  # Required for OpenAI server.
 aioprometheus[starlette]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -3,7 +3,10 @@
 import time
 from typing import Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 
 from vllm.utils import random_uuid
 


### PR DESCRIPTION
closes #1396
closes #2313 
closes #2322 

relaxes the pydantic version, which was previously pinned to 1.10.13 due to openai-python's dependency requirements. since openai has loosened their requirement, vllm should as well.

this is a retry of https://github.com/vllm-project/vllm/pull/2322. that PR has gotten a bit stale after the openai refactor, and there's been no communication from the author for a couple weeks