### PR TITLE
[Core] Add retention policy code for processing requests

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -31,8 +31,8 @@ def resolve_environ_as_type(name: str, datatype: Type[T]) -> Optional[T]:
     """
     ret = os.environ.get(name, None)
     if ret is not None:
-        ret = datatype(ret)
-    return ret
+        ret = datatype(ret) # type: ignore
+    return ret # type: ignore
 
 
 ENGINE_MAX_CONCURRENT_REQUESTS = resolve_environ_as_type(

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -169,7 +169,7 @@ class RequestTracker:
         running_requests.sort(key = lambda it: it[1]) # smallest first, so oldest will be first, and oldest will be killed first
           
         total_running_requests = len(running_requests)
-        out_of_quota_running_requests = total_running_requests-VLLM_ENGINE_MAX_CONCURRENT_REQUESTS
+        out_of_quota_running_requests = total_running_requests-ENGINE_MAX_CONCURRENT_REQUESTS
         if out_of_quota_running_requests > 0:
             for i in range(out_of_quota_running_requests):
                 k, _ = running_requests[i]

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -167,7 +167,8 @@ class RequestTracker:
         """Kill every outdated running request.
         Configurable via: `VLLM_ENGINE_MAX_REQUEST_LIFESPAN`
         """
-        if ENGINE_MAX_REQUEST_LIFESPAN is None: return
+        if ENGINE_MAX_REQUEST_LIFESPAN is None:
+            return
         for k, v in self.running_requests.items():
             lifespan = arrival_time - v
             if lifespan > ENGINE_MAX_REQUEST_LIFESPAN:
@@ -178,7 +179,8 @@ class RequestTracker:
         """Kill every request that exceeding max concurrency request limit.
         Configurable via `VLLM_ENGINE_MAX_CONCURRENT_REQUESTS`
         """
-        if ENGINE_MAX_CONCURRENT_REQUESTS is None: return
+        if ENGINE_MAX_CONCURRENT_REQUESTS is None:
+            return
         running_requests = [(k, v) for k, v in self.running_requests.items()]
         running_requests.sort(key=lambda it: it[1])
         # smallest first, so oldest will be first

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -3,7 +3,7 @@ import os
 import time
 from functools import partial
 from typing import (Any, AsyncIterator, Callable, Dict, Iterable, List,
-                    Optional, Set, Tuple, Type, Union, TypeVar)
+                    Optional, Set, Tuple, Type, TypeVar, Union)
 
 from transformers import PreTrainedTokenizer
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -157,7 +157,7 @@ class RequestTracker:
     def running_requests(self) -> Dict[str, float]:
         """Get running requests"""
         dead_request_ids = []
-        for request_id in self._running_requests.keys():
+        for request_id in self._running_requests:
             if self.check_if_request_has_finished(request_id):
                 dead_request_ids.append(request_id)
         for request_id in dead_request_ids:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -22,6 +22,17 @@ logger = init_logger(__name__)
 ENGINE_ITERATION_TIMEOUT_S = int(
     os.environ.get("VLLM_ENGINE_ITERATION_TIMEOUT_S", "60"))
 
+def resolve_environ_as_type(name:str, datatype):
+    ret = os.environ.get(name, None)
+    if ret is not None:
+        ret = datatype(ret)
+    return ret
+
+ENGINE_MAX_CONCURRENT_REQUESTS = resolve_environ_as_type("VLLM_ENGINE_MAX_CONCURRENT_REQUESTS", int)
+"""Max concurrent requests to process at anytime, if set."""
+
+ENGINE_MAX_REQUEST_LIFESPAN = resolve_environ_as_type("VLLM_ENGINE_REQUEST_LIFESPAN", int)
+"""Max lifespan in seconds for any request, if set."""
 
 class AsyncEngineDeadError(RuntimeError):
     pass

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -193,10 +193,10 @@ class RequestTracker:
         Remove running requests based on retention policies 
         specified by the following environment variables:
         
-        - ENGINE_MAX_CONCURRENT_REQUESTS:
+        - VLLM_ENGINE_MAX_CONCURRENT_REQUESTS:
         Max concurrent requests to process at anytime, if set.
 
-        - ENGINE_MAX_REQUEST_LIFESPAN:
+        - VLLM_ENGINE_MAX_REQUEST_LIFESPAN:
         Max lifespan in seconds for any request, if set.
         """
         if arrival_time is None:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -31,8 +31,8 @@ def resolve_environ_as_type(name: str, datatype: Type[T]) -> Optional[T]:
     """
     ret = os.environ.get(name, None)
     if ret is not None:
-        ret = datatype(ret) # type: ignore
-    return ret # type: ignore
+        ret = datatype(ret)  # type: ignore
+    return ret  # type: ignore
 
 
 ENGINE_MAX_CONCURRENT_REQUESTS = resolve_environ_as_type(

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -3,7 +3,7 @@ import os
 import time
 from functools import partial
 from typing import (Any, AsyncIterator, Callable, Dict, Iterable, List,
-                    Optional, Set, Tuple, Type, Union)
+                    Optional, Set, Tuple, Type, Union, TypeVar)
 
 from transformers import PreTrainedTokenizer
 
@@ -18,12 +18,13 @@ from vllm.sampling_params import SamplingParams
 from vllm.sequence import MultiModalData
 from vllm.usage.usage_lib import UsageContext
 
+T = TypeVar("T")
 logger = init_logger(__name__)
 ENGINE_ITERATION_TIMEOUT_S = int(
     os.environ.get("VLLM_ENGINE_ITERATION_TIMEOUT_S", "60"))
 
 
-def resolve_environ_as_type(name: str, datatype):
+def resolve_environ_as_type(name: str, datatype: Type[T]) -> Optional[T]:
     """
     Resolve environmental variable by name as given datatype if exists, 
     otherwise return `None`.

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -195,7 +195,7 @@ class RequestTracker:
 
         total_running_requests = len(running_requests)
         out_of_quota_running_requests = (total_running_requests -
-                                         ENGINE_MAX_CONCURRENT_REQUESTS)
+                                         ENGINE_MAX_CONCURRENT_REQUESTS) + 1
         if out_of_quota_running_requests > 0:
             for i in range(out_of_quota_running_requests):
                 k, _ = running_requests[i]

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -164,7 +164,10 @@ class RequestTracker:
         return self._running_requests
 
     def kill_outdated_requests(self, arrival_time: float):
