### PR TITLE
[Fix] Fix memory profiling when GPU is used by multiple processes

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -128,6 +128,8 @@ class Worker:
         # profiled peak memory.
         torch.cuda.synchronize()
         free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info()
+        # NOTE(woosuk): Here we assume that the other processes using the same
+        # GPU did not change their memory usage during the profiling.
         peak_memory = self.init_gpu_memory - free_gpu_memory
 
         cache_block_size = CacheEngine.get_cache_block_size(

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -84,6 +84,8 @@ class Worker:
             torch.cuda.set_device(self.device)
 
             _check_if_gpu_supports_dtype(self.model_config.dtype)
+            torch.cuda.empty_cache()
+            self.init_gpu_memory = torch.cuda.mem_get_info()[0]
         else:
             raise RuntimeError(
                 f"Not support device type: {self.device_config.device}")
@@ -126,7 +128,7 @@ class Worker:
         # profiled peak memory.
         torch.cuda.synchronize()
         free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info()
-        peak_memory = total_gpu_memory - free_gpu_memory
+        peak_memory = self.init_gpu_memory - free_gpu_memory
 
         cache_block_size = CacheEngine.get_cache_block_size(
             block_size, cache_dtype, self.model_config, self.parallel_config)


### PR DESCRIPTION
Currently, the memory profiling logic assumes that the GPU memory is initially empty. However, this might not be always true since multiple processes can share a GPU. This PR fixes it by considering the other processes' GPU memory usage at the engine initialization time.

Original PR: #2249 by @hanzhi713 