### PR TITLE
remove hard code cuda related API.

### DIFF
--- a/vllm/device_utils.py
+++ b/vllm/device_utils.py
@@ -61,3 +61,11 @@ def could_pin_memory(target_device: Optional[torch.device]):
         return True
     else:
         return target_device.type == "cuda"
+
+
+def get_device_memory(device: Optional[torch.device]):
+    mem = 0
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+        mem = torch.cuda.max_memory_allocated(device)
+    return mem

--- a/vllm/device_utils.py
+++ b/vllm/device_utils.py
@@ -1,0 +1,63 @@
+import torch
+from typing import Optional
+
+from vllm.config import DeviceConfig
+from vllm.utils import in_wsl, is_neuron
+
+
+def get_device_stream(device_config: DeviceConfig):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        stream = torch.cuda.stream
+    else:
+        stream = None
+    return stream
+
+
+def get_device_cache_events(device_config: DeviceConfig, num_layers):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        cache_stream = torch.cuda.Stream()
+        assert cache_stream != torch.cuda.current_stream()
+        # Initialize the events for stream synchronization.
+        events = [torch.cuda.Event() for _ in range(num_layers)]
+    else:
+        cache_stream = None
+        events = None
+    return cache_stream, events
+
+
+def device_empty_cache(device_config: DeviceConfig):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        torch.cuda.empty_cache()
+    else:
+        pass
+
+
+def device_synchronize(device_config: DeviceConfig):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        torch.cuda.synchronize()
+    else:
+        pass
+
+
+def mem_get_info(device_config: DeviceConfig):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        return torch.cuda.mem_get_info()
+    else:
+        return 0, 0
+
+
+def get_distribute_backend(device_config: DeviceConfig):
+    if torch.cuda.is_available() and device_config.device.type == "cuda":
+        backend = "nccl"
+    else:
+        backend = ""
+    return backend
+
+
+def could_pin_memory(target_device: Optional[torch.device]):
+    if in_wsl() or is_neuron():
+        return False
+    if target_device is None:
+        return True
+    else:
+        return target_device.type == "cuda"

--- a/vllm/device_utils.py
+++ b/vllm/device_utils.py
@@ -61,11 +61,3 @@ def could_pin_memory(target_device: Optional[torch.device]):
         return True
     else:
         return target_device.type == "cuda"
-
-
-def get_device_memory(device: Optional[torch.device]):
-    mem = 0
-    if torch.cuda.is_available():
-        torch.cuda.reset_peak_memory_stats(device)
-        mem = torch.cuda.max_memory_allocated(device)
-    return mem

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -5,7 +5,7 @@ import torch
 
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.sequence import SequenceData
-from vllm.utils import in_wsl, is_neuron
+from vllm.device_utils import could_pin_memory
 
 _SAMPLING_EPS = 1e-5
 
@@ -156,7 +156,7 @@ class SamplingTensors:
                    dtype: torch.dtype) -> "SamplingTensors":
         # Note that the performance will be very bad without
         # pinned memory.
