### PR TITLE
CI: prioritize pods with more GPUs

### DIFF
--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -44,6 +44,9 @@ steps:
     plugins:
       - kubernetes:
           podSpec:
+            {% if step.num_gpus %}
+            priorityClassName: gpu-priority-cls-{{ step.num_gpus }}
+            {% endif %}
             volumes:
               - name: dshm
                 emptyDir:


### PR DESCRIPTION
Without mechanism like this, we are seeing 4 GPU nodes are used by jobs requiring only 1 GPU.
Priority level set here: https://github.com/vllm-project/buildkite-ci/blob/main/infra-k8s/priority-class.yaml