### PR TITLE
Linear Layer - Torch Compatibility with current 2.1.2

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -61,7 +61,7 @@ class UnquantizedLinearMethod(LinearMethodBase):
                        output_size: int,
                        params_dtype: torch.dtype) -> Dict[str, Any]:
         weight = Parameter(torch.empty(size=(output_size_per_partition,
-                                       input_size_per_partition),
+                                             input_size_per_partition),
                                        dtype=params_dtype),
                            requires_grad=False)
         set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
@@ -120,7 +120,8 @@ class ReplicatedLinear(torch.nn.Module):
                 self.register_parameter(name, weight)
         if bias:
             self.bias = Parameter(
-                torch.empty(size=(self.output_size, ), dtype=self.params_dtype))
+                torch.empty(size=(self.output_size, ),
+                            dtype=self.params_dtype))
             set_weight_attrs(self.bias, {"output_dim": 0})
         else:
             self.register_parameter("bias", None)

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -60,8 +60,8 @@ class UnquantizedLinearMethod(LinearMethodBase):
                        output_size_per_partition: int, input_size: int,
                        output_size: int,
                        params_dtype: torch.dtype) -> Dict[str, Any]:
-        weight = Parameter(torch.empty(output_size_per_partition,
-                                       input_size_per_partition,
+        weight = Parameter(torch.empty(size=(output_size_per_partition,
+                                       input_size_per_partition),
                                        dtype=params_dtype),
                            requires_grad=False)
         set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
@@ -120,7 +120,7 @@ class ReplicatedLinear(torch.nn.Module):
                 self.register_parameter(name, weight)
         if bias:
             self.bias = Parameter(
-                torch.empty(self.output_size, dtype=self.params_dtype))
+                torch.empty(size=(self.output_size, ), dtype=self.params_dtype))
             set_weight_attrs(self.bias, {"output_dim": 0})
         else:
             self.register_parameter("bias", None)
@@ -187,7 +187,7 @@ class ColumnParallelLinear(torch.nn.Module):
                 set_weight_attrs(weight, {"weight_loader": self.weight_loader})
         if bias:
             self.bias = Parameter(
-                torch.empty(self.output_size_per_partition,
+                torch.empty(size=(self.output_size_per_partition, ),
                             dtype=params_dtype))
             set_weight_attrs(self.bias, {
                 "output_dim": 0,
@@ -534,7 +534,7 @@ class RowParallelLinear(torch.nn.Module):
 
         if bias:
             self.bias = Parameter(
-                torch.empty(self.output_size, dtype=params_dtype))
+                torch.empty(size=(self.output_size, ), dtype=params_dtype))
             set_weight_attrs(self.bias, {
                 "output_dim": 0,
                 "weight_loader": self.weight_loader,


### PR DESCRIPTION
<img width="1518" alt="Screenshot 2024-03-07 at 12 16 52 PM" src="https://github.com/vllm-project/vllm/assets/162512284/42e3c2a6-e144-4d98-8f18-95dbb99a9eee">

Seeing a bug in a model load that calls torch.empty() with the wrong function signature, as there was a breaking change in this function from 1.9.0 and onwards.

Current versions expect a tuple for the size parameters: https://pytorch.org/docs/stable/generated/torch.empty.html

Correcting this in the layers/linear.py file.