### PR TITLE
properly handle situation when step_top_logprobs is None

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -103,9 +103,10 @@ class OpenAIServing:
             step_top_logprobs = top_logprobs[i]
             if step_top_logprobs is not None:
                 token_logprob = step_top_logprobs[token_id].logprob
+                token = step_top_logprobs[token_id].decoded_token
             else:
                 token_logprob = None
-            token = step_top_logprobs[token_id].decoded_token
+                token = None
             logprobs.tokens.append(token)
             logprobs.token_logprobs.append(token_logprob)
             if len(logprobs.text_offset) == 0:

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -106,7 +106,8 @@ class OpenAIServing:
                 token = step_top_logprobs[token_id].decoded_token
             else:
                 token_logprob = None
-                token = None
+                # The tokens in LogProbs are expected to be strings.
+                token = ""
             logprobs.tokens.append(token)
             logprobs.token_logprobs.append(token_logprob)
             if len(logprobs.text_offset) == 0:


### PR DESCRIPTION
When step_top_logprobs is None, calling `step_top_logprobs[token_id]` will cause exception. This PR will handle such situation properly.