### PR TITLE
[Core] Support thread-based async tokenizer pools

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,8 +264,7 @@ def vllm_runner():
 def get_tokenizer_pool_config(tokenizer_group_type):
     if tokenizer_group_type is None:
         return None
-    if tokenizer_group_type == "ray":
-        return TokenizerPoolConfig(pool_size=1,
-                                   pool_type="ray",
-                                   extra_config={})
+    if tokenizer_group_type in ("ray", "thread"):
+        return TokenizerPoolConfig.create_config(
+            tokenizer_pool_size=1, tokenizer_pool_type=tokenizer_group_type)
     raise ValueError(f"Unknown tokenizer_group_type: {tokenizer_group_type}")

--- a/tests/tokenization/test_tokenizer_group.py
+++ b/tests/tokenization/test_tokenizer_group.py
@@ -38,8 +38,9 @@ async def test_tokenizer_group(tokenizer_group_type):
 @pytest.mark.parametrize("tokenizer_group_type", ["ray", "thread"])
 async def test_tokenizer_group_pool(tokenizer_group_type):
     reference_tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer_pool_config = get_tokenizer_pool_config(tokenizer_group_type)
     tokenizer_group_pool = get_tokenizer_group(
-        get_tokenizer_pool_config(tokenizer_group_type),
+        tokenizer_pool_config,
         tokenizer_id="gpt2",
         enable_lora=False,
         max_num_seqs=1,
@@ -48,7 +49,7 @@ async def test_tokenizer_group_pool(tokenizer_group_type):
     # Send multiple requests to the tokenizer group pool
     # (more than the pool size)
     # and check that all requests are processed correctly.
-    num_requests = tokenizer_group_pool.pool_size * 5
+    num_requests = tokenizer_pool_config.pool_size * 5
     requests = [
         tokenizer_group_pool.encode_async(request_id=str(i),
                                           prompt=f"prompt {i}",

--- a/tests/tokenization/test_tokenizer_group.py
+++ b/tests/tokenization/test_tokenizer_group.py
@@ -13,7 +13,7 @@ from ..conftest import get_tokenizer_pool_config
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tokenizer_group_type", [None, "ray"])
+@pytest.mark.parametrize("tokenizer_group_type", [None, "ray", "thread"])
 async def test_tokenizer_group(tokenizer_group_type):
     reference_tokenizer = AutoTokenizer.from_pretrained("gpt2")
     tokenizer_group = get_tokenizer_group(
@@ -35,7 +35,7 @@ async def test_tokenizer_group(tokenizer_group_type):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tokenizer_group_type", ["ray"])
+@pytest.mark.parametrize("tokenizer_group_type", ["ray", "thread"])
 async def test_tokenizer_group_pool(tokenizer_group_type):
     reference_tokenizer = AutoTokenizer.from_pretrained("gpt2")
     tokenizer_group_pool = get_tokenizer_group(
@@ -63,7 +63,7 @@ async def test_tokenizer_group_pool(tokenizer_group_type):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("tokenizer_group_type", ["ray"])
+@pytest.mark.parametrize("tokenizer_group_type", ["ray", "thread"])
 async def test_tokenizer_group_ray_pool_env_var_propagation(
         tokenizer_group_type):
     """Test that env vars from caller process are propagated to

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -420,8 +420,8 @@ class TokenizerPoolConfig:
         cls,
         tokenizer_pool_size: Optional[int],
         tokenizer_pool_type: Literal["ray", "thread"],
-        tokenizer_pool_extra_config: Optional[Union[str, dict]],
-        tensor_parallel_size: int,
+        tokenizer_pool_extra_config: Optional[Union[str, dict]] = None,
+        tensor_parallel_size: Optional[int] = None,
     ) -> Optional["TokenizerPoolConfig"]:
         """Create a TokenizerPoolConfig from the given parameters.
 
@@ -439,6 +439,9 @@ class TokenizerPoolConfig:
             return None
 
         if tokenizer_pool_size is None:
+            if tensor_parallel_size is None:
+                # Maximally conservative in this case
+                tensor_parallel_size = 8
             # Default based on CPU count
             tokenizer_pool_size = min(
                 MAX_TOKENIZER_WORKERS,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -18,6 +18,10 @@ logger = init_logger(__name__)
 
 _GB = 1 << 30
 
+# A cap on the number of async tokenizer worker pool size when computing
+# based on the number of available CPU cores
+MAX_TOKENIZER_WORKERS = 16
+
 
 class ModelConfig:
     """Configuration for the model.
@@ -437,7 +441,7 @@ class TokenizerPoolConfig:
         if tokenizer_pool_size is None:
             # Default based on CPU count
             tokenizer_pool_size = min(
-                16,
+                MAX_TOKENIZER_WORKERS,
                 os.cpu_count() - tensor_parallel_size - 1)
             tokenizer_pool_size = max(1, tokenizer_pool_size)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -15,6 +15,7 @@ from vllm.engine.ray_utils import initialize_ray_cluster, ray
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
+from vllm.transformers_utils.tokenizer_group import BaseTokenizerGroup
 
 logger = init_logger(__name__)
 ENGINE_ITERATION_TIMEOUT_S = int(
@@ -365,6 +366,12 @@ class AsyncLLMEngine:
     def _error_callback(self, exc: Exception) -> None:
         self.set_errored(exc)
         self._request_tracker.propagate_exception(exc)
+
+    async def get_tokenizer_group(self) -> BaseTokenizerGroup:
+        if self.engine_use_ray:
+            return await self.engine.get_tokenizer_group.remote()
+        else:
+            return self.engine.get_tokenizer_group()
 
     async def get_tokenizer(self) -> "PreTrainedTokenizer":
         if self.engine_use_ray:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -148,6 +148,9 @@ class LLMEngine:
         # the closure used to initialize Ray worker actors
         raise RuntimeError("LLMEngine should not be pickled!")
 
+    def get_tokenizer_group(self) -> BaseTokenizerGroup:
+        return self.tokenizer
+
     def get_tokenizer(self) -> "PreTrainedTokenizer":
         return self.tokenizer.get_lora_tokenizer()
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -61,10 +61,13 @@ class OpenAIServingChat(OpenAIServing):
 
         request_id = f"cmpl-{random_uuid()}"
         try:
-            token_ids = self._validate_prompt_and_tokenize(request,
-                                                           prompt=prompt)
-            sampling_params = request.to_sampling_params()
             lora_request = self._maybe_get_lora(request)
+            token_ids = await self._validate_prompt_and_tokenize(
+                request,
+                request_id=request_id,
+                lora_request=lora_request,
+                prompt=prompt)
+            sampling_params = request.to_sampling_params()
             guided_decode_logits_processor = (
                 await get_guided_decoding_logits_processor(
                     request, await self.engine.get_tokenizer()))

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -136,17 +136,18 @@ class OpenAIServingCompletion(OpenAIServing):
             prompt_is_tokens, prompts = parse_prompt_format(request.prompt)
 
             for i, prompt in enumerate(prompts):
-                if prompt_is_tokens:
-                    input_ids = self._validate_prompt_and_tokenize(
-                        request, prompt_ids=prompt)
-                else:
-                    input_ids = self._validate_prompt_and_tokenize(
-                        request, prompt=prompt)
+                sub_request_id = f"{request_id}-{i}"
+                prompt_arg = "prompt_ids" if prompt_is_tokens else "prompt"
+                input_ids = await self._validate_prompt_and_tokenize(
+                    request,
+                    request_id=sub_request_id,
+                    lora_request=lora_request,
+                    **{prompt_arg: prompt})
 
                 generators.append(
                     self.engine.generate(prompt,
                                          sampling_params,
-                                         f"{request_id}-{i}",
+                                         sub_request_id,
                                          prompt_token_ids=input_ids,
                                          lora_request=lora_request))
         except ValueError as e:

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -4,7 +4,7 @@ import logging
 import math
 import os
 import re
-from typing import (Any, Callable, Dict, Hashable, List, Optional, Tuple, Type)
+from typing import (Callable, Dict, Hashable, List, Optional, Tuple, Type)
 
 import safetensors.torch
 import torch
@@ -535,14 +535,14 @@ class LoRAModelManager:
                 replacement_loras)
 
 
-class LoRALRUCache(LRUCache):
+class LoRALRUCache(LRUCache[LoRAModel]):
 
     def __init__(self, capacity: int, deactivate_lora_fn: Callable[[Hashable],
                                                                    None]):
         super().__init__(capacity)
         self.deactivate_lora_fn = deactivate_lora_fn
 
-    def _on_remove(self, key: Hashable, value: Any):
+    def _on_remove(self, key: Hashable, value: LoRAModel):
         logger.debug(f"Removing LoRA. int id: {key}")
         self.deactivate_lora_fn(key)
         return super()._on_remove(key, value)

--- a/vllm/transformers_utils/tokenizer_group/__init__.py
+++ b/vllm/transformers_utils/tokenizer_group/__init__.py
@@ -2,6 +2,8 @@ from typing import Optional
 from vllm.config import TokenizerPoolConfig
 from vllm.transformers_utils.tokenizer_group.base_tokenizer_group import (
     BaseTokenizerGroup)
+from vllm.transformers_utils.tokenizer_group.thread_tokenizer_group import (
+    ThreadPoolTokenizerGroup)
 from vllm.transformers_utils.tokenizer_group.tokenizer_group import (
     TokenizerGroup)
 from vllm.engine.ray_utils import ray
@@ -24,9 +26,10 @@ def get_tokenizer_group(tokenizer_pool_config: Optional[TokenizerPoolConfig],
                 "the ray package to use the Ray tokenizer group pool.")
         return RayTokenizerGroupPool.from_config(tokenizer_pool_config,
                                                  **init_kwargs)
-    else:
-        raise ValueError(
-            f"Unknown pool type: {tokenizer_pool_config.pool_type}")
+    if tokenizer_pool_config.pool_type == "thread":
+        return ThreadPoolTokenizerGroup(
+            max_workers=tokenizer_pool_config.pool_size, **init_kwargs)
+    raise ValueError(f"Unknown pool type: {tokenizer_pool_config.pool_type}")
 
 
 __all__ = ["get_tokenizer_group", "BaseTokenizerGroup"]

--- a/vllm/transformers_utils/tokenizer_group/base_tokenizer_group.py
+++ b/vllm/transformers_utils/tokenizer_group/base_tokenizer_group.py
@@ -22,27 +22,34 @@ class BaseTokenizerGroup(ABC):
         pass
 
     @abstractmethod
-    def encode(self, prompt: str, request_id: Optional[str],
-               lora_request: Optional[LoRARequest]) -> List[int]:
+    def encode(self,
+               prompt: str,
+               request_id: Optional[str] = None,
+               lora_request: Optional[LoRARequest] = None) -> List[int]:
         """Encode a prompt using the tokenizer group."""
         pass
 
     @abstractmethod
-    async def encode_async(self, prompt: str, request_id: Optional[str],
-                           lora_request: Optional[LoRARequest]) -> List[int]:
+    async def encode_async(
+            self,
+            prompt: str,
+            request_id: Optional[str] = None,
+            lora_request: Optional[LoRARequest] = None) -> List[int]:
         """Encode a prompt using the tokenizer group."""
         pass
 
     @abstractmethod
     def get_lora_tokenizer(
             self,
-            lora_request: Optional[LoRARequest]) -> "PreTrainedTokenizer":
+            lora_request: Optional[LoRARequest] = None
+    ) -> "PreTrainedTokenizer":
         """Get a tokenizer for a LoRA request."""
         pass
 
     @abstractmethod
     async def get_lora_tokenizer_async(
             self,
-            lora_request: Optional[LoRARequest]) -> "PreTrainedTokenizer":
+            lora_request: Optional[LoRARequest] = None
+    ) -> "PreTrainedTokenizer":
         """Get a tokenizer for a LoRA request."""
         pass

--- a/vllm/transformers_utils/tokenizer_group/thread_tokenizer_group.py
+++ b/vllm/transformers_utils/tokenizer_group/thread_tokenizer_group.py
@@ -1,0 +1,37 @@
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+from vllm.logger import init_logger
+from vllm.transformers_utils.tokenizer_group.tokenizer_group import (
+    TokenizerGroup)
+from vllm.utils import make_async
+
+logger = init_logger(__name__)
+
+
+class ThreadPoolTokenizerGroup(TokenizerGroup):
+    """A threadpool of TokenizerGroups for async tokenization."""
+
+    def __init__(self, *args, max_workers: int, **tokenizer_config):
+        super().__init__(*args, **tokenizer_config)
+        self.local = threading.local()
+
+        def init_tokenizer():
+            logger.info(
+                f"Starting tokenizer thread {threading.current_thread().name}")
+            self.local.tokenizer = TokenizerGroup(*args, **tokenizer_config)
+
+        self.executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix='tokenizer_thread',
+            initializer=init_tokenizer,
+        )
+
+        self.encode_async = make_async(self._encode_local, self.executor)
+
+    def _encode_local(self, *args, **kwargs):
+        return self.local.tokenizer.encode(*args, **kwargs)
+
+    def encode(self, *args, **kwargs):
+        return self.executor.submit(self._encode_local, *args,
+                                    **kwargs).result()

--- a/vllm/transformers_utils/tokenizer_group/thread_tokenizer_group.py
+++ b/vllm/transformers_utils/tokenizer_group/thread_tokenizer_group.py
@@ -27,7 +27,7 @@ class ThreadPoolTokenizerGroup(TokenizerGroup):
             initializer=init_tokenizer,
         )
 
-        self.encode_async = make_async(self._encode_local, self.executor)
+        self._encode_async = make_async(self._encode_local, self.executor)
 
     def _encode_local(self, *args, **kwargs):
         return self.local.tokenizer.encode(*args, **kwargs)
@@ -35,3 +35,6 @@ class ThreadPoolTokenizerGroup(TokenizerGroup):
     def encode(self, *args, **kwargs):
         return self.executor.submit(self._encode_local, *args,
                                     **kwargs).result()
+
+    async def encode_async(self, *args, **kwargs):
+        return await self._encode_async(*args, **kwargs)

--- a/vllm/transformers_utils/tokenizer_group/tokenizer_group.py
+++ b/vllm/transformers_utils/tokenizer_group/tokenizer_group.py
@@ -21,10 +21,8 @@ class TokenizerGroup(BaseTokenizerGroup):
         self.enable_lora = enable_lora
         self.max_input_length = max_input_length
         self.tokenizer = get_tokenizer(self.tokenizer_id, **tokenizer_config)
-        if enable_lora:
-            self.lora_tokenizers = LRUCache(capacity=max_num_seqs)
-        else:
-            self.lora_tokenizers = None
+        self.lora_tokenizers = LRUCache[PreTrainedTokenizer](
+            capacity=max_num_seqs) if enable_lora else None
 
     def ping(self) -> bool:
         """Check if the tokenizer group is alive."""
@@ -62,8 +60,7 @@ class TokenizerGroup(BaseTokenizerGroup):
                 lora_request, **self.tokenizer_config) or self.tokenizer)
             self.lora_tokenizers.put(lora_request.lora_int_id, tokenizer)
             return tokenizer
-        else:
-            return self.lora_tokenizers.get(lora_request.lora_int_id)
+        return self.lora_tokenizers.get(lora_request.lora_int_id)
 
     async def get_lora_tokenizer_async(
             self,
@@ -76,5 +73,4 @@ class TokenizerGroup(BaseTokenizerGroup):
                 lora_request, **self.tokenizer_config) or self.tokenizer)
             self.lora_tokenizers.put(lora_request.lora_int_id, tokenizer)
             return tokenizer
-        else:
-            return self.lora_tokenizers.get(lora_request.lora_int_id)
+        return self.lora_tokenizers.get(lora_request.lora_int_id)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -4,9 +4,10 @@ import socket
 import subprocess
 import uuid
 import gc
+from concurrent.futures import Executor
 from functools import cache
 from platform import uname
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Generic
 from packaging.version import parse, Version
 
 import psutil
@@ -54,10 +55,10 @@ class Counter:
         self.counter = 0
 
 
-class LRUCache:
+class LRUCache(Generic[T]):
 
     def __init__(self, capacity: int):
-        self.cache = OrderedDict()
+        self.cache = OrderedDict[Hashable, T]()
         self.capacity = capacity
 
     def __contains__(self, key: Hashable) -> bool:
@@ -66,10 +67,10 @@ class LRUCache:
     def __len__(self) -> int:
         return len(self.cache)
 
-    def __getitem__(self, key: Hashable) -> Any:
+    def __getitem__(self, key: Hashable) -> T:
         return self.get(key)
 
-    def __setitem__(self, key: Hashable, value: Any) -> None:
+    def __setitem__(self, key: Hashable, value: T) -> None:
         self.put(key, value)
 
     def __delitem__(self, key: Hashable) -> None:
@@ -78,7 +79,9 @@ class LRUCache:
     def touch(self, key: Hashable) -> None:
         self.cache.move_to_end(key)
 
-    def get(self, key: Hashable, default_value: Optional[Any] = None) -> int:
+    def get(self,
+            key: Hashable,
+            default_value: Optional[T] = None) -> Optional[T]:
         if key in self.cache:
             value = self.cache[key]
             self.cache.move_to_end(key)
@@ -86,12 +89,12 @@ class LRUCache:
             value = default_value
         return value
 
-    def put(self, key: Hashable, value: Any) -> None:
+    def put(self, key: Hashable, value: T) -> None:
         self.cache[key] = value
         self.cache.move_to_end(key)
         self._remove_old_if_needed()
 
-    def _on_remove(self, key: Hashable, value: Any):
+    def _on_remove(self, key: Hashable, value: T):
         pass
 
     def remove_oldest(self):
@@ -104,7 +107,7 @@ class LRUCache:
         while len(self.cache) > self.capacity:
             self.remove_oldest()
 
-    def pop(self, key: int, default_value: Optional[Any] = None) -> Any:
+    def pop(self, key: Hashable, default_value: Optional[Any] = None) -> T:
         run_on_remove = key in self.cache
         value = self.cache.pop(key, default_value)
         if run_on_remove:
@@ -160,7 +163,10 @@ def in_wsl() -> bool:
     return "microsoft" in " ".join(uname()).lower()
 
 
-def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
+def make_async(
+    func: Callable[..., T],
+    executor: Optional[Executor] = None,
+) -> Callable[..., Awaitable[T]]:
     """Take a blocking function, and run it on in an executor thread.
 
     This function prevents the blocking function from blocking the
@@ -171,7 +177,7 @@ def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
     def _async_wrapper(*args, **kwargs) -> asyncio.Future:
         loop = asyncio.get_event_loop()
         p_func = partial(func, *args, **kwargs)
-        return loop.run_in_executor(executor=None, func=p_func)
+        return loop.run_in_executor(executor=executor, func=p_func)
 
     return _async_wrapper
 


### PR DESCRIPTION
#2879 added support for using ray to offload tokenization from the asyncio event loop.

This PR extends that to support using a thread pool instead of ray, and makes that the default, with the default pool size determined based on the number of available CPU cores and the tensor parallel size.

The main thing to note is that separate tokenizer instances are used per thread. This is because officially the HF tokenizers are not thread-safe. In practice I think they are unless you're making use of padding/truncation, which we aren't currently but may want to soon (see for example https://github.com/vllm-project/vllm/pull/3144).

Also includes some type hint additions to related parts of the code.

This replaces the original PR #3206 from before #2879 was reworked and merged.