### PR TITLE
[FIX] Simpler fix for async engine running on ray

### DIFF
--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -430,8 +430,7 @@ class RayGPUExecutorAsync(RayGPUExecutor, ExecutorAsyncBase):
                 "blocks_to_swap_in": blocks_to_swap_in,
                 "blocks_to_swap_out": blocks_to_swap_out,
                 "blocks_to_copy": blocks_to_copy,
-            },
-            use_ray_compiled_dag=USE_RAY_COMPILED_DAG)
+            })
 
         # Only the driver worker returns the sampling results.
         output = all_outputs[0]


### PR DESCRIPTION
This is a simpler fix for the bug reported in #3343. Given that `ray_compiled_dag` is a experimental feature. Let's try to reduce its scope.

cc @rkooo567 

TODO: #3370 