### PR TITLE
Add control panel allow manage multi vllm instances

### DIFF
--- a/tests/entrypoints/test_controller.py
+++ b/tests/entrypoints/test_controller.py
@@ -1,0 +1,366 @@
+"""We here have test setting as one controller with two worker.
+From controller's perspective, its main duty is to maintain unique central
+entrance place, a.k.a service URL, and dispatch request to workers.
+
+To accomplish this job, it need to:
+    1. make sure controller could correctly receive worker's join request
+    2. make sure worker would repeatly sending heart beat signal to controller
+    3. make sure remove stale worker if not receive worker's heart beat
+
+And by worker registration, it also could do the job as:
+    1. autoscale with new worker of the same serving model join in.
+    2. model roll update by gradudtely join new model pod while delete old one.
+    3. request load balance by inspect worker's engine pending request len.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+# using Ray for overall ease of process management, parallel requests,
+# and debugging.
+import ray
+import requests
+import openai  # use the official client for correctness check
+import pytest
+from huggingface_hub import snapshot_download
+from vllm.utils import get_ip
+
+MAX_SERVER_START_WAIT_S = 600  # wait for server to start for 60 seconds
+# any model with a chat template should work here
+MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
+# technically this needs Mistral-7B-v0.1 as base, but we're not testing
+# generation quality here
+LORA_NAME = "typeof/zephyr-7b-beta-lora"
+
+# make check fast
+CONTROLLER_HEART_BEAT_EXPIRATION = 10
+os.environ["VLLM_CONTROLLER_HEART_BEAT_EXPIRATION"] = str(
+    CONTROLLER_HEART_BEAT_EXPIRATION)
+os.environ["VLLM_WORKER_HEART_BEAT_INTERVAL"] = "5"
+host_ip = get_ip()
+controller_addr = "{}:8000".format(host_ip)
+worker1_addr = "{}:8001".format(host_ip)
+worker2_addr = "{}:8002".format(host_ip)
+
+pytestmark = pytest.mark.asyncio
+
+
+@ray.remote
+class Controller:
+
+    def __init__(self, args):
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+        self.proc = subprocess.Popen(
+            ["python3", "-m", "vllm.entrypoints.openai.controller"] + args,
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        self._wait_for_server()
+
+    def ready(self):
+        return True
+
+    def _wait_for_server(self):
+        # run health check
+        start = time.time()
+        while True:
+            try:
+                if requests.get("http://{}/health".format(
+                        controller_addr)).status_code == 200:
+                    break
+            except Exception as err:
+                if self.proc.poll() is not None:
+                    raise RuntimeError("Server exited unexpectedly.") from err
+
+                time.sleep(0.5)
+                if time.time() - start > MAX_SERVER_START_WAIT_S:
+                    raise RuntimeError(
+                        "Server failed to start in time.") from err
+
+    def __del__(self):
+        if hasattr(self, "proc"):
+            self.proc.terminate()
+
+
+@ray.remote(num_gpus=1)
+class Worker:
+
+    def __init__(self, args, port):
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+        self.port = port
+        self.proc = subprocess.Popen(
+            ["python3", "-m", "vllm.entrypoints.openai.api_server"] + args,
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
+        self._wait_for_worker()
+
+    def ready(self):
+        return True
+
+    def _wait_for_worker(self):
+        # run health check
+        start = time.time()
+        while True:
+            try:
+                if requests.get("http://{}:{}/health".format(
+                        host_ip, self.port)).status_code == 200:
+                    break
+            except Exception as err:
+                if self.proc.poll() is not None:
+                    raise RuntimeError("Server exited unexpectedly.") from err
+
+                time.sleep(0.5)
+                if time.time() - start > MAX_SERVER_START_WAIT_S:
+                    raise RuntimeError(
+                        "Server failed to start in time.") from err
+
+    def __del__(self):
+        if hasattr(self, "proc"):
+            self.proc.terminate()
+
+
+@pytest.fixture(scope="module")
+def client():
+    client = openai.AsyncOpenAI(
+        base_url="http://{}/v1".format(controller_addr),
+        api_key="token-abc123",
+    )
+
+    yield client
+
+
+@pytest.fixture(scope="session")
+def zephyr_lora_files():
+    return snapshot_download(repo_id=LORA_NAME)
+
+
+@pytest.fixture(scope="function")
+def singleserver(zephyr_lora_files):
+    ray.init()
+    # start controller first
+    controller = Controller.remote(["--host", host_ip])
+    ray.get(controller.ready.remote())
+    worker = Worker.remote(
+        [
+            "--model",
+            MODEL_NAME,
+            # use half precision for speed and memory savings in CI environment
+            "--dtype",
+            "bfloat16",
+            "--max-model-len",
+            "512",
+            "--host",
+            host_ip,
+            "--port",
+            "8001",
+            "--controller",
+            controller_addr,
+            "--enforce-eager",
+            # lora config below
+            "--enable-lora",
+            "--lora-modules",
+            f"zephyr-lora={zephyr_lora_files}",
+            f"zephyr-lora2={zephyr_lora_files}",
+            "--max-lora-rank",
+            "64",
+            "--max-cpu-loras",
+            "2",
+            "--max-num-seqs",
+            "128",
+        ],
+        8001)
+    ray.get(worker.ready.remote())
+
+    yield controller
+    ray.shutdown()
+
+
+@pytest.fixture(scope="function")
+def doubleserver(zephyr_lora_files):
+    ray.init()
+    # start controller first
+    controller = Controller.remote(["--host", host_ip])
+    ray.get(controller.ready.remote())
+    worker0 = Worker.remote(
+        [
+            "--model",
+            MODEL_NAME,
+            # use half precision for speed and memory savings in CI environment
+            "--dtype",
+            "bfloat16",
+            "--max-model-len",
+            "512",
+            "--host",
+            host_ip,
+            "--port",
+            "8001",
+            "--controller",
+            controller_addr,
+            "--enforce-eager",
+            # lora config below
+            "--enable-lora",
+            "--lora-modules",
+            f"zephyr-lora={zephyr_lora_files}",
+            f"zephyr-lora2={zephyr_lora_files}",
+            "--max-lora-rank",
+            "64",
+            "--max-cpu-loras",
+            "2",
+            "--max-num-seqs",
+            "128",
+        ],
+        8001)
+    ray.get(worker0.ready.remote())
+
+    worker1 = Worker.remote(
+        [
+            "--model",
+            MODEL_NAME,
+            # use half precision for speed and memory savings in CI environment
+            "--dtype",
+            "bfloat16",
+            "--max-model-len",
+            "512",
+            "--host",
+            host_ip,
+            "--port",
+            "8002",
+            "--controller",
+            controller_addr,
+            "--enforce-eager",
+            # lora config below
+            "--enable-lora",
+            "--lora-modules",
+            f"zephyr-lora={zephyr_lora_files}",
+            f"zephyr-lora2={zephyr_lora_files}",
+            "--max-lora-rank",
+            "64",
+            "--max-cpu-loras",
+            "2",
+            "--max-num-seqs",
+            "128",
+        ],
+        8002)
+    ray.get(worker1.ready.remote())
+
+    yield controller
+    ray.shutdown()
+
+
+async def test_check_models(singleserver):
+    res = requests.get("http://{}/list_models".format(controller_addr))
+    assert res.status_code == 200
+
+    res = json.loads(res.content.decode('utf-8'))
+    models = res["models"]
+    served_model = models[0]
+    lora_models = models[1:]
+
+    assert served_model == MODEL_NAME
+    assert lora_models[0] == "zephyr-lora"
+    assert lora_models[1] == "zephyr-lora2"
+
+
+@pytest.mark.parametrize(
+    # first test base model, then test loras
+    "model_name",
+    [MODEL_NAME, "zephyr-lora", "zephyr-lora2"],
+)
+async def test_load_balance(doubleserver, client: openai.AsyncOpenAI,
+                            model_name: str):
+    res = requests.get("http://{}/list_models".format(controller_addr))
+    assert res.status_code == 200
+
+    res = json.loads(res.content.decode('utf-8'))
+
+    res = requests.get("http://{}/list_workers".format(controller_addr))
+    assert res.status_code == 200
+
+    res = json.loads(res.content.decode('utf-8'))
+
+    for i in range(5):
+        completion = await client.completions.create(
+            model=model_name,
+            prompt="Hello, my name is",
+            max_tokens=5,
+            temperature=0.0)
+
+        assert completion.choices[0].text is not None and len(
+            completion.choices[0].text) >= 5
+
+    res = requests.get("http://{}/list_workers".format(controller_addr))
+    assert res.status_code == 200
+
+    res = json.loads(res.content.decode('utf-8'))
+    worker1 = res[worker1_addr]
+    worker2 = res[worker2_addr]
+
+    assert abs(worker1["req_cnt"] - worker2["req_cnt"]) <= 1
+
+
+async def test_join_and_leave(singleserver):
+    res = requests.get("http://{}/list_models".format(controller_addr))
+    assert res.status_code == 200
+
+    res = json.loads(res.content.decode('utf-8'))
+
+    res = requests.get("http://{}/list_workers".format(controller_addr))
+    assert res.status_code == 200
+    res = json.loads(res.content.decode('utf-8'))
+    assert worker1_addr in res
+
+    worker1 = Worker.remote(
+        [
+            "--model",
+            MODEL_NAME,
+            # use half precision for speed and memory savings in CI environment
+            "--dtype",
+            "bfloat16",
+            "--max-model-len",
+            "512",
+            "--host",
+            host_ip,
+            "--port",
+            "8002",
+            "--controller",
+            controller_addr,
+            "--enforce-eager",
+            # lora config below
+            "--enable-lora",
+            "--lora-modules",
+            f"zephyr-lora={zephyr_lora_files}",
+            f"zephyr-lora2={zephyr_lora_files}",
+            "--max-lora-rank",
+            "64",
+            "--max-cpu-loras",
+            "2",
+            "--max-num-seqs",
+            "128",
+        ],
+        8002)
+    ray.get(worker1.ready.remote())
+
+    res = requests.get("http://{}/list_workers".format(controller_addr))
+    assert res.status_code == 200
+    res = json.loads(res.content.decode('utf-8'))
+
+    assert worker1_addr in res
+    assert worker2_addr in res
+
+    del worker1
+    # make sure controller already take clean up
+    time.sleep(CONTROLLER_HEART_BEAT_EXPIRATION * 2)
+
+    res = requests.get("http://{}/list_workers".format(controller_addr))
+    assert res.status_code == 200
+    res = json.loads(res.content.decode('utf-8'))
+
+    assert worker1_addr in res
+    assert worker2_addr not in res

--- a/tests/entrypoints/test_controller.py
+++ b/tests/entrypoints/test_controller.py
@@ -4,7 +4,7 @@ entrance place, a.k.a service URL, and dispatch request to workers.
 
 To accomplish this job, it need to:
     1. make sure controller could correctly receive worker's join request
-    2. make sure worker would repeatly sending heart beat signal to controller
+    2. make sure worker would repeatedly sending heart beat signal to controller
     3. make sure remove stale worker if not receive worker's heart beat
 
 And by worker registration, it also could do the job as:

--- a/tests/entrypoints/test_controller.py
+++ b/tests/entrypoints/test_controller.py
@@ -18,13 +18,14 @@ import subprocess
 import sys
 import time
 
+import openai  # use the official client for correctness check
+import pytest
 # using Ray for overall ease of process management, parallel requests,
 # and debugging.
 import ray
 import requests
-import openai  # use the official client for correctness check
-import pytest
 from huggingface_hub import snapshot_download
+
 from vllm.utils import get_ip
 
 MAX_SERVER_START_WAIT_S = 600  # wait for server to start for 60 seconds

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -20,6 +20,7 @@ import vllm.envs as envs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.openai.cli_args import make_arg_parser
+from vllm.entrypoints.openai.controller import Worker
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
                                               ChatCompletionResponse,
                                               CompletionRequest,
@@ -207,6 +208,9 @@ if __name__ == "__main__":
         engine, model_config, served_model_names, args.lora_modules)
     openai_serving_embedding = OpenAIServingEmbedding(engine, model_config,
                                                       served_model_names)
+    if args.controller is not None:
+        Worker(args.controller, args.host, args.port, args.model,
+               args.lora_modules, engine)
     app.root_path = args.root_path
     uvicorn.run(app,
                 host=args.host,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -29,6 +29,10 @@ def make_arg_parser():
                         type=nullable_str,
                         default=None,
                         help="host name")
+    parser.add_argument("--controller",
+                        type=nullable_str,
+                        default=None,
+                        help="controller addr")
     parser.add_argument("--port", type=int, default=8000, help="port number")
     parser.add_argument(
         "--uvicorn-log-level",

--- a/vllm/entrypoints/openai/controller.py
+++ b/vllm/entrypoints/openai/controller.py
@@ -161,8 +161,8 @@ def heart_beat_worker(obj):
 
 class Worker:
 
-    def __init__(self, controller_addr, worker_ip, worker_port, model_names,
-                 lora_modules: List[LoRAModulePath], engine):
+    def __init__(self, controller_addr: str, worker_ip: str, worker_port: int,
+                 model_names: str, lora_modules: List[LoRAModulePath], engine):
         self.controller_addr = controller_addr
         self.worker_addr = "{}:{}".format(worker_ip, worker_port)
         self.model_names = [model_names]

--- a/vllm/entrypoints/openai/controller.py
+++ b/vllm/entrypoints/openai/controller.py
@@ -1,0 +1,366 @@
+import argparse
+import dataclasses
+import json
+import os
+import time
+from typing import List
+import threading
+
+import uuid
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse, Response, JSONResponse
+import httpx
+import numpy as np
+import requests
+import uvicorn
+
+from vllm.entrypoints.openai.serving_engine import LoRAModulePath
+from vllm.entrypoints.openai.protocol import ErrorResponse
+import vllm.envs as envs
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+CONTROLLER_HEART_BEAT_EXPIRATION = envs.VLLM_CONTROLLER_HEART_BEAT_EXPIRATION
+WORKER_HEART_BEAT_INTERVAL = envs.VLLM_WORKER_HEART_BEAT_INTERVAL
+
+
+@dataclasses.dataclass
+class WorkerInfo:
+    model_names: List[str]
+    check_heart_beat: bool
+    last_heart_beat: str
+    req_cnt: int
+    speed: float
+
+
+def heart_beat_controller(controller):
+    while True:
+        time.sleep(CONTROLLER_HEART_BEAT_EXPIRATION)
+        controller.remove_stale_workers_by_expiration()
+
+
+class Controller:
+
+    def __init__(self):
+        # Dict[str -> WorkerInfo]
+        self.worker_info = {}
+
+        self.heart_beat_thread = threading.Thread(target=heart_beat_controller,
+                                                  args=(self, ))
+        self.heart_beat_thread.start()
+
+    def register_worker(self, worker_addr: str, check_heart_beat: bool,
+                        model_names: str, queue_length: int):
+        if worker_addr not in self.worker_info:
+            logger.info("Register a new worker: %s", worker_addr)
+        else:
+            logger.info("Register an existing worker: %s", worker_addr)
+
+        # adjust new comming worker according its queue status
+        # normally if it is a fresh worker
+        req_cnt = 0
+        for w_info in self.worker_info.values():
+            if req_cnt < w_info.req_cnt:
+                req_cnt = w_info.req_cnt
+
+        self.worker_info[worker_addr] = WorkerInfo(
+            model_names,
+            check_heart_beat,
+            time.time(),
+            req_cnt,
+            self.speed_normalize(queue_length),
+        )
+
+        logger.info("Register done: %s, %s", worker_addr, model_names)
+        return True
+
+    def speed_normalize(self, queue_length: int):
+        """For the worker, the more it has unfisinished queue,
+        it means that it has less capacity for serving future request.
+
+        Thus we here use 1/(queue_length+1) for load balance algo.
+        """
+        return 1. / (queue_length + 1)
+
+    def remove_worker(self, worker_addr: str):
+        logger.info("Remove stale worker: %s", worker_addr)
+        del self.worker_info[worker_addr]
+
+    def list_models(self):
+        model_names = []
+
+        for w_name, w_info in self.worker_info.items():
+            for model in w_info.model_names:
+                model_names.append(model)
+
+        return sorted(set(model_names))
+
+    def list_workers(self):
+        cur = time.time()
+        workers = {}
+
+        for w_name, w_info in self.worker_info.items():
+            worker = {
+                w_name: {
+                    "model": w_info.model_names,
+                    "req_cnt": w_info.req_cnt,
+                    "speed": w_info.speed,
+                    "check_heart_beat": w_info.check_heart_beat,
+                    "last_heart_beat": cur - w_info.last_heart_beat,
+                }
+            }
+            workers.update(worker)
+
+        return workers
+
+    def get_worker_address(self, model_name: str):
+        worker_names = []
+        worker_qlen = []
+        for w_name, w_info in self.worker_info.items():
+            worker_names.append(w_name)
+            worker_qlen.append(w_info.req_cnt / w_info.speed)
+        if len(worker_names) == 0:
+            return ""
+
+        # return the worker with least normalized queue length
+        min_index = np.argmin(worker_qlen)
+        w_name = worker_names[min_index]
+        self.worker_info[w_name].req_cnt += 1
+
+        return w_name
+
+    def receive_heart_beat(self, worker_addr: str, queue_length: int):
+        if worker_addr not in self.worker_info:
+            logger.info("Receive unknown heart beat. %s", worker_addr)
+            return False
+
+        speed = self.speed_normalize(queue_length)
+        self.worker_info[worker_addr].speed = speed
+        self.worker_info[worker_addr].last_heart_beat = time.time()
+        logger.info("Receive heart beat. %s speed %f", worker_addr, speed)
+        return True
+
+    def remove_stale_workers_by_expiration(self):
+        expire = time.time() - CONTROLLER_HEART_BEAT_EXPIRATION
+        to_delete = []
+        for worker_addr, w_info in self.worker_info.items():
+            if w_info.check_heart_beat and w_info.last_heart_beat < expire:
+                to_delete.append(worker_addr)
+
+        for worker_addr in to_delete:
+            self.remove_worker(worker_addr)
+
+
+def heart_beat_worker(obj):
+    while True:
+        time.sleep(WORKER_HEART_BEAT_INTERVAL)
+        obj.send_heart_beat()
+
+
+class Worker:
+
+    def __init__(self, controller_addr, worker_ip, worker_port, model_names,
+                 lora_modules: List[LoRAModulePath], engine):
+        self.controller_addr = controller_addr
+        self.worker_addr = "{}:{}".format(worker_ip, worker_port)
+        self.model_names = [model_names]
+        self.worker_id = str(uuid.uuid4())[:8]
+        self.call_ct = 0
+        self.engine = engine
+
+        if lora_modules is not None:
+            for lora in lora_modules:
+                self.model_names.append(lora.name)
+
+        self.register_to_controller()
+        self.heart_beat_thread = threading.Thread(
+            target=heart_beat_worker,
+            args=(self, ),
+            daemon=True,
+        )
+        self.heart_beat_thread.start()
+
+    def register_to_controller(self):
+        logger.info("Register to controller")
+
+        url = "http://" + self.controller_addr + "/register_worker"
+        data = {
+            "worker_addr": self.worker_addr,
+            "check_heart_beat": True,
+            "model_names": self.model_names,
+            "queue_length": self.get_queue_length(),
+        }
+
+        r = requests.post(url, json=data)
+        assert r.status_code == 200
+
+    def get_queue_length(self):
+        return self.engine.engine.get_num_unfinished_requests()
+
+    def send_heart_beat(self):
+        logger.info(
+            "Send heart beat. Models: %s. call_ct: %d. "
+            "worker_id: %s. ", self.model_names, self.call_ct, self.worker_id)
+
+        url = "http://" + self.controller_addr + "/receive_heart_beat"
+
+        while True:
+            try:
+                ret = requests.post(
+                    url,
+                    json={
+                        "worker_addr": self.worker_addr,
+                        "queue_length": self.get_queue_length(),
+                    },
+                    timeout=5,
+                )
+                exist = ret.json()["exist"]
+                break
+            except (requests.exceptions.RequestException, KeyError) as e:
+                logger.error("heart beat error: ", exc_info=e)
+            time.sleep(5)
+
+        if not exist:
+            self.register_to_controller()
+
+
+app = FastAPI()
+
+
+def create_controller():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--ssl",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable SSL. Requires OS Environment variables "
+        "'SSL_KEYFILE' and 'SSL_CERTFILE'.",
+    )
+    args = parser.parse_args()
+    logger.info("Start up controller: ", args)
+
+    controller = Controller()
+    return args, controller
+
+
+@app.post("/register_worker")
+async def register_worker(request: Request):
+    data = await request.json()
+    controller.register_worker(
+        data["worker_addr"],
+        data["check_heart_beat"],
+        data["model_names"],
+        data["queue_length"],
+    )
+
+
+@app.post("/receive_heart_beat")
+async def receive_heart_beat(request: Request):
+    data = await request.json()
+    exist = controller.receive_heart_beat(data["worker_addr"],
+                                          data["queue_length"])
+    return {"exist": exist}
+
+
+@app.get("/list_workers")
+async def show_available_workers():
+    return controller.list_workers()
+
+
+class MultiContextManager:
+
+    def __init__(self, client, method, url, json_data):
+        self.client = client
+        self.method = method
+        self.url = url
+        self.json_data = json_data
+        self.response = None
+
+    async def __aenter__(self):
+        self.response = await self.client.stream(self.method,
+                                                 self.url,
+                                                 json=self.json_data)
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.response.aclose()
+
+
+async def generate_completions_stream(worker_addr, data, api):
+    async with MultiContextManager(httpx.AsyncClient(), "POST",
+                                   f"http://{worker_addr}/{api}", data) as mcm:
+        async for chunk in mcm.response.aiter_raw():
+            yield chunk
+
+
+async def generate_completions(worker_addr, data, api):
+    async with httpx.AsyncClient() as client:
+        response = client.post(f"http://{worker_addr}/{api}", json=data)
+        return JSONResponse(content=response.json())
+
+
+async def gen_response(request, api):
+    try:
+        data = await request.json()
+    except json.JSONDecodeError:
+        return ErrorResponse(message="Json decode error",
+                             type="BadRequestError",
+                             code=400)
+    if "model" not in data:
+        return ErrorResponse(message="No model field found in the request",
+                             type="BadRequestError",
+                             code=400)
+    model = data["model"]
+    worker_addr = controller.get_worker_address(model)
+    if worker_addr == "":
+        return ErrorResponse(message=f"model [{model}] not register yet",
+                             type="BadRequestError",
+                             code=400)
+    if request.stream:
+        return StreamingResponse(generate_completions_stream(
+            worker_addr, data, api),
+                                 media_type="text/event-stream")
+    else:
+        return generate_completions(worker_addr, data, api)
+
+
+@app.get("/health")
+async def health() -> Response:
+    """Health check."""
+    return Response(status_code=200)
+
+
+@app.get("/list_models")
+async def show_available_models():
+    models = controller.list_models()
+    return {"models": models}
+
+
+@app.post("/v1/chat/completions")
+async def create_chat_completion(request: Request):
+
+    return await gen_response(request, "v1/chat/completions")
+
+
+@app.post("/v1/completions")
+async def create_completion(request: Request):
+    return await gen_response(request, "v1/completions")
+
+
+if __name__ == "__main__":
+    args, controller = create_controller()
+    if args.ssl:
+        uvicorn.run(
+            app,
+            host=args.host,
+            port=args.port,
+            log_level="info",
+            ssl_keyfile=os.environ["SSL_KEYFILE"],
+            ssl_certfile=os.environ["SSL_CERTFILE"],
+        )
+    else:
+        uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/vllm/entrypoints/openai/controller.py
+++ b/vllm/entrypoints/openai/controller.py
@@ -57,7 +57,7 @@ class Controller:
         else:
             logger.info("Register an existing worker: %s", worker_addr)
 
-        # adjust new comming worker according its queue status
+        # adjust new coming worker according its queue status
         # normally if it is a fresh worker
         req_cnt = 0
         for w_info in self.worker_info.values():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     VLLM_INSTALL_PUNICA_KERNELS: bool = False
     CMAKE_BUILD_TYPE: Optional[str] = None
     VERBOSE: bool = False
+    VLLM_CONTROLLER_HEART_BEAT_EXPIRATION: int = 90
+    VLLM_WORKER_HEART_BEAT_INTERVAL: int = 45
 
 # The begin-* and end* here are used by the documentation generator
 # to extract the used env vars.
@@ -201,6 +203,14 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Both spawn and fork work
     "VLLM_WORKER_MULTIPROC_METHOD":
     lambda: os.getenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn"),
+
+    # controller heart beat interval to check worker status
+    "VLLM_CONTROLLER_HEART_BEAT_EXPIRATION":
+    lambda: int(os.getenv("VLLM_CONTROLLER_HEART_BEAT_EXPIRATION", 90)),
+
+    # worker heart beat interval to send liveness signal towards controller
+    "VLLM_WORKER_HEART_BEAT_INTERVAL":
+    lambda: int(os.getenv("VLLM_CONTROLLER_HEART_BEAT_EXPIRATION", 45)),
 }
 
 # end-env-vars-definition

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -40,6 +40,11 @@ DEFAULT_LOGGING_CONFIG = {
             "level": "DEBUG",
             "propagate": False,
         },
+        "__main__": {
+            "handlers": ["vllm"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
     },
     "version": 1,
 }


### PR DESCRIPTION
This PR import controller feature from fastchat, which make vllm could be running with its full openai compatible server of latest features.

* it inherits original fastchat controller core feature, such like model registry, auto scale, model roll update

* it keeps controller logic layer at minimal shape, which it would forward whatever user request pass to vllm openai compatible server worker

* it would also track each worker's unfinished queue length, and adjust the request sending speed accordingly. Thus keep the whole cluster balanced, and at its full serving capability.

* Currently, only v1/completions and v1/chat/completions are implemented. Along with other three interface to help check controller status. 
   * /list_workers: show current registered workers and their status
   * /health: whether current controller is functional 
   * /list_models: all registered model names

FILL IN THE PR DESCRIPTION HERE

FIX #4226 
Since vllm openai compatible server is evolving rapidly, I think we may need to move the control panel feature we
see from fastchat into vllm itself, to enjoy those feature fastchat brought to us along with latest vllm functions.
