### PR TITLE
Explicitly clean up allocated memory on LLM deletion

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -220,7 +220,7 @@ class LLM:
         return outputs
 
     def __del__(self):
+        del self.llm_engine.driver_worker.model_runner
+        del self.llm_engine.driver_worker
         import gc
-        del llm_engine.driver_worker.model_runner
-        del llm_engine.driver_worker
         gc.collect()

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -218,3 +218,9 @@ class LLM:
         # its previous requests.
         outputs = sorted(outputs, key=lambda x: int(x.request_id))
         return outputs
+
+    def __del__(self):
+        import gc
+        del llm_engine.driver_worker.model_runner
+        del llm_engine.driver_worker
+        gc.collect()


### PR DESCRIPTION
Experiments with trying to release allocated memory when the LLM creation wasn't successful