### PR TITLE
feat: implement local_files_only to use pre-cached files

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar, Optional, Union
 import torch
 from packaging.version import Version
 from transformers import PretrainedConfig
+from huggingface_hub import try_to_load_from_cache
 
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_config, get_hf_text_config
@@ -92,12 +93,14 @@ class ModelConfig:
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
         max_logprobs: int = 5,
+        local_files_only: bool = False,
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode
         self.trust_remote_code = trust_remote_code
         self.download_dir = download_dir
+        self.local_files_only = local_files_only
         self.load_format = load_format
         self.seed = seed
         self.revision = revision
@@ -116,6 +119,10 @@ class ModelConfig:
             from modelscope.hub.snapshot_download import snapshot_download
 
             if not os.path.exists(model):
+                if self.local_files_only:
+                    raise ValueError(
+                        f"Unable to find cached ModelScope model for {model}"
+                        f"with local_files_only==True")
                 model_path = snapshot_download(model_id=model,
                                                cache_dir=download_dir,
                                                revision=revision)
@@ -124,6 +131,46 @@ class ModelConfig:
             self.model = model_path
             self.download_dir = model_path
             self.tokenizer = model_path
+
+        elif self.local_files_only:
+            # when using local_files_only, accept a HF model name but resolve it to the
+            # full path within the local HF Hub cache
+            if not os.path.exists(model):
+                filepath = try_to_load_from_cache(
+                    repo_id=model,
+                    filename='config.json',
+                    cache_dir=download_dir,
+                    revision=revision,
+                )
+                if not isinstance(filepath, str):
+                    raise ValueError(
+                        f"Unable to find cached model for {model} "
+                        f"with local_files_only==True")
+                self.model = os.path.dirname(filepath)
+
+            if tokenizer == model:
+                self.tokenizer = self.model
+            elif not os.path.exists(tokenizer):
+                filepath = None
+                # tokenizer.json is for fast tokenizers
+                # tokenizer_config.json for "slow" tokenizers
+                tokenizer_files = ["tokenizer_config.json", "tokenizer.json"]
+                for file_to_check in tokenizer_files:
+                    try_load_result = try_to_load_from_cache(
+                        repo_id=tokenizer,
+                        filename=file_to_check,
+                        cache_dir=download_dir,
+                        revision=revision,
+                    )
+                    if isinstance(try_load_result, str):
+                        filepath = try_load_result
+                        break
+
+                if not filepath:
+                    raise ValueError(
+                        f"Unable to find cached tokenizer for {tokenizer}"
+                        f"with local_files_only==True")
+                self.tokenizer = os.path.dirname(filepath)
 
         self.hf_config = get_config(self.model, trust_remote_code, revision,
                                     code_revision)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -172,8 +172,12 @@ class ModelConfig:
                         f"with local_files_only==True")
                 self.tokenizer = os.path.dirname(filepath)
 
