### PR TITLE
docs: Add tutorial on deploying vLLM model with KServe

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,6 +68,7 @@ Documentation
 
    serving/distributed_serving
    serving/run_on_sky
+   serving/deploying_with_kserve
    serving/deploying_with_triton
    serving/deploying_with_docker
    serving/serving_with_langchain

--- a/docs/source/serving/deploying_with_kserve.rst
+++ b/docs/source/serving/deploying_with_kserve.rst
@@ -6,35 +6,36 @@ Deploying with KServe
 vLLM can be deployed with `KServe <https://github.com/kserve/kserve>`_ on Kubernetes for highly scalable distributed model serving by defining the following :code:`InferenceService` YAML spec:
 
 .. code-block:: yaml
-	apiVersion: serving.kserve.io/v1beta1
-	kind: InferenceService
-	metadata:
-	  name: llama-2-7b
-	spec:
-	  predictor:
-	    containers:
-	      - args:
-	        - --port
-	        - "8080"
-	        - --model
-	        - /mnt/models
-	      command:
-	        - python3
-	        - -m
-	        - vllm.entrypoints.api_server
-	      env:
-	        - name: STORAGE_URI
-	          value: gcs://kfserving-examples/llm/huggingface/llama
-	      image: kserve/vllmserver:latest
-	      name: kserve-container
-	      resources:
-	        limits:
-	          cpu: "4"
-	          memory: 50Gi
-	          nvidia.com/gpu: "1"
-	        requests:
-	          cpu: "1"
-	          memory: 50Gi
-	          nvidia.com/gpu: "1"
+
+    apiVersion: serving.kserve.io/v1beta1
+    kind: InferenceService
+    metadata:
+      name: llama-2-7b
+    spec:
+      predictor:
+        containers:
+          - args:
+              - --port
+              - "8080"
+              - --model
+              - /mnt/models
+          command:
+            - python3
+            - -m
+            - vllm.entrypoints.api_server
+          env:
+            - name: STORAGE_URI
+              value: gcs://kfserving-examples/llm/huggingface/llama
+          image: kserve/vllmserver:latest
+          name: kserve-container
+          resources:
+            limits:
+              cpu: "4"
+              memory: 50Gi
+              nvidia.com/gpu: "1"
+            requests:
+              cpu: "1"
+              memory: 50Gi
+              nvidia.com/gpu: "1"
 
 Please see `Deploy the LLaMA model with vLLM Runtime <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/>`_ for more details.

--- a/docs/source/serving/deploying_with_kserve.rst
+++ b/docs/source/serving/deploying_with_kserve.rst
@@ -1,0 +1,40 @@
+.. _deploying_with_kserve:
+
+Deploying with KServe
+============================
+
+vLLM can be deployed with `KServe <https://github.com/kserve/kserve>`_ on Kubernetes for highly scalable distributed model serving by defining the following :code:`InferenceService` YAML spec:
+
+.. code-block:: yaml
+	apiVersion: serving.kserve.io/v1beta1
+	kind: InferenceService
+	metadata:
+	  name: llama-2-7b
+	spec:
+	  predictor:
+	    containers:
+	      - args:
+	        - --port
+	        - "8080"
+	        - --model
+	        - /mnt/models
+	      command:
+	        - python3
+	        - -m
+	        - vllm.entrypoints.api_server
+	      env:
+	        - name: STORAGE_URI
+	          value: gcs://kfserving-examples/llm/huggingface/llama
+	      image: kserve/vllmserver:latest
+	      name: kserve-container
+	      resources:
+	        limits:
+	          cpu: "4"
+	          memory: 50Gi
+	          nvidia.com/gpu: "1"
+	        requests:
+	          cpu: "1"
+	          memory: 50Gi
+	          nvidia.com/gpu: "1"
+
+Please see `Deploy the LLaMA model with vLLM Runtime <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/>`_ for more details.

--- a/docs/source/serving/deploying_with_kserve.rst
+++ b/docs/source/serving/deploying_with_kserve.rst
@@ -3,39 +3,6 @@
 Deploying with KServe
 ============================
 
-vLLM can be deployed with `KServe <https://github.com/kserve/kserve>`_ on Kubernetes for highly scalable distributed model serving by defining the following :code:`InferenceService` YAML spec:
+vLLM can be deployed with `KServe <https://github.com/kserve/kserve>`_ on Kubernetes for highly scalable distributed model serving.
 
-.. code-block:: yaml
-
-    apiVersion: serving.kserve.io/v1beta1
-    kind: InferenceService
-    metadata:
-      name: llama-2-7b
-    spec:
-      predictor:
-        containers:
-          - args:
-              - --port
-              - "8080"
-              - --model
-              - /mnt/models
-          command:
-            - python3
-            - -m
-            - vllm.entrypoints.api_server
-          env:
-            - name: STORAGE_URI
-              value: gcs://kfserving-examples/llm/huggingface/llama
-          image: kserve/vllmserver:latest
-          name: kserve-container
-          resources:
-            limits:
-              cpu: "4"
-              memory: 50Gi
-              nvidia.com/gpu: "1"
-            requests:
-              cpu: "1"
-              memory: 50Gi
-              nvidia.com/gpu: "1"
-
-Please see `Deploy the LLaMA model with vLLM Runtime <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/>`_ for more details.
+Please see `this guide <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/>`_ for more details on using vLLM with KServe.


### PR DESCRIPTION
The original source of the example can be found here: https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/