### PR TITLE
Introduce speculative decoding with draft models to vLLM

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -18,6 +18,7 @@ def main(args: argparse.Namespace):
     # the engine will automatically process the request in multiple batches.
     llm = LLM(
         model=args.model,
+        draft_model=args.draft_model,
         tokenizer=args.tokenizer,
         quantization=args.quantization,
         tensor_parallel_size=args.tensor_parallel_size,
@@ -27,11 +28,12 @@ def main(args: argparse.Namespace):
         kv_cache_dtype=args.kv_cache_dtype,
         device=args.device,
         use_flash_attn=args.use_flash_attn,
+        parallel_decoding_lookahead=args.parallel_decoding_lookahead,
     )
 
     sampling_params = SamplingParams(
         n=args.n,
-        temperature=0.0 if args.use_beam_search else 1.0,
+        temperature=0.0 if args.use_beam_search else args.temperature,
         top_p=1.0,
         use_beam_search=args.use_beam_search,
         ignore_eos=True,
@@ -90,6 +92,7 @@ if __name__ == '__main__':
         description='Benchmark the latency of processing a single batch of '
         'requests till completion.')
     parser.add_argument('--model', type=str, default='facebook/opt-125m')
+    parser.add_argument("--draft-model", type=str, default=None)
     parser.add_argument('--tokenizer', type=str, default=None)
     parser.add_argument('--quantization',
                         '-q',
@@ -104,6 +107,7 @@ if __name__ == '__main__':
                         default=1,
                         help='Number of generated sequences per prompt.')
     parser.add_argument('--use-beam-search', action='store_true')
+    parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument('--num-iters',
                         type=int,
                         default=3,
@@ -150,5 +154,10 @@ if __name__ == '__main__':
         "--use-flash-attn",
         action="store_true",
         help="Use flash attention (requires flash-attn >= 2.5.0).")
+    parser.add_argument(
+        "--parallel-decoding-lookahead",
+        type=int,
+        default=1,
+        help="Number of lookahead steps for speculativespeculative decoding.")
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -26,6 +26,7 @@ def main(args: argparse.Namespace):
         enforce_eager=args.enforce_eager,
         kv_cache_dtype=args.kv_cache_dtype,
         device=args.device,
+        use_flash_attn=args.use_flash_attn,
     )
 
     sampling_params = SamplingParams(
@@ -145,5 +146,9 @@ if __name__ == '__main__':
         default="cuda",
         choices=["cuda"],
         help='device type for vLLM execution, supporting CUDA only currently.')
