### PR TITLE
fix passing hf_config args: #2547

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -75,6 +75,7 @@ class ModelConfig:
         quantization: Optional[str] = None,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
+        hf_kwargs: Optional[dict] = None
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
@@ -100,7 +101,7 @@ class ModelConfig:
             self.download_dir = model_path
             self.tokenizer = model_path
 
-        self.hf_config = get_config(self.model, trust_remote_code, revision)
+        self.hf_config = get_config(self.model, trust_remote_code, revision, **hf_kwargs)
         self.dtype = _get_and_verify_dtype(self.hf_config, dtype)
         self.max_model_len = _get_and_verify_max_len(self.hf_config,
                                                      max_model_len)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -43,6 +43,7 @@ class EngineArgs:
     lora_extra_vocab_size: int = 256
     lora_dtype = 'auto'
     max_cpu_loras: Optional[int] = None
+    hf_kwargs: Optional[dict] = None
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -275,7 +276,7 @@ class EngineArgs:
                                    self.dtype, self.seed, self.revision,
                                    self.tokenizer_revision, self.max_model_len,
                                    self.quantization, self.enforce_eager,
-                                   self.max_context_len_to_capture)
+                                   self.max_context_len_to_capture, hf_kwargs=(self.hf_kwargs or {}))
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -18,10 +18,11 @@ _CONFIG_REGISTRY = {
 
 def get_config(model: str,
                trust_remote_code: bool,
-               revision: Optional[str] = None) -> PretrainedConfig:
+               revision: Optional[str] = None,
+               **hf_kwargs) -> PretrainedConfig:
     try:
         config = AutoConfig.from_pretrained(
-            model, trust_remote_code=trust_remote_code, revision=revision)
+            model, hf_kwargs, trust_remote_code=trust_remote_code, revision=revision)
     except ValueError as e:
         if (not trust_remote_code and
                 "requires you to execute the configuration file" in str(e)):


### PR DESCRIPTION
### Overview

This fix addresses issue #2547 

I followed what Simon Mo suggested and modified EngineArgs and the ModelConfig class.

Here are the following changes i made:

### args_utils.py
changed the `EngineArgs` class definition to include a new argument:
`hf_kwargs: Optional[dict] = None`
In `create_engine_configs`, I passed this in to the `ModelConfig` instantiation as follows:
 `hf_kwargs=(self.hf_kwargs or {})`

### vllm/config.py
In `__ init__` function, I added the same argument: 
`hf_kwargs: Optional[dict] = None`
I unpacked this in the `get_config` function call as follows:
`**hf_kwargs`

### transformers_utils/config.py
added `**hf_kwargs` to the `get_config` function definition
inserted `hf_kwargs` into the `AutoConfig.pretrained` call


