### PR TITLE
Set&Get llm internal tokenizer instead of the TokenizerGroup

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -111,13 +111,13 @@ class LLM:
 
     def get_tokenizer(
             self) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
-        return self.llm_engine.tokenizer
+        return self.llm_engine.tokenizer.tokenizer
 
     def set_tokenizer(
         self,
         tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
     ) -> None:
-        self.llm_engine.tokenizer = tokenizer
+        self.llm_engine.tokenizer.tokenizer = tokenizer
 
     def generate(
         self,


### PR DESCRIPTION
Since `LLMEngine` uses `TokenizerGroup`, the `get_tokenizer` and `set_tokenizer` methods in `LLM` need to be adjusted so that they operate on the **original tokenizer**  in `LLMEngine`.
@WoosukKwon 