### PR TITLE
[ROCm] Fix build problem resulted from previous commit related to FP8 kv-cache support 

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -79,6 +79,8 @@ RUN cd /app \
     && cd vllm \
     && pip install -U -r requirements-rocm.txt \
     && bash patch_xformers.rocm.sh \
+    && if [ "$BASE_IMAGE" = "rocm/pytorch:rocm6.0_ubuntu20.04_py3.9_pytorch_2.1.1" ]; then \
+       patch /opt/rocm/include/hip/amd_detail/amd_hip_bf16.h /app/vllm/rocm_patch/rocm_bf16.patch; fi \
     && python3 setup.py install \
     && cd ..
 

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -79,8 +79,7 @@ RUN cd /app \
     && cd vllm \
     && pip install -U -r requirements-rocm.txt \
     && bash patch_xformers.rocm.sh \
-    && if [ "$BASE_IMAGE" = "rocm/pytorch:rocm6.0_ubuntu20.04_py3.9_pytorch_2.1.1" ]; then \
-       patch /opt/rocm/include/hip/amd_detail/amd_hip_bf16.h /app/vllm/rocm_patch/rocm_bf16.patch; fi \
+    && patch /opt/rocm/include/hip/amd_detail/amd_hip_bf16.h /app/vllm/rocm_patch/rocm_bf16.patch \
     && python3 setup.py install \
     && cd ..
 

--- a/rocm_patch/rocm_bf16.patch
+++ b/rocm_patch/rocm_bf16.patch
@@ -1,0 +1,15 @@
+--- amd_hip_bf16.h	2024-02-06 18:28:58.268699142 +0000
++++ amd_hip_bf16.h.new	2024-02-06 18:28:31.988647133 +0000
+@@ -90,10 +90,10 @@
+ #include "math_fwd.h"              // ocml device functions
+ 
+ #if defined(__HIPCC_RTC__)
+-#define __HOST_DEVICE__ __device__
++#define __HOST_DEVICE__ __device__ static
+ #else
+ #include <climits>
+-#define __HOST_DEVICE__ __host__ __device__
++#define __HOST_DEVICE__ __host__ __device__ static inline
+ #endif
+ 
+ // Since we are using unsigned short to represent data in bfloat16, it can be of different sizes on


### PR DESCRIPTION
Fixes: https://github.com/vllm-project/vllm/issues/2725
Current head failed to build on ROCm, and I got errors like:
```
g++ -pthread -B /opt/conda/envs/py_3.8/compiler_compat -Wl,--sysroot=/ -pthread -shared -B /opt/conda/envs/py_3.8/compiler_compat -L/opt/conda/envs/py_3.8/lib -Wl,-rpath=/opt/conda/envs/py_3.8/lib -WlEN,--no-as-needed -Wl,--sysroot=/ /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/activation_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/attention/attention_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/cache_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/hip_utils_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/layernorm_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/moe_align_block_size_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/pos_encoding_kernels.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/pybind.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/quantization/gptq/q_gemm.o /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/quantization/squeezellm/quant_hip_kernel.o -L/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/lib -L/opt/rocm/lib -L/opt/rocm/hip/lib -lc10 -ltorch -ltorch_cpu -ltorch_python -lamdhip64 -lc10_hip -ltorch_hip -o build/lib.linux-x86_64-cpython-38/vllm/_C.cpython-38-x86_64-linux-gnu.so
/opt/conda/envs/py_3.8/compiler_compat/ld: /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/cache_kernels.o: in function `__float2bfloat16(float)':
cache_kernels.hip:(.text+0x0): multiple definition of `__float2bfloat16(float)'; /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/attention/attention_kernels.o:attention_kernels.hip:(.text+0x0): first defined here
/opt/conda/envs/py_3.8/compiler_compat/ld: /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/cache_kernels.o: in function `__bfloat1622float2(__hip_bfloat162)':
cache_kernels.hip:(.text+0x40): multiple definition of `__bfloat1622float2(__hip_bfloat162)'; /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/attention/attention_kernels.o:attention_kernels.hip:(.text+0x40): first defined here
/opt/conda/envs/py_3.8/compiler_compat/ld: /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/cache_kernels.o: in function `__double2bfloat16(double)':
cache_kernels.hip:(.text+0x60): multiple definition of `__double2bfloat16(double)'; /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/attention/attention_kernels.o:attention_kernels.hip:(.text+0x60): first defined here
/opt/conda/envs/py_3.8/compiler_compat/ld: /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/cache_kernels.o: in function `__float22bfloat162_rn(HIP_vector_type<float, 2u>)':
cache_kernels.hip:(.text+0xa0): multiple definition of `__float22bfloat162_rn(HIP_vector_type<float, 2u>)'; /app/vllm/build/temp.linux-x86_64-cpython-38/csrc/attention/attention_kernels.o:attention_kernels.hip:(.text+0xa0): first defined here
/opt/conda/envs/py_3.8/compiler_compat/ld: /app/vllm/build/temp.linux-x86_64-cpython-
```

We need a patch to fix the compilation issue before the next ROCm release is available.
This pull request fixed the build issue for ROCm build.
