### PR TITLE
Fix build when nvtools is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,11 @@ find_package(Torch REQUIRED)
 # config is used for standalone C++ binaries that link against torch).
 # The `libtorch_python.so` library defines some of the glue code between
 # torch/python via pybind and is required by VLLM extensions for this
-# reason. So, add it by manually using `append_torchlib_if_found` from
-# torch's cmake setup.
+# reason. So, add it by manually with `find_library` using torch's
+# installed library path.
 #
-append_torchlib_if_found(torch_python)
+find_library(torch_python_LIBRARY torch_python PATHS
+  "${TORCH_INSTALL_PREFIX}/lib")
 
 #
 # Set up GPU language and check the torch version and warn if it isn't

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -327,8 +327,8 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   target_include_directories(${GPU_MOD_NAME} PRIVATE csrc
     ${GPU_INCLUDE_DIRECTORIES})
 
-  target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES}
-    ${GPU_LIBRARIES})
+  target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${torch_python_LIBRARY}
+    ${GPU_LINK_LIBRARIES})
 
   install(TARGETS ${GPU_MOD_NAME} LIBRARY DESTINATION ${GPU_DESTINATION})
 endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -328,7 +328,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
     ${GPU_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${torch_python_LIBRARY}
-    ${GPU_LIBRARIES})
+    ${CUDA_CUDA_LIB} ${CUDA_LIBRARIES} ${GPU_LIBRARIES})
 
   install(TARGETS ${GPU_MOD_NAME} LIBRARY DESTINATION ${GPU_DESTINATION})
 endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -281,7 +281,7 @@ endmacro()
 #                              not provided.
 # COMPILE_FLAGS <flags>      - Extra compiler flags passed to NVCC/hip.
 # INCLUDE_DIRECTORIES <dirs> - Extra include directories.
-# LINK_LIBRARIES <libraries> - Extra link libraries.
+# LIBRARIES <libraries>      - Extra link libraries.
 # WITH_SOABI                 - Generate library with python SOABI suffix name.
 #
 # Note: optimization level/debug info is set via cmake build type.
@@ -328,7 +328,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
     ${GPU_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${torch_python_LIBRARY}
-    ${GPU_LINK_LIBRARIES})
+    ${GPU_LIBRARIES})
 
   install(TARGETS ${GPU_MOD_NAME} LIBRARY DESTINATION ${GPU_DESTINATION})
 endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -330,9 +330,13 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${torch_python_LIBRARY}
     ${GPU_LIBRARIES})
 
-  if (GPU_LANGUAGE STREQUAL "HIP" OR GPU_LANGUAGE STREQUAL "CUDA")
-    target_link_libraries(${GPU_MOD_NAME} PRIVATE
-      ${CUDA_CUDA_LIB} ${CUDA_LIBRARIES})
+  # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
+  # dependencies that are not necessary and may not be installed.
+  if (GPU_LANGUAGE STREQUAL "CUDA")
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE ${CUDA_CUDA_LIB}
+      ${CUDA_LIBRARIES})
+  else()
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES})
   endif()
 
   install(TARGETS ${GPU_MOD_NAME} LIBRARY DESTINATION ${GPU_DESTINATION})

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -328,7 +328,12 @@ function (define_gpu_extension_target GPU_MOD_NAME)
     ${GPU_INCLUDE_DIRECTORIES})
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${torch_python_LIBRARY}
-    ${CUDA_CUDA_LIB} ${CUDA_LIBRARIES} ${GPU_LIBRARIES})
+    ${GPU_LIBRARIES})
+
+  if (GPU_LANGUAGE STREQUAL "HIP" OR GPU_LANGUAGE STREQUAL "CUDA")
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE
+      ${CUDA_CUDA_LIB} ${CUDA_LIBRARIES})
+  endif()
 
   install(TARGETS ${GPU_MOD_NAME} LIBRARY DESTINATION ${GPU_DESTINATION})
 endfunction()


### PR DESCRIPTION
Rather than adding all the `TORCH_LIBRARIES` to a target explicitly, we add a dependency on the `torch` target and `torch_python_LIBRARY`.  This should allow cmake to pick up the dependencies of `torch` and `torch_python_LIBRARY` without the need to explicitly enumerate them.  Since nvtools is not required, it should not throw an error since it is not listed explicitly.

I was able to reproduce the issue from #3673 using a fresh conda environment and made sure that the build was successful after making these changes.

Also fixed a typo in the comment for `define_gpu_extension_target`.