### PR TITLE
[Misc] Logits processor plugins

### DIFF
--- a/docs/source/dev/logits_processors/logits_processor_plugins.rst
+++ b/docs/source/dev/logits_processors/logits_processor_plugins.rst
@@ -1,0 +1,111 @@
+.. Logits Processor Plugins:
+
+Logits Processor Plugins
+========================
+
+vLLM supports using custom logits processors through plugins.
+This means you can use custom logits processors, and even create your own without having to change vLLM.
+
+Installing a logits processor plugin
+------------------------------------
+
+To install a logits processor plugin,
+all you have to do it install the Python package containing the plugin in the same environment as vLLM.
+
+
+Using the installed plugin
+--------------------------------
+
+To use the logits processor plugins you installed,
+you can use the :code:`logits_processors` field in the generation request body as such:
+
+.. code-block:: console
+
+    $ curl http://localhost:8000/v1/completions \
+    $     -H "Content-Type: application/json" \
+    $     -d '{
+    $         "model": "...",
+    $         "prompt": "Hello!",
+    $         "max_tokens": 32,
+    $         "temperature": 0,
+    $         "logits_processors": {
+    $           "my_logits_processor": {
+    $               "my_param": 100
+    $           }
+    $         }
+    $     }'
+
+.. note::
+    This is only an example, in reality each logits processor plugin has a name which is the key in the :code:`logits_processors` dictionary.
+    The value is a dictionary of parameters passed to the plugin's implementation.
+
+
+Creating your own logits processor plugin
+-----------------------------------------
+
+Advanced users might want to build their custom logits processors and publish them as plugins.
+This can be done by simply creating a Python package with your implementation.
+
+Here is an example :code:`main.py` for a logits processor plugin implementation,
+that takes a token ID and multiplies it's logit by 100:
+
+.. code-block:: python
+
+    from pydantic import BaseModel
+
+
+    class MyParameters(BaseModel):
+        token_id: int
+
+
+    class MyLogitsProcessor:
+        def __init__(self, tokenizer, parameters: MyParameters):
+            self.tokenizer = tokenizer
+            self.parameters = parameters
+
+        def __call__(self, token_ids, logits):
+            new_logits = logits.clone()
+            new_logits[self.parameters.token_id] *= 100
+            return new_logits
+
+
+    LOGITS_PROCESSOR_PLUGIN = {
+        'logits_processor_class': MyLogitsProcessor,
+        'parameters_model': MyParameters
+    }
+
+
+The :code:`setup.py` file for the plugin package should look something like this:
+
+.. code-block:: python
+
+    from setuptools import setup
+
+    setup(name='example_logits_processor',
+          version='0.1',
+          install_requires=[
+                "pydantic>=1.8.2"
+          ],
+          entry_points={
+                'vllm.logits_processors': ['example_plugin=example_plugin.main:LOGITS_PROCESSOR_PLUGIN']
+          }
+   )
+
+After installing the plugin package in the same environment as vLLM,
+you can run vLLM and use you custom logits processor as such:
+
+.. code-block:: console
+
+    $ curl http://localhost:8000/v1/completions \
+    $     -H "Content-Type: application/json" \
+    $     -d '{
+    $         "model": "...",
+    $         "prompt": "Hello!",
+    $         "max_tokens": 32,
+    $         "temperature": 0,
+    $         "logits_processors": {
+    $           "example_plugin": {
+    $               "token_id": 10
+    $           }
+    $         }
+    $     }'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -105,6 +105,7 @@ Documentation
    dev/engine/engine_index
    dev/kernel/paged_attention
    dev/dockerfile/dockerfile
+   dev/logits_processors/logits_processor_plugins
 
 Indices and tables
 ==================

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -4,8 +4,8 @@ import inspect
 import re
 from contextlib import asynccontextmanager
 from http import HTTPStatus
-from typing import Optional, Set
 from importlib.metadata import entry_points
+from typing import Optional, Set
 
 import fastapi
 import uvicorn
@@ -204,15 +204,12 @@ if __name__ == "__main__":
         # When using single vLLM without engine_use_ray
         model_config = asyncio.run(engine.get_model_config())
 
