### PR TITLE
[Bugfix][CI/Build] Fix codespell failing to skip files in `git diff`

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -113,8 +113,11 @@ mypy vllm/logging --config-file pyproject.toml
 mypy vllm/model_executor --config-file pyproject.toml
 
 
+# If git diff returns a file that is in the skip list, the file may be checked anyway:
+# https://github.com/codespell-project/codespell/issues/1915
+# Avoiding the "./" prefix and using "/**" globs for directories appears to solve the problem
 CODESPELL_EXCLUDES=(
-    '--skip' '*docs/source/_build/**,./tests/lora/data'
+    '--skip' 'tests/prompts/**,./benchmarks/sonnet.txt,tests/lora/data/**,build/**'
 )
 
 # check spelling of specified files


### PR DESCRIPTION
This PR fixes an issue where `codespell` incorrectly includes files returned by `git diff` even though they are supposedly filtered by the `skip` CLI option. This is probably related to an existing bug in codespell (codespell-project/codespell#1915).

This PR also updates the `skip`ped directories to be consistent with those in `pyproject.toml`.

### Related contributions

This is part 2/5 of #5004.