### PR TITLE
Measurement of HPU utilization time

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -6,6 +6,9 @@ from typing import Optional
 
 import numpy as np
 import torch
+from vllm.utils import is_hpu
+if is_hpu():
+    import habana_frameworks.torch as htorch
 from tqdm import tqdm
 
 from vllm import LLM, SamplingParams

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -25,6 +25,10 @@ from typing import AsyncGenerator, List, Tuple
 import aiohttp
 import numpy as np
 from transformers import PreTrainedTokenizerBase
+import torch
+from vllm.utils import is_hpu
+if is_hpu():
+    import habana_frameworks.torch as htorch
 from vllm.transformers_utils.tokenizer import get_tokenizer
 
 # (prompt len, output len, latency)

--- a/benchmarks/kernels/benchmark_paged_attention.py
+++ b/benchmarks/kernels/benchmark_paged_attention.py
@@ -4,7 +4,11 @@ import time
 
 import torch
 
-from vllm._C import ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+else:
+    from vllm._C import ops
 
 NUM_BLOCKS = 1024
 PARTITION_SIZE = 512

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,0 +1,14 @@
+ninja  # For faster builds.
+psutil
+ray >= 2.5.1
+pandas  # Required for Ray data.
+pyarrow  # Required for Ray data.
+sentencepiece  # Required for LLaMA tokenizer.
+numpy
+#torch == 2.1.2
+transformers >= 4.36.0  # Required for Mixtral.
+#xformers == 0.0.23.post1  # Required for CUDA 12.1.
+fastapi
+uvicorn[standard]
+pydantic == 1.10.13  # Required for OpenAI server.
+aioprometheus[starlette]

--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -1,6 +1,6 @@
 ninja  # For faster builds.
 psutil
-ray >= 2.5.1
+ray == 2.9.3
 pandas  # Required for Ray data.
 pyarrow  # Required for Ray data.
 sentencepiece  # Required for LLaMA tokenizer.

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -2,6 +2,7 @@ from typing import List, Tuple
 
 import pytest
 import torch
