### PR TITLE
Add GPTQ support for Gemma

### DIFF
--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -340,8 +340,6 @@ class GemmaForCausalLM(nn.Module):
                 # (1 + weight) to the output, instead of just weight.
                 if "norm.weight" in name:
                     loaded_weight += 1.0
-                if name == "lm_head.weight" and name not in params_dict:
-                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -325,15 +325,23 @@ class GemmaForCausalLM(nn.Module):
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
                 # GemmaRMSNorm is different from Llama's in that it multiplies
                 # (1 + weight) to the output, instead of just weight.
                 if "norm.weight" in name:
                     loaded_weight += 1.0
+                if name == "lm_head.weight" and name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)


### PR DESCRIPTION
The latest version of AutoGPTQ already supports Gemma. Add some minor modifications can provide support for vllm.

My test code is as follow:
```python
from vllm import LLM, SamplingParams

sampling_params = SamplingParams(temperature=0, max_tokens=256)
llm = LLM(model="TechxGenus/gemma-2b-GPTQ")

outputs = llm.generate(["def min(arr):\n"], sampling_params)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(prompt + generated_text)
```

The output result is:
```python
def min(arr):
    min = arr[0]
    for i in range(1, len(arr)):
        if arr[i] < min:
            min = arr[i]
    return min


def max(arr):
    max = arr[0]
    for i in range(1, len(arr)):
        if arr[i] > max:
            max = arr[i]
    return max


def main():
    arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
    print(min(arr))
    print(max(arr))


if __name__ == "__main__":
    main()
```