-        """Kill every outdated running request."""
+        """Kill every outdated running request.
+        Configurable via: `VLLM_ENGINE_MAX_REQUEST_LIFESPAN`
+        """
+        if ENGINE_MAX_REQUEST_LIFESPAN is None: return
         for k, v in self.running_requests.items():
             lifespan = arrival_time - v
             if lifespan > ENGINE_MAX_REQUEST_LIFESPAN:
@@ -172,7 +175,10 @@ class RequestTracker:
                 self.abort_request(k)
 
     def kill_quota_exceeding_requests(self):
-        """Kill every request that exceeding max concurrency request limit."""
+        """Kill every request that exceeding max concurrency request limit.
+        Configurable via `VLLM_ENGINE_MAX_CONCURRENT_REQUESTS`
+        """
+        if ENGINE_MAX_CONCURRENT_REQUESTS is None: return
         running_requests = [(k, v) for k, v in self.running_requests.items()]
         running_requests.sort(key=lambda it: it[1])
         # smallest first, so oldest will be first

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -47,7 +47,7 @@ ENGINE_HAS_RETENTION_POLICY = any([
     it is not None
     for it in [ENGINE_MAX_CONCURRENT_REQUESTS, ENGINE_MAX_REQUEST_LIFESPAN]
 ])
-"""Having at least one retention policy configured."""
+"""Flag of having at least one retention policy configured."""
 
 
 class AsyncEngineDeadError(RuntimeError):


### PR DESCRIPTION
This pull request is intended to resolve the concurrency problem across various LLMs.

It brings about two important configurable environmental variables:

- VLLM_ENGINE_MAX_CONCURRENT_REQUESTS: Max concurrent requests to process at anytime, if set.
- VLLM_ENGINE_MAX_REQUEST_LIFESPAN: Max lifespan in seconds for any request, if set.

I use a specific model called Mixtral-Instruct which will be unstable with trivial parameter configurations, and will generate nonsense for a long time till it hits limit. 

For many implementations of Langchain it will not abort connection after interruption and even if user refreshes the frontend vLLM does not stop generation therefore slowing down the overall generation process, leaving the server occupied for nothing.

WIth this solution long running requests will be killed during each new request (soft limit), and older running requests will be killed if they are out of request quota (hard limit).

FIX #4240 
