### PR TITLE
[Bugfix] Adds outlines performance improvement

### DIFF
--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -28,17 +28,24 @@ from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 
 
+class LogitsInfo:
+
+    def __init__(self, fsm: FSM):
+        self.fsm: FSM = fsm
+        self.mask: Optional[torch.Tensor] = None
+        self.allowed_tokens: Dict[int, torch.Tensor] = {}
+        self.cache_hash: Dict[int, int] = {}
+
+
 class BaseLogitsProcessor:
 
-    def __init__(self):
-        # Child class should use initialize in their init.
-        self.fsm: FSM
-        self.mask: Optional[torch.Tensor] = None
-        self.allowed_tokens_cache: Dict[tuple, torch.Tensor] = {}
+    def __init__(self, fsm: FSM):
+        self.fsm = fsm
 
     def init_state(self):
         """Initialize the FSM states"""
         self.fsm_state: DefaultDict[int, int] = defaultdict(int)
+        self.info: LogitsInfo = LogitsInfo(self.fsm)
 
     def __call__(self, input_ids: List[int],
                  scores: torch.Tensor) -> torch.Tensor:
@@ -50,15 +57,17 @@ class BaseLogitsProcessor:
         else:
             last_token = input_ids[-1]
             last_seq_id = hash(tuple(input_ids[:-1]))
