### PR TITLE
Add Splitwise implementation to vLLM

### DIFF
--- a/csrc/kv_comm_kernels.cu
+++ b/csrc/kv_comm_kernels.cu
@@ -1,0 +1,29 @@
+#include <mscclpp/proxy_channel_device.hpp>
+
+extern "C" __global__ void __launch_bounds__(1024, 1)
+    nw_cache_in_kernel(mscclpp::ProxyChannelDeviceHandle* proxyChannel) {
+  int globalIndex = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalIndex == 0) {
+    proxyChannel[0].wait(100000000);
+  }
+}
+
+extern "C" __global__ void __launch_bounds__(1024, 1)
+    nw_cache_out_kernel(mscclpp::ProxyChannelDeviceHandle* proxyChannel, int dst_mem, int src_mem, int kv_block_offset, int dataSize, int flush) {
+  int globalIndex = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalIndex == 0) {
+    proxyChannel[0].put(dst_mem, kv_block_offset, src_mem, kv_block_offset, dataSize);
+    if (flush) {
+      proxyChannel[0].flush();
+    }
+  }
+}
+
+extern "C" __global__ void __launch_bounds__(1024, 1)
+    nw_cache_out_signal_kernel(mscclpp::ProxyChannelDeviceHandle* proxyChannel, int flush) {
+  int globalIndex = blockIdx.x * blockDim.x + threadIdx.x;
+  if (globalIndex == 0) {
+    proxyChannel[0].signal();
+    proxyChannel[0].flush();
+  }
+}

--- a/csrc/kv_comm_kernels.cu
+++ b/csrc/kv_comm_kernels.cu
@@ -20,7 +20,7 @@ extern "C" __global__ void __launch_bounds__(1024, 1)
 }
 
 extern "C" __global__ void __launch_bounds__(1024, 1)
-    nw_cache_out_signal_kernel(mscclpp::ProxyChannelDeviceHandle* proxyChannel, int flush) {
+    nw_cache_out_signal_kernel(mscclpp::ProxyChannelDeviceHandle* proxyChannel) {
   int globalIndex = blockIdx.x * blockDim.x + threadIdx.x;
   if (globalIndex == 0) {
     proxyChannel[0].signal();

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -93,6 +93,7 @@ Documentation
    :maxdepth: 1
    :caption: Splitwise
 
+   splitwise/getting_started
    splitwise/installing_mscclpp
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,12 @@ Documentation
    quantization/auto_awq
 
 .. toctree::
+   :maxdepth: 1
+   :caption: Splitwise
+
+   splitwise/installing_mscclpp
+
+.. toctree::
    :maxdepth: 2
    :caption: Developer Documentation
 

--- a/docs/source/splitwise/getting_started.rst
+++ b/docs/source/splitwise/getting_started.rst
@@ -1,0 +1,16 @@
+.. _getting_started:
+
+Getting Started with Splitwise
+==============================
+
+`Splitwise <https://www.microsoft.com/en-us/research/publication/splitwise-efficient-generative-llm-inference-using-phase-splitting/>`_ is a technique to split the two phases of an LLM inference request - prompt processing and token generation - on to separate machines for efficient inference.
+
+Installing MSCCL++
+-------------------------
+
+Please follow :ref:`MSCCL++ installation instructions <installing_mscclpp>` to install the MSCCL++ communication library used for implementing the communication of KV caches from prompt to token workers.
+
+Running inference with Splitwise
+--------------------------------
+
+Simply add ``--sep-prompt-token`` flag to the vLLM command in order to use Splitwise.

--- a/docs/source/splitwise/installing_mscclpp.rst
+++ b/docs/source/splitwise/installing_mscclpp.rst
@@ -1,0 +1,9 @@
+.. _installing_mscclpp:
+
+Installing MSCCL++
+============================
+
+`MSCCL++ <https://github.com/microsoft/mscclpp>`_ is a GPU-driven communication stack for scalable AI applications.
+It is used to implement KV cache communication in Splitwise.
+
+To install MSCCL++, please follow the instructions at `Installing for vLLM <https://github.com/microsoft/mscclpp/blob/main/docs/vllm_installation.md>`_.

--- a/docs/source/splitwise/installing_mscclpp.rst
+++ b/docs/source/splitwise/installing_mscclpp.rst
@@ -7,6 +7,7 @@ Installing MSCCL++
 It is used to implement KV cache communication in Splitwise.
 
 To install MSCCL++, please follow the instructions at  `MSCCL++ Quickstart <https://github.com/microsoft/mscclpp/blob/main/docs/quickstart.md>`_ or follow the steps below to install it from source:
+MSCCL++ required libnuma, which can be installed using `apt install libnuma-dev` on Debian-based systems.
 
 .. code-block:: console
 

--- a/docs/source/splitwise/installing_mscclpp.rst
+++ b/docs/source/splitwise/installing_mscclpp.rst
@@ -6,4 +6,12 @@ Installing MSCCL++
 `MSCCL++ <https://github.com/microsoft/mscclpp>`_ is a GPU-driven communication stack for scalable AI applications.
 It is used to implement KV cache communication in Splitwise.
 
-To install MSCCL++, please follow the instructions at `Installing for vLLM <https://github.com/microsoft/mscclpp/blob/main/docs/vllm_installation.md>`_.
+To install MSCCL++, please follow the instructions at  `MSCCL++ Quickstart <https://github.com/microsoft/mscclpp/blob/main/docs/quickstart.md>`_ or follow the steps below to install it from source:
+
+.. code-block:: console
+
+    $ git clone https://github.com/microsoft/mscclpp;
+    $ mkdir mscclpp/build; cd mscclpp/build; cmake -DCMAKE_BUILD_TYPE=Release ..; make -j;
+    $ conda install -c conda-forge mpi4py
+    $ cd ../python; pip install -r requirements_c12.txt;
+    $ cd ..; pip install -e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic >= 2.0  # Required for OpenAI server.
 aioprometheus[starlette]
 pynvml == 11.5.0
 triton >= 2.1.0
+gputil

--- a/tests/distributed/test_kvcache_comm.py
+++ b/tests/distributed/test_kvcache_comm.py
@@ -1,0 +1,41 @@
+"""Test the KV cache communication operators.
+
+Run `python test_kvcache_comm.py`.
+"""
+import argparse
+import ray
+
+from vllm import EngineArgs, LLMEngine
+
+def initialize_engine(args: argparse.Namespace) -> LLMEngine:
+    """Initialize the LLMEngine from the command line arguments."""
+    engine_args = EngineArgs.from_cli_args(args)
+    return LLMEngine.from_engine_args(engine_args)
+
+def run_all_workers(engine: LLMEngine, method: str, *args):
+    """Run all the workers."""
+    ray_worker_outputs = [
+        worker.execute_method.remote(method, *args)
+        for worker in engine.workers
+    ]
+    _ = getattr(engine.driver_worker,
+            method)(*args)
+    ray.get(ray_worker_outputs)
+
+
+"""Test the kv cache communication."""
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Demo on using the LLMEngine class directly')
+    parser = EngineArgs.add_cli_args(parser)
+    args = parser.parse_args()
+    args.model = "meta-llama/Llama-2-70b-hf"
+    args.tensor_parallel_size = 2
+    args.sep_prompt_token = True
+    engine = initialize_engine(args)
+
+    run_all_workers(engine, "set_gpucache")
+    run_all_workers(engine, "send_recv_kvcache_all")
+    run_all_workers(engine, "check_gpucache")
+
+    engine.dismantle_kvcache_comm()

--- a/tests/distributed/test_kvcache_comm.py
+++ b/tests/distributed/test_kvcache_comm.py
@@ -7,10 +7,12 @@ import ray
 
 from vllm import EngineArgs, LLMEngine
 
+
 def initialize_engine(args: argparse.Namespace) -> LLMEngine:
     """Initialize the LLMEngine from the command line arguments."""
     engine_args = EngineArgs.from_cli_args(args)
     return LLMEngine.from_engine_args(engine_args)
+
 
 def run_all_workers(engine: LLMEngine, method: str, *args):
     """Run all the workers."""
@@ -18,8 +20,7 @@ def run_all_workers(engine: LLMEngine, method: str, *args):
         worker.execute_method.remote(method, *args)
         for worker in engine.workers
     ]
-    _ = getattr(engine.driver_worker,
-            method)(*args)
+    _ = getattr(engine.driver_worker, method)(*args)
     ray.get(ray_worker_outputs)
 
 
@@ -38,4 +39,4 @@ if __name__ == '__main__':
     run_all_workers(engine, "send_recv_kvcache_all")
     run_all_workers(engine, "check_gpucache")
 
-    engine.dismantle_kvcache_comm()
+    engine.destroy_kvcache_comm()

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -369,14 +369,22 @@ class ParallelConfig:
         worker_use_ray: bool,
         max_parallel_loading_workers: Optional[int] = None,
         disable_custom_all_reduce: bool = False,
+        sep_prompt_token: bool = False,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size
         self.worker_use_ray = worker_use_ray
         self.max_parallel_loading_workers = max_parallel_loading_workers
         self.disable_custom_all_reduce = disable_custom_all_reduce
+        self.sep_prompt_token = sep_prompt_token
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
+        if sep_prompt_token:
+            # Half of the workers are prompt workers and the other half are token
+            self.num_prompt_workers = self.world_size
+            self.num_token_workers = self.world_size
+            self.world_size = self.num_prompt_workers + self.num_token_workers
+
         if self.world_size > 1:
             self.worker_use_ray = True
         self._verify_args()

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -11,8 +11,7 @@ from vllm.logger import init_logger
 from vllm.sequence import (Sequence, SequenceData, SequenceGroup,
                            SequenceGroupMetadata, SequenceStatus)
 from vllm.prefix import PrefixPool
-from vllm.utils import coalesce_blocks_by_id
-from vllm.worker.comm_utils import Seq2SemMapper
+from vllm.utils import SeqToSlotMapper, coalesce_blocks_by_id
 
 logger = init_logger(__name__)
 
@@ -82,7 +81,7 @@ class Scheduler:
         scheduler_config: SchedulerConfig,
         cache_config: CacheConfig,
         lora_config: Optional[LoRAConfig],
-        seq_sem_mapper: Optional[Seq2SemMapper] = None,
+        track_prompt_blocks: bool = False,
     ) -> None:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
@@ -90,7 +89,10 @@ class Scheduler:
         # simple and NOT fair. It can lead to starvation of some
         # LoRAs. This should be improved in the future.
         self.lora_config = lora_config
-        self.seq_sem_mapper = seq_sem_mapper
+        self.track_prompt_blocks = track_prompt_blocks
+        self.seq_to_slot_mapper: Optional[SeqToSlotMapper] = None
+        if track_prompt_blocks:
+            self.seq_to_slot_mapper = SeqToSlotMapper()
 
         self.prompt_limit = min(self.scheduler_config.max_model_len,
                                 self.scheduler_config.max_num_batched_tokens)
@@ -260,14 +262,14 @@ class Scheduler:
                 self.running.append(seq_group)
                 num_curr_seqs += num_new_seqs
                 scheduled.append(seq_group)
-                if self.seq_sem_mapper is not None:
+                if self.track_prompt_blocks:
                     for seq in seq_group.get_seqs():
                         # Populate blocks_to_nw for the sequences in prompt phase
                         # and first step of generation phase
                         if seq.get_output_len() <= 1:
                             block_ids = self.block_manager.get_block_table(seq)
-                            sem_id = self.seq_sem_mapper.get_sem_id(seq.seq_id)
-                            blocks_to_nw[sem_id].extend(block_ids)
+                            slot_id = self.seq_to_slot_mapper.get_slot_id(seq.seq_id)
+                            blocks_to_nw[slot_id].extend(block_ids)
 
             self.waiting.extendleft(leftover_waiting_sequences)
 
@@ -366,15 +368,15 @@ class Scheduler:
             seq_group.num_seqs(status=SequenceStatus.RUNNING)
             for seq_group in self.running)
 
