### PR TITLE
[Build/CI] set CMAKE_BUILD_TYPE=release on wheel build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,7 @@ jobs:
         env:
           CMAKE_BUILD_TYPE: Release # do not compile with debug symbol to reduce wheel size
         run: |
+          export CMAKE_BUILD_TYPE=Release
           bash -x .github/workflows/scripts/build.sh ${{ matrix.python-version }} ${{ matrix.cuda-version }}
           wheel_name=$(ls dist/*whl | xargs -n 1 basename)
           asset_name=${wheel_name//"linux"/"manylinux1"}


### PR DESCRIPTION
This builds the Extensions with `-DCMAKE_BUILD_TYPE=Release`, which enables optimizations and disables debugging symbols in the generated build files. This results in faster smaller and  more efficient artifacts.


Thanks @z103cb @RH-steve-grubb