### PR TITLE
torch.compile() support

### DIFF
--- a/vllm/lowering_utils.py
+++ b/vllm/lowering_utils.py
@@ -1,0 +1,305 @@
+import torch
+import torch._inductor.ir as ir
+import torch._inductor.lowering as lowering
+from torch._inductor.virtualized import V
+
+vllm_lib = torch.library.Library("vllm", "DEF")
+
+# Available starting PT 2.2
+class NoneLayout(ir.IRNode):
+    def __init__(self, device):
+        self.device = device
+        self.size = [0]
+        self.stride = [0]
+
+    def storage_size(self):
+        return 0
+
+    def as_fixed(self):
+        return self
+
+
+# Available starting PT 2.2
+class MutationOutput(ir.ExternKernel):
+    def get_mutation_names(self):
+        return [self.inputs[0].get_name()]
+
+    def __init__(self, layout, input, parent):
+        super().__init__(None, layout, [input, parent], ())
+        self.name = V.graph.register_buffer(self)
+
+    def should_allocate(self):
+        return False
+
+    def is_no_op(self):
+        return True
+
+    def has_side_effects(self):
+        return True
+
+    def get_alias_names(self):
+        return [self.inputs[0].get_name()]
+
+
+class VllmCudaKernel(ir.FallbackKernel):
+    def should_allocate(self):
+        return False
+
+    def has_side_effects(self):
+        return True
+
+    @classmethod
+    def create(cls, kernel, *args, mutated_inputs=[], **kwargs) -> None:
+        with V.graph.fake_mode:
+            (
+                example_output,
+                tensor_args,
+                non_tensor_args,
+                unflatten_args,
+                schema,
+            ) = cls.process_kernel(kernel, *args, **kwargs)
+        for tensor_arg in tensor_args:
+            tensor_arg.realize()
+
+        packed = cls(
+            NoneLayout(tensor_args[0].get_device()),
+            kernel,
+            tensor_args,
+            non_tensor_args,
+            unflatten_args,
+            schema=schema,
+        )
+        # Mark inplace inputs as mutated
+        for kernel_input in mutated_inputs:
+            V.graph.mark_buffer_mutated(kernel_input.get_name())
+            MutationOutput(kernel_input.layout, kernel_input, packed)
+
+def register_vllm_lowering(op, mutating_inputs):
+    lowering.fallbacks.add(op)
+
+    @lowering.register_lowering(op, type_promotion_kind=None)
+    def op_lowering(
+        *args,
+        **kwargs,
+    ):
+        VllmCudaKernel.create(
+            op.default,
+            *args,
+            **kwargs,
+            mutated_inputs=mutating_inputs,
+        )
+        returns = [args[i] for i in mutating_inputs]
+        if len(returns) == 1:
+            return returns[0]
+        else:
+            return tuple(returns)
+
+
+# lib.define(
+#     "paged_attention_v2(Tensor out, Tensor exp_sums, Tensor max_logits, Tensor tmp_out, Tensor query, Tensor key_cache, Tensor value_cache, int num_kv_heads, float scale, Tensor block_tables, Tensor context_lens, int block_size, SymInt max_context_len, Tensor? alibi_slopes) -> Tensor"
+# )
+
+
+# @torch.library.impl(lib, "paged_attention_v2", "Meta")
+# def _paged_attention_v2_meta(
+#     out,
+#     exp_sums,
+#     max_logits,
+#     tmp_out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     return out.contiguous()
+
+
+# @torch.library.impl(lib, "paged_attention_v2", "CUDA")
+# def _paged_attention_v2(
+#     out,
+#     exp_sums,
+#     max_logits,
+#     tmp_out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     out = out.contiguous()
+#     exp_sums = exp_sums.contiguous()
+#     max_logits = max_logits.contiguous()
+#     tmp_out = tmp_out.contiguous()
+#     query = query.contiguous()
+#     key_cache = key_cache.contiguous()
+#     value_cache = value_cache.contiguous()
+#     block_tables = block_tables.contiguous()
+#     context_lens = context_lens.contiguous()
+
+#     attn_ops.paged_attention_v2(
+#         out,
+#         exp_sums,
+#         max_logits,
+#         tmp_out,
+#         query,
+#         key_cache,
+#         value_cache,
+#         num_kv_heads,
+#         scale,
+#         block_tables,
+#         context_lens,
+#         block_size,
+#         max_context_len,
+#         alibi_slopes,
+#     )
+#     return out
+
+
+# lowering.fallbacks.add(torch.ops.paged_attention.paged_attention_v2)
+
+
+# @lowering.register_lowering(
+#     torch.ops.paged_attention.paged_attention_v2, type_promotion_kind=None
+# )
+# def _paged_attention_v2_lowering(
+#     out,
+#     exp_sums,
+#     max_logits,
+#     tmp_out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     VllmCudaKernel.create(
+#         torch.ops.paged_attention.paged_attention_v2.default,
+#         out,
+#         exp_sums,
+#         max_logits,
+#         tmp_out,
+#         query,
+#         key_cache,
+#         value_cache,
+#         num_kv_heads,
+#         scale,
+#         block_tables,
+#         context_lens,
+#         block_size,
+#         max_context_len,
+#         alibi_slopes,
+#         mutated_inputs=[out],
+#     )
+#     return out
+
+
+# lib.define(
+#     "paged_attention_v1(Tensor out, Tensor query, Tensor key_cache, Tensor value_cache, int num_kv_heads, float scale, Tensor block_tables, Tensor context_lens, int block_size, SymInt max_context_len, Tensor? alibi_slopes) -> Tensor"
+# )
+
+
+# @torch.library.impl(lib, "paged_attention_v1", "Meta")
+# def _paged_attention_v1_meta(
+#     out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     return out.contiguous()
+
+
+# @torch.library.impl(lib, "paged_attention_v1", "CUDA")
+# def _paged_attention_v1(
+#     out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     out = out.contiguous()
+#     query = query.contiguous()
+#     key_cache = key_cache.contiguous()
+#     value_cache = value_cache.contiguous()
+#     block_tables = block_tables.contiguous()
+#     context_lens = context_lens.contiguous()
+
+#     attn_ops.paged_attention_v1(
+#         out,
+#         query,
+#         key_cache,
+#         value_cache,
+#         num_kv_heads,
+#         scale,
+#         block_tables,
+#         context_lens,
+#         block_size,
+#         max_context_len,
+#         alibi_slopes,
+#     )
+#     return out
+
+
+# lowering.fallbacks.add(torch.ops.paged_attention.paged_attention_v1)
+
+
+# @lowering.register_lowering(
+#     torch.ops.paged_attention.paged_attention_v1, type_promotion_kind=None
+# )
+# def _paged_attention_v1_lowering(
+#     out,
+#     query,
+#     key_cache,
+#     value_cache,
+#     num_kv_heads,
+#     scale,
+#     block_tables,
+#     context_lens,
+#     block_size,
+#     max_context_len,
+#     alibi_slopes=None,
+# ):
+#     PagedAttnKernel.create(
+#         torch.ops.paged_attention.paged_attention_v1.default,
+#         out,
+#         query,
+#         key_cache,
+#         value_cache,
+#         num_kv_heads,
+#         scale,
+#         block_tables,
+#         context_lens,
+#         block_size,
+#         max_context_len,
+#         alibi_slopes,
+#         mutated_inputs=[out],
+#     )
+#     return out

