### PR TITLE
[Bug fix][Core] fixup ngram not setup correctly

### DIFF
--- a/tests/spec_decode/e2e/conftest.py
+++ b/tests/spec_decode/e2e/conftest.py
@@ -182,8 +182,7 @@ def get_output_from_llm_generator(
         if (not isinstance(llm, AsyncLLM)
                 and llm.llm_engine.speculative_config is not None and
                 llm.llm_engine.speculative_config.ngram_prompt_lookup_max > 0):
-            assert ("set_ngram_window_size" in dir(
-                llm.llm_engine.model_executor.driver_worker.proposer_worker))
+            assert isinstance(llm.llm_engine.model_executor.driver_worker.proposer_worker, NGramWorker)
         outputs = llm.generate(prompts, sampling_params, use_tqdm=True)
         token_ids = [output.outputs[0].token_ids for output in outputs]
         tokens = [output.outputs[0].text for output in outputs]

--- a/tests/spec_decode/e2e/conftest.py
+++ b/tests/spec_decode/e2e/conftest.py
@@ -180,6 +180,10 @@ def get_output_from_llm_generator(
     tokens = []
     token_ids = []
     for llm in llm_generator():
+        if (llm.llm_engine.speculative_config is not None and
+                llm.llm_engine.speculative_config.ngram_prompt_lookup_max > 0):
+            assert ("set_ngram_window_size" in dir(
+                llm.llm_engine.model_executor.driver_worker.proposer_worker))
         outputs = llm.generate(prompts, sampling_params, use_tqdm=True)
         token_ids = [output.outputs[0].token_ids for output in outputs]
         tokens = [output.outputs[0].text for output in outputs]

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -82,6 +82,10 @@ class GPUExecutor(ExecutorBase):
         draft_worker_kwargs.update(
             model_config=self.speculative_config.draft_model_config,
             parallel_config=self.speculative_config.draft_parallel_config,
+            ngram_prompt_lookup_max=
+            self.speculative_config.ngram_prompt_lookup_max,
+            ngram_prompt_lookup_min=
+            self.speculative_config.ngram_prompt_lookup_min,
             # TODO allow draft-model specific load config.
             #load_config=self.load_config,
         )

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -82,10 +82,10 @@ class GPUExecutor(ExecutorBase):
         draft_worker_kwargs.update(
             model_config=self.speculative_config.draft_model_config,
             parallel_config=self.speculative_config.draft_parallel_config,
-            ngram_prompt_lookup_max=
-            self.speculative_config.ngram_prompt_lookup_max,
-            ngram_prompt_lookup_min=
-            self.speculative_config.ngram_prompt_lookup_min,
+            ngram_prompt_lookup_max=self.speculative_config.
+            ngram_prompt_lookup_max,
+            ngram_prompt_lookup_min=self.speculative_config.
+            ngram_prompt_lookup_min,
             # TODO allow draft-model specific load config.
             #load_config=self.load_config,
         )

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -55,13 +55,10 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         draft_worker_kwargs,
     ) -> "SpecDecodeWorker":
 
-        if "ngram_prompt_lookup_max" in draft_worker_kwargs:
-            ngram_prompt_lookup_max = (
-                draft_worker_kwargs.pop("ngram_prompt_lookup_max"))
-            ngram_prompt_lookup_min = (
-                draft_worker_kwargs.pop("ngram_prompt_lookup_min"))
-        else:
-            ngram_prompt_lookup_max = 0
+        ngram_prompt_lookup_max = (
+            draft_worker_kwargs.pop("ngram_prompt_lookup_max"))
+        ngram_prompt_lookup_min = (
+            draft_worker_kwargs.pop("ngram_prompt_lookup_min"))
 
         if ngram_prompt_lookup_max > 0:
             proposer_worker = NGramWorker(**draft_worker_kwargs)

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -67,6 +67,9 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         else:
             proposer_worker = MultiStepWorker(**draft_worker_kwargs)
 
+        logger.info("Configuring SpecDecodeWorker with proposer=%s",
+                    type(proposer_worker))
+
         return SpecDecodeWorker(
             proposer_worker,
             scorer_worker,


### PR DESCRIPTION
ngram_prompt_lookup_max/ngram_prompt_lookup_min need to be past through SpecDecodeWorker.create_worker's draft_worker_kwargs.

If those two doesn't get past, now there will be exception as dict cannot pop those two keys.

