### PR TITLE
[Core][Logging] Add last frame information for better debugging

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -83,13 +83,27 @@ def _trace_calls(log_path, root_dir, frame, event, arg=None):
             return
         # Log every function call or return
         try:
+            last_frame = frame.f_back
+            if last_frame is not None:
+                last_filename = last_frame.f_code.co_filename
+                last_lineno = last_frame.f_lineno
+                last_func_name = last_frame.f_code.co_name
+            else:
+                # initial frame
+                last_filename = ""
+                last_lineno = 0
+                last_func_name = ""
             with open(log_path, 'a') as f:
                 if event == 'call':
                     f.write(f"{datetime.datetime.now()} Call to"
-                            f" {func_name} in {filename}:{lineno}\n")
+                            f" {func_name} in {filename}:{lineno}"
+                            f" from {last_func_name} in {last_filename}:"
+                            f"{last_lineno}\n")
                 else:
                     f.write(f"{datetime.datetime.now()} Return from"
-                            f" {func_name} in {filename}:{lineno}\n")
+                            f" {func_name} in {filename}:{lineno}"
+                            f" to {last_func_name} in {last_filename}:"
+                            f"{last_lineno}\n")
         except NameError:
             # modules are deleted during shutdown
             pass


### PR DESCRIPTION
When the process hangs after returning to a function, it is unclear where is the process, and users have to analyze the call chain manually. This PR adds the `from` and `to` information directly in the log file, so that debugging issues like https://github.com/vllm-project/vllm/issues/4277 will be easier.