### PR TITLE
[BugFix] Use different mechanism to get vllm version in `is_cpu()`

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -119,9 +119,11 @@ def is_hip() -> bool:
 
 @lru_cache(maxsize=None)
 def is_cpu() -> bool:
-    import vllm
-    is_cpu_flag = "cpu" in vllm.__version__
-    return is_cpu_flag
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        return "cpu" in version("vllm")
+    except PackageNotFoundError:
+        return False
 
 
 @lru_cache(maxsize=None)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -119,8 +119,8 @@ def is_hip() -> bool:
 
 @lru_cache(maxsize=None)
 def is_cpu() -> bool:
-    from importlib.metadata import version
-    is_cpu_flag = "cpu" in version("vllm")
+    import vllm
+    is_cpu_flag = "cpu" in vllm.__version__
     return is_cpu_flag
 
 


### PR DESCRIPTION
Using `importlib.metadata.version()` function doesn't work in the non-CPU docker image.

Introduced in #3634

Equivalent fix to #3735