### PR TITLE
[CI/Build] Codespell ignore `build/` directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ exclude = [
 
 [tool.codespell]
 ignore-words-list = "dout, te, indicies"
-skip = "./tests/prompts,./benchmarks/sonnet.txt,./tests/lora/data"
+skip = "./tests/prompts,./benchmarks/sonnet.txt,./tests/lora/data,./build"
 
 [tool.isort]
 use_parentheses = true


### PR DESCRIPTION
Adds the `build/` directory to the ignore list of codespell. This directory is present after building binaries when installing from source.

Before this change, if you run `./format.sh --all` we will fail during the codespell check and report many issues like:
```
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:9967: finitel ==> finite
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27889: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27891: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27891: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27929: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27931: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27942: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27944: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27944: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27982: ans ==> and
./build/temp.linux-x86_64-3.10/CMakeFiles/3.29.2/CompilerIdCUDA/tmp/CMakeCUDACompilerId.cpp4.ii:27984: ans ==> and
...
```