### PR TITLE
Connect engine healthcheck to openai server

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -160,6 +160,7 @@ async def validation_exception_handler(_, exc):
 @app.get("/health")
 async def health() -> Response:
     """Health check."""
+    await openai_serving_chat.engine.check_health()
     return Response(status_code=200)
 
 


### PR DESCRIPTION
@Yard1 added an engine health check in #3015, it would be useful to use this in the http `/health` endpoint, e.g. for use by Kubernetes health probes.