### PR TITLE
[ci] Add --kv-cache-dtype option in run-benchmark.sh

### DIFF
--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 # run benchmarks and upload the result to buildkite
 kv_cache_dtypes=("auto" "fp8_e5m2")
-do cache_dtype in "${kv_cache_dtypes[@]}"; do
+for cache_dtype in "${kv_cache_dtypes[@]}"; do
     python3 benchmarks/benchmark_latency.py --kv-cache-dtype ${cache_dtype} 2>&1 | tee -a benchmark_latency.txt
     bench_latency_exit_code=$?
 

--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -9,26 +9,33 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 (wget && curl) || (apt-get update && apt-get install -y wget curl)
 
 # run benchmarks and upload the result to buildkite
-python3 benchmarks/benchmark_latency.py 2>&1 | tee benchmark_latency.txt
-bench_latency_exit_code=$?
+kv_cache_dtypes=("auto" "fp8_e5m2")
+do cache_dtype in "${kv_cache_dtypes[@]}"; do
+    python3 benchmarks/benchmark_latency.py --kv-cache-dtype ${cache_dtype} 2>&1 | tee benchmark_latency.txt
+    bench_latency_exit_code=$?
 
-python3 benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 2>&1 | tee benchmark_throughput.txt
-bench_throughput_exit_code=$?
+    python3 benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 --kv-cache-dtype ${cache_dtype} 2>&1 | tee benchmark_throughput.txt
+    bench_throughput_exit_code=$?
 
-python3 -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-2-7b-chat-hf &
-server_pid=$!
-wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
+    python3 -m vllm.entrypoints.openai.api_server --model meta-llama/Llama-2-7b-chat-hf --kv-cache-dtype ${cache_dtype} &
+    server_pid=$!
 
-# wait for server to start, timeout after 600 seconds
-timeout 600 bash -c 'until curl localhost:8000/v1/models; do sleep 1; done' || exit 1
-python3 benchmarks/benchmark_serving.py \
-    --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json \
-    --model meta-llama/Llama-2-7b-chat-hf \
-    --num-prompts 20 \
-    --endpoint /v1/completions \
-    --tokenizer meta-llama/Llama-2-7b-chat-hf 2>&1 | tee benchmark_serving.txt
-bench_serving_exit_code=$?
-kill $server_pid
+    dataset_file="ShareGPT_V3_unfiltered_cleaned_split.json"
+    if [ ! -f "${dataset_file}" ]; then
+        wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/${dataset_file}
+    fi
+    # wait for server to start, timeout after 600 seconds
+    timeout 600 bash -c 'until curl localhost:8000/v1/models; do sleep 1; done' || exit 1
+    python3 benchmarks/benchmark_serving.py \
+        --dataset ./${dataset_file} \
+        --model meta-llama/Llama-2-7b-chat-hf \
+        --num-prompts 20 \
+        --endpoint /v1/completions \
+        --kv-cache-dtype ${cache_dtype} \
+        --tokenizer meta-llama/Llama-2-7b-chat-hf 2>&1 | tee benchmark_serving.txt
+    bench_serving_exit_code=$?
+    kill $server_pid
+done
 
 # write the results into a markdown file
 echo "### Latency Benchmarks" >> benchmark_results.md

--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -31,7 +31,6 @@ for cache_dtype in "${kv_cache_dtypes[@]}"; do
         --model meta-llama/Llama-2-7b-chat-hf \
         --num-prompts 20 \
         --endpoint /v1/completions \
-        --kv-cache-dtype ${cache_dtype} \
         --tokenizer meta-llama/Llama-2-7b-chat-hf 2>&1 | tee -a benchmark_serving.txt
     bench_serving_exit_code=$?
     kill $server_pid


### PR DESCRIPTION
vLLM now supports kv cache data type fp8_e5m2. I think we need to update run-benchmark.sh. @simon-mo @zhuohan123 Could you please have a review?