### PR TITLE
Prefix caching and deallocation mechanism

### DIFF
--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -95,6 +95,14 @@ Below, you can find an explanation of every engine argument for vLLM:
     For example, a value of 0.5 would imply 50% GPU memory utilization.
     If unspecified, will use the default value of 0.9.
 
+.. option:: --prefix-caching-memory-utilization <fraction>
+
+    The fraction of GPU memory to be used for the prefix caching, which can range from 0 to --gpu-memory-utilization. 
+    For example, a value of 0.5 would imply 50% GPU memory utilization.
+    If unspecified, will use the default value of 0. A value of 0 means no prefix caching at all.
+    The size of the prefixes relative to the length of the rest of the prompts and the generated
+    sequences should dictate the relative value of this parameter with respect to gpu-memory-utilization.
+
 .. option:: --max-num-batched-tokens <tokens>
 
     Maximum number of batched tokens per iteration.

--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -69,7 +69,7 @@ def test_prefix_caching_with_multiple_prefixes(
     reload(parallel_state)
     llm = LLM(model="facebook/opt-125m",
               prefix_pool_max_capacity=prefix_pool_max_capacity)
-    
+
     # Use 10 different prefixes:
     for i in range(prefix_pool_max_capacity + 1):
         new_prefix = str(i) + ' ' + prefix

--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -2,7 +2,6 @@
 
 Run `pytest tests/prefix_caching/test_prefix_caching.py`.
 """
-from typing import Optional
 from importlib import reload
 
 import pytest
@@ -36,7 +35,8 @@ def test_prefix_caching(
     # to fail with the message: "AssertionError: tensor model parallel group is
     # already initialized."
     reload(parallel_state)
-    llm = LLM(model=model, prefix_pool_memory_utilization=prefix_pool_memory_utilization)
+    llm = LLM(model=model,
+              prefix_pool_memory_utilization=prefix_pool_memory_utilization)
     # -1 since the last token can change when concatenating prompts.
     prefix_pos = len(llm.llm_engine.tokenizer.encode(prefix)) - 1
     prompts = [prefix + prompt for prompt in example_prompts]
@@ -51,6 +51,7 @@ def test_prefix_caching(
                 output_with_prefix.outputs[0].token_ids)
     if prefix_pool_memory_utilization == 0:
         assert len(llm.llm_engine.scheduler.prefix_pool.prefixes) == 0
+
 
 @pytest.mark.parametrize("model", ["facebook/opt-125m"])
 @pytest.mark.parametrize("max_tokens", [16])
@@ -79,12 +80,11 @@ def test_prefix_caching_with_multiple_prefixes(
         sampling_params = SamplingParams(temperature=0.0,
                                          max_tokens=max_tokens)
         outputs_with_prefix = llm.generate(prompts,
-                         sampling_params,
-                         prefix_pos=[prefix_pos] * len(prompts))
-        outputs_without_prefix = llm.generate(prompts,
-                         sampling_params)
+                                           sampling_params,
+                                           prefix_pos=[prefix_pos] *
+                                           len(prompts))
+        outputs_without_prefix = llm.generate(prompts, sampling_params)
         for output_without_prefix, output_with_prefix in zip(
-            outputs_without_prefix, outputs_with_prefix):
+                outputs_without_prefix, outputs_with_prefix):
             assert (output_without_prefix.outputs[0].token_ids ==
-                output_with_prefix.outputs[0].token_ids)
-
+                    output_with_prefix.outputs[0].token_ids)

--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -62,14 +62,18 @@ def test_prefix_caching_with_multiple_prefixes(
     Tests that the scheduler prefix pool size (length) does not go over the
     maximum capacity at any moment in time.
     """
+    # IMPORTANT: If this line is removed from here, adding more than 1 item to
+    # any of the parametrization lists above causes all tests but the first one
+    # to fail with the message: "AssertionError: tensor model parallel group is
+    # already initialized."
     reload(parallel_state)
     llm = LLM(model="facebook/opt-125m",
               prefix_pool_max_capacity=prefix_pool_max_capacity)
-    # -1 since the last token can change when concatenating prompts.
-
+    
     # Use 10 different prefixes:
     for i in range(prefix_pool_max_capacity + 1):
         new_prefix = str(i) + ' ' + prefix
+        # -1 since the last token can change when concatenating prompts.
         prefix_pos = len(llm.llm_engine.tokenizer.encode(new_prefix)) - 1
         prompts = [new_prefix + prompt for prompt in example_prompts]
         sampling_params = SamplingParams(temperature=0.0,

--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -2,8 +2,12 @@
 
 Run `pytest tests/prefix_caching/test_prefix_caching.py`.
 """
+from typing import Optional
+from importlib import reload
+
 import pytest
 
+import vllm.model_executor.parallel_utils.parallel_state as parallel_state
 from vllm import LLM, SamplingParams
 
 prefix = (
@@ -20,12 +24,19 @@ prefix = (
 
 @pytest.mark.parametrize("model", ["facebook/opt-125m"])
 @pytest.mark.parametrize("max_tokens", [16])
+@pytest.mark.parametrize("prefix_pool_max_capacity", [None, 1, 2])
 def test_prefix_caching(
     example_prompts,
     model: str,
     max_tokens: int,
+    prefix_pool_max_capacity: Optional[int],
 ):
-    llm = LLM(model=model)
+    # IMPORTANT: If this line is removed from here, adding more than 1 item to
+    # any of the parametrization lists above causes all tests but the first one
+    # to fail with the message: "AssertionError: tensor model parallel group is
+    # already initialized."
+    reload(parallel_state)
+    llm = LLM(model=model, prefix_pool_max_capacity=prefix_pool_max_capacity)
     # -1 since the last token can change when concatenating prompts.
     prefix_pos = len(llm.llm_engine.tokenizer.encode(prefix)) - 1
     prompts = [prefix + prompt for prompt in example_prompts]
@@ -39,3 +50,32 @@ def test_prefix_caching(
         assert (output_without_prefix.outputs[0].token_ids ==
                 output_with_prefix.outputs[0].token_ids)
     assert len(llm.llm_engine.scheduler.prefix_pool.prefixes) == 1
+
+
+@pytest.mark.parametrize("model", ["facebook/opt-125m"])
+@pytest.mark.parametrize("max_tokens", [16])
+@pytest.mark.parametrize("prefix_pool_max_capacity", [1, 2, 4, 6])
+def test_prefix_caching_with_multiple_prefixes(
+        example_prompts, model: str, max_tokens: int,
+        prefix_pool_max_capacity: Optional[int]):
+    """
+    Tests that the scheduler prefix pool size (length) does not go over the
+    maximum capacity at any moment in time.
+    """
+    reload(parallel_state)
+    llm = LLM(model="facebook/opt-125m",
+              prefix_pool_max_capacity=prefix_pool_max_capacity)
+    # -1 since the last token can change when concatenating prompts.
+
+    # Use 10 different prefixes:
+    for i in range(prefix_pool_max_capacity + 1):
+        new_prefix = str(i) + ' ' + prefix
+        prefix_pos = len(llm.llm_engine.tokenizer.encode(new_prefix)) - 1
+        prompts = [new_prefix + prompt for prompt in example_prompts]
+        sampling_params = SamplingParams(temperature=0.0,
+                                         max_tokens=max_tokens)
+        _ = llm.generate(prompts,
+                         sampling_params,
+                         prefix_pos=[prefix_pos] * len(prompts))
+        assert len(llm.llm_engine.scheduler.prefix_pool.prefixes) == min(
+            i + 1, prefix_pool_max_capacity)

--- a/tests/prefix_caching/test_prefix_pool.py
+++ b/tests/prefix_caching/test_prefix_pool.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture
 def no_max_capacity_prefix_pool() -> PrefixPool:
-    return PrefixPool(block_size=32)
+    return PrefixPool(block_size=32, max_capacity_in_blocks=float('inf'))
 
 
 def test_prefix_length_behaviours(no_max_capacity_prefix_pool: PrefixPool):
@@ -39,9 +39,12 @@ def test_same_prefix_added_twice(no_max_capacity_prefix_pool: PrefixPool):
 
 
 def test_prefix_pool_max_capacity():
-    max_capacity = 1
+    """
+    Tests that the pool is evicting prefixes when it reaches max capacity.
+    """
+    max_capacity_in_blocks = 2
     max_capacity_prefix_pool = PrefixPool(block_size=32,
-                                          max_capacity=max_capacity)
+                                          max_capacity_in_blocks=max_capacity_in_blocks)
 
     # Tests that on the third insertion, new object is created because capacity limits reached,
     # but that the newly created object is equal to the old object
@@ -53,20 +56,73 @@ def test_prefix_pool_max_capacity():
         list(range(max_capacity_prefix_pool.block_size)))
     assert prefix_1 is not prefix_3
     assert prefix_1 == prefix_3
+    
+    assert len(max_capacity_prefix_pool) == 1
+    assert max_capacity_prefix_pool.current_block_usage == 1
 
-    # Tests that the max capacity remains the same
+def test_current_block_usage():
+    """
+    Tests that the current_block_usage property remains the same thorough the
+    lifetime of the pool when adding prefixes that are always the same length equal
+    to the max capacity.
+    """
+    max_capacity_in_blocks = 2
+    max_capacity_prefix_pool = PrefixPool(block_size=32,
+                                          max_capacity_in_blocks=max_capacity_in_blocks)
+    
     for i in range(10):
         _ = max_capacity_prefix_pool.add_or_get_prefix(
-            list(range(max_capacity_prefix_pool.block_size + i)))
-        assert len(max_capacity_prefix_pool) == max_capacity
+            list(range(max_capacity_prefix_pool.block_size * max_capacity_in_blocks)))
+        assert len(max_capacity_prefix_pool) == 1
+        assert max_capacity_prefix_pool.current_block_usage == max_capacity_in_blocks
 
+def test_prefix_truncation_1():
+    """
+    Tests that prefix is truncated if it exceeds the max capacity.
+    """
+    prefix_pool = PrefixPool(block_size=1, max_capacity_in_blocks=2)
+    prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4])
+    assert prefix.token_ids == (1, 2)
+
+def test_prefix_truncation_2():
+    """
+    Testing truncation on non-block boundary
+    """
+    prefix_pool = PrefixPool(block_size=2, max_capacity_in_blocks=3)
+    prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4, 5])
+    assert prefix.token_ids == (1, 2, 3, 4)
+
+def test_prefix_truncation_3():
+    """
+    Tests truncation because of both max capacity exceeded and no block boundary.
+    """
+    prefix_pool = PrefixPool(block_size=2, max_capacity_in_blocks=2)
+    prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4, 5])
+    assert prefix.token_ids == (1, 2, 3, 4)
+
+def test_none_prefix_returned_1():
+    """
+    Tests that when the max capacity is zero, no prefix is created and None is returned.
+    """
+    prefix_pool = PrefixPool(block_size=32, max_capacity_in_blocks=0)
+    prefix = prefix_pool.add_or_get_prefix(
+        list(range(prefix_pool.block_size)))
+    assert prefix is None
+    assert len(prefix_pool) == 0
+
+def test_none_prefix_returned_2():
+    """
+    Tests that when prefix length is less than block size, a None prefix is returned.
+    """
+    prefix_pool = PrefixPool(block_size=32, max_capacity_in_blocks=2)
+    prefix = prefix_pool.add_or_get_prefix(
+        list(range(prefix_pool.block_size - 1)))
+    assert prefix is None
+    assert len(prefix_pool) == 0
 
 def test_assertion_raised_with_invalid_max_capacity():
     with pytest.raises(AssertionError):
-        _ = PrefixPool(32, max_capacity=-1)
-
-    with pytest.raises(AssertionError):
-        _ = PrefixPool(32, max_capacity=0)
+        _ = PrefixPool(32, max_capacity_in_blocks=-1)
 
 
 if __name__ == "__main__":

--- a/tests/prefix_caching/test_prefix_pool.py
+++ b/tests/prefix_caching/test_prefix_pool.py
@@ -1,0 +1,61 @@
+from vllm.prefix import PrefixPool
+
+import pytest
+
+@pytest.fixture
+def no_max_capacity_prefix_pool() -> PrefixPool:
+    return PrefixPool(block_size=32)
+
+
+def test_prefix_length_behaviours(no_max_capacity_prefix_pool: PrefixPool):
+    """
+    This test checks that prefixes of length less than pool.block_size are not created and are not added to the pool.
+    It also checks that prefixes of length equal to or greater to pool.block_size are created and added to the pool.
+    """
+    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size - 1)))
+    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
+    prefix_3 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size * 2)))
+    assert prefix_1 is None
+    assert prefix_2 is not None
+    assert prefix_3 is not None
+    assert len(no_max_capacity_prefix_pool) == 2
+
+def test_same_prefix_added_twice(no_max_capacity_prefix_pool: PrefixPool):
+    """
+    Tests that when a prefix is added more than once to the pool, all subsequent additions
+    return the same prefix object that was created the first time.
+    """
+    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
+    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
+    assert prefix_1 is prefix_2
+    assert len(no_max_capacity_prefix_pool) == 1
+
+def test_prefix_pool_max_capacity():
+    max_capacity = 1
+    max_capacity_prefix_pool = PrefixPool(block_size=32, max_capacity=max_capacity)
+
+    # Tests that on the third insertion, new object is created because capacity limits reached,
+    # but that the newly created object is equal to the old object
+    prefix_1 = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size)))
+    _ = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size * 2)))
+    prefix_3 = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size)))
+    assert prefix_1 is not prefix_3
+    assert prefix_1 == prefix_3
+
+    # Tests that the max capacity remains the same
+    for i in range(10):
+        _ = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size + i)))
+        assert len(max_capacity_prefix_pool) == max_capacity
+
+
+def test_assertion_raised_with_invalid_max_capacity():
+    with pytest.raises(AssertionError):
+        _ = PrefixPool(32, max_capacity=-1)
+
+    with pytest.raises(AssertionError):
+        _ = PrefixPool(32, max_capacity=0)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])

--- a/tests/prefix_caching/test_prefix_pool.py
+++ b/tests/prefix_caching/test_prefix_pool.py
@@ -43,8 +43,8 @@ def test_prefix_pool_max_capacity():
     Tests that the pool is evicting prefixes when it reaches max capacity.
     """
     max_capacity_in_blocks = 2
-    max_capacity_prefix_pool = PrefixPool(block_size=32,
-                                          max_capacity_in_blocks=max_capacity_in_blocks)
+    max_capacity_prefix_pool = PrefixPool(
+        block_size=32, max_capacity_in_blocks=max_capacity_in_blocks)
 
     # Tests that on the third insertion, new object is created because capacity limits reached,
     # but that the newly created object is equal to the old object
@@ -56,9 +56,10 @@ def test_prefix_pool_max_capacity():
         list(range(max_capacity_prefix_pool.block_size)))
     assert prefix_1 is not prefix_3
     assert prefix_1 == prefix_3
-    
+
     assert len(max_capacity_prefix_pool) == 1
     assert max_capacity_prefix_pool.current_block_usage == 1
+
 
 def test_current_block_usage():
     """
@@ -67,14 +68,17 @@ def test_current_block_usage():
     to the max capacity.
     """
     max_capacity_in_blocks = 2
-    max_capacity_prefix_pool = PrefixPool(block_size=32,
-                                          max_capacity_in_blocks=max_capacity_in_blocks)
-    
-    for i in range(10):
+    max_capacity_prefix_pool = PrefixPool(
+        block_size=32, max_capacity_in_blocks=max_capacity_in_blocks)
+
+    for _ in range(10):
         _ = max_capacity_prefix_pool.add_or_get_prefix(
-            list(range(max_capacity_prefix_pool.block_size * max_capacity_in_blocks)))
+            list(
+                range(max_capacity_prefix_pool.block_size *
+                      max_capacity_in_blocks)))
         assert len(max_capacity_prefix_pool) == 1
         assert max_capacity_prefix_pool.current_block_usage == max_capacity_in_blocks
