### PR TITLE
[Speculative decoding] [Bugfix] Fix overallocation in ngram + spec logprobs

### DIFF
--- a/vllm/spec_decode/ngram_worker.py
+++ b/vllm/spec_decode/ngram_worker.py
@@ -138,7 +138,7 @@ class NGramWorker(LoraNotSupportedWorkerBase):
                 SamplerOutput(
                     outputs=None,
                     sampled_token_probs=token_probs[i],
-                    logprobs=token_logprobs,
+                    logprobs=token_logprobs[i],
                     sampled_token_ids=token_ids[i],
                 ))
         return outputs, False


### PR DESCRIPTION
There's a bug introduced in my spec logprobs PR that only shows up for ngram. We missed it because the ngram tests weren't actually running until recently (https://github.com/vllm-project/vllm/pull/4551).

The bug is that the output logprob tensor of shape (batch_size, num_speculation, vocab_size, sizeof(float32)) is returned once per step, instead of slicing it into (batch_size, 1, vocab_size, sizeof(float32)) views. The spec decode framework does a torch.stack to make contiguous the logprobs of all steps; this caused quadratic memory allocation in num_steps. for a high enough batch size it can cause ooms (e.g. 64).

This is fixed by appropriately slicing the output logprobs.