### PR TITLE
Fix: Output text is always truncated in some models

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -936,9 +936,10 @@ class LLMEngine:
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
             stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
                 seq.get_last_token_id())
-            self._finalize_sequence(seq, sampling_params, stop_str)
-            seq.status = SequenceStatus.FINISHED_STOPPED
-            return
+            if seq.output_text.endswith(stop_str):
+                self._finalize_sequence(seq, sampling_params, stop_str)
+                seq.status = SequenceStatus.FINISHED_STOPPED
+                return
 
         # Check if the sequence has reached max_model_len.
         if seq.get_len() > self.scheduler_config.max_model_len:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -959,11 +959,13 @@ class LLMEngine:
     def _finalize_sequence(self, seq: Sequence,
                            sampling_params: SamplingParams,
                            stop_string: str) -> None:
-        if not sampling_params.include_stop_str_in_output and stop_string:
+        if sampling_params.include_stop_str_in_output:
+            return
+
+        if stop_string and seq.output_text.endswith(stop_string):
             # Truncate the output text so that the stop string is
             # not included in the output.
-            if seq.output_text.endswith(stop_string):
-                seq.output_text = seq.output_text[:-len(stop_string)]
+            seq.output_text = seq.output_text[:-len(stop_string)]
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         assert lora_request.lora_int_id > 0, "lora_id must be greater than 0."

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -936,10 +936,9 @@ class LLMEngine:
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
             stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
                 seq.get_last_token_id())
-            if seq.output_text.endswith(stop_str):
-                self._finalize_sequence(seq, sampling_params, stop_str)
-                seq.status = SequenceStatus.FINISHED_STOPPED
-                return
+            self._finalize_sequence(seq, sampling_params, stop_str)
+            seq.status = SequenceStatus.FINISHED_STOPPED
+            return
 
         # Check if the sequence has reached max_model_len.
         if seq.get_len() > self.scheduler_config.max_model_len:
@@ -963,7 +962,8 @@ class LLMEngine:
         if not sampling_params.include_stop_str_in_output and stop_string:
             # Truncate the output text so that the stop string is
             # not included in the output.
-            seq.output_text = seq.output_text[:-len(stop_string)]
+            if seq.output_text.endswith(stop_string):
+                seq.output_text = seq.output_text[:-len(stop_string)]
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         assert lora_request.lora_int_id > 0, "lora_id must be greater than 0."


### PR DESCRIPTION
When I use Yi-34B-Chat for inference based on vllm==0.3.2, the text in CompletionOutput is always truncated (see the example below). This PR ensures that when `stop_token_ids` is configured in the `sampling_params`, it first checks for the existence of the `stop_str` before truncating the sequence.


Truncated CompletionOutput example:

```
CompletionOutput(index=17, text='\n你好！我是一个人工智能助手，由零一万物训练，专门设计用来回答问题和提供信息。你可以问我任何问题，我会尽力帮助你。有什', token_ids=[144, 25902, 103, 59646, 4748, 13992, 44307, 101, 59903, 60738, 59625, 24018, 6994, 101, 11515, 2958, 13231, 8992, 53032, 2479, 2530, 102, 14760, 22126, 3944, 1650, 101, 14107, 32151, 4002, 59725, 102, 9300, 29287, 21645, 19610, 104, 7], cumulative_logprob=-11.930044378333832, logprobs=None, finish_reason=stop)
```