### PR TITLE
[CI] Reduce wheel size by not shipping debug symbols

### DIFF
--- a/.buildkite/check-wheel-size.py
+++ b/.buildkite/check-wheel-size.py
@@ -25,6 +25,9 @@ def check_wheel_size(directory):
                         f"compare to the allowed size ({MAX_SIZE_MB} MB).")
                     print_top_10_largest_files(wheel_path)
                     return 1
+                else:
+                    print(f"Wheel {wheel_path} is within the allowed size "
+                          f"({wheel_size_mb} MB).")
     return 0
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Build wheel
         shell: bash
+        env:
+          CMAKE_BUILD_TYPE: Release # do not compile with debug symbol to reduce wheel size
         run: |
           bash -x .github/workflows/scripts/build.sh ${{ matrix.python-version }} ${{ matrix.cuda-version }}
           wheel_name=$(ls dist/*whl | xargs -n 1 basename)


### PR DESCRIPTION
Due to #3792, we cannot ship wheels greater than 100MB in size. However, the latest wheel build from v0.4.2 https://github.com/vllm-project/vllm/commit/8d8357c8ed1f3ddb6a0e8f3287ec669a13d77df1 generated wheel is 103MB. This is pretty strange as my locally built wheel with the same environment generated wheel of size 97MB. The two wheels have exactly the same set of kernels for same set of `sm`s. 

Rather than comparing the binaries, I found if debug info is stripped, the wheel size can be greatly reduced. Therefore, until we figure out other approaches to reduce the debug info for the wheel build, the PyPI packages will live without debug symbols 😢 