### PR TITLE
[Frontend][OpenAI] Support for returning max_model_len on /v1/models response

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -47,6 +47,7 @@ class ModelCard(OpenAIBaseModel):
     owned_by: str = "vllm"
     root: Optional[str] = None
     parent: Optional[str] = None
+    max_model_len: Optional[int] = None
     permission: List[ModelPermission] = Field(default_factory=list)
 
 

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -83,6 +83,7 @@ class OpenAIServing:
         """Show available models. Right now we only have one model."""
         model_cards = [
             ModelCard(id=served_model_name,
+                      max_model_len=self.max_model_len,
                       root=self.served_model_names[0],
                       permission=[ModelPermission()])
             for served_model_name in self.served_model_names


### PR DESCRIPTION
This pull request introduces the `max_model_len` parameter to the response of the OpenAI server's `/v1/models` endpoint. This enhancement provides clients with information about the maximum number of tokens (prompt_tokens + output_tokens) that a model can support.