### PR TITLE
[Bugfix] fix_log_time_in_metrics

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -130,7 +130,7 @@ class StatLogger:
 
     def __init__(self, local_interval: float, labels: Dict[str, str]) -> None:
         # Metadata for logging locally.
-        self.last_local_log = time.monotonic()
+        self.last_local_log = time.time()
         self.local_interval = local_interval
 
         # Tracked stats over current local logging interval.


### PR DESCRIPTION
I have noticed that `now` in `_get_throughput` is `time.time()`, but `self.last_local_log` is `time.monotonic()`, these two function cannot be used to subtract to compute the duration.
![image](https://github.com/vllm-project/vllm/assets/26846598/3c4f2727-89a5-4b3d-a300-28fb1cce7e1b)
