### PR TITLE
[Kernel] add bfloat16 support for gptq kernel

### DIFF
--- a/csrc/quantization/gptq/data_types.cuh
+++ b/csrc/quantization/gptq/data_types.cuh
@@ -1,0 +1,108 @@
+
+#ifndef _data_types_cuh
+#define _data_types_cuh
+#include <cuda_fp16.h>
+
+
+#if ((__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))) && !defined(USE_ROCM)
+#include <cuda_bf16.h>
+#endif
+
+
+class FP16TYPE {
+public:
+    using T = half;
+    using T2 = half2;
+
+    static __device__ float inline num2float(const half x) { return __half2float(x); }
+
+    static __device__ half2 inline num2num2(const half x) { return __half2half2(x); }
+
+    static __device__ half inline low2num(const half2 x) { return __low2half(x); }
+
+    static __device__ half inline high2num(const half2 x) { return __high2half(x); }
+
+    static __device__ float inline low2float(const half2 x) { return __low2float(x); }
+
+    static __device__ float inline high2float(const half2 x) { return __high2float(x); }
+
+    static __device__ half2 inline nums2num2(const half x1, const half x2) { return __halves2half2(x1, x2); }
+
+    static __device__ half2 inline num2_fma(const half2 x1, const half2 x2, const half2 x3) { return __hfma2(x1, x2, x3); }
+
+    static __device__ half inline high2float(const half x1, const half x2, const half x3) { return __hfma(x1, x2, x3); }
+
+    static __device__ half2 inline num2_add(const half2 x1, const half2 x2) { return __hadd2(x1, x2); }
+
+    static __device__ half inline num_add(const half x1, const half x2) { return __hadd(x1, x2); }
+
+    static __device__ half2 inline num2_mul(const half2 x1, const half2 x2) { return __hmul2(x1, x2); }
+
+    static __device__ half inline num_mul(const half x1, const half x2) { return __hmul(x1, x2); }
+
+    static __device__ half2 inline num2_sub(const half2 x1, const half2 x2) { return __hsub2(x1, x2); }
+
+    static __device__ half inline num_sub(const half x1, const half x2) { return __hsub(x1, x2); }
+
+    static __device__ ushort inline num_as_ushort(const half x) { return __half_as_ushort(x); }
+
+    static __device__ half inline int2num_rn(unsigned int x) { return __int2half_rn(x); }
+
+    static __device__ half inline int2num_rn(int x) { return __int2half_rn(x); }
+
+    static __device__ half inline float2num_rn(const float x) { return __float2half_rn(x); }
+
+    static __host__ __device__ half inline float2num(const float x) { return __float2half(x); }
+};
+
+#if ((__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))) && !defined(USE_ROCM)
+
+class BF16TYPE {
+public:
+    using T = nv_bfloat16;
+    using T2 = nv_bfloat162;
+
+    static __device__ float inline num2float(const nv_bfloat16 x) { return __bfloat162float(x); }
+
+    static __device__ nv_bfloat162 inline num2num2(const nv_bfloat16 x) { return __bfloat162bfloat162(x); }
+
+    static __device__ nv_bfloat16 inline low2num(const nv_bfloat162 x) { return __low2bfloat16(x); }
+
+    static __device__ nv_bfloat16 inline high2num(const nv_bfloat162 x) { return __high2bfloat16(x); }
+
+    static __device__ float inline low2float(const nv_bfloat162 x) { return __low2float(x); }
+
+    static __device__ float inline high2float(const nv_bfloat162 x) { return __high2float(x); }
+
+    static __device__ nv_bfloat162 inline nums2num2(const nv_bfloat16 x1, const nv_bfloat16 x2) { return __halves2bfloat162(x1, x2); }
+
+    static __device__ nv_bfloat162 inline num2_fma(const nv_bfloat162 x1, const nv_bfloat162 x2, const nv_bfloat162 x3) { return __hfma2(x1, x2, x3); }
+
+    static __device__ nv_bfloat16 inline high2float(const nv_bfloat16 x1, const nv_bfloat16 x2, const nv_bfloat16 x3) { return __hfma(x1, x2, x3); }
+
+    static __device__ nv_bfloat162 inline num2_add(const nv_bfloat162 x1, const nv_bfloat162 x2) { return __hadd2(x1, x2); }
+
+    static __device__ nv_bfloat16 inline num_add(const nv_bfloat16 x1, const nv_bfloat16 x2) { return __hadd(x1, x2); }
+
+    static __device__ nv_bfloat162 inline num2_mul(const nv_bfloat162 x1, const nv_bfloat162 x2) { return __hmul2(x1, x2); }
+
+    static __device__ nv_bfloat16 inline num_mul(const nv_bfloat16 x1, const nv_bfloat16 x2) { return __hmul(x1, x2); }
+
+    static __device__ nv_bfloat162 inline num2_sub(const nv_bfloat162 x1, const nv_bfloat162 x2) { return __hsub2(x1, x2); }
+
+    static __device__ nv_bfloat16 inline num_sub(const nv_bfloat16 x1, const nv_bfloat16 x2) { return __hsub(x1, x2); }
+
+    static __device__ ushort inline num_as_ushort(const nv_bfloat16 x) { return __bfloat16_as_ushort(x); }
+
+    static __device__ nv_bfloat16 inline int2num_rn(unsigned int x) { return __int2bfloat16_rn(x); }
+
+    static __device__ nv_bfloat16 inline int2num_rn(int x) { return __int2bfloat16_rn(x); }
+
+    static __device__ nv_bfloat16 inline float2num_rn(const float x) { return __float2bfloat16_rn(x); }
+
+    static __host__ __device__ nv_bfloat16 inline float2num(const float x) { return __float2bfloat16(x); }
+};
+
+#endif
+
+#endif

--- a/csrc/quantization/gptq/matrix_view.cuh
+++ b/csrc/quantization/gptq/matrix_view.cuh
@@ -9,81 +9,84 @@ Adapted from https://github.com/turboderp/exllamav2 and https://github.com/turbo
 #include <cuda_fp16.h>
 
 #include "qdq_util.cuh"
