### PR TITLE
[BugFix] Fix ipv4 address parsing regression

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -205,6 +205,8 @@ def get_ip() -> str:
 
 
 def get_distributed_init_method(ip: str, port: int) -> str:
+    # Brackets are not permitted in ipv4 addresses,
+    # see https://github.com/python/cpython/issues/103848
     return f"tcp://[{ip}]:{port}" if ":" in ip else f"tcp://{ip}:{port}"
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -205,7 +205,7 @@ def get_ip() -> str:
 
 
 def get_distributed_init_method(ip: str, port: int) -> str:
-    return f"tcp://[{ip}]:{port}"
+    return f"tcp://[{ip}]:{port}" if ":" in ip else f"tcp://{ip}:{port}"
 
 
 def get_open_port() -> int:


### PR DESCRIPTION
#3641 was a fix for ipv6 but broke ipv4 case.

```
  File "/workspace/vllm/worker/worker.py", line 100, in init_device
    init_distributed_environment(self.parallel_config, self.rank,
  File "/workspace/vllm/worker/worker.py", line 269, in init_distributed_environment
    torch.distributed.init_process_group(
  File "/opt/vllm/lib/python3.11/site-packages/torch/distributed/c10d_logger.py", line 74, in wrapper
    func_return = func(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 1138, in init_process_group
    rendezvous_iterator = rendezvous(
                          ^^^^^^^^^^^
  File "/opt/vllm/lib/python3.11/site-packages/torch/distributed/rendezvous.py", line 98, in rendezvous
    return _rendezvous_helper(url, rank, world_size, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib/python3.11/site-packages/torch/distributed/rendezvous.py", line 60, in _rendezvous_helper
    result = urlparse(url)
             ^^^^^^^^^^^^^
  File "/opt/vllm/lib/python3.11/urllib/parse.py", line 395, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/vllm/lib/python3.11/urllib/parse.py", line 500, in urlsplit
    _check_bracketed_host(bracketed_host)
  File "/opt/vllm/lib/python3.11/urllib/parse.py", line 448, in _check_bracketed_host
    raise ValueError(f"An IPv4 address cannot be in brackets")
ValueError: An IPv4 address cannot be in brackets

```