### PR TITLE
Fix building from source on WSL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def _is_neuron() -> bool:
     torch_neuronx_installed = True
     try:
         subprocess.run(["neuron-ls"], capture_output=True, check=True)
-    except FileNotFoundError:
+    except (FileNotFoundError, PermissionError):
         torch_neuronx_installed = False
     return torch_neuronx_installed
 


### PR DESCRIPTION
On WSL, attempting to run `neuron-ls` will not raised a `FileNotFound` error, but a `PermissionError`. This causes building from source to fail.