### PR TITLE
[Doc] fix doc to install build requirement first

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -58,6 +58,7 @@ You can also build and install vLLM from source:
 
     $ git clone https://github.com/vllm-project/vllm.git
     $ cd vllm
+    $ pip install -r requirements-build.txt
     $ pip install -e .  # This may take 5-10 minutes.
 
 .. tip::


### PR DESCRIPTION
Running `setup.py` requires some packages like `torch` and `packaging`. We need to install them first before running `python setup.py develop`.