### PR TITLE
/metrics 's model_name optimization

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
         engine, served_model, args.lora_modules)
 
     # Register labels for metrics
-    add_global_metrics_labels(model_name=engine_args.model)
+    add_global_metrics_labels(model_name=served_model)
 
     app.root_path = args.root_path
     uvicorn.run(app,


### PR DESCRIPTION
when server run 'python -m vllm.entrypoints.openai.api_server --model /root/opt-125m/'
by default, user will get metrics like below 
vllm:time_to_first_token_seconds_bucket{le="0.06",model_name="/root/opt-125m/"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.08",model_name="/root/opt-125m/"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.1",model_name="/root/opt-125m/"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.25",model_name="/root/opt-125m/"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.5",model_name="/root/opt-125m/"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.75",model_name="/root/opt-125m/"} 4.0

model_name is equal --model's content, but in grafana, the model_name is usually as variables in grafana, as you see, /root/opt-125m/ contain directory character, this is inconvenient for granfa administror,

so, i suggest, modify add_global_metrics_labels(model_name=engine_args.model) to add_global_metrics_labels(model_name=served_model), user could set /metrics's model_name through 'python -m vllm.entrypoints.openai.api_server --model /root/opt-125m/ --served-model-name modelx' as below

vllm:time_to_first_token_seconds_bucket{le="0.04",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.06",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.08",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.1",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.25",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.5",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="0.75",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="1.0",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="2.5",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="5.0",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="7.5",model_name="modelx"} 4.0
vllm:time_to_first_token_seconds_bucket{le="10.0",model_name="modelx"} 4.0

this is better for grafana display,  when --served-model-name is not specified, it will be displayed in the old way.