### PR TITLE
[CI/Build] from scratch build for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ARG CUDATOOLKIT='12.1'
 RUN apt-get install -y libxml2 build-essential
 
 # use /root/download for manual cache
-RUN --mount=type=cache,target=/root/download <<EOF bash
+RUN <<EOF bash
 # download url from https://developer.nvidia.com/cuda-toolkit-archive
 mkdir -p /usr/local/cuda
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ einops # required for MPT
 requests
 ray
 peft
-awscli
+awscli==1.32.98 # specify version to avoid dependency hell
 
 # Benchmarking
 aiohttp


### PR DESCRIPTION
NVIDIA containers are only supported for a certain period: https://gitlab.com/nvidia/container-images/cuda/-/blob/master/doc/support-policy.md .

This PR tries to remove the dependency on NVIDIA containers, by directly building from a fresh new ubuntu 22 image.