### PR TITLE
add cache_config's info to prometheus metrics.

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -308,6 +308,10 @@ class CacheConfig:
         self.num_gpu_blocks = None
         self.num_cpu_blocks = None
 
+    def metrics_info(self):
+        # convert cache_config to dict(key: str, value:str) for prometheus metrics info
+        return {attr: str(getattr(self, attr)) for attr in self.__dict__}
+
     def _verify_args(self) -> None:
         if self.gpu_memory_utilization > 1.0:
             raise ValueError(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -310,7 +310,7 @@ class CacheConfig:
 
     def metrics_info(self):
         # convert cache_config to dict(key: str, value:str) for prometheus metrics info
-        return {attr: str(getattr(self, attr)) for attr in self.__dict__}
+        return {key: str(value) for key, value in self.__dict__.items()}
 
     def _verify_args(self) -> None:
         if self.gpu_memory_utilization > 1.0:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -138,6 +138,7 @@ class LLMEngine:
             self.stat_logger = StatLogger(
                 local_interval=_LOCAL_LOGGING_INTERVAL_SEC,
                 labels=dict(model_name=model_config.model))
+            self.stat_logger.info("cache_config", self.cache_config)
 
         self.forward_dag = None
         if USE_RAY_COMPILED_DAG:


### PR DESCRIPTION
add cache_config's info to prometheus metrics, so user can get cache config info from /metrics and dispaly it in grafana.

$ curl http://127.0.0.1:8000/metrics/

vllm:cache_config_info{block_size="16",cache_dtype="auto",gpu_memory_utilization="0.9",num_cpu_blocks="7281",num_gpu_blocks="24188",sliding_window="None",swap_space_bytes="4294967296"} 1.0
