### PR TITLE
[Bugfix] Add kv_scale input parameter to CPU backend

### DIFF
--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -419,7 +419,8 @@ void paged_attention_v1(torch::Tensor &out, torch::Tensor &query,
                         torch::Tensor &context_lens, int block_size,
                         int max_context_len,
                         const c10::optional<torch::Tensor> &alibi_slopes,
-                        const std::string &kv_cache_dtype) {
+                        const std::string &kv_cache_dtype, float kv_scale) {
+  TORCH_CHECK(kv_scale == 1.0f);
   VLLM_DISPATCH_FLOATING_TYPES(query.scalar_type(), "paged_attention_v1_impl",
                                [&] {
                                  CPU_KERNEL_GUARD_IN(paged_attention_v1_impl)
@@ -734,7 +735,8 @@ void paged_attention_v2(torch::Tensor &out, torch::Tensor &exp_sums,
                         torch::Tensor &context_lens, int block_size,
                         int max_context_len,
                         const c10::optional<torch::Tensor> &alibi_slopes,
-                        const std::string &kv_cache_dtype) {
+                        const std::string &kv_cache_dtype, float kv_scale) {
+  TORCH_CHECK(kv_scale == 1.0f);
   VLLM_DISPATCH_FLOATING_TYPES(query.scalar_type(), "paged_attention_v2_impl",
                                [&] {
                                  CPU_KERNEL_GUARD_IN(paged_attention_v2_impl)

--- a/csrc/cpu/cache.cpp
+++ b/csrc/cpu/cache.cpp
@@ -111,7 +111,9 @@ void copy_blocks(std::vector<torch::Tensor> &key_caches,
 void reshape_and_cache(torch::Tensor &key, torch::Tensor &value,
                        torch::Tensor &key_cache, torch::Tensor &value_cache,
                        torch::Tensor &slot_mapping,
-                       const std::string &kv_cache_dtype) {
+                       const std::string &kv_cache_dtype, float kv_scale) {
+  TORCH_CHECK(kv_scale == 1.0f);
+
   int num_tokens = key.size(0);
   int num_heads = key.size(1);
   int head_size = key.size(2);

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -114,6 +114,7 @@ class TorchSDPABackendImpl(AttentionImpl):
         value: torch.Tensor,
         kv_cache: Optional[torch.Tensor],
         attn_metadata: TorchSDPAMetadata,
+        kv_scale: float,
     ) -> torch.Tensor:
         """Forward pass with torch SDPA and PagedAttention.
 
@@ -138,7 +139,8 @@ class TorchSDPABackendImpl(AttentionImpl):
             PagedAttention.write_to_paged_cache(key, value, key_cache,
                                                 value_cache,
                                                 attn_metadata.slot_mapping,
-                                                attn_metadata.kv_cache_dtype)
+                                                attn_metadata.kv_cache_dtype,
+                                                kv_scale)
 
         if attn_metadata.is_prompt:
             if (kv_cache is None or attn_metadata.block_tables.numel() == 0):
@@ -199,6 +201,7 @@ class TorchSDPABackendImpl(AttentionImpl):
                 self.num_kv_heads,
                 self.scale,
                 self.alibi_slopes,
+                kv_scale,
             )
 
         # Reshape the output tensor.

--- a/vllm/attention/ops/paged_attn.py
+++ b/vllm/attention/ops/paged_attn.py
@@ -73,9 +73,8 @@ class PagedAttention:
         value_cache: torch.Tensor,
         slot_mapping: torch.Tensor,
         kv_cache_dtype: str,
-        kv_scale: Optional[float] = None,
+        kv_scale: float,
     ) -> None:
-        optional_args = [x for x in (kv_scale, ) if x is not None]
         cache_ops.reshape_and_cache(
             key,
             value,
@@ -83,7 +82,7 @@ class PagedAttention:
             value_cache,
             slot_mapping.flatten(),
             kv_cache_dtype,
-            *optional_args,
+            kv_scale,
         )
 
     @staticmethod
@@ -98,11 +97,10 @@ class PagedAttention:
         num_kv_heads: int,
         scale: float,
         alibi_slopes: Optional[torch.Tensor],
-        kv_scale: Optional[float] = None,
+        kv_scale: float,
     ) -> torch.Tensor:
-        optional_args = [x for x in (kv_scale, ) if x is not None]
-
         output = torch.empty_like(query)
+
         block_size = value_cache.shape[3]
         num_seqs, num_heads, head_size = query.shape
         max_num_partitions = ((max_context_len + _PARTITION_SIZE - 1) //
@@ -131,7 +129,7 @@ class PagedAttention:
                 max_context_len,
                 alibi_slopes,
                 kv_cache_dtype,
-                *optional_args,
+                kv_scale,
             )
         else:
             # Run PagedAttention V2.
@@ -163,7 +161,7 @@ class PagedAttention:
                 max_context_len,
                 alibi_slopes,
                 kv_cache_dtype,
-                *optional_args,
+                kv_scale,
             )
         return output
 

--- a/vllm/attention/ops/paged_attn.py
+++ b/vllm/attention/ops/paged_attn.py
@@ -75,6 +75,7 @@ class PagedAttention:
         kv_cache_dtype: str,
         kv_scale: Optional[float] = None,
     ) -> None:
+        optional_args = [x for x in (kv_scale, ) if x is not None]
         cache_ops.reshape_and_cache(
             key,
             value,
@@ -82,7 +83,7 @@ class PagedAttention:
             value_cache,
             slot_mapping.flatten(),
             kv_cache_dtype,
-            kv_scale,
+            *optional_args,
         )
 
     @staticmethod

--- a/vllm/attention/ops/paged_attn.py
+++ b/vllm/attention/ops/paged_attn.py
@@ -73,7 +73,7 @@ class PagedAttention:
         value_cache: torch.Tensor,
         slot_mapping: torch.Tensor,
         kv_cache_dtype: str,
-        kv_scale: float,
+        kv_scale: Optional[float] = None,
     ) -> None:
         cache_ops.reshape_and_cache(
             key,
@@ -97,10 +97,11 @@ class PagedAttention:
         num_kv_heads: int,
         scale: float,
         alibi_slopes: Optional[torch.Tensor],
-        kv_scale,
+        kv_scale: Optional[float] = None,
     ) -> torch.Tensor:
-        output = torch.empty_like(query)
+        optional_args = [x for x in (kv_scale, ) if x is not None]
 
+        output = torch.empty_like(query)
         block_size = value_cache.shape[3]
         num_seqs, num_heads, head_size = query.shape
         max_num_partitions = ((max_context_len + _PARTITION_SIZE - 1) //
@@ -129,7 +130,7 @@ class PagedAttention:
                 max_context_len,
                 alibi_slopes,
                 kv_cache_dtype,
-                kv_scale,
+                *optional_args,
             )
         else:
             # Run PagedAttention V2.
@@ -161,7 +162,7 @@ class PagedAttention:
                 max_context_len,
                 alibi_slopes,
                 kv_cache_dtype,
-                kv_scale,
+                *optional_args,
             )
         return output
 


### PR DESCRIPTION
This PR fixes the broken CPU CI by adding the `kv_scale` parameter to the attention-related kernels for CPUs.