### PR TITLE
Speedup model loading with safetensor format when gpu is available

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -248,7 +248,8 @@ def hf_model_weights_iterator(
             yield name, torch.from_numpy(param)
     elif use_safetensors:
         for st_file in hf_weights_files:
-            with safe_open(st_file, framework="pt") as f:
+            device_type = "cuda" if torch.cuda.is_available() else "cpu"
+            with safe_open(st_file, framework="pt", device=device_type) as f:
                 for name in f.keys():  # noqa: SIM118
                     param = f.get_tensor(name)
                     yield name, param


### PR DESCRIPTION
In /vllm/model_executor/weight_utils.py

```
elif use_safetensors:
  for st_file in hf_weights_files:
    with safe_open(st_file, framework="pt") as f:
        for name in f.keys():  # noqa: SIM118
           param = f.get_tensor(name)
           yield name, param
```
The default device for safe_open is 'cpu', which in some case severely slows down the weight loading speed. For example, in our case, it takes 194s to load a llama2-7b model.

To fix this issue, we change the implementation a little bit:

```
elif use_safetensors:
  for st_file in hf_weights_files:
    with safe_open(st_file, framework="pt", **device=device**) as f:
        for name in f.keys():  # noqa: SIM118
           param = f.get_tensor(name)
           yield name, param
```
which speed up the loading time from 194s to 6s, 32x faster.