### PR TITLE
Minor fix in prefill cache example

### DIFF
--- a/examples/offline_inference_with_prefix.py
+++ b/examples/offline_inference_with_prefix.py
@@ -45,7 +45,7 @@ prefix_pos = len(llm.llm_engine.tokenizer.encode(prefix)) - 1
 # to calculate the prefix and cache it.
 outputs = llm.generate(generating_prompts[0],
                        sampling_params,
-                       prefix_pos=prefix_pos)
+                       prefix_pos=[prefix_pos])
 
 # Subsequent batches can leverage the cached prefix
 outputs = llm.generate(generating_prompts,

--- a/examples/offline_inference_with_prefix.py
+++ b/examples/offline_inference_with_prefix.py
@@ -40,8 +40,16 @@ print("-" * 80)
 # -1 since the last token can change when concatenating prompts.
 prefix_pos = len(llm.llm_engine.tokenizer.encode(prefix)) - 1
 
-# Generate with prefix
-outputs = llm.generate(generating_prompts, sampling_params,
+# The llm.generate call will batch all prompts and send the batch at once if resources allow.
+# The prefix will only be cached after the first batch is processed, so we need to call generate once
+# to calculate the prefix and cache it.
+outputs = llm.generate(generating_prompts[0],
+                       sampling_params,
+                       prefix_pos=prefix_pos)
+
+# Subsequent batches can leverage the cached prefix
+outputs = llm.generate(generating_prompts,
+                       sampling_params,
                        prefix_pos=[prefix_pos] * len(generating_prompts))
 
 # Print the outputs. You should see the same outputs as before


### PR DESCRIPTION
In offline_inference_with_prefix.py, we pass a batch of prompts with prefix_pos to the llm.generate call. However, the llm.generate call will batch all prompts and send the batch at once if resources allow. The prefix will only be cached after the first batch is processed, so we need to call generate once to calculate the prefix, cache it, and then use a subsequent call to leverage the cached prefix.

Note: This issue was identified while attempting to do prefix cache for mistral7b, which is not supported with a sliding window. Nevertheless, this call will succeed because only the initial prefix attention computation is executed.

## Test
Test done for llama7b model


