### PR TITLE
Adding `/get_tokenizer` to api_server for lm-evaluation-harness ease integration. 

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -346,8 +346,8 @@ def main(args: argparse.Namespace):
     else:
         api_url = f"http://{args.host}:{args.port}{args.endpoint}"
 
-    tokenizer = get_tokenizer(tokenizer_id,
-                              trust_remote_code=args.trust_remote_code)
+    tokenizer, _ = get_tokenizer(tokenizer_id,
+                                 trust_remote_code=args.trust_remote_code)
 
     if args.dataset is not None:
         warnings.warn(

--- a/tests/async_engine/test_chat_template.py
+++ b/tests/async_engine/test_chat_template.py
@@ -108,7 +108,7 @@ def test_no_load_chat_template_literallike():
 async def test_get_gen_prompt(model, template, add_generation_prompt,
                               expected_output):
     # Initialize the tokenizer
-    tokenizer = get_tokenizer(tokenizer_name=model)
+    tokenizer, _ = get_tokenizer(tokenizer_name=model)
     mock_serving_chat = MockServingChat(tokenizer)
     OpenAIServingChat._load_chat_template(mock_serving_chat,
                                           chat_template=template)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,7 +164,8 @@ class HfRunner:
             )
         if tokenizer_name is None:
             tokenizer_name = model_name
-        self.tokenizer = get_tokenizer(tokenizer_name, trust_remote_code=True)
+        self.tokenizer, _ = get_tokenizer(tokenizer_name,
+                                          trust_remote_code=True)
 
     def generate(
         self,

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -463,7 +463,7 @@ async def test_batch_completions(server, client: openai.AsyncOpenAI,
 async def test_logits_bias(server, client: openai.AsyncOpenAI):
     prompt = "Hello, my name is"
     max_tokens = 5
-    tokenizer = get_tokenizer(tokenizer_name=MODEL_NAME)
+    tokenizer, _ = get_tokenizer(tokenizer_name=MODEL_NAME)
 
     # Test exclusive selection
     token_id = 1000
@@ -827,7 +827,7 @@ number: "1" | "2"
 )
 async def test_echo_logprob_completion(server, client: openai.AsyncOpenAI,
                                        model_name: str):
-    tokenizer = get_tokenizer(tokenizer_name=MODEL_NAME)
+    tokenizer, _ = get_tokenizer(tokenizer_name=MODEL_NAME)
     # test using text and token IDs
     for prompt in ("Hello, my name is", [0, 0, 0, 0, 0]):
         completion = await client.completions.create(model=model_name,

--- a/tests/tokenization/test_tokenizer.py
+++ b/tests/tokenization/test_tokenizer.py
@@ -12,7 +12,7 @@ TOKENIZER_NAMES = [
 @pytest.mark.parametrize("tokenizer_name", TOKENIZER_NAMES)
 def test_tokenizer_revision(tokenizer_name: str):
     # Assume that "main" branch always exists
-    tokenizer = get_tokenizer(tokenizer_name, revision="main")
+    tokenizer, _ = get_tokenizer(tokenizer_name, revision="main")
     assert isinstance(tokenizer, PreTrainedTokenizerBase)
 
     # Assume that "never" branch always does not exist

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -74,7 +74,11 @@ async def health() -> Response:
 
 @app.get("/v1/get_tokenizer")
 async def get_tokenizer():
-    return JSONResponse(content=openai_serving_chat.tokenizer_jsons)
+    if openai_serving_chat.shared_tokenizer:
+        return JSONResponse(content=openai_serving_chat.tokenizer_jsons)
+    else:
+        return JSONResponse(content={"error": "No shared tokenizer"},
+                            status_code=HTTPStatus.BAD_REQUEST)
 
 
 @app.get("/v1/models")
@@ -166,9 +170,10 @@ if __name__ == "__main__":
     openai_serving_chat = OpenAIServingChat(engine, served_model_names,
                                             args.response_role,
                                             args.lora_modules,
+                                            args.shared_tokenizer,
                                             args.chat_template)
     openai_serving_completion = OpenAIServingCompletion(
-        engine, served_model_names, args.lora_modules)
+        engine, served_model_names, args.lora_modules, args.shared_tokenizer)
 
     app.root_path = args.root_path
     uvicorn.run(app,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -72,6 +72,11 @@ async def health() -> Response:
     return Response(status_code=200)
 
 
+@app.get("/get_tokenizer")
+async def get_tokenizer():
+    return JSONResponse(content=openai_serving_chat.tokenizer_jsons)
+
+
 @app.get("/v1/models")
 async def show_available_models():
     models = await openai_serving_chat.show_available_models()

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -72,7 +72,7 @@ async def health() -> Response:
     return Response(status_code=200)
 
 
-@app.get("/get_tokenizer")
+@app.get("/v1/get_tokenizer")
 async def get_tokenizer():
     return JSONResponse(content=openai_serving_chat.tokenizer_jsons)
 

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -64,6 +64,10 @@ def make_arg_parser():
                         "list. If not specified, the model name will be the "
                         "same as the `--model` argument.")
     parser.add_argument(
+        "--shared-tokenizer",
+        action='store_true',
+        help="Allow to share the tokenizer with /v1/get_tokenizer api path")
+    parser.add_argument(
         "--lora-modules",
         type=str,
         default=None,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -37,10 +37,12 @@ class OpenAIServingChat(OpenAIServing):
                  served_model_names: List[str],
                  response_role: str,
                  lora_modules: Optional[List[LoRAModulePath]] = None,
+                 shared_tokenizer: Optional[bool] = True,
                  chat_template: Optional[str] = None):
         super().__init__(engine=engine,
                          served_model_names=served_model_names,
-                         lora_modules=lora_modules)
+                         lora_modules=lora_modules,
+                         shared_tokenizer=shared_tokenizer)
         self.response_role = response_role
         self._load_chat_template(chat_template)
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -55,10 +55,12 @@ class OpenAIServingCompletion(OpenAIServing):
     def __init__(self,
                  engine: AsyncLLMEngine,
                  served_model_names: List[str],
-                 lora_modules: Optional[List[LoRAModulePath]] = None):
+                 lora_modules: Optional[List[LoRAModulePath]] = None,
+                 shared_tokenizer: Optional[bool] = True):
         super().__init__(engine=engine,
                          served_model_names=served_model_names,
-                         lora_modules=lora_modules)
+                         lora_modules=lora_modules,
+                         shared_tokenizer=shared_tokenizer)
 
     async def create_completion(self, request: CompletionRequest,
                                 raw_request: Request):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import shutil
