### PR TITLE
[Bugfix] add truncate_prompt_tokens to work offline, directly from LLM class.

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -222,6 +222,7 @@ class LLM:
         multi_modal_data: Optional[MultiModalData] = None,
     ) -> None:
         request_id = str(next(self.request_counter))
+        prompt, prompt_token_ids = self._validate_prompt(prompt, prompt_token_ids, sampling_params)
         self.llm_engine.add_request(request_id,
                                     prompt,
                                     sampling_params,
@@ -252,3 +253,17 @@ class LLM:
         # its previous requests.
         outputs = sorted(outputs, key=lambda x: int(x.request_id))
         return outputs
+
+    def _validate_prompt(
+        self,
+        prompt: Optional[str],
+        prompt_token_ids: Optional[List[int]],
+        sampling_params: SamplingParams,
+    ) -> Optional[str]:
+
+        if sampling_params.truncate_prompt_tokens is not None:
+            if prompt_token_ids is None:
+                prompt_token_ids = self.llm_engine.tokenizer.tokenizer(prompt).input_ids
+            prompt_token_ids = prompt_token_ids[-sampling_params.truncate_prompt_tokens:]
+        return prompt, prompt_token_ids
+        


### PR DESCRIPTION
Fixes #4507. 

* added function _validate_prompt to make sure prompt is a right format and run some validations.  
* truncate_prompt_tokens should take truncate the prompt to the left as seen in vllm/entrypoints/openai/serving_engine.py line 182. 

