### PR TITLE
Add `group` as an argument in broadcast ops

### DIFF
--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -89,7 +89,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
 def broadcast(input_: torch.Tensor, src: int = 0, group=None):
     """Broadcast the input tensor."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_group(group).ranks()
+    ranks = torch.distributed.get_process_group_ranks()
     assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
@@ -104,7 +104,7 @@ def broadcast(input_: torch.Tensor, src: int = 0, group=None):
 def broadcast_object_list(obj_list: List[Any], src: int = 0, group=None):
     """Broadcast the input object list."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_group(group).ranks()
+    ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
@@ -126,7 +126,7 @@ def broadcast_tensor_dict(
 ) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_group(group).ranks()
+    ranks = torch.distributed.get_process_group_ranks()
     assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -89,7 +89,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
 def broadcast(input_: torch.Tensor, src: int = 0, group=None):
     """Broadcast the input tensor."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_process_group_ranks()
+    ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
@@ -126,7 +126,7 @@ def broadcast_tensor_dict(
 ) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_process_group_ranks()
+    ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -119,11 +119,11 @@ def broadcast_object_list(obj_list: List[Any], src: int = 0, group=None):
 TensorMetadata = namedtuple("TensorMetadata", ["dtype", "size"])
 
 
-def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
-                                                                Any]]] = None,
-                          src: int = 0,
-                          group=None,
-                          ) -> Dict[Any, Union[torch.Tensor, Any]]:
+def broadcast_tensor_dict(
+    tensor_dict: Optional[Dict[Any, Union[torch.Tensor, Any]]] = None,
+    src: int = 0,
+    group=None,
+) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_group(group).ranks()
@@ -149,14 +149,18 @@ def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                     (key, TensorMetadata(value.dtype, value.size())))
             else:
                 metadata_list.append((key, value))
-        torch.distributed.broadcast_object_list([metadata_list], src=src, group=group)
+        torch.distributed.broadcast_object_list([metadata_list],
+                                                src=src,
+                                                group=group)
         for key, value in metadata_list:
             if isinstance(value, TensorMetadata):
                 tensor = tensor_dict[key]
                 torch.distributed.broadcast(tensor, src=src)
     else:
         recv_metadata_list = [None]
-        torch.distributed.broadcast_object_list(recv_metadata_list, src=src, group=group)
+        torch.distributed.broadcast_object_list(recv_metadata_list,
+                                                src=src,
+                                                group=group)
         metadata_list = recv_metadata_list[0]
         tensor_dict = {}
         async_handles = []
@@ -168,8 +172,7 @@ def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                 async_handle = torch.distributed.broadcast(tensor,
                                                            src=src,
                                                            async_op=True,
-                                                           group=group
-                                                           )
+                                                           group=group)
                 async_handles.append(async_handle)
                 tensor_dict[key] = tensor
             else:

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -86,29 +86,33 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
     return output_tensor
 
 
-def broadcast(input_: torch.Tensor, src: int = 0):
+def broadcast(input_: torch.Tensor, src: int = 0, group=None):
     """Broadcast the input tensor."""
-    world_size = torch.distributed.get_world_size()
-    assert 0 <= src < world_size, f"Invalid src rank ({src})"
+    group = group or torch.distributed.group.WORLD
+    ranks = torch.distributed.get_group(group).ranks()
+    assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
+    world_size = torch.distributed.get_world_size(group=group)
     if world_size == 1:
         return input_
     # Broadcast.
-    torch.distributed.broadcast(input_, src=src)
+    torch.distributed.broadcast(input_, src=src, group=group)
     return input_
 
 
-def broadcast_object_list(obj_list: List[Any], src: int = 0):
+def broadcast_object_list(obj_list: List[Any], src: int = 0, group=None):
     """Broadcast the input object list."""
-    world_size = torch.distributed.get_world_size()
-    assert 0 <= src < world_size, f"Invalid src rank ({src})"
+    group = group or torch.distributed.group.WORLD
+    ranks = torch.distributed.get_group(group).ranks()
+    assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
+    world_size = torch.distributed.get_world_size(group=group)
     if world_size == 1:
         return obj_list
     # Broadcast.
-    torch.distributed.broadcast_object_list(obj_list, src=src)
+    torch.distributed.broadcast_object_list(obj_list, src=src, group=group)
     return obj_list
 
 
@@ -117,16 +121,20 @@ TensorMetadata = namedtuple("TensorMetadata", ["dtype", "size"])
 
 def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                                                                 Any]]] = None,
-                          src: int = 0) -> Dict[Any, Union[torch.Tensor, Any]]:
+                          src: int = 0,
+                          group=None,
+                          ) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
-    rank = torch.distributed.get_rank()
-    world_size = torch.distributed.get_world_size()
-    assert 0 <= src < world_size, f"Invalid src rank ({src})"
+    group = group or torch.distributed.group.WORLD
+    ranks = torch.distributed.get_group(group).ranks()
+    assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
+    world_size = torch.distributed.get_world_size(group=group)
     if world_size == 1:
         return tensor_dict
 
+    rank = torch.distributed.get_rank()
     if rank == src:
         assert isinstance(
             tensor_dict,
@@ -141,14 +149,14 @@ def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                     (key, TensorMetadata(value.dtype, value.size())))
             else:
                 metadata_list.append((key, value))
-        torch.distributed.broadcast_object_list([metadata_list], src=src)
+        torch.distributed.broadcast_object_list([metadata_list], src=src, group=group)
         for key, value in metadata_list:
             if isinstance(value, TensorMetadata):
                 tensor = tensor_dict[key]
                 torch.distributed.broadcast(tensor, src=src)
     else:
         recv_metadata_list = [None]
-        torch.distributed.broadcast_object_list(recv_metadata_list, src=src)
+        torch.distributed.broadcast_object_list(recv_metadata_list, src=src, group=group)
         metadata_list = recv_metadata_list[0]
         tensor_dict = {}
         async_handles = []
@@ -159,7 +167,9 @@ def broadcast_tensor_dict(tensor_dict: Optional[Dict[Any, Union[torch.Tensor,
                                      device="cuda")
                 async_handle = torch.distributed.broadcast(tensor,
                                                            src=src,
-                                                           async_op=True)
+                                                           async_op=True,
+                                                           group=group
+                                                           )
                 async_handles.append(async_handle)
                 tensor_dict[key] = tensor
             else:

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -1,5 +1,8 @@
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from torch.distributed import ProcessGroup
 
 import torch
 
@@ -86,7 +89,9 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
     return output_tensor
 
 
-def broadcast(input_: torch.Tensor, src: int = 0, group=None):
+def broadcast(input_: torch.Tensor,
+              src: int = 0,
+              group: "Optional[ProcessGroup]" = None):
     """Broadcast the input tensor."""
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
@@ -101,7 +106,9 @@ def broadcast(input_: torch.Tensor, src: int = 0, group=None):
     return input_
 
 
-def broadcast_object_list(obj_list: List[Any], src: int = 0, group=None):
+def broadcast_object_list(obj_list: List[Any],
+                          src: int = 0,
+                          group: "Optional[ProcessGroup]" = None):
     """Broadcast the input object list."""
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
@@ -122,7 +129,7 @@ TensorMetadata = namedtuple("TensorMetadata", ["dtype", "size"])
 def broadcast_tensor_dict(
     tensor_dict: Optional[Dict[Any, Union[torch.Tensor, Any]]] = None,
     src: int = 0,
-    group=None,
+    group: "Optional[ProcessGroup]" = None,
 ) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -1,8 +1,7 @@
 from collections import namedtuple
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union
 
-if TYPE_CHECKING:
-    from torch.distributed import ProcessGroup
+from torch.distributed import ProcessGroup
 
 import torch
 
@@ -91,7 +90,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
 
 def broadcast(input_: torch.Tensor,
               src: int = 0,
-              group: "Optional[ProcessGroup]" = None):
+              group: Optional[ProcessGroup] = None):
     """Broadcast the input tensor."""
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
@@ -108,7 +107,7 @@ def broadcast(input_: torch.Tensor,
 
 def broadcast_object_list(obj_list: List[Any],
                           src: int = 0,
-                          group: "Optional[ProcessGroup]" = None):
+                          group: Optional[ProcessGroup] = None):
     """Broadcast the input object list."""
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
@@ -129,7 +128,7 @@ TensorMetadata = namedtuple("TensorMetadata", ["dtype", "size"])
 def broadcast_tensor_dict(
     tensor_dict: Optional[Dict[Any, Union[torch.Tensor, Any]]] = None,
     src: int = 0,
-    group: "Optional[ProcessGroup]" = None,
+    group: Optional[ProcessGroup] = None,
 ) -> Dict[Any, Union[torch.Tensor, Any]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD


### PR DESCRIPTION
Follow up with #2501. 

**Changes**

In `communication_ops.py`, add `group` as an argument in the `broadcast` auxiliary function family. This helps designate the group to communicate (for example, a designated tensor-parallel group, or pipeline-parallel group) in the future.