### PR TITLE
Fix prefix caching is currently not supported with sliding window attention when using qwen1.5

### DIFF
--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -1,11 +1,14 @@
-from vllm import LLM, SamplingParams
+from vllm import LLM
 
 
-# For qwen1.5 the default value of sliding_window is not None, the default value of use_sliding_window is False
+# For qwen1.5 the default value of sliding_window is not None,
+# the default value of use_sliding_window is False
 # This test aims to verify two scenarios.
-# 1. Verify their default values, and whether the return value of get_sliding_window function is right
-#    when model is qwen1.5 and the value of use_sliding_window is different
-# 2. whether the return value of get_sliding_window function is right when using other model
+# 1. Verify their default values, and whether the return value of
+#    get_sliding_window function is right when model is qwen1.5 and
+#    the value of use_sliding_window is different
+# 2. whether the return value of get_sliding_window function is right
+#    when using other model
 def test_sliding_window_value():
     qwen = LLM(
         model="Qwen/Qwen-0.5B",
@@ -17,21 +20,27 @@ def test_sliding_window_value():
     )
 
     # verify default values
-    default_sliding_window = qwen.llm_engine.model_config.hf_config.sliding_window
-    default_use_sliding_window = qwen.llm_engine.model_config.hf_config.use_sliding_window
-    assert default_sliding_window is not None, ("In Qwen1.5, sliding_window default value should not be None")
-    assert default_use_sliding_window == False, ("In Qwen1.5, use_sliding_window default value should be True")
+    hf_config = qwen.llm_engine.model_config.hf_config
+    default_sliding_window = hf_config.sliding_window
+    default_use_sliding_window = hf_config.use_sliding_window
+    assert default_sliding_window is not None, \
+        ("In Qwen1.5, sliding_window default value should not be None")
+    assert default_use_sliding_window == False, \
+        ("In Qwen1.5, use_sliding_window default value should be True")
 
     # verify the return value of get_sliding_window function
     get_sliding_window = qwen.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window is None, ("In Qwen1.5, sliding_window should be None, "
-                                      "because use_sliding_window is False")
+    assert get_sliding_window is None, \
+        ("In Qwen1.5, sliding_window should be None, "
+         "because use_sliding_window is False")
 
     # verify the return value of get_sliding_window function
     qwen.llm_engine.model_config.hf_config.use_sliding_window = True
     get_sliding_window = qwen.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window == default_sliding_window, (f"In Qwen1.5, sliding_window should be "
-                                                        "{default_sliding_window}, because use_sliding_window is True")
+    assert get_sliding_window == default_sliding_window, \
+        (f"In Qwen1.5, sliding_window should be "
+         "{default_sliding_window}, because use_sliding_window is True")
+
 
 def test_sliding_window_with_other_model():
     facebook = LLM(
@@ -45,14 +54,18 @@ def test_sliding_window_with_other_model():
 
     # verify the return value of get_sliding_window function
     get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window is None, ("In facebook/opt-125m, sliding_window should be None, "
-                                      "because the default value of sliding_window is None")
+    assert get_sliding_window is None, \
+        ("In facebook/opt-125m, sliding_window should be None, "
+         "because the default value of sliding_window is None")
 
     sliding_window = 4096
     facebook.llm_engine.model_config.hf_config.sliding_window = sliding_window
     get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window == sliding_window, (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
+    assert get_sliding_window == sliding_window, \
+        (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
+
 
 if __name__ == "__main__":
     import pytest
+
     pytest.main([__file__])

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -34,7 +34,22 @@ def test_sliding_window_value():
         ("In Qwen1.5, sliding_window should be "
          f"{default_sliding_window}, because use_sliding_window is True")
 
+def test_sliding_window_with_other_model():
+    facebook = LLM(model="facebook/opt-125m")
+
+    # verify the return value of get_sliding_window function
+    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window is None, \
+        ("In facebook/opt-125m, sliding_window should be None, "
+         "because the default value of sliding_window is None")
+
+    sliding_window = 4096
+    facebook.llm_engine.model_config.hf_config.sliding_window = sliding_window
+    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window == sliding_window, \
+        (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
+
+
 if __name__ == "__main__":
     import pytest
-
     pytest.main([__file__])

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -1,0 +1,56 @@
+from vllm import LLM, SamplingParams
+
+
+# For qwen1.5 the default value of sliding_window is not None, the default value of use_sliding_window is False
+# This test aims to verify two scenarios.
+# 1. Verify their default values, and whether the return value of get_sliding_window function is right
+#    when model is qwen1.5 and the value of use_sliding_window is different
+# 2. whether the return value of get_sliding_window function is right when using other model
+def test_sliding_window_value():
+    qwen = LLM(
+        model="Qwen/Qwen-1.8B",
+        trust_remote_code=True,
+        enforce_eager=True,
+        download_dir=None,
+        tokenizer_mode='auto'
+    )
+
+    # verify default values
+    default_sliding_window = qwen.llm_engine.model_config.hf_config.sliding_window
+    default_use_sliding_window = qwen.llm_engine.model_config.hf_config.use_sliding_window
+    assert default_sliding_window is not None, ("In Qwen1.5, sliding_window default value should not be None")
+    assert default_use_sliding_window == False, ("In Qwen1.5, use_sliding_window default value should be True")
+
+    # verify the return value of get_sliding_window function
+    get_sliding_window = qwen.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window is None, ("In Qwen1.5, sliding_window should be None, "
+                                      "because use_sliding_window is False")
+
+    # verify the return value of get_sliding_window function
+    qwen.llm_engine.model_config.hf_config.use_sliding_window = True
+    get_sliding_window = qwen.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window == default_sliding_window, (f"In Qwen1.5, sliding_window should be "
+                                                        "{default_sliding_window}, because use_sliding_window is True")
+
+    facebook = LLM(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        enforce_eager=True,
+        download_dir=None,
+        tokenizer_mode='auto'
+    )
+
+    # verify the return value of get_sliding_window function
+    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window is None, ("In facebook/opt-125m, sliding_window should be None, "
+                                      "because the default value of sliding_window is None")
+
+    sliding_window = 4096
+    facebook.llm_engine.model_config.hf_config.sliding_window = sliding_window
+    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
+    assert get_sliding_window == sliding_window, (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__])

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -25,7 +25,7 @@ def test_sliding_window_value():
     default_use_sliding_window = hf_config.use_sliding_window
     assert default_sliding_window is not None, \
         ("In Qwen1.5, sliding_window default value should not be None")
-    assert default_use_sliding_window == False, \
+    assert default_use_sliding_window is False, \
         ("In Qwen1.5, use_sliding_window default value should be True")
 
     # verify the return value of get_sliding_window function
@@ -38,8 +38,8 @@ def test_sliding_window_value():
     qwen.llm_engine.model_config.hf_config.use_sliding_window = True
     get_sliding_window = qwen.llm_engine.model_config.get_sliding_window()
     assert get_sliding_window == default_sliding_window, \
-        (f"In Qwen1.5, sliding_window should be "
-         "{default_sliding_window}, because use_sliding_window is True")
+        ("In Qwen1.5, sliding_window should be "
+         f"{default_sliding_window}, because use_sliding_window is True")
 
 
 def test_sliding_window_with_other_model():

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -12,7 +12,6 @@ from vllm import LLM
 def test_sliding_window_value():
     qwen = LLM(
         model="Qwen/Qwen-0.5B",
-        trust_remote_code=True,
         enforce_eager=True,
         download_dir=None,
         dtype="float16",
@@ -45,7 +44,6 @@ def test_sliding_window_value():
 def test_sliding_window_with_other_model():
     facebook = LLM(
         model="facebook/opt-125m",
-        trust_remote_code=True,
         enforce_eager=True,
         download_dir=None,
         dtype="float16",

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -10,9 +10,7 @@ from vllm import LLM
 # 2. whether the return value of get_sliding_window function is right
 #    when using other model
 def test_sliding_window_value():
-    qwen = LLM(
-        model="Qwen/Qwen-0.5B"
-    )
+    qwen = LLM(model="Qwen/Qwen-0.5B")
 
     # verify default values
     hf_config = qwen.llm_engine.model_config.hf_config
@@ -35,25 +33,6 @@ def test_sliding_window_value():
     assert get_sliding_window == default_sliding_window, \
         ("In Qwen1.5, sliding_window should be "
          f"{default_sliding_window}, because use_sliding_window is True")
-
-
-def test_sliding_window_with_other_model():
-    facebook = LLM(
-        model="facebook/opt-125m"
-    )
-
-    # verify the return value of get_sliding_window function
-    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window is None, \
-        ("In facebook/opt-125m, sliding_window should be None, "
-         "because the default value of sliding_window is None")
-
-    sliding_window = 4096
-    facebook.llm_engine.model_config.hf_config.sliding_window = sliding_window
-    get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
-    assert get_sliding_window == sliding_window, \
-        (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
-
 
 if __name__ == "__main__":
     import pytest

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -34,6 +34,7 @@ def test_sliding_window_value():
         ("In Qwen1.5, sliding_window should be "
          f"{default_sliding_window}, because use_sliding_window is True")
 
+
 def test_sliding_window_with_other_model():
     facebook = LLM(model="facebook/opt-125m")
 

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -10,7 +10,7 @@ from vllm import LLM
 # 2. whether the return value of get_sliding_window function is right
 #    when using other model
 def test_sliding_window_value():
-    qwen = LLM(model="Qwen/Qwen-0.5B")
+    qwen = LLM(model="Qwen/Qwen1.5-0.5B")
 
     # verify default values
     hf_config = qwen.llm_engine.model_config.hf_config

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -11,11 +11,7 @@ from vllm import LLM
 #    when using other model
 def test_sliding_window_value():
     qwen = LLM(
-        model="Qwen/Qwen-0.5B",
-        enforce_eager=True,
-        download_dir=None,
-        dtype="float16",
-        tokenizer_mode='auto'
+        model="Qwen/Qwen-0.5B"
     )
 
     # verify default values
@@ -43,11 +39,7 @@ def test_sliding_window_value():
 
 def test_sliding_window_with_other_model():
     facebook = LLM(
-        model="facebook/opt-125m",
-        enforce_eager=True,
-        download_dir=None,
-        dtype="float16",
-        tokenizer_mode='auto'
+        model="facebook/opt-125m"
     )
 
     # verify the return value of get_sliding_window function

--- a/tests/prefix_caching/test_sliding_window.py
+++ b/tests/prefix_caching/test_sliding_window.py
@@ -8,10 +8,11 @@ from vllm import LLM, SamplingParams
 # 2. whether the return value of get_sliding_window function is right when using other model
 def test_sliding_window_value():
     qwen = LLM(
-        model="Qwen/Qwen-1.8B",
+        model="Qwen/Qwen-0.5B",
         trust_remote_code=True,
         enforce_eager=True,
         download_dir=None,
+        dtype="float16",
         tokenizer_mode='auto'
     )
 
@@ -32,11 +33,13 @@ def test_sliding_window_value():
     assert get_sliding_window == default_sliding_window, (f"In Qwen1.5, sliding_window should be "
                                                         "{default_sliding_window}, because use_sliding_window is True")
 
+def test_sliding_window_with_other_model():
     facebook = LLM(
         model="facebook/opt-125m",
         trust_remote_code=True,
         enforce_eager=True,
         download_dir=None,
+        dtype="float16",
         tokenizer_mode='auto'
     )
 
@@ -49,7 +52,6 @@ def test_sliding_window_value():
     facebook.llm_engine.model_config.hf_config.sliding_window = sliding_window
     get_sliding_window = facebook.llm_engine.model_config.get_sliding_window()
     assert get_sliding_window == sliding_window, (f"In facebook/opt-125m, sliding_window should be {sliding_window}, ")
-
 
 if __name__ == "__main__":
     import pytest

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -239,7 +239,8 @@ class ModelConfig:
         # 'AssertionError: Prefix caching is currently not supported
         # with sliding window attention' when using prefix caching with
         # qwen1.5 and use_sliding_window is false
-        use_sliding_window = getattr(self.hf_config, "use_sliding_window", True)
+        use_sliding_window = getattr(self.hf_config, "use_sliding_window",
+                                     True)
         return (getattr(self.hf_config, "sliding_window", None)
                 if use_sliding_window else None)
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -232,11 +232,14 @@ class ModelConfig:
                 f"({pipeline_parallel_size}).")
 
     def get_sliding_window(self) -> Optional[int]:
+        # The use_sliding_window is a new configuration option introduced in Qwen 1.5 that
+        # controls whether to use a sliding window and its default value is false.
+        # The default value of the sliding_window is no longer None
+        # Add this judgment to avoid
+        # 'AssertionError: Prefix caching is currently not supported with sliding window attention'
+        # when using prefix caching with qwen1.5 and use_sliding_window is false
         return (getattr(self.hf_config, "sliding_window", None)
-                if self.get_use_sliding_window() else None)
-
-    def get_use_sliding_window(self) -> bool:
-        return getattr(self.hf_config, "use_sliding_window", False)
+                if getattr(self.hf_config, "use_sliding_window", True) else None)
 
     def get_vocab_size(self) -> int:
         return self.hf_config.vocab_size

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -239,8 +239,9 @@ class ModelConfig:
         # 'AssertionError: Prefix caching is currently not supported
         # with sliding window attention' when using prefix caching with
         # qwen1.5 and use_sliding_window is false
+        use_sliding_window = getattr(self.hf_config, "use_sliding_window", True)
         return (getattr(self.hf_config, "sliding_window", None)
-                if getattr(self.hf_config, "use_sliding_window", True) else None)
+                if use_sliding_window else None)
 
     def get_vocab_size(self) -> int:
         return self.hf_config.vocab_size

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -232,7 +232,11 @@ class ModelConfig:
                 f"({pipeline_parallel_size}).")
 
     def get_sliding_window(self) -> Optional[int]:
-        return getattr(self.hf_config, "sliding_window", None)
+        return (getattr(self.hf_config, "sliding_window", None)
+                if self.get_use_sliding_window() else None)
+
+    def get_use_sliding_window(self) -> bool:
+        return getattr(self.hf_config, "use_sliding_window", False)
 
     def get_vocab_size(self) -> int:
         return self.hf_config.vocab_size

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -232,12 +232,13 @@ class ModelConfig:
                 f"({pipeline_parallel_size}).")
 
     def get_sliding_window(self) -> Optional[int]:
-        # The use_sliding_window is a new configuration option introduced in Qwen 1.5 that
-        # controls whether to use a sliding window and its default value is false.
-        # The default value of the sliding_window is no longer None
-        # Add this judgment to avoid
-        # 'AssertionError: Prefix caching is currently not supported with sliding window attention'
-        # when using prefix caching with qwen1.5 and use_sliding_window is false
+        # The use_sliding_window is a new configuration introduced
+        # in Qwen 1.5 that controls whether to use a sliding window
+        # and its default value is false. The default value of the
+        # sliding_window is no longer None.Add this judgment to avoid
+        # 'AssertionError: Prefix caching is currently not supported
+        # with sliding window attention' when using prefix caching with
+        # qwen1.5 and use_sliding_window is false
         return (getattr(self.hf_config, "sliding_window", None)
                 if getattr(self.hf_config, "use_sliding_window", True) else None)
 


### PR DESCRIPTION
My model is trained using qwen1.5. When I use prefix caching to do offline batch inference, the program throws AssertionError: Prefix caching is currently not supported with sliding window attention. I noticed that in vllm/config.py,  [the get_sliding_window function](https://github.com/a516072575/vllm/blob/main/vllm/config.py#L234) does not take into account whether the value of use_sliding_window is set to true. 
The use_sliding_window is a new configuration option introduced in Qwen 1.5 that controls whether to use a sliding window, and its default value is set to false. So I add a judgment for value of use_sliding_window when calling the get_sliding_window function. This is similar to  [the implementation in qwen2.py](https://github.com/a516072575/vllm/blob/main/vllm/model_executor/models/qwen2.py#L115)

The AssertionError error message is as follows
<p>
File "/test.py", line 45, in <module>
  outputs = model.generate(prompts, sampling_params, prefix_pos=[prefix_pos] * len(prompts))
File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/llm.py", line 182, in generate
  return self._run_engine(use_tqdm)
File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/llm.py", line 208, in _run_engine
  step_outputs = self.llm_engine.step()
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 838, in step
  all_outputs = self._run_workers(
File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 1041, in _run_workers
  driver_worker_output = getattr(self.driver_worker,
File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
  return func(*args, **kwargs)
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 223, in execute_model
  output = self.model_runner.execute_model(seq_group_metadata_list,
File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
  return func(*args, **kwargs)
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 571, in execute_model
  lora_mapping) = self.prepare_input_tensors(seq_group_metadata_list)
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 490, in prepare_input_tensors
  lora_requests) = self._prepare_prompt(seq_group_metadata_list)
File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 193, in _prepare_prompt
  assert prefix_len == 0, (
AssertionError: Prefix caching is currently not supported with sliding window attention
</p>