### PR TITLE
add chatglm3 template and llama2 template

### DIFF
--- a/examples/chatglm3.jinjia
+++ b/examples/chatglm3.jinjia
@@ -1,0 +1,21 @@
+{% if messages[0]['role'] == 'system' %}
+{% set loop_messages = messages[1:] %}
+{% set system_message = '[gMASK]sop<|' + messages[0]['role'] + '|>' + '\n ' + messages[0]['content'] %}
+{% else %}
+{% set loop_messages = messages %}
+{% set system_message = '' %}
+{% endif %}
+{% for message in loop_messages %}
+{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
+{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
+{% endif %}
+{% if loop.index0==0 and system_message=='' %}
+{{'[gMASK]sop<|' + message['role'] + '|>' + '\n ' + message['content']  + '<|assistant|>'  }}
+{% elif system_message!='' and loop.index0==0 %}
+{{system_message +  '<|' + message['role'] + '|>' + '\n ' + message['content'] + '<|assistant|>'}}
+{% elif message['role'] == 'user'%}
+{{' ' + message['content'] + '<|assistant|>'}}
+{% else %}
+{{message['content']+'<|user|>'}}
+{% endif %}
+{% endfor %}

--- a/examples/llama2.jinjia
+++ b/examples/llama2.jinjia
@@ -1,0 +1,28 @@
+{% if messages[0]['role'] == 'system' %}
+    {% set loop_messages = messages[1:] %}
+    {% set system_message = '<<SYS>>\n' + messages[0]['content'].strip() + '\n<</SYS>>\n\n' %}
+{% else %}
+    {% set loop_messages = messages %}
+    {% set system_message = '' %}
+{% endif %}
+
+{{bos_token}}
+{% for message in loop_messages %}
+    {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
+        {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
+    {% endif %}
+    
+    {% if loop.index0 == 0 %}
+        {% set content = system_message + message['content'] %}
+    {% else %}
+        {% set content = message['content'] %}
+    {% endif %}
+    
+    {% if message['role'] == 'user' and loop.index0 == 0 %}
+        {{ '[INST] ' + content.strip() + ' [/INST]' }}
+    {% elif message['role'] == 'user' and loop.index0 != 0 %}
+	{{ bos_token + '[INST] ' + content.strip() + ' [/INST]' }}
+    {% elif message['role'] == 'assistant' %}
+        {{ ' ' + content.strip() + ' ' + eos_token }}
+    {% endif %}
+{% endfor %}


### PR DESCRIPTION
Since vllm 0.3.3 are encourge us to use chat template to build prompt for input, the old model like llama2 and ChatGLM3 do not have chat template to use. I implmented those template for multiple rounds of conversations.

By the way, in multiple rounds of conversations, the request need to add eos tokens on stream mode, here is an example for request parameters:

curl 0.0.0.0:7861/v1/chat/completions -H 'Content-Type: application/json' \
     -d '{"model": "/path/to/chatglm3-6b/","messages": [{"role":"system","content":"你是人工智能助手Baichuan2-7b,请按照这种提示回答以下问题"},{"role":"user","content":"你好"}],"temperature":"0.1","max_tokens":1024,"stream":"true","stop":["<|user|>", "<|observation|>", "<"] }'