### PR TITLE
[Model][Misc] Add MistralModel and Embedding API

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -85,6 +85,7 @@ class ModelConfig:
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,
         max_logprobs: int = 5,
+        embedding_mode: Optional[bool] = False,
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
@@ -100,6 +101,7 @@ class ModelConfig:
         self.enforce_eager = enforce_eager
         self.max_context_len_to_capture = max_context_len_to_capture
         self.max_logprobs = max_logprobs
+        self.embedding_mode = embedding_mode
 
         if os.environ.get("VLLM_USE_MODELSCOPE", "False").lower() == "true":
             # download model from ModelScope hub,
@@ -402,7 +404,7 @@ class CacheConfig:
 @dataclass
 class TokenizerPoolConfig:
     """Configuration for the tokenizer pool.
-    
+
     Args:
         pool_size: Number of tokenizer workers in the pool.
         pool_type: Type of the pool.
@@ -426,9 +428,9 @@ class TokenizerPoolConfig:
         tokenizer_pool_extra_config: Optional[Union[str, dict]]
     ) -> Optional["TokenizerPoolConfig"]:
         """Create a TokenizerPoolConfig from the given parameters.
-        
+
         If tokenizer_pool_size is 0, return None.
-        
+
         Args:
             tokenizer_pool_size: Number of tokenizer workers in the pool.
             tokenizer_pool_type: Type of the pool.
@@ -528,6 +530,7 @@ class SchedulerConfig:
             and generated text).
         delay_factor: Apply a delay (of delay factor multiplied by previous
             prompt latency) before scheduling next prompt.
