### PR TITLE
[CI/Build] Enable entrypoints tests to be run in a single command

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -53,9 +53,7 @@ steps:
 
 - label: Entrypoints Test
   commands:
-  # these tests have to be separated, because each one will allocate all posible GPU memory
-  - pytest -v -s entrypoints --ignore=entrypoints/test_server_oot_registration.py
-  - pytest -v -s entrypoints/test_server_oot_registration.py
+  - pytest -v -s entrypoints
 
 - label: Examples Test
   working_dir: "/vllm-workspace/examples"

--- a/tests/entrypoints/test_llm_generate.py
+++ b/tests/entrypoints/test_llm_generate.py
@@ -7,7 +7,9 @@ def test_multiple_sampling_params():
 
     llm = LLM(model="facebook/opt-125m",
               max_num_batched_tokens=4096,
-              tensor_parallel_size=1)
+              tensor_parallel_size=1,
+              gpu_memory_utilization=0.10,
+              enforce_eager=True)
 
     prompts = [
         "Hello, my name is",

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -121,7 +121,7 @@ def zephyr_lora_files():
     return snapshot_download(repo_id=LORA_NAME)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def server(zephyr_lora_files):
     ray.init()
     server_runner = ServerRunner.remote([
@@ -133,6 +133,8 @@ def server(zephyr_lora_files):
         "--max-model-len",
         "8192",
         "--enforce-eager",
+        "--gpu-memory-utilization",
+        "0.75",
         # lora config below
         "--enable-lora",
         "--lora-modules",

--- a/tests/entrypoints/test_openai_server.py
+++ b/tests/entrypoints/test_openai_server.py
@@ -890,7 +890,3 @@ async def test_long_seed(server, client: openai.AsyncOpenAI):
 
         assert ("greater_than_equal" in exc_info.value.message
                 or "less_than_equal" in exc_info.value.message)
-
-
-if __name__ == "__main__":
-    pytest.main([__file__])

--- a/tests/entrypoints/test_server_oot_registration.py
+++ b/tests/entrypoints/test_server_oot_registration.py
@@ -36,6 +36,7 @@ def test_oot_registration_for_api_server():
     port = get_open_port()
     ctx = multiprocessing.get_context("spawn")
     server = ctx.Process(target=server_function, args=(port, ))
+    server.start()
     client = OpenAI(
         base_url=f"http://localhost:{port}/v1",
         api_key="token-abc123",

--- a/tests/entrypoints/test_server_oot_registration.py
+++ b/tests/entrypoints/test_server_oot_registration.py
@@ -26,16 +26,16 @@ def server_function(port):
     # register our dummy model
     ModelRegistry.register_model("OPTForCausalLM", MyOPTForCausalLM)
     sys.argv = ["placeholder.py"] + \
-        ("--model facebook/opt-125m --dtype"
-        f" float32 --api-key token-abc123 --port {port}").split()
+        ("--model facebook/opt-125m --gpu-memory-utilization 0.10 "
+        f"--dtype float32 --api-key token-abc123 --port {port}").split()
     import runpy
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 
 
 def test_oot_registration_for_api_server():
     port = get_open_port()
-    server = multiprocessing.Process(target=server_function, args=(port, ))
-    server.start()
+    ctx = multiprocessing.get_context("spawn")
+    server = ctx.Process(target=server_function, args=(port, ))
     client = OpenAI(
         base_url=f"http://localhost:{port}/v1",
         api_key="token-abc123",


### PR DESCRIPTION
By setting `gpu_memory_utilization` to a low value for tests that only use small models, all `entrypoints` tests can now be run in a single command.

However, I now get this warning when running `test_oot_registration_for_api_server` after changing `multiprocessing` to use the `'spawn'` [start method](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) instead of the default `'fork'`:

```
/usr/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown
```

Does this mean the OS has to restart in order to clean this memory leak? Hopefully it won't become a significant issue.
