### PR TITLE
[Server] Support openai prefix cache

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -78,6 +78,7 @@ class ChatCompletionRequest(BaseModel):
     echo: Optional[bool] = False
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
+    prefix_pos: Optional[int] = None
 
     def to_sampling_params(self) -> SamplingParams:
         return SamplingParams(
@@ -127,6 +128,7 @@ class CompletionRequest(BaseModel):
     spaces_between_special_tokens: Optional[bool] = True
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
+    prefix_pos: Optional[int] = None
 
     def to_sampling_params(self):
         echo_without_generation = self.echo and self.max_tokens == 0

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -79,6 +79,7 @@ class ChatCompletionRequest(BaseModel):
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
     prefix_pos: Optional[int] = None
+    prefix_stop: Optional[str] = None
 
     def to_sampling_params(self) -> SamplingParams:
         return SamplingParams(
@@ -129,6 +130,7 @@ class CompletionRequest(BaseModel):
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
     prefix_pos: Optional[int] = None
+    prefix_stop: Optional[str] = None
 
     def to_sampling_params(self):
         echo_without_generation = self.echo and self.max_tokens == 0

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -67,10 +67,8 @@ class OpenAIServingChat(OpenAIServing):
         except ValueError as e:
             return self.create_error_response(str(e))
 
-        result_generator = self.engine.generate(prompt,
-                                                sampling_params,
-                                                request_id,
-                                                token_ids,
+        result_generator = self.engine.generate(prompt, sampling_params,
+                                                request_id, token_ids,
                                                 request.prefix_pos)
         # Streaming response
         if request.stream:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -67,9 +67,16 @@ class OpenAIServingChat(OpenAIServing):
         except ValueError as e:
             return self.create_error_response(str(e))
 
+        prefix_pos = request.prefix_pos
+        if request.prefix_stop is not None:
+            prefix_index = prompt.index(request.prefix_stop)
+            prefix_pos = len(self.tokenizer.encode(prompt[:prefix_index])) - 1
+            prompt = prompt.replace(request.prefix_stop, '')
+
         result_generator = self.engine.generate(prompt, sampling_params,
                                                 request_id, token_ids,
-                                                request.prefix_pos)
+                                                prefix_pos)
+
         # Streaming response
         if request.stream:
             return self.chat_completion_stream_generator(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -67,8 +67,11 @@ class OpenAIServingChat(OpenAIServing):
         except ValueError as e:
             return self.create_error_response(str(e))
 
-        result_generator = self.engine.generate(prompt, sampling_params,
-                                                request_id, token_ids)
+        result_generator = self.engine.generate(prompt,
+                                                sampling_params,
+                                                request_id,
+                                                token_ids,
+                                                request.prefix_pos)
         # Streaming response
         if request.stream:
             return self.chat_completion_stream_generator(

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -68,7 +68,7 @@ class OpenAIServingChat(OpenAIServing):
             return self.create_error_response(str(e))
 
         prefix_pos = request.prefix_pos
-        if request.prefix_stop is not None:
+        if request.prefix_stop is not None and request.prefix_stop in prompt:
             prefix_index = prompt.index(request.prefix_stop)
             prefix_pos = len(self.tokenizer.encode(prompt[:prefix_index])) - 1
             prompt = prompt.replace(request.prefix_stop, '')

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -243,11 +243,12 @@ class OpenAIServingCompletion(OpenAIServing):
                 input_ids = self._validate_prompt_and_tokenize(request,
                                                                prompt=prompt)
 
-            result_generator = self.engine.generate(None,
-                                                    sampling_params,
-                                                    request_id,
-                                                    prompt_token_ids=input_ids,
-                                                    prefix_pos=request.prefix_pos)
+            result_generator = self.engine.generate(
+                None,
+                sampling_params,
+                request_id,
+                prompt_token_ids=input_ids,
+                prefix_pos=request.prefix_pos)
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -246,7 +246,8 @@ class OpenAIServingCompletion(OpenAIServing):
             result_generator = self.engine.generate(None,
                                                     sampling_params,
                                                     request_id,
-                                                    prompt_token_ids=input_ids)
+                                                    prompt_token_ids=input_ids,
+                                                    prefix_pos=request.prefix_pos)
         except ValueError as e:
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -292,9 +292,11 @@ class OpenAIServingCompletion(OpenAIServing):
                     input_ids = self._validate_prompt_and_tokenize(
                         request, prompt_ids=prompt)
                 else:
+                    # Parse prefix position by prompt and prefix_stop indicator
                     if request.prefix_stop is not None and request.prefix_stop in prompt:
                         prefix_index = prompt.index(request.prefix_stop)
-                        prefix_pos = len(self.tokenizer.encode(prompt[:prefix_index])) - 1
+                        prefix_pos = len(
+                            self.tokenizer.encode(prompt[:prefix_index])) - 1
                         prompt = prompt.replace(request.prefix_stop, '')
 
                     input_ids = self._validate_prompt_and_tokenize(

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -244,7 +244,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 input_ids = self._validate_prompt_and_tokenize(request,
                                                                prompt=prompt)
 
-            if request.prefix_stop is not None:
+            if request.prefix_stop is not None and request.prefix_stop in prompt:
                 prefix_index = prompt.index(request.prefix_stop)
                 prefix_pos = len(self.tokenizer.encode(
                     prompt[:prefix_index])) - 1


### PR DESCRIPTION
Adding support `prefix_pos` and `prefix_stop` parameter for api server.

1. `prefix_pos` is the position of prefix string length - 1
2. `prefix_stop` is the prefix stop string of prompt.
If we have a prompt 
```Below is an instruction that describes a task. Write a response that appropriately completes the request.\nHello```. 
We can use prefix caching feature for the prefix string 
```Below is an instruction that describes a task. Write a response that appropriately completes the request.```. 
So we can add `prefix_stop` with something special like `<|prefix|>`, and the real prompt should be 
```Below is an instruction that describes a task. Write a response that appropriately completes the request.\n<|prefix|>Hello```.

There is a example about how to use:
Bootstrap the openai server. Then request the server with below chat completion json:
```json
{
    "model": "your-model-name",
    "messages":  {
          "role": "user",
          "content": "Below is an instruction that describes a task. Write a response that appropriately completes the request.\n<|prefix|>Hello"
    },
    "prefix_stop": "<|prefix|>"
}
```

Furthermore, if some model's system prompt already contains the special str, like `<|endoftext|>` which indicating the end of the system prompt, this prefix caching feature could be smoothly used.