### PR TITLE
[Model] [Kernel] Add 16, 32 kernel sizes in compliation

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -682,6 +682,10 @@ void paged_attention_v1_launcher(
     // NOTE(woosuk): To reduce the compilation time, we only compile for the
     // head sizes that we use in the model. However, we can easily extend this
     // to support any head size which is a multiple of 16.
+    case 16:
+      LAUNCH_PAGED_ATTENTION_V1(16);
+    case 32:
+      LAUNCH_PAGED_ATTENTION_V1(32);
     case 64:
       LAUNCH_PAGED_ATTENTION_V1(64);
       break;


### PR DESCRIPTION
This adds smaller kernel sizes. Recently a slew of new tiny models have come out such as
SanjiWatsuki/TinyMixtral-32x248M
BEE-spoke-data/smol_llama-220M-GQA

I am deploying the later and it is incompatible with vllm at the moment because of missing kernel sizes.