### PR TITLE
[Core] Bump up the default of --gpu_memory_utilization to be more similar to TensorRT Triton's default

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -10,6 +10,7 @@ import torch
 from tqdm import tqdm
 
 from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import DEFAULT_GPU_MEMORY_UTILIZATION
 from vllm.inputs import PromptStrictInputs
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
 
@@ -215,11 +216,13 @@ if __name__ == '__main__':
         type=str,
         default=None,
         help='Path to save the latency results in JSON format.')
-    parser.add_argument('--gpu-memory-utilization',
-                        type=float,
-                        default=0.9,
-                        help='the fraction of GPU memory to be used for '
-                        'the model executor, which can range from 0 to 1.'
-                        'If unspecified, will use the default value of 0.9.')
+    parser.add_argument(
+        '--gpu-memory-utilization',
+        type=float,
+        default=DEFAULT_GPU_MEMORY_UTILIZATION,
+        help='the fraction of GPU memory to be used for '
+        'the model executor, which can range '
+        ' from 0 to 1. If unspecified, will use the default value of {}.'.
+        format(DEFAULT_GPU_MEMORY_UTILIZATION))
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from transformers import (AutoModelForCausalLM, AutoTokenizer,
                           PreTrainedTokenizerBase)
 
+from vllm.engine.arg_utils import DEFAULT_GPU_MEMORY_UTILIZATION
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
 
 
@@ -78,7 +79,7 @@ def run_vllm(
     enable_prefix_caching: bool,
     enable_chunked_prefill: bool,
     max_num_batched_tokens: int,
-    gpu_memory_utilization: float = 0.9,
+    gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
     download_dir: Optional[str] = None,
 ) -> float:
     from vllm import LLM, SamplingParams
@@ -313,12 +314,14 @@ if __name__ == "__main__":
         'The "auto" option will use FP16 precision '
         'for FP32 and FP16 models, and BF16 precision '
         'for BF16 models.')
-    parser.add_argument('--gpu-memory-utilization',
-                        type=float,
-                        default=0.9,
-                        help='the fraction of GPU memory to be used for '
-                        'the model executor, which can range from 0 to 1.'
-                        'If unspecified, will use the default value of 0.9.')
+    parser.add_argument(
+        '--gpu-memory-utilization',
+        type=float,
+        default=DEFAULT_GPU_MEMORY_UTILIZATION,
+        help='the fraction of GPU memory to be used for '
+        'the model executor, which can range '
+        'from 0 to 1. If unspecified, will use the default value of {}.'.
+        format(DEFAULT_GPU_MEMORY_UTILIZATION))
     parser.add_argument("--enforce-eager",
                         action="store_true",
                         help="enforce eager execution")

--- a/docs/source/serving/usage_stats.md
+++ b/docs/source/serving/usage_stats.md
@@ -29,7 +29,7 @@ Here is an example as of v0.4.0:
   "dtype": "torch.float16",
   "tensor_parallel_size": 1,
   "block_size": 16,
-  "gpu_memory_utilization": 0.9,
+  "gpu_memory_utilization": 0.98,
   "quantization": null,
   "kv_cache_dtype": "auto",
   "enable_lora": false,

--- a/tests/spec_decode/e2e/conftest.py
+++ b/tests/spec_decode/e2e/conftest.py
@@ -14,7 +14,8 @@ if (not is_hip()):
                         nvmlInit)
 
 from vllm import LLM
-from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.arg_utils import (DEFAULT_GPU_MEMORY_UTILIZATION,
+                                   AsyncEngineArgs)
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.utils import set_random_seed
@@ -52,7 +53,7 @@ class AsyncLLM:
         revision: Optional[str] = None,
         tokenizer_revision: Optional[str] = None,
         seed: int = 0,
-        gpu_memory_utilization: float = 0.9,
+        gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
         swap_space: int = 4,
         enforce_eager: bool = False,
         max_seq_len_to_capture: int = 8192,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -19,6 +19,9 @@ def nullable_str(val: str):
     return val
 
 
+DEFAULT_GPU_MEMORY_UTILIZATION = 0.98
+
+
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
@@ -45,7 +48,7 @@ class EngineArgs:
     disable_sliding_window: bool = False
     use_v2_block_manager: bool = False
     swap_space: int = 4  # GiB
-    gpu_memory_utilization: float = 0.90
+    gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
     max_logprobs: int = 5  # OpenAI default value
@@ -356,9 +359,10 @@ class EngineArgs:
             type=float,
             default=EngineArgs.gpu_memory_utilization,
             help='The fraction of GPU memory to be used for the model '
