### PR TITLE
Restrict jsonschema >= 4.3.0 to prevent errors when importing pkgs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pynvml == 11.5.0
 triton >= 2.1.0
 outlines >= 0.0.27
 cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
+jsonschema >= 4.3.0 # Required for avoid importing jsonschema.protocols error.


### PR DESCRIPTION
`python3 -m vllm.entrypoints.openai.api_server --model /root/opt-6.7b/ --served-model-name modelx`

```
/usr/lib/python3/dist-packages/requests/__init__.py:87: RequestsDependencyWarning: urllib3 (2.2.1) or chardet (4.0.0) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/root/vllm/vllm/entrypoints/openai/api_server.py", line 23, in <module>
    from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
  File "/root/vllm/vllm/entrypoints/openai/serving_chat.py", line 15, in <module>
    from vllm.model_executor.guided_decoding import get_guided_decoding_logits_processor
  File "/root/vllm/vllm/model_executor/guided_decoding.py", line 12, in <module>
    from vllm.model_executor.guided_logits_processors import JSONLogitsProcessor, RegexLogitsProcessor
  File "/root/vllm/vllm/model_executor/guided_logits_processors.py", line 23, in <module>
    from outlines.fsm.fsm import RegexFSM
  File "/usr/local/lib/python3.10/dist-packages/outlines/__init__.py", line 2, in <module>
    import outlines.generate
  File "/usr/local/lib/python3.10/dist-packages/outlines/generate/__init__.py", line 6, in <module>
    from .json import json
  File "/usr/local/lib/python3.10/dist-packages/outlines/generate/json.py", line 7, in <module>
    from outlines.fsm.json_schema import build_regex_from_schema, get_schema_from_signature
  File "/usr/local/lib/python3.10/dist-packages/outlines/fsm/json_schema.py", line 6, in <module>
    from jsonschema.protocols import Validator
ModuleNotFoundError: No module named 'jsonschema.protocols'
```

The version of jsonschema should be at least 4.3.0
