### PR TITLE
silu_and_mul kernel only supports contiguous tensors

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -43,6 +43,7 @@ __device__ __forceinline__ T gelu_kernel(const T& x) {
 
 // Launch activation and gating kernel.
 #define LAUNCH_ACTIVATION_GATE_KERNEL(KERNEL)                                             \
+  TORCH_CHECK(input.is_contiguous(), "input tensor must be contiguous");                  \
   int d = input.size(-1) / 2;                                                             \
   int64_t num_tokens = input.numel() / input.size(-1);                                    \
   dim3 grid(num_tokens);                                                                  \

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -33,7 +33,7 @@ class SiluAndMul(nn.Module):
         d = x.shape[-1] // 2
         output_shape = (x.shape[:-1] + (d, ))
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        ops.silu_and_mul(out, x)
+        ops.silu_and_mul(out, x.contiguous())
         return out
 
 
@@ -56,7 +56,7 @@ class GeluAndMul(nn.Module):
         d = x.shape[-1] // 2
         output_shape = (x.shape[:-1] + (d, ))
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        ops.gelu_and_mul(out, x)
+        ops.gelu_and_mul(out, x.contiguous())
         return out
 
 


### PR DESCRIPTION
`ops.silu_and_mul` and `ops.gelu_and_mul` kernel only supports contiguous tensors.

Non-contiguous tensors can also be run, but they will output incorrect results and fail unit tests. 
Therefore, when calling the `silu_and_mul` and `gelu_and_mul` kernels, modify them to use contiguous tensors.