### PR TITLE
[Bugfix] Fix ipv6 address parsing bug

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -205,7 +205,7 @@ def get_ip() -> str:
 
 
 def get_distributed_init_method(ip: str, port: int) -> str:
-    return f"tcp://{ip}:{port}"
+    return f"tcp://[{ip}]:{port}"
 
 
 def get_open_port() -> int:


### PR DESCRIPTION
In a pure IPv6 environment, the `get_distributed_init_method` function in `vllm/utils.py` returns a URL such as "tcp://2001:4860:4860::8888:8086", where "2001:4860:4860::8888" is the IP address. This format leads to an error when `urllib.parse.urlparse` attempts to parse the URL and extract the port number:
```
>>> urllib.parse.urlparse("tcp://2001:4860:4860::8888:8086").port
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/mambaforge/envs/vllm/lib/python3.10/urllib/parse.py", line 185, in port
    raise ValueError(f"Port could not be cast to integer value as {port!r}")
ValueError: Port could not be cast to integer value as '4860:4860::8888:8086'
```
We can resolve this issue by constructing the URL with square brackets around the IPv6 address, like so: "tcp://[2001:4860:4860::8888]:8086". With this format, the port is correctly parsed:
```
>>> urllib.parse.urlparse("tcp://[2001:4860:4860::8888]:8086").port
8086
```
This fix addresses a new bug encountered following the fix for issue #2685 