### PR TITLE
[Bugfix] Fix arguments passed to `Sequence` in stop checker test

### DIFF
--- a/tests/engine/output_processor/test_stop_checker.py
+++ b/tests/engine/output_processor/test_stop_checker.py
@@ -15,8 +15,11 @@ def sequence_with_eos(text: str, eos_token: str,
     """
     seq = Sequence(
         seq_id=0,
-        prompt="",
-        prompt_token_ids=[],
+        inputs={
+            "prompt": "",
+            "prompt_token_ids": [],
+            "multi_modal_data": None,
+        },
         block_size=16,
         eos_token_id=eos_token_id,
     )


### PR DESCRIPTION
Incorrect arguments are being passed to `Sequence` in #5077 after it was changed in #4328.

This PR updates the test in #5077 to fix this issue.