+#include "data_types.cuh"
 
 namespace vllm {
 namespace gptq {
 
+template <class D>
 class MatrixView_half
 {
 public:
-    const half* data;
+    const typename D::T* data;
     const int height;
     const int width;
 
-    __device__ __forceinline__ MatrixView_half(const half* data, const int height, const int width)
+    __device__ __forceinline__ MatrixView_half(const typename D::T* data, const int height, const int width)
         : data(data), height(height), width(width)
     { }
 
-    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
-    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
-    __device__ __forceinline__ half2 item_half2half2(int row, int column) const { return __half2half2(data[row * width + column]); }
-    __device__ __forceinline__ const half* item_ptr(int row, int column) const { return &data[row * width + column]; }
+    __device__ __forceinline__ typename D::T item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ typename D::T2 item_half2(int row, int column) const { return ((typename D::T2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ typename D::T2 item_half2half2(int row, int column) const { return D::num2num2(data[row * width + column]); }
+    __device__ __forceinline__ const typename D::T* item_ptr(int row, int column) const { return &data[row * width + column]; }
 
-    __device__ __forceinline__ void item4(half (&items)[4], int row, int column) const
+    __device__ __forceinline__ void item4(typename D::T (&items)[4], int row, int column) const
     {
-        half2* ptr = (half2*) item_ptr(row, column);
-        half2 i01 = ptr[0];
-        half2 i23 = ptr[1];
-        items[0] = __low2half(i01);
-        items[1] = __high2half(i01);
-        items[2] = __low2half(i23);
-        items[3] = __high2half(i23);
+        typename D::T2* ptr = (typename D::T2*) item_ptr(row, column);
+        typename D::T2 i01 = ptr[0];
+        typename D::T2 i23 = ptr[1];
+        items[0] = D::low2num(i01);
+        items[1] = D::high2num(i01);
+        items[2] = D::low2num(i23);
+        items[3] = D::high2num(i23);
     }
     __device__ __forceinline__ void item4_f(float (&items)[4], int row, int column) const
     {
-        half2* ptr = (half2*)item_ptr(row, column);
-        half2 i01 = ptr[0];
-        half2 i23 = ptr[1];
-        items[0] = __half2float(__low2half(i01));
-        items[1] = __half2float(__high2half(i01));
-        items[2] = __half2float(__low2half(i23));
-        items[3] = __half2float(__high2half(i23));
+        typename D::T2* ptr = (typename D::T2*)item_ptr(row, column);
+        typename D::T2 i01 = ptr[0];
+        typename D::T2 i23 = ptr[1];
+        items[0] = D::num2float(D::low2num(i01));
+        items[1] = D::num2float(D::high2num(i01));
+        items[2] = D::num2float(D::low2num(i23));
+        items[3] = D::num2float(D::high2num(i23));
     }
 
-    __device__ __forceinline__ void item4_h2(half2 (&items)[4], int row, int column) const
+    __device__ __forceinline__ void item4_h2(typename D::T2 (&items)[4], int row, int column) const
     {
-        half2* ptr = (half2*)item_ptr(row, column);
-        half2 i01 = ptr[0];
-        half2 i23 = ptr[1];
-        items[0] = __half2half2(__low2half(i01));
-        items[1] = __half2half2(__high2half(i01));
-        items[2] = __half2half2(__low2half(i23));
-        items[3] = __half2half2(__high2half(i23));
+        typename D::T2* ptr = (typename D::T2*)item_ptr(row, column);
+        typename D::T2 i01 = ptr[0];
+        typename D::T2 i23 = ptr[1];
+        items[0] = D::num2num2(D::low2num(i01));
+        items[1] = D::num2num2(D::high2num(i01));
+        items[2] = D::num2num2(D::low2num(i23));
+        items[3] = D::num2num2(D::high2num(i23));
     }
 };
 
+template <class D>
 class MatrixView_half_rw
 {
 public:
-    half* data;
+    typename D::T* data;
     const int height;
     const int width;
 
-    __device__ __forceinline__ MatrixView_half_rw(half* data, const int height, const int width)
+    __device__ __forceinline__ MatrixView_half_rw(typename D::T* data, const int height, const int width)
         : data(data), height(height), width(width)
     { }
 
-    __device__ __forceinline__ half item(int row, int column) const { return data[row * width + column]; }
-    __device__ __forceinline__ half2 item_half2(int row, int column) const { return ((half2*)data)[(row * width + column) / 2]; }
-    __device__ __forceinline__ half* item_ptr(int row, int column) { return &data[row * width + column]; }
-    __device__ __forceinline__ void set(int row, int column, half value) { data[row * width + column] = value; }
-    __device__ __forceinline__ void set_half2(int row, int column, half2 value) { ((half2*)data)[(row * width + column) / 2] = value; }
+    __device__ __forceinline__ typename D::T item(int row, int column) const { return data[row * width + column]; }
+    __device__ __forceinline__ typename D::T2 item_half2(int row, int column) const { return ((typename D::T2*)data)[(row * width + column) / 2]; }
+    __device__ __forceinline__ typename D::T* item_ptr(int row, int column) { return &data[row * width + column]; }
+    __device__ __forceinline__ void set(int row, int column, typename D::T value) { data[row * width + column] = value; }
+    __device__ __forceinline__ void set_half2(int row, int column, typename D::T2 value) { ((typename D::T2*)data)[(row * width + column) / 2] = value; }
 
-    __device__ __forceinline__ void set4(int row, int column, half v0, half v1, half v2, half v3)
+    __device__ __forceinline__ void set4(int row, int column, typename D::T v0, typename D::T v1, typename D::T v2, typename D::T v3)
     {
-        half2 v01 = __halves2half2(v0, v1);
-        half2 v23 = __halves2half2(v2, v3);
-        half2* ptr = (half2*) item_ptr(row, column);
+        typename D::T2 v01 = D::nums2num2(v0, v1);
+        typename D::T2 v23 = D::nums2num2(v2, v3);
+        typename D::T2* ptr = (typename D::T2*) item_ptr(row, column);
         ptr[0] = v01;
         ptr[1] = v23;
     }

--- a/csrc/quantization/gptq/qdq_2.cuh
+++ b/csrc/quantization/gptq/qdq_2.cuh
@@ -35,7 +35,19 @@ __forceinline__ __device__ void shuffle_2bit_16
     q[0] = qb;
 }
 
+template <class D>
 __forceinline__ __device__ void dequant_2bit_16
+(
+    const uint32_t q_0,
+    typename D::T2 (&dq)[8],
+    int stride,
+    const uint32_t zero
+);
+
+
+
+template <>
+__forceinline__ __device__ void dequant_2bit_16<FP16TYPE>
 (
     const uint32_t q_0,
     half2 (&dq)[8],
@@ -43,43 +55,94 @@ __forceinline__ __device__ void dequant_2bit_16
     const uint32_t zero
 )
 {
+    using D = FP16TYPE;
     const uint32_t c0 = 0x64006400;
-    const half y4_  = __float2half_rn(1.0f /  4.0f);
-    const half y16_ = __float2half_rn(1.0f / 16.0f);
-    const half y64_ = __float2half_rn(1.0f / 64.0f);
-    const half2 y4  = __halves2half2(y4_,  y4_);
-    const half2 y16 = __halves2half2(y16_, y16_);
-    const half2 y64 = __halves2half2(y64_, y64_);
+    const typename D::T y4_  = D::float2num_rn(1.0f /  4.0f);
+    const typename D::T y16_ = D::float2num_rn(1.0f / 16.0f);
+    const typename D::T y64_ = D::float2num_rn(1.0f / 64.0f);
+    const typename D::T2 y4  = D::nums2num2(y4_,  y4_);
+    const typename D::T2 y16 = D::nums2num2(y16_, y16_);
+    const typename D::T2 y64 = D::nums2num2(y64_, y64_);
 
-    const half_uint16 z1_(0xe400 | zero); // half(-1024.0f - zero);
-    const half z4_ = __hsub(__int2half_rn(-256), __int2half_rn(zero));
-    const half z16_ = __hsub(__int2half_rn(-64), __int2half_rn(zero));
-    const half z64_ = __hsub(__int2half_rn(-16), __int2half_rn(zero));
-    const half2 z1 = __half2half2(z1_.as_half);
-    const half2 z4 = __half2half2(z4_);
-    const half2 z16 = __half2half2(z16_);
-    const half2 z64 = __half2half2(z64_);
+    const half_uint16<D> z1_(0xe400 | zero); // half(-1024.0f - zero);
+    const typename D::T z4_ = D::num_sub(D::int2num_rn(-256), D::int2num_rn(zero));
+    const typename D::T z16_ = D::num_sub(D::int2num_rn(-64), D::int2num_rn(zero));
+    const typename D::T z64_ = D::num_sub(D::int2num_rn(-16), D::int2num_rn(zero));
+    const typename D::T2 z1 = D::num2num2(z1_.as_half);
+    const typename D::T2 z4 = D::num2num2(z4_);
+    const typename D::T2 z16 = D::num2num2(z16_);
+    const typename D::T2 z64 = D::num2num2(z64_);
 
     uint32_t qa = q_0;
-    half2_uint32 q0((qa & 0x00030003) | c0); // half2(q[ 0], q[ 1])      + 1024
-    half2_uint32 q1((qa & 0x000c000c) | c0); // half2(q[ 2], q[ 3]) *  4 + 1024
-    half2_uint32 q2((qa & 0x00300030) | c0); // half2(q[ 4], q[ 5]) * 16 + 1024
-    half2_uint32 q3((qa & 0x00c000c0) | c0); // half2(q[ 6], q[ 7]) * 64 + 1024
+    half2_uint32<D> q0((qa & 0x00030003) | c0); // half2(q[ 0], q[ 1])      + 1024
+    half2_uint32<D> q1((qa & 0x000c000c) | c0); // half2(q[ 2], q[ 3]) *  4 + 1024
+    half2_uint32<D> q2((qa & 0x00300030) | c0); // half2(q[ 4], q[ 5]) * 16 + 1024
+    half2_uint32<D> q3((qa & 0x00c000c0) | c0); // half2(q[ 6], q[ 7]) * 64 + 1024
     qa >>= 8;
-    half2_uint32 q4((qa & 0x00030003) | c0); // half2(q[ 8], q[ 8])      + 1024
-    half2_uint32 q5((qa & 0x000c000c) | c0); // half2(q[10], q[11]) *  4 + 1024
-    half2_uint32 q6((qa & 0x00300030) | c0); // half2(q[12], q[13]) * 16 + 1024
-    half2_uint32 q7((qa & 0x00c000c0) | c0); // half2(q[14], q[15]) * 64 + 1024
+    half2_uint32<D> q4((qa & 0x00030003) | c0); // half2(q[ 8], q[ 9])      + 1024
+    half2_uint32<D> q5((qa & 0x000c000c) | c0); // half2(q[10], q[11]) *  4 + 1024
+    half2_uint32<D> q6((qa & 0x00300030) | c0); // half2(q[12], q[13]) * 16 + 1024
+    half2_uint32<D> q7((qa & 0x00c000c0) | c0); // half2(q[14], q[15]) * 64 + 1024
 
-    dq[0] = __hadd2(q0.as_half2, z1);
-    dq[1] = __hfma2(q1.as_half2, y4,  z4);
-    dq[2] = __hfma2(q2.as_half2, y16, z16);
-    dq[3] = __hfma2(q3.as_half2, y64, z64);
-    dq[4] = __hadd2(q4.as_half2, z1);
-    dq[5] = __hfma2(q5.as_half2, y4,  z4);
-    dq[6] = __hfma2(q6.as_half2, y16, z16);
-    dq[7] = __hfma2(q7.as_half2, y64, z64);
+    dq[0] = D::num2_add(q0.as_half2, z1);
+    dq[1] = D::num2_fma(q1.as_half2, y4,  z4);
+    dq[2] = D::num2_fma(q2.as_half2, y16, z16);
+    dq[3] = D::num2_fma(q3.as_half2, y64, z64);
+    dq[4] = D::num2_add(q4.as_half2, z1);
+    dq[5] = D::num2_fma(q5.as_half2, y4,  z4);
+    dq[6] = D::num2_fma(q6.as_half2, y16, z16);
+    dq[7] = D::num2_fma(q7.as_half2, y64, z64);
 }
+
+
+#if ((__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))) && !defined(USE_ROCM)
+template <>
+__forceinline__ __device__ void dequant_2bit_16<BF16TYPE>
+(
+    const uint32_t q_0,
+    nv_bfloat162 (&dq)[8],
+    int stride,
+    const uint32_t zero
+)
+{
+    using D = BF16TYPE;
+    const uint32_t c0 = 0x43004300;
+    const typename D::T y4_  = D::float2num_rn(1.0f /  4.0f);
+    const typename D::T y16_ = D::float2num_rn(1.0f / 16.0f);
+    const typename D::T2 y4  = D::nums2num2(y4_,  y4_);
+    const typename D::T2 y16 = D::nums2num2(y16_, y16_);
+
+    const half_uint16<D> z1_(0xc300 | zero); // half(-128.0f - zero);
+    const typename D::T z4_ = D::num_sub(D::int2num_rn(-32), D::int2num_rn(zero));
+    const typename D::T z16_ = D::num_sub(D::int2num_rn(-8), D::int2num_rn(zero));
+    const typename D::T2 z1 = D::num2num2(z1_.as_half);
+    const typename D::T2 z4 = D::num2num2(z4_);
+    const typename D::T2 z16 = D::num2num2(z16_);
+
+    uint32_t qa = q_0;
+    half2_uint32<D> q0((qa & 0x00030003) | c0); // half2(q[ 0], q[ 1])      + 128
+    half2_uint32<D> q1((qa & 0x000c000c) | c0); // half2(q[ 2], q[ 3]) *  4 + 128
+    half2_uint32<D> q2((qa & 0x00300030) | c0); // half2(q[ 4], q[ 5]) * 16 + 128
+    qa >>= 6;
+    half2_uint32<D> q3((qa & 0x00030003) | c0); // half2(q[ 6], q[ 7])      + 128
+    half2_uint32<D> q4((qa & 0x000c000c) | c0); // half2(q[ 8], q[ 9]) *  4 + 128
+    half2_uint32<D> q5((qa & 0x00300030) | c0); // half2(q[10], q[11]) * 16 + 128
+    qa >>= 6;
+    half2_uint32<D> q6((qa & 0x00030003) | c0); // half2(q[12], q[13])      + 128
+    half2_uint32<D> q7((qa & 0x000c000c) | c0); // half2(q[14], q[15]) *  4 + 128
+
+    dq[0] = D::num2_add(q0.as_half2, z1);
+    dq[1] = D::num2_fma(q1.as_half2, y4,  z4);
+    dq[2] = D::num2_fma(q2.as_half2, y16, z16);
+    dq[3] = D::num2_add(q3.as_half2, z1);
+    dq[4] = D::num2_fma(q4.as_half2, y4,  z4);
+    dq[5] = D::num2_fma(q5.as_half2, y16, z16);
+    dq[6] = D::num2_add(q6.as_half2, z1);
+    dq[7] = D::num2_fma(q7.as_half2, y4,  z4);
+}
+
+#endif
+
 
 }  // namespace gptq
 }  // namespace vllm

--- a/csrc/quantization/gptq/qdq_3.cuh
+++ b/csrc/quantization/gptq/qdq_3.cuh
@@ -65,7 +65,20 @@ __forceinline__ __device__ void shuffle_3bit_32
     q[2 * stride] = zc;
 }
 
+template <class D>
 __forceinline__ __device__ void dequant_3bit_32
+(
+    const uint32_t q_0,
+    const uint32_t q_1,
+    const uint32_t q_2,
+    typename D::T2 (&dq)[16],
+    int stride,
+    const uint32_t zero
+);
+
+
+template <>
+__forceinline__ __device__ void dequant_3bit_32<FP16TYPE>
 (
     const uint32_t q_0,
     const uint32_t q_1,
@@ -75,66 +88,148 @@ __forceinline__ __device__ void dequant_3bit_32
     const uint32_t zero
 )
 {
+    using D = FP16TYPE;
     const uint32_t c0 = 0x64006400;
-    const half y8_  = __float2half_rn(1.0f /  8.0f);
-    const half y64_ = __float2half_rn(1.0f / 64.0f);
-    const half2 y8  = __halves2half2(y8_,  y8_);
-    const half2 y64 = __halves2half2(y64_, y64_);
-    const half_uint16 z1_(0xe400 | zero); // half(-1024.0f - zero);
-    const half z8_ = __hsub(__int2half_rn(-128), __int2half_rn(zero));
-    const half z64_ = __hsub(__int2half_rn(-16), __int2half_rn(zero));
-    const half2 z1  = __halves2half2(z1_.as_half,  z1_.as_half);
-    const half2 z8  = __halves2half2(z8_,  z8_);
-    const half2 z64 = __halves2half2(z64_, z64_);
+    const typename D::T y8_  = D::float2num_rn(1.0f /  8.0f);
+    const typename D::T y64_ = D::float2num_rn(1.0f / 64.0f);
+    const typename D::T2 y8  = D::nums2num2(y8_,  y8_);
+    const typename D::T2 y64 = D::nums2num2(y64_, y64_);
+    const half_uint16<D> z1_(0xe400 | zero); // half(-1024.0f - zero);
+    const typename D::T z8_ = D::num_sub(D::int2num_rn(-128), D::int2num_rn(zero));
+    const typename D::T z64_ = D::num_sub(D::int2num_rn(-16), D::int2num_rn(zero));
+    const typename D::T2 z1  = D::nums2num2(z1_.as_half,  z1_.as_half);
+    const typename D::T2 z8  = D::nums2num2(z8_,  z8_);
+    const typename D::T2 z64 = D::nums2num2(z64_, z64_);
 
     uint32_t qa = q_0;
     uint32_t qb = q_1;
     uint32_t qc = q_2;
 
-    half2_uint32 q0((qa & 0x00070007) | c0); // half2(q[ 0], q[ 1])      + 1024
-    half2_uint32 q1((qa & 0x00380038) | c0); // half2(q[ 2], q[ 3]) *  8 + 1024
+    half2_uint32<D> q0((qa & 0x00070007) | c0); // half2(q[ 0], q[ 1])      + 1024
+    half2_uint32<D> q1((qa & 0x00380038) | c0); // half2(q[ 2], q[ 3]) *  8 + 1024
     qa >>= 6;
-    half2_uint32 q2((qa & 0x00070007) | c0); // half2(q[ 4], q[ 5])      + 1024
-    half2_uint32 q3((qa & 0x00380038) | c0); // half2(q[ 6], q[ 7]) *  8 + 1024
-    half2_uint32 q4((qa & 0x01c001c0) | c0); // half2(q[ 8], q[ 9]) * 64 + 1024
+    half2_uint32<D> q2((qa & 0x00070007) | c0); // half2(q[ 4], q[ 5])      + 1024
+    half2_uint32<D> q3((qa & 0x00380038) | c0); // half2(q[ 6], q[ 7]) *  8 + 1024
+    half2_uint32<D> q4((qa & 0x01c001c0) | c0); // half2(q[ 8], q[ 9]) * 64 + 1024
     qa >>= 9;
     qa &= 0x00010001;
-    half2_uint32 q5((qb & 0x00070007) | c0); // half2(q[10], q[11])      + 1024
-    half2_uint32 q6((qb & 0x00380038) | c0); // half2(q[12], q[13]) *  8 + 1024
+    half2_uint32<D> q5((qb & 0x00070007) | c0); // half2(q[10], q[11])      + 1024
+    half2_uint32<D> q6((qb & 0x00380038) | c0); // half2(q[12], q[13]) *  8 + 1024
     qb >>= 6;
-    half2_uint32 q7((qb & 0x00070007) | c0); // half2(q[14], q[15])      + 1024
-    half2_uint32 q8((qb & 0x00380038) | c0); // half2(q[16], q[17]) *  8 + 1024
-    half2_uint32 q9((qb & 0x01c001c0) | c0); // half2(q[18], q[19]) * 64 + 1024
+    half2_uint32<D> q7((qb & 0x00070007) | c0); // half2(q[14], q[15])      + 1024
+    half2_uint32<D> q8((qb & 0x00380038) | c0); // half2(q[16], q[17]) *  8 + 1024
+    half2_uint32<D> q9((qb & 0x01c001c0) | c0); // half2(q[18], q[19]) * 64 + 1024
     qb >>= 8;
     qb &= 0x00020002;
-    half2_uint32 q10((qc & 0x00070007) | c0); // half2(q[20], q[21])      + 1024
-    half2_uint32 q11((qc & 0x00380038) | c0); // half2(q[22], q[23]) *  8 + 1024
+    half2_uint32<D> q10((qc & 0x00070007) | c0); // half2(q[20], q[21])      + 1024
+    half2_uint32<D> q11((qc & 0x00380038) | c0); // half2(q[22], q[23]) *  8 + 1024
     qc >>= 6;
-    half2_uint32 q12((qc & 0x00070007) | c0); // half2(q[24], q[25])      + 1024
-    half2_uint32 q13((qc & 0x00380038) | c0); // half2(q[26], q[27]) *  8 + 1024
-    half2_uint32 q14((qc & 0x01c001c0) | c0); // half2(q[28], q[29]) * 64 + 1024
+    half2_uint32<D> q12((qc & 0x00070007) | c0); // half2(q[24], q[25])      + 1024
+    half2_uint32<D> q13((qc & 0x00380038) | c0); // half2(q[26], q[27]) *  8 + 1024
+    half2_uint32<D> q14((qc & 0x01c001c0) | c0); // half2(q[28], q[29]) * 64 + 1024
     qc >>= 7;
     qc &= 0x00040004;
-    half2_uint32 q15((qa | qb | qc) | c0);
+    half2_uint32<D> q15((qa | qb | qc) | c0);
 
-    dq[ 0] = __hadd2( q0.as_half2, z1);
-    dq[ 1] = __hfma2( q1.as_half2, y8,  z8);
-    dq[ 2] = __hadd2( q2.as_half2, z1);
-    dq[ 3] = __hfma2( q3.as_half2, y8,  z8);
-    dq[ 4] = __hfma2( q4.as_half2, y64, z64);
-    dq[ 5] = __hadd2( q5.as_half2, z1);
-    dq[ 6] = __hfma2( q6.as_half2, y8,  z8);
-    dq[ 7] = __hadd2( q7.as_half2, z1);
-    dq[ 8] = __hfma2( q8.as_half2, y8,  z8);
-    dq[ 9] = __hfma2( q9.as_half2, y64, z64);
-    dq[10] = __hadd2(q10.as_half2, z1);
-    dq[11] = __hfma2(q11.as_half2, y8,  z8);
-    dq[12] = __hadd2(q12.as_half2, z1);
-    dq[13] = __hfma2(q13.as_half2, y8,  z8);
-    dq[14] = __hfma2(q14.as_half2, y64, z64);
-    dq[15] = __hadd2(q15.as_half2, z1);
+    dq[ 0] = D::num2_add( q0.as_half2, z1);
+    dq[ 1] = D::num2_fma( q1.as_half2, y8,  z8);
+    dq[ 2] = D::num2_add( q2.as_half2, z1);
+    dq[ 3] = D::num2_fma( q3.as_half2, y8,  z8);
+    dq[ 4] = D::num2_fma( q4.as_half2, y64, z64);
+    dq[ 5] = D::num2_add( q5.as_half2, z1);
+    dq[ 6] = D::num2_fma( q6.as_half2, y8,  z8);
+    dq[ 7] = D::num2_add( q7.as_half2, z1);
+    dq[ 8] = D::num2_fma( q8.as_half2, y8,  z8);
+    dq[ 9] = D::num2_fma( q9.as_half2, y64, z64);
+    dq[10] = D::num2_add(q10.as_half2, z1);
+    dq[11] = D::num2_fma(q11.as_half2, y8,  z8);
+    dq[12] = D::num2_add(q12.as_half2, z1);
+    dq[13] = D::num2_fma(q13.as_half2, y8,  z8);
+    dq[14] = D::num2_fma(q14.as_half2, y64, z64);
+    dq[15] = D::num2_add(q15.as_half2, z1);
 }
 
+
+#if ((__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))) && !defined(USE_ROCM)
+template <>
+__forceinline__ __device__ void dequant_3bit_32<BF16TYPE>
+(
+    const uint32_t q_0,
+    const uint32_t q_1,
+    const uint32_t q_2,
+    nv_bfloat162 (&dq)[16],
+    int stride,
+    const uint32_t zero
+)
+{
+    using D = BF16TYPE;
+    const uint32_t c0 = 0x43004300;
+    const typename D::T y8_  = D::float2num_rn(1.0f /  8.0f);
+    const typename D::T2 y8  = D::nums2num2(y8_,  y8_);
+    const half_uint16<D> z1_(0xc300 | zero); // half(-128.0f - zero);
+
+    const typename D::T z8_ = D::num_sub(D::int2num_rn(-16), D::int2num_rn(zero));
+    const typename D::T2 z1  = D::nums2num2(z1_.as_half,  z1_.as_half);
+    const typename D::T2 z8  = D::nums2num2(z8_,  z8_);
+
+    uint32_t qa = q_0;
+    uint32_t qb = q_1;
+    uint32_t qc = q_2;
+
+    half2_uint32<D> q0((qa & 0x00070007) | c0); // half2(q[ 0], q[ 1])      + 128
+    half2_uint32<D> q1((qa & 0x00380038) | c0); // half2(q[ 2], q[ 3]) *  8 + 128
+    qa >>= 6;
+    half2_uint32<D> q2((qa & 0x00070007) | c0); // half2(q[ 4], q[ 5])      + 128
+    half2_uint32<D> q3((qa & 0x00380038) | c0); // half2(q[ 6], q[ 7]) *  8 + 128
+    qa >>= 6;
+    half2_uint32<D> q4((qa & 0x00070007) | c0); // half2(q[ 8], q[ 9])      + 128
+    qa >>= 3;
+    qa &= 0x00010001;
+
+
+    half2_uint32<D> q5((qb & 0x00070007) | c0); // half2(q[10], q[11])      + 128
+    half2_uint32<D> q6((qb & 0x00380038) | c0); // half2(q[12], q[13]) *  8 + 128
+    qb >>= 6;
+    half2_uint32<D> q7((qb & 0x00070007) | c0); // half2(q[14], q[15])      + 128
+    half2_uint32<D> q8((qb & 0x00380038) | c0); // half2(q[16], q[17]) *  8 + 128
+    qb >>= 6;
+    half2_uint32<D> q9((qb & 0x00070007) | c0); // half2(q[18], q[19])      + 128
+    qb >>= 2;
+    qb &= 0x00020002;
+
+    half2_uint32<D> q10((qc & 0x00070007) | c0); // half2(q[20], q[21])      + 128
+    half2_uint32<D> q11((qc & 0x00380038) | c0); // half2(q[22], q[23]) *  8 + 128
+    qc >>= 6;
+    half2_uint32<D> q12((qc & 0x00070007) | c0); // half2(q[24], q[25])      + 128
+    half2_uint32<D> q13((qc & 0x00380038) | c0); // half2(q[26], q[27]) *  8 + 128
+    qc >>= 6;
+    half2_uint32<D> q14((qc & 0x00070007) | c0); // half2(q[28], q[29])      + 128
+    qc >>= 1;
+    qc &= 0x00040004;
+
+    half2_uint32<D> q15((qa | qb | qc) | c0);
+
+    dq[ 0] = D::num2_add( q0.as_half2, z1);
+    dq[ 1] = D::num2_fma( q1.as_half2, y8,  z8);
+    dq[ 2] = D::num2_add( q2.as_half2, z1);
+    dq[ 3] = D::num2_fma( q3.as_half2, y8,  z8);
+    dq[ 4] = D::num2_add( q4.as_half2, z1);
+
+    dq[ 5] = D::num2_add( q5.as_half2, z1);
+    dq[ 6] = D::num2_fma( q6.as_half2, y8,  z8);
+    dq[ 7] = D::num2_add( q7.as_half2, z1);
+    dq[ 8] = D::num2_fma( q8.as_half2, y8,  z8);
+    dq[ 9] = D::num2_add( q9.as_half2, z1);
+
+    dq[10] = D::num2_add(q10.as_half2, z1);
+    dq[11] = D::num2_fma(q11.as_half2, y8,  z8);
+    dq[12] = D::num2_add(q12.as_half2, z1);
+    dq[13] = D::num2_fma(q13.as_half2, y8,  z8);
+    dq[14] = D::num2_add(q14.as_half2, z1);
+
+    dq[15] = D::num2_add(q15.as_half2, z1);
+}
+#endif
 }  // namespace gptq
 }  // namespace vllm
 

