### PR TITLE
Fix potential IndexError in `Sequence` implementation

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -280,8 +280,9 @@ class Sequence:
                 last_block = self.logical_token_blocks[-1]
 
             num_empty_slots = last_block.get_num_empty_slots()
+            num_tokens_to_place = min(num_empty_slots, len(token_ids) - cursor - 1)
             last_block.append_tokens(token_ids[cursor:cursor +
-                                               num_empty_slots])
+                                               num_tokens_to_place])
             cursor += num_empty_slots
 
     def append_token_id(

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -280,8 +280,8 @@ class Sequence:
                 last_block = self.logical_token_blocks[-1]
 
             num_empty_slots = last_block.get_num_empty_slots()
-            num_tokens_to_place = min(num_empty_slots, len(token_ids) -
-                                      cursor - 1)
+            num_tokens_to_place = min(num_empty_slots,
+                                      len(token_ids) - cursor - 1)
             last_block.append_tokens(token_ids[cursor:cursor +
                                                num_tokens_to_place])
             cursor += num_empty_slots

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -280,7 +280,8 @@ class Sequence:
                 last_block = self.logical_token_blocks[-1]
 
             num_empty_slots = last_block.get_num_empty_slots()
-            num_tokens_to_place = min(num_empty_slots, len(token_ids) - cursor - 1)
+            num_tokens_to_place = min(num_empty_slots, len(token_ids) -
+                                      cursor - 1)
             last_block.append_tokens(token_ids[cursor:cursor +
                                                num_tokens_to_place])
             cursor += num_empty_slots


### PR DESCRIPTION
In the implementation of `Sequence._append_tokens_to_blocks()`, there's a danger of `IndexError: index out of bounds`. This PR fixes that issue.

### Original Implementation
```python
num_empty_slots = last_block.get_num_empty_slots()
last_block.append_tokens(token_ids[cursor:cursor +
                                   num_empty_slots])
```
However, `cursor + num_empty_slots` can be bigger than `len(token_ids) - 1`. This can potentially cause the `IndexError`.

### Explanation of my fix
Take the minor value between `num_empty_slots` and `len(token_ids) - 1 - cursor` will fix the issue.

***The <a href="https://github.com/vllm-project/vllm/blob/main/vllm/sequence.py#L285">cursor update formula</a> isn't changed.*** Because if the minor result is `len(token_ids) - 1 - cursor`, adding cursor with `num_empty_slots` will still make the `cursor >= len(token_ids)`, and thus we won't get into the while loop wrongly.

### Edge case analysis
If cursor = len(token_ids) - 1, `num_tokens_to_place` is 0, and `token_ids[cursor:cursor +num_tokens_to_place]` is exactly `token_ids[-1]`. The cursor will then be updated to be bigger than len(token_ids) and we can successfully jump out of the while loop.

Though the name `num_tokens_to_place` is potentially not appropiate because actually `num_tokens_to_place` -1 tokens will be placed......