### PR TITLE
Tuning layernorm kernels

### DIFF
--- a/tests/kernels/test_layernorm.py
+++ b/tests/kernels/test_layernorm.py
@@ -5,7 +5,7 @@ from vllm.model_executor.layers.layernorm import RMSNorm
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [7, 83, 4096]  # Arbitrary values for testing
-HIDDEN_SIZES = [768, 5120, 8192]  # Arbitrary values for testing
+HIDDEN_SIZES = [768, 5120, 8192, 65536]  # Arbitrary values for testing
 ADD_RESIDUAL = [False, True]
 SEEDS = [0]
 CUDA_DEVICES = [


### PR DESCRIPTION
Use shared memory to get better performance. 

because hidden size is usually less than 4090. So dynamic shared memory could hold such data. and have better performance. 

I tested rms_norm function with or without shared memory(higher is better) on NVIDIA V100:

![rms-norm-performance](https://github.com/vllm-project/vllm/assets/475224/b339565c-6049-41aa-834b-39707c891e02)

smaller hidden size can have up to ~30% better throughput. 