### PR TITLE
[Minor] Add benchmark for activation layer

### DIFF
--- a/benchmarks/layers/benchmark_activation.py
+++ b/benchmarks/layers/benchmark_activation.py
@@ -1,0 +1,39 @@
+import torch
+from torch import nn
+from torch.utils.benchmark import Timer
+
+from vllm.model_executor.layers.activation import NewGELU
+
+
+def benchmark_activation(num_tokens: int,
+                         d: int,
+                         activation_function: nn.Module,
+                         num_trials: int = 100,
+                         seed: int = 0,
+                         device: str = 'cuda'):
+    torch.random.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+    torch.set_default_device(device)
+
+    x = torch.randn(num_tokens, d, dtype=torch.float)
+
+    timer = Timer(stmt='layer(x)',
+                  globals={
+                      'layer': activation_function,
+                      'x': x
+                  })
+
+    print(
+        f"{activation_function.__class__.__name__} function: {timer.timeit(num_trials)}"
+    )
+
+
+if __name__ == '__main__':
+    # Test with NewGELU
+    new_gelu = NewGELU()
+    benchmark_activation(2048, 8192, new_gelu)
+
+    # Test with nn.GELU(approximate="tanh")
+    nn_gelu = nn.GELU(approximate="tanh")
+    benchmark_activation(2048, 8192, nn_gelu)

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -134,7 +134,8 @@ _ACTIVATION_REGISTRY = {
     "gelu_fast": FastGELU(),
     "gelu_new": NewGELU(),
     "gelu_pytorch_tanh":
-    nn.GELU(approximate="tanh"),  # Pytorch's is slightly faster than custom NewGELU
+    nn.GELU(approximate="tanh"
+            ),  # Pytorch's is slightly faster than custom NewGELU
     "relu": nn.ReLU(),
 }
 

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -133,7 +133,8 @@ _ACTIVATION_REGISTRY = {
     "gelu": nn.GELU(),
     "gelu_fast": FastGELU(),
     "gelu_new": NewGELU(),
-    "gelu_pytorch_tanh": NewGELU(),
+    "gelu_pytorch_tanh":
+    nn.GELU(approximate="tanh"),  # Pytorch's is slightly faster than custom NewGELU
     "relu": nn.ReLU(),
 }
 

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -133,7 +133,7 @@ _ACTIVATION_REGISTRY = {
     "gelu": nn.GELU(),
     "gelu_fast": FastGELU(),
     "gelu_new": NewGELU(),
-    "gelu_pytorch_tanh": nn.GELU(approximate="tanh"),
+    "gelu_pytorch_tanh": NewGELU(),
     "relu": nn.ReLU(),
 }
 


### PR DESCRIPTION
I found that `nn.GELU(approximate="tanh")` is identical to `NewGELU()`, so I made this change.
Additionally, should we migrate all other activation kernels `gelu_fast` and `gelu_new` to `act_and_mul` in the same manner as `SiluAndMul` and `GeluAndMul`? @WoosukKwon