--- a/csrc/quantization/gptq/qdq_4.cuh
+++ b/csrc/quantization/gptq/qdq_4.cuh
@@ -34,7 +34,53 @@ __forceinline__ __device__ void shuffle_4bit_8
     q[0] = qb;
 }
 
+template <class D>
 __forceinline__ __device__ void dequant_4bit_8
+(
+    const uint32_t q_0,
+    typename D::T2 (&dq)[4],
+    int stride,
+    const uint32_t zero
+);
+
+
+
+template <class D>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero_scale
+(
+    const uint32_t zero,
+    const typename D::T scale,
+    typename D::T2 (&z1z16)[2],
+    typename D::T2 (&y1y16)[2]
+);
+
+
+template <class D>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero
+(
+    const uint32_t zero,
+    typename D::T2(&z1z16)[2],
+    typename D::T2(&y1y16)[2]
+);
+
+
+
+
+template <class D>
+__forceinline__ __device__ void dequant_4bit_8_gptq
+(
+    const uint32_t q_0,
+    typename D::T2 (&dq)[4],
+    typename D::T2 (&z1z16)[2],
+    typename D::T2 (&y1y16)[2],
+    int stride,
+    bool scaled
+);
+
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8<FP16TYPE>
 (
     const uint32_t q_0,
     half2 (&dq)[4],
@@ -42,28 +88,34 @@ __forceinline__ __device__ void dequant_4bit_8
     const uint32_t zero
 )
 {
+    using D = FP16TYPE;
+    const typename D::T y16_ = D::float2num_rn(1.0f / 16.0f);
+    const typename D::T2 y16 = D::nums2num2(y16_, y16_);
+    const half_uint16<D> z1_(0xe400 | zero); // half(-1024.0f - zero);
+
+    const typename D::T z16_ = D::num_sub(D::int2num_rn(-64), D::int2num_rn(zero));
+    const typename D::T2 z1 = D::num2num2(z1_.as_half);
+    const typename D::T2 z16 = D::num2num2(z16_);
+
     const uint32_t c0 = 0x64006400;
-    const half y16_ = __float2half_rn(1.0f / 16.0f);
-    const half2 y16 = __halves2half2(y16_, y16_);
-    const half_uint16 z1_(0xe400 | zero); // half(-1024.0f - zero);
-    const half z16_ = __hsub(__int2half_rn(-64), __int2half_rn(zero));
-    const half2 z1 = __half2half2(z1_.as_half);
-    const half2 z16 = __half2half2(z16_);
-
     uint32_t qa = q_0;
-    half2_uint32 q0((qa & 0x000f000f) | c0); // half2(q[ 0], q[ 1])      + 1024
-    half2_uint32 q1((qa & 0x00f000f0) | c0); // half2(q[ 2], q[ 3]) * 16 + 1024
+    half2_uint32<D> q0((qa & 0x000f000f) | c0); // half2(q[ 0], q[ 1])      + 1024
+    half2_uint32<D> q1((qa & 0x00f000f0) | c0); // half2(q[ 2], q[ 3]) * 16 + 1024
     qa >>= 8;
-    half2_uint32 q2((qa & 0x000f000f) | c0); // half2(q[ 4], q[ 5])      + 1024
-    half2_uint32 q3((qa & 0x00f000f0) | c0); // half2(q[ 6], q[ 7]) * 16 + 1024
+    half2_uint32<D> q2((qa & 0x000f000f) | c0); // half2(q[ 4], q[ 5])      + 1024
+    half2_uint32<D> q3((qa & 0x00f000f0) | c0); // half2(q[ 6], q[ 7]) * 16 + 1024
 
-    dq[0] = __hadd2(q0.as_half2, z1);
-    dq[1] = __hfma2(q1.as_half2, y16, z16);
-    dq[2] = __hadd2(q2.as_half2, z1);
-    dq[3] = __hfma2(q3.as_half2, y16, z16);
+    dq[0] = D::num2_add(q0.as_half2, z1);
+    dq[1] = D::num2_fma(q1.as_half2, y16, z16);
+    dq[2] = D::num2_add(q2.as_half2, z1);
+    dq[3] = D::num2_fma(q3.as_half2, y16, z16);
 }
 
