### PR TITLE
fix hipFuncSetAttribute API not found issue

### DIFF
--- a/csrc/cuda_compat.h
+++ b/csrc/cuda_compat.h
@@ -2,6 +2,7 @@
 
 #ifdef USE_ROCM
 #include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
 #endif
 
 #ifndef USE_ROCM


### PR DESCRIPTION
Without the header, hipFuncSetAttribute won't be able to find, which causes compilation errors.