### PR TITLE
[CI] hotfix: soft fail neuron test

### DIFF
--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -25,6 +25,7 @@ steps:
     agents:
       queue: neuron
     command: bash .buildkite/run-neuron-test.sh
+    soft_fail: true
 
   - label: "CPU Test"
     command: bash .buildkite/run-cpu-test.sh


### PR DESCRIPTION
Current the neuron tests are still failing due to disk space after daily cleanup addition #4441