### PR TITLE
chore(vllm): Bot for Stale Issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,15 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.0.0
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-issue-close: 5


### PR DESCRIPTION
vLLM currently has over 1.1k issues whereas many of them have been stale/irrelevant. Adding this stale bot to automate issue cleanup for better organization. Current configuration is directly taken from `action/stale`'s [documentation](https://github.com/marketplace/actions/close-stale-issues) but I'll leave you guys to decide on the number for dats for stale/close status.

We could also add actions for PRs but I don't think we need that for now.