### PR TITLE
[Kernel][FP8] Initial support with dynamic per-tensor scaling

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,5 +1,5 @@
 # Common dependencies
-# -r requirements-common.txt
+-r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
 ray >= 2.9

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,5 +1,5 @@
 # Common dependencies
--r requirements-common.txt
+# -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
 ray >= 2.9

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -3,26 +3,22 @@
 Run `pytest tests/quantization/test_fp8.py --forked`.
 """
 import pytest
-
 import torch
 
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
-from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod, Fp8LinearState
+from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod
 
 capability = torch.cuda.get_device_capability()
 capability = capability[0] * 10 + capability[1]
 
 
-@pytest.mark.skipif(capability
-                    < QUANTIZATION_METHODS["fp8"].get_min_capability(),
-                    reason="FP8 is not supported on this GPU type.")
+@pytest.mark.skipif(
+    capability < QUANTIZATION_METHODS["fp8"].get_min_capability(),
+    reason="FP8 is not supported on this GPU type.")
 def test_load_fp16_model(vllm_runner) -> None:
     llm = vllm_runner("facebook/opt-125m", quantization="fp8")
 
     model = llm.llm_engine.model_executor.driver_worker.model_runner.model
     fc1 = model.model.decoder.layers[0].fc1
     assert isinstance(fc1.linaer_method, Fp8LinearMethod)
-
-    # The engine has been warmed up and the state should be ready.
-    assert fc1.fp8_linear_state == Fp8LinearState.READY
     assert fc1.weight.dtype == torch.float8_e4m3fn

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -1,0 +1,28 @@
+"""Tests whether FP8 computation is enabled correctly.
+
+Run `pytest tests/quantization/test_fp8.py --forked`.
+"""
+import pytest
+
+import torch
+
+from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
+from vllm.model_executor.layers.quantization.fp8 import Fp8LinearMethod, Fp8LinearState
+
+capability = torch.cuda.get_device_capability()
+capability = capability[0] * 10 + capability[1]
+
+
+@pytest.mark.skipif(capability
+                    < QUANTIZATION_METHODS["fp8"].get_min_capability(),
+                    reason="FP8 is not supported on this GPU type.")
+def test_load_fp16_model(vllm_runner) -> None:
+    llm = vllm_runner("facebook/opt-125m", quantization="fp8")
+
+    model = llm.llm_engine.model_executor.driver_worker.model_runner.model
+    fc1 = model.model.decoder.layers[0].fc1
+    assert isinstance(fc1.linaer_method, Fp8LinearMethod)
+
+    # The engine has been warmed up and the state should be ready.
+    assert fc1.fp8_linear_state == Fp8LinearState.READY
+    assert fc1.weight.dtype == torch.float8_e4m3fn

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -18,7 +18,7 @@ capability = capability[0] * 10 + capability[1]
 def test_load_fp16_model(vllm_runner) -> None:
     llm = vllm_runner("facebook/opt-125m", quantization="fp8")
 
-    model = llm.llm_engine.model_executor.driver_worker.model_runner.model
+    model = llm.model.llm_engine.model_executor.driver_worker.model_runner.model
     fc1 = model.model.decoder.layers[0].fc1
-    assert isinstance(fc1.linaer_method, Fp8LinearMethod)
+    assert isinstance(fc1.linear_method, Fp8LinearMethod)
     assert fc1.weight.dtype == torch.float8_e4m3fn

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -42,7 +42,7 @@ class LLM:
             However, if the `torch_dtype` in the config is `float32`, we will
             use `float16` instead.
         quantization: The method used to quantize the model weights. Currently,
-            we support "awq", "gptq" and "squeezellm". If None, we first check
+            we support "awq", "gptq", "fp8 and "squeezellm". If None, we first check
             the `quantization_config` attribute in the model config file. If
             that is None, we assume the model weights are not quantized and use
             `dtype` to determine the data type of the weights.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -42,10 +42,10 @@ class LLM:
             However, if the `torch_dtype` in the config is `float32`, we will
             use `float16` instead.
         quantization: The method used to quantize the model weights. Currently,
-            we support "awq", "gptq", "fp8 and "squeezellm". If None, we first check
-            the `quantization_config` attribute in the model config file. If
-            that is None, we assume the model weights are not quantized and use
-            `dtype` to determine the data type of the weights.
+            we support "awq", "gptq", "fp8 and "squeezellm". If None, we first
+            check the `quantization_config` attribute in the model config file.
+            If that is None, we assume the model weights are not quantized and
+            use `dtype` to determine the data type of the weights.
         revision: The specific model version to use. It can be a branch name,
             a tag name, or a commit id.
         tokenizer_revision: The specific tokenizer version to use. It can be a

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -42,10 +42,11 @@ class LLM:
             However, if the `torch_dtype` in the config is `float32`, we will
             use `float16` instead.
         quantization: The method used to quantize the model weights. Currently,
-            we support "awq", "gptq", "fp8 and "squeezellm". If None, we first
-            check the `quantization_config` attribute in the model config file.
-            If that is None, we assume the model weights are not quantized and
-            use `dtype` to determine the data type of the weights.
+            we support "awq", "gptq", "squeezellm", and "fp8" (experimental).
+            If None, we first check the `quantization_config` attribute in the
+            model config file. If that is None, we assume the model weights are
+            not quantized and use `dtype` to determine the data type of
+            the weights.
         revision: The specific model version to use. It can be a branch name,
             a tag name, or a commit id.
         tokenizer_revision: The specific tokenizer version to use. It can be a

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -38,6 +38,9 @@ class LinearMethodBase(ABC):
         The weights will be set as attributes of the layer."""
         raise NotImplementedError
 
