### PR TITLE
[KERNEL] int8 quantization kernel refactoring & optimization WIP

### DIFF
--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -26,7 +26,7 @@ static inline __device__ int8_t float_to_int8_rn(float x) {
 namespace vllm {
 
 template <typename scalar_t, typename scale_type>
-__global__ void static_scaled_int8_quant_kernel3(
+__global__ void static_scaled_int8_quant_kernel(
     const scalar_t* __restrict__ input, int8_t* __restrict__ out,
     scale_type inverted_scale, const int hidden_size) {
   const int tid = threadIdx.x;
@@ -56,18 +56,6 @@ __global__ void static_scaled_int8_quant_kernel3(
   }
 }
 
-template <typename scalar_t, typename scale_type>
-__global__ void static_scaled_int8_quant_kernel(
-    const scalar_t* __restrict__ input, int8_t* __restrict__ out,
-    scale_type scale, const int hidden_size) {
-  const int tid = threadIdx.x;
-  const int token_idx = blockIdx.x;
-
-  for (int i = tid; i < hidden_size; i += blockDim.x) {
-    out[token_idx * hidden_size + i] =
-        float_to_int8_rn(((float)input[token_idx * hidden_size + i]) * scale);
-  }
-}
 }  // namespace vllm
 
 void static_scaled_int8_quant(torch::Tensor& out,    // [..., hidden_size]

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -27,7 +27,7 @@ static inline __device__ int8_t half_to_int8_rn(__half x) {
   uint32_t dst;
   unsigned short conv = *(reinterpret_cast<unsigned short*>(&(x)));
   asm("cvt.rni.sat.s8.f16 %0, %1;" : "=r"(dst) : "h"(conv));
-  return dst;
+  return static_cast<int8_t>dst;
 }
 
 namespace vllm {

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -27,7 +27,7 @@ static inline __device__ int8_t half_to_int8_rn(__half x) {
   uint32_t dst;
   unsigned short conv = *(reinterpret_cast<unsigned short*>(&(x)));
   asm("cvt.rni.sat.s8.f16 %0, %1;" : "=r"(dst) : "h"(conv));
-  return static_cast<int8_t>dst;
+  return static_cast<int8_t>(dst);
 }
 
 namespace vllm {

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -23,39 +23,79 @@ static inline __device__ int8_t float_to_int8_rn(float x) {
 #endif
 }
 
+static inline __device__ int8_t half_to_int8_rn(__half x) {
+  uint32_t dst;
+  unsigned short conv = *(reinterpret_cast<unsigned short*>(&(x)));
+  asm("cvt.rni.sat.s8.f16 %0, %1;" : "=r"(dst) : "h"(conv));
+  return dst;
+}
+
 namespace vllm {
+
+typedef struct __align__(8) {
+  half x;
+  half y;
+  half z;
+  half w;
+}
+half4;
 
 template <typename scalar_t, typename scale_type>
 __global__ void static_scaled_int8_quant_kernel(
     const scalar_t* __restrict__ input, int8_t* __restrict__ out,
-    scale_type inverted_scale, const int hidden_size) {
+    scale_type inverted_scale, const int hidden_size);
+
+template <>
+__global__ void static_scaled_int8_quant_kernel<at::Half, float>(
+    const at::Half* __restrict__ input, int8_t* __restrict__ out,
+    float inverted_scale, const int hidden_size) {
   const int tid = threadIdx.x;
   const int token_idx = blockIdx.x;
-  const float4* vectorized = reinterpret_cast<const float4*>(input);
+  const half4* vectorized = reinterpret_cast<const half4*>(input);
   const int traverse_space = hidden_size >> 2;
+  // float2half is inexpensive plus multiplying two halves leads to a larger
+  // loss of precision
+  const __half h_inverted_scale = __float2half(inverted_scale);
 
 #pragma unroll 4
   for (int i = tid; i < traverse_space; i += blockDim.x) {
     int index = token_idx * traverse_space + i;
 
-    float4 data = vectorized[index];
+    half4 data_half4 = vectorized[index];
 
-    data.x *= inverted_scale;
-    data.y *= inverted_scale;
-    data.z *= inverted_scale;
-    data.w *= inverted_scale;
+    float4 data_float4;
+    data_float4.x = __half2float(data_half4.x) * inverted_scale;
+    data_float4.y = __half2float(data_half4.y) * inverted_scale;
+    data_float4.z = __half2float(data_half4.z) * inverted_scale;
+    data_float4.w = __half2float(data_half4.w) * inverted_scale;
 
-    // use char4 for vectorized stores
+    int8_t quantized0 = half_to_int8_rn(__float2half(data_float4.x));
+    int8_t quantized1 = half_to_int8_rn(__float2half(data_float4.y));
+    int8_t quantized2 = half_to_int8_rn(__float2half(data_float4.z));
+    int8_t quantized3 = half_to_int8_rn(__float2half(data_float4.w));
+
     char4 store_value;
-    store_value.x = static_cast<char>(float_to_int8_rn(data.x));
-    store_value.y = static_cast<char>(float_to_int8_rn(data.y));
-    store_value.z = static_cast<char>(float_to_int8_rn(data.z));
-    store_value.w = static_cast<char>(float_to_int8_rn(data.w));
+    store_value.x = static_cast<char>(quantized0);
+    store_value.y = static_cast<char>(quantized1);
+    store_value.z = static_cast<char>(quantized2);
+    store_value.w = static_cast<char>(quantized3);
 
     reinterpret_cast<char4*>(out)[index] = store_value;
   }
 }
 
+template <typename scalar_t, typename scale_type>
+__global__ void static_scaled_int8_quant_kernel(
+    const scalar_t* __restrict__ input, int8_t* __restrict__ out,
+    scale_type scale, const int hidden_size) {
+  const int tid = threadIdx.x;
+  const int token_idx = blockIdx.x;
+
+  for (int i = tid; i < hidden_size; i += blockDim.x) {
+    out[token_idx * hidden_size + i] =
+        float_to_int8_rn(((float)input[token_idx * hidden_size + i]) * scale);
+  }
+}
 }  // namespace vllm
 
 void static_scaled_int8_quant(torch::Tensor& out,    // [..., hidden_size]


### PR DESCRIPTION
This refactors the int8 quantization kernel so that it will optimize `f32 -> i8`. However, please note that fp16 will require use of `half2` though. That can be done with some template specializations but for brevity I will leave that outside of this PR for now. 

1) Reorders instructions to improve ILP with unrolling(manual unrolling can also be done)
2) Use vectorized loads and stores for `fp32`, this will significantly increase memory throughput. 
3) Refactors to use the reciprocal of the scale so that we can avoid doing division on the GPU, which is categorically slower because of how many more instructions it leads to.  
4) From the profiling I've done, the problem is that there is a dependency chain of instructions going on. Warps get stalled at the multiplication becasue they are dependent on the memory instruction to complete before they get to do anything.  So we want to interleave independent instructions(this is handled by the unrolling) in order to minimize the stalling. 
5) Memory accesses are already coalesced from the original kernel. Since this streams into global memory, we aren't reusing data. Follows the same pattern as the original.

This was profiled on my 3080 and cuda 12.4. 
---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


