### PR TITLE
Don't build punica kernels by default

### DIFF
--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -13,6 +13,8 @@ $python_executable -m pip install -r requirements.txt
 
 # Limit the number of parallel jobs to avoid OOM
 export MAX_JOBS=1
+# Make sure punica is built for the release (for LoRA)
+export VLLM_INSTALL_PUNICA_KERNELS=1
 
 # Build
 $python_executable setup.py bdist_wheel --dist-dir=dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ ENV MAX_JOBS=${max_jobs}
 # number of threads used by nvcc
 ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
+# make sure punica kernels are built (for LoRA)
+ENV VLLM_INSTALL_PUNICA_KERNELS=1
 
 RUN python3 setup.py build_ext --inplace
 #################### EXTENSION Build IMAGE ####################

--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ if _is_cuda():
         with contextlib.suppress(ValueError):
             torch_cpp_ext.COMMON_NVCC_FLAGS.remove(flag)
 
-    install_punica = bool(int(os.getenv("VLLM_INSTALL_PUNICA_KERNELS", "1")))
+    install_punica = bool(int(os.getenv("VLLM_INSTALL_PUNICA_KERNELS", "0")))
     device_count = torch.cuda.device_count()
     for i in range(device_count):
         major, minor = torch.cuda.get_device_capability(i)

--- a/vllm/lora/punica.py
+++ b/vllm/lora/punica.py
@@ -157,14 +157,13 @@ else:
         **kwargs  # pylint: disable=unused-argument
     ):
         if torch.cuda.get_device_capability() < (8, 0):
-            raise ImportError(
-                "punica LoRA kernels require compute "
-                "capability>=8.0") from import_exc
+            raise ImportError("punica LoRA kernels require compute "
+                              "capability>=8.0") from import_exc
         else:
             raise ImportError(
-              "punica LoRA kernels could not be imported. If you built vLLM "
-              "from source, make sure VLLM_INSTALL_PUNICA_KERNELS=1 env var "
-              "was set.") from import_exc
+                "punica LoRA kernels could not be imported. If you built vLLM "
+                "from source, make sure VLLM_INSTALL_PUNICA_KERNELS=1 env var "
+                "was set.") from import_exc
 
     bgmv = _raise_exc
     add_lora = _raise_exc

--- a/vllm/lora/punica.py
+++ b/vllm/lora/punica.py
@@ -158,9 +158,13 @@ else:
     ):
         if torch.cuda.get_device_capability() < (8, 0):
             raise ImportError(
-                "LoRA kernels require compute capability>=8.0") from import_exc
+                "punica LoRA kernels require compute "
+                "capability>=8.0") from import_exc
         else:
-            raise import_exc
+            raise ImportError(
+              "punica LoRA kernels could not be imported. If you built vLLM "
+              "from source, make sure VLLM_INSTALL_PUNICA_KERNELS=1 env var "
+              "was set.") from import_exc
 
     bgmv = _raise_exc
     add_lora = _raise_exc


### PR DESCRIPTION
The punica kernels take quite a while to build and most developers won't need them, so it will be better to not build them by default.

Maybe in the future the build can be optimized and then we can bring them back. E.g. if we had good incremental compilation that would probably solve the problem.

Fixes https://github.com/vllm-project/vllm/issues/2604