+        embedding_mode: Whether the running model is for embedding.
     """
 
     def __init__(
@@ -536,6 +539,7 @@ class SchedulerConfig:
         max_num_seqs: int,
         max_model_len: int,
         delay_factor: float = 0.0,
+        embedding_mode: Optional[bool] = False,
     ) -> None:
         if max_num_batched_tokens is not None:
             self.max_num_batched_tokens = max_num_batched_tokens
@@ -546,6 +550,7 @@ class SchedulerConfig:
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len
         self.delay_factor = delay_factor
+        self.embedding_mode = embedding_mode
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -592,3 +592,60 @@ class BlockSpaceManager:
         if self.enable_caching:
             for seq in seq_group.seqs_dict.values():
                 self.compute_full_blocks_in_seq(seq)
+
+
+class DummyBlockSpaceManager:
+    """A no-operation version of BlockSpaceManager for use in environments where block management is not required.
+
+    This class provides the same interface as BlockSpaceManager, but its methods perform no actions. It's designed
+    to be used in scenarios where the overhead of block management is unnecessary, such as in an embedding server
+    environment."""
+
+    def __init__(
+        self,
+        block_size: int,
+        num_gpu_blocks: int,
+        num_cpu_blocks: int,
+        watermark: float = 0.01,
+        sliding_window: Optional[int] = None,
+    ) -> None:
+        pass
+
+    def can_allocate(self, seq_group: SequenceGroup) -> AllocStatus:
+        # Always return OK for dummy purposes
+        return AllocStatus.OK
+
+    def allocate(self, seq_group: SequenceGroup) -> None:
+        # No actual allocation logic needed
+        pass
+
+    def free(self, seq: Sequence) -> None:
+        # No operation on free
+        pass
+
+    def append_slot(self, seq: Sequence) -> Optional[Tuple[int, int]]:
+        return None
+
+    def fork(self, parent_seq: Sequence, child_seq: Sequence) -> None:
+        pass
+
+    def swap_in(self, seq_group: SequenceGroup) -> Dict[int, int]:
+        return {}
+
+    def swap_out(self, seq_group: SequenceGroup) -> Dict[int, int]:
+        return {}
+
+    def can_swap_in(self, seq_group: SequenceGroup) -> bool:
+        return True
+
+    def can_swap_out(self, seq_group: SequenceGroup) -> bool:
+        return True
+
+    def get_block_table(self, seq: Sequence) -> List[int]:
+        return []
+
+    def reset(self) -> None:
+        pass
+
+    def can_append_slot(self, seq_group: SequenceGroup) -> bool:
+        return True

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -595,19 +595,17 @@ class BlockSpaceManager:
 
 
 class DummyBlockSpaceManager:
-    """A no-operation version of BlockSpaceManager for use in environments where block management is not required.
+    """A no-operation version of BlockSpaceManager for use in environments
+    where block management is not required.
 
-    This class provides the same interface as BlockSpaceManager, but its methods perform no actions. It's designed
-    to be used in scenarios where the overhead of block management is unnecessary, such as in an embedding server
-    environment."""
+    This class provides the same interface as BlockSpaceManager, but its
+    methods perform no actions. It's designed to be used in scenarios where
+    the overhead of block management is unnecessary, such as in an embedding
+    mode environment."""
 
     def __init__(
         self,
-        block_size: int,
-        num_gpu_blocks: int,
-        num_cpu_blocks: int,
-        watermark: float = 0.01,
-        sliding_window: Optional[int] = None,
+        **kwargs,
     ) -> None:
         pass
 
@@ -649,3 +647,23 @@ class DummyBlockSpaceManager:
 
     def can_append_slot(self, seq_group: SequenceGroup) -> bool:
         return True
+
+    def access_all_blocks_in_seq(
+        self,
+        seq: Sequence,
+        access_time: float,
+    ) -> None:
+        pass
+
+    def get_common_computed_block_ids(self,
+                                      seq_group: SequenceGroup) -> List[int]:
+        return []
+
+    def get_num_free_gpu_blocks(self) -> int:
+        return 1
+
+    def get_num_free_cpu_blocks(self) -> int:
+        return 1
+
+    def mark_blocks_as_computed(self, seq_group: SequenceGroup):
+        pass

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -4,7 +4,8 @@ from collections import deque
 from typing import Deque, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from vllm.config import CacheConfig, LoRAConfig, SchedulerConfig
-from vllm.core.block_manager import AllocStatus, BlockSpaceManager, DummyBlockSpaceManager
+from vllm.core.block_manager import (AllocStatus, BlockSpaceManager,
+                                     DummyBlockSpaceManager)
 from vllm.core.policy import PolicyFactory
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
@@ -94,7 +95,9 @@ class Scheduler:
         # Instantiate the scheduling policy.
         self.policy = PolicyFactory.get_policy(policy_name="fcfs")
         # Decide on the block manager class based on embedding mode
-        block_manager_class = DummyBlockSpaceManager if self.scheduler_config.embedding_mode else BlockSpaceManager
+        block_manager_class = (DummyBlockSpaceManager
+                               if self.scheduler_config.embedding_mode else
+                               BlockSpaceManager)
         self.block_manager = block_manager_class(
             block_size=cache_config.block_size,
             num_gpu_blocks=cache_config.num_gpu_blocks,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -58,6 +58,7 @@ class EngineArgs:
     image_input_shape: Optional[str] = None
     image_feature_size: Optional[int] = None
     scheduler_delay_factor: float = 0.0
+    embedding_mode: bool = False
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -343,6 +344,9 @@ class EngineArgs:
             default=EngineArgs.scheduler_delay_factor,
             help='Apply a delay (of delay factor multiplied by previous'
             'prompt latency) before scheduling next prompt.')
+        parser.add_argument("--embedding-mode",
+                            action="store_true",
+                            help="Enable embedding mode for the server")
         return parser
 
     @classmethod
@@ -365,7 +369,7 @@ class EngineArgs:
             self.dtype, self.seed, self.revision, self.code_revision,
             self.tokenizer_revision, self.max_model_len, self.quantization,
             self.enforce_eager, self.max_context_len_to_capture,
-            self.max_logprobs)
+            self.max_logprobs, self.embedding_mode)
         cache_config = CacheConfig(self.block_size,
                                    self.gpu_memory_utilization,
                                    self.swap_space, self.kv_cache_dtype,
@@ -383,7 +387,8 @@ class EngineArgs:
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.max_model_len,
-                                           self.scheduler_delay_factor)
+                                           self.scheduler_delay_factor,
+                                           model_config.embedding_mode)
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,
@@ -409,7 +414,7 @@ class EngineArgs:
             vision_language_config = None
 
         return (model_config, cache_config, parallel_config, scheduler_config,
-                device_config, lora_config, vision_language_config)
+                device_config, lora_config)
 
 
 @dataclass

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -414,7 +414,7 @@ class EngineArgs:
             vision_language_config = None
 
         return (model_config, cache_config, parallel_config, scheduler_config,
-                device_config, lora_config)
+                device_config, lora_config, vision_language_config)
 
 
 @dataclass

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -54,7 +54,8 @@ class AsyncStream:
         self._queue = asyncio.Queue()
         self._finished = False
 
-    def put(self, item: Union[RequestOutput, EmbeddingRequestOutput, Exception]) -> None:
+    def put(self, item: Union[RequestOutput, EmbeddingRequestOutput,
+                              Exception]) -> None:
         if self._finished:
             return
         self._queue.put_nowait(item)

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -13,7 +13,7 @@ from vllm.engine.llm_engine import LLMEngine
 from vllm.engine.ray_utils import initialize_ray_cluster, ray
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.outputs import RequestOutput
+from vllm.outputs import RequestOutput, EmbeddingRequestOutput
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import MultiModalData
 
@@ -46,15 +46,15 @@ def _raise_exception_on_finish(
 
 
 class AsyncStream:
-    """A stream of RequestOutputs for a request that can be
-    iterated over asynchronously."""
+    """A stream of RequestOutputs or EmbeddingRequestOutputs for a request
+    that can be iterated over asynchronously."""
 
     def __init__(self, request_id: str) -> None:
         self.request_id = request_id
         self._queue = asyncio.Queue()
         self._finished = False
 
-    def put(self, item: Union[RequestOutput, Exception]) -> None:
+    def put(self, item: Union[RequestOutput, EmbeddingRequestOutput, Exception]) -> None:
         if self._finished:
             return
         self._queue.put_nowait(item)
@@ -70,7 +70,7 @@ class AsyncStream:
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> RequestOutput:
+    async def __anext__(self) -> Union[RequestOutput, EmbeddingRequestOutput]:
         result = await self._queue.get()
         if isinstance(result, Exception):
             raise result
@@ -107,7 +107,8 @@ class RequestTracker:
                 self.abort_request(rid)
 
     def process_request_output(self,
-                               request_output: RequestOutput,
+                               request_output: Union[RequestOutput,
+                                                     EmbeddingRequestOutput],
                                *,
                                verbose: bool = False) -> None:
         """Process a request output from the engine."""
@@ -195,7 +196,8 @@ class RequestTracker:
 class _AsyncLLMEngine(LLMEngine):
     """Extension of LLMEngine to add async methods."""
 
-    async def step_async(self) -> List[RequestOutput]:
+    async def step_async(
+            self) -> List[Union[RequestOutput, EmbeddingRequestOutput]]:
         """Performs one decoding iteration and returns newly generated results.
         The workers are ran asynchronously if possible.
 
