### PR TITLE
[Bugfix] Fix ray workers profiling with nsight 

### DIFF
--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -68,6 +68,21 @@ class RayGPUExecutor(ExecutorBase):
         if USE_RAY_COMPILED_DAG:
             self.forward_dag = self._compiled_ray_dag()
 
+    def _configure_ray_workers_use_nsight(self,
+                                          ray_remote_kwargs) -> Dict[str, Any]:
+        # If nsight profiling is enabled, we need to set the profiling
+        # configuration for the ray workers as runtime env.
+        runtime_env = ray_remote_kwargs.setdefault("runtime_env", {})
+        runtime_env.update({
+            "nsight": {
+                "t": "cuda,cudnn,cublas",
+                "o": "'worker_process_%p'",
+                "cuda-graph-trace": "node",
+            }
+        })
+
+        return ray_remote_kwargs
+
     def _init_workers_ray(self, placement_group: "PlacementGroup",
                           **ray_remote_kwargs):
         if self.parallel_config.tensor_parallel_size == 1:
@@ -82,6 +97,10 @@ class RayGPUExecutor(ExecutorBase):
         self.driver_dummy_worker: RayWorkerVllm = None
         # The remaining workers are the actual ray actors.
         self.workers: List[RayWorkerVllm] = []
+
+        if self.parallel_config.ray_workers_use_nsight:
+            ray_remote_kwargs = self._configure_ray_workers_use_nsight(
+                ray_remote_kwargs)
 
         # Create the workers.
         driver_ip = get_ip()


### PR DESCRIPTION
Fix the nsight profiling feature added in https://github.com/vllm-project/vllm/pull/3162

```
python benchmarks/benchmark_latency.py --model=meta-llama/Llama-2-7b-chat-hf  --input-len 1000 --output-len 50 -
tp 2 --num-iters 5 --batch-size 1 --ray-workers-use-nsight
```