-__forceinline__ __device__ void dequant_4bit_8_prep_zero_scale
+
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero_scale<FP16TYPE>
 (
     const uint32_t zero,
     const half scale,
@@ -71,43 +123,53 @@ __forceinline__ __device__ void dequant_4bit_8_prep_zero_scale
     half2 (&y1y16)[2]
 )
 {
-    half_uint16 z1(0xe400 | zero); // half(-1024.0f - zero);
-    half z16 = __hsub(__int2half_rn(-64), __int2half_rn(zero));
+    using D = FP16TYPE;
+    half_uint16<D> z1(0xe400 | zero); // half(-1024.0f - zero);
+    typename D::T z16 = D::num_sub(D::int2num_rn(-64), D::int2num_rn(zero));
 
-    half2 scale2 = __half2half2(scale);
+    typename D::T2 scale2 = D::num2num2(scale);
 
-    z1z16[0] = __hmul2(scale2, __half2half2(z1.as_half));
-    z1z16[1] = __hmul2(scale2, __half2half2(z16));
+    z1z16[0] = D::num2_mul(scale2, D::num2num2(z1.as_half));
+    z1z16[1] = D::num2_mul(scale2, D::num2num2(z16));
 
-    const half y1 = __float2half_rn(1.0f);
-    const half y16 = __float2half_rn(1.0f / 16.0f);
+    const typename D::T y1 = D::float2num_rn(1.0f);
+    const typename D::T y16 = D::float2num_rn(1.0f / 16.0f);
 
-    y1y16[0] = __hmul2(scale2, __half2half2(y1));
-    y1y16[1] = __hmul2(scale2, __half2half2(y16));
+    y1y16[0] = D::num2_mul(scale2, D::num2num2(y1));
+    y1y16[1] = D::num2_mul(scale2, D::num2num2(y16));
 }
 
