### PR TITLE
Fix docker python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,12 +80,6 @@ RUN --mount=type=cache,target=/root/.cache/pip VLLM_USE_PRECOMPILED=1 pip instal
 # In the future it would be nice to get a container with pytorch and cuda without duplicating cuda
 FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS vllm-base
 
-# Somehow the official cuda containers from Nvidia have the wrong LD_LIBRARY_PATH set.
-# It is set to /usr/local/nvidia/libs and /usr/local/nvidia/lib64, but the actual
-# cuda libraries are in /usr/local/cuda/compat.
-# There are also cuda libraries in python site-packages, but they don't have everything.
-ENV LD_LIBRARY_PATH="/usr/local/cuda/compat:${LD_LIBRARY_PATH}"
-
 # libnccl required for ray
 RUN apt-get update -y \
     && apt-get install -y python3-pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,8 @@
 #################### BASE BUILD IMAGE ####################
 FROM nvidia/cuda:12.1.0-devel-ubuntu22.04 AS dev
 
-# Set the DEBIAN_FRONTEND variable to noninteractive to avoid interactive prompts
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Preconfigure tzdata for US Central Time (build running in us-central-1 but this really doesn't matter.)
-RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
-    && echo 'tzdata tzdata/Zones/America select Chicago' | debconf-set-selections
-
-# We install an older version of python here for testing to make sure vllm works with older versions of Python.
-# For the actual openai compatible server, we will use the latest version of Python.
 RUN apt-get update -y \
-    && apt-get install -y software-properties-common \
-    && add-apt-repository ppa:deadsnakes/ppa -y \
-    && apt-get update -y \
-    && apt-get install -y python3.8 python3.8-dev python3.8-venv python3-pip git \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+    && apt-get install -y python3-pip git
 
 # Workaround for https://github.com/openai/triton/issues/2507 and
 # https://github.com/pytorch/pytorch/issues/107960 -- hopefully
@@ -88,8 +75,16 @@ RUN --mount=type=cache,target=/root/.cache/pip VLLM_USE_PRECOMPILED=1 pip instal
 
 
 #################### RUNTIME BASE IMAGE ####################
-# use CUDA base as CUDA runtime dependencies are already installed via pip
-FROM nvidia/cuda:12.1.0-base-ubuntu22.04 AS vllm-base
+# We used base cuda image because pytorch installs its own cuda libraries.
+# However cupy depends on cuda libraries so we had to switch to the runtime image
+# In the future it would be nice to get a container with pytorch and cuda without duplicating cuda
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04 AS vllm-base
+
+# Somehow the official cuda containers from Nvidia have the wrong LD_LIBRARY_PATH set.
+# It is set to /usr/local/nvidia/libs and /usr/local/nvidia/lib64, but the actual
+# cuda libraries are in /usr/local/cuda/compat.
+# There are also cuda libraries in python site-packages, but they don't have everything.
+ENV LD_LIBRARY_PATH="/usr/local/cuda/compat:${LD_LIBRARY_PATH}"
 
 # libnccl required for ray
 RUN apt-get update -y \

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pydantic >= 2.0  # Required for OpenAI server.
 aioprometheus[starlette]
 pynvml == 11.5.0
 triton >= 2.1.0
-cupy-cuda12x == 12.3.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
+cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.


### PR DESCRIPTION
Docker images were broken because we build the extensions with python3.8 but then we try to run them with other version of python.

This results in exception error
```
  File "/workspace/vllm/model_executor/layers/quantization/awq.py", line 6, in <module>
    from vllm._C import ops
ModuleNotFoundError: No module named 'vllm._C'
```

I think if we want to make sure vllm works in older versions of python we should do something else.

To reproduce
`docker build .`
`docker run ... ` 
It crashes with the above exception. I think as part of the CI there should be something that checks if the docker build containers work. 