### PR TITLE
Directly call cublas in awq_dequant

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -72,14 +72,6 @@ torch::Tensor awq_gemm(
   torch::Tensor _scaling_factors,
   torch::Tensor _zeros,
   int split_k_iters);
-
-torch::Tensor awq_dequantize(
-    torch::Tensor _kernel,
-    torch::Tensor _scaling_factors,
-    torch::Tensor _zeros,
-    int split_k_iters,
-    int thx,
-    int thy);
 #endif
 
 void squeezellm_gemm(

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -51,7 +51,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   // Quantization ops
 #ifndef USE_ROCM
   ops.def("awq_gemm", &awq_gemm, "Quantized GEMM for AWQ");
-  ops.def("awq_dequantize", &awq_dequantize, "Dequantization for AWQ");
 #endif
   ops.def("gptq_gemm", &gptq_gemm, "Quantized GEMM for GPTQ");
   ops.def("gptq_shuffle", &gptq_shuffle, "Post processing for GPTQ");

--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -385,6 +385,7 @@ torch::Tensor awq_gemm(
       const __half alpha = at::Half(1.0f);
       const __half beta = at::Half(0.0f);
       const cublasHandle_t cublas_handle = at::cuda::getCurrentCUDABlasHandle();
+      cublasSetStream(cublas_handle, stream);
       cublasHgemm(
         cublas_handle,
         CUBLAS_OP_N,

--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -420,7 +420,7 @@ torch::Tensor awq_gemm(
         throw std::invalid_argument("OC is not multiple of Group size");
 
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    if (num_in_channels > 256) {
+    if (num_in_feats > 256) {
       at::Tensor _de_kernel = torch::empty({num_in_channels, num_out_channels}, options);
       auto de_kernel = reinterpret_cast<half*>(_de_kernel.data_ptr<at::Half>());
 

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -154,12 +154,12 @@ class AWQLinearMethod(LinearMethodBase):
         # num_tokens >= threshold
         FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
 
-        if FP16_MATMUL_HEURISTIC_CONDITION:
-            out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
-            out = torch.matmul(reshaped_x, out)
-        else:
-            out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
-                               pack_factor)
+        # if FP16_MATMUL_HEURISTIC_CONDITION:
+        #     out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
+        #     out = torch.matmul(reshaped_x, out)
+        # else:
+        out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
+                            pack_factor)
         if bias is not None:
             out = out + bias
         return out.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -150,16 +150,8 @@ class AWQLinearMethod(LinearMethodBase):
         pack_factor = self.quant_config.pack_factor
         out_shape = (x.shape[:-1] + (qweight.shape[-1] * pack_factor, ))
         reshaped_x = x.reshape(-1, x.shape[-1])
-
-        # num_tokens >= threshold
-        FP16_MATMUL_HEURISTIC_CONDITION = x.shape[:-1].numel() >= 256
-
-        # if FP16_MATMUL_HEURISTIC_CONDITION:
-        #     out = ops.awq_dequantize(qweight, scales, qzeros, 0, 0, 0)
-        #     out = torch.matmul(reshaped_x, out)
-        # else:
         out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
-                            pack_factor)
+                           pack_factor)
         if bias is not None:
             out = out + bias
         return out.reshape(out_shape)

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -150,8 +150,7 @@ class AWQLinearMethod(LinearMethodBase):
         pack_factor = self.quant_config.pack_factor
         out_shape = (x.shape[:-1] + (qweight.shape[-1] * pack_factor, ))
         reshaped_x = x.reshape(-1, x.shape[-1])
-        out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros,
-                           pack_factor)
+        out = ops.awq_gemm(reshaped_x, qweight, scales, qzeros, pack_factor)
         if bias is not None:
             out = out + bias
         return out.reshape(out_shape)


### PR DESCRIPTION
For long input sequences (>256), it performs better today with dequant + torch.matmul than the original awq_gemm. This PR changes to directly call cuBLAS instead of the torch.matmul.

Surprisingly it's much slower than the current main.

| input len | output len | main reqs/s | main tokens/s | PR reqs/s | PR tokens/s | Speed Up |
|-|-|-|-|-|-|-|
| 1024 | 64 | 8.61 | 9365.52 | 4.23 | 4597 | .49 |
| 512 | 64 | 14.24 | 8202.31 | 7.58 | 4368.18 | .53 |
| 256 | 64 | 20.78 | 6648.15 | 12.56 | 4018.48 | .60 |
| 128 | 128 | 15.75 | 4031.75 | 12.66 | 3239.88 | .80 |
| 64 | 64 | 32.44 | 4152.96 | 28.53 | 3651.43 | .88 |
| 32 | 64 | 35.44 | 3402.48 | 33.36 | 3202.88 | .94 |
| 32 | 32 | 65 | 4160.22 | 65.28 | 4177.73 | 1 |


This PR also refactored the awq_gemm which isn't the source of performance degrade. Observed similar results when directly adding the cublas gemm to the original awq_dequantize kernel.