### PR TITLE
[CI][Build] change pynvml to nvidia-ml-py

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -3,7 +3,7 @@
 
 # Dependencies for NVIDIA GPUs
 ray >= 2.9
-pynvml == 11.5.0
+nvidia-ml-py # for pynvml package
 vllm-nccl-cu12>=2.18,<2.19  # for downloading nccl library
 torch == 2.2.1
 xformers == 0.0.25  # Requires PyTorch 2.2.1


### PR DESCRIPTION
Quote from nv team:

> The pynvml library is effectively a mirror of whatever is released by nvidia-ml-py (which is managed by the "real" NVML team). We don't do any development or bug-fixes in pynvml, so the official recommendation is to use nvidia-ml-py directly.