-__forceinline__ __device__ void dequant_4bit_8_prep_zero
+
+
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero<FP16TYPE>
 (
     const uint32_t zero,
     half2(&z1z16)[2],
     half2(&y1y16)[2]
 )
 {
-    half_uint16 z1(0xe400 | zero); // half(-1024.0f - zero);
-    half z16 = __hsub(__int2half_rn(-64), __int2half_rn(zero));
+    using D = FP16TYPE;
+    half_uint16<D> z1(0xe400 | zero); // half(-1024.0f - zero);
+    typename D::T z16 = D::num_sub(D::int2num_rn(-64), D::int2num_rn(zero));
 
-    z1z16[0] = __half2half2(z1.as_half);
-    z1z16[1] = __half2half2(z16);
+    z1z16[0] = D::num2num2(z1.as_half);
+    z1z16[1] = D::num2num2(z16);
 
-    const half y1 = __float2half_rn(1.0f);
-    const half y16 = __float2half_rn(1.0f / 16.0f);
+    const typename D::T y1 = D::float2num_rn(1.0f);
+    const typename D::T y16 = D::float2num_rn(1.0f / 16.0f);
 
-    y1y16[0] = __half2half2(y1);
-    y1y16[1] = __half2half2(y16);
+    y1y16[0] = D::num2num2(y1);
+    y1y16[1] = D::num2num2(y16);
 }
 
 