-        if self.seq_sem_mapper is not None:
+        if self.track_prompt_blocks:
             for seq_group in self.running:
                 for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
                     # Populate blocks_to_nw for the sequences in prompt phase
                     # and first step of generation phase
                     if seq.get_output_len() <= 1:
                         block_ids = self.block_manager.get_block_table(seq)
-                        sem_id = self.seq_sem_mapper.get_sem_id(seq.seq_id)
-                        blocks_to_nw[sem_id].extend(block_ids)
+                        slot_id = self.seq_to_slot_mapper.get_slot_id(seq.seq_id)
+                        blocks_to_nw[slot_id].extend(block_ids)
 
         scheduler_outputs = SchedulerOutputs(
             scheduled_seq_groups=self.running,
@@ -421,8 +423,8 @@ class Scheduler:
 
     def free_seq(self, seq: Sequence) -> None:
         self.block_manager.free(seq)
-        if self.seq_sem_mapper is not None:
-            self.seq_sem_mapper.free_seq(seq.seq_id)
+        if self.seq_to_slot_mapper is not None:
+            self.seq_to_slot_mapper.free_seq(seq.seq_id)
 
     def free_finished_seq_groups(self) -> None:
         self.running = deque(seq_group for seq_group in self.running
@@ -432,8 +434,8 @@ class Scheduler:
         self.block_manager.allocate(seq_group)
         for seq in seq_group.get_seqs(status=SequenceStatus.WAITING):
             seq.status = SequenceStatus.RUNNING
-            if self.seq_sem_mapper is not None:
-                self.seq_sem_mapper.set_seq(seq.seq_id)
+            if self.seq_to_slot_mapper is not None:
+                self.seq_to_slot_mapper.set_seq(seq.seq_id)
 
     def _append_slot(
         self,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -268,7 +268,8 @@ class Scheduler:
                         # and first step of generation phase
                         if seq.get_output_len() <= 1:
                             block_ids = self.block_manager.get_block_table(seq)
-                            slot_id = self.seq_to_slot_mapper.get_slot_id(seq.seq_id)
+                            slot_id = self.seq_to_slot_mapper.get_slot_id(
+                                seq.seq_id)
                             blocks_to_nw[slot_id].extend(block_ids)
 
             self.waiting.extendleft(leftover_waiting_sequences)
@@ -375,7 +376,8 @@ class Scheduler:
                     # and first step of generation phase
                     if seq.get_output_len() <= 1:
                         block_ids = self.block_manager.get_block_table(seq)
-                        slot_id = self.seq_to_slot_mapper.get_slot_id(seq.seq_id)
+                        slot_id = self.seq_to_slot_mapper.get_slot_id(
+                            seq.seq_id)
                         blocks_to_nw[slot_id].extend(block_ids)
 
         scheduler_outputs = SchedulerOutputs(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,6 +24,7 @@ class EngineArgs:
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
     max_parallel_loading_workers: Optional[int] = None
+    sep_prompt_token: bool = False
     block_size: int = 16
     swap_space: int = 4  # GiB
     gpu_memory_utilization: float = 0.90
@@ -159,6 +160,9 @@ class EngineArgs:
             help='load model sequentially in multiple batches, '
             'to avoid RAM OOM when using tensor '
             'parallel and large models')
+        parser.add_argument('--sep-prompt-token',
+                            action='store_true',
+                            help='separate the prompt processing and token sampling')
         # KV cache arguments
         parser.add_argument('--block-size',
                             type=int,
@@ -294,7 +298,8 @@ class EngineArgs:
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,
                                          self.max_parallel_loading_workers,
-                                         self.disable_custom_all_reduce)
+                                         self.disable_custom_all_reduce,
+                                         self.sep_prompt_token)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -160,9 +160,10 @@ class EngineArgs:
             help='load model sequentially in multiple batches, '
             'to avoid RAM OOM when using tensor '
             'parallel and large models')
-        parser.add_argument('--sep-prompt-token',
-                            action='store_true',
-                            help='separate the prompt processing and token sampling')
+        parser.add_argument(
+            '--sep-prompt-token',
+            action='store_true',
+            help='separate the prompt processing and token sampling')
         # KV cache arguments
         parser.add_argument('--block-size',
                             type=int,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -118,7 +118,7 @@ class LLMEngine:
 
         if self.parallel_config.sep_prompt_token:
             # Setup the MSCCL++ communication required for KV cache transfer
-            self._setup_mscclpp_comm()
+            self._setup_kvcache_comm()
 
         # Create the scheduler.
         self.scheduler = Scheduler(scheduler_config, cache_config, lora_config)
@@ -356,9 +356,13 @@ class LLMEngine:
         # if enforce_eager is False.
         self._run_workers("warm_up_model")
 
-    def _setup_mscclpp_comm(self) -> None:
+    def _setup_kvcache_comm(self) -> None:
         """Setup MSCCL++ communication connections for KV cache transfer."""
-        self._run_workers("setup_mscclpp_comm")
+        self._run_workers("setup_kvcache_comm")
+
+    def dismantle_kvcache_comm(self) -> None:
+        """Stop MSCCL++ communication connections for KV cache transfer."""
+        self._run_workers("dismantle_kvcache_comm")
 
     @classmethod
     def from_engine_args(cls, engine_args: EngineArgs) -> "LLMEngine":

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -58,10 +58,10 @@ class PagedAttention(nn.Module):
             raise ValueError(f"head_size ({self.head_size}) is not supported. "
                              f"Supported head sizes: {_SUPPORTED_HEAD_SIZES}.")
 
-        self.kvcache_comm = None
+        self.kvcache_comm_manager = None
 
-    def set_kvcache_comm(self, kvcache_comm):
-        self.kvcache_comm = kvcache_comm
+    def set_kvcache_comm_manager(self, kvcache_comm_manager):
+        self.kvcache_comm_manager = kvcache_comm_manager
 
     def forward(
         self,
@@ -107,10 +107,10 @@ class PagedAttention(nn.Module):
             )
 
             if input_metadata.is_prompt and len(input_metadata.blocks_to_nw):
-                assert self.kvcache_comm is not None
+                assert self.kvcache_comm_manager is not None
                 for semid in input_metadata.blocks_to_nw:
                     for block_start, num_blocks in input_metadata.blocks_to_nw[semid]:
-                        self.kvcache_comm.put(semid, self.layer_id, block_start, num_blocks)
+                        self.kvcache_comm_manager.put(semid, self.layer_id, block_start, num_blocks)
 
         if input_metadata.is_prompt:
             # Prompt run.

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -13,7 +13,6 @@ from vllm.model_executor.input_metadata import InputMetadata
 from vllm.model_executor.layers.triton_kernel.prefix_prefill import (
     context_attention_fwd)
 from vllm.utils import is_hip
-from vllm.worker.comm_utils import KVCacheCommunicator
 
 _SUPPORTED_HEAD_SIZES = [64, 80, 96, 112, 128, 256]
 # Should be the same as PARTITION_SIZE in `paged_attention_v2_launcher`.
@@ -59,9 +58,9 @@ class PagedAttention(nn.Module):
             raise ValueError(f"head_size ({self.head_size}) is not supported. "
                              f"Supported head sizes: {_SUPPORTED_HEAD_SIZES}.")
 
-        self.kvcache_comm : KVCacheCommunicator = None
+        self.kvcache_comm = None
 
-    def set_kvcache_comm(self, kvcache_comm: KVCacheCommunicator):
+    def set_kvcache_comm(self, kvcache_comm):
         self.kvcache_comm = kvcache_comm
 
     def forward(

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -34,6 +34,7 @@ class Sampler(nn.Module):
         self.vocab_size = vocab_size
         # original vocabulary size (without LoRA).
         self.org_vocab_size = org_vocab_size or vocab_size
+        self.dst_rank = None
 
     def _get_logits(self, hidden_states: torch.Tensor, embedding: torch.Tensor,
                     embedding_bias: Optional[torch.Tensor], dst_rank: int = 0) -> torch.Tensor:
@@ -53,7 +54,6 @@ class Sampler(nn.Module):
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
         embedding_bias: Optional[torch.Tensor] = None,
-        dst_rank: Optional[int] = None,
     ) -> Optional[SamplerOutput]:
         # Get the hidden states that we use for sampling.
         hidden_states = _prune_hidden_states(hidden_states, sampling_metadata)

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -36,8 +36,11 @@ class Sampler(nn.Module):
         self.org_vocab_size = org_vocab_size or vocab_size
         self.dst_rank = 0
 
-    def _get_logits(self, hidden_states: torch.Tensor, embedding: torch.Tensor,
-                    embedding_bias: Optional[torch.Tensor], dst_rank: int = 0) -> torch.Tensor:
+    def _get_logits(self,
+                    hidden_states: torch.Tensor,
+                    embedding: torch.Tensor,
+                    embedding_bias: Optional[torch.Tensor],
+                    dst_rank: int = 0) -> torch.Tensor:
         # Get the logits for the next tokens.
         logits = torch.matmul(hidden_states, embedding.t())
         if embedding_bias is not None:
@@ -62,7 +65,10 @@ class Sampler(nn.Module):
         hidden_states = _prune_hidden_states(hidden_states, sampling_metadata)
 
         # Get the logits for the next tokens.
-        logits = self._get_logits(hidden_states, embedding, embedding_bias, dst_rank=self.dst_rank)
+        logits = self._get_logits(hidden_states,
+                                  embedding,
+                                  embedding_bias,
+                                  dst_rank=self.dst_rank)
 
         # Only perform sampling in the driver worker.
         # Note: `_get_logits` is still distributed across TP workers because

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -310,10 +310,9 @@ class LlamaForCausalLM(nn.Module):
         self,
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
-        dst_rank: Optional[int] = None,
     ) -> Optional[SamplerOutput]:
         next_tokens = self.sampler(self.lm_head.weight, hidden_states,
-                                   sampling_metadata, dst_rank)
+                                   sampling_metadata)
         return next_tokens
 
     def load_weights(self,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -310,9 +310,10 @@ class LlamaForCausalLM(nn.Module):
         self,
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
+        dst_rank: Optional[int] = None,
     ) -> Optional[SamplerOutput]:
         next_tokens = self.sampler(self.lm_head.weight, hidden_states,
-                                   sampling_metadata)
+                                   sampling_metadata, dst_rank)
         return next_tokens
 
     def load_weights(self,

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -6,7 +6,6 @@ from torch.distributed import ProcessGroup
 import torch
 
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
     get_tensor_model_parallel_group,
 )

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -82,7 +82,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
         # Convert negative dim to positive.
         dim += input_.dim()
     # Allocate output tensor.