-            self.fsm_state[seq_id] = self.fsm.next_state(
+            self.fsm_state[seq_id] = self.info.fsm.next_state(
                 self.fsm_state[last_seq_id], last_token)
 
         state = self.fsm_state[seq_id]
-        allowed_tokens = self.fsm.allowed_token_ids(state)
-        allowed_tokens_key = tuple(allowed_tokens)
+        allowed_tokens = self.info.fsm.allowed_token_ids(state)
 
-        # Retrieve allowed tokens from cache using the current state
-        if allowed_tokens_key not in self.allowed_tokens_cache:
+        allowed_tokens_hash = hash(tuple(allowed_tokens))
+        cacheEntry = (self.info.allowed_tokens[allowed_tokens_hash]
+                      if allowed_tokens_hash in self.info.cache_hash else None)
+
+        if cacheEntry is None:
             # Cache miss, calculate allowed tokens and cache them
             np_allowed_tokens = np.array(allowed_tokens, dtype=np.int32)
             allowed_tokens_tensor = torch.from_numpy(
@@ -70,24 +79,35 @@ class BaseLogitsProcessor:
             else:
                 allowed_tokens_tensor = allowed_tokens_tensor.to(torch.int64)
 
-            self.allowed_tokens_cache[
-                allowed_tokens_key] = allowed_tokens_tensor
+            self.info.allowed_tokens[
+                allowed_tokens_hash] = allowed_tokens_tensor
+            self.info.cache_hash[allowed_tokens_hash] = allowed_tokens_hash
 
         else:
-            allowed_tokens_tensor = self.allowed_tokens_cache[
-                allowed_tokens_key]
+            allowed_tokens_tensor = self.info.allowed_tokens[
+                allowed_tokens_hash]
 
-        if self.mask is None:
-            self.mask = torch.full((scores.shape[-1], ),
-                                   -math.inf,
-                                   device=scores.device)
+        if self.info.mask is None:
+            self.info.mask = torch.full((scores.shape[-1], ),
+                                        -math.inf,
+                                        device=scores.device)
         else:
-            self.mask.fill_(-math.inf)
+            self.info.mask.fill_(-math.inf)
 
-        self.mask.index_fill_(0, allowed_tokens_tensor, 0)
-        scores.add_(self.mask)
+        self.info.mask.index_fill_(0, allowed_tokens_tensor, 0)
+        scores.add_(self.info.mask)
 
         return scores
+
+    def state_reset_required(self) -> bool:
+        """Determine if a state reset is required for this processor.
+
+        Returns
+        -------
+        bool
+            Indicates whether a reset is required. Default is False.
+        """
+        return False
 
 
 class RegexLogitsProcessor(BaseLogitsProcessor):
@@ -105,9 +125,7 @@ class RegexLogitsProcessor(BaseLogitsProcessor):
         """
         tokenizer = _adapt_tokenizer(tokenizer)
         fsm = RegexFSM(regex_string, tokenizer)
-        self.fsm = fsm
-        self.mask: Optional[torch.Tensor] = None
-        self.allowed_tokens_cache: Dict[tuple, torch.Tensor] = {}
+        super().__init__(fsm=fsm)
 
 
 class JSONLogitsProcessor(RegexLogitsProcessor):
@@ -163,14 +181,20 @@ class CFGLogitsProcessor(BaseLogitsProcessor):
         """
         tokenizer = _adapt_tokenizer(tokenizer)
         fsm = CFGFSM(cfg, tokenizer)
-        self.fsm = fsm
-        self.mask: Optional[torch.Tensor] = None
-        self.allowed_tokens_cache: Dict[tuple, torch.Tensor] = {}
+        self._previous_fsm = None
+        super().__init__(fsm=fsm)
 
     def init_state(self):
         """Initialize state with a CFGFSM copy."""
         super().init_state()
-        self.fsm = self.fsm.copy()
+        self.fsm = self.info.fsm.copy()
+
+    def state_reset_required(self) -> bool:
+        requiresReset = (self._previous_fsm is None or self.info.fsm.regex_fsm
+                         is not self.info._previous_fsm)
+
+        self._previous_fsm = self.info.fsm.regex_fsm
+        return requiresReset
 
 
 @lru_cache


### PR DESCRIPTION
This addresses concurrency performance issues when using Outlines leading to high CPU usage and a reduction in batching throughput. Timings showed ~1600% performance increase but I would very much appreciate validation of this method!

Overall approach:

1. Moved the mask to be created once for each request rather than per iteration to reduce memory allocations.
2. Use a simple caching object to reduce overall computational and data transformation costs.
3. Convert to a numpy array as this showed a 200% decrease in cost for Python List to Tensor conversion.
4. Offload int32 to int64 conversion to the GPU to maximize throughput.
5. Use non_blocking during tensor move operations to reduce CPU contention.

```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    46                                               @line_profiler.profile
    47                                               def __call__(self, input_ids: List[int],
    48                                                            scores: torch.Tensor) -> torch.Tensor:
    49                                                   """Use the FSM to bias the logits before sampling the next token."""
    50     38607     210730.1      5.5      5.6          seq_id = hash(tuple(input_ids))
    51
    52     38607      17504.0      0.5      0.5          if len(input_ids) == 0:
    53        48        430.8      9.0      0.0              self.init_state()
    54                                                   else:
    55     38559       9725.8      0.3      0.3              last_token = input_ids[-1]
    56     38559     148043.9      3.8      3.9              last_seq_id = hash(tuple(input_ids[:-1]))
    57     77118     102817.6      1.3      2.7              self.fsm_state[seq_id] = self.fsm.next_state(
    58     38559      25271.5      0.7      0.7                  self.fsm_state[last_seq_id], last_token)
    59
    60     38607      11364.8      0.3      0.3          state = self.fsm_state[seq_id]
    61
    62                                                   # Retrieve allowed tokens from cache using the current state
    63     38607      11408.9      0.3      0.3          if state not in self.allowed_tokens_cache:
    64                                                       # Cache miss, calculate allowed tokens and cache them
    65       576     175710.0    305.1      4.7              allowed_tokens = self.fsm.allowed_token_ids(state)
    66       576     793771.6   1378.1     21.1              np_allowed_tokens = np.array(allowed_tokens, dtype=np.int32)
    67       576       2933.5      5.1      0.1              allowed_tokens_tensor = torch.from_numpy(np_allowed_tokens)
    68                                                       
    69       576        812.7      1.4      0.0              if (allowed_tokens_tensor.device != scores.device):
    70       576    1434945.6   2491.2     38.1                  allowed_tokens_tensor = allowed_tokens_tensor.to(scores.device, dtype=torch.int64, non_blocking=True)
    71                                                       else:
    72                                                           allowed_tokens_tensor = allowed_tokens_tensor.to(torch.int64)
    73
    74       576        600.9      1.0      0.0              self.allowed_tokens_cache[state] = allowed_tokens_tensor
    75
    76                                                   else:
    77     38031      11473.7      0.3      0.3              allowed_tokens_tensor = self.allowed_tokens_cache[self.fsm_state[seq_id]]
    78
    79     38607      10663.8      0.3      0.3          if self.mask is None:
    80        48        928.5     19.3      0.0              self.mask = torch.full_like(scores, -math.inf)
    81                                                   else:
    82     38559     291444.4      7.6      7.7              self.mask.fill_(-math.inf)
    83                                                   
    84     38607     285348.3      7.4      7.6          self.mask.index_fill_(0, allowed_tokens_tensor, 0)
    85     38607     209957.4      5.4      5.6          scores.add_(self.mask)
    86
    87     38607       7854.3      0.2      0.2          return scores
```

Fixes #3567

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


