### PR TITLE
[Doc] Add API reference for offline inference

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,6 +69,12 @@ Documentation
 
 .. toctree::
    :maxdepth: 1
+   :caption: Offline Inference
+
+   offline_inference/llm
+
+.. toctree::
+   :maxdepth: 1
    :caption: Serving
 
    serving/openai_compatible_server

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,7 @@ Documentation
    :caption: Offline Inference
 
    offline_inference/llm
+   offline_inference/sampling_params
 
 .. toctree::
    :maxdepth: 1
@@ -107,7 +108,6 @@ Documentation
    :maxdepth: 2
    :caption: Developer Documentation
 
-   dev/sampling_params
    dev/engine/engine_index
    dev/kernel/paged_attention
    dev/dockerfile/dockerfile

--- a/docs/source/offline_inference/llm.rst
+++ b/docs/source/offline_inference/llm.rst
@@ -1,0 +1,6 @@
+API Client
+=================================
+
+.. autoclass:: vllm.LLM
+    :members:
+    :show-inheritance:

--- a/docs/source/offline_inference/llm.rst
+++ b/docs/source/offline_inference/llm.rst
@@ -1,4 +1,4 @@
-API Client
+LLM Class
 ==========
 
 .. autoclass:: vllm.LLM

--- a/docs/source/offline_inference/llm.rst
+++ b/docs/source/offline_inference/llm.rst
@@ -1,5 +1,5 @@
 API Client
-=================================
+==========
 
 .. autoclass:: vllm.LLM
     :members:

--- a/docs/source/offline_inference/sampling_params.rst
+++ b/docs/source/offline_inference/sampling_params.rst
@@ -1,5 +1,5 @@
 Sampling Parameters
-===============
+===================
 
 .. autoclass:: vllm.SamplingParams
     :members:

--- a/docs/source/offline_inference/sampling_params.rst
+++ b/docs/source/offline_inference/sampling_params.rst
@@ -1,4 +1,4 @@
-Sampling Params
+Sampling Parameters
 ===============
 
 .. autoclass:: vllm.SamplingParams

--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -48,7 +48,7 @@ completion = client.chat.completions.create(
 ```
 
 ### Extra Parameters for Chat API
-The following [sampling parameters (click through to see documentation)](../dev/sampling_params.rst) are supported.
+The following [sampling parameters (click through to see documentation)](../offline_inference/sampling_params.rst) are supported.
 
 ```{literalinclude} ../../../vllm/entrypoints/openai/protocol.py
 :language: python
@@ -65,7 +65,7 @@ The following extra parameters are supported:
 ```
 
 ### Extra Parameters for Completions API
-The following [sampling parameters (click through to see documentation)](../dev/sampling_params.rst) are supported.
+The following [sampling parameters (click through to see documentation)](../offline_inference/sampling_params.rst) are supported.
 
 ```{literalinclude} ../../../vllm/entrypoints/openai/protocol.py
 :language: python


### PR DESCRIPTION
This PR provides the bare minimum API reference that is required for offline inference using vLLM.

RESOLVE #4684