### PR TITLE
Fix decilm.py

### DIFF
--- a/vllm/model_executor/models/decilm.py
+++ b/vllm/model_executor/models/decilm.py
@@ -61,7 +61,9 @@ class DeciLMForCausalLM(LlamaForCausalLM):
     ) -> None:
         config.num_key_value_heads = max(config.num_key_value_heads_per_layer)
         delattr(config, "num_key_value_heads_per_layer")
-        super().__init__(config=config, linear_method=linear_method, lora_config=lora_config)
+        super().__init__(config=config,
+                         linear_method=linear_method,
+                         lora_config=lora_config)
 
     def load_weights(self,
                      model_name_or_path: str,

--- a/vllm/model_executor/models/decilm.py
+++ b/vllm/model_executor/models/decilm.py
@@ -28,6 +28,7 @@ from typing import Optional
 import torch
 from transformers import PretrainedConfig
 
+from vllm.config import LoRAConfig
 from vllm.model_executor.layers.linear import LinearMethodBase
 from vllm.model_executor.models.llama import LlamaForCausalLM
 from vllm.model_executor.weight_utils import (default_weight_loader,
@@ -56,10 +57,11 @@ class DeciLMForCausalLM(LlamaForCausalLM):
         self,
         config: Optional[PretrainedConfig] = None,
         linear_method: Optional[LinearMethodBase] = None,
+        lora_config: Optional[LoRAConfig] = None,
     ) -> None:
         config.num_key_value_heads = max(config.num_key_value_heads_per_layer)
         delattr(config, "num_key_value_heads_per_layer")
-        super().__init__(config=config, linear_method=linear_method)
+        super().__init__(config=config, linear_method=linear_method, lora_config=lora_config)
 
     def load_weights(self,
                      model_name_or_path: str,


### PR DESCRIPTION
Since https://github.com/vllm-project/vllm/pull/1804, the DeciLM model was broken because the constructor of `LlamaForCausalLM` was changed and the change was not reflected in the subclass `DeciLMForCausalLM`.

This was actually caught by `test_models.py`, but that test has not been running properly in the CI (it looks like due to low GPU memory), so it was not detected earlier.