### PR TITLE
[Bugfix] use SoftLockFile instead of LockFile

### DIFF
--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -34,7 +34,7 @@ def get_lock(model_name_or_path: str, cache_dir: Optional[str] = None):
     lock_dir = cache_dir if cache_dir is not None else _vllm_filelocks_path
     os.makedirs(os.path.dirname(lock_dir), exist_ok=True)
     lock_file_name = model_name_or_path.replace("/", "-") + ".lock"
-    lock = filelock.FileLock(os.path.join(lock_dir, lock_file_name))
+    lock = filelock.SoftFileLock(os.path.join(lock_dir, lock_file_name))
     return lock
 
 


### PR DESCRIPTION
`filelock.LockFile` does not delete the `.lock` file it created. Use `filelock.SoftLockFile` instead to remove `.lock` when it is no longer needed. This prevents another user from referencing an unused `.lock` file and causing an error.

FIX #2232 #2179 #2675 

<details><summary>sample code</summary>

The following script will delete the `a.lock` file created during execution after 5 seconds and finish execution.

Changing SoftLockFile to LockFile leaves the `a.lock` file undeleted on exit

```py
import filelock
import time

with filelock.SoftFileLock("a.lock"):
    time.sleep(5)
```

</details>