### PR TITLE
Fix `dist.broadcast` stall without group argument

### DIFF
--- a/vllm/model_executor/parallel_utils/communication_op.py
+++ b/vllm/model_executor/parallel_utils/communication_op.py
@@ -177,7 +177,7 @@ def broadcast_tensor_dict(
         for key, value in metadata_list:
             if isinstance(value, TensorMetadata):
                 tensor = tensor_dict[key]
-                torch.distributed.broadcast(tensor, src=src)
+                torch.distributed.broadcast(tensor, src=src, group=group)
     else:
         recv_metadata_list = [None]
         torch.distributed.broadcast_object_list(recv_metadata_list,


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/3401. Thanks @Time-Limit for calling out the bug!