### PR TITLE
Add chat templates for Falcon

### DIFF
--- a/examples/template_falcon.jinja
+++ b/examples/template_falcon.jinja
@@ -1,0 +1,15 @@
+{%- for message in messages -%}
+    {%- if message['role'] == 'user' -%}
+        {{- 'User: ' + message['content'] -}}
+    {%- elif message['role'] == 'assistant' -%}
+        {{- 'Assistant: ' + message['content'] -}}
+    {%- endif -%}
+    {%- if (loop.last and add_generation_prompt) or not loop.last -%}
+        {{- '\n' -}}
+    {%- endif -%}
+{%- endfor -%}
+
+
+{%- if add_generation_prompt and messages[-1]['role'] != 'assistant' -%}
+    {{- 'Assistant:' -}}
+{% endif %}

--- a/examples/template_falcon_180b.jinja
+++ b/examples/template_falcon_180b.jinja
@@ -1,0 +1,17 @@
+{%- for message in messages -%}
+    {%- if message['role'] == 'system' -%}
+        {{- 'System: ' + message['content'] -}}
+    {%- elif message['role'] == 'user' -%}
+        {{- 'User: ' + message['content'] -}}
+    {%- elif message['role'] == 'assistant' -%}
+        {{- 'Falcon: ' + message['content'] -}}
+    {%- endif -%}
+    {%- if (loop.last and add_generation_prompt) or not loop.last -%}
+        {{- '\n' -}}
+    {%- endif -%}
+{%- endfor -%}
+
+
+{%- if add_generation_prompt and messages[-1]['role'] != 'assistant' -%}
+    {{- 'Falcon:' -}}
+{% endif %}


### PR DESCRIPTION
The chat format of Falcon 7B/40B is different from that of Falcon 180B, thus I add two templates.
[Falcon 7B official chat format](https://huggingface.co/tiiuae/falcon-7b-instruct/discussions/1)
[Falcon 40B official chat format](https://huggingface.co/tiiuae/falcon-40b-instruct/discussions/1)
[Falcon 180B official chat API](https://huggingface.co/spaces/tiiuae/falcon-180b-demo/blob/main/app.py#L120)