### PR TITLE
Add Punica operator configuration to adapt to Chinese-Alpaca-Llama2-7b 

### DIFF
--- a/csrc/punica/bgmv/bgmv_config.h
+++ b/csrc/punica/bgmv/bgmv_config.h
@@ -67,7 +67,7 @@ void bgmv_kernel(out_T *__restrict__ Y, const in_T *__restrict__ X,
     f(in_T, out_T, W_T, narrow, 64000) \
     f(in_T, out_T, W_T, narrow, 64256) \
     f(in_T, out_T, W_T, narrow, 64512) \
-    f(in_T, out_T, W_T, narrow, 76032 ) \
+    f(in_T, out_T, W_T, narrow, 76032) \
     f(in_T, out_T, W_T, narrow, 102400) \
     f(in_T, out_T, W_T, narrow, 102656) \
     f(in_T, out_T, W_T, narrow, 102912) \

--- a/csrc/punica/bgmv/bgmv_config.h
+++ b/csrc/punica/bgmv/bgmv_config.h
@@ -63,9 +63,11 @@ void bgmv_kernel(out_T *__restrict__ Y, const in_T *__restrict__ X,
     f(in_T, out_T, W_T, narrow, 36864) \
     f(in_T, out_T, W_T, narrow, 43264) \
     f(in_T, out_T, W_T, narrow, 49152) \
+    f(in_T, out_T, W_T, narrow, 55552) \
     f(in_T, out_T, W_T, narrow, 64000) \
     f(in_T, out_T, W_T, narrow, 64256) \
     f(in_T, out_T, W_T, narrow, 64512) \
+    f(in_T, out_T, W_T, narrow, 76032 ) \
     f(in_T, out_T, W_T, narrow, 102400) \
     f(in_T, out_T, W_T, narrow, 102656) \
     f(in_T, out_T, W_T, narrow, 102912) \


### PR DESCRIPTION
[Bug]: RuntimeError: No suitable kernel. h_in=16 h_out=3424 dtype=Float out_dtype=BFloat16 #3793