### PR TITLE
[Misc]: optimize eager mode host time

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -14,6 +14,7 @@ from typing import (Any, AsyncIterator, Awaitable, Callable, Dict, Generic,
                     Hashable, List, Optional, OrderedDict, Tuple, TypeVar,
                     Union)
 
+import numpy as np
 import psutil
 import torch
 from packaging.version import Version, parse
@@ -465,11 +466,6 @@ def str_to_int_tuple(s: str) -> Tuple[int, ...]:
             f"(e.g., 1, 2, 3). Given input: {s}") from e
 
 
-def pad_to_max_length(x: List[int], max_len: int, pad: int) -> List[int]:
-    assert len(x) <= max_len
-    return x + [pad] * (max_len - len(x))
-
-
 def make_tensor_with_pad(
     x: List[List[int]],
     max_len: int,
@@ -482,7 +478,10 @@ def make_tensor_with_pad(
     The padding is applied to the end of each inner list until it reaches
     `max_len`.
     """
-    padded_x = [pad_to_max_length(x_i, max_len, pad) for x_i in x]
+    padded_x = np.zeros([len(x), max_len], dtype=np.int32) + pad
+    for ind, blocktb in enumerate(x):
+        assert len(blocktb) <= max_len
+        padded_x[ind, :len(blocktb)] = blocktb
     return torch.tensor(padded_x, dtype=dtype, device=device)
 
 


### PR DESCRIPTION
in my eager mode testing, this func brings a lot host duration time, which slight damaging performance  
using numpy to get some accelerattion

**compare of running time of func: make_tensor_with_pad**
tested on : Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz

before:
debug block talbs:  11    128   max_len:  128
debug make blocktable tensor time:  0.0983159989118576  ms
debug block talbs:  11    128   max_len:  128
debug make blocktable tensor time:  0.09891018271446228  ms

after:
debug block talbs:  11    128   max_len:  128
debug make blocktable tensor time:  0.0807461328804493  ms
debug block talbs:  11    128   max_len:  128
debug make blocktable tensor time:  0.08287793025374413  ms