### PR TITLE
[Bugfix] Fixing requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ pynvml == 11.5.0
 triton >= 2.1.0
 outlines == 0.0.34
 tiktoken == 0.6.0 # Required for DBRX tokenizer
-vllm-nccl-cu12>=2.18<2.19 # for downloading nccl library
+vllm-nccl-cu12>=2.18,<2.19 # for downloading nccl library


### PR DESCRIPTION
Pip requires a comma between multiple version requirements in a single line. This small fix makes
`pip install -e .` 
work again.
