### PR TITLE
Speculative Decoding

### DIFF
--- a/examples/api_client_spec_dec.py
+++ b/examples/api_client_spec_dec.py
@@ -1,0 +1,85 @@
+"""Example code for running queries from vLLM API server.
+Sample Usage:
+1. Launch a vLLM server with speculative decoding enabled:
+python -m vllm.entrypoints.api_server --model meta-llama/Llama-2-70b-hf \
+    --tensor-parallel-size 8 --draft-model TinyLlama/TinyLlama-1.1B-Chat-v0.6 --speculate-length 5
+2. Run query using this script:
+python api_client_spec_dec.py --prompt "San Francisco is a" --stream
+"""
+
+import argparse
+import json
+from typing import Iterable, List
+
+import requests
+
+
+def clear_line(n: int = 1) -> None:
+    LINE_UP = '\033[1A'
+    LINE_CLEAR = '\x1b[2K'
+    for _ in range(n):
+        print(LINE_UP, end=LINE_CLEAR, flush=True)
+
+
+def post_http_request(prompt: str,
+                      api_url: str,
+                      max_tokens: int = 256,
+                      stream: bool = False) -> requests.Response:
+    headers = {"User-Agent": "Test Client"}
+    pload = {
+        "prompt": prompt,
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+    response = requests.post(api_url, headers=headers, json=pload, stream=True)
+    return response
+
+
+def get_streaming_response(response: requests.Response) -> Iterable[List[str]]:
+    for chunk in response.iter_content(
+            chunk_size=8192,
+            decode_unicode=True,
+    ):
+        if chunk:
+            data = json.loads(chunk.decode("utf-8")[:-1])
+            output = data["text"]
+            yield output
+
+
+def get_response(response: requests.Response) -> List[str]:
+    data = json.loads(response.content)
+    output = data["text"]
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--prompt", type=str, default="San Francisco is a")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--stream", action="store_true")
+    args = parser.parse_args()
+    prompt = args.prompt
+    api_url = f"http://{args.host}:{args.port}/generate"
+    max_tokens = args.max_tokens
+    stream = args.stream
+
+    print(f"Prompt: {prompt!r}\n", flush=True)
+    response = post_http_request(prompt, api_url, max_tokens, stream)
+
+    if stream:
+        num_printed_lines = 0
+        char_printed = 0
+        for h in get_streaming_response(response):
+            line = h[0]
+            new_chars = line[char_printed:]
+            char_printed = len(line)
+            print(f"{new_chars}", flush=True, end='')
+            num_printed_lines += 1
+        print()
+    else:
+        output = get_response(response)
+        line = output[0]
+        print(f"{line!r}", flush=True)

--- a/examples/offline_inference_spec_dec.py
+++ b/examples/offline_inference_spec_dec.py
@@ -1,0 +1,30 @@
+import numpy as np
+from vllm import LLM, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.0, max_tokens=512)
+
+# Create an LLM.
+llm = LLM(model="lmsys/vicuna-13b-v1.5",
+          draft_model="TinyLlama/TinyLlama-1.1B-Chat-v0.6",
+          speculate_length=5)
+
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    mean_num_accepted = np.mean(output.outputs[0].acceptance_history)
+    print(
+        f"Prompt: {prompt!r}, Generated text: {generated_text!r}, Mean acceptance length={mean_num_accepted}"
+    )

--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -27,6 +27,9 @@ class InputMetadata:
         block_tables: Optional[torch.Tensor],
         use_cuda_graph: bool,
         kv_cache_dtype: str,
+        use_speculate: Optional[bool] = False,
+        is_multi_query_mode: Optional[bool] = False,
+        batch_size: Optional[int] = None,
     ) -> None:
         self.is_prompt = is_prompt
         self.prompt_lens = prompt_lens
@@ -42,6 +45,11 @@ class InputMetadata:
         # Set during the execution of the first attention op.
         # FIXME(woosuk): This is a hack.
         self.attn_bias = None
+
+        # Variables used in speculative decoding.
+        self.use_speculate = use_speculate
+        self.is_multi_query_mode = is_multi_query_mode
+        self.batch_size = batch_size
 
     def __repr__(self) -> str:
         return ("InputMetadata("

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -9,7 +9,8 @@ from vllm.model_executor.parallel_utils.communication_op import (
 from vllm.model_executor.sampling_metadata import SamplingMetadata, SamplingTensors
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import (PromptLogprobs, SampleLogprobs, SamplerOutput,
-                           SequenceData, SequenceGroupOutput, SequenceOutput)
+                           SequenceData, SequenceGroupOutput, SequenceOutput,
+                           SpeculateSequenceOutput, SpeculateSamplerOutput)
 
 
 class Sampler(nn.Module):
@@ -55,7 +56,16 @@ class Sampler(nn.Module):
         embedding_bias: Optional[torch.Tensor] = None,
     ) -> Optional[SamplerOutput]:
         # Get the hidden states that we use for sampling.
-        hidden_states = _prune_hidden_states(hidden_states, sampling_metadata)
+        if sampling_metadata.is_multi_query_mode:
+            # NOTE: For the multi-query mode in speculative decoding, we need
+            # to keep logits for all tokens.
+            # hidden_states is of shape [bsz, num_query_tokens, vocab_size]
+            assert len(hidden_states.shape) == 3
+        else:
+            # hidden_states is of shape [bsz, vocab_size]
+            hidden_states = _prune_hidden_states(hidden_states,
+                                                 sampling_metadata)
+            assert len(hidden_states.shape) == 2
 
         # Get the logits for the next tokens.
         logits = self._get_logits(hidden_states, embedding, embedding_bias)
@@ -68,19 +78,20 @@ class Sampler(nn.Module):
             return None
 
         assert logits is not None
-        _, vocab_size = logits.shape
+        vocab_size = logits.shape[-1]
 
         # Apply logits processors (if any).
         logits = _apply_logits_processors(logits, sampling_metadata)
 
         # Prepare sampling tensors with pinned memory to avoid blocking.
