### PR TITLE
Added `include_stop_str_in_output` and `length_penalty` parameters to OpenAI API

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -78,6 +78,7 @@ class ChatCompletionRequest(BaseModel):
     echo: Optional[bool] = False
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
+    include_stop_str_in_output: Optional[bool] = False
 
     def to_sampling_params(self) -> SamplingParams:
         return SamplingParams(
@@ -97,6 +98,7 @@ class ChatCompletionRequest(BaseModel):
             use_beam_search=self.use_beam_search,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
+            include_stop_str_in_output=self.include_stop_str_in_output
         )
 
 
@@ -127,6 +129,7 @@ class CompletionRequest(BaseModel):
     spaces_between_special_tokens: Optional[bool] = True
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
+    include_stop_str_in_output: Optional[bool] = False
 
     def to_sampling_params(self):
         echo_without_generation = self.echo and self.max_tokens == 0
@@ -150,6 +153,7 @@ class CompletionRequest(BaseModel):
             prompt_logprobs=self.logprobs if self.echo else None,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=(self.spaces_between_special_tokens),
+            include_stop_str_in_output=self.include_stop_str_in_output
         )
 
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -79,6 +79,7 @@ class ChatCompletionRequest(BaseModel):
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
     include_stop_str_in_output: Optional[bool] = False
+    length_penalty: Optional[float] = 1.0
 
     def to_sampling_params(self) -> SamplingParams:
         return SamplingParams(
@@ -98,7 +99,8 @@ class ChatCompletionRequest(BaseModel):
             use_beam_search=self.use_beam_search,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
-            include_stop_str_in_output=self.include_stop_str_in_output
+            include_stop_str_in_output=self.include_stop_str_in_output,
+            length_penalty=self.length_penalty,
         )
 
 
@@ -130,6 +132,7 @@ class CompletionRequest(BaseModel):
     repetition_penalty: Optional[float] = 1.0
     min_p: Optional[float] = 0.0
     include_stop_str_in_output: Optional[bool] = False
+    length_penalty: Optional[float] = 1.0
 
     def to_sampling_params(self):
         echo_without_generation = self.echo and self.max_tokens == 0
@@ -153,7 +156,8 @@ class CompletionRequest(BaseModel):
             prompt_logprobs=self.logprobs if self.echo else None,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=(self.spaces_between_special_tokens),
-            include_stop_str_in_output=self.include_stop_str_in_output
+            include_stop_str_in_output=self.include_stop_str_in_output,
+            length_penalty=self.length_penalty,
         )
 
 


### PR DESCRIPTION
This PR adds the `include_stop_str_in_output` and `length_penalty` sampling parameters (defined [here](https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py))  to the OpenAI API parameters.

Note: The force push addresses a missing comma, corrected without making a new commit for a minor syntax fix.