### PR TITLE
[Bugfix] Use random seed if seed is -1

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -139,7 +139,10 @@ class SamplingParams:
         self.top_p = top_p
         self.top_k = top_k
         self.min_p = min_p
-        self.seed = seed
+        if seed == -1:
+            self.seed = None
+        else:
+            self.seed = seed
         self.use_beam_search = use_beam_search
         self.length_penalty = length_penalty
         self.early_stopping = early_stopping


### PR DESCRIPTION
AFAIK, OpenAI allows you to specify -1 to use random seed.

I haven't tested this because I don't have access to their API, but:
1. The application I am using uses -1 as a random seed and does not allow you to exclude the seed field.
2. The OpenAI-compatible server implementation I know of ([llama.cpp](https://github.com/ggerganov/llama.cpp)) allows -1 to be used as a random seed.