--- a/vllm/lowering_utils.py
+++ b/vllm/lowering_utils.py
@@ -1,4 +1,5 @@
 import collections
+import dataclasses
 from typing import DefaultDict, TypeVar, Generic
 
 import torch
@@ -12,6 +13,19 @@ vllm_lib = torch.library.Library("vllm", "DEF")
 
 
 # Fixed in PT 2.2
+def nodeuser_hash(self):
+    return hash((self.node.get_name(), self.can_inplace, self.is_weak))
+
+def nodeuser_eq(self, other):
+    return (
+        self.get_name() == other.get_name()
+        and self.can_inplace == other.can_inplace
+        and self.is_weak == other.is_weak
+    )
+    
+sched.NodeUser.__hash__ = nodeuser_hash
+sched.NodeUser.__eq__ = nodeuser_eq
+    
 def pt22_compute_dependencies(self):
     """
     Create dependency edges between nodes, handling aliasing and

--- a/vllm/lowering_utils.py
+++ b/vllm/lowering_utils.py
@@ -1,5 +1,4 @@
 import collections
-import dataclasses
 from typing import DefaultDict, TypeVar, Generic
 
 import torch
@@ -16,16 +15,17 @@ vllm_lib = torch.library.Library("vllm", "DEF")
 def nodeuser_hash(self):
     return hash((self.node.get_name(), self.can_inplace, self.is_weak))
 
+
 def nodeuser_eq(self, other):
-    return (
-        self.get_name() == other.get_name()
-        and self.can_inplace == other.can_inplace
-        and self.is_weak == other.is_weak
-    )
-    
+    return (self.get_name() == other.get_name()
+            and self.can_inplace == other.can_inplace
+            and self.is_weak == other.is_weak)
+
+
 sched.NodeUser.__hash__ = nodeuser_hash
 sched.NodeUser.__eq__ = nodeuser_eq
-    
+
+
 def pt22_compute_dependencies(self):
     """
     Create dependency edges between nodes, handling aliasing and

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -36,10 +36,10 @@ class SiluAndMul(nn.Module):
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
         return torch.ops.vllm.silu_and_mul(out, x)
 
