### PR TITLE
[CI/Build] PEP 517/518 improvements

### DIFF
--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -8,8 +8,8 @@ PATH=${cuda_home}/bin:$PATH
 LD_LIBRARY_PATH=${cuda_home}/lib64:$LD_LIBRARY_PATH
 
 # Install requirements
-$python_executable -m pip install wheel packaging
-$python_executable -m pip install -r requirements-cuda.txt
+$python_executable -m pip install build
+$python_executable -m pip install -r requirements-cuda.txt -r requirements-build.txt
 
 # Limit the number of parallel jobs to avoid OOM
 export MAX_JOBS=1
@@ -18,4 +18,4 @@ export VLLM_INSTALL_PUNICA_KERNELS=1
 # Make sure release wheels are built for the following architectures
 export TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.9 9.0+PTX"
 # Build
-$python_executable setup.py bdist_wheel --dist-dir=dist
+$python_executable -m build --wheel --output=dist --no-isolation

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ARG PYTHON_VERSION=3
 COPY requirements-build.txt requirements-build.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-build.txt
+    python3 -m pip install build -r requirements-build.txt
 
 # install compiler cache to speed up compilation leveraging local or remote caching
 RUN apt-get update -y && apt-get install -y ccache
@@ -104,7 +104,7 @@ ENV CCACHE_DIR=/root/.cache/ccache
 RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/pip \
     if [ "$USE_SCCACHE" != "1" ]; then \
-        python3 setup.py bdist_wheel --dist-dir=dist; \
+        python3 -m build --wheel --outdir=dist --no-isolation -v; \
     fi
 
 # check the size of the wheel, we cannot upload wheels larger than 100MB

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -25,7 +25,7 @@ RUN pip install -v -r requirements-cpu.txt --extra-index-url https://download.py
 ARG VLLM_CPU_DISABLE_AVX512
 ENV VLLM_CPU_DISABLE_AVX512=${VLLM_CPU_DISABLE_AVX512}
 
-RUN VLLM_TARGET_DEVICE=cpu python3 setup.py install
+RUN VLLM_TARGET_DEVICE=cpu pip3 install -v .
 
 WORKDIR /workspace/
 

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -108,7 +108,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     pip install -U -r requirements-rocm.txt \
     && if [ "$BASE_IMAGE" = "$ROCm_6_0_BASE" ]; then \
        patch /opt/rocm/include/hip/amd_detail/amd_hip_bf16.h ./rocm_patch/rocm_bf16.patch; fi \
-    && python3 setup.py install \
+    && pip3 install -v . \
     && export VLLM_PYTHON_VERSION=$(python -c "import sys; print(str(sys.version_info.major) + str(sys.version_info.minor))") \
     && cp build/lib.linux-x86_64-cpython-${VLLM_PYTHON_VERSION}/vllm/*.so vllm/ \
     && cd ..

--- a/docs/source/getting_started/cpu-installation.rst
+++ b/docs/source/getting_started/cpu-installation.rst
@@ -55,7 +55,7 @@ Build from source
 .. code-block:: console
 
     $ pip install --upgrade pip
-    $ pip install wheel packaging ninja "setuptools>=49.4.0" numpy
+    $ pip install wheel packaging ninja "setuptools>=61" numpy
     $ pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
 
 - Finally, build and install vLLM CPU backend: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.21",
     "ninja",
     "packaging",
-    "setuptools >= 49.4.0",
+    "setuptools>=61",
     "torch == 2.3.0",
     "wheel",
 ]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,6 +2,6 @@
 cmake>=3.21
 ninja
 packaging
-setuptools>=49.4.0
+setuptools>=61
 torch==2.3.0
 wheel


### PR DESCRIPTION
This PR attempts to improve a few aspects of the vLLM build process with the aim of moving towards a full [PEP-517](https://peps.python.org/pep-0517/)/[PEP-518](https://peps.python.org/pep-0518/) compliant build.

1. Use [pypa/build](https://github.com/pypa/build) to build the vllm wheel, moving away from `setup.py bdist_wheel`
2. Add `--no-build-isolation` flags when running `pip install .`
3. bump `setuptools` minimum version to 61

Note that both when building through `python -m build` and when installing through `pip install .`, build dependencies are installed before the package is actually built, thus build isolation (which implies the creation of a new virtualenv with build dependencies) is not required. This should speed up the build process a bit.

Since we can define build dependencies in `pyproject.toml`, in the future we could get rid of `--no-isolation` and avoid having to manually manage build dependencies in `requirements-build.txt` (although that does help a bit with caching in Dockerfiles).

If this is merged, I can spend some time getting rid of the `requirements*.txt` files, moving those into `setup.py` (and/or possibly package extras), in order to be able to build/install with a single command. I would appreciate some thoughts on the matter.