### PR TITLE
Async tokenization using thread pool

### DIFF
--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -25,23 +25,21 @@ def _query_server_long(prompt: str) -> dict:
 
 
 @pytest.fixture
-def api_server():
+def api_server(num_tokenizer_actors: int):
     script_path = Path(__file__).parent.joinpath(
         "api_server_async_engine.py").absolute()
     uvicorn_process = subprocess.Popen([
-        sys.executable,
-        "-u",
-        str(script_path),
-        "--model",
-        "facebook/opt-125m",
-        "--host",
-        "127.0.0.1",
+        sys.executable, "-u",
+        str(script_path), "--model", "facebook/opt-125m", "--host",
+        "127.0.0.1", "--num-tokenizer-actors",
+        str(num_tokenizer_actors)
     ])
     yield
     uvicorn_process.terminate()
 
 
-def test_api_server(api_server):
+@pytest.mark.parametrize("num_tokenizer_actors", [0, 2])
+def test_api_server(api_server, num_tokenizer_actors: int):
     """
     Run the API server and test it.
 

--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -25,21 +25,21 @@ def _query_server_long(prompt: str) -> dict:
 
 
 @pytest.fixture
-def api_server(num_tokenizer_actors: int):
+def api_server(num_tokenizer_workers: int):
     script_path = Path(__file__).parent.joinpath(
         "api_server_async_engine.py").absolute()
     uvicorn_process = subprocess.Popen([
         sys.executable, "-u",
         str(script_path), "--model", "facebook/opt-125m", "--host",
-        "127.0.0.1", "--num-tokenizer-actors",
-        str(num_tokenizer_actors)
+        "127.0.0.1", "--num-tokenizer-workers",
+        str(num_tokenizer_workers)
     ])
     yield
     uvicorn_process.terminate()
 
 
-@pytest.mark.parametrize("num_tokenizer_actors", [0, 2])
-def test_api_server(api_server, num_tokenizer_actors: int):
+@pytest.mark.parametrize("num_tokenizer_workers", [0, 2])
+def test_api_server(api_server, num_tokenizer_workers: int):
     """
     Run the API server and test it.
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -45,7 +45,7 @@ class ModelConfig:
             a tag name, or a commit id. If unspecified, will use the default
             version.
         code_revision: The specific revision to use for the model code on
-            Hugging Face Hub. It can be a branch name, a tag name, or a 
+            Hugging Face Hub. It can be a branch name, a tag name, or a
             commit id. If unspecified, will use the default version.
         tokenizer_revision: The specific tokenizer version to use. It can be a
             branch name, a tag name, or a commit id. If unspecified, will use
@@ -386,6 +386,10 @@ class ParallelConfig:
             fall back to NCCL.
         ray_workers_use_nsight: Whether to profile Ray workers with nsight, see
             https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-nsight-profiler.
+        num_tokenizer_actors: Number of tokenizer actors to use for
+            asynchronous tokenization with Ray. If 0, will use
+            synchronous tokenization.
+        tokenizer_actor_options: Options for tokenizer Ray Actors.
     """
 
     def __init__(
@@ -396,6 +400,8 @@ class ParallelConfig:
         max_parallel_loading_workers: Optional[int] = None,
         disable_custom_all_reduce: bool = False,
         ray_workers_use_nsight: bool = False,
+        num_tokenizer_actors: int = 0,
+        tokenizer_actor_options: Optional[dict] = None,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         if is_neuron():
@@ -410,6 +416,8 @@ class ParallelConfig:
         self.max_parallel_loading_workers = max_parallel_loading_workers
         self.disable_custom_all_reduce = disable_custom_all_reduce
         self.ray_workers_use_nsight = ray_workers_use_nsight
+        self.num_tokenizer_actors = num_tokenizer_actors
+        self.tokenizer_actor_options = tokenizer_actor_options
 
         self.world_size = pipeline_parallel_size * self.tensor_parallel_size
         # Ray worker is not supported for Neuron backend.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -386,8 +386,10 @@ class ParallelConfig:
             fall back to NCCL.
         ray_workers_use_nsight: Whether to profile Ray workers with nsight, see
             https://docs.ray.io/en/latest/ray-observability/user-guides/profiling.html#profiling-nsight-profiler.
-        num_tokenizer_actors: Number of tokenizer actors to use for
-            asynchronous tokenization with Ray. If 0, will use
+        async_tokenizers: Kind of workers to use for asynchronous tokenization.
+            Can be "thread", "ray", or "none".
+        num_tokenizer_workers: Number of tokenizer workers to use for
+            asynchronous tokenization. If 0, will use
             synchronous tokenization.
         tokenizer_actor_options: Options for tokenizer Ray Actors.
     """
@@ -400,7 +402,8 @@ class ParallelConfig:
         max_parallel_loading_workers: Optional[int] = None,
         disable_custom_all_reduce: bool = False,
         ray_workers_use_nsight: bool = False,
