### PR TITLE
Revert "bump version to v0.4.0"

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.4.0"
+__version__ = "0.3.3"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
Reverts vllm-project/vllm#3705 until the actual release is created.