### PR TITLE
[Bugfix] Relax tiktoken to >= 0.6.0

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -14,7 +14,7 @@ uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
-tiktoken == 0.6.0  # Required for DBRX tokenizer
+tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.10.1
 outlines == 0.0.34 # Requires torch >= 2.1.0
 typing_extensions


### PR DESCRIPTION
vLLM has a [strict requirement on using tiktoken==0.6.0](https://github.com/vllm-project/vllm/blob/33e0823de583819f39e88c39ea3f7dd4e07c3990/requirements-common.txt#L17), to cater to the DBRX tokeniser. However, this means that we cannot use vLLM in the same environment as the newest tiktoken, which includes support for OpenAI's GPT-4o model.

FIX https://github.com/vllm-project/vllm/issues/4884

