### PR TITLE
Add kernel for GeGLU with approximate GELU

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -61,6 +61,10 @@ void gelu_and_mul(
   torch::Tensor& out,
   torch::Tensor& input);
 
+void gelu_tanh_and_mul(
+  torch::Tensor& out,
+  torch::Tensor& input);
+
 void gelu_new(
   torch::Tensor& out,
   torch::Tensor& input);

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -25,7 +25,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   ops.def(
     "gelu_and_mul",
     &gelu_and_mul,
-    "Activation function used in GeGLU.");
+    "Activation function used in GeGLU with `none` approximation.");
+  ops.def(
+    "gelu_tanh_and_mul",
+    &gelu_tanh_and_mul,
+    "Activation function used in GeGLU with `tanh` approximation.");
   ops.def(
     "gelu_new",
     &gelu_new,

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -65,7 +65,7 @@ class GeluAndMul(nn.Module):
         if self.approximate == "none":
             ops.gelu_and_mul(out, x)
         elif self.approximate == "tanh":
-            ops.gelu_and_mul_tanh(out, x)
+            ops.gelu_tanh_and_mul(out, x)
         return out
 
 

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -47,16 +47,25 @@ class GeluAndMul(nn.Module):
         return: (batch_size, seq_len, d) or (num_tokens, d)
     """
 
+    def __init__(self, approximate: str = "none"):
+        super().__init__()
+        self.approximate = approximate
+        if approximate not in ("none", "tanh"):
+            raise ValueError(f"Unknown approximate mode: {approximate}")
+
     def _forward(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
         d = x.shape[-1] // 2
-        return F.gelu(x[..., :d]) * x[..., d:]
+        return F.gelu(x[..., :d], approximate=self.approximate) * x[..., d:]
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         d = x.shape[-1] // 2
         output_shape = (x.shape[:-1] + (d, ))
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        ops.gelu_and_mul(out, x)
+        if self.approximate == "none":
+            ops.gelu_and_mul(out, x)
+        elif self.approximate == "tanh":
+            ops.gelu_and_mul_tanh(out, x)
         return out
 
 

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -60,8 +60,6 @@ class GemmaMLP(nn.Module):
                                            hidden_size,
                                            bias=False,
                                            linear_method=linear_method)
-        # TODO(woosuk): Change to `GeluAndMul(approximate="tanh")` once
-        # https://github.com/huggingface/transformers/pull/29402 is merged.
         self.act_fn = GeluAndMul()
 
     def forward(self, x):

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -60,6 +60,8 @@ class GemmaMLP(nn.Module):
                                            hidden_size,
                                            bias=False,
                                            linear_method=linear_method)
+        # TODO(woosuk): Change to `GeluAndMul(approximate="tanh")` once
+        # https://github.com/huggingface/transformers/pull/29402 is merged.
         self.act_fn = GeluAndMul()
 
     def forward(self, x):


### PR DESCRIPTION
Currently, the Gemma definition in HF is different from the Deepmind's original implementation in that
1. It uses exact GELU instead of approximate GELU
2. It uses FP32 instead of BF16 for normalizing the hidden states.

Please refer to https://github.com/huggingface/transformers/pull/29402 for more information.

Currently, vLLM follows the HF's implementation. While it is questionable which one we should follow since HF hasn't fixed its model yet, this PR adds a GeGLU kernel with approximate GELU for the case we'd like to change the activation. 

**NOTE: This PR doesn't change Gemma, but only adds the approximate GELU kernel for future change in the model definition.**