### PR TITLE
Remove cuda stream in awq gemm achieved 2.5x speed up

### DIFF
--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -1,3 +1,4 @@
+
 /*
 Adapted from https://github.com/mit-han-lab/llm-awq
 @article{lin2023awq,
@@ -373,8 +374,7 @@ torch::Tensor awq_dequantize(
     dim3 num_blocks(x_blocks, y_blocks);
     dim3 threads_per_block(x_thread, y_thread);
 
-    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    vllm::awq::dequantize_weights<<<num_blocks, threads_per_block, 0, stream>>>(
+    vllm::awq::dequantize_weights<<<num_blocks, threads_per_block>>>(
         kernel, scaling_factors, zeros, de_kernel, G);
 
     return _de_kernel;
@@ -418,7 +418,6 @@ torch::Tensor awq_gemm(
     if (num_out_channels % group_size != 0)
         throw std::invalid_argument("OC is not multiple of Group size");
 
-    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     if (num_out_channels % 128 == 0)
     {
         int j_factors1 = num_out_channels / 128 / 1;
@@ -426,7 +425,7 @@ torch::Tensor awq_gemm(
         // threadIdx.x: 32
         // threadIdx.y: i_factors[2] * j_factors[2]
         dim3 threads_per_block(32, 2);
-        vllm::awq::gemm_forward_4bit_cuda_m16nXk32<128><<<num_blocks, threads_per_block, 0, stream>>>(
+        vllm::awq::gemm_forward_4bit_cuda_m16nXk32<128><<<num_blocks, threads_per_block>>>(
             group_size, split_k_iters, in_feats, kernel, scaling_factors, zeros, num_in_feats, num_in_channels,
             num_out_channels, out_feats);
     }
@@ -438,7 +437,7 @@ torch::Tensor awq_gemm(
         // threadIdx.x: 32
         // threadIdx.y: i_factors[2] * j_factors[2]
         dim3 threads_per_block(32, 2);
-        vllm::awq::gemm_forward_4bit_cuda_m16nXk32<64><<<num_blocks, threads_per_block, 0, stream>>>(
+        vllm::awq::gemm_forward_4bit_cuda_m16nXk32<64><<<num_blocks, threads_per_block>>>(
             group_size, split_k_iters, in_feats, kernel, scaling_factors, zeros, num_in_feats, num_in_channels,
             num_out_channels, out_feats);
     }


### PR DESCRIPTION
Removing cuda stream in awq both gemm and dequantize, somehow achieved max 2.5x speed up

Command for testing:
`python benchmarks/benchmark_throughput.py --input-len 1024 --output-len 64 --model TheBloke/Mistral-7B-Instruct-v0.2-AWQ --quantization awq --num-prompts 100 --max-model-len 8192 --dtype half`

| input len | output len | main reqs/s | main tokens/s | PR reqs/s | PR tokens/s | Speed Up |
|-|-|-|-|-|-|-|
| 1024 | 64 | 8.61 | 9365.52 | 10.19 | 11085.39 | 1.18 |
| 512 | 64 | 14.24 | 8202.31 | 18.94 | 10908.37 | 1.33 |
| 256 | 64 | 20.78 | 6648.15 | 32.55 | 10416.5 | 1.57 |
| 128 | 128 | 15.75 | 4031.75 | 33.53 | 8583.89 | 2.13 |
| 64 | 64 | 32.44 | 4152.96 | 72.48 | 9277.53 | 2.23 |
| 32 | 64 | 35.44 | 3402.48 | 89.3 | 8772.66 | 2.52 |
| 32 | 32 | 65 | 4160.22 | 65.84 | 42123.63 | 1.01 |