-    if get_tensor_model_parallel_rank() == dst:
+    if torch.distributed.get_rank() == dst:
         gather_list = [torch.empty_like(input_) for _ in range(world_size)]
     else:
         gather_list = None
@@ -91,7 +91,7 @@ def tensor_model_parallel_gather(input_: torch.Tensor,
                              gather_list,
                              dst=dst,
                              group=get_tensor_model_parallel_group())
-    if get_tensor_model_parallel_rank() == dst:
+    if torch.distributed.get_rank() == dst:
         output_tensor = torch.cat(gather_list, dim=dim)
     else:
         output_tensor = None

--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -171,7 +171,7 @@ def broadcast_tensor_dict(
         for key, value in metadata_list:
             if isinstance(value, TensorMetadata):
                 tensor = tensor_dict[key]
-                torch.distributed.broadcast(tensor, src=src)
+                torch.distributed.broadcast(tensor, src=src, group=group)
     else:
         recv_metadata_list = [None]
         torch.distributed.broadcast_object_list(recv_metadata_list,

--- a/vllm/model_executor/parallel_utils/custom_all_reduce.py
+++ b/vllm/model_executor/parallel_utils/custom_all_reduce.py
@@ -6,7 +6,9 @@ import torch.distributed as dist
 
 from vllm.logger import init_logger
 from vllm.model_executor.parallel_utils.parallel_state import (
-    get_tensor_model_parallel_world_size, get_tensor_model_parallel_rank)
+    get_tensor_model_parallel_world_size, get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_group
+)
 
 try:
     from vllm._C import custom_ar
@@ -180,7 +182,7 @@ class CustomAllreduce:
 
     def _gather_ipc_meta(self, shard_data):
         all_data = [None] * self.world_size
-        dist.all_gather_object(all_data, shard_data)
+        dist.all_gather_object(all_data, shard_data, group=get_tensor_model_parallel_group())
 
         handles = []
         offsets = []

--- a/vllm/model_executor/parallel_utils/custom_all_reduce.py
+++ b/vllm/model_executor/parallel_utils/custom_all_reduce.py
@@ -7,8 +7,7 @@ import torch.distributed as dist
 from vllm.logger import init_logger
 from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_world_size, get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_group
-)
+    get_tensor_model_parallel_group)
 
 try:
     from vllm._C import custom_ar
