### PR TITLE
Move model filelocks from `/tmp/` to `~/.cache/vllm/locks/` dir

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -20,8 +20,7 @@ from vllm.model_executor.layers.quantization import (get_quantization_config,
 
 logger = init_logger(__name__)
 
-_xdg_cache_home = os.getenv('XDG_CACHE_HOME',
-                             os.path.expanduser('~/.cache'))
+_xdg_cache_home = os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
 _vllm_filelocks_path = os.path.join(_xdg_cache_home, 'vllm/locks/')
 
 

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -20,6 +20,10 @@ from vllm.model_executor.layers.quantization import (get_quantization_config,
 
 logger = init_logger(__name__)
 
+_xdg_cache_home = os.getenv('XDG_CACHE_HOME',
+                             os.path.expanduser('~/.cache'))
+_vllm_filelocks_path = os.path.join(_xdg_cache_home, 'vllm/locks/')
+
 
 class Disabledtqdm(tqdm):
 
@@ -28,7 +32,8 @@ class Disabledtqdm(tqdm):
 
 
 def get_lock(model_name_or_path: str, cache_dir: Optional[str] = None):
-    lock_dir = cache_dir if cache_dir is not None else "/tmp"
+    lock_dir = cache_dir if cache_dir is not None else _vllm_filelocks_path
+    os.makedirs(os.path.dirname(lock_dir), exist_ok=True)
     lock_file_name = model_name_or_path.replace("/", "-") + ".lock"
     lock = filelock.FileLock(os.path.join(lock_dir, lock_file_name))
     return lock


### PR DESCRIPTION
Creating and accessing filelocks in the global `/tmp/` directory that are based on model names becomes problematic on multi-user systems since if one user runs `LLM("facebook/opt-125")`, then a filelock is created at `/tmp/facebook-opt-125m.lock` and left there. This is fine if a single user is doing this, but as soon as another user runs `LLM("facebook/opt-125")`, then vLLM will try to access the filelock that another user made, which they will not have permission for, triggering:
```
PermissionError: [Errno 13] Permission denied: '/tmp/facebook-opt-125m.lock'
```

This PR attempts to resolve this by using a user's local `~/.cache/vllm/locks` directory to create and access locks, preventing file permissions conflicts with other users.

Addresses: https://github.com/vllm-project/vllm/issues/2179 https://github.com/vllm-project/vllm/issues/2232 https://github.com/vllm-project/vllm/issues/2675 