+
 
 def test_prefix_truncation_1():
     """
@@ -84,6 +88,7 @@ def test_prefix_truncation_1():
     prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4])
     assert prefix.token_ids == (1, 2)
 
+
 def test_prefix_truncation_2():
     """
     Testing truncation on non-block boundary
@@ -91,6 +96,7 @@ def test_prefix_truncation_2():
     prefix_pool = PrefixPool(block_size=2, max_capacity_in_blocks=3)
     prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4, 5])
     assert prefix.token_ids == (1, 2, 3, 4)
+
 
 def test_prefix_truncation_3():
     """
@@ -100,15 +106,16 @@ def test_prefix_truncation_3():
     prefix = prefix_pool.add_or_get_prefix([1, 2, 3, 4, 5])
     assert prefix.token_ids == (1, 2, 3, 4)
 
+
 def test_none_prefix_returned_1():
     """
     Tests that when the max capacity is zero, no prefix is created and None is returned.
     """
     prefix_pool = PrefixPool(block_size=32, max_capacity_in_blocks=0)
-    prefix = prefix_pool.add_or_get_prefix(
-        list(range(prefix_pool.block_size)))
+    prefix = prefix_pool.add_or_get_prefix(list(range(prefix_pool.block_size)))
     assert prefix is None
     assert len(prefix_pool) == 0
+
 
 def test_none_prefix_returned_2():
     """
