### PR TITLE
[CI/Build] Reduce race condition in docker build

### DIFF
--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -13,7 +13,7 @@ steps:
 
   - label: ":docker: build image"
     commands:
-      - "docker build --build-arg max_jobs=16 --tag {{ docker_image }} --target test --progress plain ."
+      - "docker build --no-cache-filter vllm_nccl_cleanup --build-arg max_jobs=16 --tag {{ docker_image }} --target test --progress plain ."
       - "docker push {{ docker_image }}"
     env:
       DOCKER_BUILDKIT: "1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN ldconfig /usr/local/cuda-12.1/compat/
 
 WORKDIR /workspace
 
-# install build and runtime dependencies
+# copy build and runtime dependency files
+# no need to install now, just copy the files
+# they will be used by `setup.py` to install the dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-cuda.txt requirements-cuda.txt
 


### PR DESCRIPTION
Race condition is observed in https://github.com/vllm-project/vllm/pull/3948 , where docker build sometimes use cached `vllm-nccl` wheel and sometimes use source distribution.

This should be caused by the race condition of cache in docker build, because cache is shared across multiple build.