### PR TITLE
Add args for mTLS support

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -82,8 +82,14 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)
     parser.add_argument("--ssl-certfile", type=str, default=None)
-    parser.add_argument("--ssl-ca-certs", type=str, default=None, help="The CA certificates file")
-    parser.add_argument("--ssl-cert-reqs", type=int, default=0, help="Whether client certificate is required")
+    parser.add_argument("--ssl-ca-certs",
+                        type=str,
+                        default=None,
+                        help="The CA certificates file")
+    parser.add_argument("--ssl-cert-reqs",
+                        type=int,
+                        default=0,
+                        help="Whether client certificate is required")
     parser.add_argument(
         "--root-path",
         type=str,

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -82,6 +82,8 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)
     parser.add_argument("--ssl-certfile", type=str, default=None)
+    parser.add_argument("--ssl-ca-certs", type=str, default=None, help="The CA certificates file")
+    parser.add_argument("--ssl-cert-reqs", type=int, default=0, help="Whether client certificate is required")
     parser.add_argument(
         "--root-path",
         type=str,
@@ -100,4 +102,6 @@ if __name__ == "__main__":
                 log_level="debug",
                 timeout_keep_alive=TIMEOUT_KEEP_ALIVE,
                 ssl_keyfile=args.ssl_keyfile,
-                ssl_certfile=args.ssl_certfile)
+                ssl_certfile=args.ssl_certfile,
+                ssl_ca_certs=args.ssl_ca_certs,
+                ssl_cert_reqs=args.ssl_cert_reqs)


### PR DESCRIPTION
This PR exposes additional uvicorn TLS args `ssl_ca_certs`, `ssl_cert_reqs` to enable mTLS support.