### PR TITLE
[ROCm][Hardware][AMD] Adding Navi21 to fallback to naive attention if Triton is not used

### DIFF
--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -163,7 +163,8 @@ class ROCmFlashAttentionImpl(AttentionImpl):
             self.attn_func = triton_attention
             logger.debug("Using Triton FA in ROCmBackend")
         else:
-            # if not using triton, navi3x not use flash-attn either
+            # if not using triton, navi3x/navi21/navi10 do not use flash-attn
+            # either
             if torch.cuda.get_device_capability()[0] != 9:
                 self.use_naive_attn = True
             else:

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -164,7 +164,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
             logger.debug("Using Triton FA in ROCmBackend")
         else:
             # if not using triton, navi3x not use flash-attn either
-            if torch.cuda.get_device_capability()[0] == 11:
+            if torch.cuda.get_device_capability()[0] != 9:
                 self.use_naive_attn = True
             else:
                 try:


### PR DESCRIPTION
Navi3X - have major HW version 11, Navi21/Navi10 have HW version 10, MI series - HW version 9.

https://github.com/ROCm/FasterTransformer-Internal/issues/247


