### PR TITLE
Don't show default value for flags in `EngineArgs`

### DIFF
--- a/docs/source/models/engine_args.rst
+++ b/docs/source/models/engine_args.rst
@@ -9,6 +9,7 @@ Below, you can find an explanation of every engine argument for vLLM:
     :module: vllm.engine.arg_utils
     :func: _engine_args_parser
     :prog: -m vllm.entrypoints.openai.api_server
+    :nodefaultconst:
 
 Async Engine Arguments
 ----------------------
@@ -19,3 +20,4 @@ Below are the additional arguments related to the asynchronous engine:
     :module: vllm.engine.arg_utils
     :func: _async_engine_args_parser
     :prog: -m vllm.entrypoints.openai.api_server
+    :nodefaultconst:


### PR DESCRIPTION
A hotfix for #4219 that stops the default value for flag type arguments (e.g. `--enforce-eager`, which uses `store_true`) from being shown because the user might think they need to pass a value to them (e.g. for `--enforce-eager` the user might think they need to pass `--enforce-eager True`, which they don't)