-        pin_memory = not in_wsl() and not is_neuron()
+        pin_memory = could_pin_memory(device)
         prompt_max_len = max(len(tokens) for tokens in prompt_tokens)
         prompt_padded_tokens = [
             tokens + [vocab_size] * (prompt_max_len - len(tokens))

--- a/vllm/test_utils.py
+++ b/vllm/test_utils.py
@@ -1,6 +1,6 @@
 import ray
 
-from vllm.config import ParallelConfig
+from vllm.config import DeviceConfig, ParallelConfig
 from vllm.utils import get_open_port
 from vllm.worker.worker import init_distributed_environment
 
@@ -14,10 +14,12 @@ def init_test_distributed_environment(
     parallel_config = ParallelConfig(pipeline_parallel_size,
                                      tensor_parallel_size,
                                      worker_use_ray=True)
+    device_config = DeviceConfig("auto")
     distributed_init_method = f"tcp://localhost:{distributed_init_port}"
     init_distributed_environment(
         parallel_config,
         rank,
+        device_config,
         cupy_port=None,
         distributed_init_method=distributed_init_method)
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -21,7 +21,7 @@ from collections import OrderedDict
 from typing import Any, Hashable, Optional
 
 from vllm.logger import init_logger
-from device_utils import get_device_memory
+from vllm.device_utils import get_device_memory
 
 T = TypeVar("T")
 logger = init_logger(__name__)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from typing import Any, Hashable, Optional
 
 from vllm.logger import init_logger
+from device_utils import get_device_memory
 
 T = TypeVar("T")
 logger = init_logger(__name__)
@@ -312,15 +313,14 @@ def create_kv_caches_with_random(
     return key_caches, value_caches
 
 
-class measure_cuda_memory:
+class measure_device_memory:
 
     def __init__(self, device=None):
         self.device = device
 
     def current_memory_usage(self) -> float:
         # Return the memory usage in bytes.
-        torch.cuda.reset_peak_memory_stats(self.device)
-        mem = torch.cuda.max_memory_allocated(self.device)
+        mem = get_device_memory(self.device)
         return mem
 
     def __enter__(self):

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -21,7 +21,6 @@ from collections import OrderedDict
 from typing import Any, Hashable, Optional
 
 from vllm.logger import init_logger
-from vllm.device_utils import get_device_memory
 
 T = TypeVar("T")
 logger = init_logger(__name__)
@@ -320,7 +319,9 @@ class measure_device_memory:
 
     def current_memory_usage(self) -> float:
         # Return the memory usage in bytes.
-        mem = get_device_memory(self.device)
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats(self.device)
+            mem = torch.cuda.max_memory_allocated(self.device)
         return mem
 
     def __enter__(self):

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -6,7 +6,8 @@ import torch
 from vllm.config import CacheConfig, DeviceConfig, ModelConfig, ParallelConfig
 from vllm.logger import init_logger
 from vllm.utils import is_neuron, STR_DTYPE_TO_TORCH_DTYPE
-from vllm.device_utils import get_device_cache_events, could_pin_memory, get_device_stream
+from vllm.device_utils import (get_device_cache_events, could_pin_memory,
+                               get_device_stream)
 
 logger = init_logger(__name__)
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -21,7 +21,8 @@ from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.request import LoRARequest
-from vllm.utils import in_wsl, measure_cuda_memory
+from vllm.utils import measure_cuda_memory
+from vllm.device_utils import device_synchronize, could_pin_memory
 
 logger = init_logger(__name__)
 
@@ -76,8 +77,6 @@ class ModelRunner:
         # The shape of the cached block table will be
         # (max batch size to capture, max context len to capture / block size).
         self.graph_block_tables = None  # Set after initial profiling.
-        # cache in_wsl result
-        self.in_wsl = in_wsl()
         self.kv_cache_dtype = kv_cache_dtype
 
         # Set enforce_eager to True for Neuron backend, to avoid capturing graph
@@ -408,7 +407,7 @@ class ModelRunner:
         selected_token_start_idx = 0
         categorized_sample_indices = {t: [] for t in SamplingType}
         categorized_sample_indices_start_idx = 0
-        pin_memory = not self.in_wsl and not self.device_config.is_neuron
+        pin_memory = could_pin_memory(self.device_config.device)
 
         max_subquery_len = max(subquery_lens) if subquery_lens else 1
         for i, seq_group_metadata in enumerate(seq_group_metadata_list):
@@ -652,7 +651,7 @@ class ModelRunner:
         num_layers = self.model_config.get_num_layers(self.parallel_config)
         kv_caches = [(None, None)] * num_layers
         self.execute_model(seqs, kv_caches)
-        torch.cuda.synchronize()
+        device_synchronize(self.device_config)
         return
 
     def remove_all_loras(self) -> bool:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -21,7 +21,7 @@ from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.request import LoRARequest
-from vllm.utils import measure_cuda_memory
+from vllm.utils import measure_device_memory
 from vllm.device_utils import device_synchronize, could_pin_memory
 
 logger = init_logger(__name__)
@@ -84,7 +84,7 @@ class ModelRunner:
             self.model_config.enforce_eager = True
 
     def load_model(self) -> None:
-        with measure_cuda_memory() as m:
+        with measure_device_memory() as m:
             self.model = get_model(self.model_config,
                                    self.device_config,
                                    lora_config=self.lora_config,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -19,7 +19,8 @@ from vllm.sequence import SamplerOutput, SequenceGroupMetadata
 from vllm.worker.cache_engine import CacheEngine
 from vllm.worker.model_runner import ModelRunner
 from vllm.lora.request import LoRARequest
-from vllm.device_utils import device_empty_cache, device_synchronize, mem_get_info, get_distribute_backend
+from vllm.device_utils import (device_empty_cache, device_synchronize,
+                               mem_get_info, get_distribute_backend)
 
 
 class Worker:


### PR DESCRIPTION
this is a follow up for PR #2503.
There are some hard code cuda related API call in `cache_engine.py`, `model_runner.py`, `worker.py`, this PR try to provide some interface to hidden cuda API call which would could be more friendly to add new device support.