-        num_tokenizer_actors: int = 0,
+        async_tokenizers: Optional[str] = "thread",
+        num_tokenizer_workers: Optional[int] = None,
         tokenizer_actor_options: Optional[dict] = None,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
@@ -416,7 +419,8 @@ class ParallelConfig:
         self.max_parallel_loading_workers = max_parallel_loading_workers
         self.disable_custom_all_reduce = disable_custom_all_reduce
         self.ray_workers_use_nsight = ray_workers_use_nsight
-        self.num_tokenizer_actors = num_tokenizer_actors
+        self.async_tokenizers = async_tokenizers
+        self.num_tokenizer_workers = num_tokenizer_workers
         self.tokenizer_actor_options = tokenizer_actor_options
 
         self.world_size = pipeline_parallel_size * self.tensor_parallel_size

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -54,7 +54,8 @@ class EngineArgs:
     enforce_eager: bool = False
     max_context_len_to_capture: int = 8192
     disable_custom_all_reduce: bool = False
-    num_tokenizer_actors: int = 0
+    async_tokenizers: str = 'thread'
+    num_tokenizer_workers: Optional[int] = None
     tokenizer_actor_options: Optional[dict] = None
     enable_lora: bool = False
     max_loras: int = 1
@@ -265,12 +266,18 @@ class EngineArgs:
                             action='store_true',
                             default=EngineArgs.disable_custom_all_reduce,
                             help='See ParallelConfig')
-        parser.add_argument('--num-tokenizer-actors',
+        parser.add_argument('--async-tokenizers',
+                            type=str,
+                            default=EngineArgs.async_tokenizers,
+                            choices=['thread', 'ray', 'none'],
+                            help='Kind of workers to use for asynchronous '
+                            'tokenization. Can be "thread", "ray", or "none"')
+        parser.add_argument('--num-tokenizer-workers',
                             type=int,
-                            default=EngineArgs.num_tokenizer_actors,
-                            help='Number of tokenizer actors to use for '
-                            'asynchronous tokenization with Ray. If 0, will '
-                            'use synchronous tokenization.')
+                            default=EngineArgs.num_tokenizer_workers,
+                            help='Number of tokenizer workers to use for '
+                            'asynchronous tokenization. Default chosen  '
+                            'based on available CPU cores.')
         parser.add_argument('--tokenizer-actor-options',
                             type=str,
                             default=EngineArgs.tokenizer_actor_options,
@@ -278,7 +285,7 @@ class EngineArgs:
                             help='Options for tokenizer Ray actors. '
                             'This should be a JSON string that will be '
                             'parsed into a dictionary. Ignored if '
-                            'num_tokenizer_actors is 0.')
+                            'async-tokenizers is not "ray".')
         # LoRA related configs
         parser.add_argument('--enable-lora',
                             action='store_true',
@@ -344,14 +351,12 @@ class EngineArgs:
                                    self.swap_space, self.kv_cache_dtype,
                                    model_config.get_sliding_window(),
                                    self.enable_prefix_caching)
-        parallel_config = ParallelConfig(self.pipeline_parallel_size,
-                                         self.tensor_parallel_size,
-                                         self.worker_use_ray,
-                                         self.max_parallel_loading_workers,
-                                         self.disable_custom_all_reduce,
-                                         self.ray_workers_use_nsight,
-                                         self.num_tokenizer_actors,
-                                         self.tokenizer_actor_options)
+        parallel_config = ParallelConfig(
+            self.pipeline_parallel_size, self.tensor_parallel_size,
+            self.worker_use_ray, self.max_parallel_loading_workers,
+            self.disable_custom_all_reduce, self.ray_workers_use_nsight,
+            self.async_tokenizers if self.async_tokenizers != "none" else None,
+            self.num_tokenizer_workers, self.tokenizer_actor_options)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -372,8 +372,11 @@ class AsyncLLMEngine:
         self.set_errored(exc)
         self._request_tracker.propagate_exception(exc)
 
+    def get_tokenizer_group(self):
+        return self.engine.tokenizer
+
     def get_tokenizer(self):
-        return self.engine.tokenizer.tokenizer
+        return self.get_tokenizer_group().tokenizer
 
     def start_background_loop(self) -> None:
         """Start the background loop."""

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -59,10 +59,13 @@ class OpenAIServingChat(OpenAIServing):
 
         request_id = f"cmpl-{random_uuid()}"
         try:
-            token_ids = self._validate_prompt_and_tokenize(request,
-                                                           prompt=prompt)
-            sampling_params = request.to_sampling_params()
             lora_request = self._maybe_get_lora(request)
