### PR TITLE
[Bugfix] Command-R Max Model Length

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -765,6 +765,8 @@ def _get_and_verify_max_len(
         "max_seq_len",
         # ChatGLM2
         "seq_length",
+        # Command-R
+        "model_max_length",
         # Others
         "max_sequence_length",
         "max_seq_length",
@@ -773,6 +775,11 @@ def _get_and_verify_max_len(
     for key in possible_keys:
         max_len_key = getattr(hf_config, key, None)
         if max_len_key is not None:
+            # Command-R has a separate key for the maximum context window
+            # length of the model.
+            if key == "model_max_length":
+                derived_max_model_len = max_len_key
+                continue
             derived_max_model_len = min(derived_max_model_len, max_len_key)
     if derived_max_model_len == float("inf"):
         if max_model_len is not None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -810,9 +810,9 @@ def _get_and_verify_max_len(
         else:
             raise ValueError(
                 f"User-specified max_model_len ({max_model_len}) is greater "
-                f"than the derived max_model_len "
-                f"({max_len_key}={derived_max_model_len} in model's "
-                "config.json). This may lead to incorrect model outputs or "
-                "CUDA errors. Make sure the value is correct and within the "
-                "model context size.")
+                "than the derived max_model_len "
+                f"({max_len_key}={derived_max_model_len} or model_max_length="
+                f"{model_max_length} in model's config.json). This may lead "
+                "to incorrect model outputs or CUDA errors. Make sure the "
+                "value is correct and within the model context size.")
     return int(max_model_len)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -772,10 +772,13 @@ def _get_and_verify_max_len(
         "max_seq_length",
         "seq_len",
     ]
+    max_len_key = None
     for key in possible_keys:
-        max_len_key = getattr(hf_config, key, None)
-        if max_len_key is not None:
-            derived_max_model_len = min(derived_max_model_len, max_len_key)
+        max_len = getattr(hf_config, key, None)
+        if max_len is not None:
+            max_len_key = key if max_len < derived_max_model_len \
+                else max_len_key
+            derived_max_model_len = min(derived_max_model_len, max_len)
     if derived_max_model_len == float("inf"):
         if max_model_len is not None:
             # If max_model_len is specified, we use it.


### PR DESCRIPTION
Currently, the max context window for `CohereForAI/c4ai-command-r-v01` is not defined by `max_position_embeddings` but a special `model_max_length` key instead. This has been discussed in these two threads: [1](https://huggingface.co/CohereForAI/c4ai-command-r-v01/discussions/12#65f0871bd096db35f8763fe7), [2](https://huggingface.co/CohereForAI/c4ai-command-r-v01/discussions/24#65f35c44a11dde09bc1879c2)

We still use `max_position_embeddings` as default `max_model_len` for the memory concern, but when the user specifies a value higher than  `max_position_embeddings` but lower than or equal to `model_max_length`, we will allow this to go through.
 
This PR fixes https://github.com/vllm-project/vllm/issues/3676

cc @saurabhdash I'm not sure if there's a cleaner/better way to do this but please take a look.