### PR TITLE
[Core] fix custom allreduce default value

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -86,7 +86,7 @@ class LLM:
         swap_space: int = 4,
         enforce_eager: bool = False,
         max_context_len_to_capture: int = 8192,
-        disable_custom_all_reduce: bool = True,
+        disable_custom_all_reduce: bool = False,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:


### PR DESCRIPTION
After https://github.com/vllm-project/vllm/pull/2760 , custom allreduce should be enabled by default.