### PR TITLE
Add JSON output support for benchmark_latency and benchmark_throughput

### DIFF
--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -9,10 +9,10 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 (which wget && which curl) || (apt-get update && apt-get install -y wget curl)
 
 # run python-based benchmarks and upload the result to buildkite
-python3 benchmarks/benchmark_latency.py 2>&1 | tee benchmark_latency.txt
+python3 benchmarks/benchmark_latency.py --output-json latency_results.json 2>&1 | tee benchmark_latency.txt
 bench_latency_exit_code=$?
 
-python3 benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 2>&1 | tee benchmark_throughput.txt
+python3 benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 --output-json throughput_results.json 2>&1 | tee benchmark_throughput.txt
 bench_throughput_exit_code=$?
 
 # run server-based benchmarks and upload the result to buildkite
@@ -31,6 +31,7 @@ python3 benchmarks/benchmark_serving.py \
     --endpoint /v1/completions \
     --tokenizer meta-llama/Llama-2-7b-chat-hf \
     --save-result \
+    --output-json openai-serv.json \
     2>&1 | tee benchmark_serving.txt
 bench_serving_exit_code=$?
 kill $server_pid
@@ -74,4 +75,4 @@ if [ $bench_serving_exit_code -ne 0 ]; then
     exit $bench_serving_exit_code
 fi
 
-/workspace/buildkite-agent artifact upload openai-*.json
+/workspace/buildkite-agent artifact upload latency_results.json throughput_results.json openai-serv.json

--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -31,7 +31,6 @@ python3 benchmarks/benchmark_serving.py \
     --endpoint /v1/completions \
     --tokenizer meta-llama/Llama-2-7b-chat-hf \
     --save-result \
-    --output-json openai-serv.json \
     2>&1 | tee benchmark_serving.txt
 bench_serving_exit_code=$?
 kill $server_pid
@@ -75,4 +74,5 @@ if [ $bench_serving_exit_code -ne 0 ]; then
     exit $bench_serving_exit_code
 fi
 
-/workspace/buildkite-agent artifact upload latency_results.json throughput_results.json openai-serv.json
+rm ShareGPT_V3_unfiltered_cleaned_split.json
+/workspace/buildkite-agent artifact upload *.json

--- a/.buildkite/run-benchmarks.sh
+++ b/.buildkite/run-benchmarks.sh
@@ -75,4 +75,4 @@ if [ $bench_serving_exit_code -ne 0 ]; then
 fi
 
 rm ShareGPT_V3_unfiltered_cleaned_split.json
-/workspace/buildkite-agent artifact upload *.json
+/workspace/buildkite-agent artifact upload "*.json"

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -103,7 +103,6 @@ def main(args: argparse.Namespace):
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
-        print(f"Latency results saved to {args.output_json}")
 
 
 if __name__ == '__main__':

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -203,9 +203,10 @@ if __name__ == '__main__':
                         default=None,
                         help='directory to download and load the weights, '
                         'default to the default cache dir of huggingface')
-    parser.add_argument('--output-json',
-                        type=str,
-                        default=None,
-                        help='Path to save the latency results in JSON format.')
+    parser.add_argument(
+        '--output-json',
+        type=str,
+        default=None,
+        help='Path to save the latency results in JSON format.')
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -1,5 +1,6 @@
 """Benchmark the latency of processing a single batch of requests."""
 import argparse
+import json
 import time
 from pathlib import Path
 from typing import Optional
@@ -93,6 +94,17 @@ def main(args: argparse.Namespace):
     for percentage, percentile in zip(percentages, percentiles):
         print(f'{percentage}% percentile latency: {percentile} seconds')
 
+    # Output JSON results if specified
+    if args.output_json:
+        results = {
+            "avg_latency": np.mean(latencies),
+            "latencies": latencies.tolist(),
+            "percentiles": dict(zip(percentages, percentiles.tolist())),
+        }
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=4)
+        print(f"Latency results saved to {args.output_json}")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -144,8 +156,8 @@ if __name__ == '__main__':
         help=
         'Data type for kv cache storage. If "auto", will use model data type. '
         'FP8_E5M2 (without scaling) is only supported on cuda version greater '
-        'than 11.8. On ROCm (AMD GPU), FP8_E4M3 is instead supported for '
-        'common inference criteria.')
+        'than 11.8. On ROCm (AMD GPU), FP8_E4M3 is '
+        'instead supported for common inference criteria.')
     parser.add_argument(
         '--quantization-param-path',
         type=str,
@@ -191,5 +203,9 @@ if __name__ == '__main__':
                         default=None,
                         help='directory to download and load the weights, '
                         'default to the default cache dir of huggingface')
+    parser.add_argument('--output-json',
+                        type=str,
+                        default=None,
+                        help='Path to save the latency results in JSON format.')
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -253,7 +253,6 @@ def main(args: argparse.Namespace):
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
-        print(f"Throughput results saved to {args.output_json}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -366,10 +366,11 @@ if __name__ == "__main__":
                         default=None,
                         help='directory to download and load the weights, '
                         'default to the default cache dir of huggingface')
-    parser.add_argument('--output-json',
-                        type=str,
-                        default=None,
-                        help='Path to save the throughput results in JSON format.')
+    parser.add_argument(
+        '--output-json',
+        type=str,
+        default=None,
+        help='Path to save the throughput results in JSON format.')
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -242,6 +242,19 @@ def main(args: argparse.Namespace):
     print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
           f"{total_num_tokens / elapsed_time:.2f} tokens/s")
 
+    # Output JSON results if specified
+    if args.output_json:
+        results = {
+            "elapsed_time": elapsed_time,
+            "num_requests": len(requests),
+            "total_num_tokens": total_num_tokens,
+            "requests_per_second": len(requests) / elapsed_time,
+            "tokens_per_second": total_num_tokens / elapsed_time,
+        }
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=4)
+        print(f"Throughput results saved to {args.output_json}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Benchmark the throughput.")
@@ -353,6 +366,10 @@ if __name__ == "__main__":
                         default=None,
                         help='directory to download and load the weights, '
                         'default to the default cache dir of huggingface')
+    parser.add_argument('--output-json',
+                        type=str,
+                        default=None,
+                        help='Path to save the throughput results in JSON format.')
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model


### PR DESCRIPTION
Fixes #4847

Adds JSON output functionality to `benchmark_latency.py` and `benchmark_throughput.py`, and updates the `.buildkite/run-benchmarks.sh` script to utilize this feature and upload the results as artifacts.

- **Latency and Throughput Benchmarks**: Both `benchmark_latency.py` and `benchmark_throughput.py` scripts now accept an `--output-json` argument to specify a file path for saving the benchmark results in JSON format. This allows for easier parsing and aggregation of benchmark data.
- **Benchmark Script Updates**: The `.buildkite/run-benchmarks.sh` script is modified to include the `--output-json` argument when running latency and throughput benchmarks, directing the output to specific JSON files. These files are then uploaded as artifacts, facilitating the collection and analysis of benchmark data.
- **Serving Benchmark**: The serving benchmark command within the `.buildkite/run-benchmarks.sh` script is also updated to save its results to a JSON file, maintaining consistency across benchmarking scripts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vllm-project/vllm/issues/4847?shareId=d6bd7e92-7e12-4c4f-935d-1db63a49443d).