### PR TITLE
[CI/Build] respect the common environment variable MAX_JOBS

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -61,6 +61,15 @@ You can also build and install vLLM from source:
     $ pip install -e .  # This may take 5-10 minutes.
 
 .. tip::
+    To avoid your system being overloaded, you can limit the number of compilation jobs
+    to be run simultaneously, via the environment variable `MAX_JOBS`. For example:
+
+    .. code-block:: console
+
+        $ export MAX_JOBS=6
+        $ pip install -e .
+
+.. tip::
     If you have trouble building vLLM, we recommend using the NVIDIA PyTorch Docker image.
 
     .. code-block:: console


### PR DESCRIPTION
The default config crashes my devbox with g2-standard-24 VM. It is often the case in projects requiring compiling cuda kernels, such as xformers (related issue: https://github.com/facebookresearch/xformers/issues/748 ).

This PR respects the commonly used environment variable `MAX_JOBS`, and add a note in the installation guide documentation.

I tested it in my devbox, and it works well.