### PR TITLE
support stop_token_ids_group like stop_str in check_stop

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -933,7 +933,8 @@ class LLMEngine:
             find_stop_token_ids = None
             if isinstance(sampling_params.stop_token_ids[0], list):
                 for stop_token_ids_group in sampling_params.stop_token_ids:
-                    find_stop_token_ids = seq.get_last_n_token_id(len(stop_token_ids_group))
+                    find_stop_token_ids = seq.get_last_n_token_id(
+                        len(stop_token_ids_group))
                     if find_stop_token_ids == stop_token_ids_group:
                         break
                     else:
@@ -944,7 +945,8 @@ class LLMEngine:
                     find_stop_token_ids = None
 
             if find_stop_token_ids is not None:
-                stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(find_stop_token_ids)
+                stop_str = self.get_tokenizer_for_seq(
+                    seq).convert_ids_to_tokens(find_stop_token_ids)
                 self._finalize_sequence(seq, sampling_params, stop_str)
                 seq.status = SequenceStatus.FINISHED_STOPPED
                 return

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -90,6 +90,11 @@ class SequenceData:
             return self.prompt_token_ids[-1]
         return self.output_token_ids[-1]
 
+    def get_last_n_token_id(self, n: int) -> List[int]:
+        if not self.output_token_ids:
+            return self.prompt_token_ids[-n:]
+        return self.output_token_ids[-n:]
+
     def __repr__(self) -> str:
         return (f"SequenceData("
                 f"prompt_token_ids={self.prompt_token_ids}, "
@@ -188,6 +193,9 @@ class Sequence:
 
     def get_last_token_id(self) -> int:
         return self.data.get_last_token_id()
+
+    def get_last_n_token_id(self, n: int) -> List[int]:
+        return self.data.get_last_n_token_id(n)
 
     def get_output_token_ids(self) -> List[int]:
         return self.data.output_token_ids


### PR DESCRIPTION
When the stop words are multiple words, currently only the stop string support can be used, so I updated the stop_token_ids in SamplingParams to support multiple stop words.

Example:
When the stop words are "<| endsoftext |>" and "hello world", we can set SamplingParams.stop_token_ids to [[151643], [9707, 1879]].