### PR TITLE
[Fix] Fix assertion on Mistral YaRN model len

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -354,7 +354,6 @@ def get_rope(
         elif scaling_type == "yarn":
             original_max_position = rope_scaling[
                 "original_max_position_embeddings"]
-            assert max_position == original_max_position * scaling_factor
             extra_kwargs = {
                 k: v
                 for k, v in rope_scaling.items()


### PR DESCRIPTION
For Mistral + YaRN models such as `NousResearch/Yarn-Mistral-7b-128k`, the current assertion does not hold. This PR deletes it.