+    def postproc_weights(self, layer: torch.nn.Module):
+        """Postprocess the weights after loading (optional)."""
+
     @abstractmethod
     def apply_weights(self,
                       layer: torch.nn.Module,
@@ -209,6 +212,7 @@ class ColumnParallelLinear(torch.nn.Module):
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
         assert param_data.shape == loaded_weight.shape
+        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
     def forward(self, input_):
@@ -328,6 +332,7 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     "MergedColumnParallelLinear, assume the weight is "
                     "the same for all partitions.")
         assert param_data.shape == loaded_weight.shape
+        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
 
@@ -469,6 +474,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                     "QKVParallelLinear, assume the weight is the same "
                     "for all partitions.")
         assert param_data.shape == loaded_weight.shape
+        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
 
@@ -558,6 +564,7 @@ class RowParallelLinear(torch.nn.Module):
             loaded_weight = loaded_weight.narrow(input_dim, start_idx,
                                                  shard_size)
         assert param_data.shape == loaded_weight.shape
+        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
     def forward(self, input_):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -38,9 +38,6 @@ class LinearMethodBase(ABC):
         The weights will be set as attributes of the layer."""
         raise NotImplementedError
 
-    def postproc_weights(self, layer: torch.nn.Module):
-        """Postprocess the weights after loading (optional)."""
-
     @abstractmethod
     def apply_weights(self,
                       layer: torch.nn.Module,
@@ -212,7 +209,6 @@ class ColumnParallelLinear(torch.nn.Module):
             loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                                                  shard_size)
         assert param_data.shape == loaded_weight.shape
-        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
     def forward(self, input_):
@@ -332,7 +328,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     "MergedColumnParallelLinear, assume the weight is "
                     "the same for all partitions.")
         assert param_data.shape == loaded_weight.shape
-        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
 
@@ -474,7 +469,6 @@ class QKVParallelLinear(ColumnParallelLinear):
                     "QKVParallelLinear, assume the weight is the same "
                     "for all partitions.")
         assert param_data.shape == loaded_weight.shape
-        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
 
@@ -564,7 +558,6 @@ class RowParallelLinear(torch.nn.Module):
             loaded_weight = loaded_weight.narrow(input_dim, start_idx,
                                                  shard_size)
         assert param_data.shape == loaded_weight.shape
-        loaded_weight = self.linear_method.postproc_weights(loaded_weight)
         param_data.copy_(loaded_weight)
 
     def forward(self, input_):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -54,7 +54,7 @@ class LinearMethodBase(ABC):
 
         This can be used for example, to transpose weights for computation.
         """