@@ -182,7 +181,9 @@ class CustomAllreduce:
 
     def _gather_ipc_meta(self, shard_data):
         all_data = [None] * self.world_size
-        dist.all_gather_object(all_data, shard_data, group=get_tensor_model_parallel_group())
+        dist.all_gather_object(all_data,
+                               shard_data,
+                               group=get_tensor_model_parallel_group())
 
         handles = []
         offsets = []

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -49,10 +49,10 @@ def initialize_model_parallel(
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
     # World size is scaled by two in case of separate prompt token machines.
-    scale_factor : int = 2 if sep_prompt_token else 1
+    scale_factor: int = 2 if sep_prompt_token else 1
 
-    if (world_size !=
-            tensor_model_parallel_size * pipeline_model_parallel_size * scale_factor):
+    if (world_size != tensor_model_parallel_size *
+            pipeline_model_parallel_size * scale_factor):
         raise RuntimeError(
             f"world_size ({world_size}) is not equal to "
             f"tensor_model_parallel_size ({tensor_model_parallel_size}) x "
@@ -94,7 +94,8 @@ def initialize_model_parallel(
             _STAGE_PARALLEL_GROUP = _TENSOR_MODEL_PARALLEL_GROUP
         else:
             prompt_group = torch.distributed.new_group(range(world_size // 2))
-            token_group = torch.distributed.new_group(range(world_size // 2, world_size))
+            token_group = torch.distributed.new_group(
+                range(world_size // 2, world_size))
             if rank < world_size // 2:
                 _STAGE_PARALLEL_GROUP = prompt_group
             else:
@@ -168,8 +169,7 @@ def get_pipeline_model_parallel_world_size():
 
 def get_stage_parallel_world_size():
     """Return world size for the stage parallel group."""
-    return torch.distributed.get_world_size(
-        group=get_stage_parallel_group())
+    return torch.distributed.get_world_size(group=get_stage_parallel_group())
 
 
 def get_tensor_model_parallel_rank():
@@ -185,8 +185,7 @@ def get_pipeline_model_parallel_rank():
 
 def get_stage_parallel_rank():
     """Return my rank for the pipeline model parallel group."""
-    return torch.distributed.get_rank(
-        group=get_stage_parallel_group())
+    return torch.distributed.get_rank(group=get_stage_parallel_group())
 
 
 def get_tensor_model_parallel_src_rank():

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -19,6 +19,7 @@ _PIPELINE_GLOBAL_RANKS = None
 def initialize_model_parallel(
     tensor_model_parallel_size: int = 1,
     pipeline_model_parallel_size: int = 1,
+    sep_prompt_token: bool = False,
 ) -> None:
     """
     Initialize model parallel groups.
@@ -45,13 +46,16 @@ def initialize_model_parallel(
     # Get world size and rank. Ensure some consistencies.
     assert torch.distributed.is_initialized()
     world_size: int = torch.distributed.get_world_size()
+    # World size is scaled by two in case of separate prompt token machines.
+    scale_factor : int = 2 if sep_prompt_token else 1
 
     if (world_size !=
-            tensor_model_parallel_size * pipeline_model_parallel_size):
+            tensor_model_parallel_size * pipeline_model_parallel_size * scale_factor):
         raise RuntimeError(
             f"world_size ({world_size}) is not equal to "
             f"tensor_model_parallel_size ({tensor_model_parallel_size}) x "
-            f"pipeline_model_parallel_size ({pipeline_model_parallel_size})")
+            f"pipeline_model_parallel_size ({pipeline_model_parallel_size}) x "
+            f"scale_factor ({scale_factor})")
 
     num_tensor_model_parallel_groups: int = (world_size //
                                              tensor_model_parallel_size)
@@ -86,6 +90,7 @@ def initialize_model_parallel(
 def ensure_model_parallel_initialized(
     tensor_model_parallel_size: int,
     pipeline_model_parallel_size: int,
+    sep_prompt_token: bool = False,
 ) -> None:
     """Helper to initialize model parallel groups if they are not initialized,
     or ensure tensor-parallel and pipeline-parallel sizes are equal to expected
@@ -93,7 +98,8 @@ def ensure_model_parallel_initialized(
     """
     if not model_parallel_is_initialized():
         initialize_model_parallel(tensor_model_parallel_size,
-                                  pipeline_model_parallel_size)
+                                  pipeline_model_parallel_size,
+                                  sep_prompt_token)
         return
 
     assert (

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -4,7 +4,7 @@ import socket
 import subprocess
 import uuid
 from platform import uname
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 from packaging.version import parse, Version
 
 import GPUtil
@@ -287,3 +287,29 @@ def create_kv_caches_with_random(
 
 def get_total_num_gpus() -> int:
     return len(GPUtil.getGPUs())
+
+
+def coalesce_blocks(block_list: List[int]):
+    '''Coalesce of list of blocks to exploit contiguous chunks.
+    '''
+    if not block_list:
+        return []
+    sorted_block_list = sorted(block_list)
+    ret = []
+    current_block_start = sorted_block_list[0]
+    current_block_length = 1
+    for i in range(1, len(sorted_block_list)):
+        if sorted_block_list[i] == sorted_block_list[i - 1] + 1:
+            current_block_length += 1
+        else:
+            ret.append((current_block_start, current_block_length))
+            current_block_start = sorted_block_list[i]
+            current_block_length = 1
+    ret.append((current_block_start, current_block_length))
+    return ret
+
+
+def coalesce_blocks_by_id(blocks_to_nw_dict: Dict[int, List[int]]):
+    for cur_id in blocks_to_nw_dict:
+        blocks_to_nw_dict[cur_id] = coalesce_blocks(blocks_to_nw_dict[cur_id])
+    return blocks_to_nw_dict

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -7,6 +7,7 @@ from platform import uname
 from typing import List, Tuple, Union
 from packaging.version import parse, Version
 
+import GPUtil
 import psutil
 import torch
 import asyncio
@@ -35,6 +36,12 @@ STR_DTYPE_TO_TORCH_DTYPE = {
 class Device(enum.Enum):
     GPU = enum.auto()
     CPU = enum.auto()
+
+
+class WorkerType(enum.Enum):
+    PROMPT = enum.auto()
+    TOKEN = enum.auto()
+    MIXED = enum.auto()
 
 
 class Counter:
@@ -276,3 +283,7 @@ def create_kv_caches_with_random(
             _generate_random_fp8_e5m2(value_cache, -scale, scale)
         value_caches.append(value_cache)
     return key_caches, value_caches
+
+
+def get_total_num_gpus() -> int:
+    return len(GPUtil.getGPUs())

--- a/vllm/worker/comm_utils.py
+++ b/vllm/worker/comm_utils.py
@@ -1,0 +1,105 @@
+import cupy as cp
+import os
+
+from mscclpp.utils import KernelBuilder, pack
+MAX_SEMIDS = 10
+FLUSH_COUNT = 128
+
+KERNEL_DIR = os.path.dirname(os.path.abspath(__file__)) + "/../../csrc"
+
+class SplitCommInfo():
+    def __init__(self,
+                 worker_type,
+                 proxy_service,
+                 device_handles,
+                 flush_counter,
+                 block_size,
+                 memory_ids,
+                 my_rank,
+                 remote_rank,):
+        self.worker_type = worker_type
+        self.proxy_service = proxy_service
+        self.device_handles = device_handles
+        self.flush_counter = flush_counter
+        self.block_size = block_size
+        self.memory_ids = memory_ids
+        self.my_rank = my_rank
+        self.remote_rank = remote_rank
+
+class SendKVKernel:
+    def __init__(self):
+        self._kernel = KernelBuilder(
+            file="kv_comm_kernels.cu",
+            kernel_name="nw_cache_out_kernel",
+            file_dir=KERNEL_DIR
+        ).get_compiled_kernel()
+        self.nblocks = 1
+        self.nthreads = 1
+
+    def __call__(self, params):
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+
+class SignalKVKernel:
+    def __init__(self):
+        self._kernel = KernelBuilder(
+            file="kv_comm_kernels.cu",
+            kernel_name="nw_cache_out_signal_kernel",
+            file_dir=KERNEL_DIR
+        ).get_compiled_kernel()
+        self.nblocks = 1
+        self.nthreads = 1
+
+    def __call__(self, params):
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+
+class WaitKVKernel:
+    def __init__(self):
+        self._kernel = KernelBuilder(
+            file="kv_comm_kernels.cu",
+            kernel_name="nw_cache_in_kernel",
+            file_dir=KERNEL_DIR
+        ).get_compiled_kernel()
+        self.nblocks = 1
+        self.nthreads = 1
+
+    def __call__(self, params):
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+
+class KVCacheCommunicator:
+    def __init__(self, comm_info):
+        self.comm_info = comm_info
+        self.send_kernel = SendKVKernel()
+        self.signal_kernel = SignalKVKernel()
+        self.wait_kernel = WaitKVKernel()
+
+    def wait(self, sem_id):
+        dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
+        params = pack(dh)
+        self.wait_kernel(params)
+
+    def signal_and_flush(self, sem_id):
+        dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
+        self.comm_info.flush_counter += 1
+        flush = True if self.comm_info.flush_counter % FLUSH_COUNT == 0 else False
+        params = pack(dh, flush)
+        self.signal_kernel(params)
+
+    def put(self, sem_id, layer_id, block_start, num_blocks):
+        block_size = self.comm_info.block_size
+        remote_rank = self.comm_info.remote_rank
+        my_rank = self.comm_info.my_rank
+        for k_or_v in [0, 1]:
+            block_offset = block_start * block_size
+            dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
+            self.comm_info.flush_counter += 1
+            flush = True if self.comm_info.flush_counter % FLUSH_COUNT == 0 else False
+            params = b""
+            params += pack(
+                dh,
+                self.comm_info.memory_ids[layer_id][k_or_v][remote_rank],
+                self.comm_info.memory_ids[layer_id][k_or_v][my_rank],
+                block_offset,
+                block_size * num_blocks,
+                flush
+            )
+            self.send_kernel(params)

--- a/vllm/worker/comm_utils.py
+++ b/vllm/worker/comm_utils.py
@@ -4,51 +4,22 @@ import os
 try:
     from mscclpp.utils import KernelBuilder, pack
 except ImportError:
-    pass
+    raise ImportError(
+        "MSCCL++ is not installed. Please install MSCCL++ to use this feature."
+    )
 
-MAX_SEMIDS = 10
+# Flush MSCCL++ fifo every 128 operations
 FLUSH_COUNT = 128
+
+HEAD_TYPES = [0, 1] # 0 for keys, 1 for values
 
 KERNEL_DIR = os.path.dirname(os.path.abspath(__file__)) + "/../../csrc"
 
-# Seq2SemMapper is a class that maps sequence ids to semaphore ids
-# It is used to manage the semaphore ids for MSCCL++ proxy channels
-class Seq2SemMapper:
-    def __init__(self):
-        self.available_semids = list(range(MAX_SEMIDS))
-        self.seq_to_sem = {}
-
-    def set_seq(self, seq_id):
-        sem_id = self.available_semids.pop(0)
-        self.seq_to_sem[seq_id] = sem_id
-
-    def free_seq(self, seq_id):
-        sem_id = self.seq_to_sem.pop(seq_id)
-        self.available_semids.insert(0, sem_id)
-
-    def get_sem_id(self, seq_id):
-        return self.seq_to_sem[seq_id]
-
-class SplitCommInfo():
-    def __init__(self,
-                 worker_type,
-                 proxy_service,
-                 device_handles,
-                 flush_counter,
-                 block_size,
-                 memory_ids,
-                 my_rank,
-                 remote_rank,):
-        self.worker_type = worker_type
-        self.proxy_service = proxy_service
-        self.device_handles = device_handles
-        self.flush_counter = flush_counter
-        self.block_size = block_size
-        self.memory_ids = memory_ids
-        self.my_rank = my_rank
-        self.remote_rank = remote_rank
-
 class SendKVKernel:
+    """ SendKVKernel is a wrapper around a CUDA kernel that uses
+    MSCCL++ proxy channels to asynchronously send key-value cache
+    """
+
     def __init__(self):
         self._kernel = KernelBuilder(
             file="kv_comm_kernels.cu",
@@ -58,10 +29,17 @@ class SendKVKernel:
         self.nblocks = 1
         self.nthreads = 1
 
+    # nw_cache_out_kernel takes device handles, memory offset, memory size,
+    # and flush flag as parameters
     def __call__(self, params):
-        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads,
+                                          shared=0, stream=None)
 
 class SignalKVKernel:
+    """ SignalKVKernel is a wrapper around a CUDA kernel that signals
+    the semaphore associated with the MSCCL++ proxy channel
+    """
+
     def __init__(self):
         self._kernel = KernelBuilder(
             file="kv_comm_kernels.cu",
@@ -71,10 +49,17 @@ class SignalKVKernel:
         self.nblocks = 1
         self.nthreads = 1
 
+    # nw_cache_out_signal_kernel takes device handles of proxy channels
+    # as parameters
     def __call__(self, params):
-        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads,
+                                          shared=0, stream=None)
 
 class WaitKVKernel:
+    """ WaitKVKernel is a wrapper around a CUDA kernel that waits on
+    the semaphore associated with the MSCCL++ proxy channel
+    """
+
     def __init__(self):
         self._kernel = KernelBuilder(
             file="kv_comm_kernels.cu",
@@ -84,42 +69,67 @@ class WaitKVKernel:
         self.nblocks = 1
         self.nthreads = 1
 
+    # nw_cache_in_kernel takes device handles of proxy channels as parameters
     def __call__(self, params):
-        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads, 0, None)
+        return self._kernel.launch_kernel(params, self.nblocks, self.nthreads,
+                                          shared=0, stream=None)
 
 class KVCacheCommunicator:
-    def __init__(self, comm_info):
-        self.comm_info = comm_info
+    """ KVCacheCommunicator provides an interface to communicate the KV cache
+    between prompt and token workers using MSCCL++ proxy channels.
+
+    block_size: int - size of a single KV cache block
+    device_handles: dict - device handles of MSCCL++ proxy channels
+    flush_counter: int - counter to keep track of number of operations
+    memory_ids: dict - memory ids of KV cache on prompt and token workers
+    my_rank: int - rank of the prompt worker
+    remote_rank: int - rank of the token worker
+
+    SendKVKernel and SignalKVKernel put KV cache data and signal semaphores on the prompt side
+    WaitKVKernel waits on semaphores on the token side.
+    """
+
+    def __init__(self, block_size, device_handles, memory_ids, my_rank, remote_rank):
+        self.block_size = block_size
+        self.device_handles = device_handles
+        self.memory_ids = memory_ids
+        self.my_rank = my_rank
+        self.remote_rank = remote_rank
+        self.flush_counter = 0
         self.send_kernel = SendKVKernel()
         self.signal_kernel = SignalKVKernel()
         self.wait_kernel = WaitKVKernel()
 
+    def get_device_handles(self, sem_ids):
+        device_handles = [self.device_handles[sem_id] for sem_id in sem_ids]
+        return cp.asarray(memoryview(b"".join(device_handles)), dtype=cp.uint8)
+
     def wait(self, sem_id):
-        dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
+        dh = self.get_device_handles([sem_id])
         params = pack(dh)
         self.wait_kernel(params)
 
     def signal_and_flush(self, sem_id):
-        dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
-        self.comm_info.flush_counter += 1
-        flush = True if self.comm_info.flush_counter % FLUSH_COUNT == 0 else False
-        params = pack(dh, flush)
+        dh = self.get_device_handles([sem_id])
+        params = pack(dh)
         self.signal_kernel(params)
+        self.flush_counter = 0
 
     def put(self, sem_id, layer_id, block_start, num_blocks):
-        block_size = self.comm_info.block_size
-        remote_rank = self.comm_info.remote_rank
-        my_rank = self.comm_info.my_rank
-        for k_or_v in [0, 1]:
+        block_size = self.block_size
+        remote_rank = self.remote_rank
+        my_rank = self.my_rank
+        for head_type in HEAD_TYPES:
             block_offset = block_start * block_size
-            dh = cp.asarray(memoryview(b"".join([self.comm_info.device_handles[sem_id]])), dtype=cp.uint8)
-            self.comm_info.flush_counter += 1
-            flush = True if self.comm_info.flush_counter % FLUSH_COUNT == 0 else False
-            params = b""
-            params += pack(
+            dh = self.get_device_handles([sem_id])
+            self.flush_counter += 1
+            flush = self.flush_counter >= FLUSH_COUNT
+            if flush:
+                self.flush_counter = 0
+            params = pack(
                 dh,
-                self.comm_info.memory_ids[layer_id][k_or_v][remote_rank],
-                self.comm_info.memory_ids[layer_id][k_or_v][my_rank],
+                self.memory_ids[layer_id][head_type][remote_rank],
+                self.memory_ids[layer_id][head_type][my_rank],
                 block_offset,
                 block_size * num_blocks,
                 flush

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -501,9 +501,12 @@ class ModelRunner:
                 "lora_requests": lora_requests,
                 "lora_mapping": lora_mapping,
             }
-            broadcast_tensor_dict(metadata_dict, src=self.driver_rank, group=stage_group)
+            broadcast_tensor_dict(metadata_dict,
+                                  src=self.driver_rank,
+                                  group=stage_group)
         else:
-            metadata_dict = broadcast_tensor_dict(src=self.driver_rank, group=stage_group)
+            metadata_dict = broadcast_tensor_dict(src=self.driver_rank,
+                                                  group=stage_group)
             input_tokens = metadata_dict["input_tokens"]
             input_positions = metadata_dict["input_positions"]
             lora_mapping = metadata_dict["lora_mapping"]
@@ -542,7 +545,8 @@ class ModelRunner:
     ) -> Optional[SamplerOutput]:
         (input_tokens, input_positions, input_metadata, sampling_metadata,
          lora_requests,
-         lora_mapping) = self.prepare_input_tensors(seq_group_metadata_list, blocks_to_nw)
+         lora_mapping) = self.prepare_input_tensors(seq_group_metadata_list,
+                                                    blocks_to_nw)
 
         if self.lora_config:
             self.set_active_loras(lora_requests, lora_mapping)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -13,8 +13,9 @@ from vllm.model_executor.parallel_utils.communication_op import (
     broadcast_tensor_dict)
 from vllm.model_executor.parallel_utils.custom_all_reduce import init_custom_ar
 from vllm.model_executor.parallel_utils.parallel_state import (
-    ensure_model_parallel_initialized)
+    ensure_model_parallel_initialized, get_tensor_model_parallel_group)
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
+from vllm.utils import get_total_num_gpus, WorkerType
 from vllm.worker.cache_engine import CacheEngine
 from vllm.worker.model_runner import ModelRunner
 from vllm.lora.request import LoRARequest
@@ -40,6 +41,7 @@ class Worker:
         lora_config: Optional[LoRAConfig] = None,
         kv_cache_dtype: Optional[str] = "auto",
         mscclpp_init_method: str = None,
+        worker_type: WorkerType = WorkerType.MIXED,
         is_driver_worker: bool = False,
     ) -> None:
         self.model_config = model_config
@@ -51,6 +53,7 @@ class Worker:
         self.distributed_init_method = distributed_init_method
         self.lora_config = lora_config
         self.mscclpp_init_method = mscclpp_init_method
+        self.worker_type = worker_type
         self.is_driver_worker = is_driver_worker
         if self.is_driver_worker:
             assert self.rank == 0, "The driver worker must have rank 0."
@@ -68,6 +71,15 @@ class Worker:
         self.cache_engine = None
         self.cache_events = None
         self.gpu_cache = None
+
+    def is_prompt_worker(self) -> bool:
+        return self.worker_type == WorkerType.PROMPT
+
+    def is_token_worker(self) -> bool:
+        return self.worker_type == WorkerType.TOKEN
+
+    def is_mixed_worker(self) -> bool:
+        return self.worker_type == WorkerType.MIXED
 
     def init_model(self) -> None:
         if self.device_config.device.type == "cuda":
@@ -110,9 +122,66 @@ class Worker:
                 size=self.parallel_config.world_size,
                 interfaceIpPortTrio=mscclpp_init_method
             )
+            self.mscclpp_conns = None
+            self.worker_type = WorkerType.PROMPT if self.rank < self.parallel_config.num_prompt_workers else WorkerType.TOKEN
 
-    def setup_mscclpp_comm(self):
-        pass
+    def setup_kvcache_comm(self) -> None:
+        # Setup the communication for the KV cache.
+        from vllm.worker.comm_utils import MAX_SEMIDS, SplitCommInfo, KVCacheCommunicator
+        import mscclpp.comm as mscclpp_comm
+
+        self.model_runner.driver_rank = (self.rank // self.parallel_config.num_prompt_workers) * self.parallel_config.num_prompt_workers
+        if self.rank == self.model_runner.driver_rank:
+            self.model_runner.is_driver_worker = True
+
+        corr_worker_rank = (self.mscclpp_group.my_rank + self.parallel_config.num_prompt_workers) % self.mscclpp_group.nranks
+        transport = self.mscclpp_group.my_ib_device(self.mscclpp_group.my_rank % get_total_num_gpus())
+        self.mscclpp_conns = self.mscclpp_group.make_connection(
+            [corr_worker_rank], transport
+        )
+
+        num_layers = self.model_config.get_num_layers(self.parallel_config)
+        proxy_service = mscclpp_comm.ProxyService()
+        proxy_service.start_proxy()
+
+        memory_ids = [[None, None] for _ in range(num_layers)]
+        for layer_id in range(num_layers):
+            for k_or_v in [0, 1]:
+                memory_ids[layer_id][k_or_v] = self.mscclpp_group.register_memory_with_proxy(
+                    proxy_service,
+                    self.gpu_cache[layer_id][k_or_v],
+                    self.mscclpp_conns,
+                )
+
+        proxy_channels = [None for _ in range(MAX_SEMIDS)]
+        device_handles = [None for _ in range(MAX_SEMIDS)]
+        for sem_id in range(MAX_SEMIDS):
+            proxy_channels[sem_id] = self.mscclpp_group.register_semaphore_with_proxy(
+                proxy_service,
+                self.mscclpp_conns,
+            )[corr_worker_rank]
+            device_handles[sem_id] = proxy_channels[sem_id].device_handle().raw
+
+        all_blocks_size = self.gpu_cache[0][0].numel() * self.gpu_cache[0][0].element_size()
+        block_size = all_blocks_size // self.gpu_cache[0][0].size(0)
+        flush_counter = 0
+        self.split_comm_info = SplitCommInfo(
+            self.worker_type,
+            proxy_service,
+            device_handles,
+            flush_counter,
+            block_size,
+            memory_ids,
+            self.rank,
+            corr_worker_rank,
+        )
+        self.kvcache_comm = KVCacheCommunicator(self.split_comm_info)
+
+    def dismantle_kvcache_comm(self) -> None:
+        self.split_comm_info.proxy_service.stop_proxy()
+        del self.split_comm_info
+        del self.kvcache_comm
+        del self.mscclpp_group
 
     @torch.inference_mode()
     def profile_num_available_blocks(
@@ -136,26 +205,30 @@ class Worker:
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
-        self.model_runner.profile_run()
 
-        # Calculate the number of blocks that can be allocated with the
-        # profiled peak memory.
-        torch.cuda.synchronize()
-        free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info()
-        peak_memory = total_gpu_memory - free_gpu_memory
+        num_gpu_blocks = float("inf")
+        num_cpu_blocks = float("inf")
+        if not self.is_token_worker():
+            self.model_runner.profile_run()
 
-        cache_block_size = CacheEngine.get_cache_block_size(
-            block_size, cache_dtype, self.model_config, self.parallel_config)
-        num_gpu_blocks = int(
-            (total_gpu_memory * gpu_memory_utilization - peak_memory) //
-            cache_block_size)
-        num_cpu_blocks = int(cpu_swap_space // cache_block_size)
-        num_gpu_blocks = max(num_gpu_blocks, 0)
-        num_cpu_blocks = max(num_cpu_blocks, 0)
-        if self.model_runner.lora_manager:
-            self.model_runner.remove_all_loras()
-        gc.collect()
-        torch.cuda.empty_cache()
+            # Calculate the number of blocks that can be allocated with the
+            # profiled peak memory.
+            torch.cuda.synchronize()
+            free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info()
+            peak_memory = total_gpu_memory - free_gpu_memory
+
+            cache_block_size = CacheEngine.get_cache_block_size(
+                block_size, self.model_config, self.parallel_config)
+            num_gpu_blocks = int(
+                (total_gpu_memory * gpu_memory_utilization - peak_memory) //
+                cache_block_size)
+            num_cpu_blocks = int(cpu_swap_space // cache_block_size)
+            num_gpu_blocks = max(num_gpu_blocks, 0)
+            num_cpu_blocks = max(num_cpu_blocks, 0)
+            if self.model_runner.lora_manager:
+                self.model_runner.remove_all_loras()
+            gc.collect()
+            torch.cuda.empty_cache()
         return num_gpu_blocks, num_cpu_blocks
 
     def init_cache_engine(self, cache_config: CacheConfig) -> None:
@@ -207,7 +280,8 @@ class Worker:
         blocks_to_swap_out: Optional[Dict[int, int]] = None,
         blocks_to_copy: Optional[Dict[int, List[int]]] = None,
     ) -> Optional[SamplerOutput]:
-        if self.is_driver_worker:
+        is_prompt = seq_group_metadata_list[0].is_prompt
+        if self.is_driver_worker and ((is_prompt and self.is_prompt_worker()) or (not is_prompt and self.is_token_worker()) or self.is_mixed_worker()):
             assert seq_group_metadata_list is not None
             num_seq_groups = len(seq_group_metadata_list)
             assert blocks_to_swap_in is not None
@@ -219,9 +293,12 @@ class Worker:
                 "blocks_to_swap_out": blocks_to_swap_out,
                 "blocks_to_copy": blocks_to_copy,
             }
-            broadcast_tensor_dict(data, src=0)
+            broadcast_tensor_dict(data,
+                                  src=self.model_runner.driver_rank,
+                                  group=get_tensor_model_parallel_group())
         else:
-            data = broadcast_tensor_dict(src=0)
+            data = broadcast_tensor_dict(src=self.model_runner.driver_rank,
+                                         group=get_tensor_model_parallel_group())
             num_seq_groups = data["num_seq_groups"]
             blocks_to_swap_in = data["blocks_to_swap_in"]
             blocks_to_swap_out = data["blocks_to_swap_out"]
@@ -246,6 +323,35 @@ class Worker:
     def list_loras(self) -> Set[int]:
         return self.model_runner.list_loras()
 
+    def set_gpucache(self):
+        num_layers = self.model_config.get_num_layers(self.parallel_config)
+        for layer_id in range(num_layers):
+            for k_or_v in [0, 1]:
+                self.gpu_cache[layer_id][k_or_v][:] = self.rank * (num_layers * 2) + layer_id * 2 + k_or_v
+        torch.cuda.synchronize()
+
+    def send_recv_kvcache_all(self):
+        if self.kvcache_comm is not None:
+            num_gpu_blocks = self.cache_config.num_gpu_blocks
+            num_layers = self.model_config.get_num_layers(self.parallel_config)
+            if self.rank < self.parallel_config.num_prompt_workers:
+                for layer_id in range(num_layers):
+                    self.kvcache_comm.put(0, layer_id, 0, num_gpu_blocks)
+                self.kvcache_comm.signal_and_flush(0)
+            else:
+                self.kvcache_comm.wait(0)
+            torch.cuda.synchronize()
+
+    def check_gpucache(self):
+        if self.kvcache_comm is not None:
+            num_prompt_workers = self.parallel_config.num_prompt_workers
+            num_layers = self.model_config.get_num_layers(self.parallel_config)
+            expected_worker_id = self.rank if self.rank < num_prompt_workers else self.rank - num_prompt_workers
+            for layer_id in range(num_layers):
+                for k_or_v in [0, 1]:
+                    expected_scalar = (expected_worker_id * (num_layers * 2) + layer_id * 2 + k_or_v)
+                    expected_tensor = torch.ones_like(self.gpu_cache[layer_id][k_or_v]) * expected_scalar
+                    assert torch.allclose(self.gpu_cache[layer_id][k_or_v], expected_tensor)
 
 def init_distributed_environment(
     parallel_config: ParallelConfig,
@@ -275,7 +381,8 @@ def init_distributed_environment(
     # A small all_reduce for warmup.
     torch.distributed.all_reduce(torch.zeros(1).cuda())
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
-                                      parallel_config.pipeline_parallel_size)
+                                      parallel_config.pipeline_parallel_size,
+                                      parallel_config.sep_prompt_token)
 
 
 def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):


### PR DESCRIPTION
This PR follows up on https://github.com/vllm-project/vllm/issues/2472 to implement the prompt and token stage parallelism introduced in Splitwise.
On enabling the `--sep-prompt-token` flag, first half of the workers are assigned to process prompts and the second half perform token sampling. The KV-cache state is communicated over the network in a layer-wise manner as soon as it is ready on the prompt side. We use the MSCCL++ communication library to perform fast asynchronous KV-cache transfers over the IB fabric.

This PR makes the following changes:
- Add MSCCL++ support (https://github.com/microsoft/mscclpp)
- Adds logic to separate execution of prompt and token workers
- Adds per-layer KV-cache transfer
- Documents usage for Splitwise

#### Installation dependencies:
We use the MSCCL++ collective communication library for KV-cache transfers.
Please follow these instructions at [MSCCL++ Quickstart](https://github.com/microsoft/mscclpp/blob/main/docs/quickstart.md) or follow the steps below to install it from source:

```
$ git clone https://github.com/microsoft/mscclpp;
$ mkdir mscclpp/build; cd mscclpp/build; cmake -DCMAKE_BUILD_TYPE=Release ..; make -j;
$ conda install -c conda-forge mpi4py
$ cd ../python; pip install -r requirements_c12.txt;
$ cd ..; pip install -e .
```

Make sure that `$MSCCLPP_HOME` is set to the installation directory or run `sudo make install`


#### Tests:
This PR has been tested in the following scenarios.
1. Validating communication of KV cache:
    
    Command used: `python tests/distributed/test_kvcache_comm.py`
    Result: Runs without assertion errors.

2. Without MSCCL++ environment, no stage parallelism:

    Command used: `python examples/llm_engine_example_single.py --tensor-parallel-size 8 --model bigscience/bloom`
    Result: Runs like normal.

3. With stage parallelism:

    Command used: `python examples/llm_engine_example_single.py --tensor-parallel-size 8 --model bigscience/bloom --sep-prompt-token`
    Result: Same output as before.


`llm_engine_example_single.py` is the llm_engine_example.py with n=1 and deterministic SamplingParameters.


#### Known issues:
1. Missing support for n>1 in SamplingParameters
2. Since the sampling happens in a different token device than before, the sampled output for RANDOM SamplingType is sometimes different. This is likely due to nondeterminism introduced in the exponential_ operation in calculating multinomial of probs.
3. Number of profiled GPU cache blocks is different with and without stage parallelism