@@ -119,6 +126,7 @@ def test_none_prefix_returned_2():
         list(range(prefix_pool.block_size - 1)))
     assert prefix is None
     assert len(prefix_pool) == 0
+
 
 def test_assertion_raised_with_invalid_max_capacity():
     with pytest.raises(AssertionError):

--- a/tests/prefix_caching/test_prefix_pool.py
+++ b/tests/prefix_caching/test_prefix_pool.py
@@ -2,6 +2,7 @@ from vllm.prefix import PrefixPool
 
 import pytest
 
+
 @pytest.fixture
 def no_max_capacity_prefix_pool() -> PrefixPool:
     return PrefixPool(block_size=32)
@@ -12,39 +13,51 @@ def test_prefix_length_behaviours(no_max_capacity_prefix_pool: PrefixPool):
     This test checks that prefixes of length less than pool.block_size are not created and are not added to the pool.
     It also checks that prefixes of length equal to or greater to pool.block_size are created and added to the pool.
     """
-    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size - 1)))
-    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
-    prefix_3 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size * 2)))
+    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(no_max_capacity_prefix_pool.block_size - 1)))
+    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(no_max_capacity_prefix_pool.block_size)))
+    prefix_3 = no_max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(no_max_capacity_prefix_pool.block_size * 2)))
     assert prefix_1 is None
     assert prefix_2 is not None
     assert prefix_3 is not None
     assert len(no_max_capacity_prefix_pool) == 2
+
 
 def test_same_prefix_added_twice(no_max_capacity_prefix_pool: PrefixPool):
     """
     Tests that when a prefix is added more than once to the pool, all subsequent additions
     return the same prefix object that was created the first time.
     """
-    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
-    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(list(range(no_max_capacity_prefix_pool.block_size)))
+    prefix_1 = no_max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(no_max_capacity_prefix_pool.block_size)))
+    prefix_2 = no_max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(no_max_capacity_prefix_pool.block_size)))
     assert prefix_1 is prefix_2
     assert len(no_max_capacity_prefix_pool) == 1
 
+
 def test_prefix_pool_max_capacity():
     max_capacity = 1
-    max_capacity_prefix_pool = PrefixPool(block_size=32, max_capacity=max_capacity)
+    max_capacity_prefix_pool = PrefixPool(block_size=32,
+                                          max_capacity=max_capacity)
 
     # Tests that on the third insertion, new object is created because capacity limits reached,
     # but that the newly created object is equal to the old object
-    prefix_1 = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size)))
-    _ = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size * 2)))
-    prefix_3 = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size)))
+    prefix_1 = max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(max_capacity_prefix_pool.block_size)))
+    _ = max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(max_capacity_prefix_pool.block_size * 2)))
+    prefix_3 = max_capacity_prefix_pool.add_or_get_prefix(
+        list(range(max_capacity_prefix_pool.block_size)))
     assert prefix_1 is not prefix_3
     assert prefix_1 == prefix_3
 
     # Tests that the max capacity remains the same
     for i in range(10):
-        _ = max_capacity_prefix_pool.add_or_get_prefix(list(range(max_capacity_prefix_pool.block_size + i)))
+        _ = max_capacity_prefix_pool.add_or_get_prefix(
+            list(range(max_capacity_prefix_pool.block_size + i)))
         assert len(max_capacity_prefix_pool) == max_capacity
 
 

--- a/vllm/block.py
+++ b/vllm/block.py
@@ -60,6 +60,12 @@ class PhysicalTokenBlock:
         self.block_number = block_number
         self.block_size = block_size
 
+        # Contains the number of sequences that share this block that
+        # are currently allocated in the same device as this block.
+        # Notice that prefix blocks will have an extra 1 added to this
+        # reference count to guarantee that prefix blocks are not deallocated
+        # by the standard way that the block manager uses to free the memory
+        # for blocks.
         self.ref_count = 0
 
     def __repr__(self) -> str:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -286,12 +286,14 @@ class CacheConfig:
         swap_space: int,
         cache_dtype: str,
         sliding_window: Optional[int] = None,
+        prefix_pool_max_capacity: Optional[int] = None
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
         self.swap_space_bytes = swap_space * _GB
         self.cache_dtype = cache_dtype
         self.sliding_window = sliding_window
+        self.prefix_pool_max_capacity = prefix_pool_max_capacity
         self._verify_args()
         self._verify_cache_dtype()
 
@@ -304,6 +306,11 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
+        if self.prefix_pool_max_capacity is not None:
+            if self.prefix_pool_max_capacity <= 0:
+                raise ValueError(
+                    "prefix_pool_max_capacity must be positive. Got "
+                    f"{self.prefix_pool_max_capacity}.")
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -307,13 +307,13 @@ class CacheConfig:
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
         if self.prefix_pool_memory_utilization < 0:
-            raise ValueError("prefix_pool_memory_utilization must be non negative. "
-                             f"{self.prefix_pool_memory_utilization}.")
+            raise ValueError(
+                "prefix_pool_memory_utilization must be non negative. "
+                f"{self.prefix_pool_memory_utilization}.")
         if self.prefix_pool_memory_utilization > self.gpu_memory_utilization:
             raise ValueError(
                 "prefix_pool_memory_utilization must be less than or equal to "
-                "gpu_memory_utilization."
-            )
+                "gpu_memory_utilization.")
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -286,14 +286,14 @@ class CacheConfig:
         swap_space: int,
         cache_dtype: str,
         sliding_window: Optional[int] = None,
-        prefix_pool_max_capacity: Optional[int] = None
+        prefix_pool_memory_utilization: float = 0
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
         self.swap_space_bytes = swap_space * _GB
         self.cache_dtype = cache_dtype
         self.sliding_window = sliding_window
-        self.prefix_pool_max_capacity = prefix_pool_max_capacity
+        self.prefix_pool_memory_utilization = prefix_pool_memory_utilization
         self._verify_args()
         self._verify_cache_dtype()
 
@@ -306,9 +306,14 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
-        if self.prefix_pool_max_capacity is not None and self.prefix_pool_max_capacity <= 0:
-            raise ValueError("prefix_pool_max_capacity must be positive. Got "
-                             f"{self.prefix_pool_max_capacity}.")
+        if self.prefix_pool_memory_utilization < 0:
+            raise ValueError("prefix_pool_memory_utilization must be non negative. "
+                             f"{self.prefix_pool_memory_utilization}.")
+        if self.prefix_pool_memory_utilization > self.gpu_memory_utilization:
+            raise ValueError(
+                "prefix_pool_memory_utilization must be less than or equal to "
+                "gpu_memory_utilization."
+            )
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -279,15 +279,13 @@ class CacheConfig:
         cache_dtype: Data type for kv cache storage.
     """
 
