### PR TITLE
specify that backend is openai, since server was started with openai entrypoint

### DIFF
--- a/examples/production_monitoring/README.md
+++ b/examples/production_monitoring/README.md
@@ -30,7 +30,8 @@ python3 ../../benchmarks/benchmark_serving.py \
     --tokenizer mistralai/Mistral-7B-v0.1 \
     --endpoint /v1/completions \
     --dataset ShareGPT_V3_unfiltered_cleaned_split.json \
-    --request-rate 3.0
+    --request-rate 3.0 \
+    --backend openai
 ```
 
 Navigating to [`http://localhost:8000/metrics`](http://localhost:8000/metrics) will show the raw Prometheus metrics being exposed by vLLM.


### PR DESCRIPTION
there is something wrong in https://github.com/vllm-project/vllm/tree/main/examples/production_monitoring
when server start with openai entrypoint
`
python3 -m vllm.entrypoints.openai.api_server --model mistralai/Mistral-7B-v0.1 --max-model-len 2048 --disable-log-requests
`

benchmark example
`
python3  benchmarks/benchmark_serving.py --model mistralai/Mistral-7B-v0.1 --tokenizer mistralai/Mistral-7B-v0.1 --endpoint /v1/completions --dataset /root/ShareGPT_V3_unfiltered_cleaned_split.json --request-rate 3.0 --num-prompt 10 
`

should use '--backend openai' while default backend is vllm, otherwise, it will cause an error

`Namespace(backend='vllm', version='N/A', base_url=None, host='localhost', port=8000, endpoint='/v1/completions', dataset='/root/ShareGPT_V3_unfiltered_cleaned_split.json', model='mistralai/Mistral-7B-v0.1', tokenizer='mistralai/Mistral-7B-v0.1', best_of=1, use_beam_search=False, num_prompts=10, request_rate=3.0, seed=0, trust_remote_code=False, disable_tqdm=False, save_result=False)
Traffic request rate: 3.0
  0%|                                                                                            | 0/10 [00:00<?, ?it/s]Traceback (most recent call last):
  File "/root/vllm/benchmarks/benchmark_serving.py", line 389, in <module>
    main(args)
  File "/root/vllm/benchmarks/benchmark_serving.py", line 259, in main
    benchmark_result = asyncio.run(
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/root/vllm/benchmarks/benchmark_serving.py", line 195, in benchmark
    outputs = await asyncio.gather(*tasks)
  File "/root/vllm/benchmarks/backend_request_func.py", line 85, in async_request_vllm
    assert api_url.endswith("generate")
AssertionError
  0%|                                                                                            | 0/10 [00:04<?, ?it/s]
`



