### PR TITLE
[Misc] add gpu_memory_utilization arg

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -35,8 +35,7 @@ def main(args: argparse.Namespace):
               enable_chunked_prefill=args.enable_chunked_prefill,
               download_dir=args.download_dir,
               block_size=args.block_size,
-              gpu_memory_utilization=args.gpu_memory_utilization
-              )
+              gpu_memory_utilization=args.gpu_memory_utilization)
 
     sampling_params = SamplingParams(
         n=args.n,

--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -34,7 +34,9 @@ def main(args: argparse.Namespace):
               use_v2_block_manager=args.use_v2_block_manager,
               enable_chunked_prefill=args.enable_chunked_prefill,
               download_dir=args.download_dir,
-              block_size=args.block_size)
+              block_size=args.block_size,
+              gpu_memory_utilization=args.gpu_memory_utilization
+              )
 
     sampling_params = SamplingParams(
         n=args.n,
@@ -211,5 +213,11 @@ if __name__ == '__main__':
         type=str,
         default=None,
         help='Path to save the latency results in JSON format.')
+    parser.add_argument('--gpu-memory-utilization',
+                        type=float,
+                        default=0.9,
+                        help='the fraction of GPU memory to be used for '
+                        'the model executor, which can range from 0 to 1.'
+                        'If unspecified, will use the default value of 0.9.')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
For Larger models like: meta-llama/Meta-Llama-3-70B  It throws

 ValueError: The model's max seq len (8192) is larger than the maximum number of tokens that can be stored in KV cache (4688). Try increasing `gpu_memory_utilization` or decreasing `max_model_len` when initializing the engine. 

It's required to specify gpu_memory_utilization to successfully run the benchmark. 