-    def __init__(
-        self,
-        block_size: int,
-        gpu_memory_utilization: float,
-        swap_space: int,
-        cache_dtype: str,
-        sliding_window: Optional[int] = None,
-        prefix_pool_memory_utilization: float = 0
-    ) -> None:
+    def __init__(self,
+                 block_size: int,
+                 gpu_memory_utilization: float,
+                 swap_space: int,
+                 cache_dtype: str,
+                 sliding_window: Optional[int] = None,
+                 prefix_pool_memory_utilization: float = 0) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
         self.swap_space_bytes = swap_space * _GB

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -349,6 +349,7 @@ class BlockSpaceManager:
         block_table = prefix.block_table
         for block in set(block_table):
             self.gpu_allocator.force_free(block)
+        prefix.block_table = None
 
     def reset(self) -> None:
         for block_table in self.block_tables.values():

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -140,15 +140,15 @@ class BlockSpaceManager:
         num_prefix_blocks = 0
 
         prefix = seq_group.prefix
-        # Update the reference counts to the prefix from all the seqs
-        # in this group.
-        prefix.seq_ref_count += seq_group.num_seqs()
-        if prefix is not None and prefix.allocated:
-            # Prefix has already been allocated. Use the existing block table.
-            num_prompt_blocks -= prefix.get_num_blocks()
-            for block in prefix.block_table:
-                block.ref_count += seq_group.num_seqs()
-                block_table.append(block)
+        if prefix is not None:
+            prefix.seq_ref_count += seq_group.num_seqs()
+
+            if prefix.allocated:
+                # Prefix has already been allocated. Use the existing block table.
+                num_prompt_blocks -= prefix.get_num_blocks()
+                for block in prefix.block_table:
+                    block.ref_count += seq_group.num_seqs()
+                    block_table.append(block)
 
         for logical_idx in range(num_prompt_blocks):
             if (self.block_sliding_window is not None

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -99,9 +99,8 @@ class Scheduler:
 
         # Create the prefix pool to cache the prefixes.
         self.prefix_pool = PrefixPool(
-            self.cache_config.block_size, 
-            max_capacity=self.cache_config.prefix_pool_max_capacity
-        )
+            self.cache_config.block_size,
+            max_capacity=self.cache_config.prefix_pool_max_capacity)
 
         # Sequence groups in the WAITING state.
         self.waiting: Deque[SequenceGroup] = deque()

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -424,7 +424,7 @@ class Scheduler:
         """
         prefixes_to_free = self.prefix_pool.get_prefixes_to_free()
         for prefix in prefixes_to_free:
-            self.block_manager.free_prefix(prefix)
+            self.block_manager.free_prefix_blocks(prefix)
 
     def _allocate(self, seq_group: SequenceGroup) -> None:
         self.block_manager.allocate(seq_group)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -98,7 +98,10 @@ class Scheduler:
             sliding_window=self.cache_config.sliding_window)
 
         # Create the prefix pool to cache the prefixes.
-        self.prefix_pool = PrefixPool(self.cache_config.block_size)
+        self.prefix_pool = PrefixPool(
+            self.cache_config.block_size, 
+            max_capacity=self.cache_config.prefix_pool_max_capacity
+        )
 
         # Sequence groups in the WAITING state.
         self.waiting: Deque[SequenceGroup] = deque()

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -100,7 +100,8 @@ class Scheduler:
         # Create the prefix pool to cache the prefixes.
         self.prefix_pool = PrefixPool(
             self.cache_config.block_size,
-            max_capacity=self.cache_config.prefix_pool_max_capacity)
+            max_capacity_in_blocks= \
+                int(self.cache_config.prefix_pool_memory_utilization * self.cache_config.num_gpu_blocks))
 
         # Sequence groups in the WAITING state.
         self.waiting: Deque[SequenceGroup] = deque()
@@ -424,7 +425,7 @@ class Scheduler:
         Deallocates the GPU memory of prefixes that have been moved to the list of candidates
         for deallocation in the prefix pool and that are not currently being used by any sequence group.
         """
