### PR TITLE
[Misc] Exclude the `tests` directory from being packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -404,7 +404,7 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     packages=find_packages(exclude=("benchmarks", "csrc", "docs", "examples",
-                                    "tests")),
+                                    "tests*")),
     python_requires=">=3.8",
     install_requires=get_requirements(),
     ext_modules=ext_modules,


### PR DESCRIPTION
### Problem

When the vLLM pypi package is built, it would include some files under the `tests` directory. When users install it via the `pip install` command, the tests directory is also installed on the system.

The existing build rules already exclude the `tests` directory by excluding it in the `find_package` function. However, it doesn't apply to subdirectories/submodules. Thus, some files are still being packaged. When users list files installed by the `vLLM` package, they could find those files on their system.

```
$ pip show -f vllm
Name: vllm
Version: 0.4.1
Summary: A high-throughput and memory-efficient inference and serving engine for LLMs
Home-page: https://github.com/vllm-project/vllm
Author: vLLM Team
Author-email: 
License: Apache 2.0
Location: /XXX/.venv/lib/python3.10/site-packages
Requires: cmake, fastapi, filelock, lm-format-enforcer, ninja, numpy, nvidia-ml-py, outlines, prometheus-client, psutil, py-cpuinfo, pydantic, ray, requests, sentencepiece, tiktoken, tokenizers, torch, transformers, typing-extensions, uvicorn, vllm-nccl-cu12, xformers
Required-by: 
Files:
  tests/core/__init__.py
  tests/core/__pycache__/__init__.cpython-310.pyc
  tests/core/__pycache__/test_block_manager.cpython-310.pyc
  tests/core/__pycache__/test_chunked_prefill_scheduler.cpython-310.pyc
  tests/core/__pycache__/test_scheduler.cpython-310.pyc
  tests/core/__pycache__/utils.cpython-310.pyc
  tests/core/block/__init__.py
  tests/core/block/__pycache__/__init__.cpython-310.pyc
  tests/core/block/__pycache__/conftest.cpython-310.pyc
  tests/core/block/__pycache__/test_block_manager_v2.cpython-310.pyc
  tests/core/block/__pycache__/test_block_table.cpython-310.pyc
  tests/core/block/__pycache__/test_common.cpython-310.pyc
  tests/core/block/__pycache__/test_cpu_gpu_block_allocator.cpython-310.pyc
  tests/core/block/__pycache__/test_naive_block.cpython-310.pyc
  tests/core/block/__pycache__/test_prefix_caching_block.cpython-310.pyc
  tests/core/block/conftest.py
  tests/core/block/test_block_manager_v2.py
  tests/core/block/test_block_table.py
  tests/core/block/test_common.py
  tests/core/block/test_cpu_gpu_block_allocator.py
  tests/core/block/test_naive_block.py
  tests/core/block/test_prefix_caching_block.py
  tests/core/test_block_manager.py
  tests/core/test_chunked_prefill_scheduler.py
  tests/core/test_scheduler.py
  tests/core/utils.py
  tests/lora/__init__.py
  tests/lora/__pycache__/__init__.cpython-310.pyc
  tests/lora/__pycache__/conftest.cpython-310.pyc
  tests/lora/__pycache__/test_baichuan.cpython-310.pyc
  tests/lora/__pycache__/test_chatglm3.cpython-310.pyc
  tests/lora/__pycache__/test_gemma.cpython-310.pyc
  tests/lora/__pycache__/test_layer_variation.cpython-310.pyc
  tests/lora/__pycache__/test_layers.cpython-310.pyc
  tests/lora/__pycache__/test_llama.cpython-310.pyc
  tests/lora/__pycache__/test_lora.cpython-310.pyc
  tests/lora/__pycache__/test_lora_checkpoints.cpython-310.pyc
  tests/lora/__pycache__/test_lora_manager.cpython-310.pyc
  tests/lora/__pycache__/test_mixtral.cpython-310.pyc
  tests/lora/__pycache__/test_punica.cpython-310.pyc
  tests/lora/__pycache__/test_quant_model.cpython-310.pyc
  tests/lora/__pycache__/test_tokenizer_group.cpython-310.pyc
  tests/lora/__pycache__/test_utils.cpython-310.pyc
  tests/lora/__pycache__/test_worker.cpython-310.pyc
  tests/lora/__pycache__/utils.cpython-310.pyc
  tests/lora/conftest.py
  tests/lora/test_baichuan.py
  tests/lora/test_chatglm3.py
  tests/lora/test_gemma.py
  tests/lora/test_layer_variation.py
  tests/lora/test_layers.py
  tests/lora/test_llama.py
  tests/lora/test_lora.py
  tests/lora/test_lora_checkpoints.py
  tests/lora/test_lora_manager.py
  tests/lora/test_mixtral.py
  tests/lora/test_punica.py
  tests/lora/test_quant_model.py
  tests/lora/test_tokenizer_group.py
  tests/lora/test_utils.py
  tests/lora/test_worker.py
  tests/lora/utils.py
  tests/spec_decode/__init__.py
  tests/spec_decode/__pycache__/__init__.cpython-310.pyc
  tests/spec_decode/__pycache__/test_batch_expansion.cpython-310.pyc
  tests/spec_decode/__pycache__/test_metrics.cpython-310.pyc
  tests/spec_decode/__pycache__/test_multi_step_worker.cpython-310.pyc
  tests/spec_decode/__pycache__/test_spec_decode_worker.cpython-310.pyc
  tests/spec_decode/__pycache__/test_utils.cpython-310.pyc
  tests/spec_decode/__pycache__/utils.cpython-310.pyc
  tests/spec_decode/e2e/__init__.py
  tests/spec_decode/e2e/__pycache__/__init__.cpython-310.pyc
  tests/spec_decode/e2e/__pycache__/conftest.cpython-310.pyc
  tests/spec_decode/e2e/__pycache__/test_compatibility.cpython-310.pyc
  tests/spec_decode/e2e/__pycache__/test_correctness.cpython-310.pyc
  tests/spec_decode/e2e/conftest.py
  tests/spec_decode/e2e/test_compatibility.py
  tests/spec_decode/e2e/test_correctness.py
  tests/spec_decode/test_batch_expansion.py
  tests/spec_decode/test_metrics.py
  tests/spec_decode/test_multi_step_worker.py
  tests/spec_decode/test_spec_decode_worker.py
  tests/spec_decode/test_utils.py
  tests/spec_decode/utils.py
  tests/tensorizer_loader/__init__.py
  tests/tensorizer_loader/__pycache__/__init__.cpython-310.pyc
  tests/tensorizer_loader/__pycache__/tensorize_vllm_model_for_testing.cpython-310.pyc
  tests/tensorizer_loader/__pycache__/test_tensorizer.cpython-310.pyc
  tests/tensorizer_loader/tensorize_vllm_model_for_testing.py
  tests/tensorizer_loader/test_tensorizer.py
  tests/tokenization/__init__.py
  tests/tokenization/__pycache__/__init__.cpython-310.pyc
  tests/tokenization/__pycache__/test_cached_tokenizer.cpython-310.pyc
  tests/tokenization/__pycache__/test_detokenize.cpython-310.pyc
  tests/tokenization/__pycache__/test_tokenizer_group.cpython-310.pyc
  tests/tokenization/test_cached_tokenizer.py
  tests/tokenization/test_detokenize.py
  tests/tokenization/test_tokenizer_group.py
  tests/worker/__init__.py
  tests/worker/__pycache__/__init__.cpython-310.pyc
  tests/worker/__pycache__/test_model_runner.cpython-310.pyc
  tests/worker/__pycache__/test_swap.cpython-310.pyc
  tests/worker/test_model_runner.py
  tests/worker/test_swap.py
  vllm-0.4.1.dist-info/INSTALLER
  vllm-0.4.1.dist-info/LICENSE
  vllm-0.4.1.dist-info/METADATA
  vllm-0.4.1.dist-info/RECORD
  vllm-0.4.1.dist-info/REQUESTED
  vllm-0.4.1.dist-info/WHEEL
  vllm-0.4.1.dist-info/top_level.txt
  vllm/_C.cpython-310-x86_64-linux-gnu.so
  vllm/__init__.py
  vllm/__pycache__/__init__.cpython-310.pyc
  vllm/__pycache__/_custom_ops.cpython-310.pyc
  vllm/__pycache__/block.cpython-310.pyc
  vllm/__pycache__/config.cpython-310.pyc
  vllm/__pycache__/logger.cpython-310.pyc
  vllm/__pycache__/outputs.cpython-310.pyc
  vllm/__pycache__/sampling_params.cpython-310.pyc
  vllm/__pycache__/sequence.cpython-310.pyc
  vllm/__pycache__/test_utils.cpython-310.pyc
  vllm/__pycache__/utils.cpython-310.pyc
  vllm/_custom_ops.py
  vllm/_moe_C.cpython-310-x86_64-linux-gnu.so
  vllm/_punica_C.cpython-310-x86_64-linux-gnu.so
  vllm/attention/__init__.py
  vllm/attention/__pycache__/__init__.cpython-310.pyc
  vllm/attention/__pycache__/layer.cpython-310.pyc
  vllm/attention/__pycache__/selector.cpython-310.pyc
  vllm/attention/backends/__init__.py
  vllm/attention/backends/__pycache__/__init__.cpython-310.pyc
  vllm/attention/backends/__pycache__/abstract.cpython-310.pyc
  vllm/attention/backends/__pycache__/flash_attn.cpython-310.pyc
  vllm/attention/backends/__pycache__/rocm_flash_attn.cpython-310.pyc
  vllm/attention/backends/__pycache__/torch_sdpa.cpython-310.pyc
  vllm/attention/backends/__pycache__/xformers.cpython-310.pyc
  vllm/attention/backends/abstract.py
  vllm/attention/backends/flash_attn.py
  vllm/attention/backends/rocm_flash_attn.py
  vllm/attention/backends/torch_sdpa.py
  vllm/attention/backends/xformers.py
  vllm/attention/layer.py
  vllm/attention/ops/__init__.py
  vllm/attention/ops/__pycache__/__init__.cpython-310.pyc
  vllm/attention/ops/__pycache__/paged_attn.cpython-310.pyc
  vllm/attention/ops/__pycache__/prefix_prefill.cpython-310.pyc
  vllm/attention/ops/__pycache__/triton_flash_attention.cpython-310.pyc
  vllm/attention/ops/paged_attn.py
  vllm/attention/ops/prefix_prefill.py
  vllm/attention/ops/triton_flash_attention.py
  vllm/attention/selector.py
  vllm/block.py
  vllm/config.py
  vllm/core/__init__.py
  vllm/core/__pycache__/__init__.cpython-310.pyc
  vllm/core/__pycache__/block_manager_v1.cpython-310.pyc
  vllm/core/__pycache__/block_manager_v2.cpython-310.pyc
  vllm/core/__pycache__/evictor.cpython-310.pyc
  vllm/core/__pycache__/interfaces.cpython-310.pyc
  vllm/core/__pycache__/policy.cpython-310.pyc
  vllm/core/__pycache__/scheduler.cpython-310.pyc
  vllm/core/block/__init__.py
  vllm/core/block/__pycache__/__init__.cpython-310.pyc
  vllm/core/block/__pycache__/block_table.cpython-310.pyc
  vllm/core/block/__pycache__/common.cpython-310.pyc
  vllm/core/block/__pycache__/cpu_gpu_block_allocator.cpython-310.pyc
  vllm/core/block/__pycache__/interfaces.cpython-310.pyc
  vllm/core/block/__pycache__/naive_block.cpython-310.pyc
  vllm/core/block/__pycache__/prefix_caching_block.cpython-310.pyc
  vllm/core/block/block_table.py
  vllm/core/block/common.py
  ...
```

### Solution

Per the [setuptools' official doc](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html), we should use `tests*` instead of `tests` in the `exclude` parameter of the `find_package` function.

```
include and exclude accept strings representing [glob](https://docs.python.org/3.11/library/glob.html#module-glob) patterns. These patterns should match the full name of the Python module (as if it was written in an import statement).

For example if you have util pattern, it will match util/__init__.py but not util/files/__init__.py.

The fact that the parent package is matched by the pattern will not dictate if the submodule will be included or excluded from the distribution. You will need to explicitly add a wildcard (e.g. util*) if you want the pattern to also match submodules.
```