### PR TITLE
ROCm: Allow setting compilation target

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -282,14 +282,15 @@ if _is_cuda():
                 },
             ))
 elif _is_hip():
-    if os.getenv("GPU_ARCHS") is not None:
-        amd_arch = os.getenv("GPU_ARCHS")
-    else:
-        amd_arch = get_amdgpu_offload_arch()
-    if amd_arch not in ROCM_SUPPORTED_ARCHS:
-        raise RuntimeError(
-            f"Only the following arch is supported: {ROCM_SUPPORTED_ARCHS}"
-            f"amdgpu_arch_found: {amd_arch}")
+    amd_archs = os.getenv("GPU_ARCHS")
+    if amd_archs is None:
+        amd_archs = get_amdgpu_offload_arch()
+    for arch in amd_archs.split(";"):
+        if arch not in ROCM_SUPPORTED_ARCHS:
+            raise RuntimeError(
+                f"Only the following arch is supported: {ROCM_SUPPORTED_ARCHS}"
+                f"amdgpu_arch_found: {arch}")
+        NVCC_FLAGS += [f"--offload-arch={arch}"]
 
 elif _is_neuron():
     neuronxcc_version = get_neuronxcc_version()

--- a/setup.py
+++ b/setup.py
@@ -282,7 +282,10 @@ if _is_cuda():
                 },
             ))
 elif _is_hip():
-    amd_arch = get_amdgpu_offload_arch()
+    if os.getenv("GPU_ARCHS") is not None:
+        amd_arch = os.getenv("GPU_ARCHS")
+    else:
+        amd_arch = get_amdgpu_offload_arch()
     if amd_arch not in ROCM_SUPPORTED_ARCHS:
         raise RuntimeError(
             f"Only the following arch is supported: {ROCM_SUPPORTED_ARCHS}"


### PR DESCRIPTION
Currently, building the package requires a machine that has a GPU with the desired architecture. This is however not necessary, you can easily compile for another target, even if the build machine has no GPU at all.
This PR simply enables one to set the `GPU_ARCHS` environment variable, for example as `GPU_ARCHS=gfx90a` or GPU_ARCHS=gfx90a;gfx1100` if you want to build for multiple targets.
This resolves #2127.