@@ -550,7 +552,7 @@ class AsyncLLMEngine:
         prompt_token_ids: Optional[List[int]] = None,
         lora_request: Optional[LoRARequest] = None,
         multi_modal_data: Optional[MultiModalData] = None
-    ) -> AsyncIterator[RequestOutput]:
+    ) -> AsyncIterator[Union[RequestOutput, EmbeddingRequestOutput]]:
         """Generate outputs for a request.
 
         Generate outputs for a request. This method is a coroutine. It adds the
@@ -568,8 +570,8 @@ class AsyncLLMEngine:
             multi_modal_data: Multi modal data per request.
 
         Yields:
-            The output `RequestOutput` objects from the LLMEngine for the
-            request.
+            The output `RequestOutput` or `EmbeddingRequestOutput` objects
+            from the LLMEngine for the request.
 
         Details:
             - If the engine is not running, start the background loop,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -16,9 +16,9 @@ from vllm.lora.request import LoRARequest
 from vllm.outputs import (EmbeddingRequestOutput, RequestOutput,
                           RequestOutputFactory)
 from vllm.sampling_params import SamplingParams
-from vllm.sequence import (EmbeddingSequenceGroupOutput, MultiModalData, SamplerOutput, Sequence,
-                           SequenceGroup, SequenceGroupOutput, SequenceOutput,
-                           SequenceStatus)
+from vllm.sequence import (EmbeddingSequenceGroupOutput, MultiModalData,
+                           SamplerOutput, Sequence, SequenceGroup,
+                           SequenceGroupOutput, SequenceOutput, SequenceStatus)
 from vllm.transformers_utils.detokenizer import Detokenizer
 from vllm.transformers_utils.tokenizer_group import (BaseTokenizerGroup,
                                                      get_tokenizer_group)
@@ -666,22 +666,16 @@ class LLMEngine:
         now = time.time()
 
         # KV Cache Usage in %.
-        if not self.model_config.embedding_mode:
-            num_total_gpu = self.cache_config.num_gpu_blocks
-            num_free_gpu = self.scheduler.block_manager.get_num_free_gpu_blocks(
-            )
-            gpu_cache_usage = 1.0 - (num_free_gpu / num_total_gpu)
+        num_total_gpu = self.cache_config.num_gpu_blocks
+        num_free_gpu = self.scheduler.block_manager.get_num_free_gpu_blocks()
+        gpu_cache_usage = 1.0 - (num_free_gpu / num_total_gpu)
 
-            num_total_cpu = self.cache_config.num_cpu_blocks
-            cpu_cache_usage = 0.
-            if num_total_cpu > 0:
-                num_free_cpu = self.scheduler.block_manager.get_num_free_cpu_blocks(
-                )
-                cpu_cache_usage = 1.0 - (num_free_cpu / num_total_cpu)
-        else:
-            # No need to log KV cache usage in embedding mode
-            gpu_cache_usage = 0
-            cpu_cache_usage = 0
+        num_total_cpu = self.cache_config.num_cpu_blocks
+        cpu_cache_usage = 0.
+        if num_total_cpu > 0:
+            num_free_cpu = self.scheduler.block_manager.get_num_free_cpu_blocks(
+            )
+            cpu_cache_usage = 1.0 - (num_free_cpu / num_total_cpu)
 
         # Scheduler State
         num_running = len(self.scheduler.running)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -654,16 +654,22 @@ class LLMEngine:
         now = time.time()
 
         # KV Cache Usage in %.
-        num_total_gpu = self.cache_config.num_gpu_blocks
-        num_free_gpu = self.scheduler.block_manager.get_num_free_gpu_blocks()
-        gpu_cache_usage = 1.0 - (num_free_gpu / num_total_gpu)
-
-        num_total_cpu = self.cache_config.num_cpu_blocks
-        cpu_cache_usage = 0.
-        if num_total_cpu > 0:
-            num_free_cpu = self.scheduler.block_manager.get_num_free_cpu_blocks(
+        if not self.model_config.embedding_mode:
+            num_total_gpu = self.cache_config.num_gpu_blocks
+            num_free_gpu = self.scheduler.block_manager.get_num_free_gpu_blocks(
             )
-            cpu_cache_usage = 1.0 - (num_free_cpu / num_total_cpu)
+            gpu_cache_usage = 1.0 - (num_free_gpu / num_total_gpu)
+
+            num_total_cpu = self.cache_config.num_cpu_blocks
+            cpu_cache_usage = 0.
+            if num_total_cpu > 0:
+                num_free_cpu = self.scheduler.block_manager.get_num_free_cpu_blocks(
+                )
+                cpu_cache_usage = 1.0 - (num_free_cpu / num_total_cpu)
+        else:
+            # No need to log KV cache usage in embedding mode
+            gpu_cache_usage = 0
+            cpu_cache_usage = 0
 
         # Scheduler State
         num_running = len(self.scheduler.running)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -18,7 +18,8 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              CompletionRequest, ErrorResponse)
+                                              CompletionRequest,
+                                              EmbeddingRequest, ErrorResponse)
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 from vllm.entrypoints.openai.serving_embedding import OpenAIServingEmbedding

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -21,12 +21,14 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               CompletionRequest, ErrorResponse)
 from vllm.entrypoints.openai.serving_chat import OpenAIServingChat
 from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
+from vllm.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
 from vllm.logger import init_logger
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds
 
 openai_serving_chat: OpenAIServingChat = None
 openai_serving_completion: OpenAIServingCompletion = None
+openai_serving_embedding: OpenAIServingEmbedding = None
 logger = init_logger(__name__)
 
 
@@ -111,6 +113,17 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         return JSONResponse(content=generator.model_dump())
 
 
+@app.post("/v1/embedding")
+async def create_embedding(request: EmbeddingRequest, raw_request: Request):
+    generator = await openai_serving_embedding.create_embedding(
+        request, raw_request)
+    if isinstance(generator, ErrorResponse):
+        return JSONResponse(content=generator.model_dump(),
+                            status_code=generator.code)
+    else:
+        return JSONResponse(content=generator.model_dump())
+
+
 if __name__ == "__main__":
     args = parse_args()
 
@@ -160,7 +173,7 @@ if __name__ == "__main__":
                                             args.chat_template)
     openai_serving_completion = OpenAIServingCompletion(
         engine, served_model, args.lora_modules)
-
+    openai_serving_embedding = OpenAIServingEmbedding(engine, served_model)
     app.root_path = args.root_path
     uvicorn.run(app,
                 host=args.host,

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -13,35 +13,12 @@ from vllm.entrypoints.openai.protocol import (
 )
 from vllm.outputs import EmbeddingRequestOutput
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
+from vllm.entrypoints.openai.serving_completion import parse_prompt_format
 from vllm.sampling_params import SamplingParams
 
 logger = init_logger(__name__)
 
 TypeTokenIDs = List[int]
-
-
-def parse_prompt_format(prompt) -> Tuple[bool, list]:
-    # get the prompt, openai supports the following
-    # "a string, array of strings, array of tokens, or array of token arrays."
-    prompt_is_tokens = False
-    prompts = [prompt]  # case 1: a string
-    if isinstance(prompt, list):
-        if len(prompt) == 0:
-            raise ValueError("please provide at least one prompt")
-        elif isinstance(prompt[0], str):
-            prompt_is_tokens = False
-            prompts = prompt  # case 2: array of strings
-        elif isinstance(prompt[0], int):
-            prompt_is_tokens = True
-            prompts = [prompt]  # case 3: array of tokens
-        elif isinstance(prompt[0], list) and isinstance(prompt[0][0], int):
-            prompt_is_tokens = True
-            prompts = prompt  # case 4: array of token arrays
-        else:
-            raise ValueError(
-                "prompt must be a string, array of strings, array of tokens, or array of token arrays"
-            )
-    return prompt_is_tokens, prompts
 
 
 def request_output_to_embedding_response(

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -1,0 +1,174 @@
+import asyncio
+import time
+from fastapi import Request
+from typing import AsyncIterator, List, Tuple
+from vllm.logger import init_logger
+from vllm.utils import random_uuid
+from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.entrypoints.openai.protocol import (
+    EmbeddingRequest,
+    EmbeddingResponse,
+    EmeddingResponseData,
+    UsageInfo,
+)
+from vllm.outputs import EmbeddingRequestOutput
+from vllm.entrypoints.openai.serving_engine import OpenAIServing
+from vllm.sampling_params import SamplingParams
+
+logger = init_logger(__name__)
+
+TypeTokenIDs = List[int]
+
+
+def parse_prompt_format(prompt) -> Tuple[bool, list]:
+    # get the prompt, openai supports the following
+    # "a string, array of strings, array of tokens, or array of token arrays."
+    prompt_is_tokens = False
+    prompts = [prompt]  # case 1: a string
+    if isinstance(prompt, list):
+        if len(prompt) == 0:
+            raise ValueError("please provide at least one prompt")
+        elif isinstance(prompt[0], str):
+            prompt_is_tokens = False
+            prompts = prompt  # case 2: array of strings
+        elif isinstance(prompt[0], int):
+            prompt_is_tokens = True
+            prompts = [prompt]  # case 3: array of tokens
+        elif isinstance(prompt[0], list) and isinstance(prompt[0][0], int):
+            prompt_is_tokens = True
+            prompts = prompt  # case 4: array of token arrays
+        else:
+            raise ValueError(
+                "prompt must be a string, array of strings, array of tokens, or array of token arrays"
+            )
+    return prompt_is_tokens, prompts
+
+
+def request_output_to_embedding_response(
+    final_res_batch: List[EmbeddingRequestOutput],
+    request_id: str,
+    created_time: int,
+    model_name: str,
+) -> EmbeddingResponse:
+    data = []
+    num_prompt_tokens = 0
+    for idx, final_res in enumerate(final_res_batch):
+        assert final_res is not None
+        prompt_token_ids = final_res.prompt_token_ids
+
+        embedding_data = EmeddingResponseData(
+            index=idx, embedding=final_res.outputs.embedding)
+        data.append(embedding_data)
+
+        num_prompt_tokens += len(prompt_token_ids)
+
+    usage = UsageInfo(
+        prompt_tokens=num_prompt_tokens,
+        total_tokens=num_prompt_tokens,
+    )
+
+    return EmbeddingResponse(
+        id=request_id,
+        created=created_time,
+        model=model_name,
+        data=data,
+        usage=usage,
+    )
+
+
+def merge_async_iterators(*iterators):
+    """Merge multiple asynchronous iterators into a single iterator.
+
+    This method handle the case where some iterators finish before others.
+    When it yields, it yields a tuple (i, item) where i is the index of the
+    iterator that yields the item.
+    """
+    queue = asyncio.Queue()
+
+    finished = [False] * len(iterators)
+
+    async def producer(i, iterator):
+        async for item in iterator:
+            await queue.put((i, item))
+        finished[i] = True
+
+    _tasks = [
+        asyncio.create_task(producer(i, iterator))
+        for i, iterator in enumerate(iterators)
+    ]
+
+    async def consumer():
+        while not all(finished) or not queue.empty():
+            item = await queue.get()
+            yield item
+        await asyncio.gather(*_tasks)
+
+    return consumer()
+
+
+class OpenAIServingEmbedding(OpenAIServing):
+
+    def __init__(self, engine: AsyncLLMEngine, served_model: str):
+        super().__init__(engine=engine,
+                         served_model=served_model,
+                         lora_modules=None)
+
+    async def create_embedding(self, request: EmbeddingRequest,
+                               raw_request: Request):
+        """Completion API similar to OpenAI's API.
+
+        See https://platform.openai.com/docs/api-reference/embeddings/create
+        for the API specification. This API mimics the OpenAI Embedding API.
+        """
+        error_check_ret = await self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
+
+        # Return error for unsupported features.
+        if request.encoding_format == "base64":
+            return self.create_error_response(
+                "base64 encoding is not currently supported")
+        if request.dimensions is not None:
+            return self.create_error_response(
+                "dimensions is currently not supported")
+
+        model_name = request.model
+        request_id = f"cmpl-{random_uuid()}"
+        created_time = int(time.monotonic())
+
+        # Schedule the request and get the result generator.
+        generators = []
+        try:
+            prompt_is_tokens, prompts = parse_prompt_format(request.input)
+
+            for i, prompt in enumerate(prompts):
+                if prompt_is_tokens:
+                    input_ids = self._validate_prompt_and_tokenize(
+                        request, prompt_ids=prompt)
+                else:
+                    input_ids = self._validate_prompt_and_tokenize(
+                        request, prompt=prompt)
+
+                generators.append(
+                    self.engine.generate(prompt,
+                                         SamplingParams(),
+                                         f"{request_id}-{i}",
+                                         prompt_token_ids=input_ids))
+        except ValueError as e:
+            return self.create_error_response(str(e))
+
+        result_generator: AsyncIterator[Tuple[
+            int, EmbeddingRequestOutput]] = merge_async_iterators(*generators)
+
+        # Non-streaming response
+        final_res_batch: EmbeddingRequestOutput = [None] * len(prompts)
+        async for i, res in result_generator:
+            if await raw_request.is_disconnected():
+                # Abort the request if the client disconnects.
+                await self.engine.abort(f"{request_id}-{i}")
+                return self.create_error_response("Client disconnected")
+            final_res_batch[i] = res
+        response = request_output_to_embedding_response(
+            final_res_batch, request_id, created_time, model_name)
+
+        return response

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -6,7 +6,8 @@ from typing import Dict, List, Optional, Union
 
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              CompletionRequest, ErrorResponse,
+                                              CompletionRequest,
+                                              EmbeddingRequest, ErrorResponse,
                                               LogProbs, ModelCard, ModelList,
                                               ModelPermission)
 from vllm.logger import init_logger
@@ -170,7 +171,8 @@ class OpenAIServing:
 
     def _validate_prompt_and_tokenize(
             self,
-            request: Union[ChatCompletionRequest, CompletionRequest],
+            request: Union[ChatCompletionRequest, CompletionRequest,
+                           EmbeddingRequest],
             prompt: Optional[str] = None,
             prompt_ids: Optional[List[int]] = None) -> List[int]:
         if not (prompt or prompt_ids):

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -36,6 +36,7 @@ _MODELS = {
     # For decapoda-research/llama-*
     "LLaMAForCausalLM": ("llama", "LlamaForCausalLM"),
     "MistralForCausalLM": ("llama", "LlamaForCausalLM"),
+    "MistralModel": ("llama", "LlamaModel"),
     "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"),
     "QuantMixtralForCausalLM": ("mixtral_quant", "MixtralForCausalLM"),
     # transformers's mpt class has lower case

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -360,11 +360,13 @@ class LlamaForCausalLM(nn.Module):
         next_tokens = self.sampler(logits, sampling_metadata)
         return next_tokens
 
-    def load_weights(self,
-                     model_name_or_path: str,
-                     cache_dir: Optional[str] = None,
-                     load_format: str = "auto",
-                     revision: Optional[str] = None):
+    def load_weights(
+        self,
+        model_name_or_path: str,
+        cache_dir: Optional[str] = None,
+        load_format: str = "auto",
+        revision: Optional[str] = None,
+    ):
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
             ("qkv_proj", "q_proj", "q"),

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -175,7 +175,7 @@ class EmbeddingRequestOutput:
         request_id (str): A unique identifier for the embedding request.
         outputs (EmbeddingOutput): The embedding results for the given input.
         prompt_token_ids (List[int]): A list of token IDs used in the prompt.
-        finished (bool): A flag indicating whether the embedding process is completed.
+        finished (bool): A flag indicating whether the embedding is completed.
     """
 
     def __init__(self, request_id: str, outputs: 'EmbeddingOutput',
@@ -198,8 +198,8 @@ class EmbeddingRequestOutput:
         """
         Returns a string representation of an EmbeddingRequestOutput instance.
 
-        The representation includes the request_id and the number of outputs, providing
-        a quick overview of the embedding request's results.
+        The representation includes the request_id and the number of outputs,
+        providing a quick overview of the embedding request's results.
 
         Returns:
             str: A string representation of the EmbeddingRequestOutput instance.

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -587,7 +587,7 @@ class SamplerOutput:
     """For each sequence group, we generate a list of SequenceOutput object,
     each of which contains one possible candidate for the next token.
 
-    This datastructure implements methods so it can be used like a list, but
+    This data structure implements methods so it can be used like a list, but
     also has optional fields for device tensors.
     """
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -657,11 +657,16 @@ class ModelRunner:
         if not sampling_metadata.perform_sampling:
             return None
 
-        # Sample the next token.
-        output = self.model.sample(
-            logits=logits,
-            sampling_metadata=sampling_metadata,
-        )
+        if self.model_config.embedding_mode:
+            # Get embedding vectors.
+            output = self.model.embedding(input_ids=input_tokens,
+                                          hidden_states=hidden_states)
+        else:
+            # Sample the next token.
+            output = self.model.sample(
+                hidden_states=hidden_states,
+                sampling_metadata=sampling_metadata,
+            )
         return output
 
     @torch.inference_mode()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -166,7 +166,8 @@ class Worker:
 
         while not out_of_memory:
             try:
-                # Adjust profile_run to take and use a batch_size argument for embedding profiling
+                # Adjust profile_run to take and use a batch_size argument
+                # for embedding profiling
                 self.model_runner.profile_run(
                     max_num_batched_tokens=initial_batch_size * max_model_len)
                 # If successful, increment the batch size
@@ -174,9 +175,10 @@ class Worker:
                 initial_batch_size *= step_size
             except RuntimeError as e:
                 if "CUDA out of memory" in str(e):
-                    out_of_memory = True  # Exit the loop if a CUDA OOM error is encountered
+                    # Exit the loop if a CUDA OOM error is encountered
+                    out_of_memory = True
                 else:
-                    raise  # Reraise unexpected errors
+                    raise  # Re-raise unexpected errors
 
             torch.cuda.synchronize()
             # Clear the CUDA memory after each attempt to ensure a fresh start


### PR DESCRIPTION
Fix generation in model_runner.py and formatting
- Fix model.sample and embedding generation in model_runner.py
- Format files changed
- Fix embedding in llama.py as input_tokens' shape has changed
- Enable embedding in ray_gpu_executor.py

**Add Embedding generation**

Add Embedding API to entrypoints/openai
- Add EmbeddingRequest and Response to protocol
- Add serving_embedding
- Add OpenAIServingEmbedding to api_server
- Make llm.py work with embedding

Add Embedding in outputs and sequence
- Add EmbeddingOutput, EmbeddingRequestOutput, RequestOutputFactory and
EmbeddingSequenceGroupOutput to support process the embedding output
sequence
- Update process output and sequence in *llm_engine to use embedding

Add MistralModel and embedding generation
- Add embedding and load_weights in LlamaModel to support forward
- Adapted from code examples in https://huggingface.co/intfloat/e5-mistral-7b
-instruct
- Ensures the ops are run on GPU.
- Mistral uses LlamaModel
- Use embedding when embedding_mode is True in model_runner
- Add load_weights in llama.py to support embedding models

Uniform typing in multiple files
- Add EmbeddingRequestOutput to the output typing in llm,
async_llm_engine
- Add validation for max_tokens in EmbeddingRequest
- Fix __repr__ of EmbeddingSequenceGroupOutput

**Disable KV Cache for Embedding serving**

Update profiling max_batch_size logic
- Return max_batch_size as each Ray worker runs the profiling once

Skip slot_mapping with embedding mode
slot_mapping is only used in model_executor/layers/attention.py when
kv_cache is not None. In embedding mode we pass None kv_cache. So no
need to process slot_mapping.

Disable KV cache for embedding mode
- Add embedding_mode to ModelConfig and SchedulerConfig
- Add profile_max_batched_tokens_for_embedding to profile the
max_num_batched_tokens for embedding server mode
- Add DummyBlockManager for No-op block management in embedding mode