### PR TITLE
[Core][Distributed] make init_distributed_environment compatible with init_process_group

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -39,9 +39,9 @@ _PIPELINE_GLOBAL_RANKS = None
 
 
 def init_distributed_environment(
-    world_size: int,
-    rank: int,
-    distributed_init_method: Optional[str] = None,
+    world_size: int = -1,
+    rank: int = -1,
+    distributed_init_method: str = "env://",
     local_rank: int = -1,
     backend: str = "nccl",
 ):


### PR DESCRIPTION
Currently we require `world_size` and `rank`, but we can make them optional, and have a default `distributed_init_method` to `env://` .

This way, the following code just works with `torchrun`, which makes test and development very convenient.

```python
from vllm.distributed.parallel_state import init_distributed_environment
init_distributed_environment()
```

This should not affect other part of the code, as it only provides some default value for the function.

I do think we can change the arg name `distributed_init_method` to `init_method`, which is more aligned with pytorch. But that will require more code change. Not sure if it is worth the change.

cc @zhuohan123 for opinions.