### PR TITLE
Fix logits processor when prompt_logprobs is not None

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -144,7 +144,8 @@ def _apply_logits_processors(
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
     # when prompt_logprobs is not None, we need to skip the prompt tokens.
-    logits_with_prompt = len(sampling_metadata.prompt_lens) > 0 and sum(sampling_metadata.prompt_lens) == logits.shape[0]
+    logits_with_prompt = len(sampling_metadata.prompt_lens) > 0 and sum(
+        sampling_metadata.prompt_lens) == logits.shape[0]
     logits_row_idx = -1
     found_logits_processors = False
     for seq_ids, sampling_params in sampling_metadata.seq_groups:

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -143,23 +143,29 @@ def _apply_logits_processors(
     logits: torch.Tensor,
     sampling_metadata: SamplingMetadata,
 ) -> torch.Tensor:
-    logits_row_idx = 0
+    # when prompt_logprobs is not None, we need to skip the prompt tokens.
+    logits_with_prompt = len(sampling_metadata.prompt_lens) > 0 and sum(sampling_metadata.prompt_lens) == logits.shape[0]
+    logits_row_idx = -1
     found_logits_processors = False
     for seq_ids, sampling_params in sampling_metadata.seq_groups:
         logits_processors = sampling_params.logits_processors
         if logits_processors:
             found_logits_processors = True
             for seq_id in seq_ids:
+                # skip prompt tokens for the first iteration.
+                if logits_with_prompt:
+                    logits_row_idx += sampling_metadata.prompt_lens[seq_id]
+                else:
+                    logits_row_idx += 1
                 logits_row = logits[logits_row_idx]
                 token_ids = sampling_metadata.seq_data[seq_id].output_token_ids
                 for logits_processor in logits_processors:
                     logits_row = logits_processor(token_ids, logits_row)
                 logits[logits_row_idx] = logits_row
-                logits_row_idx += 1
         else:
             logits_row_idx += len(seq_ids)
     if found_logits_processors:
-        assert logits_row_idx == logits.shape[0]
+        assert logits_row_idx == logits.shape[0] - 1
     return logits
 
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -261,6 +261,4 @@ class SamplingParams:
             f"prompt_logprobs={self.prompt_logprobs}, "
             f"skip_special_tokens={self.skip_special_tokens}, "
             "spaces_between_special_tokens="
-            f"{self.spaces_between_special_tokens}, "
-            "logits_processors="
-            f"{self.logits_processors})")
+            f"{self.spaces_between_special_tokens})")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -261,4 +261,6 @@ class SamplingParams:
             f"prompt_logprobs={self.prompt_logprobs}, "
             f"skip_special_tokens={self.skip_special_tokens}, "
             "spaces_between_special_tokens="
-            f"{self.spaces_between_special_tokens})")
+            f"{self.spaces_between_special_tokens}, "
+            "logits_processors="
+            f"{self.logits_processors})")


### PR DESCRIPTION
Hello,

I am currently developing an LLM toolkit based on vLLM. However, I encountered a bug related to logits processor #2141 developed by @noamgat within vllm detailed at #2800 . The primary issue with this bug is that when `prompt_logprobs` in `SamplingParams` is set to a value other than None, the logits for the first iteration include the prompt. This evidently occurs while calculating the logprobs for the tokens corresponding to the prompt. However, this leads to an AssertionError at [this](https://github.com/vllm-project/vllm/blob/f7c1234990793008f3d44790fd274040f26c4ee4/vllm/model_executor/layers/sampler.py#L162) assert statement.

I have fixed this bug when `prompt_logprobs` is not None and conducted tests with different values for `prompt_logprobs`. With these changes, the error does not occur in either scenario.

In detail, when `len(sampling_metadata.prompt_lens) > 0`, it means this is the first iteration; whereas `sum(sampling_metadata.prompt_lens) == logits.shape[0]` implies that the logits include the prompt.

Thank you for your review. I look forward to your fix for this issue, which will assist us in completing our project development.

Wishing you a happy day.