### PR TITLE
[CI/Build] fix pip cache with vllm_nccl & refactor dockerfile to build wheels

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -90,7 +90,7 @@ steps:
   - bash run-benchmarks.sh
 
 - label: Documentation Build
-  working_dir: "/vllm-workspace/docs"
+  working_dir: "/vllm-workspace/test_docs/docs"
   no_gpu: True
   commands:
   - pip install -r requirements-docs.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ FROM vllm-base AS test
 # files and directories related to tests (CI)
 COPY tests tests
 COPY benchmarks benchmarks
+COPY examples examples
 
 # install development dependencies (for testing)
 COPY requirements-dev.txt requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ ENV VLLM_INSTALL_PUNICA_KERNELS=1
 
 ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
+    --mount=type=cache,target=/root/.cache/pip \
     python3 setup.py bdist_wheel --dist-dir=dist
 
 # the `vllm_nccl` package must be installed from source distribution

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ RUN --mount=type=bind,from=flash-attn-builder,src=/usr/src/flash-attention-v2,ta
 
 #################### TEST IMAGE ####################
 # image to run unit testing suite
+# note that this uses vllm installed by `pip`
 FROM vllm-base AS test
 
 # install development dependencies (for testing)
@@ -132,10 +133,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY tests tests
 COPY benchmarks benchmarks
 COPY examples examples
-COPY docs docs
-# doc requires source code
-COPY vllm vllm
 COPY .buildkite .buildkite
+
+# doc requires source code
+# we hide them inside `test_docs/` , so that this source code
+# will not be imported by other tests
+COPY docs test_docs/docs
+COPY vllm test_docs/vllm
 
 #################### TEST IMAGE ####################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,22 +124,18 @@ RUN --mount=type=bind,from=flash-attn-builder,src=/usr/src/flash-attention-v2,ta
 # note that this uses vllm installed by `pip`
 FROM vllm-base AS test
 
+ADD . /vllm-workspace/
+
 # install development dependencies (for testing)
-COPY requirements-dev.txt requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements-dev.txt
-
-# files and directories related to tests (CI)
-COPY tests tests
-COPY benchmarks benchmarks
-COPY examples examples
-COPY .buildkite .buildkite
 
 # doc requires source code
 # we hide them inside `test_docs/` , so that this source code
 # will not be imported by other tests
-COPY docs test_docs/docs
-COPY vllm test_docs/vllm
+RUN mkdir test_docs
+RUN mv docs test_docs/
+RUN mv vllm test_docs/
 
 #################### TEST IMAGE ####################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,17 +123,17 @@ RUN --mount=type=bind,from=flash-attn-builder,src=/usr/src/flash-attention-v2,ta
 # image to run unit testing suite
 FROM vllm-base AS test
 
+# install development dependencies (for testing)
+COPY requirements-dev.txt requirements-dev.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -r requirements-dev.txt
+
 # files and directories related to tests (CI)
 COPY tests tests
 COPY benchmarks benchmarks
 COPY examples examples
 COPY docs docs
 COPY .buildkite .buildkite
-
-# install development dependencies (for testing)
-COPY requirements-dev.txt requirements-dev.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -r requirements-dev.txt
 
 #################### TEST IMAGE ####################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,8 @@ COPY tests tests
 COPY benchmarks benchmarks
 COPY examples examples
 COPY docs docs
+# doc requires source code
+COPY vllm vllm
 COPY .buildkite .buildkite
 
 #################### TEST IMAGE ####################

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 RUN apt-get update -y && apt-get install -y ccache
 
 # files and directories related to build wheels
-ADD cmake /workspace/cmake
-ADD csrc /workspace/csrc
-ADD vllm /workspace/vllm
-ADD setup.py /workspace/setup.py
-ADD CMakeLists.txt /workspace/CMakeLists.txt
+COPY csrc csrc
+COPY setup.py setup.py
+COPY cmake cmake
+COPY CMakeLists.txt CMakeLists.txt
+COPY requirements.txt requirements.txt
+COPY pyproject.toml pyproject.toml
+COPY vllm vllm
 
 # max jobs used by Ninja to build extensions
 ARG max_jobs=2

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ COPY requirements.txt requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt
 
+# the `vllm_nccl` package must be installed from source distribution
+# pip is too smart to store a wheel in the cache, and other CI jobs
+# will directly use the wheel from the cache, which is not what we want.
+# we need to remove it manually
+RUN pip cache remove vllm_nccl*
 # install development dependencies
 COPY requirements-dev.txt requirements-dev.txt
 RUN --mount=type=cache,target=/root/.cache/pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,8 @@ FROM vllm-base AS test
 COPY tests tests
 COPY benchmarks benchmarks
 COPY examples examples
+COPY docs docs
+COPY .buildkite .buildkite
 
 # install development dependencies (for testing)
 COPY requirements-dev.txt requirements-dev.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import logging
-import os
 import sys
 
 from sphinx.ext import autodoc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,6 @@ import sys
 
 from sphinx.ext import autodoc
 
-sys.path.insert(0, os.path.abspath(os.path.join('..', '..')))
-
 logger = logging.getLogger(__name__)
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
the `vllm_nccl` package must be installed from source distribution
pip is too smart to store a wheel in the cache, and other CI jobs
will directly use the wheel from the cache, which is not what we want.
we need to remove it manually