### PR TITLE
[Core][Bugfix]: fix prefix caching for blockv2

### DIFF
--- a/tests/core/block/test_prefix_caching_block.py
+++ b/tests/core/block/test_prefix_caching_block.py
@@ -490,7 +490,7 @@ class TestPrefixCachingBlockAllocator:
         assert allocator._refcounter.get(0) == 1
         assert 0 not in allocator.evictor
 
-        # allocate mutable block again, it shall be poped from evictor
+        # allocate mutable block again, it shall be popped from evictor
         mutable = allocator.allocate_mutable(prev_block=None)
         assert len(allocator._hashless_allocator._free_block_indices) == 0
         assert mutable.block_id not in allocator.evictor.free_table


### PR DESCRIPTION
Previously, we mistake didn't delete block from _cached_blocks's tracking list when it pop from evictor, which would cause immutable allocator still could get that "cached" block, even it is already being freed into hashless as mutablable allocator did in the middle.

Also add testcase for this bug reproduce.
cc @cadedaniel 