### PR TITLE
Restrict prometheus_client >= 0.18.0 to prevent errors when importing pkgs

### DIFF
--- a/requirements-neuron.txt
+++ b/requirements-neuron.txt
@@ -6,4 +6,4 @@ neuronx-cc
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.
-prometheus_client
+prometheus_client >= 0.18.0

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -10,4 +10,4 @@ transformers >= 4.38.0  # Required for Gemma.
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.
-prometheus_client
+prometheus_client >= 0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ xformers == 0.0.23.post1  # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.
-prometheus_client
+prometheus_client >= 0.18.0
 pynvml == 11.5.0
 triton >= 2.1.0
 cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/root/vllm/vllm/__init__.py", line 4, in <module>
    from vllm.engine.async_llm_engine import AsyncLLMEngine
  File "/root/vllm/vllm/engine/async_llm_engine.py", line 10, in <module>
    from vllm.engine.llm_engine import LLMEngine
  File "/root/vllm/vllm/engine/llm_engine.py", line 14, in <module>
    from vllm.engine.metrics import StatLogger, Stats
  File "/root/vllm/vllm/engine/metrics.py", line 2, in <module>
    from prometheus_client import Counter, Gauge, Histogram, REGISTRY, disable_created_metrics
ImportError: cannot import name 'disable_created_metrics' from 'prometheus_client' (/usr/local/lib/python3.10/dist-packages/prometheus_client/__init__.py)

restrict prometheus_client to >= 0.18.0 to prevent errors when importing pkgs