### PR TITLE
[Core] Add integrity check during initialization; add test for it

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -33,6 +33,7 @@ steps:
   num_gpus: 2 # only support 1 or 2 for now.
   commands:
   - pytest -v -s test_pynccl.py
+  - pytest -v -s test_pynccl_library.py
   - TEST_DIST_MODEL=facebook/opt-125m pytest -v -s test_basic_distributed_correctness.py
   - TEST_DIST_MODEL=meta-llama/Llama-2-7b-hf pytest -v -s test_basic_distributed_correctness.py
   - TEST_DIST_MODEL=facebook/opt-125m pytest -v -s test_chunked_prefill_distributed.py

--- a/tests/distributed/test_pynccl_library.py
+++ b/tests/distributed/test_pynccl_library.py
@@ -10,7 +10,8 @@ def target_fn(env, filepath):
 
 
 def test_library_file():
-    from vllm.distributed.device_communicators.pynccl import so_file
+    from vllm.utils import find_nccl_library
+    so_file = find_nccl_library()
     with open(so_file, 'rb') as f:
         content = f.read()
     try:

--- a/tests/distributed/test_pynccl_library.py
+++ b/tests/distributed/test_pynccl_library.py
@@ -10,6 +10,9 @@ def target_fn(env, filepath):
 
 
 def test_library_file():
+    # note: don't import vllm.distributed.device_communicators.pynccl
+    # before running this test, otherwise the library file will be loaded
+    # and it might interfere with the test
     from vllm.utils import find_nccl_library
     so_file = find_nccl_library()
     with open(so_file, 'rb') as f:

--- a/tests/distributed/test_pynccl_library.py
+++ b/tests/distributed/test_pynccl_library.py
@@ -1,17 +1,12 @@
 import multiprocessing
 import tempfile
 
-from vllm.utils import update_environment_variables
-
 
 def target_fn(env, filepath):
+    from vllm.utils import update_environment_variables
     update_environment_variables(env)
-    import os
-    exit_code = os.system(f"ldd {filepath}")
-    if exit_code != 0:
-        exit(-1)
-    from vllm.distributed.device_communicators.pynccl import ncclGetVersion
-    ncclGetVersion()
+    from vllm.utils import nccl_integrity_check
+    nccl_integrity_check(filepath)
 
 
 def test_library_file():

--- a/tests/distributed/test_pynccl_library.py
+++ b/tests/distributed/test_pynccl_library.py
@@ -1,0 +1,40 @@
+import multiprocessing
+import tempfile
+
+from vllm.utils import update_environment_variables
+
+
+def target_fn(env):
+    update_environment_variables(env)
+    from vllm.distributed.device_communicators.pynccl import ncclGetVersion
+    ncclGetVersion()
+
+
+def test_library_file():
+    from vllm.distributed.device_communicators.pynccl import so_file
+    with open(so_file, 'rb') as f:
+        content = f.read()
+    try:
+        # corrupt the library file, should raise an exception
+        with open(so_file, 'wb') as f:
+            f.write(content[:len(content) // 2])
+        p = multiprocessing.Process(target=target_fn, args=({}, ))
+        p.start()
+        p.join()
+        assert p.exitcode != 0
+
+        # move the library file to a tmp path
+        # test VLLM_NCCL_SO_PATH
+        path = tempfile.mkstemp()
+        with open(path, 'wb') as f:
+            f.write(content)
+        p = multiprocessing.Process(target=target_fn,
+                                    args=({
+                                        "VLLM_NCCL_SO_PATH": path
+                                    }, ))
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+    finally:
+        with open(so_file, 'wb') as f:
+            f.write(content)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -568,3 +568,4 @@ def find_nccl_library():
         else:
             raise ValueError("NCCL only supports CUDA and ROCm backends.")
         logger.info(f"Found nccl from library {so_file}")
+    return so_file

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -533,7 +533,6 @@ def nccl_integrity_check(filepath):
         raise RuntimeError(f"Failed to load NCCL library from {filepath} .")
     import ctypes
 
-    import torch  # noqa
     nccl = ctypes.CDLL(filepath)
     version = ctypes.c_int()
     nccl.ncclGetVersion.restype = ctypes.c_int

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -527,7 +527,7 @@ def nccl_integrity_check(filepath):
     if the library is corrupted. if not, we will return
     the version of the library.
     """
-    exit_code = os.system(f"ldd {filepath}")
+    exit_code = os.system(f"ldd {filepath} 2>&1 > /dev/null")
     if exit_code != 0:
         raise RuntimeError(f"Failed to load NCCL library from {filepath} .")
     import ctypes


### PR DESCRIPTION
As we move to vllm-managed nccl, users have reported incompletely downloaded nccl library due to network issues. This will lead to core dump, and is not easy to debug. See https://github.com/vllm-project/vllm/issues/3916 .

This PR adds integrity check during initialization, in another process by `os.system` . If the process crashes, we will know and give warnings to users.

In addition, this PR adds tests for the corruption and environment variable to set the library path.