### PR TITLE
Bump up version to v0.3.2

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
This version is for more model support. Add support for Gemma models (#2964) and OLMo models (#2832).