### PR TITLE
CMake build elf without PTX

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -240,9 +240,12 @@ macro(override_gpu_arches GPU_ARCHES GPU_LANG GPU_SUPPORTED_ARCHES)
       endif()
 
       if (_SM)
+        # -real suffix let CMake to only generate elf code for the kernels.
+        # we want this, otherwise the added ptx (default) will increase binary size.
         set(_VIRT "-real")
         set(_CODE_ARCH ${_SM})
       else()
+        # -virtual suffix let CMake to generate ptx code for the kernels.
         set(_VIRT "-virtual")
         set(_CODE_ARCH ${_CODE})
       endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -240,7 +240,7 @@ macro(override_gpu_arches GPU_ARCHES GPU_LANG GPU_SUPPORTED_ARCHES)
       endif()
 
       if (_SM)
-        set(_VIRT "")
+        set(_VIRT "-real")
         set(_CODE_ARCH ${_SM})
       else()
         set(_VIRT "-virtual")


### PR DESCRIPTION
Without this `-real` flag, the output binary includes `PTX` for all code architecture we are generating, which in turns double the size. 

https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html#examples