### PR TITLE
fix: ignore non-LoRA tensors in adapter model

### DIFF
--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -145,43 +145,45 @@ class LoRAModel:
         pin_memory = str(device) == "cpu" and not in_wsl()
         loras: Dict[str, LoRALayerWeights] = {}
         for tensor_name, tensor in tensors.items():
-            module_name, is_lora_a = parse_fine_tuned_lora_name(tensor_name)
-            if module_name not in loras:
-                lora_embeddings_tensor = None
-                if embeddings:
-                    embeddings_module = next(
-                        (k for k in embedding_modules if k in module_name),
-                        None)
-                    if embeddings_module:
-                        lora_embeddings_tensor = embeddings[
-                            embedding_modules[embeddings_module]].to(
-                                device=device, dtype=dtype)
-                        if pin_memory:
-                            lora_embeddings_tensor = (
-                                lora_embeddings_tensor.pin_memory())
-                loras[module_name] = LoRALayerWeights(module_name, rank,
-                                                      lora_alpha, None, None,
-                                                      lora_embeddings_tensor)
-            if is_lora_a:
-                loras[module_name].lora_a = tensor.to(device=device,
-                                                      dtype=dtype).t()
-                if pin_memory:
-                    loras[module_name].lora_a = loras[
-                        module_name].lora_a.pin_memory()
-            else:
-                loras[module_name].lora_b = tensor.to(device=device,
-                                                      dtype=dtype).t()
-                if any(name in module_name
-                       for name in embedding_padding_modules
-                       ) and target_embedding_padding is not None:
-                    lora_b = loras[module_name].lora_b
-                    assert target_embedding_padding >= lora_b.shape[1]
-                    addition = target_embedding_padding - lora_b.shape[1]
-                    loras[module_name].lora_b = torch.nn.functional.pad(
-                        lora_b, (0, addition))
-                if pin_memory:
-                    loras[module_name].lora_b = loras[
-                        module_name].lora_b.pin_memory()
+            result = parse_fine_tuned_lora_name(tensor_name)
+            if result is not None:
+                module_name, is_lora_a = result
+                if module_name not in loras:
+                    lora_embeddings_tensor = None
+                    if embeddings:
+                        embeddings_module = next(
+                            (k for k in embedding_modules if k in module_name),
+                            None)
+                        if embeddings_module:
+                            lora_embeddings_tensor = embeddings[
+                                embedding_modules[embeddings_module]].to(
+                                    device=device, dtype=dtype)
+                            if pin_memory:
+                                lora_embeddings_tensor = (
+                                    lora_embeddings_tensor.pin_memory())
+                    loras[module_name] = LoRALayerWeights(module_name, rank,
+                                                          lora_alpha, None, None,
+                                                          lora_embeddings_tensor)
+                if is_lora_a:
+                    loras[module_name].lora_a = tensor.to(device=device,
+                                                          dtype=dtype).t()
+                    if pin_memory:
+                        loras[module_name].lora_a = loras[
+                            module_name].lora_a.pin_memory()
+                else:
+                    loras[module_name].lora_b = tensor.to(device=device,
+                                                          dtype=dtype).t()
+                    if any(name in module_name
+                           for name in embedding_padding_modules
+                           ) and target_embedding_padding is not None:
+                        lora_b = loras[module_name].lora_b
+                        assert target_embedding_padding >= lora_b.shape[1]
+                        addition = target_embedding_padding - lora_b.shape[1]
+                        loras[module_name].lora_b = torch.nn.functional.pad(
+                            lora_b, (0, addition))
+                    if pin_memory:
+                        loras[module_name].lora_b = loras[
+                            module_name].lora_b.pin_memory()
 
         for lora in loras.values():
             lora.optimize()

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -161,9 +161,9 @@ class LoRAModel:
                             if pin_memory:
                                 lora_embeddings_tensor = (
                                     lora_embeddings_tensor.pin_memory())
-                    loras[module_name] = LoRALayerWeights(module_name, rank,
-                                                          lora_alpha, None, None,
-                                                          lora_embeddings_tensor)
+                    loras[module_name] = LoRALayerWeights(
+                        module_name, rank, lora_alpha, None, None,
+                        lora_embeddings_tensor)
                 if is_lora_a:
                     loras[module_name].lora_a = tensor.to(device=device,
                                                           dtype=dtype).t()

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -30,8 +30,10 @@ def parse_fine_tuned_lora_name(name: str) -> Tuple[str, bool]:
     assert parts[0] == "base_model"
     assert parts[1] == "model"
     if parts[-1] == "weight":
-        assert parts[-2] == "lora_A" or parts[-2] == "lora_B"
-        return ".".join(parts[2:-2]), parts[-2] == "lora_A"
+        if parts[-2] == "lora_A" or parts[-2] == "lora_B":
+            return ".".join(parts[2:-2]), parts[-2] == "lora_A"
+        else:
+            return None  # Ignore Non-LoRA tensors
 
     if parts[-1] == "lora_embedding_A" or parts[-1] == "lora_embedding_B":
         return ".".join(parts[2:-1]), parts[-1] == "lora_embedding_A"


### PR DESCRIPTION
Some LoRA adapters contain leftover tensors, such as lm_head and embed_tokens. The current parser doesn't account for them, resulting in an Assertion Error.

Current fix is a bit hacky, can probably be handled in a better way.

Adapter to test with:
[PocketDoc/Dans-RetroRodeo-13b-lora](https://huggingface.co/PocketDoc/Dans-RetroRodeo-13b-lora)