### PR TITLE
Use head_dim in config if exists

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -213,6 +213,8 @@ class ModelConfig:
         return self.hf_config.hidden_size
 
     def get_head_size(self) -> int:
+        if hasattr(self.hf_config, "head_dim"):
+            return self.hf_config.head_dim
         # FIXME(woosuk): This may not be true for all models.
         return self.hf_config.hidden_size // self.hf_config.num_attention_heads
 


### PR DESCRIPTION
The change is for some models which set `head_dim` explicitly instead of using `hidden_size // num_attention_heads`.

The wrong `head_dim` read leads to the wrong size kv_cache created, which makes the PagedAttention CUDA kernel writes the new KV to unexpected GPU memory. During our case, with the `head_dim` setting wrong, the PagedAttention kernel writes values into model weights, which causes huge confusion and higher debugging cost (because the model can run without any CUDA memory error raised, and the model weights are modified unexpectedly during forward).