### PR TITLE
add ccache to docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ COPY requirements-build.txt requirements-build.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-build.txt
 
+# install sscahe to speed up compilation leveraging local or remote caching
+RUN wget https://github.com/mozilla/sccache/releases/download/v0.7.7/sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz  && \
+    tar -xvf sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz && \
+    mv sccache-dist-v0.7.7-x86_64-unknown-linux-musl/sccache-dist /usr/local/bin/sccache && \
+    chmod +x /usr/local/bin/sccache
+
 # copy input files
 COPY csrc csrc
 COPY setup.py setup.py
@@ -56,7 +62,8 @@ ENV NVCC_THREADS=$nvcc_threads
 # make sure punica kernels are built (for LoRA)
 ENV VLLM_INSTALL_PUNICA_KERNELS=1
 
-RUN python3 setup.py build_ext --inplace
+RUN --mount=type=cache,target=/root/.cache/sccache \
+    python3 setup.py build_ext --inplace
 #################### EXTENSION Build IMAGE ####################
 
 #################### FLASH_ATTENTION Build IMAGE ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,8 @@ COPY requirements-build.txt requirements-build.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-build.txt
 
-# install sscahe to speed up compilation leveraging local or remote caching
-# install wget first
-RUN apt-get update -y && apt-get install -y wget
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.7.7/sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz  && \
-    tar -xvf sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz && \
-    mv sccache-dist-v0.7.7-x86_64-unknown-linux-musl/sccache-dist /usr/local/bin/sccache && \
-    chmod +x /usr/local/bin/sccache
+# install compiler cache to speed up compilation leveraging local or remote caching
+RUN apt-get update -y && apt-get install -y ccache
 
 # copy input files
 COPY csrc csrc
@@ -64,7 +59,8 @@ ENV NVCC_THREADS=$nvcc_threads
 # make sure punica kernels are built (for LoRA)
 ENV VLLM_INSTALL_PUNICA_KERNELS=1
 
-RUN --mount=type=cache,target=/root/.cache/sccache \
+ENV CCACHE_DIR=/root/.cache/ccache
+RUN --mount=type=cache,target=/root/.cache/ccache \
     python3 setup.py build_ext --inplace
 #################### EXTENSION Build IMAGE ####################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-build.txt
 
 # install sscahe to speed up compilation leveraging local or remote caching
+# install wget first
+RUN apt-get update -y && apt-get install -y wget
 RUN wget https://github.com/mozilla/sccache/releases/download/v0.7.7/sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz  && \
     tar -xvf sccache-dist-v0.7.7-x86_64-unknown-linux-musl.tar.gz && \
     mv sccache-dist-v0.7.7-x86_64-unknown-linux-musl/sccache-dist /usr/local/bin/sccache && \


### PR DESCRIPTION
this is now available after CMake changes. it should cut down CI time for building images from 10 minutes to <1 minutes without kernel changes. 