### PR TITLE
Fix `autodoc` directives

### DIFF
--- a/docs/source/dev/engine/async_llm_engine.rst
+++ b/docs/source/dev/engine/async_llm_engine.rst
@@ -1,7 +1,6 @@
-
 AsyncLLMEngine
 =================================
 
-.. autoclass:: vllm.engine.async_llm_engine.AsyncLLMEngine
-    :members: generate, abort
+.. autoclass:: vllm.AsyncLLMEngine
+    :members:
     :show-inheritance:

--- a/docs/source/dev/engine/llm_engine.rst
+++ b/docs/source/dev/engine/llm_engine.rst
@@ -1,6 +1,6 @@
 LLMEngine
 =================================
 
-.. autoclass:: vllm.engine.llm_engine.LLMEngine
-    :members: add_request, abort_request, step
+.. autoclass:: vllm.LLMEngine
+    :members:
     :show-inheritance:

--- a/docs/source/dev/sampling_params.rst
+++ b/docs/source/dev/sampling_params.rst
@@ -1,4 +1,5 @@
 Sampling Params
 ===============
 
-.. automodule:: vllm.sampling_params.SamplingParams
+.. autoclass:: vllm.SamplingParams
+    :members:


### PR DESCRIPTION
Documentation updates:
- Update `SamplingParams` to use `autoclass` instead of `automodule` so that the `SamplingParams` class is properly documented.
- Add `:members:` option to `SamplingParams` so it is fully documented.
- Remove specific `:members:` from `AsyncLLMEngine` and `LLMEngine` because they weren't being kept up to date and functions were missing. `:members:` will only document public class members anyway.
- Update import paths used in `autoclass` for `AsyncLLMEngine` and `LLMEngine` so that they match the way we expect users to import them.