### PR TITLE
Fix/bug Qwen1.5-14B-Chat  benchmark float division zero

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -133,7 +133,10 @@ def calculate_metrics(
             output_len = len(tokenizer.encode(outputs[i].generated_text))
             total_output += output_len
             total_input += input_requests[i][1]
-            per_token_latencies.append(outputs[i].latency / output_len)
+            if outputs[i].latency == 0 or output_len == 0:
+                print("output length cannot be zero!")
+            else:
+                per_token_latencies.append(outputs[i].latency / output_len)
             ttfts.append(outputs[i].ttft)
             completed += 1
 


### PR DESCRIPTION
script：
`python benchmark_serving.py --backend vllm --model /home/zmyl/data/qwen/Qwen1.5-14B-Chat --dataset /home/zmyl/data/sharegpt_v3_unfiltered_cleaned_split/ShareGPT_V3_unfiltered_cleaned_split.json --request-rate 10 --num-prompts 500 --trust-remote-code    --save-result`

Error result：
`Traceback (most recent call last):
  File "/home/zmyl/Documents/vllm/benchmarks/benchmark_serving.py", line 387, in <module>
    main(args)
  File "/home/zmyl/Documents/vllm/benchmarks/benchmark_serving.py", line 259, in main
    benchmark_result = asyncio.run(
  File "/home/zmyl/anaconda3/envs/p39/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/zmyl/anaconda3/envs/p39/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/home/zmyl/Documents/vllm/benchmarks/benchmark_serving.py", line 202, in benchmark
    metrics = calculate_metrics(
  File "/home/zmyl/Documents/vllm/benchmarks/benchmark_serving.py", line 136, in calculate_metrics
    per_token_latencies.append(outputs[i].latency / output_len)
ZeroDivisionError: float division by zero`


The numerator and denominator are equal to zero, and they have been processed separately


```
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -133,7 +133,10 @@ def calculate_metrics(
             output_len = len(tokenizer.encode(outputs[i].generated_text))
             total_output += output_len
             total_input += input_requests[i][1]
-            per_token_latencies.append(outputs[i].latency / output_len)
+            if outputs[i].latency == 0 or output_len == 0:
+                print("output length cannot be zero!")
+            else:
+                per_token_latencies.append(outputs[i].latency / output_len)
             ttfts.append(outputs[i].ttft)
             completed += 1
```
