### PR TITLE
GQA models have not supported prefix caching

### DIFF
--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -206,6 +206,8 @@ class PagedAttention(nn.Module):
                 output = out.view_as(query)
             else:
                 # prefix-enabled attention
+                assert self.num_kv_heads == self.num_heads, (
+                    "Prefix caching is currently not supported with MQA/GQA")
                 output = torch.empty_like(query)
                 context_attention_fwd(
                     query,


### PR DESCRIPTION
I found a model that uses GQA returns wrong result with `prefix_pos`.  After some investigation, the code to support MQA/GQA
https://github.com/vllm-project/vllm/blob/7e45107f51bcb38c22dd9916c61226078e8eb26d/vllm/model_executor/layers/attention.py#L141-L155
, which repeats the inputs, is not compatible with the current implementation of prefix caching (`context_attention_fwd`).

To support MQA/GQA,
```python
                if self.num_kv_heads != self.num_heads:
                    query = query.view(batch_size * seq_len, self.num_heads, self.head_size)
                    key = key.reshape(batch_size * seq_len, self.num_heads, self.head_size)
                    value = value.reshape(batch_size * seq_len, self.num_heads, self.head_size)
```
is closer, but KV of prefix should also be expanded (after they are read from `key_cache` and `value_cache`).
