### PR TITLE
Support eos_token_id from generation_config.json

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1,7 +1,7 @@
 import time
 from typing import Iterable, List, Optional, Type, Union
 
-from transformers import PreTrainedTokenizer, GenerationConfig
+from transformers import GenerationConfig, PreTrainedTokenizer
 
 import vllm
 from vllm.config import (CacheConfig, DecodingConfig, DeviceConfig, LoadConfig,

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -2,7 +2,7 @@
 import copy
 from enum import IntEnum
 from functools import cached_property
-from typing import Callable, List, Optional, Union, Dict, Any
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 from pydantic import Field

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -2,7 +2,7 @@
 import copy
 from enum import IntEnum
 from functools import cached_property
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union, Dict, Any
 
 import torch
 from pydantic import Field
@@ -270,6 +270,18 @@ class SamplingParams:
         if self.best_of > 1:
             raise ValueError("best_of must be 1 when using greedy sampling."
                              f"Got {self.best_of}.")
+
+    def update_from_generation_config(
+            self, generation_config: Dict[str, Any]) -> None:
+        """Update if there are non-default values from generation_config"""
+        # Update eos_token_id for generation
+        if eos_ids := generation_config.get("eos_token_id"):
+            # it can be either int or list of int
+            if isinstance(eos_ids, int):
+                eos_ids = [eos_ids]
+            original_stop_token_ids = set(self.stop_token_ids)
+            original_stop_token_ids.update(eos_ids)
+            self.stop_token_ids = list(original_stop_token_ids)
 
     @cached_property
     def sampling_type(self) -> SamplingType:


### PR DESCRIPTION
Related to #4180 

Some models uses `eos_token_id` field (`Optional[Union[int, list[int]]`) in `generation_config.json` 
https://huggingface.co/docs/transformers/v4.39.3/en/main_classes/text_generation#transformers.GenerationConfig

This PR will load the config, get the value if user supplied, and inject it into `stop_token_ids` in sampling params. Notably this does not change the `os_token_id` in the sampling param or tokenizer config. 

One example is DRBX. Meta Llama 3 _might_ use generation config to reconcile the difference between `<endoftext|>` and `<eot_id|>`.

## Testing
Because this model dependent, I have performed manual testing:

1. Run Meta Llama 3 8B instruct, see the endofturn is not respected. 

```
~$ curl http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Who are you?"
      }
    ],
    "max_tokens": 256
  }'
{"id":"cmpl-ca00059831714382b0104ca1cb7e407d","object":"chat.completion","created":1713481143,"model":"meta-llama/Meta-Llama-3-8B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"I'm your helpful assistant! I'm an AI designed to assist and support you in various ways. I can help with tasks, answer questions, provide information, and even engage in conversations. My purpose is to make your life easier and more efficient, so feel free to ask me anything or tell me what's on your mind! What can I help you with today?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nI'm happy to help with any questions or tasks you have.<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nI'm a large language model, trained on a massive dataset of text from the internet, books, and other sources. I can understand and respond to natural language input, and I'm constantly learning and improving my abilities.\n\nI can help with a wide range of tasks, such as:\n\n* Answering questions on various topics, from science and history to entertainment and culture\n* Generating text, such as articles, stories, or emails\n* Translating text from one language to another\n* Summarizing long pieces of text into shorter, more digestible versions\n* Offering suggestions and ideas for creative projects or problems you're trying to solve\n* Even just chatting with you and engaging in conversation!\n\nWhat do you need help with today?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\nI'm excited to hear"},"logprobs":null,"finish_reason":"length","stop_reason":null}],"
```

2. Change the field in generation config of the hf model 
```diff
-   "eos_token_id": 128001,
+   "eos_token_id": [128001,128009],
```

3. Same query
```
~$ curl http://localhost:8000/v1/chat/completions   -H "Content-Type: application/json"   -d '{
    "model": "meta-llama/Meta-Llama-3-8B-Instruct",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Who are you?"
      }
    ],
    "max_tokens": 256
  }'
{"id":"cmpl-bf80caf7d899446fa9e148d1714b0552","object":"chat.completion","created":1713481243,"model":"meta-llama/Meta-Llama-3-8B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"I'm your helpful assistant! I'm an AI designed to assist and support you in various ways. I can help with tasks, answer questions, provide information, and even engage in conversations. My purpose is to make your life easier and more efficient, so feel free to ask me anything or tell me what's on your mind! What can I help you with today?"},"logprobs":null,"finish_
```