-        self.hf_config = get_config(self.model, trust_remote_code, revision,
-                                    code_revision)
+        self.hf_config = get_config(self.model,
+                                    trust_remote_code=trust_remote_code,
+                                    local_files_only=local_files_only,
+                                    cache_dir=download_dir,
+                                    revision=revision,
+                                    code_revision=code_revision)
         self.hf_text_config = get_hf_text_config(self.hf_config)
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
         self.max_model_len = _get_and_verify_max_len(self.hf_text_config,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from huggingface_hub.constants import HF_HUB_OFFLINE
+
 from vllm.config import (CacheConfig, DeviceConfig, EngineConfig, LoRAConfig,
                          ModelConfig, ParallelConfig, SchedulerConfig,
                          SpeculativeConfig, TokenizerPoolConfig,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -3,6 +3,7 @@ import dataclasses
 from dataclasses import dataclass
 from typing import Optional
 
+from huggingface_hub.constants import HF_HUB_OFFLINE
 from vllm.config import (CacheConfig, DeviceConfig, EngineConfig, LoRAConfig,
                          ModelConfig, ParallelConfig, SchedulerConfig,
                          SpeculativeConfig, TokenizerPoolConfig,
@@ -18,6 +19,7 @@ class EngineArgs:
     tokenizer_mode: str = 'auto'
     trust_remote_code: bool = False
     download_dir: Optional[str] = None
+    local_files_only: bool = HF_HUB_OFFLINE  # checks TRANSFORMERS_OFFLINE too
     load_format: str = 'auto'
     dtype: str = 'auto'
     kv_cache_dtype: str = 'auto'
@@ -131,6 +133,11 @@ class EngineArgs:
                             help='directory to download and load the weights, '
                             'default to the default cache dir of '
                             'huggingface')
+        parser.add_argument(
+            '--local-files-only',
+            action='store_true',
+            default=EngineArgs.local_files_only,
+            help='disable downloads and only look at local files')
         parser.add_argument(
             '--load-format',
             type=str,
@@ -421,7 +428,8 @@ class EngineArgs:
             self.dtype, self.seed, self.revision, self.code_revision,
             self.tokenizer_revision, self.max_model_len, self.quantization,
             self.quantization_param_path, self.enforce_eager,
-            self.max_context_len_to_capture, self.max_logprobs)
+            self.max_context_len_to_capture, self.max_logprobs,
+            self.local_files_only)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -257,6 +257,8 @@ class LLMEngine:
             max_input_length=None,
             tokenizer_mode=self.model_config.tokenizer_mode,
             trust_remote_code=self.model_config.trust_remote_code,
+            local_files_only=self.model_config.local_files_only,
+            cache_dir=self.model_config.download_dir,
             revision=self.model_config.tokenizer_revision)
         init_kwargs.update(tokenizer_init_kwargs)
         self.tokenizer: BaseTokenizerGroup = get_tokenizer_group(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -90,6 +90,7 @@ class LLMEngine:
             f"dtype={model_config.dtype}, "
             f"max_seq_len={model_config.max_model_len}, "
             f"download_dir={model_config.download_dir!r}, "
+            f"local_files_only={model_config.local_files_only}, "
             f"load_format={model_config.load_format}, "
             f"tensor_parallel_size={parallel_config.tensor_parallel_size}, "
             f"disable_custom_all_reduce="

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -69,7 +69,10 @@ class OpenAIServing:
             engine_model_config.tokenizer,
             tokenizer_mode=engine_model_config.tokenizer_mode,
             trust_remote_code=engine_model_config.trust_remote_code,
-            truncation_side="left")
+            local_files_only=engine_model_config.local_files_only,
+            cache_dir=engine_model_config.download_dir,
+            truncation_side="left",
+        )
 
     async def show_available_models(self) -> ModelList:
         """Show available models. Right now we only have one model."""

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -14,16 +14,23 @@ _CONFIG_REGISTRY = {
 }
 
 
-def get_config(model: str,
-               trust_remote_code: bool,
-               revision: Optional[str] = None,
-               code_revision: Optional[str] = None) -> PretrainedConfig:
+def get_config(
+    model: str,
+    trust_remote_code: bool,
+    revision: Optional[str] = None,
+    code_revision: Optional[str] = None,
+    cache_dir: Optional[str] = None,
+    local_files_only: bool = False,
+) -> PretrainedConfig:
     try:
         config = AutoConfig.from_pretrained(
             model,
             trust_remote_code=trust_remote_code,
             revision=revision,
-            code_revision=code_revision)
+            code_revision=code_revision,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+        )
     except ValueError as e:
         if (not trust_remote_code and
                 "requires you to execute the configuration file" in str(e)):
@@ -37,9 +44,13 @@ def get_config(model: str,
             raise e
     if config.model_type in _CONFIG_REGISTRY:
         config_class = _CONFIG_REGISTRY[config.model_type]
-        config = config_class.from_pretrained(model,
-                                              revision=revision,
-                                              code_revision=code_revision)
+        config = config_class.from_pretrained(
+            model,
+            revision=revision,
+            code_revision=code_revision,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+        )
     return config
 
 


### PR DESCRIPTION
Updates how files are pulled from HF Hub to support offline usage with cached files and a fallback in case of networking issues or if HF Hub is down.

- Adds a `--local-files-only` flag meant to match the behavior of `transformers` `local_files_only` argument to `.from_pretrained()` functions. This supports offline environments with no access to HF Hub and loading from a pre-existing  model cache.
  - setting `HF_HUB_OFFLINE` works too to have the same effect
- In support of `--local-files-only`, there's some plumbing of `--download-dir` as well so that it can be used to configure the path to the local cache
  - setting `HF_HUB_CACHE` to point to the cache instead of specifying `--download-dir` works as well

The non-plumbing code changes are to `prepare_hf_model_weights`:
- guard use of `HfFileSystem` for offline mode since it will raise an exception if called with HF_HUB_OFFLINE=1
- catch exceptions related to networking and not finding a model on HF Hub so that we can fallback to try loading from the local cache
- even for the local cache case, `snapshot_download` is used to resolve the path to the model files in the cache