### PR TITLE
[Core] Improve detokenization performance for prefill

### DIFF
--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -156,16 +156,19 @@ def test_decode_sequence_logprobs(complete_sequence: str,
             seq.output_logprobs[-1][new_token + 1].decoded_token)
     sequential_result = seq.output_text
 
-    assert sequential_result == complete_sequence
-    # Text for logprobs for the chosen token should be the same as the
-    # generated text.
     assert sequential_result == "".join(sequential_logprobs_text_chosen_token)
     assert sequential_result != "".join(sequential_logprobs_text_other_token)
+
+    if skip_special_tokens:
+        # Text for logprobs for the chosen token should be the same as the
+        # generated text. Note that this will only be true if we skip
+        # special tokens.
+        assert sequential_result == complete_sequence
 
 
 @pytest.mark.parametrize("complete_sequence", TRUTH)
 @pytest.mark.parametrize("tokenizer_name", TOKENIZERS)
-@pytest.mark.parametrize("skip_special_tokens", [True, False])
+@pytest.mark.parametrize("skip_special_tokens", [True])
 def test_decode_prompt_logprobs(complete_sequence: str,
                                 complete_sequence_token_ids: List[int],
                                 detokenizer: Detokenizer,
@@ -183,13 +186,16 @@ def test_decode_prompt_logprobs(complete_sequence: str,
     dummy_logprobs = create_dummy_logprobs(complete_sequence_token_ids)
     decoded_prompt_logprobs = detokenizer.decode_prompt_logprobs(
         seq_group, dummy_logprobs)
-    # Text for logprobs for the chosen token should be the same as the
-    # prompt text.
-    assert complete_sequence == "".join([
-        logprobs[token_id].decoded_token for token_id, logprobs in zip(
-            complete_sequence_token_ids, decoded_prompt_logprobs)
-    ])
-    assert complete_sequence != "".join([
-        logprobs[token_id + 1].decoded_token for token_id, logprobs in zip(
-            complete_sequence_token_ids, decoded_prompt_logprobs)
-    ])
+
+    if skip_special_tokens:
+        # Text for logprobs for the chosen token should be the same as the
+        # prompt text. Note that this will only be true if we skip
+        # special tokens.
+        assert complete_sequence == "".join([
+            logprobs[token_id].decoded_token for token_id, logprobs in zip(
+                complete_sequence_token_ids, decoded_prompt_logprobs)
+        ])
+        assert complete_sequence != "".join([
+            logprobs[token_id + 1].decoded_token for token_id, logprobs in zip(
+                complete_sequence_token_ids, decoded_prompt_logprobs)
+        ])

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -184,8 +184,8 @@ def test_decode_prompt_logprobs(complete_sequence: str,
                               sampling_params=sampling_params,
                               arrival_time=0.0)
     dummy_logprobs = create_dummy_logprobs(complete_sequence_token_ids)
-    decoded_prompt_logprobs = detokenizer.decode_prompt_logprobs_inplace(
-        seq_group, dummy_logprobs)
+    detokenizer.decode_prompt_logprobs_inplace(seq_group, dummy_logprobs)
+    decoded_prompt_logprobs = dummy_logprobs
 
     if skip_special_tokens:
         # Text for logprobs for the chosen token should be the same as the

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -1,13 +1,19 @@
 import pytest
 
+from functools import partial
 from transformers import AutoTokenizer
+from typing import Callable, List, Dict
+from unittest.mock import MagicMock
 
+from vllm.engine.llm_engine import LLMEngine
+from vllm.sequence import Sequence, Logprob
+from vllm.transformers_utils.tokenizer_group import get_tokenizer_group
 from vllm.transformers_utils.tokenizer import detokenize_incrementally
 
 TRUTH = [
-    "Hello here, this is a simple test",  # noqa: E501
-    "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",  # noqa: E501
-    "我很感谢你的热情"  # noqa: E501
+    "Hello here, this is a simple test",
+    "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",  # noqa
+    "我很感谢你的热情"
 ]
 TOKENIZERS = [
     "facebook/opt-125m",
@@ -24,12 +30,12 @@ TOKENIZERS = [
 
 
 def _run_incremental_decode(tokenizer, all_input_ids,
-                            skip_special_tokens: bool):
+                            skip_special_tokens: bool, starting_index: int):
     decoded_text = ""
     offset = 0
     token_offset = 0
     prev_tokens = None
-    for i in range(len(all_input_ids)):
+    for i in range(starting_index, len(all_input_ids)):
         new_tokens, text, offset, token_offset = detokenize_incrementally(
             tokenizer,
             all_input_ids[:i + 1],
@@ -46,17 +52,81 @@ def _run_incremental_decode(tokenizer, all_input_ids,
 
 
 @pytest.mark.parametrize("truth", TRUTH)
+@pytest.mark.parametrize("with_prompt", [True, False])
 @pytest.mark.parametrize("tokenizer_id", TOKENIZERS)
 @pytest.mark.parametrize("skip_special_tokens", (True, False))
-def test_decode_streaming(tokenizer_id, truth, skip_special_tokens):
+def test_decode_streaming(tokenizer_id, truth, with_prompt,
+                          skip_special_tokens):
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
-    all_input_ids = tokenizer(truth, add_special_tokens=False)["input_ids"]
+    if with_prompt:
+        truth_tokens = tokenizer(truth, add_special_tokens=False)["input_ids"]
+        prompt_input_ids = truth_tokens[:len(truth) // 2]
+        generated_input_ids = truth_tokens[len(truth) // 2:]
+        all_input_ids = prompt_input_ids + generated_input_ids
+        starting_index = len(prompt_input_ids)
+        prompt = tokenizer.decode(prompt_input_ids,
+                                  skip_special_tokens=skip_special_tokens)
+        generated = truth[len(prompt):]
+    else:
+        generated = truth
+        starting_index = 0
+        all_input_ids = tokenizer(truth, add_special_tokens=False)["input_ids"]
     if skip_special_tokens:
-        all_input_ids = ([tokenizer.bos_token_id]
-                         if tokenizer.bos_token_id is not None else
-                         []) + all_input_ids + [tokenizer.eos_token_id]
+        if tokenizer.bos_token_id is not None:
+            all_input_ids = [tokenizer.bos_token_id] + all_input_ids
+            starting_index += 1
+        all_input_ids = all_input_ids + [tokenizer.eos_token_id]
 
     decoded_text = _run_incremental_decode(
-        tokenizer, all_input_ids, skip_special_tokens=skip_special_tokens)
+        tokenizer,
+        all_input_ids,
+        skip_special_tokens=skip_special_tokens,
+        starting_index=starting_index)
 
-    assert decoded_text == truth
+    assert decoded_text == generated
+
+
+@pytest.fixture(name="decode_sequence")
+def create_decode_sequence(tokenizer_name: str) -> Callable:
+    init_kwargs = dict(
+        tokenizer_id=tokenizer_name,
+        enable_lora=False,
+        max_num_seqs=100,
+        max_input_length=None,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        revision=None,
+    )
+
+    self = MagicMock()
+    self.tokenizer = get_tokenizer_group(
+        None,
+        **init_kwargs,
+    )
+
+    decode_sequence = partial(LLMEngine._decode_sequence, self)  # pylint: disable=protected-access
+    return decode_sequence
+
+
+@pytest.fixture(name="complete_sequence_token_ids")
+def create_complete_sequence_token_ids(complete_sequence: str,
+                                       tokenizer_name: str) -> List[int]:
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    complete_sequence_token_ids = tokenizer(complete_sequence)["input_ids"]
+    return complete_sequence_token_ids
+
+
+def create_empty_sequence():
+    return Sequence(
+        seq_id=0,
+        prompt="<s>",
+        prompt_token_ids=[1],
+        block_size=16,
+    )
+
+
+def create_dummy_logprobs(
+        complete_sequence_token_ids: List[int]) -> List[Dict[int, float]]:
+    return [{
+        token_id: Logprob(logprob=0.0)
+    } for token_id in complete_sequence_token_ids]

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -149,7 +149,7 @@ def test_decode_sequence_logprobs(complete_sequence: str,
     for new_token, logprobs in zip(complete_sequence_token_ids,
                                    dummy_logprobs):
         seq.append_token_id(new_token, logprobs)
-        detokenizer.decode_sequence(seq, sampling_params)
+        detokenizer.decode_sequence_inplace(seq, sampling_params)
         sequential_logprobs_text_chosen_token.append(
             seq.output_logprobs[-1][new_token].decoded_token)
         sequential_logprobs_text_other_token.append(
@@ -184,7 +184,7 @@ def test_decode_prompt_logprobs(complete_sequence: str,
                               sampling_params=sampling_params,
                               arrival_time=0.0)
     dummy_logprobs = create_dummy_logprobs(complete_sequence_token_ids)
-    decoded_prompt_logprobs = detokenizer.decode_prompt_logprobs(
+    decoded_prompt_logprobs = detokenizer.decode_prompt_logprobs_inplace(
         seq_group, dummy_logprobs)
 
     if skip_special_tokens:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -359,8 +359,9 @@ class LLMEngine:
         # Process prompt logprobs
         prompt_logprobs = outputs.prompt_logprobs
         if prompt_logprobs is not None:
-            seq_group.prompt_logprobs = self.detokenizer.decode_prompt_logprobs(
+            self.detokenizer.decode_prompt_logprobs_inplace(
                 seq_group, prompt_logprobs)
+            seq_group.prompt_logprobs = prompt_logprobs
 
         # Process samples
         samples = outputs.samples
@@ -403,7 +404,8 @@ class LLMEngine:
             child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:
-            self.detokenizer.decode_sequence(seq, seq_group.sampling_params)
+            self.detokenizer.decode_sequence_inplace(seq,
+                                                     seq_group.sampling_params)
             self._check_stop(seq, seq_group.sampling_params)
 
         # Non-beam search case

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -89,12 +89,10 @@ class Detokenizer:
         next_iter_read_offset = 0
         next_iter_tokens = []
         prev_tokens = None
-        first_non_none_index = 0
 
         for token_position, prompt_logprobs_for_token in enumerate(
                 prompt_logprobs):
             if not prompt_logprobs_for_token:
-                first_non_none_index = token_position + 1
                 continue
             for token_id, sample_logprob in prompt_logprobs_for_token.items():
                 if (sample_logprob.decoded_token is None and token_id != -1):
@@ -130,7 +128,7 @@ class Detokenizer:
             else:
                 prev_tokens.extend(next_iter_tokens)
 
-        return prompt_logprobs[first_non_none_index:]
+        return prompt_logprobs
 
     def decode_sequence(self, seq: Sequence, prms: SamplingParams) -> None:
         """Decodes the new token for a sequence. In-place operation.

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -3,7 +3,9 @@ from transformers import PreTrainedTokenizer
 from vllm.sequence import Sequence, Logprob, SequenceGroup, SamplingParams
 from vllm.transformers_utils.tokenizer import (detokenize_incrementally,
                                                convert_prompt_ids_to_tokens)
-from vllm.transformers_utils.tokenizer_group.base_tokenizer_group import BaseTokenizerGroup
+from vllm.transformers_utils.tokenizer_group.base_tokenizer_group import (
+    BaseTokenizerGroup)
+
 
 class Detokenizer:
     """Provides methods to decode the output of a model into text."""
@@ -89,15 +91,15 @@ class Detokenizer:
         prev_tokens = None
         first_non_none_index = 0
 
-        for token_position, prompt_logprobs_for_token in enumerate(prompt_logprobs):
+        for token_position, prompt_logprobs_for_token in enumerate(
+                prompt_logprobs):
             if not prompt_logprobs_for_token:
                 first_non_none_index = token_position + 1
                 continue
             for token_id, sample_logprob in prompt_logprobs_for_token.items():
                 if (sample_logprob.decoded_token is None and token_id != -1):
-                    prompt_token_ids_with_token = prompt_token_ids[:token_position] + [
-                        token_id
-                    ]
+                    prompt_token_ids_with_token = (
+                        prompt_token_ids[:token_position] + [token_id])
                     (new_tokens, new_text, new_prefix_offset,
                      new_read_offset) = detokenize_incrementally(
                          tokenizer=tokenizer,
@@ -163,11 +165,11 @@ class Detokenizer:
          )
 
         self.decode_logprobs(seq,
-                              prms,
-                              seq.output_logprobs[-1],
-                              all_input_ids,
-                              generated_token_id_and_text=(all_input_ids[-1],
-                                                           new_output_text))
+                             prms,
+                             seq.output_logprobs[-1],
+                             all_input_ids,
+                             generated_token_id_and_text=(all_input_ids[-1],
+                                                          new_output_text))
 
         if seq.tokens is None:
             seq.tokens = new_tokens

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -1,0 +1,178 @@
+from typing import List, Dict, Tuple, Optional
+from transformers import PreTrainedTokenizer
+from vllm.sequence import Sequence, Logprob, SequenceGroup, SamplingParams
+from vllm.transformers_utils.tokenizer import (detokenize_incrementally,
+                                               convert_prompt_ids_to_tokens)
+from vllm.transformers_utils.tokenizer_group.base_tokenizer_group import BaseTokenizerGroup
+
+class Detokenizer:
+    """Provides methods to decode the output of a model into text."""
+
+    def __init__(self, tokenizer_group: BaseTokenizerGroup):
+        self.tokenizer_group = tokenizer_group
+
+    def get_tokenizer_for_seq(self,
+                              sequence: Sequence) -> "PreTrainedTokenizer":
+        """Returns the HF tokenizer to use for a given sequence."""
+        return self.tokenizer_group.get_lora_tokenizer(sequence.lora_request)
+
+    def decode_logprobs(
+            self,
+            seq: Sequence,
+            prms: SamplingParams,
+            logprobs: Dict[int, Logprob],
+            all_input_ids: List[int],
+            generated_token_id_and_text: Optional[Tuple[int,
+                                                        str]] = None) -> None:
+        """Decodes the logprobs for a sequence. In-place operation.
+
+        Args:
+            seq: The sequence to decode.
+            prms: The sampling parameters used to generate the sequence.
+            logprobs: The logprobs to decode.
+            all_input_ids: The token IDs of the sequence, including the
+                token generated this iteration.
+            generated_token_id_and_text: The token ID and text of the token
+                generated this iteration. If provided, will be used to
+                avoid decoding the token again.
+        """
+        if not logprobs:
+            return
+        tokenizer = self.get_tokenizer_for_seq(seq)
+        previous_tokens = all_input_ids[:-1]
+        for token_id, sample_logprob in logprobs.items():
+            # If the token was generated this iteration, use the provided text.
+            if (generated_token_id_and_text is not None
+                    and token_id == generated_token_id_and_text[0]):
+                sample_logprob.decoded_token = generated_token_id_and_text[1]
+                continue
+
+            if (sample_logprob.decoded_token is None and token_id != -1):
+                all_input_ids_with_logprob = previous_tokens + [token_id]
+                (_, new_text, _, _) = detokenize_incrementally(
+                    tokenizer=tokenizer,
+                    all_input_ids=all_input_ids_with_logprob,
+                    prev_tokens=seq.tokens,
+                    prefix_offset=seq.prefix_offset,
+                    read_offset=seq.read_offset,
+                    skip_special_tokens=prms.skip_special_tokens,
+                    spaces_between_special_tokens=prms.
+                    spaces_between_special_tokens,
+                )
+                sample_logprob.decoded_token = new_text
+
+    def decode_prompt_logprobs(
+            self, seq_group: SequenceGroup,
+            prompt_logprobs: List[Dict[int,
+                                       Logprob]]) -> List[Dict[int, Logprob]]:
+        """Decodes the logprobs for the prompt of a sequence group.
+
+        Args:
+            seq_group: The sequence group to decode.
+            prompt_logprobs: The logprobs to decode.
+        
+        Returns:
+            The prompt logprobs with the decoded tokens.
+        """
+        prms = seq_group.sampling_params
+        # We can pick any sequence for the prompt.
+        seq = next(iter(seq_group.seqs_dict.values()))
+        # Only prompt, without the generated token.
+        all_token_ids = seq.get_token_ids()
+        prompt_token_ids = all_token_ids[:-1]
+        tokenizer = self.get_tokenizer_for_seq(seq)
+        prefix_offset = 0
+        read_offset = 0
+        next_iter_prefix_offset = 0
+        next_iter_read_offset = 0
+        next_iter_tokens = []
+        prev_tokens = None
+        first_non_none_index = 0
+
+        for token_position, prompt_logprobs_for_token in enumerate(prompt_logprobs):
+            if not prompt_logprobs_for_token:
+                first_non_none_index = token_position + 1
+                continue
+            for token_id, sample_logprob in prompt_logprobs_for_token.items():
+                if (sample_logprob.decoded_token is None and token_id != -1):
+                    prompt_token_ids_with_token = prompt_token_ids[:token_position] + [
+                        token_id
+                    ]
+                    (new_tokens, new_text, new_prefix_offset,
+                     new_read_offset) = detokenize_incrementally(
+                         tokenizer=tokenizer,
+                         all_input_ids=prompt_token_ids_with_token,
+                         prev_tokens=prev_tokens,
+                         prefix_offset=prefix_offset,
+                         read_offset=read_offset,
+                         skip_special_tokens=prms.skip_special_tokens,
+                         spaces_between_special_tokens=prms.
+                         spaces_between_special_tokens,
+                     )
+
+                    sample_logprob.decoded_token = new_text
+
+                    # Use the offsets & prev tokens corresponding to
+                    # real tokens to ensure detokenization is consistent
+                    # actual with prompt.
+                    if token_id == all_token_ids[token_position]:
+                        next_iter_prefix_offset = new_prefix_offset
+                        next_iter_read_offset = new_read_offset
+                        next_iter_tokens = new_tokens
+
+            # Advance to the next token position.
+            prefix_offset = next_iter_prefix_offset
+            read_offset = next_iter_read_offset
+            if prev_tokens is None:
+                prev_tokens = next_iter_tokens
+            else:
+                prev_tokens.extend(next_iter_tokens)
+
+        return prompt_logprobs[first_non_none_index:]
+
+    def decode_sequence(self, seq: Sequence, prms: SamplingParams) -> None:
+        """Decodes the new token for a sequence. In-place operation.
+
+        Args:
+            seq: The sequence to decode.
+            prms: The sampling parameters used to generate the sequence.
+        """
+        all_input_ids = seq.get_token_ids()
+        tokenizer = self.get_tokenizer_for_seq(seq)
+
+        # Convert prompt token IDs to tokens if necessary.
+        # Do it here so that we don't have to repeat this
+        # computation for each logprob.
+        if seq.tokens is None:
+            (seq.tokens, seq.prefix_offset,
+             seq.read_offset) = convert_prompt_ids_to_tokens(
+                 tokenizer=tokenizer,
+                 prompt_ids=all_input_ids[:-1],
+                 skip_special_tokens=prms.skip_special_tokens,
+             )
+
+        (new_tokens, new_output_text, prefix_offset,
+         read_offset) = detokenize_incrementally(
+             tokenizer=tokenizer,
+             all_input_ids=all_input_ids,
+             prev_tokens=seq.tokens,
+             prefix_offset=seq.prefix_offset,
+             read_offset=seq.read_offset,
+             skip_special_tokens=prms.skip_special_tokens,
+             spaces_between_special_tokens=prms.spaces_between_special_tokens,
+         )
+
+        self.decode_logprobs(seq,
+                              prms,
+                              seq.output_logprobs[-1],
+                              all_input_ids,
+                              generated_token_id_and_text=(all_input_ids[-1],
+                                                           new_output_text))
+
+        if seq.tokens is None:
+            seq.tokens = new_tokens
+        else:
+            seq.tokens.extend(new_tokens)
+        seq.prefix_offset = prefix_offset
+        seq.read_offset = read_offset
+        seq.output_text += new_output_text


### PR DESCRIPTION
<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to expand. Please read before submitting.) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>

---

This PR improved detokenization performance for the prefill step by doing the following:
1. Avoiding the detokenization of the entire prompt when unnecessary
2. Improving logprob token detokenization to avoid repeated computation
3. Making prompt logprob detokenization incremental

In order to facilitate testing, the detokenization logic is moved to its own abstraction.

Benchmark results (BS=1, the gain will be linear depending on the number of input tokens in a batch) on a single A10 GPU, with 5 logprobs to decode:
```python /home/ray/default/vllm_public/benchmarks/benchmark_latency.py --model meta-llama/Llama-2-7b-chat-hf  --batch-size 1 --output-len 2 --input-len 1000 --num-iters 1```
* Before PR: Avg latency: 0.292 seconds
* After PR: Avg latency: 0.287 seconds

Benchmark results on a single A10 GPU, with 5 prompt logprobs to decode:
```python /home/ray/default/vllm_public/benchmarks/benchmark_latency.py --model meta-llama/Llama-2-7b-chat-hf  --batch-size 1 --output-len 2 --input-len 1000 --num-iters 1```
* Before PR: Avg latency: 2.133 seconds
* After PR: Avg latency: 0.362 seconds

