### PR TITLE
[Doc] Fix vLLMEngine Doc Page

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,3 +8,4 @@ sphinx-argparse
 pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
+transformers

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,3 +8,5 @@ sphinx-argparse
 pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
+transformers
+cpuinfo

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -9,4 +9,4 @@ pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
 transformers
-cpuinfo
+py-cpuinfo

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,5 +8,3 @@ sphinx-argparse
 pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
-transformers
-py-cpuinfo

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -9,3 +9,4 @@ pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
 py-cpuinfo
+transformers

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,4 +8,3 @@ sphinx-argparse
 pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
-transformers

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -8,3 +8,4 @@ sphinx-argparse
 pydantic
 -f https://download.pytorch.org/whl/cpu
 torch
+py-cpuinfo

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ html_theme_options = {
 
 # Mock out external dependencies here.
 autodoc_mock_imports = [
+    "cpuinfo",
     "torch",
     "transformers",
     "psutil",


### PR DESCRIPTION
The documentation page is[ down again for `vLLMEngine`](https://docs.vllm.ai/en/latest/dev/engine/llm_engine.html) :(

I'm not sure why but this time we necessarily need to include both `transformers` and `py-cpuinfo` in `requirements-docs.txt` to make it work. See https://vllm--3791.org.readthedocs.build/en/3791/dev/engine/llm_engine.html for a working version.