### PR TITLE
[Bugfix] Ensure download_weights_from_hf(..) inside loader is using the revision parameter

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -172,7 +172,8 @@ class DefaultModelLoader(BaseModelLoader):
         if not is_local:
             hf_folder = download_weights_from_hf(model_name_or_path,
                                                  self.load_config.download_dir,
-                                                 allow_patterns)
+                                                 allow_patterns
+                                                 revision)
         else:
             hf_folder = model_name_or_path
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -172,8 +172,7 @@ class DefaultModelLoader(BaseModelLoader):
         if not is_local:
             hf_folder = download_weights_from_hf(model_name_or_path,
                                                  self.load_config.download_dir,
-                                                 allow_patterns
-                                                 revision)
+                                                 allow_patterns, revision)
         else:
             hf_folder = model_name_or_path
 


### PR DESCRIPTION
The revision was not passed to the download_weights_from_hf(..) function in the loader.py, which was causing mismatch issues when loading models with a specific revision.