### PR TITLE
[Core][Dsitributed] fix del exception

### DIFF
--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -280,9 +280,6 @@ class NCCLCommunicator:
                              ctypes.c_void_p(stream.cuda_stream)))
 
     def __del__(self):
-        # `dist` module might have been already destroyed
-        if hasattr(dist, 'destroy_process_group'):
-            dist.destroy_process_group()
         # function might have been already destroyed
         if _c_ncclCommDestroy is not None:
             _c_ncclCommDestroy(self.comm)


### PR DESCRIPTION
Exception warnings found in main branch:

https://buildkite.com/vllm/ci/builds/6086#018f2c52-88b7-4d39-a948-1529eca365e8 

> tests/distributed/test_chunked_prefill_distributed.py::test_models[16-5-half-meta-llama/Llama-2-7b-hf]
>   /usr/local/lib/python3.10/dist-packages/_pytest/unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function NCCLCommunicator.__del__ at 0x7f6ce2d739a0>
>   Traceback (most recent call last):
>     File "/usr/local/lib/python3.10/dist-packages/vllm/distributed/device_communicators/pynccl.py", line 285, in __del__
>       dist.destroy_process_group()
>     File "/usr/local/lib/python3.10/dist-packages/torch/distributed/distributed_c10d.py", line 1656, in destroy_process_group
>       assert pg is not None
>   AssertionError

Try to see if this fixes the exception.