-        prefixes_to_free = self.prefix_pool.get_prefixes_to_free()
+        prefixes_to_free = self.prefix_pool.get_prefixes_to_deallocate()
         for prefix in prefixes_to_free:
             self.block_manager.free_prefix_blocks(prefix)
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -27,7 +27,7 @@ class EngineArgs:
     block_size: int = 16
     swap_space: int = 4  # GiB
     gpu_memory_utilization: float = 0.90
-    prefix_pool_max_capacity: Optional[int] = None
+    prefix_pool_memory_utilization: float = 0.0
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     max_paddings: int = 256
@@ -183,10 +183,10 @@ class EngineArgs:
         parser.add_argument(
             '--prefix-pool-max-capacity',
             type=int,
-            default=EngineArgs.prefix_pool_max_capacity,
-            help=
-            'the maximum number of prefixes allowed in the prefix pool. If None, '
-            'there is no limit. It can only take positive values.')
+            default=EngineArgs.prefix_pool_memory_utilization,
+            help='the fraction of GPU memory to be used by prefixes allocated and '
+            'present in the prefix pool. If 0, no prefix cache is used. It cannot be '
+            'larger than gpu_memory_utilization. If unspecified, will use the default of 0.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,
@@ -288,7 +288,7 @@ class EngineArgs:
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,
                                    model_config.get_sliding_window(),
