### PR TITLE
[BugFix] Fix Falcon tied embeddings

### DIFF
--- a/vllm/model_executor/models/falcon.py
+++ b/vllm/model_executor/models/falcon.py
@@ -37,7 +37,7 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.sampler import Sampler
 from vllm.model_executor.layers.vocab_parallel_embedding import (
-    VocabParallelEmbedding, ParallelLMHead)
+    VocabParallelEmbedding)
 from vllm.model_executor.parallel_utils.communication_op import (
     tensor_model_parallel_all_reduce)
 from vllm.model_executor.parallel_utils.parallel_state import (


### PR DESCRIPTION
Supersedes #3579

This PR fixes a bug that vLLM does not use tied embeddings for Falcon models. This bug didn't appear on Falcon-7B since the checkpoint has duplicated weights for word embeddings and LM head. However, the bug appeared for other Falcon models who don't duplicate the weights. The PR was tested on both Falcon-7B and Falcon-40B.