### PR TITLE
[Minor fix] The domain dns.google may cause a socket.gaierror exception

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -173,7 +173,7 @@ def get_ip() -> str:
     # try ipv4
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(("dns.google", 80))  # Doesn't need to be reachable
+        s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
         return s.getsockname()[0]
     except OSError:
         # try ipv6


### PR DESCRIPTION
May Fix #3170 

In specific network environments, the following code may throw a socket.gaierror exception because the domain dns.google cannot be resolved correctly to an IP address. The issue can be solved by directly using 8.8.8.8, even if 8.8.8.8:80 is not accessible.

```Python
def get_ip() -> str:
    # try ipv4
    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
    try:
        s.connect(("dns.google", 80))  # Doesn't need to be reachable
        return s.getsockname()[0]
    except OSError:
        # try ipv6
        s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
        s.connect(("dns.google", 80))
        return s.getsockname()[0]
```



File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/llm.py", line 109, in __init__
    self.llm_engine = LLMEngine.from_engine_args(engine_args)
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 391, in from_engine_args
    engine = cls(*engine_configs,
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 128, in __init__
    self._init_workers()
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 167, in _init_workers
    get_ip(), get_open_port())
  File "/usr/local/lib/python3.10/dist-packages/vllm/utils.py", line 181, in get_ip
    s.connect(("dns.google", 80))
socket.gaierror: [Errno -2] Name or service not known
