### PR TITLE
[Misc] Fix Benchmark TTFT Calculation for Chat Completions

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -334,7 +334,8 @@ async def async_request_openai_chat_completions(
                             timestamp = time.perf_counter()
                             data = json.loads(chunk)
 
-                            if "content" in data["choices"][0]["delta"]:
+                            delta = data["choices"][0]["delta"]
+                            if delta.get("content", None):
                                 # First token
                                 if ttft == 0:
                                     ttft = time.perf_counter() - st
@@ -345,8 +346,7 @@ async def async_request_openai_chat_completions(
                                     output.itl.append(timestamp -
                                                       most_recent_timestamp)
 
-                                generated_text += data["choices"][0]["delta"][
-                                    "content"]
+                                generated_text += delta["content"]
 
                             most_recent_timestamp = timestamp
 


### PR DESCRIPTION
This PR fixes the TTFT calculation when running serving benchmark with chat completions API. Previously it didn't check if actual `content` is `Null` in the delta, and thus `role` chunk with empty `content` could be mistakenly treated as a real token response.

Note: This does not affect existing CI results since by default `vLLM` uses completions instead of chat completions for benchmarking.

Fixes https://github.com/vllm-project/vllm/issues/3759