-        (sampling_tensors, do_penalties, do_top_p_top_k,
-         do_min_p) = SamplingTensors.from_sampling_metadata(
+        (sampling_tensors, do_penalties, do_top_p_top_k, do_min_p,
+         do_greedy) = SamplingTensors.from_sampling_metadata(
              sampling_metadata, vocab_size, logits.device, logits.dtype)
 
         # Apply presence and frequency penalties.
         if do_penalties:
-            logits = _apply_penalties(logits, sampling_tensors.prompt_tokens,
+            logits = _apply_penalties(logits, sampling_metadata,
+                                      sampling_tensors.prompt_tokens,
                                       sampling_tensors.output_tokens,
                                       sampling_tensors.presence_penalties,
                                       sampling_tensors.frequency_penalties,
@@ -88,8 +99,10 @@ class Sampler(nn.Module):
 
         # Apply temperature scaling.
         # Use in-place division to avoid creating a new tensor.
-        logits.div_(sampling_tensors.temperatures.unsqueeze_(dim=1))
-
+        if sampling_metadata.is_multi_query_mode:
+            logits.div_(sampling_tensors.temperatures.view(-1, 1, 1))
+        else:
+            logits.div_(sampling_tensors.temperatures.unsqueeze_(dim=1))
         if do_top_p_top_k:
             logits = _apply_top_k_top_p(logits, sampling_tensors.top_ps,
                                         sampling_tensors.top_ks)
@@ -103,14 +116,31 @@ class Sampler(nn.Module):
         # Compute the log probabilities.
         # Use log_softmax to ensure numerical stability.
         logprobs = torch.log_softmax(logits, dim=-1, dtype=torch.float)
-
-        # Sample the next tokens.
-        sample_results = _sample(probs, logprobs, sampling_metadata)
-        # Get the logprobs query results.
-        prompt_logprobs, sample_logprobs = _get_logprobs(
-            logprobs, sampling_metadata, sample_results)
-        return _build_sampler_output(sample_results, sampling_metadata,
-                                     prompt_logprobs, sample_logprobs)
+        if sampling_metadata.is_multi_query_mode:
+            # Run rejection sampling algorithm in speculative decoding.
+            sampled_token_ids, num_accepted = _reject_sample(
+                probs, logprobs, sampling_metadata, do_greedy,
+                sampling_tensors.greedy_flags)
+            out = _build_reject_sampler_output(logprobs, sampling_metadata,
+                                               sampled_token_ids, num_accepted)
+            return out
+        else:
+            # Sample the next tokens.
+            sample_results = _sample(probs, logprobs, sampling_metadata)
+            # Get the logprobs query results.
+            prompt_logprobs, sample_logprobs = _get_logprobs(
+                logprobs, sampling_metadata, sample_results)
+            parent_probs_list = None
+            if sampling_metadata.use_speculate:
+                bs = probs.shape[0]
+                parent_probs_list = torch.split(probs, 1, dim=0)
+                assert len(parent_probs_list) == bs
+            out = _build_sampler_output(sample_results,
+                                        sampling_metadata,
+                                        prompt_logprobs,
+                                        sample_logprobs,
+                                        parent_probs_list=parent_probs_list)
+            return out
 
 
 def _prune_hidden_states(
@@ -139,6 +169,55 @@ def _get_bin_counts_and_mask(
     return bin_counts, mask
 
 
+def _get_multi_query_bin_counts_and_mask(
+    tokens: torch.Tensor,
+    input_token_ids: torch.Tensor,
+    vocab_size: int,
+    num_seqs: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Similar to _get_bin_counts_and_mask, this function
+    supports multiple tokens per request.
+
+    Args:
+        tokens (torch.Tensor): tensor of all generated token ids, padded to
+            the longest sequence.
+        input_token_ids (torch.Tensor): tensor of all input token ids.
+        vocab_size (int): vocabulary size, vocab_size + 1 is used for padding.
+        num_seqs (int): batch size.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: (bin_counts, mask)
+    """
+    assert len(tokens.shape) == len(input_token_ids.shape) == 2
+    assert input_token_ids.shape[0] == num_seqs
+    num_tokens = input_token_ids.shape[1]
+
+    # For the case of multiple input tokens per request, each token will have
+    # one bin counter. We also need to consider the causal relationship among
+    # tokens of the same request. We first construct bins by counting all tokens
+    # and then fix the them by reversing errorly counted tokens using causal mask.
+    bin_counts = torch.zeros((num_seqs, vocab_size + 1),
+                             dtype=torch.long,
+                             device=tokens.device)
+    bin_counts.scatter_add_(1, tokens, torch.ones_like(tokens))
+
+    # reshape bin_counts to [num_seqs, num_tokens, vocab_size + 1]
+    bin_counts = bin_counts[:, None, :].repeat([1, num_tokens, 1])
+
+    # construct tokens_to_remove with shape [num_seqs, num_tokens, num_tokens]
+    tokens_to_remove = input_token_ids[:, None, :].repeat(1, num_tokens, 1)
+
+    # select tokens to be removed using causal mask
+    causal_mask = torch.tril(torch.ones(num_tokens, num_tokens)).to(torch.bool)
+    tokens_to_remove[causal_mask[None, :, :].expand(num_seqs, num_tokens,
+                                                    num_tokens)] = vocab_size
+    bin_counts = bin_counts.scatter_add_(2, tokens_to_remove,
+                                         -torch.ones_like(tokens_to_remove))
+    bin_counts = bin_counts[:, :, :vocab_size]
+    mask = bin_counts > 0
+    return (bin_counts, mask)
+
+
 def _apply_logits_processors(
     logits: torch.Tensor,
     sampling_metadata: SamplingMetadata,
@@ -163,26 +242,47 @@ def _apply_logits_processors(
     return logits
 
 
-def _apply_penalties(logits: torch.Tensor, prompt_tokens_tensor: torch.Tensor,
+def _apply_penalties(logits: torch.Tensor, sampling_metadata: SamplingMetadata,
+                     prompt_tokens_tensor: torch.Tensor,
                      output_tokens_tensor: torch.Tensor,
                      presence_penalties: torch.Tensor,
                      frequency_penalties: torch.Tensor,
                      repetition_penalties: torch.Tensor) -> torch.Tensor:
-    num_seqs, vocab_size = logits.shape
+    num_seqs, vocab_size = logits.shape[0], logits.shape[-1]
     _, prompt_mask = _get_bin_counts_and_mask(prompt_tokens_tensor, vocab_size,
                                               num_seqs)
-    output_bin_counts, output_mask = _get_bin_counts_and_mask(
-        output_tokens_tensor, vocab_size, num_seqs)
+    if sampling_metadata.is_multi_query_mode:
+        assert len(logits.shape) == 3
+        assert sampling_metadata.input_token_ids is not None
+    else:
+        assert len(logits.shape) == 2
 
-    repetition_penalties = repetition_penalties[:, None].repeat(1, vocab_size)
-    repetition_penalties[~(prompt_mask | output_mask)] = 1.0
-    logits = torch.where(logits > 0, logits / repetition_penalties,
-                         logits * repetition_penalties)
+    if sampling_metadata.is_multi_query_mode:
+        num_tokens = sampling_metadata.input_token_ids.shape[1]
+        output_bin_counts, output_mask = _get_multi_query_bin_counts_and_mask(
+            output_tokens_tensor, sampling_metadata.input_token_ids,
+            vocab_size, num_seqs)
+        repetition_penalties = repetition_penalties[:, None, None].repeat(
+            1, num_tokens, vocab_size)
+        repetition_penalties[~(prompt_mask[:, None, :] | output_mask)] = 1.0
+        logits = torch.where(logits > 0, logits / repetition_penalties,
+                             logits * repetition_penalties)
+        logits -= frequency_penalties[:, None, None] * output_bin_counts
+        logits -= presence_penalties[:, None, None] * output_mask
+    else:
+        output_bin_counts, output_mask = _get_bin_counts_and_mask(
+            output_tokens_tensor, vocab_size, num_seqs)
 
-    # We follow the definition in OpenAI API.
-    # Refer to https://platform.openai.com/docs/api-reference/parameter-details
-    logits -= frequency_penalties.unsqueeze_(dim=1) * output_bin_counts
-    logits -= presence_penalties.unsqueeze_(dim=1) * output_mask
+        repetition_penalties = repetition_penalties[:, None].repeat(
+            1, vocab_size)
+        repetition_penalties[~(prompt_mask | output_mask)] = 1.0
+        logits = torch.where(logits > 0, logits / repetition_penalties,
+                             logits * repetition_penalties)
+
+        # We follow the definition in OpenAI API.
+        # Refer to https://platform.openai.com/docs/api-reference/parameter-details
+        logits -= frequency_penalties.unsqueeze_(dim=1) * output_bin_counts
+        logits -= presence_penalties.unsqueeze_(dim=1) * output_mask
     return logits
 
 
@@ -191,21 +291,35 @@ def _apply_top_k_top_p(
     p: torch.Tensor,
     k: torch.Tensor,
 ) -> torch.Tensor:
+    # logits may have shape [bs, vocab_size] or [bs, num_tokens, vocab_size]
+    assert len(logits.shape) in (2, 3)
     logits_sort, logits_idx = logits.sort(dim=-1, descending=False)
 
     # Apply top-k.
-    top_k_mask = logits_sort.size(1) - k.to(torch.long)
+    top_k_mask = logits_sort.size(-1) - k.to(torch.long)
+
     # Get all the top_k values.
-    top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+    if len(logits.shape) == 2:
+        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+    else:
+        # logits has shape [bs, num_tokens, vocab_size]
+        num_tokens = logits.shape[1]
+        top_k_mask = logits_sort.gather(
+            2, top_k_mask[:, None, None].repeat(1, num_tokens, 1))
     top_k_mask = logits_sort < top_k_mask
     logits_sort.masked_fill_(top_k_mask, -float("inf"))
 
     # Apply top-p.
     probs_sort = logits_sort.softmax(dim=-1)
     probs_sum = probs_sort.cumsum(dim=-1)
-    top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
-    # at least one
-    top_p_mask[:, -1] = False
+    if len(logits.shape) == 2:
+        top_p_mask = probs_sum <= 1 - p.unsqueeze(dim=1)
+        # at least one
+        top_p_mask[:, -1] = False
+    else:
+        top_p_mask = probs_sum <= 1 - p.view(-1, 1, 1)
+        # at least one
+        top_p_mask[:, :, -1] = False
     logits_sort.masked_fill_(top_p_mask, -float("inf"))
 
     # Re-sort the probabilities.
@@ -228,7 +342,10 @@ def _apply_min_p(
     """
     probs = torch.softmax(logits, dim=-1)
     top_probs, _ = probs.max(dim=-1, keepdim=True)
-    scaled_min_p = min_p.unsqueeze_(dim=1) * top_probs
+    if len(logits.shape) == 2:
+        scaled_min_p = min_p.unsqueeze_(dim=1) * top_probs
+    else:
+        scaled_min_p = min_p.view(-1, 1, 1) * top_probs
     tokens_to_remove = probs < scaled_min_p
     logits = logits.masked_fill_(tokens_to_remove, -float("inf"))
 
@@ -557,12 +674,17 @@ def _build_sampler_output(
     sampling_metadata: SamplingMetadata,
     prompt_logprobs: List[Optional[PromptLogprobs]],
     sample_logprobs: List[SampleLogprobs],
+    parent_probs_list: List[torch.Tensor] = None,
+    num_accepted_list: List[int] = None,
 ) -> SamplerOutput:
     sampler_output = []
-    for (seq_group, sample_result, group_prompt_logprobs,
-         group_sample_logprobs) in zip(sampling_metadata.seq_groups,
-                                       sample_results, prompt_logprobs,
-                                       sample_logprobs):
+    for i, seq_group in enumerate(sampling_metadata.seq_groups):
+        sample_result = sample_results[i]
+        group_prompt_logprobs = prompt_logprobs[i]
+        group_sample_logprobs = sample_logprobs[i]
+        parent_probs = parent_probs_list[i] if parent_probs_list else None
+        num_accepted_tokens = num_accepted_list[
+            i] if num_accepted_list else None
         seq_ids, _ = seq_group
         next_token_ids, parent_ids = sample_result
         seq_outputs = []
@@ -570,7 +692,140 @@ def _build_sampler_output(
                                                       next_token_ids,
                                                       group_sample_logprobs):
             seq_outputs.append(
-                SequenceOutput(seq_ids[parent_id], next_token_id, logprobs))
+                SequenceOutput(seq_ids[parent_id], next_token_id, logprobs,
+                               parent_probs))
         sampler_output.append(
-            SequenceGroupOutput(seq_outputs, group_prompt_logprobs))
+            SequenceGroupOutput(seq_outputs, group_prompt_logprobs,
+                                num_accepted_tokens))
     return sampler_output
+
+
+def _reject_sample(
+    target_token_probs: torch.Tensor,
+    target_token_logprobs: torch.Tensor,
+    sampling_metadata: SamplingMetadata,
+    do_greedy: bool = False,
+    greedy_flags: Optional[torch.Tensor] = None,
+) -> Tuple[List[Tuple[List[int], List[int]]], torch.Tensor, List]:
+    assert sampling_metadata.draft_token_ids is not None
+    assert sampling_metadata.draft_token_probs is not None
+    draft_token_ids = sampling_metadata.draft_token_ids
+    draft_token_probs = sampling_metadata.draft_token_probs
+
+    # 1. Gather probs from both target and draft model.
+    gather_indices = draft_token_ids.unsqueeze(-1)
+    target_probs = torch.gather(target_token_probs, -1,
+                                gather_indices).squeeze(-1)
+    draft_probs = torch.gather(draft_token_probs, -1,
+                               gather_indices).squeeze(-1)
+    # 2. Calculate confidence score.
+    confidence = torch.clamp(target_probs / draft_probs, min=0, max=1)
+    # 3. Decide if tokens are accepted or not.
+    random_values = torch.rand(size=(confidence.shape[-1], ),
+                               dtype=confidence.dtype,
+                               device=confidence.device)
+    is_match = confidence > random_values
+    if do_greedy:
+        # Special treatment for greedy sampling
+        assert greedy_flags is not None
+        num_draft_tokens = draft_token_ids.shape[-1]
+        is_greedy_match = torch.argmax(
+            target_token_logprobs, -1)[:, :num_draft_tokens] == draft_token_ids
+        is_match = torch.where(
+            greedy_flags[:, None].expand(-1, num_draft_tokens),
+            is_greedy_match, is_match)
+    # For the convenience of handling the case when all tokens are accepted, we pad
+    # the acceptance matrix's shape from [bsz, n_draft] to [bsz, n_draft+1].
+    is_match = torch.nn.functional.pad(is_match, (0, 1), value=False)
+    num_accepted = torch.argmin(is_match.to(torch.int), axis=-1)
+    # 4. Construct next token probs and sample next token. Note num_acceped
+    # has shape [bsz] and gather_indices has shape[bsz, 1, vocab_size].
+    # Here we set the vocab size to be whichever smaller when the draft model
+    # has different vocab size than the target model.
+    vocab_size = min(draft_token_probs.shape[-1], target_token_probs.shape[-1])
+    gather_indices = num_accepted[:, None, None].expand(-1, 1, vocab_size)
+    # Run rejection sampling algorithm described in https://arxiv.org/abs/2302.01318
+    p = torch.gather(target_token_probs, 1, gather_indices).squeeze(1)
+    q = torch.gather(draft_token_probs, 1, gather_indices).squeeze(1)
+    # For numerical stability, convert nans in draft ptobs to 0.
+    q.nan_to_num_(0, 0, 0)
+    diff = p - q
+    diff.clamp_(min=0)
+    probs = diff / torch.sum(diff, axis=-1).view(-1, 1)
+    sampled_token_ids = _multinomial(probs, 1).squeeze(-1)
+    if do_greedy:
+        # Special treatment for greedy sampling
+        logprobs = torch.gather(target_token_logprobs, 1,
+                                gather_indices).squeeze(1)
+        greedy_sampled_token_ids = torch.argmax(logprobs, dim=-1)
+        sampled_token_ids = torch.where(greedy_flags, greedy_sampled_token_ids,
+                                        sampled_token_ids)
+    return sampled_token_ids, num_accepted
+
+
+def _build_reject_sampler_output(
+        target_token_logprobs: torch.Tensor,
+        sampling_metadata: SamplingMetadata, sampled_token_ids: torch.Tensor,
+        num_accepted_tokens: torch.Tensor) -> SpeculateSamplerOutput:
+    largest_num_logprobs = 0
+    gather_indices = sampling_metadata.draft_token_ids.unsqueeze(-1)
+    # shape: [bsz, seq_len]
+    logprob_matrix = torch.gather(target_token_logprobs, -1,
+                                  gather_indices).squeeze(-1).tolist()
+    # shape: [bsz, seq_len]
+    draft_token_ids = sampling_metadata.draft_token_ids.tolist()
+    # shape: [bsz]
+    sampled_token_ids = sampled_token_ids.tolist()
+    batch_arange = torch.arange(target_token_logprobs.size(0))
+    # shape: [bsz]
+    sampled_token_logprob = target_token_logprobs[batch_arange,
+                                                  num_accepted_tokens,
+                                                  sampled_token_ids].tolist()
+    # shape: [bsz]
+    num_accepted_tokens = num_accepted_tokens.tolist()
+
+    outputs = []
+    # Process generated tokens and their logprob.
+    for sample_idx, (seq_ids, sampling_params) in enumerate(
+            sampling_metadata.seq_groups):
+        assert len(seq_ids) == 1
+
+        num_accepted = num_accepted_tokens[sample_idx]
+        accepted_token_ids = draft_token_ids[sample_idx][:num_accepted]
+        logprob_list = logprob_matrix[sample_idx][:num_accepted]
+        gen_token_ids = accepted_token_ids + [sampled_token_ids[sample_idx]]
+        gen_token_logprob_list = logprob_list + \
+            [sampled_token_logprob[sample_idx]]
+        logprobs_dict_list = [{
+            token_id: logprob
+        } for token_id, logprob in zip(gen_token_ids, gen_token_logprob_list)]
+        outputs.append(
+            SpeculateSequenceOutput(sample_idx, gen_token_ids,
+                                    logprobs_dict_list, num_accepted))
+        if sampling_params.logprobs is not None:
+            largest_num_logprobs = max(largest_num_logprobs,
+                                       sampling_params.logprobs)
+    # Update logprobs dict in case largest_num_logprobs > 0.
+    if largest_num_logprobs > 0:
+        top_logprobs, top_token_ids = torch.topk(target_token_logprobs,
+                                                 largest_num_logprobs,
+                                                 dim=-1)
+        # shape: [bsz, seq_len, largest_num_logprobs]
+        top_logprobs = top_logprobs.cpu()
+        # shape: [bsz, seq_len, largest_num_logprobs]
+        top_token_ids = top_token_ids.cpu()
+        for sample_idx, (_, sampling_params) in enumerate(
+                sampling_metadata.seq_groups):
+            num_logprobs = sampling_params.logprobs
+            if num_logprobs:
+                num_accepted = num_accepted_tokens[sample_idx]
+                logprobs_dict_list = outputs[sample_idx].logprobs_list
+                for position in range(num_accepted + 1):
+                    logprobs_dict = logprobs_dict_list[position]
+                    selected_top_logprobs = top_logprobs[
+                        sample_idx, position, :num_logprobs].tolist()
+                    selected_top_token_ids = top_token_ids[
+                        sample_idx, position, :num_logprobs].tolist()
+                    logprobs_dict.update(
+                        zip(selected_top_token_ids, selected_top_logprobs))
+    return outputs

--- a/vllm/model_executor/layers/triton_kernel/mqa.py
+++ b/vllm/model_executor/layers/triton_kernel/mqa.py
@@ -1,0 +1,169 @@
+"""
+Paged multi-query attention.
+"""
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fwd_kernel(
+    query,  # [bsz, num_query_tokens, num_heads, head_size]
+    output,  # [bsz, num_query_tokens, num_heads, head_size]
+    key_cache,  # [num_blocks, num_kv_heads, head_size/x, block_size, x]
+    value_cache,  # [num_blocks, num_kv_heads, head_size, block_size]
+    block_tables,  # [bsz, max_num_blocks]
+    context_lens,  # [bsz]
+    stride_query_0,
+    stride_query_1,
+    stride_query_2,
+    stride_output_0,
+    stride_output_1,
+    stride_output_2,
+    stride_key_0,
+    stride_key_1,
+    stride_key_2,
+    stride_key_3,
+    stride_value_0,
+    stride_value_1,
+    stride_value_2,
+    stride_block_tables_0,
+    head_size: tl.constexpr,
+    num_query_tokens: tl.constexpr,
+    padded_num_query_tokens: tl.constexpr,
+    x: tl.constexpr,
+    block_size: tl.constexpr,
+    sm_scale: tl.constexpr,
+    num_queries_per_kv: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    kv_head_idx = head_idx // num_queries_per_kv
+    ctx_len = tl.load(context_lens + batch_idx)
+
+    offs_num_query_tokens = tl.arange(0, padded_num_query_tokens)
+    offs_block_size = tl.arange(0, block_size)
+    offs_head_size = tl.arange(0, head_size)
+
+    # load q from block ptr of shape [padded_num_query_tokens, head_size]
+    offs_q = batch_idx * stride_query_0 + \
+        offs_num_query_tokens[:, None] * stride_query_1 + head_idx * \
+        stride_query_2 + offs_head_size[None, :]
+    q = tl.load(query + offs_q,
+                mask=offs_num_query_tokens[:, None] < num_query_tokens,
+                other=0.0)
+
+    m_i = tl.zeros([padded_num_query_tokens], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([padded_num_query_tokens], dtype=tl.float32)
+    acc = tl.zeros([padded_num_query_tokens, head_size], dtype=tl.float32)
+
+    for block_idx in range(0, tl.cdiv(ctx_len, block_size)):
+        token_offs = (block_idx * block_size + offs_block_size)
+        block_offs = tl.load(block_tables + batch_idx * stride_block_tables_0 +
+                             token_offs // block_size,
+                             mask=token_offs < ctx_len)
+        # load k from block ptr of shape [head_size, block_size]
+        offs_k = block_offs[None, :] * stride_key_0 + kv_head_idx * stride_key_1 + \
+            (offs_head_size[:, None] // x) * stride_key_2 + \
+            offs_block_size[None, :] * stride_key_3 + \
+            offs_head_size[:, None] % x
+        k = tl.load(
+            key_cache + offs_k,
+            mask=block_idx * block_size + offs_block_size[None, :] < ctx_len,
+            other=0.0)
+        # calculate qk
+        qk = tl.zeros([padded_num_query_tokens, block_size], dtype=tl.float32)
+        qk += tl.dot(q, k)
+        # apply causal mask
+        offs_a = ctx_len - num_query_tokens + offs_num_query_tokens[:, None]
+        offs_b = block_idx * block_size + offs_block_size[None, :]
+        mask = offs_a >= offs_b
+        qk = qk * sm_scale + tl.where(mask, 0, -1.0e6)
+        # calculate m_ij and l_ij
+        m_ij = tl.maximum(m_i, tl.max(qk, 1))
+        qk = qk - m_ij[:, None]
+        p = tl.exp(qk)
+        l_ij = tl.sum(p, 1)
+        # update m_i and l_i
+        alpha = tl.exp(m_i - m_ij)
+        m_i = m_ij
+        l_i = l_i * alpha + l_ij
+        # rescale previous acc
+        acc = acc * alpha[:, None]
+        # load v from block ptr of shape [block_size, head_size]
+        offs_v = block_offs[:, None] * stride_value_0 + kv_head_idx * stride_value_1 + \
+            offs_head_size[None, :] * stride_value_2 + offs_block_size[:, None]
+        v = tl.load(value_cache + offs_v)
+        # update acc
+        acc += tl.dot(p.to(v.dtype), v)
+    # divide acc by row sum
+    acc = acc / l_i[:, None]
+    # update output
+    offs_output = batch_idx * stride_output_0 + \
+        offs_num_query_tokens[:, None] * stride_output_1 + head_idx * \
+        stride_output_2 + offs_head_size[None, :]
+    tl.store(output + offs_output,
+             acc.to(output.type.element_ty),
+             mask=offs_num_query_tokens[:, None] < num_query_tokens)
+    return
+
+
+def paged_multi_query_attention(
+    output: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    num_kv_heads: int,
+    scale: float,
+    block_tables: torch.Tensor,
+    context_lens: torch.Tensor,
+    alibi_slopes: Optional[torch.Tensor] = None,
+) -> None:
+    assert alibi_slopes is None, "Alibi is currently not supported."
+    # Note that triton requires A.shape(0) to be at least 16 in tl.dot(A, B).
+    padded_num_query_tokens = 16
+    num_tokens, num_heads, head_size = query.shape
+    bsz = context_lens.shape[0]
+    num_query_tokens = num_tokens // bsz
+    block_size = value_cache.shape[3]
+    # Here we limit num_query_tokens <= 16 since it's rarely useful to evaluate more than 16
+    # tokens in speculative decoding.
+    assert num_query_tokens <= padded_num_query_tokens, \
+        f"The num_query_tokens ({num_query_tokens}) must be <= {padded_num_query_tokens}"
+    assert num_heads % num_kv_heads == 0
+    num_queries_per_kv = num_heads // num_kv_heads
+    x = key_cache.shape[-1]
+    grid = (bsz, num_heads)
+    query = query.view(bsz, num_query_tokens, num_heads, head_size)
+    output = output.view(bsz, num_query_tokens, num_heads, head_size)
+    _fwd_kernel[grid](
+        query,  # [bsz, num_query_tokens, num_heads, head_size]
+        output,  # [bsz, num_query_tokens, num_heads, head_size]
+        key_cache,  # [num_blocks, num_kv_heads, head_size/x, block_size, x]
+        value_cache,  # [num_blocks, num_kv_heads, head_size, block_size]
+        block_tables,  # [bsz, max_num_blocks]
+        context_lens,  # [bsz]
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        key_cache.stride(0),
+        key_cache.stride(1),
+        key_cache.stride(2),
+        key_cache.stride(3),
+        value_cache.stride(0),
+        value_cache.stride(1),
+        value_cache.stride(2),
+        block_tables.stride(0),
+        head_size,
+        num_query_tokens,
+        padded_num_query_tokens,
+        x,
+        block_size,
+        scale,
+        num_queries_per_kv,
+    )

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -30,6 +30,7 @@ class CompletionOutput:
         logprobs: Optional[SampleLogprobs],
         finish_reason: Optional[str] = None,
         lora_request: Optional[LoRARequest] = None,
+        acceptance_history: Optional[List[int]] = None,
     ) -> None:
         self.index = index
         self.text = text
@@ -38,6 +39,7 @@ class CompletionOutput:
         self.logprobs = logprobs
         self.finish_reason = finish_reason
         self.lora_request = lora_request
+        self.acceptance_history = acceptance_history
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -108,10 +110,14 @@ class RequestOutput:
                 # logprobs are not requested.
                 logprobs = None
             finshed_reason = SequenceStatus.get_finished_reason(seq.status)
-            output = CompletionOutput(seqs.index(seq), seq.output_text,
-                                      seq.get_output_token_ids(),
-                                      seq.get_cumulative_logprob(), logprobs,
-                                      finshed_reason)
+            output = CompletionOutput(
+                seqs.index(seq),
+                seq.output_text,
+                seq.get_output_token_ids(),
+                seq.get_cumulative_logprob(),
+                logprobs,
+                finish_reason=finshed_reason,
+                acceptance_history=seq.acceptance_history)
             outputs.append(output)
 
         # Every sequence in the sequence group should have the same prompt.

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -188,12 +188,13 @@ def detokenize_incrementally(
     prev_tokens: Optional[List[str]],
     prefix_offset: int = 0,
     read_offset: int = 0,
+    new_token_start_loc: int = -1,
     skip_special_tokens: bool = False,
     spaces_between_special_tokens: bool = True,
 ) -> Tuple[List[str], str, int, int]:
-    new_token_id = all_input_ids[-1]
     # This is the first iteration for this sequence
     if prev_tokens is None:
+        new_token_id = all_input_ids[-1]
         new_tokens = tokenizer.convert_ids_to_tokens(
             all_input_ids, skip_special_tokens=skip_special_tokens)
         output_tokens = new_tokens
@@ -209,7 +210,8 @@ def detokenize_incrementally(
     else:
         # Put new_token_id in a list so skip_special_tokens is respected
         new_tokens = tokenizer.convert_ids_to_tokens(
-            [new_token_id], skip_special_tokens=skip_special_tokens)
+            all_input_ids[new_token_start_loc:],
+            skip_special_tokens=skip_special_tokens)
         output_tokens = prev_tokens + new_tokens
 
     # The prefix text is necessary only to defeat cleanup algorithms in

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -12,16 +12,19 @@ from vllm.logger import init_logger
 from vllm.model_executor import get_model, InputMetadata, SamplingMetadata
 from vllm.model_executor.parallel_utils import cupy_utils
 from vllm.model_executor.parallel_utils.communication_op import (
-    broadcast_tensor_dict)
+    broadcast_object_list, broadcast_tensor_dict)
 from vllm.model_executor.parallel_utils.parallel_state import (
     with_cupy_nccl_for_all_reduce)
 from vllm.model_executor.parallel_utils import custom_all_reduce
 from vllm.sampling_params import SamplingParams, SamplingType
-from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
+from vllm.sequence import (SamplerOutput, SequenceData, SequenceGroupMetadata,
+                           SpeculateOutput, SpeculateSequenceGroupOutput)
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.request import LoRARequest
 from vllm.utils import in_wsl
+from vllm.model_executor.parallel_utils.parallel_state import (MarkActiveModel,
+                                                               ActiveModel)
 
 logger = init_logger(__name__)
 
@@ -44,6 +47,9 @@ class ModelRunner:
         lora_config: Optional[LoRAConfig],
         kv_cache_dtype: Optional[str] = "auto",
         is_driver_worker: bool = False,
+        rank: int = 0,
+        draft_model_config: Optional[ModelConfig] = None,
+        speculate_length: Optional[int] = None,
     ):
         self.model_config = model_config
         self.parallel_config = parallel_config
@@ -80,6 +86,15 @@ class ModelRunner:
         self.in_wsl = in_wsl()
         self.kv_cache_dtype = kv_cache_dtype
 
+        # Variables used in speculative decoding
+        self.rank = rank
+        self.draft_model = None
+        self.draft_model_config = draft_model_config
+        self.use_speculate = draft_model_config is not None
+        self.speculate_length = speculate_length
+        self.d_graph_runners: Dict[int, CUDAGraphRunner] = {}
+        self.d_graph_memory_pool = None  # Set during graph capture
+
     def load_model(self) -> None:
         self.model = get_model(self.model_config, self.device_config,
                                self.lora_config)
@@ -103,6 +118,14 @@ class ModelRunner:
                 self.model.embedding_padding_modules)
             self.model = self.lora_manager.create_lora_manager(self.model)
 
+        # Load draft model when enabling speculative decoding
+        if self.use_speculate and self.rank < self.parallel_config.draft_model_tp_size:
+            with MarkActiveModel(ActiveModel.DRAFT):
+                # NOTE: We use global variable to control parallel state (world size, rank)
+                # of draft model used in speculative decoding.
+                self.draft_model = get_model(self.draft_model_config,
+                                             self.device_config)
+
     def set_block_size(self, block_size: int) -> None:
         self.block_size = block_size
 
@@ -114,6 +137,7 @@ class ModelRunner:
     def _prepare_prompt(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
+        is_draft_model: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata, List[int], List[int],
                List[int], List[int], Set[LoRARequest]]:
         assert len(seq_group_metadata_list) > 0
@@ -175,7 +199,8 @@ class ModelRunner:
 
             # Compute the slot mapping.
             slot_mapping.append([])
-            block_table = seq_group_metadata.block_tables[seq_id]
+            block_table = seq_group_metadata.d_block_tables[seq_id] if is_draft_model \
+                else seq_group_metadata.block_tables[seq_id]
             # Mask the [0, start_idx) tokens of the prompt with _PAD_SLOT_ID,
             # where start_idx is max(0, prompt_len - sliding_window).
             # For example, if the prompt len is 10, sliding window is 8, and
@@ -257,6 +282,8 @@ class ModelRunner:
     def _prepare_decode(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
+        is_draft_model: bool = False,
+        is_multi_query_mode: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata, List[int], List[int],
                Set[LoRARequest]]:
         assert len(seq_group_metadata_list) > 0
@@ -280,22 +307,44 @@ class ModelRunner:
 
             for seq_id in seq_ids:
                 seq_data = seq_group_metadata.seq_data[seq_id]
-                generation_token = seq_data.get_last_token_id()
-                input_tokens.append([generation_token])
 
-                seq_len = seq_data.get_len()
-                position = seq_len - 1
-                input_positions.append([position])
+                if is_multi_query_mode:
+                    assert not is_draft_model, \
+                        "Only target model is allowed to run multi-query mode"
+                    num_generation_tokens = seq_data.get_num_draft_tokens() + 1
+                    generation_tokens = [seq_data.get_last_token_id()
+                                         ] + seq_data.get_draft_token_ids()
+                else:
+                    num_generation_tokens = 1
+                    token_id = seq_data.get_last_draft_token_id() if \
+                        seq_data.get_num_draft_tokens() > 0 else seq_data.get_last_token_id()
+                    generation_tokens = [token_id]
+
+                input_tokens.append(generation_tokens)
+                seq_len = seq_data.get_len() + seq_data.get_num_draft_tokens()
 
                 context_len = seq_len if self.sliding_window is None else min(
                     seq_len, self.sliding_window)
                 context_lens.append(context_len)
 
-                block_table = seq_group_metadata.block_tables[seq_id]
-                block_number = block_table[position // self.block_size]
-                block_offset = position % self.block_size
-                slot = block_number * self.block_size + block_offset
-                slot_mapping.append([slot])
+                first_position = seq_len - num_generation_tokens
+                positions = [
+                    first_position + offset
+                    for offset in range(num_generation_tokens)
+                ]
+                input_positions.append(positions)
+
+                block_table = seq_group_metadata.d_block_tables[seq_id] if is_draft_model \
+                    else seq_group_metadata.block_tables[seq_id]
+
+                slots = []
+                for position in positions:
+                    block_number = block_table[position // self.block_size]
+                    block_offset = position % self.block_size
+                    slot = block_number * self.block_size + block_offset
+                    slots.append(slot)
+                slot_mapping.append(slots)
+
                 lora_index_mapping.append([lora_id])
                 lora_prompt_mapping.append(lora_id)
 
@@ -306,6 +355,8 @@ class ModelRunner:
                 block_tables.append(block_table)
 
         batch_size = len(input_tokens)
+        # record the real batch size for cudagraph in case of padding
+        real_batch_size = batch_size
         max_context_len = max(context_lens)
         use_captured_graph = (
             not self.model_config.enforce_eager
@@ -324,18 +375,19 @@ class ModelRunner:
                 block_tables.append([])
             batch_size = graph_batch_size
 
+        max_len = max([len(t) for t in input_tokens])
         input_tokens = _make_tensor_with_pad(input_tokens,
-                                             max_len=1,
+                                             max_len=max_len,
                                              pad=0,
                                              dtype=torch.long,
                                              device=self.device)
         input_positions = _make_tensor_with_pad(input_positions,
-                                                max_len=1,
+                                                max_len=max_len,
                                                 pad=0,
                                                 dtype=torch.long,
                                                 device=self.device)
         slot_mapping = _make_tensor_with_pad(slot_mapping,
-                                             max_len=1,
+                                             max_len=max_len,
                                              pad=_PAD_SLOT_ID,
                                              dtype=torch.long,
                                              device=self.device)
@@ -377,15 +429,56 @@ class ModelRunner:
             block_tables=block_tables,
             use_cuda_graph=use_captured_graph,
             kv_cache_dtype=self.kv_cache_dtype,
+            use_speculate=self.use_speculate,
+            is_multi_query_mode=is_multi_query_mode,
+            batch_size=real_batch_size,
         )
         return (input_tokens, input_positions, input_metadata,
                 lora_index_mapping, lora_prompt_mapping, lora_requests)
+
+    def _prepare_draft_token_probs(
+        self, seq_group_metadata_list: List[SequenceGroupMetadata]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        probs_list = []
+        token_ids_list = []
+        for seq_group_metadata in seq_group_metadata_list:
+            seq_ids = list(seq_group_metadata.seq_data.keys())
+            assert len(
+                seq_ids
+            ) == 1, "Only one seq is allowed per seq group when using speculative decoding."
+            seq_id = seq_ids[0]
+            draft_tokens = seq_group_metadata.seq_data[seq_id].draft_tokens
+            probs_builder = []
+            token_ids_builder = []
+            for draft_token_data in draft_tokens:
+                token_id, parent_probs = draft_token_data.token_id, draft_token_data.parent_probs
+                # parent_probs should have shape [1, vocab_size]
+                probs_builder.append(parent_probs)
+                token_ids_builder.append(token_id)
+            probs_list.append(probs_builder)
+            token_ids_list.append(token_ids_builder)
+        # draft_token_probs should have shape [bsz, speculate_length, vocab_size]
+        draft_token_probs = torch.stack(
+            [torch.cat(inner_list) for inner_list in probs_list])
+        # NOTE: Pad an extra draft token for the convenience of handling the case when all tokens
+        # accepted. For example, draft_token_probs will have shape [32, 7, 32000] after padding if its
+        # original shape is [32, 6, 32000].
+        draft_token_probs = torch.nn.functional.pad(draft_token_probs,
+                                                    (0, 0, 0, 1),
+                                                    value=0)
+        # draft_token_ids should have shape [bsz, speculate_length]
+        draft_token_ids = torch.tensor(token_ids_list,
+                                       dtype=torch.long,
+                                       device="cuda")
+        return (draft_token_ids, draft_token_probs)
 
     def _prepare_sample(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
         prompt_lens: List[int],
         subquery_lens: Optional[List[int]],
+        is_multi_query_mode: bool = False,
+        input_tokens_ids: Optional[torch.Tensor] = None,
     ) -> SamplingMetadata:
         seq_groups: List[Tuple[List[int], SamplingParams]] = []
         selected_token_indices: List[int] = []
@@ -456,6 +549,12 @@ class ModelRunner:
         for seq_group_metadata in seq_group_metadata_list:
             seq_data.update(seq_group_metadata.seq_data)
 
+        # Prepare draft tokens and their probs during draft token evaluation stage
+        draft_token_ids, draft_token_probs = None, None
+        if is_multi_query_mode:
+            draft_token_ids, draft_token_probs = self._prepare_draft_token_probs(
+                seq_group_metadata_list)
+
         sampling_metadata = SamplingMetadata(
             seq_groups=seq_groups,
             seq_data=seq_data,
@@ -463,12 +562,20 @@ class ModelRunner:
             selected_token_indices=selected_token_indices,
             categorized_sample_indices=categorized_sample_indices,
             generators=generators,
+            use_speculate=self.use_speculate,
+            is_multi_query_mode=is_multi_query_mode,
+            speculate_length=self.speculate_length,
+            input_token_ids=input_tokens_ids,
+            draft_token_ids=draft_token_ids,
+            draft_token_probs=draft_token_probs,
         )
         return sampling_metadata
 
     def prepare_input_tensors(
         self,
         seq_group_metadata_list: Optional[List[SequenceGroupMetadata]],
+        is_draft_model: bool = False,
+        is_multi_query_mode: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor, InputMetadata, SamplingMetadata,
                Set[int], LoRAMapping]:
         if self.is_driver_worker:
@@ -479,16 +586,24 @@ class ModelRunner:
             if is_prompt:
                 (input_tokens, input_positions, input_metadata, prompt_lens,
                  subquery_lens, lora_index_mapping, lora_prompt_mapping,
-                 lora_requests) = self._prepare_prompt(seq_group_metadata_list)
+                 lora_requests) = self._prepare_prompt(
+                     seq_group_metadata_list, is_draft_model=is_draft_model)
             else:
                 (input_tokens, input_positions, input_metadata,
                  lora_index_mapping, lora_prompt_mapping,
-                 lora_requests) = self._prepare_decode(seq_group_metadata_list)
+                 lora_requests) = self._prepare_decode(
+                     seq_group_metadata_list,
+                     is_draft_model=is_draft_model,
+                     is_multi_query_mode=is_multi_query_mode)
                 prompt_lens = []
                 subquery_lens = None
-            sampling_metadata = self._prepare_sample(seq_group_metadata_list,
-                                                     prompt_lens,
-                                                     subquery_lens)
+            sampling_metadata = self._prepare_sample(
+                seq_group_metadata_list,
+                prompt_lens,
+                subquery_lens,
+                is_multi_query_mode=is_multi_query_mode,
+                input_tokens_ids=input_tokens[:input_metadata.batch_size]
+                if is_multi_query_mode else None)
 
             if self.lora_config:
                 flat_lora_index_mapping = [
@@ -519,6 +634,9 @@ class ModelRunner:
                 sampling_metadata.selected_token_indices,
                 "lora_requests": lora_requests,
                 "lora_mapping": lora_mapping,
+                "use_speculate": input_metadata.use_speculate,
+                "is_multi_query_mode": input_metadata.is_multi_query_mode,
+                "batch_size": input_metadata.batch_size,
             }
             broadcast_tensor_dict(metadata_dict, src=0)
         else:
@@ -538,6 +656,9 @@ class ModelRunner:
                 block_tables=metadata_dict["block_tables"],
                 use_cuda_graph=metadata_dict["use_cuda_graph"],
                 kv_cache_dtype=metadata_dict["kv_cache_dtype"],
+                use_speculate=metadata_dict["use_speculate"],
+                is_multi_query_mode=metadata_dict["is_multi_query_mode"],
+                batch_size=metadata_dict["batch_size"],
             )
             sampling_metadata = SamplingMetadata(
                 seq_groups=None,
@@ -547,6 +668,8 @@ class ModelRunner:
                 categorized_sample_indices=None,
                 generators=None,
                 perform_sampling=False,
+                use_speculate=metadata_dict["use_speculate"],
+                is_multi_query_mode=metadata_dict["is_multi_query_mode"],
             )
 
         return (input_tokens, input_positions, input_metadata,
@@ -673,15 +796,7 @@ class ModelRunner:
         self.cupy_nccl_backend = cupy_utils.get_nccl_backend()
 
         assert not self.model_config.enforce_eager
-        logger.info("Capturing the model for CUDA graphs. This may lead to "
-                    "unexpected consequences if the model is not static. To "
-                    "run the model in eager mode, set 'enforce_eager=True' or "
-                    "use '--enforce-eager' in the CLI.")
-        logger.info("CUDA graphs can take additional 1~3 GiB memory per GPU. "
-                    "If you are running out of memory, consider decreasing "
-                    "`gpu_memory_utilization` or enforcing eager mode. "
-                    "You can also reduce the `max_num_seqs` as needed "
-                    "to decrease memory usage.")
+        self.log_cudagraph_warning()
         start_time = time.perf_counter()
 
         # Prepare dummy inputs. These will be reused for all batch sizes.
@@ -747,13 +862,284 @@ class ModelRunner:
         # This usually takes < 10 seconds.
         logger.info(f"Graph capturing finished in {elapsed_time:.0f} secs.")
 
+    def log_cudagraph_warning(self) -> None:
+        logger.info("Capturing the model for CUDA graphs. This may lead to "
+                    "unexpected consequences if the model is not static. To "
+                    "run the model in eager mode, set 'enforce_eager=True' or "
+                    "use '--enforce-eager' in the CLI.")
+        logger.info("CUDA graphs can take additional 1~3 GiB memory per GPU. "
+                    "If you are running out of memory, consider decreasing "
+                    "`gpu_memory_utilization` or enforcing eager mode. "
+                    "You can also reduce the `max_num_seqs` as needed "
+                    "to decrease memory usage.")
+
     def __del__(self) -> None:
         # Delete the CUDA graphs before deleting the CuPy NCCL communicator.
         # NOTE(woosuk): This is necessary because otherwise deadlocks can
         # happen.
         # FIXME(woosuk): This is a bit hacky. Find a more robust solution.
         self.graph_runners.clear()
+        if self.use_speculate:
+            self.d_graph_runners.clear()
         self.cupy_nccl_backend = None
+
+    @torch.inference_mode()
+    def speculate_capture_model(self, kv_caches: List[KVCache],
+                                draft_kv_caches: List[KVCache]) -> None:
+        # NOTE(woosuk): This is a hack to ensure that the NCCL backend is never
+        # deleted before the CUDA graphs.
+        self.cupy_nccl_backend = cupy_utils.get_nccl_backend()
+
+        assert not self.model_config.enforce_eager
+        self.log_cudagraph_warning()
+        start_time = time.perf_counter()
+
+        max_batch_size = max(_BATCH_SIZES_TO_CAPTURE)
+        graph_batch_size = _get_graph_batch_size(
+            self.scheduler_config.max_num_seqs)
+        batch_size_capture_list = [
+            bs for bs in _BATCH_SIZES_TO_CAPTURE if bs <= graph_batch_size
+        ]
+
+        def capture_graph_inner(is_draft_model: bool = False,
+                                caches: List[KVCache] = None) -> None:
+            if is_draft_model:
+                num_tokens = 1
+                is_multi_query_mode = False
+                active_model = ActiveModel.DRAFT
+                graph_runners = self.d_graph_runners
+                graph_memory_pool = self.d_graph_memory_pool
+            else:
+                num_tokens = self.speculate_length + 1
+                is_multi_query_mode = True
+                active_model = ActiveModel.TARGET
+                graph_runners = self.graph_runners
+                graph_memory_pool = self.graph_memory_pool
+
+            # Prepare dummy inputs. These will be reused for all batch sizes.
+            input_tokens = torch.zeros(max_batch_size,
+                                       num_tokens,
+                                       dtype=torch.long).cuda()
+            input_positions = torch.zeros(max_batch_size,
+                                          num_tokens,
+                                          dtype=torch.long).cuda()
+            slot_mapping = torch.empty(max_batch_size,
+                                       num_tokens,
+                                       dtype=torch.long).cuda()
+            slot_mapping.fill_(_PAD_SLOT_ID)
+            context_lens = torch.ones(max_batch_size, dtype=torch.int32).cuda()
+            block_tables = torch.from_numpy(self.graph_block_tables).cuda()
+
+            # NOTE: Capturing the largest batch size first may help reduce the
+            # memory usage of CUDA graph.
+            # NOTE(woosuk): There are 3 backends for all-reduce: custom all-reduce
+            # kernel, CuPy NCCL, and PyTorch NCCL. When using CUDA graph, we use
+            # either custom all-reduce kernel or CuPy NCCL. When not using CUDA
+            # graph, we use either custom all-reduce kernel or PyTorch NCCL.
+            # We always prioritize using custom all-reduce kernel but fall back
+            # to PyTorch or CuPy NCCL if it is disabled or not supported.
+            with custom_all_reduce.capture():
+                for batch_size in reversed(batch_size_capture_list):
+                    # Create dummy input_metadata.
+                    input_metadata = InputMetadata(
+                        is_prompt=False,
+                        slot_mapping=slot_mapping[:batch_size],
+                        prompt_lens=None,
+                        max_seq_len=None,
+                        start_loc=None,
+                        max_context_len=self.max_context_len_to_capture,
+                        context_lens=context_lens[:batch_size],
+                        block_tables=block_tables[:batch_size],
+                        use_cuda_graph=True,
+                        kv_cache_dtype=self.kv_cache_dtype,
+                        is_multi_query_mode=is_multi_query_mode,
+                    )
+                    graph_runner = CUDAGraphRunner(self.draft_model) if is_draft_model \
+                        else CUDAGraphRunner(self.model)
+                    with MarkActiveModel(active_model):
+                        graph_runner.capture(
+                            input_tokens[:batch_size],
+                            input_positions[:batch_size],
+                            caches,
+                            input_metadata,
+                            memory_pool=graph_memory_pool,
+                        )
+                    graph_memory_pool = graph_runner.graph.pool()
+                    graph_runners[batch_size] = graph_runner
+                if is_draft_model:
+                    self.d_graph_memory_pool = graph_memory_pool
+                else:
+                    self.graph_memory_pool = graph_memory_pool
+
+        # 1. Capture draft model
+        if self.rank < self.parallel_config.draft_model_tp_size:
+            capture_graph_inner(is_draft_model=True, caches=draft_kv_caches)
+        # 2. Capture target model
+        capture_graph_inner(is_draft_model=False, caches=kv_caches)
+
+        end_time = time.perf_counter()
+        elapsed_time = end_time - start_time
+        # This usually takes < 10 seconds.
+        logger.info(f"Graph capturing finished in {elapsed_time:.0f} secs.")
+
+    def speculate_step(
+        self,
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+        kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        is_draft_model: bool = False,
+        is_prompt: bool = False,
+    ) -> None:
+        is_multi_query_mode = (not is_draft_model) and (not is_prompt)
+        input_tokens, input_positions, input_metadata, sampling_metadata, _, _ = (
+            self.prepare_input_tensors(seq_group_metadata_list, is_draft_model,
+                                       is_multi_query_mode))
+
+        if is_multi_query_mode:
+            # The target model evaluates (speculate_length+1) tokens during the evaluation stage.
+            assert input_tokens.shape[1] == self.speculate_length + 1
+            assert not is_draft_model
+
+        # Unused devices in tensor parallelism will skip this step.
+        tp_size = self.parallel_config.draft_model_tp_size if is_draft_model \
+            else self.parallel_config.tensor_parallel_size
+        if self.rank >= tp_size:
+            return None
+
+        active_model = ActiveModel.DRAFT if is_draft_model else ActiveModel.TARGET
+        with MarkActiveModel(active_model):
+            graph_batch_size = input_tokens.shape[0]
+            model = self.draft_model if is_draft_model else self.model
+            model_executable = model
+            if input_metadata.use_cuda_graph:
+                graph_runners = self.d_graph_runners if is_draft_model else self.graph_runners
+                # For speculative decoding, cudagraph is only used in the evaluation stage
+                # for target model.
+                if is_draft_model or input_metadata.is_multi_query_mode:
+                    model_executable = graph_runners[graph_batch_size]
+            # Execute the model.
+            hidden_states = model_executable(
+                input_ids=input_tokens,
+                positions=input_positions,
+                kv_caches=kv_caches,
+                input_metadata=input_metadata,
+            )
+            if input_metadata.is_multi_query_mode:
+                hidden_states = hidden_states[:input_metadata.batch_size]
+            # Sample the next token.
+            output = model.sample(
+                hidden_states=hidden_states,
+                sampling_metadata=sampling_metadata,
+            )
+
+        if not self.is_driver_worker:
+            return None
+
+        speculate_outputs: SpeculateOutput = []
+
+        for seq_group_metadata, seq_group_output in zip(
+                seq_group_metadata_list, output):
+            # 1. Handling the case when multiple tokens can be generated.
+            if sampling_metadata.is_multi_query_mode:
+                # Here we drop the last sampled token when all draft tokens were accepted.
+                # When all draft tokens were accepted, the last 2 generated tokens (the last
+                # accepted draft token plus the token sampled from its logits) will miss
+                # their kv caches in the draft model and requires multi-query attention.
+                # Mixing single query and multi-query attention is currently not supported.
+                seq_id = seq_group_output.parent_seq_id
+                num_accepted = seq_group_output.num_accepted_tokens
+                max_num_generated_tokens = min(
+                    num_accepted + 1, sampling_metadata.speculate_length)
+                output_tokens = seq_group_output.output_tokens[:
+                                                               max_num_generated_tokens]
+                output_token_logprobs = seq_group_output.logprobs_list[:
+                                                                       max_num_generated_tokens]
+                speculate_outputs.append(
+                    SpeculateSequenceGroupOutput(seq_id,
+                                                 output_tokens,
+                                                 output_token_logprobs,
+                                                 num_accepted,
+                                                 prompt_logprobs=None))
+            # 2. Handling the case when only 1 token can be generated.
+            else:
+                samples = seq_group_output.samples
+                assert len(
+                    samples
+                ) == 1, "Speculative decoding only allows one seq per seq group."
+                sample = samples[0]
+                seq_id = sample.parent_seq_id
+                parent_probs = sample.parent_probs
+                token_id = sample.output_token
+                logprobs_dict = sample.logprobs
+                if is_draft_model:
+                    seq_data = seq_group_metadata.seq_data[seq_id]
+                    seq_data.append_draft_token(token_id,
+                                                logprobs_dict[token_id],
+                                                parent_probs)
+                else:
+                    speculate_outputs.append(
+                        SpeculateSequenceGroupOutput(
+                            seq_id, [token_id], [logprobs_dict], 0,
+                            seq_group_output.prompt_logprobs))
+        return speculate_outputs
+
+    def clear_draft_tokens(
+        self,
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+    ):
+        """Clear draft tokens stored in seq data.
+
+        Args:
+            seq_group_metadata_list (List[SequenceGroupMetadata]): input metadata.
+        """
+        for seq_group_metadata in seq_group_metadata_list:
+            seq_ids = list(list(seq_group_metadata.seq_data.keys()))
+            assert len(
+                seq_ids
+            ) == 1, "Speculative decoding only allows one seq per seq group."
+            seq_id = seq_ids[0]
+            seq_data = seq_group_metadata.seq_data[seq_id]
+            seq_data.clear_draft_tokens()
+
+    @torch.inference_mode()
+    def speculate_execute_model(
+        self,
+        seq_group_metadata_list: List[SequenceGroupMetadata],
+        kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+        d_kv_caches: List[Tuple[torch.Tensor, torch.Tensor]],
+    ) -> SpeculateOutput:
+        if self.is_driver_worker:
+            self.clear_draft_tokens(seq_group_metadata_list)
+            is_prompt = seq_group_metadata_list[0].is_prompt
+            broadcast_object_list([is_prompt], src=0)
+        else:
+            obj_list = [None]
+            is_prompt = broadcast_object_list(obj_list, src=0)[0]
+        # Prompt evaluation
+        if is_prompt:
+            # Step 1: Run the target model
+            output = self.speculate_step(seq_group_metadata_list,
+                                         kv_caches,
+                                         is_draft_model=False,
+                                         is_prompt=True)
+            # Step 2: Run the draft model
+            self.speculate_step(seq_group_metadata_list,
+                                d_kv_caches,
+                                is_draft_model=True,
+                                is_prompt=True)
+            return output
+        # Token generation
+        # Step 1: Generate draft tokens
+        for _ in range(self.speculate_length):
+            self.speculate_step(seq_group_metadata_list,
+                                d_kv_caches,
+                                is_draft_model=True)
+        # Step 2: Run target model to evaluate draft tokens
+        output = self.speculate_step(seq_group_metadata_list,
+                                     kv_caches,
+                                     is_draft_model=False)
+        if self.is_driver_worker:
+            self.clear_draft_tokens(seq_group_metadata_list)
+        return output
 
 
 class CUDAGraphRunner:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -206,7 +206,7 @@ class Worker:
             if blocks_to_swap_out:
                 cache_engine.swap_out(blocks_to_swap_out)
                 issued_cache_op = True
-            if blocks_to_swap_out:
+            if blocks_to_copy:
                 cache_engine.copy(blocks_to_copy)
                 issued_cache_op = True
             return issued_cache_op


### PR DESCRIPTION
# Introduction
Similar to #1797, #2188, this PR implements speculative decoding. The goal of this PR is to facilitate research in this direction, such as developing new draft token generation mechanisms, new sampling method, optimized CUDA kernels, while the vLLM community is settling on the infrastructure part.

# Example Usage
You can find two example scripts `examples/api_client_spec_dec.py` and `examples/offline_inference_spec_dec.py`.

The fastest way to try out this feature is to run the following commands:
- Launch api server with speculative decoding enabled:
```
python -m vllm.entrypoints.api_server --model lmsys/vicuna-13b-v1.5 --tensor-parallel-size 1 --draft-model TinyLlama/TinyLlama-1.1B-Chat-v1.0 --speculate-length 5
```
- Run query:
```
python api_client_spec_dec.py --stream --prompt "What's the best way to start learning a new language?" --max-tokens 512
```

# Demo
Below is a demo of Llama-70b (use TinyLlama-1.1b as draft model) running on 4 Nvidia-A100-80G GPUs.

- Demo w/o speculative decoding:
![demo2](https://github.com/vllm-project/vllm/assets/19481308/f53598e8-5a64-4789-9e49-6c05469d1adc)


- Demo with speculative decoding.
![demo](https://github.com/vllm-project/vllm/assets/19481308/dd087f21-b3b3-4557-93fa-feef58f601b9)


# Limitations
This feature is still experimental, so use with caution. The following features (not exhaustive) are currently not supported:
- stop string
- beam search
- scheduler preemption
- Alibi slopes
- prefix cache

# Acknowledgement:
I'd like to thank @whbldhwj for sharing valuable data and code, especially the first MQA kernel, @YuchengT, @li2haipeng, @KexinFeng, @Vatshank for helpful discussions, @harishneit and @lanking520 for their leadership.