### PR TITLE
Fix Baichuan chat template

### DIFF
--- a/examples/template_baichuan.jinja
+++ b/examples/template_baichuan.jinja
@@ -1,22 +1,13 @@
 {{ (messages|selectattr('role', 'equalto', 'system')|list|last).content|trim if (messages|selectattr('role', 'equalto', 'system')|list) else '' }}
 
-{% for message in messages %}
-{% if message['role'] == 'user' %}
-<reserved_106>
-{{ message['content']|trim -}}
-{% if not loop.last %}
+{%- for message in messages -%}
+    {%- if message['role'] == 'user' -%}
+        {{- '<reserved_106>' + message['content'] -}}
+    {%- elif message['role'] == 'assistant' -%}
+        {{- '<reserved_107>' + message['content'] -}}
+    {%- endif -%}
+{%- endfor -%}
 
-
-{% endif %}
-{% elif message['role'] == 'assistant' %}
-<reserved_107>
-{{ message['content']|trim -}}
-{% if not loop.last %}
-
-
-{% endif %}
-{% endif %}
-{% endfor %}
-{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}
-<reserved_107>
+{%- if add_generation_prompt and messages[-1]['role'] != 'assistant' -%}
+    {{- '<reserved_107>' -}}
 {% endif %}


### PR DESCRIPTION
The previous template_baichuan.jinja generates extra `\n` compared with [official implementation](https://huggingface.co/baichuan-inc/Baichuan-13B-Chat/blob/e3e1498bb6b7fb0bcb5a65679c09b862d7c29301/generation_utils.py#L7).

Given the input messages is
```python
[
    {'role': 'user', 'content': 'Hello, who are you'},
    {'role': 'assistant', 'content': 'I am a large language model from Baichuan Inc'},
    {'role': 'user', 'content': "What's the capital of Canada?"},
]
```
The text generated by the official version:
`<reserved_106>Hello, who are you<reserved_107>I am a large language model from Baichuan Inc<reserved_106>What's the capital of Canada?<reserved_107>`

while previous template_baichuan.jinja:
`\n\n<reserved_106>\nHello, who are you\n\n<reserved_107>\nI am a large language model from Baichuan Inc\n\n<reserved_106>\nWhat's the capital of Canada?<reserved_107>\n`

This PR fix the jinja template based on the official version.
