### PR TITLE
Dockerfile: build-arg to punica kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ ENV MAX_JOBS=${max_jobs}
 ARG nvcc_threads=8
 ENV NVCC_THREADS=$nvcc_threads
 # make sure punica kernels are built (for LoRA)
-ENV VLLM_INSTALL_PUNICA_KERNELS=1
+ARG punica_kernels=1
+ENV VLLM_INSTALL_PUNICA_KERNELS=$punica_kernels
 
 RUN python3 setup.py build_ext --inplace
 #################### EXTENSION Build IMAGE ####################

--- a/docs/source/serving/deploying_with_docker.rst
+++ b/docs/source/serving/deploying_with_docker.rst
@@ -29,7 +29,7 @@ You can build and run vLLM from source via the provided dockerfile. To build vLL
 
 .. code-block:: console
 
-    $ DOCKER_BUILDKIT=1 docker build . --target vllm-openai --tag vllm/vllm-openai # optionally specifies: --build-arg max_jobs=8 --build-arg nvcc_threads=2
+    $ DOCKER_BUILDKIT=1 docker build . --target vllm-openai --tag vllm/vllm-openai # optionally specifies: --build-arg max_jobs=8 --build-arg nvcc_threads=2 --build-arg punica_kernels=0
 
 
 .. note::


### PR DESCRIPTION
Added `--build-arg punica_kernels=0 `option to avoid building of punica kernels when building docker image. 

By default it remains as 1.