-        pass
+        return
 
 
 class UnquantizedLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -49,17 +49,7 @@ class LinearMethodBase(ABC):
         Expects create_weights to have been called before on the layer."""
         raise NotImplementedError
 
-    def proc_before_loading(self, layer: nn.Module, param: Parameter,
-                            loaded_weight: torch.Tensor) -> torch.Tensor:
-        """Process the weight before loading.
-
-        This can be used for exmaple, quantizing the weight before
-        loading it to the model.
-        """
-        return loaded_weight
-
-    def proc_after_loading(self, layer: nn.Module, param: Parameter,
-                           loaded_weight: torch.Tensor) -> None:
+    def proc_after_loading(self, layer: nn.Module) -> None:
         """Process the weight after loading.
 
         This can be used for example, to transpose weights for computation.
@@ -218,9 +208,6 @@ class ColumnParallelLinear(torch.nn.Module):
             self.register_parameter("bias", None)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        loaded_weight = self.linear_method.proc_before_loading(
-            self, param, loaded_weight)
-
         tp_rank = get_tensor_model_parallel_rank()
         output_dim = getattr(param, "output_dim", None)
         param_data = param.data
@@ -287,9 +274,6 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                       param: Parameter,
                       loaded_weight: torch.Tensor,
                       loaded_shard_id: Optional[int] = None):
-        loaded_weight = self.linear_method.proc_before_loading(
-            self, param, loaded_weight)
-
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)
         if loaded_shard_id is None:
@@ -416,9 +400,6 @@ class QKVParallelLinear(ColumnParallelLinear):
                       param: Parameter,
                       loaded_weight: torch.Tensor,
                       loaded_shard_id: Optional[str] = None):
-        loaded_weight = self.linear_method.proc_before_loading(
-            self, param, loaded_weight)
-
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)
 
