### PR TITLE
[Misc] Bump transformers version

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -7,7 +7,7 @@ ray >= 2.9
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 tokenizers>=0.15.0
-transformers >= 4.39.0  # Required for StarCoder2.
+transformers >= 4.39.1  # Required for StarCoder2 & Llava.
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ray >= 2.9
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
 torch == 2.1.2
-transformers >= 4.39.0  # Required for StarCoder2.
+transformers >= 4.39.1  # Required for StarCoder2 & Llava.
 xformers == 0.0.23.post1  # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
Bump `transformers` version to `>=4.39.1`. This is necessary since `4.39.1` patched some [breaking changes](https://github.com/huggingface/transformers/releases/tag/v4.39.1) to LLaVA model that would block https://github.com/vllm-project/vllm/pull/3042.