-
 from dataclasses import dataclass
 from http import HTTPStatus
 from pathlib import Path
@@ -51,7 +50,6 @@ class OpenAIServing:
         self.max_model_len = 0
         # Lazy initialized
         self.tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast]
-        self.tokenizer_jsons = None
 
         try:
             event_loop = asyncio.get_running_loop()
@@ -102,7 +100,7 @@ class OpenAIServing:
             shutil.rmtree(TOKENIZER_EPHIMERAL_PATH)
         except OSError as e:
             raise RuntimeError(
-                f"Error removing '{TOKENIZER_EPHIMERAL_PATH.name}' directory: {e}"
+                f"Error removing '{TOKENIZER_EPHIMERAL_PATH.name}' dir: {e}"
             ) from e
 
         return tokenizer_jsons

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -32,7 +32,9 @@ class LoRAModulePath:
 
 class OpenAIServing:
 
-    def __init__(self, engine: AsyncLLMEngine, served_model_names: List[str],
+    def __init__(self,
+                 engine: AsyncLLMEngine,
+                 served_model_names: List[str],
                  lora_modules: Optional[List[LoRAModulePath]],
                  shared_tokenizer: Optional[bool] = True):
         self.engine = engine

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -136,7 +136,7 @@ def get_lora_tokenizer(lora_request: LoRARequest, *args,
     if lora_request is None:
         return None
     try:
-        tokenizer = get_tokenizer(lora_request.lora_local_path, *args,
+        tokenizer , _ = get_tokenizer(lora_request.lora_local_path, *args,
                                   **kwargs)
     except OSError as e:
         # No tokenizer was found in the LoRA folder,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from typing import Optional, Union
 
 import huggingface_hub
@@ -126,7 +127,8 @@ def get_tokenizer(
         logger.warning(
             "Using a slow tokenizer. This might cause a significant "
             "slowdown. Consider using a fast tokenizer instead.")
-    return get_cached_tokenizer(tokenizer)
+    hf_tokenizer = deepcopy(tokenizer)
+    return get_cached_tokenizer(tokenizer), hf_tokenizer
 
 
 def get_lora_tokenizer(lora_request: LoRARequest, *args,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -136,8 +136,8 @@ def get_lora_tokenizer(lora_request: LoRARequest, *args,
     if lora_request is None:
         return None
     try:
-        tokenizer , _ = get_tokenizer(lora_request.lora_local_path, *args,
-                                  **kwargs)
+        tokenizer, _ = get_tokenizer(lora_request.lora_local_path, *args,
+                                     **kwargs)
     except OSError as e:
         # No tokenizer was found in the LoRA folder,
         # use base model tokenizer

--- a/vllm/transformers_utils/tokenizer_group/tokenizer_group.py
+++ b/vllm/transformers_utils/tokenizer_group/tokenizer_group.py
@@ -20,7 +20,8 @@ class TokenizerGroup(BaseTokenizerGroup):
         self.tokenizer_config = tokenizer_config
         self.enable_lora = enable_lora
         self.max_input_length = max_input_length
-        self.tokenizer = get_tokenizer(self.tokenizer_id, **tokenizer_config)
+        self.tokenizer, _ = get_tokenizer(self.tokenizer_id,
+                                          **tokenizer_config)
         self.lora_tokenizers = LRUCache[PreTrainedTokenizer](
             capacity=max_num_seqs) if enable_lora else None
 


### PR DESCRIPTION
OpenAI is already supporting  [logprobs for chat models](https://platform.openai.com/docs/api-reference/chat/create#chat-create-logprobs) in most model cases. 
In paralell, lm-evaluation-harness is in dev to [add support to this feature](https://github.com/EleutherAI/lm-evaluation-harness/issues/1196).

In order to run a evaluation of an endpoint backended by vLLM, [and similarly as in the openai native case using tiktoken](https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/models/openai_completions.py), the tokenizer will be needed. 

The simple way would be to return the HF `<organization>/<repo>` string, and then relay on the use of `AutoTokenizer.from_pretrained`. 
But given that some usecase like:

* models/tokenizer can be private, or
* lm-evaluation-harness and vllm can be in the same network but without internet access.

I propose to add the `get_tokenizer` endpoit the `api_server` so then it can be used like:

```python
# Get tokenizer
response = requests.get("http://0.0.0.0:8000/get_tokenizer")
tokenizer_objects = json.loads(response.content)
# save into files
for key, value in tokenizer_objects.items():
    # create folder if not exists
    if not os.path.exists(TOKENIZER_EPHIMERAL_PATH):
        os.mkdir(TOKENIZER_EPHIMERAL_PATH)
    with open(os.path.join(TOKENIZER_EPHIMERAL_PATH, key + ".json"), "w") as f:
        json.dump(value, f)
        f.close()
try:
    shutil.rmtree(TOKENIZER_EPHIMERAL_PATH)
    #logger.info(f"Ephimeral '{TOKENIZER_EPHIMERAL_PATH.name}' directory removed successfully.")
    #logger.info(f"Tokenizer objects availables: {str(self.tokenizer_objects.keys())}")
except OSError as e:
    raise RuntimeError(f"Error removing '{TOKENIZER_EPHIMERAL_PATH.name}' directory: {e}")

# load tokenizer
vllm_tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_EPHIMERAL_PATH)
```

The next step would be to have logprobs supported in vLLM for chat cases in the OAI entryppoint, and then a PR on `lm-evaluation-harness` to catch the vLLM tokenizer feature (like using the code above).