### PR TITLE
quick evict block when needed under EvictionPolicy.LRU mode.

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,3 +4,4 @@ packaging
 setuptools>=49.4.0
 torch==2.1.2
 wheel
+sortedcontainers

--- a/requirements-neuron.txt
+++ b/requirements-neuron.txt
@@ -7,3 +7,4 @@ fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.
 prometheus_client >= 0.18.0
+sortedcontainers

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pynvml == 11.5.0
 triton >= 2.1.0
 outlines == 0.0.34
 cupy-cuda12x == 12.1.0  # Required for CUDA graphs. CUDA 11.8 users should install cupy-cuda11x instead.
+sortedcontainers

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Dict, List, Optional
+from typing import Dict
 from abc import ABC, abstractmethod, abstractproperty
 from sortedcontainers import SortedList
 


### PR DESCRIPTION
quick evict block when needed under EvictionPolicy.LRU mode,

when PhysicalTokenBlocks is recycled, it's metainfo(such as block_hash num_hashed_tokens last_accessed) will be stored in BlockMetaInfo which is sorted by SortedList, so, when evitor evicts block, sorted_list will pop one block immediately instead of loop whole free_table.

tests/prefix_caching/test_prefix_caching.py passed.