### PR TITLE
add importlib option for pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,8 @@ skip = "./tests/prompts,./benchmarks/sonnet.txt"
 [tool.isort]
 use_parentheses = true
 skip_gitignore = true
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]


### PR DESCRIPTION
According to https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html, it is better to have importlib in pyproject.toml, and it prevent the case that pytest would still use local path for module import instead the installed one.