+from vllm.utils import is_hpu
 
 
 def create_kv_caches(
@@ -18,7 +19,10 @@ def create_kv_caches(
 
     scale = head_size**-0.5
     x = 16 // torch.tensor([], dtype=dtype).element_size()
-    key_cache_shape = (num_blocks, num_heads, head_size // x, block_size, x)
+    if is_hpu():
+        key_cache_shape = (num_blocks, num_heads, head_size, block_size)
+    else:
+        key_cache_shape = (num_blocks, num_heads, head_size // x, block_size, x)
     key_caches = []
     for _ in range(num_layers):
         key_cache = torch.empty(size=key_cache_shape,

--- a/tests/kernels/test_cache.py
+++ b/tests/kernels/test_cache.py
@@ -3,7 +3,11 @@ import random
 import pytest
 import torch
 
-from vllm._C import cache_ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import cache_ops
+else:
+    from vllm._C import cache_ops
 
 DTYPES = [torch.half, torch.bfloat16, torch.float]
 NUM_TOKENS = [83]  # Arbitrary values for testing

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -145,7 +145,7 @@ class EngineArgs:
         parser.add_argument('--block-size',
                             type=int,
                             default=EngineArgs.block_size,
-                            choices=[8, 16, 32],
+                            choices=[8, 16, 32, 48, 64, 96, 128, 192, 256],
                             help='token block size')
         # TODO(woosuk): Support fine-grained seeds (e.g., seed per request).
         parser.add_argument('--seed',

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -224,7 +224,7 @@ class LLMEngine:
         # Since we use a shared centralized controller, we take the minimum
         # number of blocks across all workers to make sure all the memory
         # operators can be applied to all workers.
-        num_gpu_blocks = min(10500, min(b[0] for b in num_blocks))
+        num_gpu_blocks = min(b[0] for b in num_blocks)
         num_cpu_blocks = min(b[1] for b in num_blocks)
         # FIXME(woosuk): Change to debug log.
         logger.info(f"# GPU blocks: {num_gpu_blocks}, "

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -217,7 +217,7 @@ class LLMEngine:
         # Since we use a shared centralized controller, we take the minimum
         # number of blocks across all workers to make sure all the memory
         # operators can be applied to all workers.
-        num_gpu_blocks = min(b[0] for b in num_blocks)
+        num_gpu_blocks = min(10500, min(b[0] for b in num_blocks))
         num_cpu_blocks = min(b[1] for b in num_blocks)
         # FIXME(woosuk): Change to debug log.
         logger.info(f"# GPU blocks: {num_gpu_blocks}, "

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -1,7 +1,11 @@
 import argparse
 import json
 from typing import AsyncGenerator
-
+import torch
+from vllm.utils import is_hpu
+if is_hpu():
+    import habana_frameworks.torch.core as htcore
+    import habana_frameworks.torch.gpu_migration
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 import uvicorn

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -8,7 +8,11 @@ import json
 import time
 from http import HTTPStatus
 from typing import AsyncGenerator, Dict, List, Optional, Tuple, Union
-
+import torch
+from vllm.utils import is_hpu
+if is_hpu():
+    import habana_frameworks.torch.core as htcore
+    import habana_frameworks.torch.gpu_migration
 from aioprometheus import MetricsMiddleware
 from aioprometheus.asgi.starlette import metrics
 import fastapi

--- a/vllm/hpu/__init__.py
+++ b/vllm/hpu/__init__.py
@@ -1,0 +1,6 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################

--- a/vllm/hpu/attn_bias.py
+++ b/vllm/hpu/attn_bias.py
@@ -1,0 +1,764 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import math
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union
+
+import torch
+
+
+class AttentionBias:
+    """Base class for a custom bias that can be applied \
+        as the attn_bias argument in
+        :attr:`xformers.ops.memory_efficient_attention`.
+
+    That function has the ability to add a tensor, the
+    attention bias, to the QK^T matrix before it is used
+    in the softmax part of the attention calculation.
+    The attention bias tensor with shape
+    (B or 1, n_queries, number of keys)
+    can be given as the attn_bias input.
+    The most common use case is for an attention bias is
+    to contain only zeros and negative infinities, which forms
+    a mask so that some queries only attend to some keys.
+
+    Children of this class define alternative things which can
+    be used as the attn_bias input to define an attention bias which
+    forms such a mask, for some common cases.
+
+    When using an :attr:`xformers.ops.AttentionBias`
+    instead of a :attr:`torch.Tensor`, the mask matrix does
+    not need to be materialized, and can be
+    hardcoded into some kernels for better performance.
+
+    See:
+
+    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMask`
+    - :attr:`xformers.ops.fmha.attn_bias.LowerTriangularMaskWithTensorBias`
+    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`
+    - :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`
+
+    """
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """
+        Materializes the bias as a `torch.Tensor`. This is very slow
+        and we don't attempt to make it fast. Only use for debugging/testing.
+
+        Shape should be like `[*, q_seqlen, k_seqlen]`
+        """
+        raise NotImplementedError()
+
+
+class LowerTriangularMask(AttentionBias):
+    """
+    A lower-triangular (aka causal) mask
+
+    A query Q cannot attend to a key which is farther from the
+    initial key than Q is from the initial query.
+    """
+
+    def __init__(self, *tensor_args, **tensor_kwargs) -> None:
+        # NOTE: Unused arguments, we keep them for backward compatibility
+        super().__init__()
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        tensor = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=float("-inf"),
+            device=device,
+        )
+        return torch.triu(tensor, diagonal=1).to(dtype)  # type: ignore
+
+    def add_bias(self, bias: torch.Tensor) -> "LowerTriangularMaskWithTensorBias":
+        return LowerTriangularMaskWithTensorBias(bias)
+
+
+class LowerTriangularMaskWithTensorBias(LowerTriangularMask):
+    """A lower-triangular (aka causal) mask with an additive bias"""
+
+    def __init__(self, bias: torch.Tensor) -> None:
+        self._bias = bias
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return super().materialize(shape, dtype=dtype, device=device) + self._bias
+
+
+@dataclass
+class _SeqLenInfo:
+    """
+    (Internal) Represents the division of a dimension into blocks.
+
+    For example, to represents a dimension of length 7 divided into
+    three blocks of lengths 2, 3 and 2, use `from_seqlength([2, 3, 2])`.
+    The members will be:
+        max_seqlen: 3
+        min_seqlen: 2
+        seqstart_py: [0, 2, 5, 7]
+        seqstart: torch.IntTensor([0, 2, 5, 7])
+    """
+
+    seqstart: torch.Tensor
+    max_seqlen: int
+    min_seqlen: int
+    seqstart_py: List[int]
+
+    def to(self, device: torch.device) -> None:
+        self.seqstart = self.seqstart.to(device, non_blocking=True)
+
+    def intervals(self) -> Iterable[Tuple[int, int]]:
+        yield from zip(self.seqstart_py, self.seqstart_py[1:])
+
+    @classmethod
+    def from_seqlens(cls, seqlens: Iterable[int]) -> "_SeqLenInfo":
+        """
+        Input tensors are assumed to be in shape [B, M, *]
+        """
+        assert not isinstance(seqlens, torch.Tensor)
+        seqstart_py = [0]
+        max_seqlen = -1
+        min_seqlen = -1
+        for seqlen in seqlens:
+            min_seqlen = min(min_seqlen, seqlen) if min_seqlen != -1 else seqlen
+            max_seqlen = max(max_seqlen, seqlen)
+            seqstart_py.append(seqstart_py[len(seqstart_py) - 1] + seqlen)
+        seqstart = torch.tensor(seqstart_py, dtype=torch.int32)
+        return cls(
+            max_seqlen=max_seqlen,
+            min_seqlen=min_seqlen,
+            seqstart=seqstart,
+            seqstart_py=seqstart_py,
+        )
+
+    def split(
+        self, x: torch.Tensor, batch_sizes: Optional[Sequence[int]] = None
+    ) -> List[torch.Tensor]:
+        if self.seqstart_py[-1] != x.shape[1] or x.shape[0] != 1:
+            raise ValueError(
+                f"Invalid `torch.Tensor` of shape {x.shape}, expected format "
+                f"(B, M, *) with B=1 and M={self.seqstart_py[-1]}\n"
+                f" seqstart: {self.seqstart_py}"
+            )
+        if batch_sizes is None:
+            batch_sizes = [1] * (len(self.seqstart_py) - 1)
+        split_chunks = []
+        it = 0
+        for batch_size in batch_sizes:
+            split_chunks.append(
+                self.seqstart_py[it + batch_size] - self.seqstart_py[it]
+            )
+            it += batch_size
+        return [
+            tensor.reshape([bs, -1, *tensor.shape[2:]])
+            for bs, tensor in zip(batch_sizes, x.split(split_chunks, dim=1))
+        ]
+
+
+@dataclass
+class _PaddedSeqLenInfo(_SeqLenInfo):
+    """
+    (Internal)  Represents the division of a dimension into blocks which are
+    padded out to the same total length.
+
+    For example, to represent a dimension of length 12 with space for
+    three blocks of length 4, but where the occupied lengths are
+    2, 3 and 2, use `from_seqlens_padded([2, 3, 2], 4)`.
+
+    The layout along the dimension is
+
+     0 ─►  block 0
+           block 0
+           <space>
+           <space>
+     4 ─►  block 1
+           block 1
+           block 1
+           <space>
+     8 ─►  block 2
+           block 2
+           <space>
+           <space>
+    12 ─►
+
+    The members will be:
+        max_seqlen: 3
+        min_seqlen: 2
+        seqstart_py: [0, 4, 8, 12]
+        seqstart: torch.IntTensor([0, 4, 8, 12])
+        seqlen_py: [2, 3, 2]
+        seqlen: torch.IntTensor([2, 3, 2])
+        padding: 4
+    """
+
+    seqlen: torch.Tensor
+    seqlen_py: Sequence[int]
+    padding: int
+    # From parent: seqstart[i] contains the start position
+    # of the i-th sequence
+    # seqstart: torch.Tensor
+
+    def __post_init__(self) -> None:
+        assert len(self.seqstart_py) == len(self.seqlen_py) + 1
+
+    def to(self, device: torch.device) -> None:
+        self.seqlen = self.seqlen.to(device, non_blocking=True)
+        super().to(device)
+
+    def intervals(self) -> Iterable[Tuple[int, int]]:
+        for (start, _), length in zip(super().intervals(), self.seqlen_py):
+            yield start, start + length
+
+    @classmethod
+    def from_seqlens(cls, seqlens: Iterable[int]) -> "_SeqLenInfo":
+        raise RuntimeError(
+            "Use either `_SeqLenInfo.from_seqlens` or `_PaddedSeqLenInfo.from_seqlens_padded`"
+        )
+
+    @classmethod
+    def from_seqlens_padded(
+        cls, seqlens: Sequence[int], padding: int
+    ) -> "_PaddedSeqLenInfo":
+        """
+        Input tensors are assumed to be in shape [B, M, *]
+        seqstart = padding * torch.arange(batch_size)
+        """
+        assert not isinstance(seqlens, torch.Tensor)
+        assert all(seqlen <= padding for seqlen in seqlens)
+        seqstart_py = list(range(0, len(seqlens) * padding + 1, padding))
+        return cls(
+            seqlen=torch.tensor(seqlens, dtype=torch.int32),
+            seqlen_py=seqlens,
+            max_seqlen=max(seqlens),
+            min_seqlen=min(seqlens),
+            seqstart=torch.tensor(seqstart_py, dtype=torch.int32),
+            seqstart_py=seqstart_py,
+            padding=padding,
+        )
+
+    def split(
+        self, x: torch.Tensor, batch_sizes: Optional[Sequence[int]] = None
+    ) -> List[torch.Tensor]:
+        raise NotImplementedError("_PaddedSeqLenInfo.split")
+
+
+@dataclass
+class BlockDiagonalMask(AttentionBias):
+    """
+    A block-diagonal mask that can be passed as ``attn_bias``
+    argument to :attr:`xformers.ops.memory_efficient_attention`.
+
+    Queries and Keys are each divided into the same number of blocks.
+    Queries in block i only attend to keys in block i.
+
+    .. figure:: /_static/block_diag_bias.png
+
+        This bias can be used to handle a batch of sequences of
+        different lengths, via :attr:`BlockDiagonalMask.from_tensor_list`
+
+    :Example:
+
+    .. code-block:: python
+
+        import torch
+        from xformers.ops import fmha
+
+        K = 16
+        dtype = torch.float16
+        device = "cuda"
+        list_x = [
+            torch.randn([1, 3, 1, K], dtype=dtype, device=device),
+            torch.randn([1, 6, 1, K], dtype=dtype, device=device),
+            torch.randn([1, 2, 1, K], dtype=dtype, device=device),
+        ]
+        attn_bias, x = fmha.BlockDiagonalMask.from_tensor_list(list_x)
+        linear = torch.nn.Linear(K, K * 3).to(device=device, dtype=dtype)
+
+        q, k, v = linear(x).reshape([1, -1, 1, 3, K]).unbind(-2)
+        out = fmha.memory_efficient_attention(q, k, v, attn_bias=attn_bias)
+        list_out = attn_bias.split(out)
+        print(list_out[0].shape)  # [1, 3, 1, K]
+        assert tuple(list_out[0].shape) == (1, 3, 1, K)
+
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _SeqLenInfo
+    _batch_sizes: Optional[Sequence[int]] = None
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return torch.zeros(
+            shape,
+            dtype=dtype,
+            device=device,
+        )
+
+    def materialize(
+        self,
+        shape: Optional[Tuple[int, ...]] = None,
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape is None:
+            shape = (self.q_seqinfo.seqstart_py[-1],
+                     self.k_seqinfo.seqstart_py[-1])
+        assert shape[-1] == self.k_seqinfo.seqstart_py[-1], (
+            shape[-1],
+            self.k_seqinfo.seqstart_py[-1],
+        )
+        assert shape[-2] == self.q_seqinfo.seqstart_py[-1], (
+            shape[-2],
+            self.q_seqinfo.seqstart_py[-1],
+        )
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for i, ((q_start, q_end), (k_start, k_end)) in enumerate(
+            zip(
+                self.q_seqinfo.intervals(),
+                self.k_seqinfo.intervals(),
+            )
+        ):
+            mask[q_start:q_end, k_start:k_end] = self._create_block_mask(
+                (q_end - q_start, k_end - k_start),
+                dtype=dtype,
+                device=device,
+            )
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_seqlen: Optional[Sequence[int]] = None,
+    ) -> "BlockDiagonalMask":
+        """Creates a :attr:`BlockDiagonalMask` from a list of tensors lengths for query and key/value.
+
+        Args:
+            q_seqlen (Union[Sequence[int], torch.Tensor]): List or tensor of sequence lengths for query tensors
+            kv_seqlen (Union[Sequence[int], torch.Tensor], optional): List or tensor of sequence lengths for key/value.
+                    (Defaults to ``q_seqlen``.)
+        Returns:
+            BlockDiagonalMask
+        """
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen)
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen)
+        if kv_seqlen is None or q_seqlen == kv_seqlen:
+            k_seqinfo = q_seqinfo
+        else:
+            k_seqinfo = _SeqLenInfo.from_seqlens(kv_seqlen)
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+    @classmethod
+    def from_tensor_list(
+        cls,
+        tensors: Sequence[torch.Tensor],
+    ) -> Tuple["BlockDiagonalMask", torch.Tensor]:
+        """Creates a :attr:`BlockDiagonalMask` from a list of tensors, and returns the tensors
+        concatenated on the sequence length dimension
+
+        .. figure:: /_static/block_diag_cat_split.png
+
+            See also :attr:`BlockDiagonalMask.split` to split the returned
+            :attr:`torch.Tensor` back to a list of tensors of varying sequence length
+
+        Args:
+            tensors (Sequence[torch.Tensor]): A list of tensors of shape ``[B, M_i, *]``.
+                All tensors should have the same dimension and the same batch size ``B``, but
+                they can have different sequence length ``M``.
+
+        Returns:
+            Tuple[BlockDiagonalMask, torch.Tensor]: The corresponding bias for the attention
+            along with `tensors` concatenated on the sequence length dimension, with shape ``[1, sum_i{M_i}, *]``
+        """
+        batch_sizes = [tensor.shape[0] for tensor in tensors]
+        seqlens = []
+        for x in tensors:
+            for _ in range(x.shape[0]):
+                seqlens.append(x.shape[1])
+        block_diag = cls.from_seqlens(seqlens)
+        block_diag._batch_sizes = batch_sizes
+        tensors_bs1 = tuple(x.reshape([1, -1, *x.shape[2:]]) for x in tensors)
+        concat_tensors = torch.cat(tensors_bs1, dim=1)
+        return block_diag, concat_tensors
+
+    @classmethod
+    def from_tensor_lists_qkv(
+        cls,
+        tensors_q: Sequence[torch.Tensor],
+        tensors_k: Sequence[torch.Tensor],
+        tensors_v: Optional[Sequence[torch.Tensor]] = None,
+    ) -> Tuple["BlockDiagonalMask", torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+        assert len(tensors_q) == len(tensors_k)
+        assert tensors_v is None or len(tensors_v) == len(tensors_q)
+        batch_sizes = [tensor.shape[0] for tensor in tensors_q]
+        q_seqlens, kv_seqlens = [], []
+        for i, (q, k) in enumerate(zip(tensors_q, tensors_k)):
+            assert q.shape[0] == k.shape[0]
+            q_seqlens += [q.shape[1]] * q.shape[0]
+            kv_seqlens += [k.shape[1]] * k.shape[0]
+            assert tensors_v is None or tensors_v[i].shape[:2] == k.shape[:2]
+        block_diag = cls.from_seqlens(q_seqlens, kv_seqlens)
+        block_diag._batch_sizes = batch_sizes
+        return (
+            block_diag,
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_q], dim=1),
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_k], dim=1),
+            torch.cat([x.reshape([1, -1, *x.shape[2:]]) for x in tensors_v], dim=1)
+            if tensors_v is not None
+            else None,
+        )
+
+    def split_queries(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        return self.q_seqinfo.split(tensor, self._batch_sizes)
+
+    def split_kv(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        return self.k_seqinfo.split(tensor, self._batch_sizes)
+
+    def split(self, tensor: torch.Tensor) -> Sequence[torch.Tensor]:
+        """The inverse operation of :attr:`BlockDiagonalCausalMask.from_tensor_list`
+
+        Args:
+            tensor (torch.Tensor): Tensor of tokens of shape ``[1, sum_i{M_i}, *]``
+
+        Returns:
+            Sequence[torch.Tensor]: A list of tokens with possibly different sequence lengths
+        """
+        assert self.q_seqinfo is self.k_seqinfo
+        return self.q_seqinfo.split(tensor, self._batch_sizes)
+
+    def make_causal(self) -> "BlockDiagonalCausalMask":
+        """Makes each block causal"""
+        return BlockDiagonalCausalMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def make_causal_from_bottomright(self) -> "BlockDiagonalCausalFromBottomRightMask":
+        """Makes each block causal with a possible non-causal prefix"""
+        return BlockDiagonalCausalFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+        )
+
+    def make_local_attention(
+        self, window_size: int
+    ) -> "BlockDiagonalCausalLocalAttentionMask":
+        """Experimental: Makes each block causal with local attention"""
+        return BlockDiagonalCausalLocalAttentionMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+            _window_size=window_size,
+        )
+
+    def make_local_attention_from_bottomright(
+        self, window_size: int
+    ) -> "BlockDiagonalCausalLocalAttentionFromBottomRightMask":
+        """Experimental: Makes each block causal with local attention, start from bottom right"""
+        return BlockDiagonalCausalLocalAttentionFromBottomRightMask(
+            q_seqinfo=self.q_seqinfo,
+            k_seqinfo=self.k_seqinfo,
+            _batch_sizes=self._batch_sizes,
+            _window_size=window_size,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalMask(BlockDiagonalMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+
+    Queries and Keys are each divided into the same number of blocks.
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is farther from the initial key in block i than Q
+    is from the initial query in block i.
+    """
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        return LowerTriangularMask().materialize(
+            shape,
+            dtype=dtype,
+            device=device,
+        )
+
+
+@dataclass
+class BlockDiagonalCausalFromBottomRightMask(BlockDiagonalMask):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalMask`, except that each block is causal.
+    This mask allows for a non-causal prefix
+    NOTE: Each block should have `num_keys >= num_queries` otherwise the forward pass is not
+    defined (softmax of vector of `-inf` in the attention)
+
+    Queries and keys are each divided into the same number of blocks.
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which nearer the final key in block i than Q is to the
+    final query in block i.
+    """
+
+    def __post_init__(self) -> None:
+        for i, ((q_start, q_end), (k_start, k_end)) in enumerate(
+            zip(
+                self.q_seqinfo.intervals(),
+                self.k_seqinfo.intervals(),
+            )
+        ):
+            num_queries = q_end - q_start
+            num_keys = k_end - k_start
+            if num_keys < num_queries:
+                raise ValueError(
+                    f"Block #{i} has num_keys={num_keys} and num_queries={num_queries}."
+                    " Expected `num_keys >= num_queries`"
+                )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        tensor = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=float("-inf"),
+            device=device,
+        )
+        num_queries, num_keys = shape[-2:]
+        return torch.triu(tensor, diagonal=num_keys - num_queries + 1).to(dtype)  # type: ignore
+
+
+@dataclass
+class BlockDiagonalCausalWithOffsetPaddedKeysMask(AttentionBias):
+    """
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`,
+    except an offset on causality is allowed for each block and we support padding for k/v
+
+    The keys and values are divided into blocks which are padded out to
+    the same total length.
+    For example, if there is space for 12 keys, for three blocks of
+    max length 4, but we only want to use the first 2, 3 and 2
+    of each block, use `kv_padding=4` and `kv_seqlens=[2, 3, 2]`.
+    The queries are divided into blocks, without padding, of lengths given by
+    q_seqlen.
+
+    A query Q in block i cannot attend to a key which is not in block i,
+    nor one which is not in use (i.e. in the padded area),
+    nor one which is nearer to the final key in block i
+    than Q is to the final query in block i.
+    """
+
+    q_seqinfo: _SeqLenInfo
+    k_seqinfo: _PaddedSeqLenInfo
+    causal_diagonal: Any = None  # unused. Exists for BC only.
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        tensor = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=float("-inf"),
+            device=device,
+        )
+        num_queries, num_keys = shape[-2:]
+        return torch.triu(tensor, diagonal=1 + num_keys - num_queries).to(dtype)  # type: ignore
+
+    def materialize(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        """Materialize the attention bias - for debugging & testing"""
+        if shape[-1] != self.k_seqinfo.seqstart_py[-1]:
+            raise ValueError("k shapes wrong")
+        if shape[-2] != self.q_seqinfo.seqstart_py[-1]:
+            raise ValueError("q shapes wrong")
+        mask = torch.empty(shape[-2:], dtype=dtype, device=device)
+        mask.fill_(-math.inf)
+        for i, ((q_start, q_end), (k_start, k_end)) in enumerate(
+            zip(
+                self.q_seqinfo.intervals(),
+                self.k_seqinfo.intervals(),
+            )
+        ):
+            mask[q_start:q_end, k_start:k_end] = self._create_block_mask(
+                (q_end - q_start, k_end - k_start),
+                dtype=dtype,
+                device=device,
+            )
+        for _ in range(len(shape) - 2):
+            mask = mask.unsqueeze(0)
+        return mask.expand(shape)
+
+    @classmethod
+    def from_seqlens(
+        cls,
+        q_seqlen: Sequence[int],
+        kv_padding: int,
+        kv_seqlen: Sequence[int],
+        causal_diagonal: Any = None,
+    ) -> "BlockDiagonalCausalWithOffsetPaddedKeysMask":
+        """Creates a :attr:`BlockDiagonalCausalWithOffsetPaddedKeysMask` from a list of tensor
+        lengths for query and key/value.
+
+        Args:
+            q_seqlen (Sequence[int]): List or tensor of sequence lengths for query tensors
+            kv_padding (int): Padding for k/v - also an upperbound on each individual key length
+            kv_seqlen (Sequence[int]): List or tensor of sequence lengths for key/value.
+            causal_diagonal: unused, for BC only
+        Returns:
+            BlockDiagonalCausalWithOffsetPaddedKeysMask
+        """
+        assert kv_seqlen is None or len(q_seqlen) == len(kv_seqlen), (
+            q_seqlen,
+            kv_seqlen,
+        )
+        q_seqinfo = _SeqLenInfo.from_seqlens(q_seqlen)
+        k_seqinfo = _PaddedSeqLenInfo.from_seqlens_padded(kv_seqlen, kv_padding)
+        return cls(q_seqinfo=q_seqinfo, k_seqinfo=k_seqinfo)
+
+
+@dataclass
+class BlockDiagonalCausalLocalAttentionMask(BlockDiagonalCausalMask):
+    """
+    (Experimental feature)
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    This makes the mask "local" and the attention pattern banded.
+
+    Query i only attends to keys in its block and cannot attend keys further than "window_size"
+    from it.
+    """
+
+    _window_size: int = 0  # forced due to inheritance and default arguments
+
+    def __post_init__(self):
+        if self._window_size <= 0:
+            raise ValueError(
+                f"Expected `window_size > 0`, but window_size={self._window_size}"
+            )
+        q_seqlen = [
+            y - x
+            for x, y in zip(
+                self.q_seqinfo.seqstart_py[:-1], self.q_seqinfo.seqstart_py[1:]
+            )
+        ]
+        kv_seqlen = [
+            y - x
+            for x, y in zip(
+                self.k_seqinfo.seqstart_py[:-1], self.k_seqinfo.seqstart_py[1:]
+            )
+        ]
+        for q, k in zip(q_seqlen, kv_seqlen):
+            if q - self._window_size >= k:
+                # Each query only attends to keys no further than window_size back.
+                # When q > k + window_size, there will be a query for which the window doesn't reach any key.
+                raise RuntimeError(
+                    f"No keys are attended in q_seqlen {q} k_seqlen {k} with sliding window {self._window_size}"
+                )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        tensor = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=1,
+            device=device,
+        )
+
+        num_queries, num_keys = shape[-2:]
+        mask = torch.tril(tensor, diagonal=0).to(dtype)  # type: ignore
+        if self._window_size is not None and self._window_size > 0:
+            mask = torch.triu(mask, diagonal=-self._window_size + 1)
+        mask = torch.log(mask)
+        return mask.to(dtype)
+
+
+@dataclass
+class BlockDiagonalCausalLocalAttentionFromBottomRightMask(
+    BlockDiagonalCausalFromBottomRightMask
+):
+    """
+    (Experimental feature)
+    Same as :attr:`xformers.ops.fmha.attn_bias.BlockDiagonalCausalMask`.
+    This makes the mask "local" and the attention pattern banded.
+
+    Query i only attends to keys in its block and cannot attend keys further than "window_size"
+    from it.
+    """
+
+    _window_size: int = 0  # forced due to inheritance and default arguments
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self._window_size <= 0:
+            raise ValueError(
+                f"Expected `window_size > 0`, but window_size={self._window_size}"
+            )
+
+    def _create_block_mask(
+        self,
+        shape: Tuple[int, ...],
+        dtype: torch.dtype = torch.float32,
+        device: Union[str, torch.device] = "cpu",
+    ) -> torch.Tensor:
+        create_as = dtype if dtype is not torch.bfloat16 else torch.float32
+        tensor = torch.full(  # type: ignore
+            shape,
+            dtype=create_as,
+            fill_value=1,
+            device=device,
+        )
+        num_queries, num_keys = shape[-2:]
+        mask = torch.tril(tensor, diagonal=num_keys - num_queries).to(dtype)  # type: ignore
+        if self._window_size is not None:
+            mask = torch.triu(
+                mask, diagonal=num_keys - num_queries - self._window_size + 1
+            )
+        mask = torch.log(mask)
+        return mask.to(dtype)

--- a/vllm/hpu/cache_ops.py
+++ b/vllm/hpu/cache_ops.py
@@ -1,0 +1,41 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+from typing import Tuple
+import torch
+import habana_frameworks.torch as htorch
+
+
+def reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, is_prompt=False):
+    """
+    key: [num_tokens, num_heads, head_size]
+    value: [num_tokens, num_heads, head_size]
+    key_cache: [num_heads, head_size, block_size] * num_blocks
+    value_cache: [num_heads, head_size, block_size] * num_blocks
+    slot_mapping: [num_tokens]
+    """
+    num_tokens = key.shape[0]
+    block_size = key_cache.shape[-1]
+    slot_mapping = slot_mapping.to(key.device)
+    block_indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+    if is_prompt:
+        for i in range(0, num_tokens, block_size):
+            key_cache.index_put_([block_indices[i]], key[i:i+block_size].transpose(0,1).transpose(1,2))
+            value_cache.index_put_([block_indices[i]], value[i:i+block_size].transpose(0,1).transpose(1,2))
+    else:
+        key_cache = key_cache.permute(0, 3, 1, 2)
+        value_cache = value_cache.permute(0, 3, 1, 2)
+        block_indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+        block_offsets = torch.fmod(slot_mapping, block_size)
+        slot_indices = torch.stack([block_indices, block_offsets], dim=-1)
+        index = torch.tensor(0, device=key.device)
+        for i in range(num_tokens):
+            key_cache[slot_indices[i][0], slot_indices[i][1], :, :] = key[i]
+            value_cache[slot_indices[i][0], slot_indices[i][1], :, :] = value[i]
+            index.add_(1)
+        key_cache = key_cache.permute(0, 2, 3, 1)
+        value_cache = value_cache.permute(0, 2, 3, 1)

--- a/vllm/hpu/cache_ops.py
+++ b/vllm/hpu/cache_ops.py
@@ -39,3 +39,30 @@ def reshape_and_cache(key, value, key_cache, value_cache, slot_mapping, is_promp
             index.add_(1)
         key_cache = key_cache.permute(0, 2, 3, 1)
         value_cache = value_cache.permute(0, 2, 3, 1)
+
+
+def swap_blocks(src, dst, block_mapping):
+    index_src = torch.zeros((1,), dtype=torch.int32, device=key_caches[0].device)
+    index_dst = torch.zeros((1,), dtype=torch.int32, device=key_caches[0].device)
+    for src_idx, dst_idx in block_mapping.items():
+        index_src[0] = src_idx
+        index_dst[0] = dst_idx
+        dst.index_put_([index_dst], src.index_select(0, index_src))
+    if dst.device.type == 'hpu':
+        htorch.core.mark_step()
+        torch.hpu.synchronize()
+
+
+def copy_blocks(key_caches, value_caches, block_mapping):
+    index_src = torch.zeros((1,), dtype=torch.int32, device=key_caches[0].device)
+    index_dst = torch.zeros((1,), dtype=torch.int32, device=key_caches[0].device)
+    for src, dsts in block_mapping.items():
+        index_src[0] = src
+        for dst in dsts:
+            index_dst[0] = dst
+            for key_cache in key_caches:
+                key_cache.index_copy_(0, index_dst, key_cache.index_select(0, index_src))
+            for value_cache in value_caches:
+                value_cache.index_copy_(0, index_dst, value_cache.index_select(0, index_src))
+        if key_caches[0].device.type == 'hpu':
+            htorch.core.mark_step()

--- a/vllm/hpu/cuda_utils.py
+++ b/vllm/hpu/cuda_utils.py
@@ -1,0 +1,9 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+def get_device_attribute(attribute, device_id):
+    return 10240  # TODO: fake value now

--- a/vllm/hpu/hpu_util_time.py
+++ b/vllm/hpu/hpu_util_time.py
@@ -1,0 +1,126 @@
+import torch
+import time
+import os
+import multiprocessing
+import re
+import numpy as np
+import habana_frameworks.torch as htorch
+import pyhlml
+
+class HpuUtilTime:
+    def __init__(self, interval):
+        self.target = self.query_hl_smi
+        self.queue = multiprocessing.Queue(maxsize=1)
+        self.manager = multiprocessing.Manager().list()
+        self.process = multiprocessing.Process(
+            target=self.target,
+            args=(self.queue,)
+        )
+        pyhlml.hlmlInit()
+        self.device_count = pyhlml.hlmlDeviceGetCount()
+        self.device_time = np.zeros(self.device_count, dtype=np.float)
+        self.device_mean_utilization = np.zeros(self.device_count, dtype=np.float)
+        self.loop_counter = 0
+        self.interval = interval
+    
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exec_type, exec_value, traceback):
+        self.process.kill()
+        if self.target == self.capture_hl_smi:
+            self.postprocess_hl_smi()
+        pyhlml.hlmlShutdown()
+        self.display()
+
+    def start(self):
+        self.process.start()
+    
+    # 1st Method - paring hl-smi query output
+    def query_hl_smi(self, queue):
+        while True:
+            hl_smi_output = os.popen("hl-smi -Q power.draw,utilization.aip -f csv,noheader,nounits").read()
+            devices_utilization = re.findall(r'\, (\d+)', hl_smi_output)
+            devices_utilization_numpy = np.array(devices_utilization).astype(int)
+
+            self.loop_counter += 1
+            time.sleep(self.interval)
+            self.device_time[devices_utilization_numpy > 0] += self.interval
+            self.device_mean_utilization += (devices_utilization_numpy - self.device_mean_utilization) / self.loop_counter
+
+            devices_output = (
+                self.device_mean_utilization,
+                self.device_time,
+            )
+            self.manager.append(devices_output)
+
+    # 2nd Method - paring full hl-smi output
+    def hl_smi(self, queue):
+        while True:            
+            hl_smi_output = os.popen("hl-smi").read()
+            devices_utilization = re.findall(r'\b(\d+)%', hl_smi_output)
+            devices_utilization_numpy = np.array(devices_utilization).astype(int)
+
+            self.loop_counter += 1
+            time.sleep(self.interval)
+            self.device_time[devices_utilization_numpy > 0] += self.interval
+            self.device_mean_utilization += (devices_utilization_numpy - self.device_mean_utilization) / self.loop_counter
+
+            devices_output = (
+                self.device_mean_utilization,
+                self.device_time,
+            )
+            self.manager.append(devices_output)
+
+    # 3rd Method
+    def pyhlml(self, queue):
+        while True:
+            self.loop_counter += 1
+
+            for device_idx in range(self.device_count):
+                device = pyhlml.hlmlDeviceGetHandleByIndex(device_idx)
+                device_utilization = pyhlml.hlmlDeviceGetUtilizationRates(device)
+                # device_utilization = pyhlml.hlmlDeviceGetPowerManagementDefaultLimit(device)
+                # device_utilization = pyhlml.hlmlDeviceGetPowerUsage(device)
+                self.device_time[device_idx] += self.interval if device_utilization > 0 else 0
+                self.device_mean_utilization[device_idx] += (device_utilization - self.device_mean_utilization[device_idx]) / self.loop_counter
+            time.sleep(self.interval)
+
+            devices_output = (
+                self.device_mean_utilization,
+                self.device_time,
+            )
+            self.manager.append(devices_output)
+
+    # 4th Method
+    def capture_hl_smi(self, queue):
+        while True:
+            hl_smi_output = os.popen("hl-smi -Q power.draw,utilization.aip -f csv,noheader,nounits").read()
+            self.manager.append(hl_smi_output)
+            time.sleep(self.interval)
+
+    def postprocess_hl_smi(self):
+        devices_output = []
+        for hl_smi_output in self.manager:
+            devices_utilization = re.findall(r'\, (\d+)', hl_smi_output)
+            devices_utilization_numpy = np.array(devices_utilization).astype(int)
+
+            self.loop_counter += 1
+            time.sleep(self.interval)
+            self.device_time[devices_utilization_numpy > 0] += self.interval
+            self.device_mean_utilization += (devices_utilization_numpy - self.device_mean_utilization) / self.loop_counter
+
+            devices_output.append((
+                self.device_mean_utilization,
+                self.device_time,
+            ))
+        self.manager = devices_output
+
+    # Display final results
+    def display(self):
+        if self.manager:
+            mean_utilization = np.round(self.manager[-1][0], decimals=2)
+            time_utilization = np.round(self.manager[-1][1], decimals=6)
+            for device_idx in range(self.device_count):
+                print(f'HPU {device_idx} | Mean utilization: {mean_utilization[device_idx]}% | Time utilization: {time_utilization[device_idx]}s')

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -5,13 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 ###############################################################################
 
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import habana_frameworks.torch as htorch
 from typing import List, Optional, Tuple
-
 import vllm.hpu.utils as hpu_utils
+
+PA_SPLIT_VALUE = (os.environ.get('PA_SPLIT_VALUE', '0') == '1')
 
 
 def silu_and_mul(output, input):
@@ -30,19 +32,7 @@ def gelu_fast(output, input):
 
 
 def fetch_from_cache(cache, blocks):
-    _, seq_len = blocks.shape
-    return torch.cat([cache.index_select(0, blocks[:, i]) for i in range(seq_len)], dim=-1)
-
-
-def scaled_dot_product_attention(query, key, value, scale, mask):
-    bs = query.size(0)
-    min_inf = torch.finfo(query.dtype).min
-    value.masked_fill_(mask, min_inf)
-    return (torch.matmul(query, key)
-            .mul_(scale)
-            .masked_fill_(mask, min_inf)
-            .softmax(dim=-1)
-            .matmul(value.transpose(-1, -2)))
+    return [cache.index_select(0, blocks[:, i]) for i in range(blocks.size(1))]
 
 
 @hpu_utils.with_mark_steps
@@ -52,29 +42,40 @@ def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block
     if attn_masks is not None:
         raise NotImplementedError
 
-    key = fetch_from_cache(key_cache, block_tables)
-    value = fetch_from_cache(value_cache, block_tables)
-    query = query.unsqueeze(-2)
-    batch_size, query_heads, head_dim, _ = query.shape
-    _, kv_heads, _, seq_len = key.shape
-
-    mask = (torch.arange(0, seq_len, dtype=torch.int32, device=key.device)
+    seq_len = block_tables.size(1)
+    batch_size, query_heads, _ = query.shape
+    _, kv_heads, _, _ = key_cache.shape
+    min_inf = torch.finfo(query.dtype).min
+    mask = (torch.arange(0, seq_len * block_size, dtype=torch.int32, device=key_cache.device)
             .view(1, -1)
-            .expand(batch_size, seq_len)
+            .expand(batch_size, -1)
             .ge(context_lens.view(-1, 1))
             .view(batch_size, 1, 1, -1))
-
+    query = query.unsqueeze(-2)
+    keys = fetch_from_cache(key_cache, block_tables)
     if query_heads != kv_heads:
-        attn_weights = scaled_dot_product_attention(
-            query.unflatten(1, (kv_heads, -1)),
-            key.unsqueeze(2),
-            value.unsqueeze(2),
-            scale,
-            mask.unsqueeze(2))
-        attn_weights = attn_weights.flatten(1, 2)
+        query = query.unflatten(1, (kv_heads, -1))
+        keys = [k.unflatten(1, (kv_heads, 1)) for k in keys]
+        mask = mask.unsqueeze(2)
+
+    attn_weights = [torch.matmul(query, k) for k in keys]
+    attn_weights = (torch.cat(attn_weights, dim=-1)
+                    .mul_(scale)
+                    .masked_fill(mask, min_inf)
+                    .softmax(dim=-1))
+
+    values = fetch_from_cache(value_cache, block_tables)
+    if PA_SPLIT_VALUE:
+        attn_weights = attn_weights.split(block_size, dim=-1)
     else:
-        attn_weights = scaled_dot_product_attention(query, key, value, scale, mask)
-    attn_weights = attn_weights.squeeze(-2)
+        values = [torch.cat(values, dim=-1)]
+        attn_weights = [attn_weights]
+    if query_heads != kv_heads:
+        values = [v.unflatten(1, (kv_heads, 1)) for v in values]
+    attn_weights = [torch.matmul(a, v.transpose(-1, -2)).squeeze(-2) for a, v in zip(attn_weights, values)]
+    if query_heads != kv_heads:
+        attn_weights = [a.flatten(1, 2) for a in attn_weights]
+    attn_weights = sum(attn_weights)
 
     return attn_weights
 

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -11,87 +11,72 @@ import torch.nn.functional as F
 import habana_frameworks.torch as htorch
 from typing import List, Optional, Tuple
 
+import vllm.hpu.utils as hpu_utils
+
+
 def silu_and_mul(output, input):
-    htorch.core.mark_step()
     d = input.shape[-1] // 2
     silu = torch.nn.SiLU().to(input.device)
     x, y = torch.split(input, d, dim=-1)
     output.copy_(silu(x) * y)
-    htorch.core.mark_step()
+
 
 def gelu_new(output, input):
     raise NotImplementedError
 
+
 def gelu_fast(output, input):
     raise NotImplementedError
 
-def paged_attention_v1(query_in, key_cache_in, value_cache_in, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, attn_masks=None)  -> None:
-    query = query_in.bfloat16()
-    key_cache = key_cache_in.bfloat16()
-    value_cache = value_cache_in.bfloat16()
-    num_kv_heads = value_cache[0].shape[0]
-    head_size = value_cache[0].shape[1]
-    block_size = value_cache[0].shape[2]
-    num_seqs = query.shape[0]
-    num_query_heads = query.shape[1]
-    max_num_blocks_per_seq = block_tables.shape[1]
 
-    if alibi_slopes or num_query_heads != num_kv_heads: #or attn_masks is None:
+def fetch_from_cache(cache, blocks):
+    _, seq_len = blocks.shape
+    return torch.cat([cache.index_select(0, blocks[:, i]) for i in range(seq_len)], dim=-1)
+
+
+def scaled_dot_product_attention(query, key, value, scale, mask):
+    bs = query.size(0)
+    min_inf = torch.finfo(query.dtype).min
+    return (torch.matmul(query, key)
+            .mul_(scale)
+            .masked_fill_(mask, min_inf)
+            .softmax(dim=-1)
+            .matmul(value.transpose(-1, -2)))
+
+
+@hpu_utils.with_mark_steps
+def paged_attention_v1(query, key_cache, value_cache, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, attn_masks=None)  -> None:
+    if alibi_slopes is not None:
+        raise NotImplementedError
+    if attn_masks is not None:
         raise NotImplementedError
 
-    attn_weights_blocks = []
-    value_blocks = []
-    seq_index = torch.tensor([0], dtype=torch.int64, device="hpu")
+    key = fetch_from_cache(key_cache, block_tables)
+    value = fetch_from_cache(value_cache, block_tables)
+    query = query.unsqueeze(-2)
+    batch_size, query_heads, head_dim, _ = query.shape
+    _, kv_heads, _, seq_len = key.shape
 
-    for i in range(0, max_num_blocks_per_seq):
-        # FIXME: dynamic hard override for filler. These blocks would contribute nothing to the output due to zero attention_probs and
-        #  will clog up compute resources. The override itself makes the code unsuitable for graph precompilation
-        if (i - 2) * block_size > torch.max(context_lens):
-            break
-        attn_weights = torch.full((num_seqs, num_query_heads, 1, block_size), torch.finfo(query.dtype).min, dtype=query.dtype, device="hpu")
-        values = torch.zeros((num_seqs, num_query_heads, head_size, block_size), dtype=query.dtype, device="hpu")
-        for seq_id in range(num_seqs):
-            seq_index.fill_(seq_id)
-            if i * block_size < context_lens[seq_id]:
+    mask = (torch.arange(0, seq_len, dtype=torch.int32, device=key.device)
+            .view(1, -1)
+            .expand(batch_size, seq_len)
+            .ge(context_lens.view(-1, 1))
+            .view(batch_size, 1, 1, -1))
 
-                q =  torch.index_select(query, 0, seq_index).transpose(0, 1)
-                key = torch.index_select(key_cache, 0, block_tables[seq_id][i]).squeeze(0)
-                attn_weight = scale * torch.matmul(q, key)
+    if query_heads != kv_heads:
+        attn_weights = scaled_dot_product_attention(
+            query.unflatten(1, (kv_heads, -1)),
+            key.unsqueeze(2),
+            value.unsqueeze(2),
+            scale,
+            mask.unsqueeze(2))
+        attn_weights = attn_weights.flatten(1, 2)
+    else:
+        attn_weights = scaled_dot_product_attention(query, key, value, scale, mask)
+    attn_weights = attn_weights.squeeze(-2)
 
-                if attn_masks is not None:
-                    attn_mask = torch.index_select(attn_masks[i], 0, seq_index)
-                    attn_weight = torch.masked_fill(attn_weight, ~(attn_mask.unsqueeze(0).to(torch.bool)), torch.finfo(attn_weight.dtype).min)
+    return attn_weights
 
-                # FIXME: these dynamic checks serve to ensure the -inf default value is not overwritten with fillers that would cause errors
-                #  in logsoftmax computation. A change to custom block multiplication code is required to avoid incurring extra costs here
-                if context_lens[seq_id] < (i + 1) * block_size:
-                    if context_lens[seq_id] - i*block_size < 0:
-                        attn_weight = torch.finfo(query.dtype).min
-                    else:
-                        attn_weight[:, :, context_lens[seq_id] - i*block_size:] = torch.finfo(query.dtype).min
-                attn_weights.index_copy_(0, seq_index, attn_weight.unsqueeze(0))
-            value = torch.index_select(value_cache, 0, block_tables[seq_id][i])
-            # FIXME: these checks concern filler values in the V cache and should be removed once the underlying issue is addressed
-            value = torch.nan_to_num(value)
-            value[value < -1.0e+30] = 0.0
-            values.index_copy_(0, seq_index, value)
-            torch.hpu.synchronize()
-
-        attn_weights_blocks.append(attn_weights.reshape(num_seqs * num_query_heads, 1, block_size))
-        value_blocks.append(values.reshape(num_seqs * num_query_heads, head_size, block_size).transpose(1, 2))
-
-    exp_sum = torch.zeros((*attn_weights_blocks[0].shape[:2], 1), dtype=attn_weights_blocks[0].dtype, device="hpu")
-    for x in attn_weights_blocks:
-        exp_sum.add_(torch.exp(x).sum(dim=-1, keepdim=True))
-
-    output = torch.zeros_like(query)
-    for i in range(len(attn_weights_blocks)):
-        attention_probs = torch.exp(attn_weights_blocks[i]) / exp_sum
-        value = value_blocks[i]
-        out = torch.matmul(attention_probs.to(value.dtype), value).reshape(num_seqs, num_query_heads, head_size)
-        output.add_(out)
-    htorch.core.mark_step()
-    return output.to(dtype=query_in.dtype)
 
 def rms_norm(out, hidden_states, weight, eps):
     htorch.core.mark_step()
@@ -101,6 +86,7 @@ def rms_norm(out, hidden_states, weight, eps):
     hidden_states = hidden_states * torch.rsqrt(variance + eps)
     out.copy_(weight * hidden_states.to(input_dtype))
     htorch.core.mark_step()
+
 
 def rotate_neox(x: torch.Tensor) -> torch.Tensor:
     x1 = x[..., :x.shape[-1] // 2]

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -1,0 +1,137 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import habana_frameworks.torch as htorch
+from typing import List, Optional, Tuple
+
+def silu_and_mul(output, input):
+    htorch.core.mark_step()
+    d = input.shape[-1] // 2
+    silu = torch.nn.SiLU().to(input.device)
+    x, y = torch.split(input, d, dim=-1)
+    output.copy_(silu(x) * y)
+    htorch.core.mark_step()
+
+def gelu_new(output, input):
+    raise NotImplementedError
+
+def gelu_fast(output, input):
+    raise NotImplementedError
+
+def paged_attention_v1(query_in, key_cache_in, value_cache_in, head_mapping, scale, block_tables, context_lens, block_size, max_context_len, alibi_slopes, attn_masks=None)  -> None:
+    query = query_in.bfloat16()
+    key_cache = key_cache_in.bfloat16()
+    value_cache = value_cache_in.bfloat16()
+    num_kv_heads = value_cache[0].shape[0]
+    head_size = value_cache[0].shape[1]
+    block_size = value_cache[0].shape[2]
+    num_seqs = query.shape[0]
+    num_query_heads = query.shape[1]
+    max_num_blocks_per_seq = block_tables.shape[1]
+
+    if alibi_slopes or num_query_heads != num_kv_heads: #or attn_masks is None:
+        raise NotImplementedError
+
+    attn_weights_blocks = []
+    value_blocks = []
+    seq_index = torch.tensor([0], dtype=torch.int64, device="hpu")
+
+    for i in range(0, max_num_blocks_per_seq):
+        # FIXME: dynamic hard override for filler. These blocks would contribute nothing to the output due to zero attention_probs and
+        #  will clog up compute resources. The override itself makes the code unsuitable for graph precompilation
+        if (i - 2) * block_size > torch.max(context_lens):
+            break
+        attn_weights = torch.full((num_seqs, num_query_heads, 1, block_size), torch.finfo(query.dtype).min, dtype=query.dtype, device="hpu")
+        values = torch.zeros((num_seqs, num_query_heads, head_size, block_size), dtype=query.dtype, device="hpu")
+        for seq_id in range(num_seqs):
+            seq_index.fill_(seq_id)
+            if i * block_size < context_lens[seq_id]:
+
+                q =  torch.index_select(query, 0, seq_index).transpose(0, 1)
+                key = torch.index_select(key_cache, 0, block_tables[seq_id][i]).squeeze(0)
+                attn_weight = scale * torch.matmul(q, key)
+
+                if attn_masks is not None:
+                    attn_mask = torch.index_select(attn_masks[i], 0, seq_index)
+                    attn_weight = torch.masked_fill(attn_weight, ~(attn_mask.unsqueeze(0).to(torch.bool)), torch.finfo(attn_weight.dtype).min)
+
+                # FIXME: these dynamic checks serve to ensure the -inf default value is not overwritten with fillers that would cause errors
+                #  in logsoftmax computation. A change to custom block multiplication code is required to avoid incurring extra costs here
+                if context_lens[seq_id] < (i + 1) * block_size:
+                    if context_lens[seq_id] - i*block_size < 0:
+                        attn_weight = torch.finfo(query.dtype).min
+                    else:
+                        attn_weight[:, :, context_lens[seq_id] - i*block_size:] = torch.finfo(query.dtype).min
+                attn_weights.index_copy_(0, seq_index, attn_weight.unsqueeze(0))
+            value = torch.index_select(value_cache, 0, block_tables[seq_id][i])
+            # FIXME: these checks concern filler values in the V cache and should be removed once the underlying issue is addressed
+            value = torch.nan_to_num(value)
+            value[value < -1.0e+30] = 0.0
+            values.index_copy_(0, seq_index, value)
+            torch.hpu.synchronize()
+
+        attn_weights_blocks.append(attn_weights.reshape(num_seqs * num_query_heads, 1, block_size))
+        value_blocks.append(values.reshape(num_seqs * num_query_heads, head_size, block_size).transpose(1, 2))
+
+    exp_sum = torch.zeros((*attn_weights_blocks[0].shape[:2], 1), dtype=attn_weights_blocks[0].dtype, device="hpu")
+    for x in attn_weights_blocks:
+        exp_sum.add_(torch.exp(x).sum(dim=-1, keepdim=True))
+
+    output = torch.zeros_like(query)
+    for i in range(len(attn_weights_blocks)):
+        attention_probs = torch.exp(attn_weights_blocks[i]) / exp_sum
+        value = value_blocks[i]
+        out = torch.matmul(attention_probs.to(value.dtype), value).reshape(num_seqs, num_query_heads, head_size)
+        output.add_(out)
+    htorch.core.mark_step()
+    return output.to(dtype=query_in.dtype)
+
+def rms_norm(out, hidden_states, weight, eps):
+    htorch.core.mark_step()
+    input_dtype = hidden_states.dtype
+    hidden_states = hidden_states.to(torch.float32)
+    variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    hidden_states = hidden_states * torch.rsqrt(variance + eps)
+    out.copy_(weight * hidden_states.to(input_dtype))
+    htorch.core.mark_step()
+
+def rotate_neox(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., :x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2:]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def rotate_gptj(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., ::2]
+    x2 = x[..., 1::2]
+    x = torch.stack((-x2, x1), dim=-1)
+    return x.flatten(-2)
+
+
+def apply_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    is_neox_style: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    rotate_fn = rotate_neox if is_neox_style else rotate_gptj
+    q_embed = (q * cos) + (rotate_fn(q) * sin)
+    k_embed = (k * cos) + (rotate_fn(k) * sin)
+    return q_embed, k_embed
+
+
+def rotary_embedding(positions, query, key, head_size, cos_sin_cache, is_neox_style):
+    # FIXME: the below code is unused legacy code not meant to be used. Use FusedRoPE
+    #  on HPU and delete this once coverage is verified
+    raise NotImplementedError
+
+def awq_gemm(*args):
+    raise NotImplementedError

--- a/vllm/hpu/ops.py
+++ b/vllm/hpu/ops.py
@@ -37,6 +37,7 @@ def fetch_from_cache(cache, blocks):
 def scaled_dot_product_attention(query, key, value, scale, mask):
     bs = query.size(0)
     min_inf = torch.finfo(query.dtype).min
+    value.masked_fill_(mask, min_inf)
     return (torch.matmul(query, key)
             .mul_(scale)
             .masked_fill_(mask, min_inf)

--- a/vllm/hpu/ray_torch_dist.py
+++ b/vllm/hpu/ray_torch_dist.py
@@ -1,0 +1,195 @@
+"""This file is modeled after ray/python/ray/train/torch/config.py
+The logics are duplicated right now to allow maximum flexibility for
+setting up PyTorch DDP process groups outside the context of Ray Train.
+Eventually, these use cases should be consolidated.
+"""
+
+from abc import ABC
+from collections import defaultdict
+from datetime import timedelta
+import os
+import torch
+import torch.distributed as dist
+from typing import Callable, List, T
+
+import ray
+from ray.actor import ActorHandle
+from ray.train._internal.utils import get_address_and_port
+from ray.train.constants import DEFAULT_NCCL_SOCKET_IFNAME
+from ray.air._internal.torch_utils import get_device
+
+
+class TorchDistributedWorker(ABC):
+    """Defines the interfaces required by the init_torch_dist_process_group().
+    This is modeled after RayTrainerWorker, which allows arbitrary functions
+    to be executed on a remote DDP worker.
+    """
+
+    def execute(self, func: Callable[..., T], *args, **kwargs) -> T:
+        """Executes the input function and returns the output.
+        Args:
+            func: The function to execute.
+            args, kwargs: The arguments to pass into func.
+        """
+        return func(*args, **kwargs)
+
+
+def _init_torch_distributed(
+    init_method: str,
+    backend: str,
+    rank: int,
+    world_size: int,
+    local_rank: int,
+    local_world_size: int,
+    master_addr: str,
+    master_port: str,
+    gpu_ids: List[int],
+    **init_process_group_kwargs,
+):
+    """Initialize torch distributed backend"""
+    if init_method == "env":
+        os.environ["MASTER_ADDR"] = str(master_addr)
+        os.environ["MASTER_PORT"] = str(master_port)
+        url = "env://"
+    elif init_method == "tcp":
+        url = f"tcp://{master_addr}:{master_port}"
+    else:
+        raise ValueError(
+            f"The provided init_method ("
+            f"{init_method}) is not supported. Must "
+            f"be either 'env' or 'tcp'."
+        )
+
+    if backend == "nccl":
+        # Same as in Ray Train
+        os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"
+        # All workers on a same node should share the same set of
+        # visible GPUs. Otherwise they can't talk among themselves.
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(gid) for gid in gpu_ids)
+        if "NCCL_SOCKET_IFNAME" not in os.environ:
+            os.environ["NCCL_SOCKET_IFNAME"] = DEFAULT_NCCL_SOCKET_IFNAME
+    if backend == 'hccl':
+        import torch
+        import habana_frameworks.torch.core as htcore 
+        import habana_frameworks.torch.distributed.hccl as hccl
+        import habana_frameworks.torch.gpu_migration
+
+    init_process_group_kwargs.update(
+        dict(
+            backend=backend,
+            init_method=url,
+            rank=rank,
+            world_size=world_size,
+        )
+    )
+    init_process_group_kwargs.setdefault("timeout", timedelta(seconds=1800))
+
+    dist.init_process_group(**init_process_group_kwargs)
+
+    os.environ["RANK"] = str(rank)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_WORLD_SIZE"] = str(local_world_size)
+
+
+def _get_node_and_gpu_ids():
+    """Returns the node_id and gpu_ids for this worker."""
+    node_id = ray.get_runtime_context().get_node_id()
+    gpu_ids = ray.get_gpu_ids()
+    return node_id, gpu_ids
+
+
+def init_torch_dist_process_group(
+    workers: List[ActorHandle],
+    backend: str = "gloo",
+    init_method: str = "env",
+    **init_process_group_kwargs,
+) -> List[int]:
+    """Initialize a torch distributed process group.
+    Note: this util assumes that the order of the workers passed in
+    are their global ranks.
+    Args:
+        workers: A list of TorchDistributedWorker actors.
+        backend: The torch distributed backend to use,
+            possible choices are "gloo" or "nccl".
+        init_method: The initialization method to use,
+            possible choices are "env" or "tcp".
+        init_process_group_kwargs: Additional kwargs to pass to the call to
+            :meth:`torch.distributed.init_process_group`.
+    Returns:
+        Local ranks on their respective nodes for the list of workers.
+    """
+    if not dist.is_available():
+        raise RuntimeError("Distributed torch is not available.")
+
+    # Build a map from node_id to workers on that node.
+    node_and_gpu_ids = ray.get(
+        [w.execute.remote(_get_node_and_gpu_ids) for w in workers]
+    )
+    # All the workers on a specific node.
+    node_to_workers = defaultdict(list)
+    # All the gpu ids visible to all the workers on a specific node.
+    node_to_gpu_ids = defaultdict(set)
+    for i, (node_id, gpu_ids) in enumerate(node_and_gpu_ids):
+        node_to_workers[node_id].append(i)
+        # Force list.
+        if not isinstance(gpu_ids, list):
+            gpu_ids = [gpu_ids]
+        # It is possible for a worker to have access to multiple GPUs.
+        for gpu_id in gpu_ids:
+            node_to_gpu_ids[node_id].add(gpu_id)
+
+    # Assume the first worker is the master.
+    master_addr, master_port = ray.get(workers[0].execute.remote(get_address_and_port))
+
+    setup_futures = []
+    world_size = len(workers)
+    local_ranks = []
+    for rank, worker in enumerate(workers):
+        node_id = node_and_gpu_ids[rank][0]
+        local_rank = node_to_workers[node_id].index(rank)
+        local_world_size = len(node_to_workers[node_id])
+        setup_futures.append(
+            worker.execute.remote(
+                _init_torch_distributed,
+                init_method=init_method,
+                backend=backend,
+                rank=rank,
+                world_size=world_size,
+                local_rank=local_rank,
+                local_world_size=local_world_size,
+                master_addr=master_addr,
+                master_port=master_port,
+                # list(set) will sort the gpu ids, so VISIBLE_CUDA_DEVICES
+                # is always sorted.
+                gpu_ids=list(node_to_gpu_ids[node_id]),
+                **init_process_group_kwargs,
+            )
+        )
+        local_ranks.append(local_rank)
+
+    # Wait for all workers to join the process group.
+    ray.get(setup_futures)
+
+    return local_ranks
+
+
+def _shutdown_torch_distributed():
+    """Shutdown torch distributed backend"""
+    dist.destroy_process_group()
+
+    if not torch.cuda.is_available():
+        return
+
+    # Clean up cuda memory.
+    devices = get_device()
+    if not isinstance(devices, list):
+        devices = [devices]
+    for device in devices:
+        with torch.cuda.device(device):
+            torch.cuda.empty_cache()
+
+
+def shutdown_torch_dist_process_group(workers: List[ActorHandle]):
+    ray.get([w.execute.remote(_shutdown_torch_distributed) for w in workers])
+

--- a/vllm/hpu/rotary_embed.py
+++ b/vllm/hpu/rotary_embed.py
@@ -1,0 +1,117 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import torch
+import torch.nn as nn
+
+def get_device_name():
+    """
+    Returns the name of the current device: Gaudi or Gaudi2.
+
+    Inspired by: https://github.com/HabanaAI/Model-References/blob/a87c21f14f13b70ffc77617b9e80d1ec989a3442/PyTorch/computer_vision/classification/torchvision/utils.py#L274
+    """
+    import habana_frameworks.torch.utils.experimental as htexp
+
+    device_type = htexp._get_device_type()
+
+    if device_type == htexp.synDeviceType.synDeviceGaudi:
+        return "gaudi"
+    elif device_type == htexp.synDeviceType.synDeviceGaudi2:
+        return "gaudi2"
+    else:
+        raise ValueError(f"Unsupported device: the device type is {device_type}.")
+
+# TODO: remove this workaround when FusedRoPE properly works on Gaudi
+if get_device_name() == "gaudi2":
+    try:
+        from habana_frameworks.torch.hpex.kernels import RotaryPosEmbeddingHelperV1 as FusedRoPE
+    except ImportError:
+        print("Not using HPU fused kernel for apply_rotary_pos_emb")
+        FusedRoPE = None
+else:
+    FusedRoPE = None
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`):
+            The position indices of the tokens corresponding to the query and key tensors. For example, this can be
+            used to pass offsetted position ids when working with a KV-cache.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos[position_ids]#.unsqueeze(unsqueeze_dim)
+    sin = sin[position_ids]#.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class HpuRotaryEmbedding(nn.Module):
+    def __init__(self, head_size, rotary_dim, max_position_embeddings=2048, base=10000, is_neox_style=None, device='cuda'):
+        super().__init__()
+
+        self.head_size = head_size
+        self.dim = rotary_dim
+        self.max_position_embeddings = max_position_embeddings
+        self.base = base
+        inv_freq = 1.0 / (self.base ** (torch.arange(0, self.dim, 2).float().to(device) / self.dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+        # Build here to make `torch.jit.trace` work.
+        self._set_cos_sin_cache(
+            seq_len=max_position_embeddings, device=self.inv_freq.device, dtype=torch.get_default_dtype()
+        )
+
+    def _set_cos_sin_cache(self, seq_len, device, dtype):
+        self.max_seq_len_cached = seq_len
+        t = torch.arange(self.max_seq_len_cached, device=device, dtype=self.inv_freq.dtype)
+
+        freqs = torch.einsum("i,j->ij", t, self.inv_freq)
+        # Different from paper, but it uses a different permutation in order to obtain the same calculation
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos().to(dtype), persistent=False)
+        self.register_buffer("sin_cached", emb.sin().to(dtype), persistent=False)
+
+    def forward(self, positions: torch.Tensor, query: torch.Tensor, key: torch.Tensor):
+        seq_len = key.shape[-2]
+        if seq_len > self.max_seq_len_cached:
+            self._set_cos_sin_cache(seq_len=seq_len, device=query.device, dtype=query.dtype)
+
+        cos, sin = self.cos_cached[:seq_len].to(dtype=query.dtype), self.sin_cached[:seq_len].to(dtype=query.dtype)
+        query = query.reshape((query.shape[0], query.shape[1], query.shape[2] // self.head_size, self.head_size))
+        key = key.reshape((key.shape[0], key.shape[1], key.shape[2] // self.head_size, self.head_size))
+        if query.device.type == "hpu" and FusedRoPE:
+            if len(positions[0]) == 1:
+                cos = self.cos_cached[positions].unsqueeze(2).to(dtype=query.dtype)
+                sin = self.sin_cached[positions].unsqueeze(2).to(dtype=query.dtype)
+            else:
+                cos = cos[positions].unsqueeze(2)
+                sin = sin[positions].unsqueeze(2)
+            query, key = FusedRoPE.apply(query, cos, sin, 0), FusedRoPE.apply(key, cos, sin, 0)
+        else:
+            query, key = apply_rotary_pos_emb(query, key, cos, sin, positions)
+        return query.reshape((query.shape[0], query.shape[1], query.shape[2] * query.shape[3])), key.reshape((key.shape[0], key.shape[1], key.shape[2] * key.shape[3]))

--- a/vllm/hpu/utils.py
+++ b/vllm/hpu/utils.py
@@ -1,0 +1,20 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import habana_frameworks.torch as htorch
+
+def with_mark_steps(fn):
+    def wrapped(*args, **kwargs):
+        htorch.core.mark_step()
+        result = fn(*args, **kwargs)
+        del args
+        del kwargs
+        htorch.core.mark_step()
+        return result
+    return wrapped
+
+

--- a/vllm/hpu/xops.py
+++ b/vllm/hpu/xops.py
@@ -1,0 +1,67 @@
+###############################################################################
+# Copyright (C) 2024 Habana Labs, Ltd. an Intel Company
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+###############################################################################
+
+import habana_frameworks.torch as htorch
+import torch
+import torch.nn.functional as F
+from typing import List, Optional, Tuple, Union
+from .attn_bias import AttentionBias
+
+
+def block_masked_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+    attn_mask: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    query = query * scale
+    attn = query.transpose(0,1) @ key.transpose(0, 1).transpose(1, 2)
+    if attn_mask is not None:
+        attn = attn + attn_mask.to(attn.dtype)
+    attn = attn.softmax(-1)
+    out = attn @ value.transpose(0, 1)
+    out = out.transpose(0, 1)
+    return out
+
+
+def memory_efficient_attention_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    cu_seq_lens: List[int],
+    attn_bias: Optional[torch.Tensor] = None,
+    p: float = 0.0,
+    scale: Optional[float] = None,
+) -> torch.Tensor:
+    dim = query.dim()
+    if dim == 4:
+        query, key, value = query.squeeze(0), key.squeeze(0), value.squeeze(0)
+    num_seqs = len(cu_seq_lens) - 1
+    outputs = []
+    for i in range(num_seqs):
+        start_idx = cu_seq_lens[i]
+        end_idx = cu_seq_lens[i + 1]
+        seq_len = end_idx - start_idx
+        mask_start_idx = i * seq_len
+        mask_end_idx = (i + 1) * seq_len
+
+        # Create attention mask.
+        attn_mask = attn_bias.materialize(device=query.device)
+        output = block_masked_attention(
+            query[start_idx:end_idx],
+            key[start_idx:end_idx],
+            value[start_idx:end_idx],
+            scale,
+            attn_mask=attn_mask[mask_start_idx:mask_end_idx,
+                                mask_start_idx:mask_end_idx],
+        )
+        outputs.append(output)
+    out = torch.cat(outputs, dim=0)
+    if dim == 4:
+        out = out.unsqueeze(0)
+    return out

--- a/vllm/hpu/xops.py
+++ b/vllm/hpu/xops.py
@@ -9,7 +9,13 @@ import habana_frameworks.torch as htorch
 import torch
 import torch.nn.functional as F
 from typing import List, Optional, Tuple, Union
-from .attn_bias import AttentionBias
+from .attn_bias import AttentionBias, BlockDiagonalCausalMask
+
+try:
+    from habana_frameworks.torch.hpex.kernels import FusedSDPA
+except ImportError:
+    print("Not using HPU fused scaled dot-product attention kernel.")
+    FusedSDPA = None
 
 
 def block_masked_attention(
@@ -38,30 +44,48 @@ def memory_efficient_attention_forward(
     p: float = 0.0,
     scale: Optional[float] = None,
 ) -> torch.Tensor:
+    assert attn_bias is not None, "Attention mask is required for prompt processing"
     dim = query.dim()
-    if dim == 4:
-        query, key, value = query.squeeze(0), key.squeeze(0), value.squeeze(0)
-    num_seqs = len(cu_seq_lens) - 1
-    outputs = []
-    for i in range(num_seqs):
-        start_idx = cu_seq_lens[i]
-        end_idx = cu_seq_lens[i + 1]
-        seq_len = end_idx - start_idx
-        mask_start_idx = i * seq_len
-        mask_end_idx = (i + 1) * seq_len
+    if FusedSDPA and isinstance(attn_bias, BlockDiagonalCausalMask):
+        _, _, heads, head_dim = query.shape
+        bs = len(cu_seq_lens) - 1
+        seq_len_q = query.shape[1] // bs
+        seq_len_kv = key.shape[1] // bs
+        query = query.reshape(bs, seq_len_q, heads, head_dim).permute(0, 2, 1, 3)
+        key = key.reshape(bs, seq_len_kv, heads, head_dim).permute(0, 2, 1, 3)
+        value = value.reshape(bs, seq_len_kv, heads, head_dim).permute(0, 2, 1, 3)
+        attn_mask = torch.ones((bs, heads, seq_len_q, seq_len_kv), device=query.device, dtype=torch.bool).tril()
+        import habana_frameworks.torch.hpu as ht
+        with ht.sdp_kernel(enable_recompute=False):  # (flash_attention_recompute and q_len == 1)):
+            out = FusedSDPA.apply(
+                query, key, value, attn_mask, 0.0, False, None
+            )
+        htorch.core.mark_step()
+        out = out.permute(0, 2, 1, 3).reshape(bs * seq_len_q, heads, head_dim)
+    else:
+        if dim == 4:
+            query, key, value = query.squeeze(0), key.squeeze(0), value.squeeze(0)
+        num_seqs = len(cu_seq_lens) - 1
+        outputs = []
+        for i in range(num_seqs):
+            start_idx = cu_seq_lens[i]
+            end_idx = cu_seq_lens[i + 1]
+            seq_len = end_idx - start_idx
+            mask_start_idx = i * seq_len
+            mask_end_idx = (i + 1) * seq_len
 
-        # Create attention mask.
-        attn_mask = attn_bias.materialize(device=query.device)
-        output = block_masked_attention(
-            query[start_idx:end_idx],
-            key[start_idx:end_idx],
-            value[start_idx:end_idx],
-            scale,
-            attn_mask=attn_mask[mask_start_idx:mask_end_idx,
-                                mask_start_idx:mask_end_idx],
-        )
-        outputs.append(output)
-    out = torch.cat(outputs, dim=0)
+            # Create attention mask.
+            attn_mask = attn_bias.materialize(device=query.device)
+            output = block_masked_attention(
+                query[start_idx:end_idx],
+                key[start_idx:end_idx],
+                value[start_idx:end_idx],
+                scale,
+                attn_mask=attn_mask[mask_start_idx:mask_end_idx,
+                                    mask_start_idx:mask_end_idx],
+            )
+            outputs.append(output)
+        out = torch.cat(outputs, dim=0)
     if dim == 4:
         out = out.unsqueeze(0)
     return out

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from vllm._C import ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+else:
+    from vllm._C import ops
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.parallel_utils.parallel_state import (
     get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size)

--- a/vllm/model_executor/layers/attention.py
+++ b/vllm/model_executor/layers/attention.py
@@ -98,13 +98,23 @@ class PagedAttention(nn.Module):
         # vectors will not be cached. This happens during the initial memory
         # profiling run.
         if key_cache is not None and value_cache is not None:
-            cache_ops.reshape_and_cache(
-                key,
-                value,
-                key_cache,
-                value_cache,
-                input_metadata.slot_mapping.flatten(),
-            )
+            if not is_hpu():
+                cache_ops.reshape_and_cache(
+                    key,
+                    value,
+                    key_cache,
+                    value_cache,
+                    input_metadata.slot_mapping.flatten(),
+                )
+            else:
+                cache_ops.reshape_and_cache(
+                    key,
+                    value,
+                    key_cache,
+                    value_cache,
+                    input_metadata.slot_mapping,
+                    input_metadata.is_prompt
+                )
 
         if input_metadata.is_prompt:
             # Prompt run.

--- a/vllm/model_executor/layers/quantization/awq.py
+++ b/vllm/model_executor/layers/quantization/awq.py
@@ -3,7 +3,11 @@ from typing import Any, Dict, List, Optional
 import torch
 from torch.nn.parameter import Parameter
 
-from vllm._C import ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+else:
+    from vllm._C import ops
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig

--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -5,7 +5,11 @@ from typing import Any, Dict, List, Optional
 import torch
 from torch.nn.parameter import Parameter
 
-from vllm._C import ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+else:
+    from vllm._C import ops
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization.base_config import (

--- a/vllm/model_executor/layers/quantization/squeezellm.py
+++ b/vllm/model_executor/layers/quantization/squeezellm.py
@@ -3,11 +3,14 @@ from typing import Any, Dict, List, Optional
 import torch
 from torch.nn.parameter import Parameter
 
-from vllm._C import ops
 from vllm.model_executor.layers.linear import (LinearMethodBase,
                                                set_weight_attrs)
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
-from vllm.utils import is_hip
+from vllm.utils import is_hip, is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+else:
+    from vllm._C import ops
 
 
 class SqueezeLLMConfig(QuantizationConfig):

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -27,7 +27,12 @@ from typing import Any, Dict, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
-from vllm._C import ops
+from vllm.utils import is_hpu
+if is_hpu():
+    from vllm.hpu import ops
+    from vllm.hpu.rotary_embed import HpuRotaryEmbedding
+else:
+    from vllm._C import ops
 
 
 def _rotate_neox(x: torch.Tensor) -> torch.Tensor:
@@ -343,8 +348,12 @@ def get_rope(
         return _ROPE_DICT[key]
 
     if rope_scaling is None:
-        rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base,
-                                     is_neox_style)
+        if is_hpu():
+            rotary_emb = HpuRotaryEmbedding(head_size, rotary_dim, max_position, base,
+                                            is_neox_style)
+        else:
+            rotary_emb = RotaryEmbedding(head_size, rotary_dim, max_position, base,
+                                            is_neox_style)
     else:
         scaling_type = rope_scaling["type"]
         scaling_factor = rope_scaling["factor"]

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -146,7 +146,7 @@ class SamplingTensors:
                    dtype: torch.dtype) -> "SamplingTensors":
         # Note that the performance will be very bad without
         # pinned memory.
-        pin_memory = not in_wsl()
+        pin_memory = not in_wsl() and not device.type == "hpu"
         prompt_max_len = max(len(tokens) for tokens in prompt_tokens)
         prompt_padded_tokens = [
             tokens + [vocab_size] * (prompt_max_len - len(tokens))

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -35,13 +35,11 @@ def is_hpu() -> bool:
     return importlib.util.find_spec('habana_frameworks') is not None
 
 
-if is_hpu():
-    from vllm.hpu import cuda_utils
-else:
-    from vllm._C import cuda_utils
-
-
 def get_max_shared_memory_bytes(gpu: int = 0) -> int:
+    if is_hpu():
+        from vllm.hpu import cuda_utils
+    else:
+        from vllm._C import cuda_utils
     """Returns the maximum shared memory per thread block in bytes."""
     # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html
     cudaDevAttrMaxSharedMemoryPerBlockOptin = 97 if not is_hip() else 74

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1,12 +1,11 @@
 import enum
 import socket
 import uuid
+import importlib
 from platform import uname
 
 import psutil
 import torch
-
-from vllm._C import cuda_utils
 
 
 class Device(enum.Enum):
@@ -30,6 +29,16 @@ class Counter:
 
 def is_hip() -> bool:
     return torch.version.hip is not None
+
+
+def is_hpu() -> bool:
+    return importlib.util.find_spec('habana_frameworks') is not None
+
+
+if is_hpu():
+    from vllm.hpu import cuda_utils
+else:
+    from vllm._C import cuda_utils
 
 
 def get_max_shared_memory_bytes(gpu: int = 0) -> int:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -9,6 +9,7 @@ from vllm.utils import in_wsl, is_hpu
 
 if is_hpu():
     from vllm.hpu import cache_ops
+    import habana_frameworks.torch as htorch
 else:
     from vllm._C import cache_ops
 
@@ -88,11 +89,12 @@ class CacheEngine:
                 dtype=self.dtype,
                 device="hpu",
             )
-            value_blocks = torch.empty(
+            value_blocks = torch.zeros(
                 size=(self.num_gpu_blocks, *kv_block_shape),
                 dtype=self.dtype,
                 device="hpu",
             )
+            htorch.core.mark_step()
             hpu_cache.append((key_blocks, value_blocks))
         return hpu_cache
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -239,9 +239,10 @@ class ModelRunner:
                     input_block_tables[i, :len(block_table)] = block_table
             block_tables = torch.tensor(input_block_tables, device=device)
         else:
+            block_table_len = (max_context_len + self.block_size - 1) // self.block_size
             block_tables = _make_tensor_with_pad(
                 block_tables,
-                max_len=max_context_len,
+                max_len=block_table_len,
                 pad=0,
                 dtype=torch.int,
             )


### PR DESCRIPTION
### This PR adds HPU utilization time measurement functionality. 
The file vllm/hpu/time_util_time.py contains the HpuUtilTime class with 4 time measurement methods using pyhlml and hl-smi. To measure the workload fragment you need to add:
```
from vllm.hpu.hpu_util_time import HpuUtilTime
import os
os.environ["TOKENIZERS_PARALLELISM"] = "false"
```
and call the context manager:
```
with HpuUtilTime(interval=0.000005):
	has_requests_in_progress = await self.engine_step()
	await asyncio.sleep(0)
```
Here [SW-179136: vLLM: Collect device to host time ratio](https://jira.habana-labs.com/browse/SW-179136) is attached `time_util_demo.py` with a simple prototype for using HpuUtilTime
