### PR TITLE
[Core][Distributed] add cleanup code for model parallel

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -323,3 +323,20 @@ def is_pynccl_enabled_for_all_reduce():
     """check if pynccl is enabled for all reduce"""
     global _ENABLE_PYNCCL_FOR_ALL_REDUCE
     return _ENABLE_PYNCCL_FOR_ALL_REDUCE
+
+
+class _Destructor:
+    """
+    Python does not support destructors for modules. This class is a
+     workaround to ensure that the model parallel groups are destroyed.
+    This is needed because many Python objects hold resources that live
+     outside of Python's garbage collection system, e.g. process groups,
+     NCCL communicators, etc.
+    """
+
+    def __del__(self):
+        destroy_model_parallel()
+
+# When `_destructor` is garbage collected, the model parallel groups will be
+# destroyed.
+_destructor = _Destructor()

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -337,6 +337,7 @@ class _Destructor:
     def __del__(self):
         destroy_model_parallel()
 
+
 # When `_destructor` is garbage collected, the model parallel groups will be
 # destroyed.
 _destructor = _Destructor()


### PR DESCRIPTION
I did a quick search and find that only test code calls `destroy_model_parallel`:

https://github.com/vllm-project/vllm/blob/d627a3d837976a23f89ba808f5ef6908fdb65bfa/tests/lora/conftest.py#L26

https://github.com/vllm-project/vllm/blob/d627a3d837976a23f89ba808f5ef6908fdb65bfa/tests/conftest.py#L50

This means user's code never called `destroy_model_parallel`.