### PR TITLE
GCP/A3 doesn't work with torch<2.2 - suggesting to change the deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ psutil
 ray >= 2.9
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
-torch == 2.1.2
+torch >= 2.1.2
 transformers >= 4.38.0  # Required for Gemma.
 xformers == 0.0.23.post1  # Required for CUDA 12.1.
 fastapi


### PR DESCRIPTION
GCP/A3 doesn't work with torch<2.2 - so we can't use vllm - this PR is suggesting to relax the deps