### PR TITLE
[Bugfix] Fix CLI arguments in OpenAI server docs

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -10,3 +10,4 @@ pydantic
 torch
 py-cpuinfo
 transformers
+openai # Required by docs/source/serving/openai_compatible_server.md's vllm.entrypoints.openai.cli_args


### PR DESCRIPTION
fix https://github.com/vllm-project/vllm/issues/4707 Fix CLI arguments in OpenAI server docs

```{argparse}
:module: vllm.entrypoints.openai.cli_args
:func: make_arg_parser
:prog: -m vllm.entrypoints.openai.api_server
``` 
is similar with 
```
# python3 -c "from vllm.entrypoints.openai.cli_args import make_arg_parser"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/vllm/vllm/entrypoints/openai/cli_args.py", line 12, in <module>
    from vllm.entrypoints.openai.serving_engine import LoRAModulePath
  File "/root/vllm/vllm/entrypoints/openai/serving_engine.py", line 11, in <module>
    from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
  File "/root/vllm/vllm/entrypoints/openai/protocol.py", line 7, in <module>
    from openai.types.chat import ChatCompletionMessageParam
ModuleNotFoundError: No module named 'openai'
```

In fact serving_chat.py protocol.py depends on openai, "from openai.types.chat import **"

when openai package was removed, the problem occurred
```
# make html 
Running Sphinx v6.2.1
making output directory... done
[autosummary] generating autosummary for: dev/dockerfile/dockerfile.rst, dev/engine/async_llm_engine.rst, dev/engine/engine_index.rst, dev/engine/llm_engine.rst, dev/kernel/paged_attention.rst, dev/sampling_params.rst, getting_started/amd-installation.rst, getting_started/cpu-installation.rst, getting_started/examples/api_client.rst, getting_started/examples/aqlm_example.rst, ..., serving/deploying_with_kserve.rst, serving/deploying_with_triton.rst, serving/distributed_serving.rst, serving/env_vars.rst, serving/integrations.rst, serving/metrics.rst, serving/openai_compatible_server.md, serving/run_on_sky.rst, serving/serving_with_langchain.rst, serving/usage_stats.md
myst v2.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions=set(), disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
The default value for `navigation_with_keys` will change to `False` in the next release. If you wish to preserve the old behavior for your site, set `navigation_with_keys=True` in the `html_theme_options` dict in your `conf.py` file. Be aware that `navigation_with_keys = True` has negative accessibility implications: https://github.com/pydata/pydata-sphinx-theme/issues/1492
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 48 source files that are out of date
updating environment: [new config] 48 added, 0 changed, 0 removed
reading sources... [100%] serving/usage_stats                                                                          
/root/vllm/docs/source/serving/openai_compatible_server.md:108: ERROR: Failed to import "make_arg_parser" from "vllm.entrypoints.openai.cli_args".
No module named 'openai'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] serving/usage_stats                                                                           
generating indices... genindex py-modindex done
highlighting module code... [100%] vllm.sampling_params                                                                
writing additional pages... search done
copying images... [100%] assets/logos/vllm-logo-text-light.png                                                         
```

the problem is sphinx doesn't show more details about needed package info. https://readthedocs.org/projects/vllm/builds/24329938/ `"python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html"`



<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