-    openai_serving_chat = OpenAIServingChat(engine, model_config,
-                                            served_model_names,
-                                            args.response_role,
-                                            logits_processors_plugins,
-                                            args.lora_modules,
-                                            args.chat_template)
+    openai_serving_chat = OpenAIServingChat(
+        engine, model_config, served_model_names, args.response_role,
+        args.lora_modules, logits_processors_plugins, args.chat_template)
     openai_serving_completion = OpenAIServingCompletion(
-        engine, model_config, served_model_names, logits_processors_plugins,
-        args.lora_modules)
+        engine, model_config, served_model_names, args.lora_modules,
+        logits_processors_plugins)
 
     app.root_path = args.root_path
     uvicorn.run(app,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -200,8 +200,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         tokenizer, lp_parameters)
                     logits_processors.append(logits_processor)
                 except ValidationError as e:
-                    raise ValueError(f"Invalid parameters for logits processor "
-                                     f"{lp_name}: {e}") from e
+                    raise ValueError(
+                        f"Invalid parameters for logits processor "
+                        f"{lp_name}: {e}") from e
 
         return SamplingParams(
             n=self.n,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -190,7 +190,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 if lp_plugin is None:
                     available_lps = list(logits_processor_plugins.keys())
                     raise ValueError(
-                        f"Logits processor {lp_name} not found in available"
+                        f"Logits processor {lp_name} not found in available "
                         f"logits processors ({available_lps}).")
 
                 try:
@@ -200,7 +200,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         tokenizer, lp_parameters)
                     logits_processors.append(logits_processor)
                 except ValidationError as e:
-                    raise ValueError(f"Invalid parameters for logits processor"
+                    raise ValueError(f"Invalid parameters for logits processor "
                                      f"{lp_name}: {e}") from e
 
         return SamplingParams(
@@ -360,7 +360,7 @@ class CompletionRequest(OpenAIBaseModel):
                 if lp_plugin is None:
                     available_lps = list(logits_processor_plugins.keys())
                     raise ValueError(
-                        f"Logits processor {lp_name} not found in available"
+                        f"Logits processor {lp_name} not found in available "
                         f"logits processors ({available_lps}).")
 
                 try:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -39,14 +39,15 @@ class OpenAIServingChat(OpenAIServing):
                  model_config: ModelConfig,
                  served_model_names: List[str],
                  response_role: str,
-                 logits_processor_plugins: Dict[str, LogitsProcessorPlugin],
                  lora_modules: Optional[List[LoRAModulePath]] = None,
+                 logits_processor_plugins: Optional[Dict[
+                     str, LogitsProcessorPlugin]] = None,
                  chat_template: Optional[str] = None):
         super().__init__(engine=engine,
                          model_config=model_config,
                          served_model_names=served_model_names,
-                         logits_processor_plugins=logits_processor_plugins,
-                         lora_modules=lora_modules)
+                         lora_modules=lora_modules,
+                         logits_processor_plugins=logits_processor_plugins)
         self.response_role = response_role
         self._load_chat_template(chat_template)
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -54,15 +54,18 @@ def parse_prompt_format(prompt) -> Tuple[bool, list]:
 
 class OpenAIServingCompletion(OpenAIServing):
 
-    def __init__(self, engine: AsyncLLMEngine, model_config: ModelConfig,
+    def __init__(self,
+                 engine: AsyncLLMEngine,
+                 model_config: ModelConfig,
                  served_model_names: List[str],
-                 logits_processor_plugins: Dict[str, LogitsProcessorPlugin],
-                 lora_modules: Optional[List[LoRAModulePath]]):
+                 lora_modules: Optional[List[LoRAModulePath]],
+                 logits_processor_plugins: Optional[Dict[
+                     str, LogitsProcessorPlugin]] = None):
         super().__init__(engine=engine,
                          model_config=model_config,
                          served_model_names=served_model_names,
-                         logits_processor_plugins=logits_processor_plugins,
-                         lora_modules=lora_modules)
+                         lora_modules=lora_modules,
+                         logits_processor_plugins=logits_processor_plugins)
 
     async def create_completion(self, request: CompletionRequest,
                                 raw_request: Request):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -29,10 +29,13 @@ class LoRAModulePath:
 
 class OpenAIServing:
 
-    def __init__(self, engine: AsyncLLMEngine, model_config: ModelConfig,
+    def __init__(self,
+                 engine: AsyncLLMEngine,
+                 model_config: ModelConfig,
                  served_model_names: List[str],
-                 logits_processor_plugins: Dict[str, LogitsProcessorPlugin],
-                 lora_modules: Optional[List[LoRAModulePath]]):
+                 lora_modules: Optional[List[LoRAModulePath]],
+                 logits_processor_plugins: Optional[Dict[
+                     str, LogitsProcessorPlugin]] = None):
         super().__init__()
         self.engine = engine
         self.max_model_len = model_config.max_model_len
