### PR TITLE
Fixes the error in num_accepted_tokens calculation in reject sampler

### DIFF
--- a/vllm/model_executor/layers/rejection_sampler.py
+++ b/vllm/model_executor/layers/rejection_sampler.py
@@ -305,8 +305,9 @@ class RejectionSampler(nn.Module):
         output.mul_(~after_false_mask).add_(
             recovered_token_ids.mul(after_false_mask))
 
-        self.num_accepted_tokens += accepted.sum()
-        self.num_emitted_tokens += (output_with_bonus_tokens != -1).sum()
+        num_emitted_tokens = (output_with_bonus_tokens != -1).sum()
+        self.num_emitted_tokens += num_emitted_tokens
+        self.num_accepted_tokens += num_emitted_tokens - batch_size
         self.num_draft_tokens += batch_size * k
 
         return output_with_bonus_tokens


### PR DESCRIPTION
The accepted mask vector `[True, False, True, True]`, the `num_accepted_tokens` should be `1` instead of `3`, as the last two tokens will be rejected as the 2-nd token is not accepted.

Thus, `accepted.sum()` is incorrect for `num_accepted_tokens.`.

The reject sampler was merged in #2336, so @cadedaniel could you please help to confirm this bugfix here? Thanks!