+    parser.add_argument(
+        "--use-flash-attn",
+        action="store_true",
+        help="Use flash attention (requires flash-attn >= 2.5.0).")
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -61,12 +61,14 @@ def sample_requests(
 def run_vllm(
     requests: List[Tuple[str, int, int]],
     model: str,
+    draft_model: str,
     tokenizer: str,
     quantization: Optional[str],
     tensor_parallel_size: int,
     seed: int,
     n: int,
     use_beam_search: bool,
+    temperature: float,
     trust_remote_code: bool,
     dtype: str,
     max_model_len: Optional[int],
@@ -74,10 +76,12 @@ def run_vllm(
     kv_cache_dtype: str,
     device: str,
     use_flash_attn: Optional[bool] = False,
+    parallel_decoding_lookahead: Optional[int] = 1,
 ) -> float:
     from vllm import LLM, SamplingParams
     llm = LLM(
         model=model,
+        draft_model=draft_model,
         tokenizer=tokenizer,
         quantization=quantization,
         tensor_parallel_size=tensor_parallel_size,
@@ -89,13 +93,14 @@ def run_vllm(
         kv_cache_dtype=kv_cache_dtype,
         device=device,
         use_flash_attn=use_flash_attn,
+        parallel_decoding_lookahead=parallel_decoding_lookahead,
     )
 
     # Add the requests to the engine.
     for prompt, _, output_len in requests:
         sampling_params = SamplingParams(
             n=n,
-            temperature=0.0 if use_beam_search else 1.0,
+            temperature=0.0 if use_beam_search else temperature,
             top_p=1.0,
             use_beam_search=use_beam_search,
             ignore_eos=True,
@@ -208,13 +213,13 @@ def main(args: argparse.Namespace):
                                    args.output_len)
 
     if args.backend == "vllm":
-        elapsed_time = run_vllm(requests, args.model, args.tokenizer,
-                                args.quantization, args.tensor_parallel_size,
-                                args.seed, args.n, args.use_beam_search,
-                                args.trust_remote_code, args.dtype,
-                                args.max_model_len, args.enforce_eager,
-                                args.kv_cache_dtype, args.device,
-                                args.use_flash_attn)
+        elapsed_time = run_vllm(
+            requests, args.model, args.draft_model, args.tokenizer,
+            args.quantization, args.tensor_parallel_size, args.seed, args.n,
+            args.use_beam_search, args.temperature, args.trust_remote_code,
+            args.dtype, args.max_model_len, args.enforce_eager,
+            args.kv_cache_dtype, args.device, args.use_flash_attn,
+            args.parallel_decoding_lookahead)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -251,6 +256,7 @@ if __name__ == "__main__":
                         help="Output length for each request. Overrides the "
                         "output length from the dataset.")
     parser.add_argument("--model", type=str, default="facebook/opt-125m")
+    parser.add_argument("--draft-model", type=str, default=None)
     parser.add_argument("--tokenizer", type=str, default=None)
     parser.add_argument('--quantization',
                         '-q',
@@ -262,6 +268,7 @@ if __name__ == "__main__":
                         default=1,
                         help="Number of generated sequences per prompt.")
     parser.add_argument("--use-beam-search", action="store_true")
+    parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--num-prompts",
                         type=int,
                         default=1000,
@@ -309,6 +316,11 @@ if __name__ == "__main__":
         "--use-flash-attn",
         action="store_true",
         help="Use flash attention (requires flash-attn >= 2.5.0).")
+    parser.add_argument(
+        "--parallel-decoding-lookahead",
+        type=int,
+        default=1,
+        help="Number of lookahead steps for speculative decoding.")
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -73,6 +73,7 @@ def run_vllm(
     enforce_eager: bool,
     kv_cache_dtype: str,
     device: str,
+    use_flash_attn: Optional[bool] = False,
 ) -> float:
     from vllm import LLM, SamplingParams
     llm = LLM(
@@ -87,6 +88,7 @@ def run_vllm(
         enforce_eager=enforce_eager,
         kv_cache_dtype=kv_cache_dtype,
         device=device,
+        use_flash_attn=use_flash_attn,
     )
 
     # Add the requests to the engine.
@@ -211,7 +213,8 @@ def main(args: argparse.Namespace):
                                 args.seed, args.n, args.use_beam_search,
                                 args.trust_remote_code, args.dtype,
                                 args.max_model_len, args.enforce_eager,
-                                args.kv_cache_dtype, args.device)
+                                args.kv_cache_dtype, args.device,
+                                args.use_flash_attn)
     elif args.backend == "hf":
         assert args.tensor_parallel_size == 1
         elapsed_time = run_hf(requests, args.model, tokenizer, args.n,
@@ -302,6 +305,10 @@ if __name__ == "__main__":
         default="cuda",
         choices=["cuda"],
         help='device type for vLLM execution, supporting CUDA only currently.')
+    parser.add_argument(
+        "--use-flash-attn",
+        action="store_true",
+        help="Use flash attention (requires flash-attn >= 2.5.0).")
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ aioprometheus[starlette]
 pynvml == 11.5.0
 triton >= 2.1.0
 cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
+flash-attn >= 2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ aioprometheus[starlette]
 pynvml == 11.5.0
 triton >= 2.1.0
 cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
+packaging
 flash-attn >= 2.5.0

--- a/tests/worker/spec_decode/utils.py
+++ b/tests/worker/spec_decode/utils.py
@@ -84,7 +84,7 @@ def create_worker(cls: type,
     )
 
     (model_config, cache_config, parallel_config, scheduler_config,
-     device_config, _) = engine_args.create_engine_configs()
+     device_config, _, _) = engine_args.create_engine_configs()
 
     distributed_init_method = get_distributed_init_method(
         get_ip(), get_open_port())

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -447,6 +447,7 @@ class SchedulerConfig:
         max_model_len: Maximum length of a sequence (including prompt
             and generated text).
         max_paddings: Maximum number of paddings to be added to a batch.
