### PR TITLE
Fix 'Actor methods cannot be called directly' when using `--engine-use-ray`

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -447,11 +447,19 @@ class AsyncLLMEngine:
 
         if arrival_time is None:
             arrival_time = time.time()
-        prompt_token_ids = await self.engine.encode_request_async(
-            request_id=request_id,
-            prompt=prompt,
-            prompt_token_ids=prompt_token_ids,
-            lora_request=lora_request)
+
+        if self.engine_use_ray:
+            prompt_token_ids = await self.engine.encode_request_async.remote(
+                request_id=request_id,
+                prompt=prompt,
+                prompt_token_ids=prompt_token_ids,
+                lora_request=lora_request)
+        else:
+            prompt_token_ids = await self.encode_request_async(
+                request_id=request_id,
+                prompt=prompt,
+                prompt_token_ids=prompt_token_ids,
+                lora_request=lora_request)
 
         stream = self._request_tracker.add_request(
             request_id,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -455,7 +455,7 @@ class AsyncLLMEngine:
                 prompt_token_ids=prompt_token_ids,
                 lora_request=lora_request)
         else:
-            prompt_token_ids = await self.encode_request_async(
+            prompt_token_ids = await self.engine.encode_request_async(
                 request_id=request_id,
                 prompt=prompt,
                 prompt_token_ids=prompt_token_ids,


### PR DESCRIPTION
When requesting a model serving with `--engine-use-ray`, the request will fail with status code 500, and the vLLM server will raise an error: `TypeError: Actor methods cannot be called directly. Instead of running 'object.encode_request_async()', try 'object.encode_request_async.remote'.`

