### PR TITLE
Fixes #1556 double free

### DIFF
--- a/tests/core/test_block_manager.py
+++ b/tests/core/test_block_manager.py
@@ -275,6 +275,7 @@ def test_reset():
     block_manager.reset()
     assert block_manager.get_num_free_gpu_blocks() == original_blocks
 
+
 def test_sliding_window_multi_seq():
     block_size = 1
     num_cpu_blocks = 8
@@ -286,18 +287,18 @@ def test_sliding_window_multi_seq():
                                       watermark=0)
 
     parent = Sequence(1, "one two three", [0, 1, 2], block_size)
-    seq_group = SequenceGroup("1", [parent], SamplingParams(),
-                              time.time(), None)
+    seq_group = SequenceGroup("1", [parent], SamplingParams(), time.time(),
+                              None)
     block_manager.allocate(seq_group)
 
     # Fork prompt and copy block tables.
     child = parent.fork(2)
     block_manager.fork(parent, child)
-    
+
     # assert both parent and child share all blocks
     assert block_manager.get_block_table(
         parent) == block_manager.get_block_table(child)
-    
+
     token_id = 4
     # Append token to child. Block is shared so copy on write occurs.
     child.append_token_id(token_id, {token_id: Logprob(0.0)})
@@ -317,5 +318,4 @@ def test_sliding_window_multi_seq():
 
     # assert freeing the sequences does not lead to a "double free" error
     block_manager.free(parent)
-    block_manager.free(child) 
-    
+    block_manager.free(child)

--- a/tests/core/test_block_manager.py
+++ b/tests/core/test_block_manager.py
@@ -277,23 +277,42 @@ def test_reset():
 
 
 def test_sliding_window_multi_seq():
+    """
+    Tests that memory allocation and deallocation is handled
+    correctly with multiple sequences that exceed the sliding
+    window's capacity.
+    """
     block_size = 1
     num_cpu_blocks = 8
     num_gpu_blocks = 8
+    sliding_window = 2
     block_manager = BlockSpaceManager(block_size,
                                       num_cpu_blocks,
                                       num_gpu_blocks,
-                                      sliding_window=2,
+                                      sliding_window=sliding_window,
                                       watermark=0)
+
+    assert block_manager.get_num_free_gpu_blocks() == num_gpu_blocks
 
     parent = Sequence(1, "one two three", [0, 1, 2], block_size)
     seq_group = SequenceGroup("1", [parent], SamplingParams(), time.time(),
                               None)
     block_manager.allocate(seq_group)
 
+    # assert the number of blocks allocated is correct
+    # the parent seq has len 3, but since sliding_window is 2,
+    # we will use at most 2 blocks
+    assert block_manager.get_num_free_gpu_blocks(
+    ) == num_gpu_blocks - sliding_window
+
     # Fork prompt and copy block tables.
     child = parent.fork(2)
     block_manager.fork(parent, child)