-__forceinline__ __device__ void dequant_4bit_8_gptq
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_gptq<FP16TYPE>
 (
     const uint32_t q_0,
     half2 (&dq)[4],
@@ -116,31 +178,149 @@ __forceinline__ __device__ void dequant_4bit_8_gptq
     int stride,
     bool scaled
 )
-{
+{   
+    using D = FP16TYPE;
     const uint32_t c0 = 0x64006400;
 
     uint32_t qa = q_0;
-    half2_uint32 q0((qa & 0x000f000f) | c0); // half2( q[0]      + 1024, q[1]      + 1024 )
-    half2_uint32 q1((qa & 0x00f000f0) | c0); // half2( q[2] * 16 + 1024, q[3] * 16 + 1024 )
+    half2_uint32<D> q0((qa & 0x000f000f) | c0); // half2( q[0]      + 1024, q[1]      + 1024 )
+    half2_uint32<D> q1((qa & 0x00f000f0) | c0); // half2( q[2] * 16 + 1024, q[3] * 16 + 1024 )
     qa >>= 8;
-    half2_uint32 q2((qa & 0x000f000f) | c0); // half2( q[4]      + 1024, q[5]      + 1024 )
-    half2_uint32 q3((qa & 0x00f000f0) | c0); // half2( q[6] * 16 + 1024, q[7] * 16 + 1024 )
+    half2_uint32<D> q2((qa & 0x000f000f) | c0); // half2( q[4]      + 1024, q[5]      + 1024 )
+    half2_uint32<D> q3((qa & 0x00f000f0) | c0); // half2( q[6] * 16 + 1024, q[7] * 16 + 1024 )
 
     if (scaled)
     {
-        dq[0] = __hfma2(q0.as_half2, y1y16[0], z1z16[0]);  // half2( q[0] * s - z * s, q[1] * s - z * s)
-        dq[1] = __hfma2(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] * s - z * s, q[3] * s - z * s)
-        dq[2] = __hfma2(q2.as_half2, y1y16[0], z1z16[0]);
-        dq[3] = __hfma2(q3.as_half2, y1y16[1], z1z16[1]);
+        dq[0] = D::num2_fma(q0.as_half2, y1y16[0], z1z16[0]);  // half2( q[0] * s - z * s, q[1] * s - z * s)
+        dq[1] = D::num2_fma(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] * s - z * s, q[3] * s - z * s)
+        dq[2] = D::num2_fma(q2.as_half2, y1y16[0], z1z16[0]);
+        dq[3] = D::num2_fma(q3.as_half2, y1y16[1], z1z16[1]);
     }
     else
     {
-        dq[0] = __hadd2(q0.as_half2,           z1z16[0]);  // half2( q[0] - z, q[1] - z )
-        dq[1] = __hfma2(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] - z, q[3] - z )
-        dq[2] = __hadd2(q2.as_half2,           z1z16[0]);  // half2( q[4] - z, q[5] - z )
-        dq[3] = __hfma2(q3.as_half2, y1y16[1], z1z16[1]);  // half2( q[6] - z, q[7] - z )
+        dq[0] = D::num2_add(q0.as_half2,           z1z16[0]);  // half2( q[0] - z, q[1] - z )
+        dq[1] = D::num2_fma(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] - z, q[3] - z )
+        dq[2] = D::num2_add(q2.as_half2,           z1z16[0]);  // half2( q[4] - z, q[5] - z )
+        dq[3] = D::num2_fma(q3.as_half2, y1y16[1], z1z16[1]);  // half2( q[6] - z, q[7] - z )
     }
 }
