### PR TITLE
Fix internlm after https://github.com/vllm-project/vllm/pull/2860

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -175,7 +175,8 @@ class LlamaDecoderLayer(nn.Module):
         self.self_attn = LlamaAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
-            num_kv_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+            num_kv_heads=getattr(config, "num_key_value_heads",
+                                 config.num_attention_heads),
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
             max_position_embeddings=max_position_embeddings,

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -175,7 +175,7 @@ class LlamaDecoderLayer(nn.Module):
         self.self_attn = LlamaAttention(
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
-            num_kv_heads=config.num_key_value_heads,
+            num_kv_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
             max_position_embeddings=max_position_embeddings,


### PR DESCRIPTION
Sorry, I was shooting a little too fast with https://github.com/vllm-project/vllm/pull/2860 and it got merged before I could try it out end-to-end. This PR fixes the model, to verify the fix I ran the following:

```python
In [1]: from vllm import LLM, SamplingParams

In [2]: prompts = [
   ...:     "Hello, my name is",
   ...:     "The president of the United States is",
   ...:     "The capital of France is",
   ...:     "The future of AI is",
   ...: ]
   ...: sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

In [3]: llm = LLM(model="internlm/internlm-7b", trust_remote_code=True)

In [5]: outputs = llm.generate(prompts, sampling_params)

In [6]: # Print the outputs.
   ...: for output in outputs:
   ...:     prompt = output.prompt
   ...:     generated_text = output.outputs[0].text
   ...:     print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
   ...: 
Prompt: 'Hello, my name is', Generated text: ' Lorena. I am a native Spanish speaker who loves to travel, read,'
Prompt: 'The president of the United States is', Generated text: " in Europe this week, but he's only making one stop in the former Soviet"
Prompt: 'The capital of France is', Generated text: ' Paris. The city is also called “City of Light” and “City of'
Prompt: 'The future of AI is', Generated text: ' bright, but there are a few things to be aware of\n\nThe future of'
```

The error was that https://huggingface.co/internlm/internlm-7b/blob/main/config.json doesn't have `num_key_value_heads`.