### PR TITLE
Update Dockerfile.rocm for gfx908 support

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -11,10 +11,10 @@ RUN echo "Base image is $BASE_IMAGE"
 # BASE_IMAGE for ROCm_6.0: "rocm/pytorch:rocm6.0_ubuntu20.04_py3.9_pytorch_2.1.1"
 
 
-ARG FA_GFX_ARCHS="gfx90a;gfx942"
+ARG FA_GFX_ARCHS="gfx90a;gfx942;gfx908"
 RUN echo "FA_GFX_ARCHS is $FA_GFX_ARCHS"
 
-ARG FA_BRANCH="3d2b6f5"
+ARG FA_BRANCH="ae7928c"
 RUN echo "FA_BRANCH is $FA_BRANCH"
 
 # whether to build flash-attention


### PR DESCRIPTION
This (https://github.com/vllm-project/vllm/commit/264017a2bf030f060ebad91eb9be9b4e0033edb9) commit added gfx908 as supported officially in vLLM, but Dockerfile.rocm used a Flash-Attention version from prior to the gfx908 pull request merge (https://github.com/ROCm/flash-attention/commit/ae7928c5aed53cf6e75cc792baa9126b2abfcf1a)

This update adds the arch to both FA_GFX_ARCHS and updates the FA branch to a commit post-support.
Attempting to build on an MI100 system without these changes makes FA fail to build due to incompatible arch.