### PR TITLE
Fix tensor gather rank error

### DIFF
--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -41,7 +41,7 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
         dim += input_.dim()
     input_size = input_.size()
     # Allocate output tensor.
-    output_tensor = torch.empty((world_size,) + input_size,
+    output_tensor = torch.empty((world_size, ) + input_size,
                                 dtype=input_.dtype,
                                 device=input_.device)
     # All-gather.
@@ -50,7 +50,7 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
     # Reshape
     output_tensor = output_tensor.movedim(0, dim)
     output_tensor = output_tensor.reshape(input_size[:dim] +
-                                          (world_size * input_size[dim],) +
+                                          (world_size * input_size[dim], ) +
                                           input_size[dim + 1:])
     return output_tensor
 

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -41,7 +41,7 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
         dim += input_.dim()
     input_size = input_.size()
     # Allocate output tensor.
-    output_tensor = torch.empty((world_size, ) + input_size,
+    output_tensor = torch.empty((world_size,) + input_size,
                                 dtype=input_.dtype,
                                 device=input_.device)
     # All-gather.
@@ -50,7 +50,7 @@ def tensor_model_parallel_all_gather(input_: torch.Tensor,
     # Reshape
     output_tensor = output_tensor.movedim(0, dim)
     output_tensor = output_tensor.reshape(input_size[:dim] +
-                                          (world_size * input_size[dim], ) +
+                                          (world_size * input_size[dim],) +
                                           input_size[dim + 1:])
     return output_tensor
 
@@ -59,6 +59,12 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
                                  dst: int = 0,
                                  dim: int = -1) -> torch.Tensor:
     """Gather the input tensor across model parallel group.
+
+    Args:
+        input_: Input tensor to gather.
+        dst: Destination rank in the tensor parallel group.
+            Defaults to 0 (the group-rank of the leader proc).
+        dim: Dimension to gather. Defaults to -1.
 
     NOTE: We assume that the input tensor is on the same device across
     all the ranks.
@@ -94,7 +100,14 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
 def broadcast(input_: torch.Tensor,
               src: int = 0,
               group: Optional[ProcessGroup] = None):
-    """Broadcast the input tensor."""
+    """Broadcast the input tensor.
+
+    Args:
+        input_: Input tensor to broadcast.
+        src: Source rank with respect to `group`. Defaults to 0.
+        group: Process group. Defaults to the world group.
+
+    """
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"
@@ -111,7 +124,13 @@ def broadcast(input_: torch.Tensor,
 def broadcast_object_list(obj_list: List[Any],
                           src: int = 0,
                           group: Optional[ProcessGroup] = None):
-    """Broadcast the input object list."""
+    """Broadcast the input object list.
+
+    Args:
+        obj_list: Input object list to broadcast.
+        src: Source rank with respect to `group`. Defaults to 0.
+        group: Process group. Defaults to the world group.
+    """
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"
@@ -133,7 +152,14 @@ def broadcast_tensor_dict(
     src: int = 0,
     group: Optional[ProcessGroup] = None,
 ) -> Dict[Any, Union[torch.Tensor, Any]]:
-    """Broadcast the input tensor dictionary."""
+    """Broadcast the input tensor dictionary.
+
+    Args:
+        tensor_dict: Input tensor dictionary to broadcast.
+        src: Source rank with respect to `group`. Defaults to 0.
+        group: Process group. Defaults to the world group.
+
+    """
     group = group or torch.distributed.group.WORLD
     ranks = torch.distributed.get_process_group_ranks(group)
     assert src in ranks, f"Invalid src rank ({src})"

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -131,12 +131,30 @@ def get_pipeline_model_parallel_rank():
         group=get_pipeline_model_parallel_group())
 
 
+def get_tensor_model_parallel_global_rank(rank):
+    """Return global rank given the tensor model parallel group rank."""
+    assert _TENSOR_GLOBAL_RANKS is not None, (
+        "Tensor model parallel group is not initialized")
+    assert rank >= 0 and rank < len(_TENSOR_GLOBAL_RANKS), (
+        f"Invalid local rank ({rank}) for tensor model parallel group")
+    return _TENSOR_GLOBAL_RANKS[rank]
+
+
+def get_pipeline_model_parallel_global_rank(rank):
+    """Return global rank given the pipeline model parallel group rank."""
+    assert _PIPELINE_GLOBAL_RANKS is not None, (
+        "Pipeline model parallel group is not initialized")
+    assert rank >= 0 and rank < len(_PIPELINE_GLOBAL_RANKS), (
+        f"Invalid local rank ({rank}) for pipeline model parallel group")
+    return _PIPELINE_GLOBAL_RANKS[rank]
+
+
 def get_tensor_model_parallel_src_rank():
     """Calculate the global rank corresponding to the first local rank
     in the tensor model parallel group."""
-    global_rank = torch.distributed.get_rank()
-    local_world_size = get_tensor_model_parallel_world_size()
-    return (global_rank // local_world_size) * local_world_size
+    assert _TENSOR_GLOBAL_RANKS is not None, (
+        "Tensor model parallel group is not initialized")
+    return _TENSOR_GLOBAL_RANKS[0]
 
 
 def get_pipeline_model_parallel_first_rank():

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -14,6 +14,9 @@ _PIPELINE_MODEL_PARALLEL_GROUP = None
 # A list of global ranks for each pipeline group to ease calculation of the
 # source rank when broadcasting from the first or last pipeline stage.
 _PIPELINE_GLOBAL_RANKS = None
+# A list of global ranks for each pipeline group to ease calculation of the
+# source rank when broadcasting within the tensor parallel group.
+_TENSOR_GLOBAL_RANKS = None
 
 
 def initialize_model_parallel(
@@ -61,6 +64,7 @@ def initialize_model_parallel(
 
     # Build the tensor model-parallel groups.
     global _TENSOR_MODEL_PARALLEL_GROUP
+    global _TENSOR_GLOBAL_RANKS
     assert _TENSOR_MODEL_PARALLEL_GROUP is None, (
         "tensor model parallel group is already initialized")
     for i in range(num_tensor_model_parallel_groups):
@@ -69,6 +73,7 @@ def initialize_model_parallel(
         group = torch.distributed.new_group(ranks)
         if rank in ranks:
             _TENSOR_MODEL_PARALLEL_GROUP = group
+            _TENSOR_GLOBAL_RANKS = ranks
 
     # Build the pipeline model-parallel groups.
     global _PIPELINE_MODEL_PARALLEL_GROUP


### PR DESCRIPTION
Fix `tensor_model_parallel_gather()` for a small bug in process rank retrieval.

**Changes**
- Ensure `tensor_model_parallel_gather` works properly when pipeline parallelism > 1. 
- Ensure the input args `src` and `dst` rank are local rank with respect to the group.
- Ensure the rank passing into `torch.distributed.func_name` is global rank. 


In function `torch.distributed.gather(..., dst=0, group=None)`, the argument `dst` requires specifying a global rank, even if the `group` argument is specified. 