### PR TITLE
[BugFix] Fix async engine running on ray

### DIFF
--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -409,15 +409,14 @@ class RayGPUExecutorAsync(RayGPUExecutor, ExecutorAsyncBase):
         # Run the driver worker asynchronously.
         driver_executor = make_async(getattr(self.driver_worker, method))
         coros.append(driver_executor(*driver_args, **driver_kwargs))
-                
+
         if use_ray_compiled_dag:
             # Right now, compiled DAG can only accept a single
             # input. TODO(sang): Fix it.
             output_channels = self.forward_dag.execute(1)
             try:
                 ray_worker_outputs = [
-                    pickle.loads(chan.begin_read())
-                    for chan in output_channels
+                    pickle.loads(chan.begin_read()) for chan in output_channels
                 ]
             finally:
                 # Has to call end_read in order to reuse the DAG.
@@ -427,7 +426,8 @@ class RayGPUExecutorAsync(RayGPUExecutor, ExecutorAsyncBase):
         else:
             # Run the ray workers asynchronously.
             for worker in self.workers:
-                coros.append(worker.execute_method.remote(method, *args, **kwargs))
+                coros.append(
+                    worker.execute_method.remote(method, *args, **kwargs))
 
             all_outputs = await asyncio.gather(*coros)
             return all_outputs


### PR DESCRIPTION
A parameter is missing: `use_ray_compiled_dag` in `RayGPUExecutorAsync` after merging #3191.

@zhuohan123 Could you help test this whether is ok when `use_ray_compiled_dag=True`, please. Because that feature doesn't work on my machine. It seems a `DevelopAPI` in ray.