@@ -46,7 +49,7 @@ class OpenAIServing:
             truncation_side="left")
 
         self.served_model_names = served_model_names
-        self.logits_processor_plugins = logits_processor_plugins
+        self.logits_processor_plugins = logits_processor_plugins or {}
 
         if lora_modules is None:
             self.lora_requests = []

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -14,6 +14,7 @@ from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               ModelPermission)
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.plugins import LogitsProcessorPlugin
 from vllm.sequence import Logprob
 from vllm.transformers_utils.tokenizer import get_tokenizer
 
@@ -30,9 +31,9 @@ class OpenAIServing:
 
     def __init__(self, engine: AsyncLLMEngine, model_config: ModelConfig,
                  served_model_names: List[str],
+                 logits_processor_plugins: Dict[str, LogitsProcessorPlugin],
                  lora_modules: Optional[List[LoRAModulePath]]):
         super().__init__()
-
         self.engine = engine
         self.max_model_len = model_config.max_model_len
 
@@ -45,6 +46,7 @@ class OpenAIServing:
             truncation_side="left")
 
         self.served_model_names = served_model_names
+        self.logits_processor_plugins = logits_processor_plugins
 
         if lora_modules is None:
             self.lora_requests = []

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .logits_processor import LogitsProcessorPlugin

--- a/vllm/plugins/logits_processor.py
+++ b/vllm/plugins/logits_processor.py
@@ -7,8 +7,11 @@ from vllm.sampling_params import LogitsProcessor
 
 
 class LogitsProcessorPlugin:
-    def __init__(self,
-                 logits_processor_class: Callable[[PreTrainedTokenizer, BaseModel], LogitsProcessor],
-                 parameters_model: Type[BaseModel]):
+
+    def __init__(
+            self,
+            logits_processor_class: Callable[[PreTrainedTokenizer, BaseModel],
+                                             LogitsProcessor],
+            parameters_model: Type[BaseModel]):
         self.logits_processor_class = logits_processor_class
         self.parameters_model = parameters_model

--- a/vllm/plugins/logits_processor.py
+++ b/vllm/plugins/logits_processor.py
@@ -1,0 +1,14 @@
+from typing import Callable, Type
+
+from pydantic import BaseModel
+from transformers import PreTrainedTokenizer
+
+from vllm.sampling_params import LogitsProcessor
+
+
+class LogitsProcessorPlugin:
+    def __init__(self,
+                 logits_processor_class: Callable[[PreTrainedTokenizer, BaseModel], LogitsProcessor],
+                 parameters_model: Type[BaseModel]):
+        self.logits_processor_class = logits_processor_class
+        self.parameters_model = parameters_model


### PR DESCRIPTION
This pull request adds support for Logits processor plugins.
This makes implementing custom Logits processors very easy, and eliminates the need to change vLLM directly to implement it.

For example with this merge request we could implement all of the guided decoding features, just by implementing a Python package and installing it in the same virtualenv as vLLM, without actually changing vLLM source code.

Example code for a logits processor plugin that given a token id multiplies its logit by 100:
```python
from pydantic import BaseModel


class MyParameters(BaseModel):
    token_id: int


class MyLogitsProcessor:
    def __init__(self, tokenizer, parameters: MyParameters):
        self.tokenizer = tokenizer
        self.parameters = parameters

    def __call__(self, token_ids, logits):
        new_logits = logits.clone()
        new_logits[self.parameters.token_id] *= 100
        return new_logits


LOGITS_PROCESSOR_PLUGIN = {
    'logits_processor_class': MyLogitsProcessor,
    'parameters_model': MyParameters
}
```
And the `setup.py` file for the package should look something like this:
```python
from setuptools import setup

setup(name='example_logits_processor',
      version='0.1',
      install_requires=[
            "pydantic>=1.8.2"
      ],
      entry_points={
            'vllm.logits_processors': ['example_plugin=example_plugin.main:LOGITS_PROCESSOR_PLUGIN']
      }
      )
```

With this merge request vLLM will load all the plugins at startup, and each inference request can specify usage of custom logits processors using the `logits_processors` field in the request body.
The `parameters_model` in the plugin dictionary is used to validate and parse the request body.

I will soon add to this pull request a page in the documentation explaining how to implement custom logits processors.