### PR TITLE
[Core][Bugfix] cache len of tokenizer

### DIFF
--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -26,6 +26,7 @@ def get_cached_tokenizer(
     tokenizer_all_special_tokens_extended = (
         tokenizer.all_special_tokens_extended)
     tokenizer_all_special_tokens = set(tokenizer.all_special_tokens)
+    tokenizer_len = len(tokenizer)
 
     class CachedTokenizer(tokenizer.__class__):
 
@@ -40,6 +41,9 @@ def get_cached_tokenizer(
         @property
         def all_special_tokens_extended(self):
             return tokenizer_all_special_tokens_extended
+
+        def __len__(self):
+            return tokenizer_len
 
     CachedTokenizer.__name__ = f"Cached{tokenizer.__class__.__name__}"
 


### PR DESCRIPTION
Computing `len` of `tokenizer` is extremely expensive:

```python
    def __len__(self):
        """
        Size of the full vocabulary with the added tokens. Counts the `keys` and not the `values` because otherwise if
        there is a hole in the vocab, we will add tokenizers at a wrong index.
        """
        return len(set(self.get_vocab().keys()))
```

This PR adds the length of tokenizer into cached property.