### PR TITLE
[CI/Benchmark] add more iteration and use multiple percentiles for robust latency benchmark

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -68,7 +68,8 @@ def main(args: argparse.Namespace):
             return latency
 
     print("Warming up...")
-    run_to_completion(profile_dir=None)
+    for _ in tqdm(range(args.num_iters_warmup), desc="Warmup iterations"):
+        run_to_completion(profile_dir=None)
 
     if args.profile:
         profile_dir = args.profile_result_dir
@@ -106,9 +107,13 @@ if __name__ == '__main__':
                         default=1,
                         help='Number of generated sequences per prompt.')
     parser.add_argument('--use-beam-search', action='store_true')
+    parser.add_argument('--num-iters-warmup',
+                        type=int,
+                        default=10,
+                        help='Number of iterations to run for warmup.')
     parser.add_argument('--num-iters',
                         type=int,
-                        default=3,
+                        default=30,
                         help='Number of iterations to run.')
     parser.add_argument('--trust-remote-code',
                         action='store_true',

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -85,7 +85,7 @@ def main(args: argparse.Namespace):
     latencies = []
     for _ in tqdm(range(args.num_iters), desc="Profiling iterations"):
         latencies.append(run_to_completion(profile_dir=None))
-    print(f'Avg latency: {np.mean(latencies)} seconds')
+    print(f'Median latency: {np.median(latencies)} seconds')
 
 
 if __name__ == '__main__':

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -85,7 +85,12 @@ def main(args: argparse.Namespace):
     latencies = []
     for _ in tqdm(range(args.num_iters), desc="Profiling iterations"):
         latencies.append(run_to_completion(profile_dir=None))
-    print(f'Median latency: {np.median(latencies)} seconds')
+    latencies = np.array(latencies)
+    percentages = [10, 25, 50, 75, 90]
+    percentiles = np.percentile(latencies, percentages)
+    print(f'Avg latency: {np.mean(latencies)} seconds')
+    for percentage, percentile in zip(percentages, percentiles):
+        print(f'{percentage}% percentile latency: {percentile} seconds')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prior to this PR, we use average latency across 3 runs, which seems to be very unstable. Here is what I get across 5 runs:

```text
0.4430512798329194
0.4450072580948472
0.45556532715757686
0.451823682213823
0.4521045722067356
```

The first step to optimize latency is to have a reliable benchmark. In this PR, I add more warmup run and profile run, and use median number that is robust to outliers.

After this PR, I get 5 runs:

```text
0.43797357752919197
0.4324369733221829
0.43426618119701743
0.4360716128721833
0.43663214799016714
```

The latency benchmark becomes more reliable and more stable.