### PR TITLE
Update lm-format-enforcer to 0.10.1

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,7 +14,7 @@ pydantic >= 2.0  # Required for OpenAI server.
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken == 0.6.0  # Required for DBRX tokenizer
-lm-format-enforcer == 0.9.8
+lm-format-enforcer == 0.10.1
 outlines == 0.0.34 # Requires torch >= 2.1.0
 typing_extensions
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4


### PR DESCRIPTION
This update adds support for configuration of lm-format-enforcer via environment variables, ideal for vLLM OpenAI Server.
It was requested by users of vLLM on the project's github as it opens options for them to receive better results when working through the OpenAI server without writing custom code.

There were no dependency or breaking API changes in the library between 0.9.8 (previous version of vLLM) and 0.10.1

From the project's [README](https://github.com/noamgat/lm-format-enforcer?tab=readme-ov-file#configuration-options):

## Configuration options

LM Format Enforcer makes use of several heuristics to avoid edge cases that may happen with LLM's generating structure outputs.
There are two ways to control these heuristics:

### Option 1: via Environment Variables

There are several environment variables that can be set, that affect the operation of the library. This method is useful when you don't want to modify the code, for example when using the library through the vLLM OpenAI server.

- `LMFE_MAX_CONSECUTIVE_WHITESPACES` - How many consecutive whitespaces are allowed when parsing JsonSchemaObjects. Default: 12.
- `LMFE_STRICT_JSON_FIELD_ORDER` - Should the JsonSchemaParser force the properties to appear in the same order as they appear in the 'required' list of the JsonSchema? (Note: this is consistent with the order of declaration in Pydantic models). Default: False.