### PR TITLE
Fix using CuPy for eager mode

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -284,7 +284,10 @@ class LLMEngine:
             is_driver_worker=True,
         )
 
-        self._run_workers("init_model", cupy_port=get_open_port())
+        # don't use cupy for eager mode
+        self._run_workers("init_model",
+                          cupy_port=get_open_port()
+                          if not model_config.enforce_eager else None)
         self._run_workers(
             "load_model",
             max_concurrent_workers=self.parallel_config.


### PR DESCRIPTION
Currently vLLM inference on multi-node is broken after #2811 introduced cupy. 
This PR support multi-node inference for eager mode.
Likely temporarily fix #2826 #2959 with eager mode.