### PR TITLE
Update requirements-dev.txt to include package for benchmarking scripts.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,3 +21,6 @@ einops # required for MPT
 openai
 requests
 ray
+
+# Benchmarking
+aiohttp==3.9.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,4 +23,4 @@ requests
 ray
 
 # Benchmarking
-aiohttp==3.9.3
+aiohttp


### PR DESCRIPTION
To add aiohttp==3.9.3, which is required for benchmarking scripts.