### PR TITLE
[CI] Add retry for agent lost

### DIFF
--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -14,6 +14,8 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 5
+        - exit_status: -10  # Agent was lost
+          limit: 5
   - wait
 
   - group: "AMD Tests"

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -55,6 +55,8 @@ steps:
       automatic:
         - exit_status: -1  # Agent was lost
           limit: 5
+        - exit_status: -10  # Agent was lost
+          limit: 5
     plugins:
       - kubernetes:
           podSpec:


### PR DESCRIPTION
Some CI runs fail with -10, which I believe we should retry. Example: https://buildkite.com/vllm/ci/builds/6657#018f4ece-88d4-4901-9e71-5621d3095d36

![Screenshot 2024-05-06 at 11 29 27 AM](https://github.com/vllm-project/vllm/assets/950914/ea9cc0b7-1194-4f92-a507-c22d39432282)
