### PR TITLE
[BugFix] Include target-device specific requirements.txt in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,9 @@
 include LICENSE
 include requirements-common.txt
 include requirements-cuda.txt
+include requirements-rocm.txt
+include requirements-neuron.txt
+include requirements-cpu.txt
 include CMakeLists.txt
 
 recursive-include cmake *


### PR DESCRIPTION
These are all referenced in setup.py, so they could all be needed for users of the sdist.

It's tempting to include requirements-*.txt but requirements-build.txt and requirements-dev.txt should not be in the sdist.
