### PR TITLE
set google dns for ipv6

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -180,7 +180,7 @@ def get_ip() -> str:
     except OSError:
         # try ipv6
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(("dns.google", 80))
+        s.connect(("2001:4860:4860:0:0:0:0:8888", 80))
         return s.getsockname()[0]
 
 


### PR DESCRIPTION
s.connect(("dns.google", 80))

may cause code crash. It should be reachable. The ipv4 case has been fixed.