### PR TITLE
Upgrade PyTorch to v2.2.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
           os: ['ubuntu-20.04']
           python-version: ['3.8', '3.9', '3.10', '3.11']
-          pytorch-version: ['2.1.2']  # Must be the most recent version that meets requirements.txt.
+          pytorch-version: ['2.2.0']  # Must be the most recent version that meets requirements.txt.
           cuda-version: ['11.8', '12.1']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "ninja",
     "packaging",
     "setuptools >= 49.4.0",
-    "torch == 2.1.2",
+    "torch == 2.2.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,5 +2,5 @@
 ninja
 packaging
 setuptools>=49.4.0
-torch==2.1.2
+torch==2.2.0
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ psutil
 ray >= 2.9
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
-torch == 2.1.2
+torch == 2.2.0
 transformers >= 4.37.0 # Required for Qwen2
-xformers == 0.0.23.post1  # Required for CUDA 12.1.
+xformers == 0.0.24 # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.


### PR DESCRIPTION
This PR upgrades the PyTorch version to v2.2.0

**NOTE**: This PR will probably break the AMD GPU support. We need to upgrade the docker file and xformers patch to fix the break.