+
+
+#if ((__CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__))) && !defined(USE_ROCM)
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8<BF16TYPE>
+(
+    const uint32_t q_0,
+    nv_bfloat162 (&dq)[4],
+    int stride,
+    const uint32_t zero
+)
+{
+    using D = BF16TYPE;
+    const half_uint16<D> z1_(0xc300 | zero); // half(-128.0f - zero);
+    const typename D::T2 z1 = D::num2num2(z1_.as_half);
+
+    const uint32_t c0 = 0x43004300;
+    uint32_t qa = q_0;
+
+    half2_uint32<D> q0((qa & 0x000f000f) | c0); // half2( q[0] + 128, q[1] + 128 )
+    dq[0] = D::num2_add(q0.as_half2, z1);
+
+    for (int i = 1; i < 4; i++) {
+        qa >>= 4;
+        half2_uint32<D> q1((qa & 0x000f000f) | c0); // half2( q[i * 2] + 128, q[i * 2 + 1] + 128 )
+        dq[i] = D::num2_add(q0.as_half2, z1);
+    }
+
+}
+
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero_scale<BF16TYPE>
+(
+    const uint32_t zero,
+    const nv_bfloat16 scale,
+    nv_bfloat162 (&z1z16)[2],
+    nv_bfloat162 (&y1y16)[2]
+)
+{
+    using D = BF16TYPE;
+    half_uint16<D> z1(0xc300 | zero); // half(-128.0f - zero);
+
+    typename D::T2 scale2 = D::num2num2(scale);
+
+    z1z16[0] = D::num2_mul(scale2, D::num2num2(z1.as_half));
+    z1z16[1] = z1z16[0];
+
+    const typename D::T y1 = D::float2num_rn(1.0f);
+
+    y1y16[0] = D::num2_mul(scale2, D::num2num2(y1));
+    y1y16[1] = y1y16[0];
+}
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_prep_zero<BF16TYPE>
+(
+    const uint32_t zero,
+    nv_bfloat162(&z1z16)[2],
+    nv_bfloat162(&y1y16)[2]
+)
+{
+    using D = BF16TYPE;
+    half_uint16<D> z1(0xc300 | zero); // half(-128.0f - zero);
+
+    z1z16[0] = D::num2num2(z1.as_half);
+    z1z16[1] = z1z16[0];
+
+    const typename D::T y1 = D::float2num_rn(1.0f);
+
+    y1y16[0] = D::num2num2(y1);
+    y1y16[1] = y1y16[0];
+}
+
+
+template <>
+__forceinline__ __device__ void dequant_4bit_8_gptq<BF16TYPE>
+(
+    const uint32_t q_0,
+    nv_bfloat162 (&dq)[4],
+    nv_bfloat162 (&z1z16)[2],
+    nv_bfloat162 (&y1y16)[2],
+    int stride,
+    bool scaled
+)
+{
+    using D = BF16TYPE;
+    const uint32_t c0 = 0x43004300;
+
+    uint32_t qa = q_0;
+    half2_uint32<D> q0((qa & 0x000f000f) | c0); // half2( q[0] + 128, q[1] + 128 )
+    qa >>= 4;
+    half2_uint32<D> q1((qa & 0x000f000f) | c0); // half2( q[2] + 128, q[3] + 128 )
+    qa >>= 4;
+    half2_uint32<D> q2((qa & 0x000f000f) | c0); // half2( q[4] + 128, q[5] + 128 )
+    qa >>= 4;
+    half2_uint32<D> q3((qa & 0x000f000f) | c0); // half2( q[6] + 128, q[7] + 128 )
+
+    if (scaled)
+    {
+        dq[0] = D::num2_fma(q0.as_half2, y1y16[0], z1z16[0]);  // half2( q[0] * s - z * s, q[1] * s - z * s)
+        dq[1] = D::num2_fma(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] * s - z * s, q[3] * s - z * s)
+        dq[2] = D::num2_fma(q2.as_half2, y1y16[0], z1z16[0]);
+        dq[3] = D::num2_fma(q3.as_half2, y1y16[1], z1z16[1]);
+    }
+    else
+    {
+        dq[0] = D::num2_add(q0.as_half2,           z1z16[0]);  // half2( q[0] - z, q[1] - z )
+        dq[1] = D::num2_fma(q1.as_half2, y1y16[1], z1z16[1]);  // half2( q[2] - z, q[3] - z )
+        dq[2] = D::num2_add(q2.as_half2,           z1z16[0]);  // half2( q[4] - z, q[5] - z )
+        dq[3] = D::num2_fma(q3.as_half2, y1y16[1], z1z16[1]);  // half2( q[6] - z, q[7] - z )
+    }
+}
+
+#endif
 }  // namespace gptq
 }  // namespace vllm
 

