### PR TITLE
Fix tensor gather rank error

### DIFF
--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -8,7 +8,7 @@ import torch
 from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    get_tensor_model_parallel_group,
+    get_tensor_model_parallel_group, get_tensor_model_parallel_src_rank,
 )
 
 
@@ -55,13 +55,14 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
 
 
 def tensor_model_parallel_gather(input_: torch.Tensor,
-                                 dst: int = 0,
+                                 dst: int = None, # FIXME: Gather should specify the target!
                                  dim: int = -1) -> torch.Tensor:
     """Gather the input tensor across model parallel group.
 
     NOTE: We assume that the input tensor is on the same device across
     all the ranks.
     """
+    dst = dst if dst is not None else get_tensor_model_parallel_src_rank()
     world_size = get_tensor_model_parallel_world_size()
     # Bypass the function if we are using only 1 GPU.
     if world_size == 1:

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -73,7 +73,9 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
         # Convert negative dim to positive.
         dim += input_.dim()
     # Allocate output tensor.
-    if get_tensor_model_parallel_rank() == dst:
+    rank = torch.distributed.get_rank()
+
+    if rank == dst:
         gather_list = [torch.empty_like(input_) for _ in range(world_size)]
     else:
         gather_list = None
@@ -82,7 +84,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
                              gather_list,
                              dst=dst,
                              group=get_tensor_model_parallel_group())
-    if get_tensor_model_parallel_rank() == dst:
+    if rank == dst:
         output_tensor = torch.cat(gather_list, dim=dim)
     else:
         output_tensor = None

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -55,12 +55,15 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
 
 
 def tensor_model_parallel_gather(input_: torch.Tensor,
-                                 dst: int = None, # FIXME: Gather should specify the target!
+                                 dst: int = None,
                                  dim: int = -1) -> torch.Tensor:
     """Gather the input tensor across model parallel group.
 
     NOTE: We assume that the input tensor is on the same device across
     all the ranks.
+    # TODO: Semantic of the `get_tensor_model_parallel_rank` function becomes unclear.
+    NOTE: `dst` is the global rank of the destination process. Do not
+    use the output from `get_tensor_model_parallel_rank()` as `dst`.
     """
     dst = dst if dst is not None else get_tensor_model_parallel_src_rank()
     world_size = get_tensor_model_parallel_world_size()

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -8,7 +8,8 @@ import torch
 from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
-    get_tensor_model_parallel_group, get_tensor_model_parallel_src_rank,
+    get_tensor_model_parallel_group,
+    get_tensor_model_parallel_src_rank,
 )
 
 

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -61,8 +61,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
 
     Args:
         input_: Input tensor to gather.
-        dst: Destination rank (global rank). If None, gather on the
-            first rank in the tensor parallel group.
+        dst: Tensor parallel rank to gather the input tensor to.
         dim: Dimension to gather.
 
     Returns:

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -59,11 +59,17 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
                                  dim: int = -1) -> torch.Tensor:
     """Gather the input tensor across model parallel group.
 
+    Args:
+        input_: Input tensor to gather.
+        dst: Destination rank (global rank). If None, gather on the
+            first rank in the tensor parallel group.
+        dim: Dimension to gather.
+
+    Returns:
+        The gathered tensor.
+
     NOTE: We assume that the input tensor is on the same device across
     all the ranks.
-    # TODO: Semantic of the `get_tensor_model_parallel_rank` function becomes unclear.
-    NOTE: `dst` is the global rank of the destination process. Do not
-    use the output from `get_tensor_model_parallel_rank()` as `dst`.
     """
     dst = dst if dst is not None else get_tensor_model_parallel_src_rank()
     world_size = get_tensor_model_parallel_world_size()

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -71,7 +71,8 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
     NOTE: We assume that the input tensor is on the same device across
     all the ranks.
     """
-    dst = dst if dst is not None else get_tensor_model_parallel_src_rank()
+    if dst is None:
+        dst = get_tensor_model_parallel_src_rank()
     world_size = get_tensor_model_parallel_world_size()
     # Bypass the function if we are using only 1 GPU.
     if world_size == 1:
@@ -93,10 +94,9 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
                              gather_list,
                              dst=dst,
                              group=get_tensor_model_parallel_group())
+    output_tensor = None
     if rank == dst:
         output_tensor = torch.cat(gather_list, dim=dim)
-    else:
-        output_tensor = None
     return output_tensor
 
 

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -6,7 +6,6 @@ from torch.distributed import ProcessGroup
 import torch
 
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     get_tensor_model_parallel_group,
     get_tensor_model_parallel_src_rank,


### PR DESCRIPTION
Fix `tensor_model_parallel_gather()` for a small bug in process rank retrieval.

**Changes**
- Ensure `tensor_model_parallel_gather` works properly when pipeline parallelism > 1. 
- Add function docs noting the `dst` is a global comm rank.


In function `torch.distributed.gather(..., dst=0, group=None)`, the argument `dst` requires specifying a global rank, even if the `group` argument is specified. As in, `torch.distributed.get_process_group_ranks(group)` returns global rank numbers for processes within the group, the semantically in `torch` is consistent. 