### PR TITLE
fix MiniCPM tie_word_embeddings

### DIFF
--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -492,6 +492,8 @@ class MiniCPMForCausalLM(nn.Module):
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                continue
             if ("rotary_emb.cos_cached" in name
                     or "rotary_emb.sin_cached" in name):
                 # Models trained using ColossalAI may include these tensors in


### PR DESCRIPTION
When loading further fine-tuned checkpoints from MiniCPM models (e.g. `openbmb/MiniCPM-2B-sft-bf16` and `openbmb/MiniCPM-2B-dpo-bf16`), I found current MiniCPM implementation failed with the error `KeyError: 'lm_head.weight'`, which is raised by loading with `tie_word_embeddings=True`. This PR will fix it.