--- a/csrc/quantization/gptq/qdq_8.cuh
+++ b/csrc/quantization/gptq/qdq_8.cuh
@@ -18,20 +18,21 @@ __forceinline__ __device__ void shuffle_8bit_4
 {
 }
 
+template <class D>
 __forceinline__ __device__ void dequant_8bit_8
 (
     const uint32_t q_0,
     const uint32_t q_1,
-    half2 (&dq)[4],
+    typename D::T2 (&dq)[4],
     int stride,
     const uint32_t zero
 )
 {
-    half dqh[8];
-    for (int i = 0; i < 4; i++) dqh[i    ] = dq_ns(exb(q_0, i * 8, 0xff), zero);
-    for (int i = 0; i < 4; i++) dqh[i + 4] = dq_ns(exb(q_1, i * 8, 0xff), zero);
+    typename D::T dqh[8];
+    for (int i = 0; i < 4; i++) dqh[i    ] = dq_ns<D>(exb(q_0, i * 8, 0xff), zero);
+    for (int i = 0; i < 4; i++) dqh[i + 4] = dq_ns<D>(exb(q_1, i * 8, 0xff), zero);
 
-    for (int i = 0; i < 4; i++) dq[i] = __halves2half2(dqh[i * 2], dqh[i * 2 + 1]);
+    for (int i = 0; i < 4; i++) dq[i] = D::nums2num2(dqh[i * 2], dqh[i * 2 + 1]);
 }
 
 }  // namespace gptq

--- a/csrc/quantization/gptq/qdq_util.cuh
+++ b/csrc/quantization/gptq/qdq_util.cuh
@@ -8,41 +8,46 @@ Copied from https://github.com/turboderp/exllamav2
 namespace vllm {
 namespace gptq {
 
+template <class D>
 union half2_uint32
 {
     uint32_t as_uint32;
-    half2 as_half2;
+    typename D::T2 as_half2;
     __device__ half2_uint32(uint32_t val) : as_uint32(val) {}
-    __device__ half2_uint32(half2 val) : as_half2(val) {}
+    __device__ half2_uint32(typename D::T2 val) : as_half2(val) {}
 };
 
+template <class D>
 union half_uint16
 {
     uint16_t as_uint16;
-    half as_half;
+    typename D::T as_half;
     __device__ half_uint16(uint16_t val) : as_uint16(val) {}
-    __device__ half_uint16(half val) : as_half(val) {}
+    __device__ half_uint16(typename D::T val) : as_half(val) {}
 };
 
 // Max_scale premultiplied by 1/256
 
-__forceinline__ __device__ half dq_scale(const int qs, const half max_scale)
+template <class D>
+__forceinline__ __device__ typename D::T dq_scale(const int qs, const typename D::T max_scale)
 {
     int qs_i = qs + 1;
-    half qs_h = __int2half_rn(qs_i * qs_i);
-    qs_h = __hmul(qs_h, max_scale);
+    typename D::T qs_h = D::int2num_rn(qs_i * qs_i);
+    qs_h = D::num_mul(qs_h, max_scale);
     return qs_h;
 }
 
-__forceinline__ __device__ half dq(const int q, const int qzero, const half scale)
+template <class D>
+__forceinline__ __device__ typename D::T dq(const int q, const int qzero, const typename D::T scale)
 {
-    return __hmul(__int2half_rn(q - qzero), scale);
+    return D::num_mul(D::int2num_rn(q - qzero), scale);
 }
 
-__forceinline__ __device__ half dq_ns(const int q, const int qzero)
+template <class D>
+__forceinline__ __device__ typename D::T dq_ns(const int q, const int qzero)
 {
     //return __hsub(__int2half_rn(q), __int2half_rn(qzero));
-    return __int2half_rn(q - qzero);
+    return D::int2num_rn(q - qzero);
 }
 
 __forceinline__ __device__ int exb(const uint32_t q, const int shift, const int mask)


### PR DESCRIPTION

Some models would overflow when using fp16 inference (e.g. Deepseek-V2), so we should add bfloat16 support for quantization kernel. This PR add bfloat16 support for gptq kernel.

Related issue: https://github.com/vllm-project/vllm/issues/2149

main changes:
- add bfloat16 input/output support for cuda kernels
- dequant qweight to bfloat16 in proper ways.

**NOTE**: Currently, bfloat16 kernel may be much slower than float16 on `>=sm80,<sm90` device since the support for `atomicAdd` with bfloat16 is not native (see [description of `atomicAdd`](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH____BFLOAT16__ARITHMETIC.html#group__CUDA__MATH____BFLOAT16__ARITHMETIC_1g9ce572e47cde154b9404bf86a0438e91)). Increase the value of `BLOCK_KN_SIZE` can much improve the performance, but I don't sure if this will affect other situations. 
