### PR TITLE
[BugFix] Prevent the task of `_force_log` from being garbage collected

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -4,6 +4,7 @@ import inspect
 import re
 from contextlib import asynccontextmanager
 from http import HTTPStatus
+from typing import Any, Set
 
 import fastapi
 import uvicorn
@@ -33,7 +34,7 @@ openai_serving_chat: OpenAIServingChat
 openai_serving_completion: OpenAIServingCompletion
 logger = init_logger(__name__)
 
-_running_tasks = set()
+_running_tasks: Set[asyncio.Task[Any]] = set()
 
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -36,6 +36,7 @@ logger = init_logger(__name__)
 
 _running_tasks: Set[asyncio.Task[Any]] = set()
 
+
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -33,6 +33,7 @@ openai_serving_chat: OpenAIServingChat
 openai_serving_completion: OpenAIServingCompletion
 logger = init_logger(__name__)
 
+_running_tasks = set()
 
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):
@@ -43,7 +44,9 @@ async def lifespan(app: fastapi.FastAPI):
             await engine.do_log_stats()
 
     if not engine_args.disable_log_stats:
-        asyncio.create_task(_force_log())
+        task = asyncio.create_task(_force_log())
+        _running_tasks.add(task)
+        task.add_done_callback(_running_tasks.remove)
 
     yield
 


### PR DESCRIPTION
The task returned by `asyncio.create_task` should not be discarded. See https://github.com/python/cpython/issues/88831




