### PR TITLE
fix default_schedule

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -427,10 +427,9 @@ class Scheduler:
                         swapped_out.append(seq_group)
                     break
             else:
-                if not budget.can_schedule(num_new_tokens = num_running_tokens,
-                                           num_new_seqs = num_running_seqs):
+                if not budget.can_schedule(num_new_tokens=num_running_tokens,
+                                           num_new_seqs=num_running_seqs):
                     break
-                    
                 logger.debug(f"append slot for {seq_group}")
                 self._append_slots(seq_group, blocks_to_copy)
                 is_prefill = seq_group.is_prefill()


### PR DESCRIPTION
Hello, I noticed a change in the behavior of the _schedule_default function in scheduler.py after adding the chunked_prefill feature to vLLM.

Previously, without this feature, vLLM would prioritize jobs in the prefill stage when there were sufficient blocks and prefill-stage jobs available. However, after adding this feature, there are cases where vLLM would still prioritize running jobs in the decode stage, even when there are sufficient blocks and prefill-stage jobs available. This is inconsistent with the original behavior of the function.

Although I didn't find any explanation for this behavior in the vLLM paper, I noticed in the [Sarathi-Serve paper](https://arxiv.org/abs/2403.02310) that vLLM is defined as prefill-prioritizing. So, I believe the previous behavior aligns better with vLLM's intended behavior. I made modifications to address this and submitted a pull request. Here's the difference between the two behaviors:

With max_num_seq set to 4 and submitting 5 prompts, if it's prefill-prioritizing, the batch size each step() calls should be 4, 1, 4, 4, ...
However, with the _schedule_default function modified after adding chunked_prefill, the batch size becomes 4, 4, 4, ..., 1, 1, ...