### PR TITLE
[Core][Distributed] improve logging for init dist

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -50,7 +50,7 @@ def init_distributed_environment(
     backend: str = "nccl",
 ):
     logger.debug(f"{world_size=} {rank=} {local_rank=} "
-                f"{distributed_init_method=} {backend=}")
+                 f"{distributed_init_method=} {backend=}")
     if not torch.distributed.is_initialized():
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -8,9 +8,9 @@ from typing import Optional
 
 import torch
 
-from vllm.logger import get_logger
+from vllm.logger import init_logger
 
-logger = get_logger(__name__)
+logger = init_logger(__name__)
 
 # Tensor model parallel group that the current rank belongs to.
 _TENSOR_MODEL_PARALLEL_GROUP = None

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -8,6 +8,10 @@ from typing import Optional
 
 import torch
 
+from vllm.logger import get_logger
+
+logger = get_logger(__name__)
+
 # Tensor model parallel group that the current rank belongs to.
 _TENSOR_MODEL_PARALLEL_GROUP = None
 # Pipeline model parallel group that the current rank belongs to.
@@ -45,6 +49,8 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
 ):
+    logger.info(f"{world_size=} {rank=} {local_rank=}"
+                f" {distributed_init_method=} {backend=}")
     if not torch.distributed.is_initialized():
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -49,8 +49,8 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
 ):
-    logger.info(f"{world_size=} {rank=} {local_rank=}"
-                f" {distributed_init_method=} {backend=}")
+    logger.info(f"{world_size=} {rank=} {local_rank=} "
+                f"{distributed_init_method=} {backend=}")
     if not torch.distributed.is_initialized():
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -49,7 +49,7 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
 ):
-    logger.info(f"{world_size=} {rank=} {local_rank=} "
+    logger.debug(f"{world_size=} {rank=} {local_rank=} "
                 f"{distributed_init_method=} {backend=}")
     if not torch.distributed.is_initialized():
         assert distributed_init_method is not None, (


### PR DESCRIPTION
Often times we see issue reports of hang during initialization. This might be caused by improper setup of ray or distributed environment.

Adding this logging will produce debugging information before the process gets stuck, helping the future debugging.