### PR TITLE
[Core] Centralize GPU Worker construction

### DIFF
--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from vllm.executor.executor_base import ExecutorAsyncBase, ExecutorBase
 from vllm.logger import init_logger
@@ -23,30 +23,37 @@ class GPUExecutor(ExecutorBase):
         else:
             self._init_spec_worker()
 
-    def _init_non_spec_worker(self):
-        # Lazy import the Worker to avoid importing torch.cuda/xformers
-        # before CUDA_VISIBLE_DEVICES is set in the Worker
-        from vllm.worker.worker import Worker
-
-        assert self.parallel_config.world_size == 1, (
-            "GPUExecutor only supports single GPU.")
-
+    def _get_worker_kwargs(self,
+                           local_rank: int = 0,
+                           rank: int = 0) -> Dict[str, Any]:
+        """Return worker init args for a given rank."""
         distributed_init_method = get_distributed_init_method(
-            get_ip(), get_open_port())
-        self.driver_worker = Worker(
+            get_ip(), get_open_port()),
+        return dict(
             model_config=self.model_config,
             parallel_config=self.parallel_config,
             scheduler_config=self.scheduler_config,
             device_config=self.device_config,
             cache_config=self.cache_config,
             load_config=self.load_config,
-            local_rank=0,
-            rank=0,
+            local_rank=local_rank,
+            rank=rank,
             distributed_init_method=distributed_init_method,
             lora_config=self.lora_config,
             vision_language_config=self.vision_language_config,
-            is_driver_worker=True,
+            is_driver_worker=rank == 0,
         )
+
+    def _create_worker(self, local_rank: int = 0, rank: int = 0):
+        # Lazy import to avoid CUDA init issues
+        from vllm.worker.worker import Worker
+        return Worker(**self._get_worker_kwargs(local_rank, rank))
+
+    def _init_non_spec_worker(self):
+        assert self.parallel_config.world_size == 1, (
+            "GPUExecutor only supports single GPU.")
+
+        self.driver_worker = self._create_worker()
         self.driver_worker.init_device()
         self.driver_worker.load_model()
 
@@ -57,41 +64,19 @@ class GPUExecutor(ExecutorBase):
 
         from vllm.spec_decode.multi_step_worker import MultiStepWorker
         from vllm.spec_decode.spec_decode_worker import SpecDecodeWorker
-        from vllm.worker.worker import Worker
 
-        distributed_init_method = get_distributed_init_method(
-            get_ip(), get_open_port())
+        target_worker = self._create_worker()
 
-        target_worker = Worker(
-            model_config=self.model_config,
-            parallel_config=self.parallel_config,
-            scheduler_config=self.scheduler_config,
-            device_config=self.device_config,
-            cache_config=self.cache_config,
-            load_config=self.load_config,
-            local_rank=0,
-            rank=0,
-            distributed_init_method=distributed_init_method,
-            lora_config=self.lora_config,
-            vision_language_config=self.vision_language_config,
-            is_driver_worker=True,
-        )
-
-        draft_worker = MultiStepWorker(
-            model_config=self.speculative_config.draft_model_config,
-            parallel_config=self.speculative_config.draft_parallel_config,
-            scheduler_config=self.scheduler_config,
-            device_config=self.device_config,
-            cache_config=self.cache_config,
-            # TODO allow draft-model specific load config.
-            load_config=self.load_config,
-            local_rank=0,
-            rank=0,
-            distributed_init_method=distributed_init_method,
-            lora_config=self.lora_config,
-            vision_language_config=self.vision_language_config,
-            is_driver_worker=True,
-        )
+        draft_worker_kwargs = self._get_worker_kwargs()
+        # Override draft-model specific worker args.
+        draft_worker_kwargs.update(
+            dict(
+                model_config=self.speculative_config.draft_model_config,
+                parallel_config=self.speculative_config.draft_parallel_config,
+                # TODO allow draft-model specific load config.
+                #load_config=self.load_config,
+            ))
+        draft_worker = MultiStepWorker(**draft_worker_kwargs)
 
         spec_decode_worker = SpecDecodeWorker.from_workers(
             proposer_worker=draft_worker, scorer_worker=target_worker)

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -70,12 +70,11 @@ class GPUExecutor(ExecutorBase):
         draft_worker_kwargs = self._get_worker_kwargs()
         # Override draft-model specific worker args.
         draft_worker_kwargs.update(
-            dict(
-                model_config=self.speculative_config.draft_model_config,
-                parallel_config=self.speculative_config.draft_parallel_config,
-                # TODO allow draft-model specific load config.
-                #load_config=self.load_config,
-            ))
+            model_config=self.speculative_config.draft_model_config,
+            parallel_config=self.speculative_config.draft_parallel_config,
+            # TODO allow draft-model specific load config.
+            #load_config=self.load_config,
+        )
         draft_worker = MultiStepWorker(**draft_worker_kwargs)
 
         spec_decode_worker = SpecDecodeWorker.from_workers(

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -28,7 +28,7 @@ class GPUExecutor(ExecutorBase):
                            rank: int = 0) -> Dict[str, Any]:
         """Return worker init args for a given rank."""
         distributed_init_method = get_distributed_init_method(
-            get_ip(), get_open_port()),
+            get_ip(), get_open_port())
         return dict(
             model_config=self.model_config,
             parallel_config=self.parallel_config,

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -47,10 +47,14 @@ class GPUExecutor(ExecutorBase):
             is_driver_worker=rank == 0,
         )
 
