### PR TITLE
[Core] Eliminate parallel worker per-step task scheduling overhead

### DIFF
--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -147,14 +147,14 @@ def broadcast_tensor_dict(
 ) -> Optional[Dict[Any, Union[torch.Tensor, Any]]]:
     """Broadcast the input tensor dictionary."""
     group = group or torch.distributed.group.WORLD
-    ranks = torch.distributed.get_process_group_ranks(group)
-    assert src in ranks, f"Invalid src rank ({src})"
 
     # Bypass the function if we are using only 1 GPU.
     world_size = torch.distributed.get_world_size(group=group)
     if world_size == 1:
         return tensor_dict
 
+    ranks = torch.distributed.get_process_group_ranks(group)
+    assert src in ranks, f"Invalid src rank ({src})"
     rank = torch.distributed.get_rank()
     if rank == src:
         metadata_list: List[Tuple[Any, Any]] = []

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -217,7 +217,11 @@ class _AsyncLLMEngine(LLMEngine):
         else:
             output = []
 
-        return self._process_model_outputs(output, scheduler_outputs)
+        outputs = self._process_model_outputs(output, scheduler_outputs)
+        if not outputs:
+            # Stop the execute model loop in parallel workers for now
+            await self.model_executor.halt_model_async()
+        return outputs
 
     async def encode_request_async(
         self,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -220,7 +220,7 @@ class _AsyncLLMEngine(LLMEngine):
         outputs = self._process_model_outputs(output, scheduler_outputs)
         if not outputs:
             # Stop the execute model loop in parallel workers for now
-            await self.model_executor.halt_model_async()
+            await self.model_executor.stop_remote_worker_execution_loop_async()
         return outputs
 
     async def encode_request_async(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -729,7 +729,7 @@ class LLMEngine:
         outputs = self._process_model_outputs(output, scheduler_outputs)
         if not outputs:
             # Stop the execute model loop in parallel workers for now
-            self.model_executor.halt_model()
+            self.model_executor.stop_remote_worker_execution_loop()
         return outputs
 
     def do_log_stats(self) -> None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -726,7 +726,11 @@ class LLMEngine:
         else:
             output = []
 
-        return self._process_model_outputs(output, scheduler_outputs)
+        outputs = self._process_model_outputs(output, scheduler_outputs)
+        if not outputs:
+            # Stop the execute model loop in parallel workers for now
+            self.model_executor.halt_model()
+        return outputs
 
     def do_log_stats(self) -> None:
         """Forced log when no requests active."""

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -76,7 +76,7 @@ class ExecutorBase(ABC):
         """Executes one model step on the given sequences."""
         raise NotImplementedError
 
-    async def halt_model(self) -> None:
+    def stop_remote_worker_execution_loop(self) -> None:
         """Releases parallel workers from model loop."""
         return
 
@@ -112,7 +112,7 @@ class ExecutorAsyncBase(ExecutorBase):
         """Executes one model step on the given sequences."""
         raise NotImplementedError
 
-    async def halt_model_async(self) -> None:
+    async def stop_remote_worker_execution_loop_async(self) -> None:
         """Releases parallel workers from model loop."""
         return
 

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -77,6 +77,11 @@ class ExecutorBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    async def halt_model(self) -> None:
+        """Releases parallel workers from model loop."""
+        pass
+
+    @abstractmethod
     def add_lora(self, lora_request: LoRARequest) -> bool:
         raise NotImplementedError
 
@@ -107,6 +112,11 @@ class ExecutorAsyncBase(ExecutorBase):
     ) -> SamplerOutput:
         """Executes one model step on the given sequences."""
         raise NotImplementedError
+
+    @abstractmethod
+    async def halt_model_async(self) -> None:
+        """Releases parallel workers from model loop."""
+        pass
 
     async def check_health_async(self) -> None:
         """Checks if the executor is healthy. If not, it should raise an

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -76,7 +76,6 @@ class ExecutorBase(ABC):
         """Executes one model step on the given sequences."""
         raise NotImplementedError
 
-    @abstractmethod
     async def halt_model(self) -> None:
         """Releases parallel workers from model loop."""
         pass

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -78,7 +78,7 @@ class ExecutorBase(ABC):
 
     async def halt_model(self) -> None:
         """Releases parallel workers from model loop."""
-        pass
+        return
 
     @abstractmethod
     def add_lora(self, lora_request: LoRARequest) -> bool:
@@ -114,7 +114,7 @@ class ExecutorAsyncBase(ExecutorBase):
 
     async def halt_model_async(self) -> None:
         """Releases parallel workers from model loop."""
-        pass
+        return
 
     async def check_health_async(self) -> None:
         """Checks if the executor is healthy. If not, it should raise an

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -113,7 +113,6 @@ class ExecutorAsyncBase(ExecutorBase):
         """Executes one model step on the given sequences."""
         raise NotImplementedError
 
-    @abstractmethod
     async def halt_model_async(self) -> None:
         """Releases parallel workers from model loop."""
         pass

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -35,6 +35,7 @@ class RayGPUExecutor(ExecutorBase):
 
         assert self.parallel_config.worker_use_ray
         placement_group = self.parallel_config.placement_group
+        self.model_running = False
 
         # Disable Ray usage stats collection.
         ray_usage = os.environ.get("RAY_USAGE_STATS_ENABLED", "0")
@@ -223,19 +224,24 @@ class RayGPUExecutor(ExecutorBase):
                       blocks_to_swap_in: Dict[int, int],
                       blocks_to_swap_out: Dict[int, int],
                       blocks_to_copy: Dict[int, List[int]]) -> SamplerOutput:
-        all_outputs = self._run_workers(
-            "execute_model",
-            driver_kwargs={
-                "seq_group_metadata_list": seq_group_metadata_list,
-                "blocks_to_swap_in": blocks_to_swap_in,
-                "blocks_to_swap_out": blocks_to_swap_out,
-                "blocks_to_copy": blocks_to_copy,
-            },
-            use_ray_compiled_dag=USE_RAY_COMPILED_DAG)
+        if not self.model_running:
+            # Start model execution loop running in the parallel workers
+            _ = self._run_workers("execute_model_parallel",
+                                  async_remote_only=True,
+                                  use_ray_compiled_dag=USE_RAY_COMPILED_DAG)
+            self.model_running = True
 
         # Only the driver worker returns the sampling results.
-        output = all_outputs[0]
-        return output
+        return self.driver_worker.execute_model(
+            seq_group_metadata_list=seq_group_metadata_list,
+            blocks_to_swap_in=blocks_to_swap_in,
+            blocks_to_swap_out=blocks_to_swap_out,
+            blocks_to_copy=blocks_to_copy)
+
+    def halt_model(self) -> None:
+        if self.model_running:
+            self.driver_worker.execute_model()
+            self.model_running = False
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         assert lora_request.lora_int_id > 0, "lora_id must be greater than 0."
@@ -258,8 +264,7 @@ class RayGPUExecutor(ExecutorBase):
         self,
         method: str,
         *args,
-        driver_args: Optional[Tuple[Any, ...]] = None,
-        driver_kwargs: Optional[Dict[str, Any]] = None,
+        async_remote_only: bool = False,
         max_concurrent_workers: Optional[int] = None,
         use_ray_compiled_dag: bool = False,
         **kwargs,
@@ -275,6 +280,7 @@ class RayGPUExecutor(ExecutorBase):
             # input. TODO(sang): Fix it.
             assert self.forward_dag is not None
             output_channels = self.forward_dag.execute(1)
+            ray_worker_outputs = None
         else:
             # Start the ray workers first.
             ray_worker_outputs = [
@@ -282,14 +288,13 @@ class RayGPUExecutor(ExecutorBase):
                 for worker in self.workers
             ]
 
-        if driver_args is None:
-            driver_args = args
-        if driver_kwargs is None:
-            driver_kwargs = kwargs
+        if async_remote_only:
+            # Just return futures
+            return ray_worker_outputs
 
         # Start the driver worker after all the ray workers.
-        driver_worker_output = getattr(self.driver_worker,
-                                       method)(*driver_args, **driver_kwargs)
+        driver_worker_output = getattr(self.driver_worker, method)(*args,
+                                                                   **kwargs)
 
         # Get the results of the ray workers.
         if self.workers:
@@ -348,33 +353,6 @@ class RayGPUExecutor(ExecutorBase):
 
 class RayGPUExecutorAsync(RayGPUExecutor, ExecutorAsyncBase):
 
-    async def _run_workers_async(
-        self,
-        method: str,
-        *args,
-        driver_args: Optional[Tuple[Any, ...]] = None,
-        driver_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs,
-    ) -> Any:
-        """Runs the given method on all workers."""
-        coros = []
-
-        if driver_args is None:
-            driver_args = args
-        if driver_kwargs is None:
-            driver_kwargs = kwargs
-
-        # Run the driver worker asynchronously.
-        driver_executor = make_async(getattr(self.driver_worker, method))
-        coros.append(driver_executor(*driver_args, **driver_kwargs))
-
-        # Run the ray workers asynchronously.
-        for worker in self.workers:
-            coros.append(worker.execute_method.remote(method, *args, **kwargs))
-
-        all_outputs = await asyncio.gather(*coros)
-        return all_outputs
-
     async def execute_model_async(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
@@ -382,15 +360,26 @@ class RayGPUExecutorAsync(RayGPUExecutor, ExecutorAsyncBase):
         blocks_to_swap_out: Dict[int, int],
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
-        all_outputs = await self._run_workers_async(
-            "execute_model",
-            driver_kwargs={
-                "seq_group_metadata_list": seq_group_metadata_list,
-                "blocks_to_swap_in": blocks_to_swap_in,
-                "blocks_to_swap_out": blocks_to_swap_out,
-                "blocks_to_copy": blocks_to_copy,
-            })
+        if not self.model_running:
+            # Start model execution loop running in the parallel workers
+            _ = asyncio.create_task(self._execute_model_parallel())
+            self.model_running = True
 
         # Only the driver worker returns the sampling results.
-        output = all_outputs[0]
-        return output
+        return await make_async(self.driver_worker.execute_model)(
+            seq_group_metadata_list=seq_group_metadata_list,
+            blocks_to_swap_in=blocks_to_swap_in,
+            blocks_to_swap_out=blocks_to_swap_out,
+            blocks_to_copy=blocks_to_copy)
+
+    async def _execute_model_parallel(self):
+        coros = [
+            worker.execute_method.remote("execute_model_parallel")
+            for worker in self.workers
+        ]
+        return await asyncio.gather(*coros)
+
+    async def halt_model_async(self) -> None:
+        if self.model_running:
+            await make_async(self.driver_worker.execute_model)()
+            self.model_running = False

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -213,6 +213,7 @@ class Worker(WorkerBase):
     ) -> Optional[SamplerOutput]:
         assert self.is_driver_worker
         if seq_group_metadata_list is None:
+            # No data to run, notify other workers to stop the execution loop.
             num_seq_groups = 0
             data = {}
         else:
@@ -238,7 +239,7 @@ class Worker(WorkerBase):
                                                self.gpu_cache)
 
     @torch.inference_mode()
-    def execute_model_parallel(self) -> None:
+    def start_worker_execution_loop(self) -> None:
         """Execute model loop in parallel worker."""
         assert not self.is_driver_worker
         while True:

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -213,8 +213,8 @@ class Worker(WorkerBase):
     ) -> Optional[SamplerOutput]:
         assert self.is_driver_worker
         if seq_group_metadata_list is None:
-            data = {}
             num_seq_groups = 0
+            data = {}
         else:
             num_seq_groups = len(seq_group_metadata_list)
             assert blocks_to_swap_in is not None


### PR DESCRIPTION
There's no need for the parallel workers to be scheduled in every step.

Using 80GB A100s, with llama-2-7b openai completion API. Single request with 5 input tokens, 2000 generated tokens. I repeated each test request multiple times, results were very consistent.

| | Time (sec) | Difference |
|---|---|---|
| TP=1 | 24.2 | 0 |
| TP=2 | 24.2 | 0 |
| TP=2 with this PR | 20.2 | -17% |
| TP=2 with #3466 (without Ray) | 17.0 | -30% |
| TP=2 with this PR combined with #3466 (without Ray) | 16.7 | -31% |

Though the relative improvement from this is much smaller in the non-Ray case, it might still be helpful for multi-node with Ray.