### PR TITLE
[BugFix] Fix tensorizer extra in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -406,7 +406,7 @@ setup(
     install_requires=get_requirements(),
     ext_modules=ext_modules,
     extras_require={
-        "optional": ["tensorizer==2.9.0a1"],
+        "tensorizer": ["tensorizer==2.9.0a1"],
     },
     cmdclass={"build_ext": cmake_build_ext} if not _is_neuron() else {},
     package_data=package_data,


### PR DESCRIPTION
`extras_require` is meant to be a dict of the names of some extra features to lists of dependencies that each requires.