### PR TITLE
[Bugfix] Set enable_prefix_caching=True in prefix caching example

### DIFF
--- a/examples/offline_inference_with_prefix.py
+++ b/examples/offline_inference_with_prefix.py
@@ -22,7 +22,7 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.0)
 
 # Create an LLM.
-llm = LLM(model="facebook/opt-125m")
+llm = LLM(model="facebook/opt-125m", enable_prefix_caching=True)
 
 generating_prompts = [prefix + prompt for prompt in prompts]
 


### PR DESCRIPTION
I believe we should explicitly set `enable_prefix_caching=True` to enable prefix caching. I found that the prefix kernel was unused otherwise. Please correct me if I'm wrong.