### PR TITLE
Remove Flash Attention in test env

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,6 @@ pytest-forked
 pytest-asyncio
 httpx
 einops # required for MPT
-flash_attn # required for HuggingFace's llama implementation
 openai
 requests
 ray


### PR DESCRIPTION
To my understanding, we don't need `flash_attn` for our testing. Removing it from dependencies will resolve the occasional test failures due to `flash_attn`.