@@ -576,9 +557,6 @@ class RowParallelLinear(torch.nn.Module):
             self.register_parameter("bias", None)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        loaded_weight = self.linear_method.proc_before_loading(
-            self, param, loaded_weight)
-
         tp_rank = get_tensor_model_parallel_rank()
         input_dim = getattr(param, "input_dim", None)
         param_data = param.data

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -49,7 +49,7 @@ class LinearMethodBase(ABC):
         Expects create_weights to have been called before on the layer."""
         raise NotImplementedError
 
-    def proc_after_loading(self, layer: nn.Module) -> None:
+    def process_weights_after_loading(self, layer: nn.Module) -> None:
         """Process the weight after loading.
 
         This can be used for example, to transpose weights for computation.

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -3,12 +3,14 @@ from typing import Type
 from vllm.model_executor.layers.quantization.awq import AWQConfig
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
+from vllm.model_executor.layers.quantization.fp8 import FP8Config
 from vllm.model_executor.layers.quantization.gptq import GPTQConfig
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.layers.quantization.squeezellm import SqueezeLLMConfig
 
 QUANTIZATION_METHODS = {
     "awq": AWQConfig,
+    "fp8": FP8Config,
     "gptq": GPTQConfig,
     "squeezellm": SqueezeLLMConfig,
     "marlin": MarlinConfig,

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,0 +1,113 @@
+from typing import Any, Dict, List, Optional
+
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.model_executor.layers.linear import (LinearMethodBase,
+                                               set_weight_attrs)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig)
+
+
+class FP8Config(QuantizationConfig):
+    """Config class for FP8."""
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "fp8"
+
+    @classmethod
+    def get_supported_act_dtypes(cls) -> List[torch.dtype]:
+        return [
+            torch.bfloat16, torch.half, torch.float8_e4m3fn, torch.float8_e5m2
+        ]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 90
+
+    @classmethod
+    def get_config_filenames(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "FP8Config":
+        return cls()
+
+    def get_linear_method(self) -> "Fp8LinearMethod":
+        return Fp8LinearMethod(self)
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+
+class Fp8LinearMethod(LinearMethodBase):
+    """Linear method for FP8.
+
+    Args:
+        quant_config: The quantization config.
+    """
+
+    def __init__(self, quant_config: FP8Config):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_size_per_partition: int,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        weight = Parameter(torch.empty(output_size_per_partition,
+                                       input_size_per_partition,
+                                       dtype=params_dtype),
+                           requires_grad=False)
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    def postproc_weights(self, weight: torch.Tensor):
+        qweight, scale = per_tensor_quantize(weight)
+        self.scale = scale
+        return qweight
+
+    def apply_weights(self,
+                      layer: torch.nn.Module,
+                      x: torch.Tensor,
+                      bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        qinput, scale = per_tensor_quantize(x)
+        output, _ = torch._scaled_mm(
+            qinput,
+            layer.weight.t(),
+            out_dtype=x.dtype,
+            scale_a=scale,
+            scale_b=self.scale,
+            bias=bias,
+        )
+        return output
+
+
+def per_tensor_quantize(
+        tensor: torch.Tensor,
+        qdtype=torch.float8_e4m3fn) -> tuple[torch.Tensor, float]:
+    """Quantize a tensor using per-tensor static scaling factor.
+
+    Args:
+        tensor: The input tensor.
+        qdtype: The quantized data type.
+    """
+    finfo = torch.finfo(qdtype)
+    # Calculate the scale as dtype max divided by absmax
+    scale = finfo.max / tensor.abs().max().clamp(min=1e-12)
+    # scale and clamp the tensor to bring it to
+    # the representative range of float8 data type
+    # (as default cast is unsaturated)
+    qweight = (tensor * scale).clamp(min=finfo.min, max=finfo.max)
+    # Return both float8 data and the inverse scale (as float),
+    # as both required as inputs to torch._scaled_mm
+    qweight = qweight.to(qdtype)
+    scale = scale.float().reciprocal()
+    return qweight, scale

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -3,6 +3,8 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import torch
+import torch._dynamo
+from torch.nn import Module
 from torch.nn.parameter import Parameter
 
 from vllm.model_executor.layers.linear import (LinearMethodBase,
@@ -10,6 +12,7 @@ from vllm.model_executor.layers.linear import (LinearMethodBase,
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 
+torch._dynamo.config.suppress_errors = True
 
 class FP8Config(QuantizationConfig):
     """Config class for FP8."""
@@ -24,10 +27,10 @@ class FP8Config(QuantizationConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        # PyTorch 2.3.0+ is required to run FP8 on SM 89 (e.g. Ada) GPUs.
-        # Specifically, this PR has to be included:
-        # https://github.com/pytorch/pytorch/pull/118881/files
-        return 89
+        # TODO: PyTorch 2.3.0+ is required to run FP8 on
+        # SM 89 (e.g. Ada) GPUs. Specifically, this PR has to
+        # be included: https://github.com/pytorch/pytorch/pull/118881
+        return 90
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:
@@ -52,14 +55,11 @@ class Fp8LinearState(Enum):
 
 class Fp8LinearMethod(LinearMethodBase):
     """Linear method for FP8.
-    We now support two types of model checkpoints:
-    1. Common FP16/BF16 model checkpoints. In this case, the weight
-       scaling factor will be initialized during the first forward pass.
-    2. FP8 model checkpoints. In this case, the weight scaling factor
-       will be loaded from the checkpoint with parameter name "w_scale",
-       and the weight should already in FP8 and has been transposed.
+    We now support common FP16/BF16 model checkpoints ONLY. The weight
+    scaling factor will be initialized during the first forward pass.
 
-    Note that we currently only support per-tensor quantization.
+    Note that we currently only support per-tensor quantization due to
+    torch._scaled_mm support.
        
     Args:
         quant_config: The quantization config.
@@ -80,20 +80,19 @@ class Fp8LinearMethod(LinearMethodBase):
     ):
         weight = Parameter(torch.empty(output_size_per_partition,
                                        input_size_per_partition,
-                                       dtype=params_dtype),
+                                       dtype=torch.float8_e4m3fn),
                            requires_grad=False)
-        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
         layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
         set_weight_attrs(weight, extra_weight_attrs)
 
-        # Will be loaded from FP8 checkpoints, or initialized for
-        # FP16/BF16 checkpoints during the first forward pass.
+        # Will be initialized for FP16/BF16 checkpoints
+        # during the first forward pass.
         w_scale = Parameter(
             torch.empty(1, dtype=torch.float32),
             requires_grad=False,
         )
-        layer.register_parameter("w_scale", w_scale)
-        set_weight_attrs(w_scale, extra_weight_attrs)
+        layer.register_parameter("weight_scaling_factor", w_scale)
 
         # We always initialize the state to UNINITIALIZED because
         # we cannot know whether weights going to be loaded are in FP8
@@ -101,22 +100,37 @@ class Fp8LinearMethod(LinearMethodBase):
         # sets the state to READY without re-quantization.
         layer.fp8_linear_state = Fp8LinearState.UNINITIALIZED
 
+    def proc_before_loading(self, layer: Module, param: Parameter,
+                            loaded_weight: torch.Tensor) -> torch.Tensor:
+        if loaded_weight.dtype != torch.float8_e4m3fn:
+            loaded_weight, weight_scale = per_tensor_quantize(loaded_weight)
+            # If the loaded weight is not in FP8, we override the
+            # weight and scaling factor with the quantized weight.
+            layer.weight_scaling_factor.data.copy_(weight_scale)
+        return loaded_weight
+
+    def proc_after_loading(self, layer: Module) -> None:
+        # Note that torch._scaled_mm requires column-major in
+        # the second input (weight), so we transpose the quantized
+        # weight here.
+        layer.weight.data = layer.weight.data.t()
+
     def apply_weights(self,
                       layer: torch.nn.Module,
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
 
-        if layer.fp8_linear_state == Fp8LinearState.UNINITIALIZED:
-            # Per-tensor scaling on the fly for FP16/BF16 weights
-            # during the first forward pass if the loaded weights
-            # are not in FP8.
-            if layer.weight.dtype != torch.float8_e4m3fn:
-                qweight, weight_scale = per_tensor_quantize(layer.weight.data)
-                # Note that torch._scaled_mm requires column-major in
-                # the second input, so we transpose the quantized weight here.
-                layer.weight.data = qweight.t()
-                layer.w_scale.data = weight_scale
-            layer.fp8_linear_state = Fp8LinearState.READY
+        # if layer.fp8_linear_state == Fp8LinearState.UNINITIALIZED:
+        #     # Per-tensor scaling on the fly for FP16/BF16 weights
+        #     # during the first forward pass if the loaded weights
+        #     # are not in FP8.
+        #     if layer.weight.dtype != torch.float8_e4m3fn:
+        #         qweight, weight_scale = per_tensor_quantize(layer.weight.data)
+        #         # Note that torch._scaled_mm requires column-major in
+        #         # the second input, so we transpose the quantized weight here.
+        #         layer.weight.data = qweight.t()
+        #         layer.weight_scaling_factor.data = weight_scale
+        #     layer.fp8_linear_state = Fp8LinearState.READY
 
         qinput, x_scale = per_tensor_quantize(x)
         output, _ = torch._scaled_mm(
@@ -124,13 +138,13 @@ class Fp8LinearMethod(LinearMethodBase):
             layer.weight,
             out_dtype=x.dtype,
             scale_a=x_scale,
-            scale_b=layer.w_scale,
+            scale_b=layer.weight_scaling_factor,
             bias=bias,
         )
         return output
 
 
-@torch.compile
+#@torch.compile
 def per_tensor_quantize(
         tensor: torch.Tensor,
         qdtype=torch.float8_e4m3fn) -> tuple[torch.Tensor, float]:
@@ -142,8 +156,9 @@ def per_tensor_quantize(
     """
     finfo = torch.finfo(qdtype)
     # Calculate the scale as dtype max divided by absmax
-    min_val, max_val = tensor.aminmax()
-    amax = max(-min_val, max_val)
+    # min_val, max_val = tensor.aminmax()
+    # amax = max(-min_val, max_val)
+    amax = tensor.abs().max()
     scale = finfo.max / amax.clamp(min=1e-12)
     # scale and clamp the tensor to bring it to
     # the representative range of float8 data type

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -1,5 +1,3 @@
-import enum
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 import torch

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -119,7 +119,6 @@ def per_tensor_quantize(tensor: torch.Tensor) -> tuple[torch.Tensor, float]:
 
     Args:
         tensor: The input tensor.
-        qdtype: The quantized data type.
     """
     finfo = torch.finfo(torch.float8_e4m3fn)
     # Calculate the scale as dtype max divided by absmax.

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -85,6 +85,10 @@ class Fp8LinearMethod(LinearMethodBase):
         layer.register_parameter("weight_scaling_factor", w_scale)
 
     def proc_after_loading(self, layer: Module) -> None:
+        # Although the linear_method is propagated to all layers,
+        # only linear layers invoke "create_weights". So we check
+        # whether "weight_scaling_facor" is registered to determine
+        # whether the layer is a linear layer that requires quantization.
         if not hasattr(layer, "weight_scaling_factor"):
             return
 

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -84,7 +84,7 @@ class Fp8LinearMethod(LinearMethodBase):
         )
         layer.register_parameter("weight_scaling_factor", w_scale)
 
-    def proc_after_loading(self, layer: Module) -> None:
+    def process_weights_after_loading(self, layer: Module) -> None:
         # Although the linear_method is propagated to all layers,
         # only linear layers invoke "create_weights". So we check
         # whether "weight_scaling_facor" is registered to determine

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -229,8 +229,9 @@ class DefaultModelLoader(BaseModelLoader):
                                                "fall_back_to_pt_during_load",
                                                True)), )
             for _, module in model.named_modules():
-                if hasattr(module, "linear_method"):
-                    module.linear_method.proc_after_loading(module)
+                linear_method = getattr(module, "linear_method", None)
+                if linear_method is not None:
+                    linear_method.proc_after_loading(module)
         return model.eval()
 
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -231,7 +231,7 @@ class DefaultModelLoader(BaseModelLoader):
             for _, module in model.named_modules():
                 linear_method = getattr(module, "linear_method", None)
                 if linear_method is not None:
-                    linear_method.proc_after_loading(module)
+                    linear_method.process_weights_after_loading(module)
         return model.eval()
 
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -228,6 +228,9 @@ class DefaultModelLoader(BaseModelLoader):
                                                model,
                                                "fall_back_to_pt_during_load",
                                                True)), )
+            for _, module in model.named_modules():
+                if hasattr(module, "linear_method") and hasattr(module, "weight"):
+                    module.linear_method.proc_after_loading(module)
         return model.eval()
 
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -229,7 +229,8 @@ class DefaultModelLoader(BaseModelLoader):
                                                "fall_back_to_pt_during_load",
                                                True)), )
             for _, module in model.named_modules():
-                if hasattr(module, "linear_method") and hasattr(module, "weight"):
+                if hasattr(module, "linear_method") and hasattr(
+                        module, "weight"):
                     module.linear_method.proc_after_loading(module)
         return model.eval()
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -229,8 +229,7 @@ class DefaultModelLoader(BaseModelLoader):
                                                "fall_back_to_pt_during_load",
                                                True)), )
             for _, module in model.named_modules():
-                if hasattr(module, "linear_method") and hasattr(
-                        module, "weight"):
+                if hasattr(module, "linear_method"):
                     module.linear_method.proc_after_loading(module)
         return model.eval()
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -134,11 +134,18 @@ def get_quant_config(model_config: ModelConfig,
                                           tqdm_class=DisabledTqdm)
     else:
         hf_folder = model_name_or_path
+
+    possible_config_filenames = quant_cls.get_config_filenames()
+
+    # If the quantization config is not found, use the default config.
+    if not possible_config_filenames:
+        return quant_cls()
+
     config_files = glob.glob(os.path.join(hf_folder, "*.json"))
 
     quant_config_files = [
         f for f in config_files if any(
-            f.endswith(x) for x in quant_cls.get_config_filenames())
+            f.endswith(x) for x in possible_config_filenames)
     ]
     if len(quant_config_files) == 0:
         raise ValueError(


### PR DESCRIPTION
Provide an initial support to FP8 computation. This PR is inspired by HuggingFace TGI: https://github.com/huggingface/text-generation-inference/pull/1726

This feature can be enabled with `--quantization fp8` or `-q fp8` when launching an engine.

## Algorithm
We still load a model checkpoint in FP16/BF16. After the weights are loaded, Fp8LinearMethod calculates the per-tensor scaling factor of weights and quantizes the weights accordingly. The scaling factor will then be stored for future use. Meanwhile, the per-tensor scaling factor for activations is calculated in every forward pass.

## Initial Results

Currently tested Mistral-7B on 1xH100. With prompt length ~5 and decoding length 128:
* BF16: 1.47s
* FP8: 1.66s

I'll try to use larger models and try to find more performance bottleneck. Meanwhile, you're welcome to try this PR.

## To Do
- [ ] Unit tests
- [ ] Comprehensive benchmarking
- [ ] Refine the interface

cc @WoosukKwon @zhuohan123 @robertgshaw2-neuralmagic @mgoin 

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


