### PR TITLE
[Core] Add `shutdown()` method to `ExecutorBase`

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -287,6 +287,12 @@ class LLMEngine:
         # the closure used to initialize Ray worker actors
         raise RuntimeError("LLMEngine should not be pickled!")
 
+    def __del__(self):
+        # Shutdown model executor when engine is garbage collected
+        # Use getattr since __init__ can fail before the field is set
+        if model_executor := getattr(self, "model_executor", None):
+            model_executor.shutdown()
+
     def get_tokenizer(self) -> "PreTrainedTokenizer":
         return self.tokenizer.get_lora_tokenizer(None)
 

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -95,6 +95,13 @@ class ExecutorBase(ABC):
         exception."""
         raise NotImplementedError
 
+    def shutdown(self) -> None:
+        """Shutdown the executor."""
+        return
+
+    def __del__(self):
+        self.shutdown()
+
 
 class ExecutorAsyncBase(ExecutorBase):
 


### PR DESCRIPTION
Called when the LLMEngine is garbage collected. The executor might not otherwise be garbage collected itself if it is referenced from other threads.

Default is no-op but can be overwritten by subclasses.

In preparation for introducing a `MultiprocessingGPUExecutor`.