-            'executor, which can range from 0 to 1. For example, a value of '
-            '0.5 would imply 50%% GPU memory utilization. If unspecified, '
-            'will use the default value of 0.9.')
+            'executor, which can range from '
+            '0 to 1. For example, a value of 0.5 would imply 50%% GPU '
+            'memory utilization. If unspecified, will use the default value'
+            ' of {}.'.format(DEFAULT_GPU_MEMORY_UTILIZATION))
         parser.add_argument(
             '--num-gpu-blocks-override',
             type=int,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -4,7 +4,7 @@ from typing import ClassVar, List, Optional, Sequence, Union, cast, overload
 from tqdm import tqdm
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 
-from vllm.engine.arg_utils import EngineArgs
+from vllm.engine.arg_utils import DEFAULT_GPU_MEMORY_UTILIZATION, EngineArgs
 from vllm.engine.llm_engine import LLMEngine
 from vllm.inputs import (PromptInputs, PromptStrictInputs, TextPrompt,
                          TextTokensPrompt, TokensPrompt,
@@ -111,7 +111,7 @@ class LLM:
         revision: Optional[str] = None,
         tokenizer_revision: Optional[str] = None,
         seed: int = 0,
-        gpu_memory_utilization: float = 0.9,
+        gpu_memory_utilization: float = DEFAULT_GPU_MEMORY_UTILIZATION,
         swap_space: int = 4,
         enforce_eager: bool = False,
         max_context_len_to_capture: Optional[int] = None,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -174,7 +174,7 @@ class Worker(WorkerBase):
         # (to accommodate possible dynamic allocations)
         gb = 1024 * 1024 * 1024
         min_dynamic_memory = int(1.5 * gb)
-        
+
         unused_gpu_memory = total_gpu_memory - available_gpu_memory
         reserve_more = min_dynamic_memory - unused_gpu_memory
 


### PR DESCRIPTION
During our comparisons of vLLM vs TRT-LLM-Triton, we have found that the default value of *--gpu_memory_utilization=0.9* parameter in vLLM is not optimal compared to TRT's usage of *--kv_cache_free_gpu_mem_fraction*. In both vLLM and TRT, the default value used is 0.9, however, in TRT the 0.9 is applied on the memory that is available **after** the model is loaded, as described here [tensorrtllm_backend](https://github.com/triton-inference-server/tensorrtllm_backend/tree/r24.04): 

![image](https://github.com/vllm-project/vllm/assets/59768536/4346ada1-afb7-462c-be5e-20228f50c79b)

In vLLM, *--gpu_memory_utilization* is applied *before* the model is loaded, and this results in vLLM under utilizing the GPU resource. For example, for 81GB A100 and 65GB model like Llama3 70B (split over 2 GPUs), the GPU memory utilization for vLLM is reaching 72GB (88%), while for TRT it is reaching 80GB (98%). As a result, the batching via KV-cache is reduced for vLLM, which in turn hurts e2e user-latency and total throughput time.

This PR bumps up *--gpu_memory_utilization* default value from 0.9 to 0.98, so that vLLM will utilize GPU memory in a way that is more similar to TensorRT. To avoid OOM errors due to the bump, logic was added to ensure availability of 1.5GB GPU memory for dynamic allocations. 

To demonstrate the performance difference, an analysis of TTFT, TPOT, e2e-user-latency and total-time is attached for LLama3 70B on 2xA100 GPUs for QPS=1,2.5,5,7.5,10. The results show the effect of bumping gpu_util to 0.98 for both default scheduler and chunked prompt scheduler. We can see that with 0.98 gpu_util and chunked scheduler, vLLM is able to achieve the same e2e latency and throughput as the optimized TensorRT-LLM-Triton (with chunked prompt or without).

![image](https://github.com/vllm-project/vllm/assets/59768536/f1b42bb1-a216-47af-9b1c-83bfd0bbac87)

Original PDF for the benchmark:

[TRT-LLM-Triton_vs_vLLM_old_vs_vLLM_new_for_Llama3_70B_2xA100_p256_o128.pdf](https://github.com/user-attachments/files/15516208/TRT-LLM-Triton_vs_vLLM_old_vs_vLLM_new_for_Llama3_70B_2xA100_p256_o128.pdf)

To reproduce these results, we have created a [tensorrt-demo](https://github.com/neuralmagic/tensorrt-demo) repository that outlines the steps that need to be taken to run TRT-LLM-Triton and vLLM.


