### PR TITLE
[Doc] Fix the syntax error in the doc of supported_models.

### DIFF
--- a/docs/source/models/supported_models.rst
+++ b/docs/source/models/supported_models.rst
@@ -68,10 +68,10 @@ Alongside each architecture, we include some popular models that use it.
   * - :code:`QWenLMHeadModel`
     - Qwen
     - :code:`Qwen/Qwen-7B`, :code:`Qwen/Qwen-7B-Chat`, etc.
-  * - :code:`StableLMEpochForCausalLM`
   * - :code:`Qwen2ForCausalLM`
     - Qwen2
     - :code:`Qwen/Qwen2-7B-beta`, :code:`Qwen/Qwen-7B-Chat-beta`, etc.
+  * - :code:`StableLMEpochForCausalLM`
     - StableLM
     - :code:`stabilityai/stablelm-3b-4e1t/` , :code:`stabilityai/stablelm-base-alpha-7b-v2`, etc.
   * - :code:`YiForCausalLM`


### PR DESCRIPTION
### Description

While reviewing the **latest** documentation, I noticed that the [Supported Models Table](https://docs.vllm.ai/en/latest/models/supported_models.html) is missing, which, in contrast, renders correctly in the [stable version](https://docs.vllm.ai/en/stable/models/supported_models.html).

Attempting to build it from the source resulted in an error:

```
$ make html
vllm/docs/source/models/supported_models.rst:10: ERROR: Error parsing content block for the "list-table" directive: uniform two-level bullet list expected, but row 20 does not contain the same number of items as row 1 (1 vs 3).
```

I believe I have identified and resolved the bug.

Many thanks to the vLLM Team for your excellent work ✨.