### PR TITLE
Don't throw error when max model len > max seq len

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -49,6 +49,9 @@ class ModelConfig:
             the default version.
         max_model_len: Maximum length of a sequence (including prompt and
             output). If None, will be derived from the model.
+        allow_override_max_model_len: If true, allows the engine to override the
+            provided or derived maximum sequence length depending on the
+            measured amount of free GPU memory.
         quantization: Quantization method that was used to quantize the model
             weights. If None, we assume the model weights are not quantized.
         enforce_eager: Whether to enforce eager execution. If True, we will
@@ -72,6 +75,7 @@ class ModelConfig:
         revision: Optional[str] = None,
         tokenizer_revision: Optional[str] = None,
         max_model_len: Optional[int] = None,
+        allow_override_max_model_len: bool = False,
         quantization: Optional[str] = None,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
@@ -107,6 +111,7 @@ class ModelConfig:
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self.max_model_len = _get_and_verify_max_len(self.hf_config,
                                                      max_model_len)
+        self.allow_override_max_model_len = allow_override_max_model_len
         self._verify_load_format()
         self._verify_tokenizer_mode()
         self._verify_quantization()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -20,6 +20,7 @@ class EngineArgs:
     kv_cache_dtype: str = 'auto'
     seed: int = 0
     max_model_len: Optional[int] = None
+    allow_override_max_model_len: bool = False
     worker_use_ray: bool = False
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
@@ -137,6 +138,12 @@ class EngineArgs:
                             default=EngineArgs.max_model_len,
                             help='model context length. If unspecified, '
                             'will be automatically derived from the model.')
+        parser.add_argument(
+            '--allow-override-max-model-len',
+            action='store_true',
+            help='If true, allows the engine to override the provided or '
+                 'derived maximum sequence length depending on the measured '
+                 'amount of free GPU memory.')
         # Parallel arguments
         parser.add_argument('--worker-use-ray',
                             action='store_true',
@@ -284,6 +291,7 @@ class EngineArgs:
                                    self.download_dir, self.load_format,
                                    self.dtype, self.seed, self.revision,
                                    self.tokenizer_revision, self.max_model_len,
+                                   self.allow_override_max_model_len,
                                    self.quantization, self.enforce_eager,
                                    self.max_context_len_to_capture)
         cache_config = CacheConfig(self.block_size,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -333,12 +333,20 @@ class LLMEngine:
                              "initializing the engine.")
         max_seq_len = self.cache_config.block_size * num_gpu_blocks
         if self.model_config.max_model_len > max_seq_len:
-            self.model_config.max_model_len = max_seq_len
-            logger.warning(
-                f"The model's max seq len ({self.model_config.max_model_len}) "
-                "is larger than the maximum number of tokens that can be "
-                f"stored in KV cache ({max_seq_len}). "
-                f"Setting max seq len to {max_seq_len}.")
+            if model_config.allow_override_max_model_len:
+                self.model_config.max_model_len = max_seq_len
+                logger.warning(
+                    f"The model's max seq len ({self.model_config.max_model_len}) "
+                    "is larger than the maximum number of tokens that can be "
+                    f"stored in KV cache ({max_seq_len}). "
+                    f"Setting max seq len to {max_seq_len}.")
+                else:
+                    raise ValueError(
+                        f"The model's max seq len ({self.model_config.max_model_len}) "
+                        "is larger than the maximum number of tokens that can be "
+                        f"stored in KV cache ({max_seq_len}). Try increasing "
+                        "`gpu_memory_utilization` or decreasing `max_model_len` when "
+                        "initializing the engine.")
 
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -334,10 +334,11 @@ class LLMEngine:
         max_seq_len = self.cache_config.block_size * num_gpu_blocks
         if self.model_config.max_model_len > max_seq_len:
             self.model_config.max_model_len = max_seq_len
-            logger.warning(f"The model's max seq len ({self.model_config.max_model_len}) "
-                           "is larger than the maximum number of tokens that can be "
-                           f"stored in KV cache ({max_seq_len}). "
-                           f"Setting max seq len to {max_seq_len}.")
+            logger.warning(
+                f"The model's max seq len ({self.model_config.max_model_len}) "
+                "is larger than the maximum number of tokens that can be "
+                f"stored in KV cache ({max_seq_len}). "
+                f"Setting max seq len to {max_seq_len}.")
 
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -333,12 +333,11 @@ class LLMEngine:
                              "initializing the engine.")
         max_seq_len = self.cache_config.block_size * num_gpu_blocks
         if self.model_config.max_model_len > max_seq_len:
-            raise ValueError(
-                f"The model's max seq len ({self.model_config.max_model_len}) "
-                "is larger than the maximum number of tokens that can be "
-                f"stored in KV cache ({max_seq_len}). Try increasing "
-                "`gpu_memory_utilization` or decreasing `max_model_len` when "
-                "initializing the engine.")
+            self.model_config.max_model_len = max_seq_len
+            logger.warning(f"The model's max seq len ({self.model_config.max_model_len}) "
+                           "is larger than the maximum number of tokens that can be "
+                           f"stored in KV cache ({max_seq_len}). "
+                           f"Setting max seq len to {max_seq_len}.")
 
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks


### PR DESCRIPTION
Override max model len when it would fail due to being larger than max seq len

The context here is that we upgraded our serving runtime to use 0.2.7 for the performance upgrades, but models that could previously be served by 0.2.5 are now failing due to this error. We had to downgrade to 0.2.6 (which does not include the error, introduced in https://github.com/vllm-project/vllm/commit/8041b7305e93a8626d85cb23b3fcb995882867c1) and are missing out on the performance upgrades.