### PR TITLE
[Minor Fix] Use cupy-cuda11x in CUDA 11.8 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -431,6 +431,12 @@ def get_requirements() -> List[str]:
     else:
         with open(get_path("requirements.txt")) as f:
             requirements = f.read().strip().split("\n")
+        if nvcc_cuda_version <= Version("11.8"):
+            # replace cupy-cuda12x with cupy-cuda11x for cuda 11.x
+            for i in range(len(requirements)):
+                if requirements[i].startswith("cupy-cuda12x"):
+                    requirements[i] = "cupy-cuda11x"
+                    break
     return requirements
 
 


### PR DESCRIPTION
The packages for CUDA 11.8 depend on cupy-cuda12x instead cupy-cuda11x (#3107). Here is a minor fix for it.

```
cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
```

We don't know which version of cupy-cuda11x is required. Thus just let pip decides it.