### PR TITLE
[Bugfix][Frontend] Raise exception when file-like chat template fails to be opened

### DIFF
--- a/tests/async_engine/test_chat_template.py
+++ b/tests/async_engine/test_chat_template.py
@@ -76,9 +76,21 @@ def test_load_chat_template():
 {% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}{{ '<|im_start|>assistant\\n' }}{% endif %}"""  # noqa: E501
 
 
-def test_no_load_chat_template():
+def test_no_load_chat_template_filelike():
     # Testing chatml template
     template = "../../examples/does_not_exist"
+    tokenizer = MockTokenizer()
+
+    mock_serving_chat = MockServingChat(tokenizer)
+
+    with pytest.raises(ValueError, match="looks like a file path"):
+        OpenAIServingChat._load_chat_template(mock_serving_chat,
+                                              chat_template=template)
+
+
+def test_no_load_chat_template_literallike():
+    # Testing chatml template
+    template = "{{ messages }}"
     tokenizer = MockTokenizer()
 
     mock_serving_chat = MockServingChat(tokenizer)
@@ -86,10 +98,7 @@ def test_no_load_chat_template():
                                           chat_template=template)
     template_content = tokenizer.chat_template
 
-    # Test assertions
-    assert template_content is not None
-    # Hard coded value for template_chatml.jinja
-    assert template_content == """../../examples/does_not_exist"""
+    assert template_content == template
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -331,7 +331,6 @@ class OpenAIServingChat(OpenAIServing):
 
     def _load_chat_template(self, chat_template):
         tokenizer = self.tokenizer
-        assert tokenizer is not None
 
         if chat_template is not None:
             try:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -25,7 +25,7 @@ def _path_is_relative_to(path: Path, other: str):
     # Polyfill for Python 3.8
     # TODO: Replace w/ Path.is_relative_to when Python 3.8 is not supported
     try:
-        path.relative_to(*other)
+        path.relative_to(other)
         return True
     except ValueError:
         return False

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1,6 +1,5 @@
 import codecs
 import time
-from pathlib import Path
 from typing import AsyncGenerator, AsyncIterator, List, Optional, Union
 
 from fastapi import Request
@@ -19,16 +18,6 @@ from vllm.outputs import RequestOutput
 from vllm.utils import random_uuid
 
 logger = init_logger(__name__)
-
-
-def _path_is_relative_to(path: Path, other: str):
-    # Polyfill for Python 3.8
-    # TODO: Replace w/ Path.is_relative_to when Python 3.8 is not supported
-    try:
-        path.relative_to(other)
-        return True
-    except ValueError:
-        return False
 
 
 class OpenAIServingChat(OpenAIServing):
@@ -337,8 +326,8 @@ class OpenAIServingChat(OpenAIServing):
                 with open(chat_template, "r") as f:
                     tokenizer.chat_template = f.read()
             except OSError as e:
-                path = Path(chat_template)
-                if path.is_absolute() or _path_is_relative_to(path, ''):
+                JINJA_CHARS = "{}\n"
+                if not any(c in chat_template for c in JINJA_CHARS):
                     msg = (f"The supplied chat template ({chat_template}) "
                            f"looks like a file path, but it failed to be "
                            f"opened. Reason: {e}")


### PR DESCRIPTION
Currently, when the value provided to `--chat-template` looks like a file path, but the file fails to be opened, the filename is read as the literal chat template, resulting in [much confusion](https://github.com/vllm-project/vllm/issues/4194#issuecomment-2071806556) as to why the model fails to generate output.

This PR adds a check for this case so that the user is notified of the error instead of silently using garbage input, which IMO is more in line with expectations.
