### PR TITLE
hotfix isort on logprobs ranks pr

### DIFF
--- a/tests/samplers/test_ranks.py
+++ b/tests/samplers/test_ranks.py
@@ -1,4 +1,5 @@
 import pytest
+
 from vllm import SamplingParams
 
 MODELS = ["facebook/opt-125m"]

--- a/tests/samplers/test_sampler.py
+++ b/tests/samplers/test_sampler.py
@@ -9,8 +9,8 @@ from transformers import GenerationConfig, GenerationMixin
 from vllm.model_executor.layers.sampler import Sampler
 from vllm.model_executor.utils import set_random_seed
 from vllm.sequence import SamplingParams, SequenceData, SequenceGroupMetadata
-from vllm.worker.model_runner import ModelRunner
 from vllm.utils import Counter
+from vllm.worker.model_runner import ModelRunner
 
 
 class MockLogitsSampler(Sampler):


### PR DESCRIPTION
There were some merge ordering issue made the main branch breaking lint. This PR reruns isort and fixes it. 