+        parallel_decoding_lookahead: Number of tokens to look ahead for parallel decoding.
     """
 
     def __init__(
@@ -455,6 +456,7 @@ class SchedulerConfig:
         max_num_seqs: int,
         max_model_len: int,
         max_paddings: int,
+        parallel_decoding_lookahead: Optional[int] = 1,
     ) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
@@ -465,6 +467,7 @@ class SchedulerConfig:
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len
         self.max_paddings = max_paddings
+        self.parallel_decoding_lookahead = parallel_decoding_lookahead
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -170,6 +170,17 @@ class BlockSpaceManager:
         num_seqs = seq_group.num_seqs(status=SequenceStatus.RUNNING)
         return num_seqs <= num_free_gpu_blocks
 
+    def can_append_slots(self,
+                         seq_group: SequenceGroup,
+                         reserve: Optional[int] = 1) -> bool:
+        # Simple heuristic: as the maximum possible parallel decoding lookahead
+        # is 8 (less than block size), if there is at least one free block for
+        # each sequence, we can append.
+        assert reserve <= self.block_size, f"Expect reserve <= block_size, got {reserve} > {self.block_size}"
+        num_free_gpu_blocks = self.gpu_allocator.get_num_free_blocks()
+        num_seqs = seq_group.num_seqs(status=SequenceStatus.RUNNING)
+        return num_seqs <= num_free_gpu_blocks
+
     def append_slot(self, seq: Sequence) -> Optional[Tuple[int, int]]:
         """Allocate a physical slot for a new token."""
         logical_blocks = seq.logical_token_blocks

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -45,6 +45,7 @@ class EngineArgs:
     lora_dtype = 'auto'
     max_cpu_loras: Optional[int] = None
     device: str = 'cuda'
+    use_flash_attn: Optional[bool] = False
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -271,6 +272,10 @@ class EngineArgs:
             choices=["cuda"],
             help=('Device type for vLLM execution. '
                   'Currently, only CUDA-compatible devices are supported.'))
+        parser.add_argument(
+            '--use-flash-attn',
+            action='store_true',
+            help='Use flash attention (requires flash-attn >= 2.5.0).')
         return parser
 
     @classmethod
@@ -285,17 +290,25 @@ class EngineArgs:
         self,
     ) -> Tuple[ModelConfig, CacheConfig, ParallelConfig, SchedulerConfig,
                DeviceConfig, Optional[LoRAConfig]]:
+
+        if self.use_flash_attn:
+            # flash-attn's flash_attn_with_kvcache requires block size must be
+            # a multiple of 256.
+            self.block_size = ((self.block_size + 256 - 1) // 256) * 256
+
         device_config = DeviceConfig(self.device)
         model_config = ModelConfig(
             self.model, self.tokenizer, self.tokenizer_mode,
             self.trust_remote_code, self.download_dir, self.load_format,
             self.dtype, self.seed, self.revision, self.code_revision,
             self.tokenizer_revision, self.max_model_len, self.quantization,
-            self.enforce_eager, self.max_context_len_to_capture)
+            self.enforce_eager, self.max_context_len_to_capture,
+            self.use_flash_attn)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,
                                    model_config.get_sliding_window())
+
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
                                          self.worker_use_ray,

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -73,6 +73,11 @@ class Stats:
     num_running: int
     num_waiting: int
     num_swapped: int
+
+    num_draft_tokens: int
+    num_emitted_tokens: int
+    reject_sampler_accept_rate: float
+
     gpu_cache_usage: float
     cpu_cache_usage: float
 
@@ -157,6 +162,15 @@ class StatLogger:
                 prompt_throughput=prompt_throughput,
                 generation_throughput=generation_throughput)
 
+            if stats.num_draft_tokens:
+                specualtive_decoding_message = (
+                    f'Drafted: {stats.num_draft_tokens}, '
+                    f'Emitted: {stats.num_emitted_tokens}, '
+                    f'Accepted rate: {stats.reject_sampler_accept_rate:.2f}%, '
+                )
+            else:
+                specualtive_decoding_message = ''
+
             # Log to stdout.
             logger.info(
                 f"Avg prompt throughput: {prompt_throughput:.1f} tokens/s, "
@@ -164,6 +178,7 @@ class StatLogger:
                 f"Running: {stats.num_running} reqs, "
                 f"Swapped: {stats.num_swapped} reqs, "
                 f"Pending: {stats.num_waiting} reqs, "
+                f"{specualtive_decoding_message}"
                 f"GPU KV cache usage: {stats.gpu_cache_usage * 100:.1f}%, "
                 f"CPU KV cache usage: {stats.cpu_cache_usage * 100:.1f}%")
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -26,6 +26,9 @@ class LLM:
 
     Args:
         model: The name or path of a HuggingFace Transformers model.
+        draft_model: The name or path of a HuggingFace Transformers model for
+            draft generation. If None, we use the same model for draft and
+            refine generations.
         tokenizer: The name or path of a HuggingFace Transformers tokenizer.
         tokenizer_mode: The tokenizer mode. "auto" will use the fast tokenizer
             if available, and "slow" will always use the slow tokenizer.
@@ -70,6 +73,7 @@ class LLM:
     def __init__(
         self,
         model: str,
+        draft_model: Optional[str] = None,
         tokenizer: Optional[str] = None,
         tokenizer_mode: str = "auto",
         trust_remote_code: bool = False,
@@ -90,6 +94,7 @@ class LLM:
             kwargs["disable_log_stats"] = True
         engine_args = EngineArgs(
             model=model,
+            draft_model=draft_model,
             tokenizer=tokenizer,
             tokenizer_mode=tokenizer_mode,
             trust_remote_code=trust_remote_code,

--- a/vllm/model_executor/input_metadata.py
+++ b/vllm/model_executor/input_metadata.py
@@ -27,6 +27,7 @@ class InputMetadata:
         block_tables: Optional[torch.Tensor],
         use_cuda_graph: bool,
         kv_cache_dtype: str,
+        use_flash_attn: bool = False,
     ) -> None:
         self.is_prompt = is_prompt
         self.prompt_lens = prompt_lens
@@ -38,6 +39,7 @@ class InputMetadata:
         self.block_tables = block_tables
         self.use_cuda_graph = use_cuda_graph
         self.kv_cache_dtype = kv_cache_dtype
+        self.use_flash_attn = use_flash_attn
 
         # Set during the execution of the first attention op.
         # FIXME(woosuk): This is a hack.
@@ -48,7 +50,10 @@ class InputMetadata:
                 f"is_prompt={self.is_prompt}, "
                 f"max_context_len={self.max_context_len}, "
                 f"slot_mapping={self.slot_mapping}, "
+                f"prompt_lens={self.prompt_lens}, "
+                f"start_loc={self.start_loc}, "
                 f"context_lens={self.context_lens}, "
                 f"block_tables={self.block_tables}, "
                 f"use_cuda_graph={self.use_cuda_graph}, "
-                f"kv_cache_dtype={self.kv_cache_dtype})")
+                f"kv_cache_dtype={self.kv_cache_dtype}, "
+                f"use_flash_attn={self.use_flash_attn})")

--- a/vllm/model_executor/layers/rejection_sampler.py
+++ b/vllm/model_executor/layers/rejection_sampler.py
@@ -30,6 +30,14 @@ class RejectionSampler(nn.Module):
         # value in a variable for readability.
         self._num_bonus_tokens = 1
 
+        # NOTE: the `num_accepted_tokens` is not the tokens actually "accepted"
+        # from the outputs of the draft model, but is used to measure the quality
+        # of the draft model.
+        #
+        # For the top-level metric on how many tokens are emitted by speculative
+        # decoding, one should use `num_emitted_tokens`.
+        #
+        # See also: https://github.com/vllm-project/vllm/pull/2658
         self.num_accepted_tokens: Optional[torch.Tensor] = None
         self.num_emitted_tokens: Optional[torch.Tensor] = None
         self.num_draft_tokens: int = 0

--- a/vllm/model_executor/layers/triton_kernel/prefix_prefill.py
+++ b/vllm/model_executor/layers/triton_kernel/prefix_prefill.py
@@ -45,6 +45,7 @@ if triton.__version__ >= "2.1.0":
         stride_v_cache_h,
         stride_v_cache_d,
         stride_v_cache_bl,
+        num_queries_per_kv: int,
         BLOCK_M: tl.constexpr,
         BLOCK_DMODEL: tl.constexpr,
         BLOCK_N: tl.constexpr,
@@ -52,6 +53,8 @@ if triton.__version__ >= "2.1.0":
         cur_batch = tl.program_id(0)
         cur_head = tl.program_id(1)
         start_m = tl.program_id(2)
+
+        cur_kv_head = cur_head // num_queries_per_kv
 
         cur_batch_ctx_len = tl.load(B_Ctxlen + cur_batch)
         cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
@@ -85,13 +88,14 @@ if triton.__version__ >= "2.1.0":
                          mask=(start_n + offs_n) < cur_batch_ctx_len,
                          other=0)
             off_k = (bn[None, :] * stride_k_cache_bs +
-                     cur_head * stride_k_cache_h +
+                     cur_kv_head * stride_k_cache_h +
                      (offs_d[:, None] // x) * stride_k_cache_d +
                      ((start_n + offs_n[None, :]) % block_size) *
                      stride_k_cache_bl +
                      (offs_d[:, None] % x) * stride_k_cache_x)
             off_v = (
-                bn[:, None] * stride_v_cache_bs + cur_head * stride_v_cache_h +
+                bn[:, None] * stride_v_cache_bs +
+                cur_kv_head * stride_v_cache_h +
                 offs_d[None, :] * stride_v_cache_d +
                 (start_n + offs_n[:, None]) % block_size * stride_v_cache_bl)
             k = tl.load(K_cache + off_k,
@@ -131,9 +135,9 @@ if triton.__version__ >= "2.1.0":
             l_i = l_i_new
             m_i = m_i_new
 
-        off_k = (offs_n[None, :] * stride_kbs + cur_head * stride_kh +
+        off_k = (offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh +
                  offs_d[:, None] * stride_kd)
-        off_v = (offs_n[:, None] * stride_vbs + cur_head * stride_vh +
+        off_v = (offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh +
                  offs_d[None, :] * stride_vd)
         k_ptrs = K + off_k
         v_ptrs = V + off_v
@@ -232,6 +236,7 @@ if triton.__version__ >= "2.1.0":
         stride_v_cache_h,
         stride_v_cache_d,
         stride_v_cache_bl,
+        num_queries_per_kv: int,
         BLOCK_M: tl.constexpr,
         BLOCK_DMODEL: tl.constexpr,
         BLOCK_N: tl.constexpr,
@@ -239,6 +244,8 @@ if triton.__version__ >= "2.1.0":
         cur_batch = tl.program_id(0)
         cur_head = tl.program_id(1)
         start_m = tl.program_id(2)
+
+        cur_kv_head = cur_head // num_queries_per_kv
 
         cur_batch_ctx_len = tl.load(B_Ctxlen + cur_batch)
         cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
@@ -272,13 +279,14 @@ if triton.__version__ >= "2.1.0":
                          mask=(start_n + offs_n) < cur_batch_ctx_len,
                          other=0)
             off_k = (bn[None, :] * stride_k_cache_bs +
-                     cur_head * stride_k_cache_h +
+                     cur_kv_head * stride_k_cache_h +
                      (offs_d[:, None] // x) * stride_k_cache_d +
                      ((start_n + offs_n[None, :]) % block_size) *
                      stride_k_cache_bl +
                      (offs_d[:, None] % x) * stride_k_cache_x)
             off_v = (
-                bn[:, None] * stride_v_cache_bs + cur_head * stride_v_cache_h +
+                bn[:, None] * stride_v_cache_bs +
+                cur_kv_head * stride_v_cache_h +
                 offs_d[None, :] * stride_v_cache_d +
                 (start_n + offs_n[:, None]) % block_size * stride_v_cache_bl)
             k = tl.load(K_cache + off_k,
@@ -317,9 +325,9 @@ if triton.__version__ >= "2.1.0":
             l_i = l_i_new
             m_i = m_i_new
 
-        off_k = (offs_n[None, :] * stride_kbs + cur_head * stride_kh +
+        off_k = (offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh +
                  offs_d[:, None] * stride_kd)
-        off_v = (offs_n[:, None] * stride_vbs + cur_head * stride_vh +
+        off_v = (offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh +
                  offs_d[None, :] * stride_vd)
         k_ptrs = K + off_k
         v_ptrs = V + off_v
@@ -420,6 +428,7 @@ if triton.__version__ >= "2.1.0":
         stride_v_cache_h,
         stride_v_cache_d,
         stride_v_cache_bl,
+        num_queries_per_kv: int,
         BLOCK_M: tl.constexpr,
         BLOCK_DMODEL: tl.constexpr,
         BLOCK_N: tl.constexpr,
@@ -428,6 +437,8 @@ if triton.__version__ >= "2.1.0":
         cur_batch = tl.program_id(0)
         cur_head = tl.program_id(1)
         start_m = tl.program_id(2)
+
+        cur_kv_head = cur_head // num_queries_per_kv
 
         # cur_batch_seq_len: the length of prompts
         # cur_batch_ctx_len: the length of prefix
@@ -468,13 +479,14 @@ if triton.__version__ >= "2.1.0":
                          mask=(start_n + offs_n) < cur_batch_ctx_len,
                          other=0)
             off_k = (bn[None, :] * stride_k_cache_bs +
-                     cur_head * stride_k_cache_h +
+                     cur_kv_head * stride_k_cache_h +
                      (offs_d[:, None] // x) * stride_k_cache_d +
                      ((start_n + offs_n[None, :]) % block_size) *
                      stride_k_cache_bl +
                      (offs_d[:, None] % x) * stride_k_cache_x)
             off_v = (
-                bn[:, None] * stride_v_cache_bs + cur_head * stride_v_cache_h +
+                bn[:, None] * stride_v_cache_bs +
+                cur_kv_head * stride_v_cache_h +
                 offs_d[None, :] * stride_v_cache_d +
                 (start_n + offs_n[:, None]) % block_size * stride_v_cache_bl)
             k = tl.load(K_cache + off_k,
@@ -522,9 +534,9 @@ if triton.__version__ >= "2.1.0":
             l_i = l_i_new
             m_i = m_i_new
 
-        off_k = (offs_n[None, :] * stride_kbs + cur_head * stride_kh +
+        off_k = (offs_n[None, :] * stride_kbs + cur_kv_head * stride_kh +
                  offs_d[:, None] * stride_kd)
-        off_v = (offs_n[:, None] * stride_vbs + cur_head * stride_vh +
+        off_v = (offs_n[:, None] * stride_vbs + cur_kv_head * stride_vh +
                  offs_d[None, :] * stride_vd)
         k_ptrs = K + off_k
         v_ptrs = V + off_v
@@ -628,6 +640,7 @@ if triton.__version__ >= "2.1.0":
 
         sm_scale = 1.0 / (Lq**0.5)
         batch, head = b_seq_len.shape[0], q.shape[1]
+        num_queries_per_kv = q.shape[1] // k.shape[1]
 
         grid = (batch, head, triton.cdiv(max_input_len, BLOCK))  # batch, head,
 
@@ -674,6 +687,7 @@ if triton.__version__ >= "2.1.0":
                 v_cache.stride(2),
                 v_cache.stride(
                     3),  #[num_blocks, num_kv_heads, head_size, block_size]
+                num_queries_per_kv=num_queries_per_kv,
                 BLOCK_M=BLOCK,
                 BLOCK_DMODEL=Lk,
                 BLOCK_N=BLOCK,
@@ -721,6 +735,7 @@ if triton.__version__ >= "2.1.0":
             v_cache.stride(2),
             v_cache.stride(
                 3),  #[num_blocks, num_kv_heads, head_size, block_size]
+            num_queries_per_kv=num_queries_per_kv,
             BLOCK_M=BLOCK,
             BLOCK_DMODEL=Lk,
             BLOCK_N=BLOCK,

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -190,8 +190,9 @@ def detokenize_incrementally(
     read_offset: int = 0,
     skip_special_tokens: bool = False,
     spaces_between_special_tokens: bool = True,
+    parallel_decoding_accepted: int = 1,
 ) -> Tuple[List[str], str, int, int]:
-    new_token_id = all_input_ids[-1]
+    new_token_ids = all_input_ids[-parallel_decoding_accepted:]
     # This is the first iteration for this sequence
     if prev_tokens is None:
         new_tokens = tokenizer.convert_ids_to_tokens(
@@ -202,14 +203,15 @@ def detokenize_incrementally(
         # Subtract 1 extra to account for the generated token.
         prefix_offset = max(len(output_tokens) - 6, 0)
         # If the first new token is a special token, we can't skip 1 extra token
-        if skip_special_tokens and new_token_id in tokenizer.all_special_ids:
+        if skip_special_tokens and new_token_ids[
+                -1] in tokenizer.all_special_ids:
             read_offset = max(len(output_tokens), 0)
         else:
             read_offset = max(len(output_tokens) - 1, 0)
     else:
-        # Put new_token_id in a list so skip_special_tokens is respected
+        # Put new_token_ids in a list so skip_special_tokens is respected
         new_tokens = tokenizer.convert_ids_to_tokens(
-            [new_token_id], skip_special_tokens=skip_special_tokens)
+            new_token_ids, skip_special_tokens=skip_special_tokens)
         output_tokens = prev_tokens + new_tokens
 
     # The prefix text is necessary only to defeat cleanup algorithms in


### PR DESCRIPTION
This PR is (yet another) implementation of speculative decoding on vLLM, compared with existing efforts (including #2607, #1797, and #1679), this PR:

- completed, confirmed workable (and correct)
- might be the most up-to-date implementation (based on current main)
- simplest
  - without adding new kernels (`context_attention_fwd` from the prefix cache PR is enough, add is compatible with further effort of introducing flash-attn and flashinfer)
  - reusing existing components: the rejected sampler (from #2336) and multi-step worker (from #2424), without reinvent a new wheel (thanks you! @cadedaniel)
- support (paged) kv-cache for draft model as well
- compatible with existing features, including paged kv-cache and the prefix cache feature

(Note that this PR is built-upon the PR #3007 (GQA fixes for `context_attention_fwd`) and #3010 (introducing flash-attn to vLLM), but not depends on these two PRs. If these two PRs can be accepted, I would rebase this PR then, otherwise submitting the speculative sampling feature in a separate PR also works for me.)

The major change only happens in `llm_engine.py`'s `step()` method, `model_runner.py`'s `_prepare_decode()/_prepare_sample()` method, should be fairly easy for code review.

**The major design & implementation can be highlighted as follows**:

- KV cache:
  - for target model and draft model: the usable memory for KV cache is splitted by respecting the per-token kv-cache size's proportion of the target and draft model.
    - i.e., the `num_gpu_blocks` is computed from `gpu_memory / (draft_block_size + target_block_size)`
  - The draft model and target block shares the same block table and slot mapping, simplifying implementation in scheduler
- The scheduler is responsible for choosing sequences to run (as usually), and the `LLMEngine`'s `step()` method will run draft model for k times and then a target model step follows.
- Attention:
  - Specualtive decoding requires verifying k tokens at the same time, this is implemented using the `context_attention_fwd` kernel (originally added for prefix caching)
  - Compatible with flash-attn's `flash_attn_with_kvcache` kernel.
- Sampling:
  - This PR follows the same logic with the `transformer` package for how to decide if a token should be accepted, more specifically,
    - using reject sampler when do random sampling
    - comparing if tokens are the same when do greedy sampling (i.e., `temperature=0.0`)
    - see also: https://github.com/huggingface/transformers/blob/45244940725ec1b3e4c390b74dbafe65b298acca/src/transformers/generation/utils.py#L4566-L4597

TODO:

- The interaction of speculative decoding and beam search is a bit complicate (see also the original ICML paper's appendix 4). This PR raising `NotImplementedError` for such case and leave it as a TODO.
- ~~Support initialize draft workers on Ray.~~

Numbers of a prompt randomly choosed from dataset, using Llama-2-70B-GPTQ as the target model and Llama-2-7B-GPTQ/TinyLLama-1.1B-Chat-v1.0-GPTQ as the draft model:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/linzhu.ht/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/linzhu.ht/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">


Model | DraftModel | Quantization | Prompt | Generation | BatchSize | Lookahead | Drafted | Accepted | AcceptRate | TG Speed (tokens/second) | TG Latency (seconds)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
70B | 1.1B | GPTQ | 10 | 200 | 1 | 1 | 0 | 0 | 0 | 33.8 | 0.0295858
70B | 7B | GPTQ | 10 | 200 | 1 | 1 | 0 | 0 | 0 | 33.9 | 0.02949853
70B | 1.1B | GPTQ | 10 | 200 | 1 | 2 | 109 | 85 | 77 | 43.3 | 0.02309469
70B | 7B | GPTQ | 10 | 200 | 1 | 2 | 107 | 93 | 86 | 42.8 | 0.02336449
70B | 1.1B | GPTQ | 10 | 200 | 1 | 3 | 162 | 113 | 69 | 53.1 | 0.01883239
70B | 7B | GPTQ | 10 | 200 | 1 | 3 | 149 | 121 | 81 | 51.4 | 0.01945525
70B | 1.1B | GPTQ | 10 | 200 | 1 | 4 | 197 | 116 | 58 | 53.6 | 0.01865672
70B | 7B | GPTQ | 10 | 200 | 1 | 4 | 203 | 150 | 73 | 47.8 | 0.0209205
70B | 1.1B | GPTQ | 10 | 200 | 1 | 5 | 234 | 136 | 58 | 52.3 | 0.01912046
70B | 7B | GPTQ | 10 | 200 | 1 | 5 | 205 | 166 | 80 | 52.6 | 0.01901141
70B | 1.1B | GPTQ | 10 | 200 | 1 | 6 | 262 | 153 | 58 | 47 | 0.0212766
70B | 7B | GPTQ | 10 | 200 | 1 | 6 | 260 | 180 | 69 | 42 | 0.02380952
70B | 1.1B | GPTQ | 10 | 200 | 1 | 7 | 295 | 154 | 52 | 46.2 | 0.02164502
70B | 7B | GPTQ | 10 | 200 | 1 | 7 | 269 | 173 | 64 | 45.7 | 0.02188184
70B | 1.1B | GPTQ | 10 | 200 | 1 | 8 | 707 | 268 | 38 | 39.7 | 0.02518892
70B | 7B | GPTQ | 10 | 200 | 1 | 8 | 274 | 184 | 67 | 46.9 | 0.02132196
70B | 1.1B | GPTQ | 10 | 200 | 64 | 1 | 0 | 0 | 0 | 283 | 0.22614841
70B | 7B | GPTQ | 10 | 200 | 64 | 1 | 0 | 0 | 0 | 283 | 0.22614841
70B | 1.1B | GPTQ | 10 | 200 | 64 | 2 | 31872 | 24621 | 78 | 427.7 | 0.1496376
70B | 7B | GPTQ | 10 | 200 | 64 | 2 | 29632 | 26226 | 90 | 422.9 | 0.15133601
70B | 1.1B | GPTQ | 10 | 200 | 64 | 3 | 41088 | 29947 | 76 | 578.1 | 0.11070749
70B | 7B | GPTQ | 10 | 200 | 64 | 3 | 36608 | 29547 | 83 | 490.5 | 0.1304791
70B | 1.1B | GPTQ | 10 | 200 | 64 | 4 | 41344 | 25872 | 63 | 610.7 | 0.10479777
70B | 7B | GPTQ | 10 | 200 | 64 | 4 | 36544 | 26938 | 76 | 562.2 | 0.11383849
70B | 1.1B | GPTQ | 10 | 200 | 64 | 5 | 45760 | 27635 | 62 | 640.7 | 0.09989074
70B | 7B | GPTQ | 10 | 200 | 64 | 5 | 40704 | 30531 | 76 | 548.3 | 0.11672442
70B | 1.1B | GPTQ | 10 | 200 | 64 | 6 | 55872 | 28106 | 51 | 661.3 | 0.09677907
70B | 7B | GPTQ | 10 | 200 | 64 | 6 | 47040 | 31387 | 69 | 597 | 0.10720268
70B | 1.1B | GPTQ | 10 | 200 | 64 | 7 | 59520 | 26615 | 50 | 654.3 | 0.09781446
70B | 7B | GPTQ | 10 | 200 | 64 | 7 | 66560 | 40516 | 64 | 612 | 0.10457516
70B | 1.1B | GPTQ | 10 | 200 | 64 | 8 | 65408 | 26316 | 44 | 710.4 | 0.09009009
70B | 7B | GPTQ | 10 | 200 | 64 | 8 | 71872 | 41465 | 60 | 593.1 | 0.1079076



</body>

</html>
