### PR TITLE
[Core] Enable hf_transfer by default if available

### DIFF
--- a/tests/model_executor/weight_utils.py
+++ b/tests/model_executor/weight_utils.py
@@ -1,9 +1,16 @@
+import os
+
 import huggingface_hub.constants
+import pytest
 
 from vllm.model_executor.weight_utils import enable_hf_transfer
 
 
 def test_hf_transfer_auto_activation():
+    if "HF_HUB_ENABLE_HF_TRANSFER" in os.environ:
+        # in case it is already set, we can't test the auto activation
+        pytest.skip(
+            "HF_HUB_ENABLE_HF_TRANSFER is set, can't test auto activation")
     enable_hf_transfer()
     try:
         # enable hf hub transfer if available

--- a/tests/model_executor/weight_utils.py
+++ b/tests/model_executor/weight_utils.py
@@ -1,0 +1,15 @@
+import  huggingface_hub.constants
+from vllm.model_executor.weight_utils import enable_hf_transfer
+
+def test_hf_transfer_auto_activation():
+    enable_hf_transfer()
+    try:
+        # enable hf hub transfer if available
+        import hf_transfer  # type: ignore # noqa
+        HF_TRANFER_ACTIVE = True
+    except ImportError:
+        HF_TRANFER_ACTIVE = False
+    assert huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER == HF_TRANFER_ACTIVE
+
+if __name__ == "__main__":
+    test_hf_transfer_auto_activation()

--- a/tests/model_executor/weight_utils.py
+++ b/tests/model_executor/weight_utils.py
@@ -1,5 +1,7 @@
-import  huggingface_hub.constants
+import huggingface_hub.constants
+
 from vllm.model_executor.weight_utils import enable_hf_transfer
+
 
 def test_hf_transfer_auto_activation():
     enable_hf_transfer()
@@ -9,7 +11,9 @@ def test_hf_transfer_auto_activation():
         HF_TRANFER_ACTIVE = True
     except ImportError:
         HF_TRANFER_ACTIVE = False
-    assert huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER == HF_TRANFER_ACTIVE
+    assert (huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER ==
+            HF_TRANFER_ACTIVE)
+
 
 if __name__ == "__main__":
     test_hf_transfer_auto_activation()

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -35,7 +35,7 @@ def enable_hf_transfer():
     """
     if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
         try:
-            # enable hf hub transfer if available
+            # enable hf hub transfer  if available
             import hf_transfer  # type: ignore # noqa
             huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
         except ImportError:

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -29,12 +29,18 @@ logger = init_logger(__name__)
 temp_dir = os.environ.get('TMPDIR') or os.environ.get(
     'TEMP') or os.environ.get('TMP') or "/tmp/"
 
-try:
-    # enable hf hub transfer if available
-    import hf_transfer  # type: ignore # noqa
-    huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
-except ImportError:
-    pass
+
+def enable_hf_transfer():
+    """enforces activation of hf_transfer if installed."""
+    try:
+        # enable hf hub transfer if available
+        import hf_transfer  # type: ignore # noqa
+        huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
+    except ImportError:
+        pass
+
+
+enable_hf_transfer()
 
 
 class Disabledtqdm(tqdm):

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -31,13 +31,18 @@ temp_dir = os.environ.get('TMPDIR') or os.environ.get(
 
 
 def enable_hf_transfer():
-    """enforces activation of hf_transfer if installed."""
-    try:
-        # enable hf hub transfer if available
-        import hf_transfer  # type: ignore # noqa
-        huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
-    except ImportError:
-        pass
+    """automatically activates hf_transfer
+    """
+    if "HF_HUB_ENABLE_HF_TRANSFER" in os.environ:
+        #  no additional logic, use default behaviour.
+        return
+    else:
+        try:
+            # enable hf hub transfer if available
+            import hf_transfer  # type: ignore # noqa
+            huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
+        except ImportError:
+            pass
 
 
 enable_hf_transfer()

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -35,7 +35,7 @@ def enable_hf_transfer():
     """
     if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
         try:
-            # enable hf hub transfer  if available
+            # enable hf hub transfer if available
             import hf_transfer  # type: ignore # noqa
             huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
         except ImportError:

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -33,10 +33,7 @@ temp_dir = os.environ.get('TMPDIR') or os.environ.get(
 def enable_hf_transfer():
     """automatically activates hf_transfer
     """
-    if "HF_HUB_ENABLE_HF_TRANSFER" in os.environ:
-        #  no additional logic, use default behaviour.
-        return
-    else:
+    if "HF_HUB_ENABLE_HF_TRANSFER" not in os.environ:
         try:
             # enable hf hub transfer if available
             import hf_transfer  # type: ignore # noqa

--- a/vllm/model_executor/weight_utils.py
+++ b/vllm/model_executor/weight_utils.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from typing import Any, Iterator, List, Optional, Tuple
 
 import filelock
+import huggingface_hub.constants
 import numpy as np
 import torch
 from huggingface_hub import HfFileSystem, snapshot_download
@@ -27,6 +28,13 @@ logger = init_logger(__name__)
 # system reboots, so users will not complain about annoying lock files
 temp_dir = os.environ.get('TMPDIR') or os.environ.get(
     'TEMP') or os.environ.get('TMP') or "/tmp/"
+
+try:
+    # enable hf hub transfer if available
+    import hf_transfer  # type: ignore # noqa
+    huggingface_hub.constants.HF_HUB_ENABLE_HF_TRANSFER = True
+except ImportError:
+    pass
 
 
 class Disabledtqdm(tqdm):


### PR DESCRIPTION
This is a "quality of life" PR. It auto enables the `hf_transfer` backend of `huggingface_hub`. As explained in #2907, `hf_transfer` should be safe to use, e.g. is the default in TGI since pretty long. https://github.com/huggingface/text-generation-inference/blob/92bb56b0c1038a35f73a6c96c506f6d1c3d7b043/Dockerfile#L151
Enabling it with a env variable misses a fair amount of users + leads to `hf_transfer` beeing forced to be enabled globally - even if available just in this Python env. 

Closes #2907 (fix)
Related #3031 #3008 

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


