### PR TITLE
[Core] :loud_sound: Improve request logging truncation

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -546,7 +546,9 @@ class AsyncEngineArgs(EngineArgs):
         parser.add_argument('--max-log-len',
                             type=int,
                             default=None,
-                            help='max number of prompt characters or prompt '
-                            'ID numbers being printed in log. '
+                            help='maximum character length to log for either '
+                            'the input prompt or list of prompt token ids '
+                            'for each request. Only applies if '
+                            '--disable-log-requests is not set.'
                             'Default: unlimited.')
         return parser

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -543,12 +543,13 @@ class AsyncEngineArgs(EngineArgs):
         parser.add_argument('--disable-log-requests',
                             action='store_true',
                             help='disable logging requests')
-        parser.add_argument('--max-log-len',
-                            type=int,
-                            default=None,
-                            help='maximum character length to log for either '
-                            'the input prompt or list of prompt token ids '
-                            'for each request. Only applies if '
-                            '--disable-log-requests is not set.'
-                            'Default: unlimited.')
+        parser.add_argument(
+            '--max-log-len',
+            type=int,
+            default=None,
+            help='Limits the input text prompt to max_log_len '
+            'characters and limits the input token ids to '
+            'max_log_len / 6 tokens in the per-request logs. '
+            'Only applies if --disable-log-requests is not set.'
+            'Default: unlimited.')
         return parser

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -698,8 +698,8 @@ class AsyncLLMEngine:
             await self.engine.check_health_async()
         logger.debug(f"Health check took {time.perf_counter()-t}s")
 
-    def _shorten_for_logging(self, prompt,
-                             prompt_token_ids) -> Tuple[str, str]:
+    def _shorten_for_logging(self, prompt: str,
+                             prompt_token_ids: List[int]) -> Tuple[str, str]:
         """Truncates the input prompt text and token ids for logging.
         The string representations of both are truncated to a maximum length
         of self.max_log_len, and then ellipses (...) are added to indicate

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -499,13 +499,18 @@ class AsyncLLMEngine:
         multi_modal_data: Optional[MultiModalData] = None,
     ) -> AsyncStream:
         if self.log_requests:
-            shortened_prompt, shortened_token_ids = self._shorten_for_logging(
-                prompt, prompt_token_ids)
-            logger.info(f"Received request {request_id}: "
-                        f"prompt: {shortened_prompt!r}, "
-                        f"sampling_params: {sampling_params}, "
-                        f"prompt_token_ids: {shortened_token_ids}, "
-                        f"lora_request: {lora_request}.")
+            if self.max_log_len > 0:
+                shortened_prompt, shortened_token_ids = (
+                    self._shorten_for_logging(prompt, prompt_token_ids))
+                logger.info(f"Received request {request_id}: "
+                            f"prompt: {shortened_prompt!r}, "
+                            f"sampling_params: {sampling_params}, "
+                            f"prompt_token_ids: {shortened_token_ids}, "
+                            f"lora_request: {lora_request}.")
+            else:
+                logger.info(f"Received request {request_id}: "
+                            f"sampling_params: {sampling_params}, "
+                            f"lora_request: {lora_request}.")
 
         if not self.is_running:
             if self.start_engine_loop:
@@ -699,20 +704,20 @@ class AsyncLLMEngine:
         logger.debug(f"Health check took {time.perf_counter()-t}s")
 
     def _shorten_for_logging(self, prompt: str,
-                             prompt_token_ids: List[int]) -> Tuple[str, str]:
+                             prompt_token_ids: List[int]) \
+            -> Tuple[str, List[int]]:
         """Truncates the input prompt text and token ids for logging.
-        The string representations of both are truncated to a maximum length
-        of self.max_log_len, and then ellipses (...) are added to indicate
-        that the values were truncated.
+        The list of token IDs is shortened to max_log_len / 6 so that it takes
+        a similar amount of visual space as the text prompt in the log output.
+        Ellipses are added to indicate that truncation happened, when either
+        value is truncated.
         """
         if self.max_log_len is not None:
             if prompt is not None and len(prompt) > self.max_log_len:
                 prompt = f"{prompt:.{self.max_log_len}}..."
-            if prompt_token_ids is not None:
-                # This regex removes the last value in the list after the
-                # string representation is truncated, to avoid logging an
-                # incorrect token id.
-                prompt_token_ids = re.sub(
-                    self.list_truncation_regex, ', ...]',
-                    f"{prompt_token_ids!s:.{self.max_log_len}}")
+            max_tokens = self.max_log_len / 6
+            if prompt_token_ids is not None and len(
+                    prompt_token_ids) > max_tokens:
+                prompt_token_ids = prompt_token_ids[0:max_tokens]
+                prompt_token_ids[-1] = "..."
         return prompt, prompt_token_ids


### PR DESCRIPTION
This PR fixes two small observability problems with the request logging we've noticed while managing deployments of vLLM:

1. When a user's prompt is truncated, there's no indication that truncation happened. This can lead SREs to believe that the logged prompt was the full input, and cause minor confusion.
2. The `--max-log-len` parameter truncates the `prompt` by character length, but truncates the token id list by list length. In deployments where we have request logging enabled, we usually want to see abut 100 characters of the input prompt to easily identify user requests or requests from our test suites, but this also causes a 100-integer long list of token ids to visually clutter the logs as well.

The proposed change here is to truncate both the input prompt and token id list by character length, and add an ellipsis when this is done to visually indicate that the input was truncated. A small regex is used to ensure that when the token id list is truncated, any partially written token id at the end of the string is removed to avoid logging incorrect token ids.

I wasn't sure which tag to put on the title, I picked [Core] because the change is in async_llm_engine.py, but the logic changes are in logging code only and should not affect the actual request processing.


Logs before this change, with `--max-log-len=100`

> INFO 04-03 17:46:15 async_llm_engine.py:517] Received request 001f19fe4e6543758e098a97d995d9c2-0: prompt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ', sampling_params: SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=True, ignore_eos=False, max_tokens=20, min_tokens=16, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True), prompt_token_ids: [47, 25549, 132314, 31531, 9002, 58912, 15, 245440, 108195, 12037, 386, 115056, 15, 5659, 727, 297, 8536, 5097, 10480, 48069, 356, 1153, 2908, 5452, 1314, 674, 13578, 1314, 181677, 521, 126245, 17, 13023, 224639, 856, 15600, 6354, 6363, 15, 53980, 2255, 454, 581, 12919, 13289, 109951, 328, 1594, 12378, 290, 230862, 2908, 201376, 606, 683, 65443, 2200, 6660, 34289, 278, 17, 524, 4886, 1808, 72, 2881, 974, 31531, 361, 6589, 71806, 3489, 291, 361, 2660, 65761, 655, 10611, 291, 13645, 268, 772, 440, 13578, 1314, 4466, 28889, 6823, 34845, 1484, 136177, 4933, 17, 4100, 7131, 10245, 30526, 5931, 68, 64322], lora_request: None.


Logs after this change, with `--max-log-len=100`

> INFO 04-03 17:49:49 async_llm_engine.py:513] Received request ba1397f1060c4e17bacb5f57ab072268-0: prompt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore ...', sampling_params: SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=True, ignore_eos=False, max_tokens=20, min_tokens=16, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True), prompt_token_ids: [47, 25549, 132314, 31531, 9002, 58912, 15, 245440, 108195, 12037, 386, 115056, 15, 5659, 727, 297, ...], lora_request: None.
