### PR TITLE
bug-fix: assign device when loading lora modules from file

### DIFF
--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -210,7 +210,7 @@ class LoRAModel:
         if os.path.isfile(lora_tensor_path):
             tensors = safetensors.torch.load_file(lora_tensor_path)
         elif os.path.isfile(lora_bin_file_path):
-            tensors = torch.load(lora_bin_file_path)
+            tensors = torch.load(lora_bin_file_path, device)
         else:
             raise ValueError(f"{lora_dir} doesn't contain tensors")
 
@@ -219,7 +219,7 @@ class LoRAModel:
             embeddings = safetensors.torch.load_file(
                 new_embeddings_tensor_path)
         elif os.path.isfile(new_embeddings_bin_file_path):
-            embeddings = torch.load(new_embeddings_bin_file_path)
+            embeddings = torch.load(new_embeddings_bin_file_path, device)
 
         with open(lora_config_path) as f:
             config = json.load(f)


### PR DESCRIPTION
fix https://github.com/vllm-project/vllm/issues/3374

based on [this](https://pytorch.org/docs/stable/generated/torch.load.html#:~:text=torch.load()%20uses%20Python%E2%80%99s%20unpickling%20facilities%20but%20treats%20storages%2C%20which%20underlie%20tensors%2C%20specially.%20They%20are%20first%20deserialized%20on%20the%20CPU%20and%20are%20then%20moved%20to%20the%20device%20they%20were%20saved%20from.), if no device is assigned, `they are first deserialized on the CPU and are then moved to the device they were saved from. `