### PR TITLE
fix cuda device not found error when LLM is initialized in ray actor

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -495,18 +495,8 @@ class SchedulerConfig:
 
 class DeviceConfig:
 
-    def __init__(self, device: str = "auto") -> None:
-        if device == "auto":
-            # Automated device type detection
-            if torch.cuda.is_available():
-                self.device_type = "cuda"
-            elif is_neuron():
-                self.device_type = "neuron"
-            else:
-                raise RuntimeError("No supported device detected.")
-        else:
-            # Device type is assigned explicitly
-            self.device_type = device
+    def __init__(self, device: str = "cuda") -> None:
+        self.device_type = device
 
         # Some device types require processing inputs on CPU
         if self.device_type in ["neuron"]:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -46,7 +46,7 @@ class EngineArgs:
     lora_extra_vocab_size: int = 256
     lora_dtype = 'auto'
     max_cpu_loras: Optional[int] = None
-    device: str = 'auto'
+    device: str = 'cuda'
     ray_workers_use_nsight: bool = False
 
     def __post_init__(self):
@@ -285,7 +285,7 @@ class EngineArgs:
         parser.add_argument("--device",
                             type=str,
                             default=EngineArgs.device,
-                            choices=["auto", "cuda", "neuron"],
+                            choices=["cuda", "neuron"],
                             help='Device type for vLLM execution.')
         return parser
 


### PR DESCRIPTION
After https://github.com/vllm-project/vllm/pull/2221, when tensor_parallel_size>1, the driver process's CUDA_VISIBLE_DEVICES is manually set after RayWorkerVllm has been up. When LLM engine is initialized in a ray actor with `num_gpus=0`, ray set its CUDA_VISIBLE_DEVICES to `''`, then torch.cuda.is_available() will return False and causes any subsequent CUDA_VISIBLE_DEVICES updates invalid. The root cause is that pytorch initializes device number only once:
https://github.com/pytorch/pytorch/blob/main/c10/cuda/CUDAFunctions.cpp#L96-L113

We should be very careful not call any **torch.cuda.*** function before CUDA_VISIBLE_DEVICES is set.
```python
import ray
from vllm import LLM

@ray.remote
class LLMDeployment:
    def __init__(self, *args, **kwargs) -> None:
        self.llm = LLM(*args, **kwargs) 


actor = LLMDeployment.remote("facebook/opt-13b", tensor_parallel_size=4)
```