-    def _create_worker(self, local_rank: int = 0, rank: int = 0):
+    def _create_worker(self,
+                       local_rank: int = 0,
+                       rank: int = 0,
+                       distributed_init_method: Optional[str] = None):
         # Lazy import to avoid CUDA init issues
         from vllm.worker.worker import Worker
-        return Worker(**self._get_worker_kwargs(local_rank, rank))
+        return Worker(**self._get_worker_kwargs(local_rank, rank,
+                                                distributed_init_method))
 
     def _init_non_spec_worker(self):
         assert self.parallel_config.world_size == 1, (

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from vllm.executor.executor_base import ExecutorAsyncBase, ExecutorBase
 from vllm.logger import init_logger
@@ -23,12 +23,15 @@ class GPUExecutor(ExecutorBase):
         else:
             self._init_spec_worker()
 
-    def _get_worker_kwargs(self,
-                           local_rank: int = 0,
-                           rank: int = 0) -> Dict[str, Any]:
+    def _get_worker_kwargs(
+            self,
+            local_rank: int = 0,
+            rank: int = 0,
+            distributed_init_method: Optional[str] = None) -> Dict[str, Any]:
         """Return worker init args for a given rank."""
-        distributed_init_method = get_distributed_init_method(
-            get_ip(), get_open_port())
+        if distributed_init_method is None:
+            distributed_init_method = get_distributed_init_method(
+                get_ip(), get_open_port())
         return dict(
             model_config=self.model_config,
             parallel_config=self.parallel_config,

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -10,8 +10,7 @@ from vllm.executor.distributed_gpu_executor import (  # yapf: disable
 from vllm.executor.ray_utils import RayWorkerWrapper, ray
 from vllm.logger import init_logger
 from vllm.sequence import SamplerOutput, SequenceGroupMetadata
-from vllm.utils import (get_distributed_init_method, get_ip, get_open_port,
-                        get_vllm_instance_id, make_async)
+from vllm.utils import get_ip, get_vllm_instance_id, make_async
 
 if ray is not None:
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -150,32 +149,13 @@ class RayGPUExecutor(DistributedGPUExecutor):
         self._run_workers("update_environment_variables",
                           all_args=all_args_to_update_environment_variables)
 
-        distributed_init_method = get_distributed_init_method(
-            driver_ip, get_open_port())
-
-        def collect_arg_helper_func(**kwargs):
-            # avoid writing `{"name": value}` manually
-            return kwargs
-
         # Initialize the actual workers inside worker wrapper.
-        init_worker_all_kwargs = []
-        for rank, (node_id, _) in enumerate(worker_node_and_gpu_ids):
-            local_rank = node_workers[node_id].index(rank)
-            init_worker_all_kwargs.append(
-                collect_arg_helper_func(
-                    model_config=self.model_config,
-                    parallel_config=self.parallel_config,
-                    scheduler_config=self.scheduler_config,
-                    device_config=self.device_config,
-                    cache_config=self.cache_config,
-                    load_config=self.load_config,
-                    local_rank=local_rank,
-                    rank=rank,
-                    distributed_init_method=distributed_init_method,
-                    lora_config=self.lora_config,
-                    vision_language_config=self.vision_language_config,
-                    is_driver_worker=rank == 0,
-                ))
+        init_worker_all_kwargs = [
+            self._get_worker_kwargs(
+                local_rank=node_workers[node_id].index(rank),
+                rank=rank,
+            ) for rank, (node_id, _) in enumerate(worker_node_and_gpu_ids)
+        ]
         self._run_workers("init_worker", all_kwargs=init_worker_all_kwargs)
 
         self._run_workers("init_device")
@@ -200,8 +180,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
             use_ray_compiled_dag=USE_RAY_COMPILED_DAG)
 
         # Only the driver worker returns the sampling results.
-        output = all_outputs[0]
-        return output
+        return all_outputs[0]
 
     def _run_workers(
         self,


### PR DESCRIPTION
Add `_get_worker_kwargs` and `_create_worker` methods to `GPUExecutor` which construct `Worker` instances from the executor configuration, and make use of these in places where the logic is currently duplicated.

This will also be used by the to-be-added `MultiprocessingGPUExecutor`.
