### PR TITLE
[Speculative decoding] CUDA graph support including e2e test

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -1,6 +1,6 @@
 from vllm import LLM, SamplingParams
 
-Sample prompts.
+#Sample prompts.
 prompts = [
     "Hello, my name is",
     "The president of the United States is",
@@ -19,7 +19,7 @@ outputs = llm.generate(prompts, sampling_params)
 for output in outputs:
     prompt = output.prompt
     generated_text = output.outputs[0].text
-    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}"
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
 
 
 

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -1,6 +1,6 @@
 from vllm import LLM, SamplingParams
 
-# Sample prompts.
+Sample prompts.
 prompts = [
     "Hello, my name is",
     "The president of the United States is",
@@ -19,4 +19,7 @@ outputs = llm.generate(prompts, sampling_params)
 for output in outputs:
     prompt = output.prompt
     generated_text = output.outputs[0].text
-    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}"
+
+
+

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -54,7 +54,8 @@ class GPUExecutor(ExecutorBase):
         """Initialize a SpecDecodeWorker, using a draft model for proposals.
         """
         assert self.speculative_config is not None
-
+        self.speculative_length = self.speculative_config.num_speculative_tokens
+        
         from vllm.spec_decode.multi_step_worker import MultiStepWorker
         from vllm.spec_decode.spec_decode_worker import SpecDecodeWorker
         from vllm.worker.worker import Worker
@@ -75,6 +76,7 @@ class GPUExecutor(ExecutorBase):
             lora_config=self.lora_config,
             vision_language_config=self.vision_language_config,
             is_driver_worker=True,
+            speculative_length=self.speculative_length
         )
 
         draft_worker = MultiStepWorker(
@@ -91,6 +93,7 @@ class GPUExecutor(ExecutorBase):
             lora_config=self.lora_config,
             vision_language_config=self.vision_language_config,
             is_driver_worker=True,
+            speculative_length=self.speculative_length
         )
 
         spec_decode_worker = SpecDecodeWorker.from_workers(

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -57,6 +57,7 @@ class CacheEngine:
         """Allocates KV cache on the specified device."""
         kv_cache_shape = self.attn_backend.get_kv_cache_shape(
             num_blocks, self.block_size, self.num_heads, self.head_size)
+        
         pin_memory = is_pin_memory_available() if device == "cpu" else False
         kv_cache: List[torch.Tensor] = []
         for _ in range(self.num_layers):

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -45,6 +45,7 @@ class Worker(WorkerBase):
         lora_config: Optional[LoRAConfig] = None,
         vision_language_config: Optional[VisionLanguageConfig] = None,
         is_driver_worker: bool = False,
+        speculative_length: int = 5, 
     ) -> None:
         self.model_config = model_config
         self.parallel_config = parallel_config
@@ -79,6 +80,7 @@ class Worker(WorkerBase):
             kv_cache_dtype=self.cache_config.cache_dtype,
             is_driver_worker=is_driver_worker,
             vision_language_config=vision_language_config,
+            speculative_length=speculative_length,
         )
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.


### PR DESCRIPTION
Thanks for reviewing PR @cadedaniel.  

I updated the PR (#4295 ) by including the test,  `test_spec_decode_cuda_graph` in `vllm/tests/spec_decode/e2e/test_correctness.py`

And then I run the test by setting `gpu_memory_utilization` as 0.2 on single A100 80GB and all tests(4 configurations) are passed. 

I also removed other changes in `examples/offline_inference.py`. Thanks @mgoin  

Could you review this PR again?

Thanks.

