### PR TITLE
[Misc] add HOST_IP env var

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -21,6 +21,7 @@ from collections import OrderedDict
 from typing import Any, Hashable, Optional
 
 from vllm.logger import init_logger
+import warnings
 
 T = TypeVar("T")
 logger = init_logger(__name__)
@@ -172,16 +173,33 @@ def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
 
 
 def get_ip() -> str:
+    host_ip = os.environ.get("HOST_IP")
+    if host_ip:
+        return host_ip
+
+    # IP is not set, try to get it from the network interface
+
     # try ipv4
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
         s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
         return s.getsockname()[0]
-    except OSError:
+    except Exception:
+        pass
+
+    try:
         # try ipv6
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         s.connect(("dns.google", 80))
         return s.getsockname()[0]
+    except Exception:
+        pass
+
+    warnings.warn(
+        "Failed to get the IP address, using 0.0.0.0 by default."
+        "The value can be set by the environment variable HOST_IP.",
+        stacklevel=2)
+    return "0.0.0.0"
 
 
 def get_distributed_init_method(ip: str, port: int) -> str:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -187,8 +187,8 @@ def get_ip() -> str:
     except Exception:
         pass
 
+    # try ipv6
     try:
-        # try ipv6
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         s.connect(("dns.google", 80))
         return s.getsockname()[0]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -190,7 +190,9 @@ def get_ip() -> str:
     # try ipv6
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(("2001:4860:4860::8888", 80))
+        # Google's public DNS server, see
+        # https://developers.google.com/speed/public-dns/docs/using#addresses
+        s.connect(("2001:4860:4860::8888", 80))  # Doesn't need to be reachable
         return s.getsockname()[0]
     except Exception:
         pass

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -190,7 +190,7 @@ def get_ip() -> str:
     # try ipv6
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        s.connect(("dns.google", 80))
+        s.connect(("2001:4860:4860::8888", 80))
         return s.getsockname()[0]
     except Exception:
         pass


### PR DESCRIPTION
if the host has multiple IPs (say one for subnet and one for public IP), and the user want to use a specific one (say the subnet IP), i.e. in distributed clusters, we have to let users specify which IP to use.