### PR TITLE
Fix: `AttributeError` in OpenAI-compatible server

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -55,7 +55,7 @@ class UsageInfo(BaseModel):
 
 class ChatCompletionRequest(BaseModel):
     model: str
-    messages: Union[str, List[Dict[str, str]]]
+    messages: List[Dict[str, str]]
     temperature: Optional[float] = 0.7
     top_p: Optional[float] = 1.0
     n: Optional[int] = 1

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -86,7 +86,7 @@ class OpenAIServingChat(OpenAIServing):
         if request.add_generation_prompt:
             return self.response_role
         else:
-            return request.messages[-1].role
+            return request.messages[-1]["role"]
 
     async def chat_completion_stream_generator(
             self, request: ChatCompletionRequest,


### PR DESCRIPTION
Fixed a small typo that triggers an `AttributeError` in the OpenAI-compatible server when `add_generation_prompt` is `False`.

Side note, it's unclear to me why `ChatCompletionRequest.messages` is typed as `Union[str, List[Dict[str, str]]]` instead of just `List[Dict[str, str]]`. The OpenAI chat API spec also says it's an array. If `messages` can sometimes actually be `str`, the modified line will raise an error and will require this case to be handled.

I'm not familiar enough with how stuff works in vLLM to confidently modify one of the core schemas, but I can push a quick fix to this PR if you think it's appropriate.

<img width="523" alt="Screenshot 2024-02-23 at 9 50 07 PM" src="https://github.com/vllm-project/vllm/assets/29395896/99902109-3e3e-472c-864f-0d52d0c2061c">
