### PR TITLE
Handle when `stop_token_ids` contain `special_tokens`

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -955,9 +955,12 @@ class LLMEngine:
                 seq.status = SequenceStatus.FINISHED_STOPPED
                 return
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
-            stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
-                [seq.get_last_token_id()],
-                skip_special_tokens=sampling_params.skip_special_tokens)
+            stop_str = self.get_tokenizer_for_seq(
+                seq).convert_tokens_to_string(
+                    self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
+                        [seq.get_last_token_id()],
+                        skip_special_tokens=sampling_params.skip_special_tokens
+                    ))
             self._finalize_sequence(seq, sampling_params, stop_str)
             seq.status = SequenceStatus.FINISHED_STOPPED
             return

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -956,7 +956,7 @@ class LLMEngine:
                 return
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
             stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
-                seq.get_last_token_id())
+                [seq.get_last_token_id()], skip_special_tokens=sampling_params.skip_special_tokens)
             self._finalize_sequence(seq, sampling_params, stop_str)
             seq.status = SequenceStatus.FINISHED_STOPPED
             return

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -956,7 +956,8 @@ class LLMEngine:
                 return
         if seq.get_last_token_id() in sampling_params.stop_token_ids:
             stop_str = self.get_tokenizer_for_seq(seq).convert_ids_to_tokens(
-                [seq.get_last_token_id()], skip_special_tokens=sampling_params.skip_special_tokens)
+                [seq.get_last_token_id()],
+                skip_special_tokens=sampling_params.skip_special_tokens)
             self._finalize_sequence(seq, sampling_params, stop_str)
             seq.status = SequenceStatus.FINISHED_STOPPED
             return


### PR DESCRIPTION
This pull request handles cases where we pass some `special_tokens` as `stop_token_ids` (e.g., the eos token `</s>` with token id 2). Otherwise, the output text would be truncated by the special token length (as the special tokens have been processed in detokenization).

My encountered case:

```python
from vllm import LLM, SamplingParams
model = LLM(
    model='mistralai/Mistral-7B-Instruct-v0.2',
    dtype='bfloat16',
    seed=42,
    gpu_memory_utilization=0.9,
)
sampling_params = SamplingParams(
    n=1,
    temperature=1, top_p=0.9,
    seed=42,
    max_tokens=1024,
    stop_token_ids=[2],
)
toker = model.get_tokenizer()
prompts = ['<s>[INST] Is a thumb war violent? [/INST]']
prompt_token_ids = [toker.convert_tokens_to_ids(toker.tokenize(prompt)) for prompt in prompts]
generations = model.generate(sampling_params=sampling_params, prompt_token_ids=prompt_token_ids)
print(generations[0].outputs[0].text)
```
Output before:
```
... between two people and is not typically associated with harm or inj
```
Output after fix:
```
... between two people and is not typically associated with harm or injury.
```