### PR TITLE
Add `vllm serve` to wrap `vllm.entrypoints.openai.api_server`

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -2,7 +2,7 @@
 
 On the server side, run one of the following commands:
     vLLM OpenAI API server
-    vllm serve --model <your_model> \
+    vllm serve <your_model> \
         --swap-space 16 \
         --disable-log-requests
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -2,8 +2,8 @@
 
 On the server side, run one of the following commands:
     vLLM OpenAI API server
-    python -m vllm.entrypoints.openai.api_server \
-        --model <your_model> --swap-space 16 \
+    vllm serve --model <your_model> \
+        --swap-space 16 \
         --disable-log-requests
 
     (TGI backend)

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -73,13 +73,13 @@ Start the server:
 
 .. code-block:: console
 
-    $ vllm serve --model facebook/opt-125m
+    $ vllm serve facebook/opt-125m
 
 By default, the server uses a predefined chat template stored in the tokenizer. You can override this template by using the ``--chat-template`` argument:
 
 .. code-block:: console
 
-   $ vllm serve --model facebook/opt-125m \
+   $ vllm serve facebook/opt-125m \
    $     --chat-template ./examples/template_chatml.jinja
 
 This server can be queried in the same format as OpenAI API. For example, list the models:

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -73,15 +73,13 @@ Start the server:
 
 .. code-block:: console
 
-    $ python -m vllm.entrypoints.openai.api_server \
-    $     --model facebook/opt-125m
+    $ vllm serve --model facebook/opt-125m
 
 By default, the server uses a predefined chat template stored in the tokenizer. You can override this template by using the ``--chat-template`` argument:
 
 .. code-block:: console
 
-   $ python -m vllm.entrypoints.openai.api_server \
-   $     --model facebook/opt-125m \
+   $ vllm serve --model facebook/opt-125m \
    $     --chat-template ./examples/template_chatml.jinja
 
 This server can be queried in the same format as OpenAI API. For example, list the models:

--- a/docs/source/models/adding_model.rst
+++ b/docs/source/models/adding_model.rst
@@ -110,7 +110,7 @@ Just add the following lines in your code:
     from your_code import YourModelForCausalLM
     ModelRegistry.register_model("YourModelForCausalLM", YourModelForCausalLM)
 
-If you are running api server with `python -m vllm.entrypoints.openai.api_server args`, you can wrap the entrypoint with the following code:
+If you are running api server with `vllm serve args`, you can wrap the entrypoint with the following code:
 
 .. code-block:: python
 

--- a/docs/source/models/lora.rst
+++ b/docs/source/models/lora.rst
@@ -58,7 +58,7 @@ LoRA adapted models can also be served with the Open-AI compatible vLLM server. 
 
 .. code-block:: bash
 
-    vllm serve --model meta-llama/Llama-2-7b-hf \
+    vllm serve meta-llama/Llama-2-7b-hf \
         --enable-lora \
         --lora-modules sql-lora=~/.cache/huggingface/hub/models--yard1--llama-2-7b-sql-lora-test/
 

--- a/docs/source/models/lora.rst
+++ b/docs/source/models/lora.rst
@@ -58,8 +58,7 @@ LoRA adapted models can also be served with the Open-AI compatible vLLM server. 
 
 .. code-block:: bash
 
-    python -m vllm.entrypoints.openai.api_server \
-        --model meta-llama/Llama-2-7b-hf \
+    vllm serve --model meta-llama/Llama-2-7b-hf \
         --enable-lora \
         --lora-modules sql-lora=~/.cache/huggingface/hub/models--yard1--llama-2-7b-sql-lora-test/
 

--- a/docs/source/serving/distributed_serving.rst
+++ b/docs/source/serving/distributed_serving.rst
@@ -21,7 +21,7 @@ To run multi-GPU serving, pass in the :code:`--tensor-parallel-size` argument wh
 
 .. code-block:: console
 
-    $ vllm serve --model facebook/opt-13b \
+    $ vllm serve facebook/opt-13b \
     $     --tensor-parallel-size 4
 
 To scale vLLM beyond a single machine, start a `Ray runtime <https://docs.ray.io/en/latest/ray-core/starting-ray.html>`_ via CLI before running vLLM:

--- a/docs/source/serving/distributed_serving.rst
+++ b/docs/source/serving/distributed_serving.rst
@@ -21,8 +21,7 @@ To run multi-GPU serving, pass in the :code:`--tensor-parallel-size` argument wh
 
 .. code-block:: console
 
-    $ python -m vllm.entrypoints.api_server \
-    $     --model facebook/opt-13b \
+    $ vllm serve --model facebook/opt-13b \
     $     --tensor-parallel-size 4
 
 To scale vLLM beyond a single machine, start a `Ray runtime <https://docs.ray.io/en/latest/ray-core/starting-ray.html>`_ via CLI before running vLLM:

--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -4,7 +4,7 @@ vLLM provides an HTTP server that implements OpenAI's [Completions](https://plat
 
 You can start the server using Python, or using [Docker](deploying_with_docker.rst):
 ```bash
-vllm serve --model mistralai/Mistral-7B-Instruct-v0.2 --dtype auto --api-key token-abc123
+vllm serve mistralai/Mistral-7B-Instruct-v0.2 --dtype auto --api-key token-abc123
 ```
 
 To call the server, you can use the official OpenAI Python client library, or any other HTTP client.
@@ -95,7 +95,7 @@ template, or the template in string form. Without a chat template, the server wi
 and all chat requests will error.
 
 ```bash
-vllm serve --model ... \
+vllm serve ... \
   --chat-template ./path-to-chat-template.jinja
 ```
 

--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -4,7 +4,7 @@ vLLM provides an HTTP server that implements OpenAI's [Completions](https://plat
 
 You can start the server using Python, or using [Docker](deploying_with_docker.rst):
 ```bash
-python -m vllm.entrypoints.openai.api_server --model mistralai/Mistral-7B-Instruct-v0.2 --dtype auto --api-key token-abc123
+vllm serve --model mistralai/Mistral-7B-Instruct-v0.2 --dtype auto --api-key token-abc123
 ```
 
 To call the server, you can use the official OpenAI Python client library, or any other HTTP client.
@@ -95,8 +95,7 @@ template, or the template in string form. Without a chat template, the server wi
 and all chat requests will error.
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-  --model ... \
+vllm serve --model ... \
   --chat-template ./path-to-chat-template.jinja
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -410,4 +410,9 @@ setup(
     },
     cmdclass={"build_ext": cmake_build_ext} if not _is_neuron() else {},
     package_data=package_data,
+    entry_points={
+        "console_scripts": [
+            "vllm=vllm.scripts:main",
+        ],
+    },
 )

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -123,7 +123,6 @@ def zephyr_lora_files():
 def server(zephyr_lora_files):
     ray.init()
     server_runner = ServerRunner.remote([
-        "--model",
         MODEL_NAME,
         # use half precision for speed and memory savings in CI environment
         "--dtype",

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -82,7 +82,7 @@ class ServerRunner:
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
         self.proc = subprocess.Popen(
-            ["python3", "-m", "vllm.entrypoints.openai.api_server"] + args,
+            ["vllm", "serve"] + args,
             env=env,
             stdout=sys.stdout,
             stderr=sys.stderr,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 
 import fastapi
 import uvicorn
-from fastapi import Request, APIRouter
+from fastapi import APIRouter, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -22,9 +22,10 @@ class LoRAParserAction(argparse.Action):
         setattr(namespace, self.dest, lora_list)
 
 
-def make_arg_parser():
-    parser = argparse.ArgumentParser(
-        description="vLLM OpenAI-Compatible RESTful API server.")
+def make_arg_parser(parser=None):
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            description="vLLM OpenAI-Compatible RESTful API server.")
     parser.add_argument("--host", type=str, default=None, help="host name")
     parser.add_argument("--port", type=int, default=8000, help="port number")
     parser.add_argument(

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -1,5 +1,6 @@
 # The CLI entrypoint to vLLM.
 import argparse
+
 from vllm.entrypoints.openai.api_server import run_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -1,0 +1,26 @@
+# The CLI entrypoint to vLLM.
+import argparse
+from vllm.entrypoints.openai.api_server import run_server
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+
+
+def main():
+    parser = argparse.ArgumentParser(description="vLLM CLI")
+    subparsers = parser.add_subparsers()
+
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Start the vLLM OpenAI Compatible API server",
+        usage="vllm serve --model <model_tag> [options]")
+    make_arg_parser(serve_parser)
+    serve_parser.set_defaults(func=run_server)
+
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -12,8 +12,10 @@ def main():
     serve_parser = subparsers.add_parser(
         "serve",
         help="Start the vLLM OpenAI Compatible API server",
-        usage="vllm serve --model <model_tag> [options]")
+        usage="vllm serve <model_tag> [options]")
     make_arg_parser(serve_parser)
+    # Override the `--model` optional argument, make it positional.
+    serve_parser.add_argument("model", type=str, help="The model tag to serve")
     serve_parser.set_defaults(func=run_server)
 
     args = parser.parse_args()


### PR DESCRIPTION
Easier to type. It will be now 

```
(base) xmo@simon-devbox:~/vllm$ vllm serve --help
usage: vllm serve <model_tag> [options]

positional arguments:
  model                 The model tag to serve

options:
  -h, --help            show this help message and exit
  --host HOST           host name
  --port PORT           port number
  --uvicorn-log-level {debug,info,warning,error,critical,trace}
                        log level for uvicorn
  --allow-credentials   allow credentials
  --allowed-origins ALLOWED_ORIGINS
                        allowed origins
  --allowed-methods ALLOWED_METHODS
                        allowed methods
.....
```