### PR TITLE
[Bugfix] [Hotfix] fix nccl library name

### DIFF
--- a/vllm/model_executor/parallel_utils/pynccl.py
+++ b/vllm/model_executor/parallel_utils/pynccl.py
@@ -39,9 +39,9 @@ if so_file:
         f"Loading nccl from environment variable VLLM_NCCL_SO_PATH={so_file}")
 else:
     if torch.version.cuda is not None:
-        so_file = "libnccl.so"
+        so_file = "libnccl.so.2"
     elif torch.version.hip is not None:
-        so_file = "librccl.so"
+        so_file = "librccl.so.2"
     else:
         raise ValueError("NCCL only supports CUDA and ROCm backends.")
     logger.debug(f"Loading nccl from library {so_file}")


### PR DESCRIPTION
Usually, the convention for dynamic shared library is: for nccl version 2.18.3, there would be a file `libnccl.so.2.18.3`, and the following files linked to that file:
- `libnccl.so.2.18`
- `libnccl.so.2`
- `libncclso.`

This is often the case for system-installed nccl, e.g. our CI machine, in `/usr/lib/x86_64-linux-gnu/libnccl.so` .

However, the version pytorch installs, does not follow this convention. It is just named as s single file `libnccl.so.2`.

This PR will make pure pytorch users happy.