### PR TITLE
Bump version to v0.4.3

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -11,7 +11,7 @@ from vllm.outputs import (CompletionOutput, EmbeddingOutput,
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 __all__ = [
     "LLM",


### PR DESCRIPTION
Result from @KuntaiDu 
https://kuntai.notion.site/vLLM-benchmark-455e830910034635839e356bcb14604b?pvs=4


|  | Offline Request throughput (req/s)/ Token throughput (tok/s) | Online Request throughput (req/s)/ Input token throughput (tok/s)/ Output token throughput (tok/s) |
| --- | --- | --- |
| 1GPU, Llama 7B, v0.4.2 | 14.33/6895.75 | 12.29/3024.07/2396.00 |
| 4GPU,  Llama 70B, v0.4.2 | 8.05/3871.86 | 7.20/1770.12/1460.62 |
| 1GPU, Llama 7B, v0.4.3 | 15.62/7516.03 | 13.18/3241.44/2566.47 |
| 4GPU,  Llama 70B, v0.4.3 | 10.15/4884.14 | 8.62/2120.21/1749.05 |
