### PR TITLE
[Build/CI] Fixing 'docker run' to re-enable AMD CI tests.

### DIFF
--- a/.buildkite/run-amd-test.sh
+++ b/.buildkite/run-amd-test.sh
@@ -40,5 +40,5 @@ docker run \
         -e HF_TOKEN \
         --name ${container_name} \
         ${container_name} \
-        /bin/bash -c $( echo $1 | sed "s/^'/\"/" | sed "s/'$/\"/" | sed "s/'//g" )
+        /bin/bash -c ${@}
 

--- a/.buildkite/run-amd-test.sh
+++ b/.buildkite/run-amd-test.sh
@@ -40,5 +40,5 @@ docker run \
         -e HF_TOKEN \
         --name ${container_name} \
         ${container_name} \
-        /bin/bash -c $(echo $1 | sed "s/^'//" | sed "s/'$//")
+        /bin/bash -c \" $(echo $1 | sed "s/^'//" | sed "s/'$//") \"
 

--- a/.buildkite/run-amd-test.sh
+++ b/.buildkite/run-amd-test.sh
@@ -40,5 +40,5 @@ docker run \
         -e HF_TOKEN \
         --name ${container_name} \
         ${container_name} \
-        /bin/bash -c ${@}
+        /bin/bash -c "${@}"
 

--- a/.buildkite/run-amd-test.sh
+++ b/.buildkite/run-amd-test.sh
@@ -40,5 +40,5 @@ docker run \
         -e HF_TOKEN \
         --name ${container_name} \
         ${container_name} \
-        /bin/bash -c \" $(echo $1 | sed "s/^'//" | sed "s/'$//") \"
+        /bin/bash -c $( echo $1 | sed "s/^'/\"/" | sed "s/'$/\"/" | sed "s/'//g" )
 

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -48,7 +48,7 @@ steps:
   - pytest -v -s test_pynccl.py
 
 - label: Engine Test
-  mirror_hardwares: [amd]
+  #mirror_hardwares: [amd]
   command: pytest -v -s engine tokenization test_sequence.py test_config.py test_logger.py
 
 - label: Entrypoints Test
@@ -73,13 +73,13 @@ steps:
   parallelism: 4
 
 - label: Models Test
-  mirror_hardwares: [amd]
+  #mirror_hardwares: [amd]
   commands:
     - bash ../.buildkite/download-images.sh
     - pytest -v -s models --ignore=models/test_llava.py --ignore=models/test_mistral.py
 
 - label: Llava Test
-  mirror_hardwares: [amd]
+  #mirror_hardwares: [amd]
   commands:
     - bash ../.buildkite/download-images.sh
     - pytest -v -s models/test_llava.py
@@ -101,7 +101,7 @@ steps:
   command: pytest -v -s worker
 
 - label: Speculative decoding tests
-  mirror_hardwares: [amd]
+  #mirror_hardwares: [amd]
   command: pytest -v -s spec_decode
 
 - label: LoRA Test %N

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -26,7 +26,9 @@ steps:
       - label: "AMD: {{ step.label }}"
         agents:
           queue: amd
-        command: bash .buildkite/run-amd-test.sh "'cd {{ (step.working_dir or default_working_dir) | safe  }} && {{ step.command  or (step.commands | join(' && ')) | safe }}'"
+        command: "bash .buildkite/run-amd-test.sh"
+        args: 
+        - "'cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(;)) | safe }}'"
         env:
           DOCKER_BUILDKIT: "1"
     {% endif %}

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -28,7 +28,7 @@ steps:
           queue: amd
         command: "bash .buildkite/run-amd-test.sh"
         args: 
-        - "'cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(;)) | safe }}'"
+        - "'cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}'"
         env:
           DOCKER_BUILDKIT: "1"
     {% endif %}

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -26,9 +26,7 @@ steps:
       - label: "AMD: {{ step.label }}"
         agents:
           queue: amd
-        command: "bash .buildkite/run-amd-test.sh"
-        args: 
-        - "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"
     {% endif %}

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -28,7 +28,7 @@ steps:
           queue: amd
         command: "bash .buildkite/run-amd-test.sh"
         args: 
-        - "'cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}'"
+        - "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"
     {% endif %}


### PR DESCRIPTION
This PR achieves the following goals:

1. Corrects docker run interface to launch containers properly;

2. Trims the number of AMD tests.