+            token_ids = await self._validate_prompt_and_tokenize(
+                request,
+                request_id=request_id,
+                lora_request=lora_request,
+                prompt=prompt)
+            sampling_params = request.to_sampling_params()
             guided_decode_logits_processor = (
                 await get_guided_decoding_logits_processor(
                     request, self.engine.get_tokenizer()))

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -135,17 +135,18 @@ class OpenAIServingCompletion(OpenAIServing):
             prompt_is_tokens, prompts = parse_prompt_format(request.prompt)
 
             for i, prompt in enumerate(prompts):
-                if prompt_is_tokens:
-                    input_ids = self._validate_prompt_and_tokenize(
-                        request, prompt_ids=prompt)
-                else:
-                    input_ids = self._validate_prompt_and_tokenize(
-                        request, prompt=prompt)
+                sub_request_id = f"{request_id}-{i}"
+                prompt_arg = "prompt_ids" if prompt_is_tokens else "prompt"
+                input_ids = await self._validate_prompt_and_tokenize(
+                    request,
+                    request_id=sub_request_id,
+                    lora_request=lora_request,
+                    **{prompt_arg: prompt})
 
                 generators.append(
                     self.engine.generate(prompt,
                                          sampling_params,
-                                         f"{request_id}-{i}",
+                                         sub_request_id,
                                          prompt_token_ids=input_ids,
                                          lora_request=lora_request))
         except ValueError as e:

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -158,19 +158,25 @@ class OpenAIServing:
         # if _check_model has been called earlier, this will be unreachable
         raise ValueError("The model `{request.model}` does not exist.")
 
-    def _validate_prompt_and_tokenize(
+    async def _validate_prompt_and_tokenize(
             self,
             request: Union[ChatCompletionRequest, CompletionRequest],
+            request_id: Optional[str] = None,
+            lora_request: Optional[LoRARequest] = None,
             prompt: Optional[str] = None,
             prompt_ids: Optional[List[int]] = None) -> List[int]:
         if not (prompt or prompt_ids):
             raise ValueError("Either prompt or prompt_ids should be provided.")
-        if (prompt and prompt_ids):
+        if prompt and prompt_ids:
             raise ValueError(
                 "Only one of prompt or prompt_ids should be provided.")
 
-        input_ids = prompt_ids if prompt_ids is not None else self.tokenizer(
-            prompt).input_ids
+        if prompt_ids is None:
+            input_ids = await self.engine.get_tokenizer_group().encode_async(
+                prompt, request_id, lora_request)
+        else:
+            input_ids = prompt_ids
+
         token_num = len(input_ids)
 
         if request.max_tokens is None:

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -3,6 +3,7 @@ import os
 import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
+from threading import current_thread
 from typing import List, Optional, Tuple, Union
 
 from transformers import (AutoTokenizer, PreTrainedTokenizer,
@@ -224,11 +225,12 @@ class ThreadPoolTokenizerGroup(TokenizerGroup):
         self.local = threading.local()
 
         def init_tokenizer():
+            logger.info(f"Starting tokenizer thread {current_thread().name}")
             self.local.tokenizer = TokenizerGroup(*args, **tokenizer_config)
 
         self.executor = ThreadPoolExecutor(
             max_workers=max_workers,
-            thread_name_prefix='tokenizer-thread-',
+            thread_name_prefix='tokenizer_thread',
             initializer=init_tokenizer,
         )
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import uuid
 import gc
+from concurrent.futures import Executor
 from platform import uname
 from typing import List, Tuple, Union
 from packaging.version import parse, Version
@@ -154,7 +155,10 @@ def in_wsl() -> bool:
     return "microsoft" in " ".join(uname()).lower()
 
 
-def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+def make_async(
+    func: Callable[..., T],
+    executor: Optional[Executor] = None,
+) -> Callable[..., Awaitable[T]]:
     """Take a blocking function, and run it on in an executor thread.
 
     This function prevents the blocking function from blocking the
@@ -165,7 +169,7 @@ def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
     def _async_wrapper(*args, **kwargs) -> asyncio.Future:
         loop = asyncio.get_event_loop()
         p_func = partial(func, *args, **kwargs)
-        return loop.run_in_executor(executor=None, func=p_func)
+        return loop.run_in_executor(executor=executor, func=p_func)
 
     return _async_wrapper
 


### PR DESCRIPTION
@Yard1's open PR https://github.com/vllm-project/vllm/pull/2879 uses ray to offload tokenization from the asyncio event loop.

This PR extends that to support using a thread pool instead of ray. [Here](https://github.com/njhill/vllm/compare/57b419697faee64368c93200806171ae3db9a38a...async_tokenization) is the diff showing just the newly added commits (note that I also rebased onto the latest main branch).

The main thing to note is that separate tokenizer instances are used per thread. This is because officially the HF tokenizers are not thread-safe. In practice I think they are unless you're making use of padding/truncation, which we aren't currently but may want to soon (see for example https://github.com/vllm-project/vllm/pull/3144).