### PR TITLE
[Minor] Fix false warning when TP=1

### DIFF
--- a/vllm/model_executor/parallel_utils/custom_all_reduce.py
+++ b/vllm/model_executor/parallel_utils/custom_all_reduce.py
@@ -29,6 +29,10 @@ def init_custom_ar() -> None:
         return
     rank = get_tensor_model_parallel_rank()
     world_size = get_tensor_model_parallel_world_size()
+    if world_size == 1:
+        # No need to initialize custom allreduce for single GPU case.
+        return
+
     if world_size not in _SUPPORTED_WORLD_SIZES:
         logger.warn(
             "Custom allreduce is disabled due to an unsupported world size: "


### PR DESCRIPTION
This PR removes the unnecessary warning:

```
WARNING 01-30 21:39:03 custom_all_reduce.py:33] Custom allreduce is disabled due to an unsupported world size: 1. Supported world sizes: [2, 4, 6, 8]. To slience this warning, specifydisable_custom_all_reduce=True explicitly.
```
