### PR TITLE
fix length_penalty default value to 1.0

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -197,7 +197,7 @@ class Sequence:
         return self.data.cumulative_logprob
 
     def get_beam_search_score(self,
-                              length_penalty: float = 0.0,
+                              length_penalty: float = 1.0,
                               seq_len: Optional[int] = None,
                               eos_token_id: Optional[int] = None) -> float:
         """Calculate the beam search score with length penalty.


### PR DESCRIPTION
fix length_penalty default value to 1.0.

https://github.com/vllm-project/vllm/blob/main/vllm/sampling_params.py#L105
https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig.length_penalty