-                                   self.prefix_pool_max_capacity)
+                                   self.prefix_pool_memory_utilization)
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -184,9 +184,11 @@ class EngineArgs:
             '--prefix-pool-max-capacity',
             type=int,
             default=EngineArgs.prefix_pool_memory_utilization,
-            help='the fraction of GPU memory to be used by prefixes allocated and '
+            help=
+            'the fraction of GPU memory to be used by prefixes allocated and '
             'present in the prefix pool. If 0, no prefix cache is used. It cannot be '
-            'larger than gpu_memory_utilization. If unspecified, will use the default of 0.')
+            'larger than gpu_memory_utilization. If unspecified, will use the default of 0.'
+        )
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -27,6 +27,7 @@ class EngineArgs:
     block_size: int = 16
     swap_space: int = 4  # GiB
     gpu_memory_utilization: float = 0.90
+    prefix_pool_max_capacity: Optional[int] = None
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     max_paddings: int = 256
@@ -179,6 +180,12 @@ class EngineArgs:
             help='the fraction of GPU memory to be used for '
             'the model executor, which can range from 0 to 1.'
             'If unspecified, will use the default value of 0.9.')
+        parser.add_argument(
+            '--prefix-pool-max-capacity',
+            type=int,
+            default=EngineArgs.prefix_pool_max_capacity,
+            help='the maximum number of prefixes allowed in the prefix pool. If None, '
+            'there is no limit. It can only take positive values.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,
                             default=EngineArgs.max_num_batched_tokens,
@@ -279,7 +286,8 @@ class EngineArgs:
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,
-                                   model_config.get_sliding_window())
+                                   model_config.get_sliding_window(),
+                                   self.prefix_pool_max_capacity)
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -181,8 +181,8 @@ class EngineArgs:
             'the model executor, which can range from 0 to 1.'
             'If unspecified, will use the default value of 0.9.')
         parser.add_argument(
-            '--prefix-pool-max-capacity',
-            type=int,
+            '--prefix-pool-memory-utilization',
+            type=float,
             default=EngineArgs.prefix_pool_memory_utilization,
             help=
             'the fraction of GPU memory to be used by prefixes allocated and '

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -184,7 +184,8 @@ class EngineArgs:
             '--prefix-pool-max-capacity',
             type=int,
             default=EngineArgs.prefix_pool_max_capacity,
-            help='the maximum number of prefixes allowed in the prefix pool. If None, '
+            help=
+            'the maximum number of prefixes allowed in the prefix pool. If None, '
             'there is no limit. It can only take positive values.')
         parser.add_argument('--max-num-batched-tokens',
                             type=int,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -84,7 +84,7 @@ class LLM:
         enforce_eager: bool = False,
         max_context_len_to_capture: int = 8192,
         disable_custom_all_reduce: bool = False,
-        prefix_pool_max_capacity: Optional[int] = None,
+        prefix_pool_memory_utilization: float = 0,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -105,7 +105,7 @@ class LLM:
             enforce_eager=enforce_eager,
             max_context_len_to_capture=max_context_len_to_capture,
             disable_custom_all_reduce=disable_custom_all_reduce,
-            prefix_pool_max_capacity=prefix_pool_max_capacity,
+            prefix_pool_memory_utilization=prefix_pool_memory_utilization,
             **kwargs,
         )
         self.llm_engine = LLMEngine.from_engine_args(engine_args)

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -84,6 +84,7 @@ class LLM:
         enforce_eager: bool = False,
         max_context_len_to_capture: int = 8192,
         disable_custom_all_reduce: bool = False,
+        prefix_pool_max_capacity: Optional[int] = None,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -104,6 +105,7 @@ class LLM:
             enforce_eager=enforce_eager,
             max_context_len_to_capture=max_context_len_to_capture,
             disable_custom_all_reduce=disable_custom_all_reduce,
+            prefix_pool_max_capacity=prefix_pool_max_capacity,
             **kwargs,
         )
         self.llm_engine = LLMEngine.from_engine_args(engine_args)

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -107,7 +107,9 @@ class PrefixPool:
         new_length = min(new_length, self.max_allowed_prefix_length)
         return tuple(token_ids[:new_length])
 
