### PR TITLE
[Bugfix] Bypass authorization API token for preflight requests

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -154,6 +154,8 @@ if __name__ == "__main__":
         @app.middleware("http")
         async def authentication(request: Request, call_next):
             root_path = "" if args.root_path is None else args.root_path
+            if request.method == "OPTIONS":
+                return await call_next(request)
             if not request.url.path.startswith(f"{root_path}/v1"):
                 return await call_next(request)
             if request.headers.get("Authorization") != "Bearer " + token:


### PR DESCRIPTION
> Browsers should not send credentials in preflight requests irrespective of this setting
[source](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included)

From this guideline, we can expect that almost all browsers won't send credentials during CORS preflight requests.

So, without this condition all preflight requests (OPTIONS) will reach the server without the authorization token and will be rejected by the middleware.

I searched for open issues, but wasn't able to find someone reporting this.