### PR TITLE
[Bugfix][Core] Restore logging of stats in the async engine

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -217,9 +217,15 @@ class _AsyncLLMEngine(LLMEngine):
         else:
             output = []
 
-        return self._process_model_outputs(
+        request_outputs = self._process_model_outputs(
             output, scheduler_outputs.scheduled_seq_groups,
             scheduler_outputs.ignored_seq_groups)
+
+        # Log stats.
+        if self.log_stats:
+            self.stat_logger.log(self._get_stats(scheduler_outputs))
+
+        return request_outputs
 
     async def encode_request_async(
         self,


### PR DESCRIPTION
Following the refactor of #3894, I noticed that the async engine has stopped logging stats to Prometheus.

The reason is that the call to `stat_logger.log()` was relocated from the `_process_model_outputs()` method (which is shared between async and non-async engines) to `LLMEngine.step()`, exclusively used in the non-async engine.

This PR fixes this by reintroducing the call to `stat_logger.log()` in the async engine.

cc @cadedaniel