-    def add_or_get_prefix(self, token_ids: Sequence[int], lora_int_id: int = 0) -> Optional[Prefix]:
+    def add_or_get_prefix(self,
+                          token_ids: Sequence[int],
+                          lora_int_id: int = 0) -> Optional[Prefix]:
         """
         Arguments:
         - token_ids: The token ids of the prefix to add to the pool.
@@ -186,14 +188,14 @@ class PrefixPool:
             i for i, prefix in enumerate(self._candidates_to_deallocate)
             if prefix.seq_ref_count == 0 and prefix.allocated
         ]
-        
+
         # Mark the prefix as expired, so that if a sequence group still in the
         # waiting list that shares this prefix tries to allocate it as a prefix,
         # it will fail.
         for i in indexes_to_remove:
             prefix = self._candidates_to_deallocate[i]
             prefix.expired = True
-        
+
         # Popping needs to happen with the indexes_to_remove list in reverse order
         # so that we don't get Index out of range errors
         return [

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -149,4 +149,6 @@ class PrefixPool:
         ]
         # Popping needs to happen with the indexes_to_remove list in reverse order
         # so that we don't get Index out of range errors
-        return [self._candidates_to_free.pop(i) for i in indexes_to_remove[::-1]]
+        return [
+            self._candidates_to_free.pop(i) for i in indexes_to_remove[::-1]
+        ]

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -78,14 +78,14 @@ class PrefixPool:
         self.prefixes: OrderedDict[int, Prefix] = OrderedDict()
         self.block_size = block_size
         self._current_block_usage = 0
-        
+
         self.max_allowed_prefix_length = float('inf')
         if max_capacity_in_blocks < float('inf'):
             assert max_capacity_in_blocks >= 0, "max_capacity must be non-negative."
             self.max_allowed_prefix_length = self.block_size * max_capacity_in_blocks
 
         self.max_capacity_in_blocks = max_capacity_in_blocks
-        
+
         self._candidates_to_deallocate: List[Prefix] = []
 
     def __len__(self) -> int:
@@ -93,7 +93,7 @@ class PrefixPool:
         Returns the number of prefixes in the pool.
         """
         return len(self.prefixes)
-    
+
     @property
     def current_block_usage(self) -> int:
         """
@@ -127,12 +127,12 @@ class PrefixPool:
         if self.max_capacity_in_blocks == 0:
             # Prefix cache is disabled.
             return None
-        
+
         token_ids = self._truncate_token_ids(token_ids)
         if len(token_ids) == 0:
             # Prefix is empty.
             return None
-        
+
         # Check first if prefix exists, moving it to the end of the OrderedDict.
         # so that the LRU policy is maintained. Return the existing prefix.
         prefix = Prefix(token_ids, self.block_size)
@@ -151,7 +151,7 @@ class PrefixPool:
             _, candidate_prefix = self.prefixes.popitem(last=False)
             self._candidates_to_deallocate.append(candidate_prefix)
             self._current_block_usage -= candidate_prefix.get_num_blocks()
-    
+
         self.prefixes[prefix_hash] = prefix
         self._current_block_usage += prefix_num_blocks
         return prefix
@@ -183,5 +183,6 @@ class PrefixPool:
         # Popping needs to happen with the indexes_to_remove list in reverse order
         # so that we don't get Index out of range errors
         return [
-            self._candidates_to_deallocate.pop(i) for i in indexes_to_remove[::-1]
+            self._candidates_to_deallocate.pop(i)
+            for i in indexes_to_remove[::-1]
         ]

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -147,4 +147,6 @@ class PrefixPool:
             i for i, prefix in enumerate(self._candidates_to_free)
             if prefix.seq_ref_count == 0 and prefix.allocated
         ]
-        return [self._candidates_to_free.pop(i) for i in indexes_to_remove]
+        # Popping needs to happen with the indexes_to_remove list in reverse order
+        # so that we don't get Index out of range errors
+        return [self._candidates_to_free.pop(i) for i in indexes_to_remove[::-1]]

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -107,8 +107,13 @@ class PrefixPool:
         new_length = min(new_length, self.max_allowed_prefix_length)
         return tuple(token_ids[:new_length])
 
-    def add_or_get_prefix(self, token_ids: Sequence[int]) -> Optional[Prefix]:
+    def add_or_get_prefix(self, token_ids: Sequence[int], lora_int_id: int = 0) -> Optional[Prefix]:
         """
+        Arguments:
+        - token_ids: The token ids of the prefix to add to the pool.
+        - lora_int_id: The lora_int_id of the request, which will be used to hash the prefix too.
+            If the lora_int_id is not given, defaults to 0.
+        
         Adds a prefix to the pool if it does not already exist. If it does exist,
         it returns the existing prefix. If the pool is at max capacity, it removes
         the least recently used prefix before adding the new prefix.
@@ -137,7 +142,7 @@ class PrefixPool:
         # Check first if prefix exists, moving it to the end of the OrderedDict.
         # so that the LRU policy is maintained. Return the existing prefix.
         prefix = Prefix(token_ids, self.block_size)
-        prefix_hash = hash(prefix)
+        prefix_hash = hash((prefix, lora_int_id))
         if prefix_hash in self.prefixes:
             prefix = self.prefixes[prefix_hash]
             self.prefixes.move_to_end(prefix_hash)

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -79,13 +79,6 @@ class PrefixPool:
         self.block_size = block_size
 
         if max_capacity is not None:
-            # NOTE(to remove after consultation): I have also been thinking if we need to
-            # assert that max_capacity must be greater than or equal to the max allowed
-            # batch size. My own analysis has led me to believe that this is not necessary
-            # because even if a prefix is removed from the pool before it even gets computed,
-            # this will not stop the prefix from being computed. It only means that the prefix
-            # will not stay allocated for next cycles of computation and future requests
-            # with the prefix will have to recompute it.
             assert max_capacity > 0, "max_capacity must be positive."
 
         self.max_capacity = max_capacity

--- a/vllm/prefix.py
+++ b/vllm/prefix.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Sequence, Tuple, Optional
+from typing import Any, Dict, List, Sequence, Tuple, Optional
+from collections import OrderedDict
 
 from vllm.block import BlockTable
 
@@ -18,7 +19,7 @@ class Prefix:
     def __init__(
         self,
         token_ids: Sequence[int],
-        block_size: int,
+        block_size: int
     ) -> None:
         self.token_ids = tuple(token_ids)
         self.block_size = block_size
@@ -43,16 +44,20 @@ class Prefix:
 
     def __hash__(self) -> int:
         return self.hash
+    
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Prefix):
+            return False
+        return self.hash == other.hash
 
     def set_block_table(self, block_table: BlockTable) -> None:
         self.block_table = block_table.copy()
 
 
 class PrefixPool:
