### PR TITLE
[Core][Distributed] refactor custom allreduce to support multiple tp groups

### DIFF
--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -16,7 +16,7 @@ from vllm.test_utils import (init_test_distributed_environment,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_reduce_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
+def all_reduce_test_worker(tp_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
@@ -24,12 +24,12 @@ def all_reduce_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tp_size, rank,
                                       distributed_init_port)
     num_elements = 8
     all_tensors = [
         torch.arange(num_elements, dtype=torch.float32, device="cuda") *
-        (r + 1) for r in range(tensor_parallel_size)
+        (r + 1) for r in range(tp_size)
     ]
     expected = torch.sum(torch.stack(all_tensors, dim=0), dim=0)
     t = all_tensors[rank]
@@ -38,7 +38,7 @@ def all_reduce_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_gather_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
+def all_gather_test_worker(tp_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
@@ -46,7 +46,7 @@ def all_gather_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tp_size, rank,
                                       distributed_init_port)
     num_dimensions = 3
     tensor_size = list(range(2, num_dimensions + 2))
@@ -57,7 +57,7 @@ def all_gather_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
         all_tensors = [
             torch.arange(total_size, dtype=torch.float32,
                          device="cuda").reshape(tensor_size) * (r + 1)
-            for r in range(tensor_parallel_size)
+            for r in range(tp_size)
         ]
         expected = torch.cat(all_tensors, dim=all_gather_dimension)
         t = all_tensors[rank]
@@ -66,15 +66,15 @@ def all_gather_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def broadcast_tensor_dict_test_worker(tensor_parallel_size: int, pp_size: int,
-                                      rank: int, distributed_init_port: str):
+def broadcast_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
+                                      distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tp_size, rank,
                                       distributed_init_port)
     test_dict = {
         # device tensor
@@ -106,10 +106,10 @@ def broadcast_tensor_dict_test_worker(tensor_parallel_size: int, pp_size: int,
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason="Need at least 2 GPUs to run the test.")
-@pytest.mark.parametrize("tensor_parallel_size", [2])
+@pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("test_target", [
     all_reduce_test_worker, all_gather_test_worker,
     broadcast_tensor_dict_test_worker
 ])
-def test_multi_process_tensor_parallel(tensor_parallel_size, test_target):
-    multi_process_tensor_parallel(tensor_parallel_size, 1, test_target)
+def test_multi_process_tensor_parallel(tp_size, test_target):
+    multi_process_tensor_parallel(tp_size, 1, test_target)

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -24,7 +24,7 @@ def all_reduce_test_worker(tp_size: int, pp_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tp_size, rank,
+    init_test_distributed_environment(tp_size, pp_size, rank,
                                       distributed_init_port)
     num_elements = 8
     all_tensors = [
@@ -46,7 +46,7 @@ def all_gather_test_worker(tp_size: int, pp_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tp_size, rank,
+    init_test_distributed_environment(tp_size, pp_size, rank,
                                       distributed_init_port)
     num_dimensions = 3
     tensor_size = list(range(2, num_dimensions + 2))
@@ -74,7 +74,7 @@ def broadcast_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tp_size, rank,
+    init_test_distributed_environment(tp_size, pp_size, rank,
                                       distributed_init_port)
     test_dict = {
         # device tensor

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -16,7 +16,7 @@ from vllm.test_utils import (init_test_distributed_environment,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_reduce_test_worker(tensor_parallel_size: int, rank: int,
+def all_reduce_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
@@ -24,7 +24,7 @@ def all_reduce_test_worker(tensor_parallel_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(1, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
                                       distributed_init_port)
     num_elements = 8
     all_tensors = [
@@ -38,7 +38,7 @@ def all_reduce_test_worker(tensor_parallel_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_gather_test_worker(tensor_parallel_size: int, rank: int,
+def all_gather_test_worker(tensor_parallel_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
@@ -46,7 +46,7 @@ def all_gather_test_worker(tensor_parallel_size: int, rank: int,
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(1, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
                                       distributed_init_port)
     num_dimensions = 3
     tensor_size = list(range(2, num_dimensions + 2))
@@ -66,15 +66,15 @@ def all_gather_test_worker(tensor_parallel_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def broadcast_tensor_dict_test_worker(tensor_parallel_size: int, rank: int,
-                                      distributed_init_port: str):
+def broadcast_tensor_dict_test_worker(tensor_parallel_size: int, pp_size: int,
+                                      rank: int, distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(1, tensor_parallel_size, rank,
+    init_test_distributed_environment(pp_size, tensor_parallel_size, rank,
                                       distributed_init_port)
     test_dict = {
         # device tensor
@@ -112,4 +112,4 @@ def broadcast_tensor_dict_test_worker(tensor_parallel_size: int, rank: int,
     broadcast_tensor_dict_test_worker
 ])
 def test_multi_process_tensor_parallel(tensor_parallel_size, test_target):
-    multi_process_tensor_parallel(tensor_parallel_size, test_target)
+    multi_process_tensor_parallel(tensor_parallel_size, 1, test_target)

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -24,7 +24,7 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tp_size, rank,
+    init_test_distributed_environment(tp_size, pp_size, rank,
                                       distributed_init_port)
 
     group = get_tensor_model_parallel_group()
@@ -67,7 +67,7 @@ def eager_allreduce(tp_size, pp_size, rank, distributed_init_port):
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(pp_size, tp_size, rank,
+    init_test_distributed_environment(tp_size, pp_size, rank,
                                       distributed_init_port)
 
     # we use the first group to communicate once

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -6,7 +6,8 @@ import ray
 import torch
 import torch.distributed as dist
 
-from vllm.distributed import tensor_model_parallel_all_reduce
+from vllm.distributed.communication_op import (
+    graph_capture, tensor_model_parallel_all_reduce)
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_group,
                                              get_tp_ca_communicator)
 from vllm.test_utils import (init_test_distributed_environment,
@@ -36,10 +37,7 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
 
     for sz in test_sizes:
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
-            from vllm.distributed.communication_op import (
-                get_tp_ca_communicator)
-            ca = get_tp_ca_communicator()
-            with ca.capture():
+            with graph_capture():
                 # use integers so result matches NCCL exactly
                 inp1 = torch.randint(1,
                                      16, (sz, ),

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed as dist
 
 from vllm.distributed import tensor_model_parallel_all_reduce
-from vllm.distributed.communication_op import graph_capture_mode
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_group,
                                              get_tp_ca_communicator)
 from vllm.test_utils import (init_test_distributed_environment,
@@ -37,7 +36,9 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
 
     for sz in test_sizes:
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
-            with graph_capture_mode():
+            from vllm.distributed.communication_op import get_tp_ca_communicator
+            ca = get_tp_ca_communicator()
+            with ca.capture():
                 # use integers so result matches NCCL exactly
                 inp1 = torch.randint(1,
                                      16, (sz, ),

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -8,7 +8,8 @@ import torch.distributed as dist
 
 from vllm.distributed import tensor_model_parallel_all_reduce
 from vllm.distributed.communication_op import graph_capture_mode
-from vllm.distributed.parallel_state import get_tp_ca_communicator
+from vllm.distributed.parallel_state import (get_tensor_model_parallel_group,
+                                             get_tp_ca_communicator)
 from vllm.test_utils import (init_test_distributed_environment,
                              multi_process_tensor_parallel)
 
@@ -21,11 +22,18 @@ for i, v in enumerate(test_sizes):
 @ray.remote(num_gpus=1, max_calls=1)
 def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
     del os.environ["CUDA_VISIBLE_DEVICES"]
-    assert pp_size == 1
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(pp_size, tp_size, rank,
                                       distributed_init_port)
+
+    group = get_tensor_model_parallel_group()
+    # we use the first group to communicate once
+    # and the second group to communicate twice
+    # and so on
+    # this is used to demonstrate that each group can
+    # communicate independently
+    num_communication = rank // tp_size + 1
 
     for sz in test_sizes:
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
@@ -42,12 +50,13 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
                 torch.cuda.synchronize()
                 graph = torch.cuda.CUDAGraph()
                 with torch.cuda.graph(graph):
-                    out1 = tensor_model_parallel_all_reduce(inp1)
-                    # the input buffer is immediately modified to test
-                    # synchronization
-                    dist.all_reduce(inp1)
-                    out2 = tensor_model_parallel_all_reduce(inp2)
-                    dist.all_reduce(inp2)
+                    for i in range(num_communication):
+                        out1 = tensor_model_parallel_all_reduce(inp1)
+                        # the input buffer is immediately modified to test
+                        # synchronization
+                        dist.all_reduce(inp1, group=group)
+                        out2 = tensor_model_parallel_all_reduce(inp2)
+                        dist.all_reduce(inp2, group=group)
             graph.replay()
             assert torch.allclose(out1, inp1)
             assert torch.allclose(out2, inp2)
@@ -82,20 +91,13 @@ def eager_allreduce(tp_size, pp_size, rank, distributed_init_port):
     assert torch.allclose(out, inp * (tp_size**num_communication))
 
 
-@pytest.mark.skipif(torch.cuda.device_count() < 2,
-                    reason="Need at least 2 GPUs to run the test.")
 @pytest.mark.parametrize("tensor_parallel_size", [2])
+@pytest.mark.parametrize("pipeline_parallel_size", [1, 2])
 @pytest.mark.parametrize("test_target", [eager_allreduce, graph_allreduce])
-def test_multi_process_tensor_parallel(tensor_parallel_size, test_target):
-    multi_process_tensor_parallel(tensor_parallel_size, 1, test_target)
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 4,
-                    reason="Need at least 4 GPUs to run the test.")
-@pytest.mark.parametrize("tensor_parallel_size", [2])
-@pytest.mark.parametrize("pipeline_parallel_size", [2])
-@pytest.mark.parametrize("test_target", [eager_allreduce])
-def test_custom_allreduce_multiple_groups(tensor_parallel_size,
-                                          pipeline_parallel_size, test_target):
+def test_custom_allreduce(tensor_parallel_size, pipeline_parallel_size,
+                          test_target):
+    world_size = tensor_parallel_size * pipeline_parallel_size
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
     multi_process_tensor_parallel(tensor_parallel_size, pipeline_parallel_size,
                                   test_target)

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -91,13 +91,11 @@ def eager_allreduce(tp_size, pp_size, rank, distributed_init_port):
     assert torch.allclose(out, inp * (tp_size**num_communication))
 
 
-@pytest.mark.parametrize("tensor_parallel_size", [2])
+@pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("pipeline_parallel_size", [1, 2])
 @pytest.mark.parametrize("test_target", [eager_allreduce, graph_allreduce])
-def test_custom_allreduce(tensor_parallel_size, pipeline_parallel_size,
-                          test_target):
-    world_size = tensor_parallel_size * pipeline_parallel_size
+def test_custom_allreduce(tp_size, pipeline_parallel_size, test_target):
+    world_size = tp_size * pipeline_parallel_size
     if world_size > torch.cuda.device_count():
         pytest.skip("Not enough GPUs to run the test.")
-    multi_process_tensor_parallel(tensor_parallel_size, pipeline_parallel_size,
-                                  test_target)
+    multi_process_tensor_parallel(tp_size, pipeline_parallel_size, test_target)

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -6,7 +6,7 @@ import ray
 import torch
 import torch.distributed as dist
 
-from vllm.distributed.communication_op import (
+from vllm.distributed.communication_op import (  # noqa
     graph_capture, tensor_model_parallel_all_reduce)
 from vllm.distributed.parallel_state import (get_tensor_model_parallel_group,
                                              get_tp_ca_communicator)

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -36,7 +36,8 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
 
     for sz in test_sizes:
         for dtype in [torch.float32, torch.float16, torch.bfloat16]:
-            from vllm.distributed.communication_op import get_tp_ca_communicator
+            from vllm.distributed.communication_op import (
+                get_tp_ca_communicator)
             ca = get_tp_ca_communicator()
             with ca.capture():
                 # use integers so result matches NCCL exactly

--- a/tests/distributed/test_pynccl.py
+++ b/tests/distributed/test_pynccl.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from vllm.distributed.communication_op import (  # noqa
-    graph_capture_mode, tensor_model_parallel_all_reduce)
+    graph_mode, tensor_model_parallel_all_reduce)
 from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.device_communicators.pynccl_wrapper import NCCLLibrary
 from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
@@ -103,7 +103,7 @@ def multiple_tp_with_vllm_worker_fn():
     device = torch.device(f"cuda:{torch.distributed.get_rank()}")
     ensure_model_parallel_initialized(2, 2)
     tensor = torch.ones(16, 1024, 1024, dtype=torch.float32, device=device)
-    with graph_capture_mode():
+    with graph_mode():
         # two tp groups can communicate independently
         if torch.distributed.get_rank() in [0, 1]:
             tensor = tensor_model_parallel_all_reduce(tensor)

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -15,7 +15,7 @@ from .parallel_state import (get_cpu_world_group,
 
 @contextmanager
 def graph_mode():
-    # In graph capture, we have to be very careful about the collective
+    # In graph mode, we have to be very careful about the collective
     # operations. The current status is:
     #     allreduce \ Mode   |  Eager  |  Graph  |
     # --------------------------------------------

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -40,6 +40,20 @@ def graph_mode():
         yield
 
 
+@contextmanager
+def graph_capture():
+    """
+    `graph_capture` is a context manager which should include the code that
+    is capturing the CUDA graph. Its main purpose is to ensure that the
+    some operations will be run after the graph is captured, before the graph
+    is replayed.
+    """
+    ca_comm = get_tp_ca_communicator()
+    context = nullcontext() if ca_comm is None else ca_comm.capture()
+    with context:
+        yield
+
+
 def tensor_model_parallel_all_reduce(input_: torch.Tensor) -> torch.Tensor:
     """All-reduce the input tensor across model parallel group.
 

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -25,6 +25,11 @@ def graph_capture_mode():
     #
     # Note that custom allreduce will have a runtime check, if the tensor size
     # is too large, it will fallback to the next available option.
+    # In summary: When using CUDA graph, we use
+    # either custom all-reduce kernel or pynccl. When not using CUDA
+    # graph, we use either custom all-reduce kernel or PyTorch NCCL.
+    # We always prioritize using custom all-reduce kernel but fall back
+    # to PyTorch or pynccl if it is disabled or not supported.
     pynccl_comm = get_tp_pynccl_communicator()
     ca_comm = get_tp_ca_communicator()
     assert pynccl_comm is not None

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -31,12 +31,9 @@ def graph_capture_mode():
     # We always prioritize using custom all-reduce kernel but fall back
     # to PyTorch or pynccl if it is disabled or not supported.
     pynccl_comm = get_tp_pynccl_communicator()
-    ca_comm = get_tp_ca_communicator()
     assert pynccl_comm is not None
-    assert ca_comm is not None
     with pynccl_comm.change_state(enable=True,
-                                  stream=torch.cuda.current_stream()), \
-                                  ca_comm.capture():
+                                  stream=torch.cuda.current_stream()):
         yield
 
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -6,6 +6,8 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 import vllm.envs as envs
+from vllm.distributed.parallel_state import (
+    get_local_rank, get_tensor_model_parallel_cpu_group)
 from vllm.logger import init_logger
 
 try:
@@ -99,8 +101,6 @@ class CustomAllreduce:
             # e.g. in a non-cuda environment
             return
 
-        from vllm.distributed.parallel_state import (
-            get_tensor_model_parallel_cpu_group)
         group = group or get_tensor_model_parallel_cpu_group()
         self.group = group
 
@@ -121,7 +121,6 @@ class CustomAllreduce:
                 world_size, str(CustomAllreduce._SUPPORTED_WORLD_SIZES))
             return
 
-        from vllm.distributed.parallel_state import get_local_rank
         if device is None:
             local_rank = get_local_rank()
             device = torch.device(f"cuda:{local_rank}")

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -189,19 +189,13 @@ class CustomAllreduce:
                                              self.full_nvlink)
         self.register_buffer(self.buffer)
 
-    def begin_capture(self) -> None:
-        self._IS_CAPTURING = True
-
-    def end_capture(self) -> None:
-        self._IS_CAPTURING = False
-
     @contextmanager
     def capture(self):
         try:
-            self.begin_capture()
+            self._IS_CAPTURING = True
             yield
         finally:
-            self.end_capture()
+            self._IS_CAPTURING = False
             if not self.disabled:
                 self.register_graph_buffers()
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -169,9 +169,6 @@ class CustomAllreduce:
     def end_capture(self) -> None:
         self._IS_CAPTURING = False
 
-    def is_capturing(self) -> bool:
-        return self._IS_CAPTURING and not self.disabled
-
     @contextmanager
     def capture(self):
         try:
@@ -234,7 +231,7 @@ class CustomAllreduce:
         # when custom allreduce is disabled, this will be None
         if self.disabled:
             return None
-        if self.is_capturing():
+        if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
                 if self.should_custom_ar(input):
                     return self.all_reduce_reg(input)

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -94,6 +94,11 @@ class CustomAllreduce:
         self._IS_CAPTURING = False
         self.disabled = True
 
+        if custom_ar is None:
+            # disable because of missing custom allreduce library
+            # e.g. in a non-cuda environment
+            return
+
         from vllm.distributed.parallel_state import (
             get_tensor_model_parallel_cpu_group)
         group = group or get_tensor_model_parallel_cpu_group()

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -106,6 +106,10 @@ class CustomAllreduce:
                 "'CUDA_VISIBLE_DEVICES' is set.")
             return
 
+        # we only use a subset of GPUs here
+        # so we only need to check the nvlink connectivity of these GPUs
+        num_dev = world_size
+
         # test nvlink first, this will filter out most of the cases
         # where custom allreduce is not supported
         cuda_visible_devices = envs.CUDA_VISIBLE_DEVICES

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -271,7 +271,7 @@ class CustomAllreduce:
         return None
 
     def close(self):
-        if self._ptr:
+        if not self.disabled and self._ptr:
             custom_ar.dispose(self._ptr)
             self._ptr = 0
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -196,6 +196,11 @@ class CustomAllreduce:
 
     @contextmanager
     def capture(self):
+        """
+        The main responsibility of this context manager is the 
+        `register_graph_buffers` call at the end of the context.
+        It records all the buffer addresses used in the CUDA graph.
+        """
         try:
             self._IS_CAPTURING = True
             yield

--- a/vllm/distributed/device_communicators/pynccl.py
+++ b/vllm/distributed/device_communicators/pynccl.py
@@ -96,8 +96,10 @@ class PyNcclCommunicator:
             self.stream = torch.cuda.Stream()
 
             # A small all_reduce for warmup.
-            self.all_reduce(torch.zeros(1, device=device))
+            data = torch.zeros(1, device=device)
+            self.all_reduce(data)
             self.stream.synchronize()
+            del data
 
         # by default it is disabled, e.g. in profiling models and prefill phase.
         # to use it, use under `with obj.change_state(enable=True)`, usually

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -13,10 +13,13 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+_ENABLE_CUSTOM_ALL_REDUCE = True
+
 # Tensor model parallel group that the current rank belongs to.
 _TP_DEVICE_GROUP: Optional[ProcessGroup] = None
 _TP_CPU_GROUP: Optional[ProcessGroup] = None
 _TP_PYNCCL_COMMUNICATOR = None
+_TP_CA_COMMUNICATOR = None
 # Pipeline model parallel group that the current rank belongs to.
 _PP_DEVICE_GROUP: Optional[ProcessGroup] = None
 
@@ -47,9 +50,19 @@ _PP_GLOBAL_RANKS: Optional[List[int]] = None
 _LOCAL_RANK = -1
 
 
+def set_custom_all_reduce(enable: bool):
+    global _ENABLE_CUSTOM_ALL_REDUCE
+    _ENABLE_CUSTOM_ALL_REDUCE = enable
+
+
 def get_tp_pynccl_communicator():
     global _TP_PYNCCL_COMMUNICATOR
     return _TP_PYNCCL_COMMUNICATOR
+
+
+def get_tp_ca_communicator():
+    global _TP_CA_COMMUNICATOR
+    return _TP_CA_COMMUNICATOR
 
 
 def get_local_rank():
@@ -149,7 +162,8 @@ def initialize_model_parallel(
     rank = torch.distributed.get_rank()
 
     # Build the tensor model-parallel groups.
-    global _TP_DEVICE_GROUP, _TP_CPU_GROUP, _TP_PYNCCL_COMMUNICATOR
+    global _TP_DEVICE_GROUP, _TP_CPU_GROUP
+    global _TP_PYNCCL_COMMUNICATOR, _TP_CA_COMMUNICATOR
     assert _TP_DEVICE_GROUP is None, (
         "tensor model parallel group is already initialized")
     for i in range(num_tensor_model_parallel_groups):
@@ -167,6 +181,12 @@ def initialize_model_parallel(
         group=_TP_CPU_GROUP,
         device=_LOCAL_RANK,
     )
+
+    # Initialize a custom fast all-reduce implementation.
+    if _ENABLE_CUSTOM_ALL_REDUCE:
+        from vllm.distributed.device_communicators.custom_all_reduce import (
+            CustomAllreduce)
+        _TP_CA_COMMUNICATOR = CustomAllreduce()
 
     # Build the pipeline model-parallel groups.
     global _PP_DEVICE_GROUP

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -113,6 +113,9 @@ def init_distributed_environment(
         if torch.cuda.is_available():
             data = data.to(device=f"cuda:{local_rank}")
         torch.distributed.all_reduce(data)
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        del data
 
 
 def initialize_model_parallel(
@@ -187,6 +190,7 @@ def initialize_model_parallel(
     torch.distributed.all_reduce(data, group=_TP_DEVICE_GROUP)
     if torch.cuda.is_available():
         torch.cuda.synchronize()
+    del data
 
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     _TP_PYNCCL_COMMUNICATOR = PyNcclCommunicator(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -185,6 +185,8 @@ def initialize_model_parallel(
     if torch.cuda.is_available():
         data = data.to(device=f"cuda:{_LOCAL_RANK}")
     torch.distributed.all_reduce(data, group=_TP_DEVICE_GROUP)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
 
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     _TP_PYNCCL_COMMUNICATOR = PyNcclCommunicator(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -186,7 +186,10 @@ def initialize_model_parallel(
     if _ENABLE_CUSTOM_ALL_REDUCE:
         from vllm.distributed.device_communicators.custom_all_reduce import (
             CustomAllreduce)
-        _TP_CA_COMMUNICATOR = CustomAllreduce()
+        _TP_CA_COMMUNICATOR = CustomAllreduce(
+            group=_TP_CPU_GROUP,
+            device=_LOCAL_RANK,
+        )
 
     # Build the pipeline model-parallel groups.
     global _PP_DEVICE_GROUP

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -179,19 +179,6 @@ def initialize_model_parallel(
             _TP_DEVICE_GROUP = group
             _TP_CPU_GROUP = cpu_group
 
-    # A small all_reduce for warmup.
-    # this is needed because device communicators might be created lazily
-    # (e.g. NCCL). This will ensure that the communicator is initialized
-    # before any communication happens, so that this group can be used for
-    # graph capture immediately.
-    data = torch.zeros(1)
-    if torch.cuda.is_available():
-        data = data.to(device=f"cuda:{_LOCAL_RANK}")
-    torch.distributed.all_reduce(data, group=_TP_DEVICE_GROUP)
-    if torch.cuda.is_available():
-        torch.cuda.synchronize()
-    del data
-
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
     _TP_PYNCCL_COMMUNICATOR = PyNcclCommunicator(
         group=_TP_CPU_GROUP,

--- a/vllm/test_utils.py
+++ b/vllm/test_utils.py
@@ -24,6 +24,7 @@ def init_test_distributed_environment(
 
 def multi_process_tensor_parallel(
     tensor_parallel_size: int,
+    pipeline_parallel_size: int,
     test_target,
 ) -> None:
     # Using ray helps debugging the error when it failed
@@ -32,10 +33,10 @@ def multi_process_tensor_parallel(
 
     distributed_init_port = get_open_port()
     refs = []
-    for rank in range(tensor_parallel_size):
+    for rank in range(tensor_parallel_size * pipeline_parallel_size):
         refs.append(
-            test_target.remote(tensor_parallel_size, rank,
-                               distributed_init_port))
+            test_target.remote(tensor_parallel_size, pipeline_parallel_size,
+                               rank, distributed_init_port))
     ray.get(refs)
 
     ray.shutdown()

--- a/vllm/test_utils.py
+++ b/vllm/test_utils.py
@@ -6,25 +6,24 @@ from vllm.utils import get_open_port
 
 
 def init_test_distributed_environment(
-    pipeline_parallel_size: int,
-    tensor_parallel_size: int,
+    pp_size: int,
+    tp_size: int,
     rank: int,
     distributed_init_port: str,
     local_rank: int = -1,
 ) -> None:
     distributed_init_method = f"tcp://localhost:{distributed_init_port}"
     init_distributed_environment(
-        world_size=pipeline_parallel_size * tensor_parallel_size,
+        world_size=pp_size * tp_size,
         rank=rank,
         distributed_init_method=distributed_init_method,
         local_rank=local_rank)
-    ensure_model_parallel_initialized(tensor_parallel_size,
-                                      pipeline_parallel_size)
+    ensure_model_parallel_initialized(tp_size, pp_size)
 
 
 def multi_process_tensor_parallel(
-    tensor_parallel_size: int,
-    pipeline_parallel_size: int,
+    tp_size: int,
+    pp_size: int,
     test_target,
 ) -> None:
     # Using ray helps debugging the error when it failed
@@ -33,10 +32,9 @@ def multi_process_tensor_parallel(
 
     distributed_init_port = get_open_port()
     refs = []
-    for rank in range(tensor_parallel_size * pipeline_parallel_size):
+    for rank in range(tp_size * pp_size):
         refs.append(
-            test_target.remote(tensor_parallel_size, pipeline_parallel_size,
-                               rank, distributed_init_port))
+            test_target.remote(tp_size, pp_size, rank, distributed_init_port))
     ray.get(refs)
 
     ray.shutdown()

--- a/vllm/test_utils.py
+++ b/vllm/test_utils.py
@@ -6,8 +6,8 @@ from vllm.utils import get_open_port
 
 
 def init_test_distributed_environment(
-    pp_size: int,
     tp_size: int,
+    pp_size: int,
     rank: int,
     distributed_init_port: str,
     local_rank: int = -1,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -942,7 +942,9 @@ class ModelRunner:
             bs for bs in _BATCH_SIZES_TO_CAPTURE if bs <= graph_batch_size
         ]
 
-        with graph_capture_mode():
+        from vllm.distributed.communication_op import get_tp_ca_communicator
+        ca = get_tp_ca_communicator()
+        with ca.capture():
             # NOTE: Capturing the largest batch size first may help reduce the
             # memory usage of CUDA graph.
             for batch_size in reversed(batch_size_capture_list):

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -12,7 +12,7 @@ from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, LoRAConfig,
                          ModelConfig, ParallelConfig, SchedulerConfig,
                          VisionLanguageConfig)
 from vllm.distributed import broadcast_tensor_dict
-from vllm.distributed.communication_op import graph_mode
+from vllm.distributed.communication_op import graph_capture, graph_mode
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.request import LoRARequest
@@ -942,9 +942,7 @@ class ModelRunner:
             bs for bs in _BATCH_SIZES_TO_CAPTURE if bs <= graph_batch_size
         ]
 
-        from vllm.distributed.communication_op import get_tp_ca_communicator
-        ca = get_tp_ca_communicator()
-        with ca.capture():
+        with graph_capture():
             # NOTE: Capturing the largest batch size first may help reduce the
             # memory usage of CUDA graph.
             for batch_size in reversed(batch_size_capture_list):

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -12,7 +12,7 @@ from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, LoRAConfig,
                          ModelConfig, ParallelConfig, SchedulerConfig,
                          VisionLanguageConfig)
 from vllm.distributed import broadcast_tensor_dict
-from vllm.distributed.communication_op import graph_capture_mode
+from vllm.distributed.communication_op import graph_mode
 from vllm.logger import init_logger
 from vllm.lora.layers import LoRAMapping
 from vllm.lora.request import LoRARequest
@@ -1036,7 +1036,7 @@ class CUDAGraphRunner:
         # Run the model once without capturing the graph.
         # This is to make sure that the captured graph does not include the
         # kernel launches for initial benchmarking (e.g., Triton autotune).
-        with graph_capture_mode():
+        with graph_mode():
             self.model(
                 input_ids,
                 positions,
@@ -1051,7 +1051,7 @@ class CUDAGraphRunner:
         # https://stackoverflow.com/questions/31039022/python-multi-line-with-statement
         self._graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(self._graph, pool=memory_pool):  # noqa: SIM117
-            with graph_capture_mode():
+            with graph_mode():
                 hidden_states = self.model(
                     input_ids,
                     positions,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -11,9 +11,8 @@ from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, LoRAConfig,
                          VisionLanguageConfig)
 from vllm.distributed import (broadcast_tensor_dict,
                               ensure_model_parallel_initialized,
-                              init_distributed_environment)
-from vllm.distributed.device_communicators.custom_all_reduce import (
-    init_custom_ar)
+                              init_distributed_environment,
+                              set_custom_all_reduce)
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.sequence import ExecuteModelRequest, SamplerOutput
@@ -298,15 +297,13 @@ def init_worker_distributed_environment(
     local_rank: int = -1,
 ) -> None:
     """Initialize the distributed environment."""
+    set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
+
     init_distributed_environment(parallel_config.world_size, rank,
                                  distributed_init_method, local_rank)
 
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)
-
-    # Initialize a custom fast all-reduce implementation.
-    if not parallel_config.disable_custom_all_reduce:
-        init_custom_ar()
 
 
 def _check_if_gpu_supports_dtype(torch_dtype: torch.dtype):


### PR DESCRIPTION
Previously custom allreduce is attached to a module, and only bound to the world group.

With this PR, it is bound correctly to the tp group.

- [ ] remove import inside function (need to remove default group None option)