+
 # needed for compile
-vllm_lib.define(
-    "silu_and_mul(Tensor out, Tensor input) -> Tensor"
-)
+vllm_lib.define("silu_and_mul(Tensor out, Tensor input) -> Tensor")
+
 
 @torch.library.impl(vllm_lib, "silu_and_mul", "Meta")
 def _silu_and_mul_meta(out, input):
@@ -48,13 +48,12 @@ def _silu_and_mul_meta(out, input):
 
 @torch.library.impl(vllm_lib, "silu_and_mul", "CUDA")
 def _silu_and_mul(out, input):
-    ops.silu_and_mul(
-        out,
-        input
-    )
+    ops.silu_and_mul(out, input)
     return out
 
+
 register_vllm_lowering(torch.ops.vllm.silu_and_mul, [0])
+
 
 class GeluAndMul(nn.Module):
     """An activation function for GeGLU.

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -347,23 +347,28 @@ def _paged_attention(
         )
     return output
 
+
 # needed for compile
 vllm_lib.define(
     "reshape_and_cache(Tensor key, Tensor value, Tensor key_cache, Tensor value_cache, Tensor slot_mapping, str dtype) -> (Tensor, Tensor)"
 )
 
+
 @torch.library.impl(vllm_lib, "reshape_and_cache", "Meta")
-def _reshape_and_cache_meta(key, value, key_cache, value_cache, slot_mapping, dtype):
+def _reshape_and_cache_meta(key, value, key_cache, value_cache, slot_mapping,
+                            dtype):
     return key_cache, value_cache
 
 
 @torch.library.impl(vllm_lib, "reshape_and_cache", "CUDA")
-def _reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, dtype):
-    cache_ops.reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, dtype)
+def _reshape_and_cache(key, value, key_cache, value_cache, slot_mapping,
+                       dtype):
+    cache_ops.reshape_and_cache(key, value, key_cache, value_cache,
+                                slot_mapping, dtype)
     return key_cache, value_cache
 
-register_vllm_lowering(torch.ops.vllm.reshape_and_cache, [2, 3])
 
+register_vllm_lowering(torch.ops.vllm.reshape_and_cache, [2, 3])
 
 vllm_lib.define(
     "paged_attention_v1(Tensor out, Tensor query, Tensor key_cache, Tensor value_cache, int num_kv_heads, float scale, Tensor block_tables, Tensor context_lens, int block_size, SymInt max_context_len, Tensor? alibi_slopes, str kv_cache_dtype) -> Tensor"
@@ -419,13 +424,13 @@ def _paged_attention_v1(
     )
     return out
 
+
 register_vllm_lowering(torch.ops.vllm.paged_attention_v1, [0])
-
-
 
 vllm_lib.define(
     "paged_attention_v2(Tensor out, Tensor exp_sums, Tensor max_logits, Tensor tmp_out, Tensor query, Tensor key_cache, Tensor value_cache, int num_kv_heads, float scale, Tensor block_tables, Tensor context_lens, int block_size, SymInt max_context_len, Tensor? alibi_slopes, str kv_cache_dtype) -> Tensor"
 )
+
 
 @torch.library.impl(vllm_lib, "paged_attention_v2", "Meta")
 def _paged_attention_v2_meta(
@@ -484,5 +489,6 @@ def _paged_attention_v2(
         kv_cache_dtype,
     )
     return out
+
 
 register_vllm_lowering(torch.ops.vllm.paged_attention_v2, [0])

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -64,10 +64,12 @@ class RMSNorm(nn.Module):
             self.variance_epsilon,
         )
 
+
 # needed for compile
 vllm_lib.define(
     "rms_norm(Tensor out, Tensor input, Tensor weight, float epsilon) -> Tensor"
 )
+
 
 @torch.library.impl(vllm_lib, "rms_norm", "Meta")
 def _rms_norm_meta(out, input, weight, epsilon):
@@ -84,12 +86,13 @@ def _rms_norm(out, input, weight, epsilon):
     )
     return out
 
-register_vllm_lowering(torch.ops.vllm.rms_norm, [0])
 
+register_vllm_lowering(torch.ops.vllm.rms_norm, [0])
 
 vllm_lib.define(
     "fused_add_rms_norm(Tensor input, Tensor residual, Tensor weight, float epsilon) -> (Tensor, Tensor)"
 )
+
 
 @torch.library.impl(vllm_lib, "fused_add_rms_norm", "Meta")
 def _fused_add_rms_norm_meta(input, residual, weight, epsilon):
@@ -105,5 +108,6 @@ def _fused_add_rms_norm(input, residual, weight, epsilon):
         epsilon,
     )
     return input, residual
+
 
 register_vllm_lowering(torch.ops.vllm.fused_add_rms_norm, [0, 1])

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -141,13 +141,12 @@ class RotaryEmbedding(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # ops.rotary_embedding() is an in-place operation that
         # updates the query and key tensors.
-        torch.ops.vllm.rotary_embedding(positions, query, key, self.head_size,
+        return torch.ops.vllm.rotary_embedding(positions, query, key, self.head_size,
                              self.cos_sin_cache, self.is_neox_style)
-        return query, key
 
 # needed for compile
 vllm_lib.define(
-    "rotary_embedding(Tensor positions, Tensor(a!) query, Tensor(b!) key, int head_size, Tensor cos_sin_cache, bool is_neox) -> (Tensor(a!), Tensor(b!))"
+    "rotary_embedding(Tensor positions, Tensor query, Tensor key, int head_size, Tensor cos_sin_cache, bool is_neox) -> (Tensor, Tensor)"
 )
 
 @torch.library.impl(vllm_lib, "rotary_embedding", "Meta")

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -141,23 +141,31 @@ class RotaryEmbedding(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # ops.rotary_embedding() is an in-place operation that
         # updates the query and key tensors.
-        return torch.ops.vllm.rotary_embedding(positions, query, key, self.head_size,
-                             self.cos_sin_cache, self.is_neox_style)
+        return torch.ops.vllm.rotary_embedding(positions, query, key,
+                                               self.head_size,
+                                               self.cos_sin_cache,
+                                               self.is_neox_style)
+
 
 # needed for compile
 vllm_lib.define(
     "rotary_embedding(Tensor positions, Tensor query, Tensor key, int head_size, Tensor cos_sin_cache, bool is_neox) -> (Tensor, Tensor)"
 )
 
+
 @torch.library.impl(vllm_lib, "rotary_embedding", "Meta")
-def _rotary_embedding_meta(positions, query, key, head_size, cos_sin_cache, is_neox):
+def _rotary_embedding_meta(positions, query, key, head_size, cos_sin_cache,
+                           is_neox):
     return query, key
 
 
 @torch.library.impl(vllm_lib, "rotary_embedding", "CUDA")
-def _rotary_embedding(positions, query, key, head_size, cos_sin_cache, is_neox):
-    ops.rotary_embedding(positions, query, key, head_size, cos_sin_cache, is_neox)
+def _rotary_embedding(positions, query, key, head_size, cos_sin_cache,
+                      is_neox):
+    ops.rotary_embedding(positions, query, key, head_size, cos_sin_cache,
+                         is_neox)
     return query, key
+
 
 register_vllm_lowering(torch.ops.vllm.rotary_embedding, [1, 2])
 

--- a/vllm/model_executor/parallel_utils/parallel_state.py
+++ b/vllm/model_executor/parallel_utils/parallel_state.py
@@ -133,8 +133,7 @@ def get_pipeline_model_parallel_group():
 
 def get_tensor_model_parallel_world_size():
     """Return world size for the tensor model parallel group."""
-    return torch.distributed.get_world_size(
-        group=get_tensor_model_parallel_group())
+    return get_tensor_model_parallel_group().size()
 
 
 def get_pipeline_model_parallel_world_size():
@@ -145,7 +144,7 @@ def get_pipeline_model_parallel_world_size():
 
 def get_tensor_model_parallel_rank():
     """Return my rank for the tensor model parallel group."""
-    return torch.distributed.get_rank(group=get_tensor_model_parallel_group())
+    return get_tensor_model_parallel_group().rank()
 
 
 def get_pipeline_model_parallel_rank():

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -712,8 +712,8 @@ class ModelRunner:
 
             # Run the model with the dummy inputs.
             self.compiled_model(
-                input_tokens,
-                input_positions,
+                input_tokens[:batch_size],
+                input_positions[:batch_size],
                 kv_caches,
                 input_metadata,
             )

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -666,7 +666,7 @@ class ModelRunner:
         if not self.lora_manager:
             raise RuntimeError("LoRA is not enabled.")
         return self.lora_manager.list_loras()
-    
+
     @torch.inference_mode()
     def compile_model(self, kv_caches: List[KVCache]) -> None:
         assert not self.model_config.enforce_eager
@@ -676,9 +676,8 @@ class ModelRunner:
                     "'enforce_eager=True' or use '--enforce-eager' in CLI.")
 
         start_time = time.perf_counter()
-        self.compiled_model = torch.compile(self.model,
-                                            fullgraph=True)
-        
+        self.compiled_model = torch.compile(self.model, fullgraph=True)
+
         # Prepare dummy inputs. These will be reused for all batch sizes.
         max_batch_size = max(_BATCH_SIZES_TO_CAPTURE)
         input_tokens = torch.zeros(max_batch_size, 1, dtype=torch.long).cuda()
@@ -787,7 +786,9 @@ class ModelRunner:
                     )
                     self.set_active_loras(set(), lora_mapping)
 
-                graph_runner = CUDAGraphRunner(self.model if self.compiled_model is None else self.compiled_model)
+                graph_runner = CUDAGraphRunner(
+                    self.model if self.compiled_model is None else self.
+                    compiled_model)
                 graph_runner.capture(
                     input_tokens[:batch_size],
                     input_positions[:batch_size],

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -155,6 +155,7 @@ class Worker:
 
     def warm_up_model(self) -> None:
         if not self.model_config.enforce_eager:
+            self.model_runner.compile_model(self.gpu_cache)
             self.model_runner.capture_model(self.gpu_cache)
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.


### PR DESCRIPTION
This PR adds support for compiling models in vLLM with torch.compile().

Consider this as a first draft/MVP. I've only tested it with Llama 7B-F in `examples/offline_inference.py`, and the results match when running with `enforce_eager=True/False`.

For this particular case, model compilation/warmup takes 151s + 12s from cudagraphs.

Next step is running some benchmarks to see if there's any improvements in timings.