-    """Manages all the prompt prefixes.
-
-    NOTE: This feature is experimental and may be replaced with automatic
-        prefix caching in the future.
+    """Manages all the prompt prefixes. If the max_capacity argument is not None,
+    the pool will act as a LRU cache and remove the least recently used prefix once
+    the capacity is reached.
 
     Args:
         block_size: The block size of the executed model.
@@ -60,28 +65,64 @@ class PrefixPool:
     Attributes:
         prefixes: A list of all the prefixes.
         block_size: The block size of the executed model.
+        max_capacity: The maximum number of prefixes allowed in the pool at any given time. 
+            The default value is None, which means there is no limit. It can only take positive
+            values.
     """
 
     def __init__(
         self,
         block_size: int,
+        max_capacity: Optional[int] = None
     ) -> None:
-        # TODO(zhuohan): Add a capacity limit to the prefix pool.
-        self.prefixes: Dict[int, Prefix] = {}
+        self.prefixes: OrderedDict[int, Prefix] = OrderedDict()
         self.block_size = block_size
+        
+        if max_capacity is not None:
+            # NOTE(to remove after consultation): I have also been thinking if we need to 
+            # assert that max_capacity must be greater than or equal to the max allowed 
+            # batch size. My own analysis has led me to believe that this is not necessary
+            # because even if a prefix is removed from the pool before it even gets computed,
+            # this will not stop the prefix from being computed. It only means that the prefix
+            # will not stay allocated for next cycles of computation and future requests
+            # with the prefix will have to recompute it.
+            assert max_capacity > 0, "max_capacity must be positive."
+        
+        self.max_capacity = max_capacity
 
+    def __len__(self) -> int:
+        return len(self.prefixes)
+    
     def _truncate_token_ids(self, token_ids: Sequence[int]) -> Tuple[int]:
         new_length = len(token_ids) // self.block_size * self.block_size
         return tuple(token_ids[:new_length])
 
-    def add_or_get_prefix(self, token_ids: Sequence[int],
-                          lora_int_id: int) -> Optional[Prefix]:
+    def add_or_get_prefix(self, token_ids: Sequence[int]) -> Optional[Prefix]:
+        """
+        Adds a prefix to the pool if it does not already exist. If it does exist,
+        it returns the existing prefix. If the pool is at max capacity, it removes
+        the least recently used prefix before adding the new prefix.
+
+        Notice that if the length of token_ids is less than the block_size, no 
+        prefix is created and None is returned.
+        """
         token_ids = self._truncate_token_ids(token_ids)
         if len(token_ids) == 0:
             # Prefix is empty.
             return None
+        
+        # Check first if prefix exists, moving it to the end of the OrderedDict.
+        # so that the LRU policy is maintained. Return the existing prefix.
         prefix = Prefix(token_ids, self.block_size)
-        prefix_hash = hash((prefix, lora_int_id))
-        if prefix_hash not in self.prefixes:
-            self.prefixes[prefix_hash] = prefix
-        return self.prefixes[prefix_hash]
+        prefix_hash = hash(prefix)
+        if prefix_hash in self.prefixes:
+            prefix = self.prefixes[prefix_hash]
+            self.prefixes.move_to_end(prefix_hash)
+            return prefix
+        
+        # Prefix does not exist. Add created prefix to the pool and return it.
+        # Always, before adding anything to the pool, checking the capacity constraints.
+        if len(self.prefixes) == self.max_capacity:
+            _ = self.prefixes.popitem(last=False)
+        self.prefixes[prefix_hash] = prefix
+        return prefix

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -281,7 +281,7 @@ class SequenceGroup:
         if self._prefix is not None and self._prefix.expired:
             self._prefix = None
         return self._prefix
-    
+
     @property
     def prompt_token_ids(self) -> List[int]:
         # All sequences in the group should have the same prompt.

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -176,6 +176,10 @@ class Sequence:
         self.data.append_token_id(token_id, logprobs[token_id])
 
     def get_len(self) -> int:
+        """
+        Returns the lenght of the sequence in number of tokens. This length
+        includes the prompt and the generated tokens up to that point.
+        """
         return self.data.get_len()
 
     def get_prompt_len(self) -> int:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -259,7 +259,7 @@ class SequenceGroup:
         self.sampling_params = sampling_params
         self.arrival_time = arrival_time
         self.lora_request = lora_request
-        self.prefix: Optional[Prefix] = prefix
+        self._prefix: Optional[Prefix] = prefix
         self.prompt_logprobs: Optional[PromptLogprobs] = None
 
     @property
@@ -268,6 +268,20 @@ class SequenceGroup:
         # We use the prompt of an arbitrary sequence.
         return next(iter(self.seqs_dict.values())).prompt
 
+    @property
+    def prefix(self) -> Optional[Prefix]:
+        """
+        If the prefix has been marked as expired, set the prefix to None.
+        The reason for this is that when a prefix has expired it means that it has
+        been moved out of the prefix pool, so is no longer valid, and it should
+        no longer be allocated as a prefix.
+        
+        Return the prefix.
+        """
+        if self._prefix is not None and self._prefix.expired:
+            self._prefix = None
+        return self._prefix
+    
     @property
     def prompt_token_ids(self) -> List[int]:
         # All sequences in the group should have the same prompt.


### PR DESCRIPTION
This branch introduces caching of prefixes and deallocation of old prefixes.
1. For caching it introduces the concept of max_capacity in the prefix pool.
2. For deallocation, it deallocates prefixes that have been evicted from the prefix pool (using an LRU policy) and that are no longer in use by any SequenceGroup. 
- There was a certain complexity with the deallocation, because of the swap_in and swap_out mechanisms for blocks, meaning that the block.ref_count was not a good representation of how many sequences were sharing a prefix. Because of that, a new seq_ref_counter was introduced in the prefix class.

I have already added some tests to the PrefixPool class. Will be adding some extra tests for the caching and deallocation mechanisms.
