### PR TITLE
[CI/Build] 0.4.0.post1, fix sm 7.0/7.5 binary

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -8,7 +8,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.4.0"
+__version__ = "0.4.0.post1"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
Upgrade to 0.4.0.post1, to include the fix of sm 7.0/7.5 binary in prebuilt wheels.