### PR TITLE
[Bugfix] Fix CLI arguments in OpenAI server docs

### DIFF
--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -108,5 +108,5 @@ directory [here](https://github.com/vllm-project/vllm/tree/main/examples/)
 ```{argparse}
 :module: vllm.entrypoints.openai.cli_args
 :func: make_arg_parser
-:prog: vllm-openai-server
+:prog: -m vllm.entrypoints.openai.api_server
 ```


### PR DESCRIPTION
`vllm-openai-server` command is not defined so the documentation failed to generate the `sphinx-argparse` docs. In the future, this patch should be replaced by the changes made by #4167.

FIX #4522
FIX #4707