+
+    # assert the number of blocks allocated is correct
+    # forking does not increase memory consumption
+    assert block_manager.get_num_free_gpu_blocks(
+    ) == num_gpu_blocks - sliding_window
 
     # assert both parent and child share all blocks
     assert block_manager.get_block_table(
@@ -304,9 +323,20 @@ def test_sliding_window_multi_seq():
     child.append_token_id(token_id, {token_id: Logprob(0.0)})
     block_manager.append_slot(child)
 
+    # assert the number of blocks allocated is correct
+    # we will use now one block more. Each seq will use 2 blocks,
+    # but only one can be shared
+    assert block_manager.get_num_free_gpu_blocks(
+    ) == num_gpu_blocks - sliding_window - 1
+
     token_id = 5
     parent.append_token_id(token_id, {token_id: Logprob(0.0)})
     block_manager.append_slot(parent)
+
+    # assert the number of blocks allocated is correct
+    # no change, because both sequences are still just sharing one block
+    assert block_manager.get_num_free_gpu_blocks(
+    ) == num_gpu_blocks - sliding_window - 1
 
     block_table_parent = block_manager.get_block_table(parent)
     block_table_child = block_manager.get_block_table(child)
@@ -316,6 +346,18 @@ def test_sliding_window_multi_seq():
     # assert both blocks are sharing the second-last block
     assert block_table_parent[-2] == block_table_child[-2]
 
-    # assert freeing the sequences does not lead to a "double free" error
+    # now let's clean up...
     block_manager.free(parent)
+
+    # assert the number of blocks allocated is correct
+    # We have freed one seq, reducing the ref count of two blocks by one.
+    # One of the two was only used by the parent seq, so this is now free.
+    # The child seq still consumes sliding_window blocks
+    assert block_manager.get_num_free_gpu_blocks(
+    ) == num_gpu_blocks - sliding_window
+
+    # free all blocks
     block_manager.free(child)
+
+    # assert all blocks are free now
+    assert block_manager.get_num_free_gpu_blocks() == num_gpu_blocks

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -393,11 +393,9 @@ class BlockSpaceManager:
         return block_number_mapping
 
     def _free_block_table(self, block_table: BlockTable) -> None:
-        blocks_to_free = (
-            block_table[-self.block_sliding_window :]
-            if self.block_sliding_window is not None
-            else block_table
-        )
+        blocks_to_free = (block_table[-self.block_sliding_window:]
+                          if self.block_sliding_window is not None else
+                          block_table)
         for block in set(blocks_to_free):
             if block.device == Device.GPU:
                 self.gpu_allocator.free(block)

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -312,6 +312,11 @@ class BlockSpaceManager:
         # Thus, it is always safe from OOM.
         src_block_table = self.block_tables[parent_seq.seq_id]
         self.block_tables[child_seq.seq_id] = src_block_table.copy()
+        # When using a sliding window, blocks will be eventually reused.
+        # In this case the block tables will contain repeated blocks.
+        # When forking, we must make sure that each block's `ref_count`
+        # is only incremented by one, so we deduplicate them by wrapping
+        # them in a set.
         for block in set(src_block_table):
             block.ref_count += 1
 
@@ -393,6 +398,11 @@ class BlockSpaceManager:
         return block_number_mapping
 
     def _free_block_table(self, block_table: BlockTable) -> None:
+        # when using a sliding window, each seq will only use up
+        # to `self.block_sliding_window` blocks. When freeing
+        # the block table, we must make sure to not free blocks more
+        # than once. If no sliding window is used, there is no block
+        # reuse in the block table, so we must free all blocks.
         blocks_to_free = (block_table[-self.block_sliding_window:]
                           if self.block_sliding_window is not None else
                           block_table)


### PR DESCRIPTION
This PR fixes issue #1556.

# Conditions for the bug to appear:
The double free error occurs when there are multiple sequences sharing blocks **and** the context window exceeds the model's sliding-window.

The test function in this PR will fail on the `block_manager.py` in main with the "double free" error mentioned in #1556.

# What is the underlying cause of the bug?
The reason this happens is that in `append_slot`, when a new block needs to be allocated because an existing block cannot be reused (because it is referenced by other sequences), its ref count is decremented for the current sequence: https://github.com/vllm-project/vllm/blob/main/vllm/core/block_manager.py#L307
This block is thus considered not to be referenced anymore by this sequence.

Later, when `_free_block_table` is called for the block table of this sequence, vllm tries to free this block once again: https://github.com/vllm-project/vllm/blob/main/vllm/core/block_manager.py#L396, leading to the error.

# What is the fix?
There are two small parts: 
1. the `ref_count` of shared blocks was being wrongly incremented on `fork` because all blocks in the block table were being incremented. This is wrong because if the context exceeds the sliding window, blocks in the block tables will be reused. The fix makes sure to only increment the `ref_count` by 1, by wrapping the table in `set()`.
2. the `_free_block_table` should not free already freed blocks. To this end, the method was changed to just free the last `sliding_window` blocks (if defined).