### PR TITLE
[Build] Do not compile cutlass scaled_mm on CUDA 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,21 +191,29 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     "csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu"
     "csrc/quantization/gptq_marlin/gptq_marlin.cu"
     "csrc/quantization/gptq_marlin/gptq_marlin_repack.cu"
-    "csrc/custom_all_reduce.cu"
-    "csrc/quantization/cutlass_w8a8/scaled_mm_dq_entry.cu"
-    "csrc/quantization/cutlass_w8a8/scaled_mm_dq_c2x.cu"
-    "csrc/quantization/cutlass_w8a8/scaled_mm_dq_c3x.cu")
+    "csrc/custom_all_reduce.cu")
 
-  #
+  # CUTLASS doesn't compile for sm90 on CUDA 11 so we only enable it in CUDA 12.
   # The CUTLASS kernels for Hopper require sm90a to be enabled.
   # This is done via the below gencode option, BUT that creates kernels for both sm90 and sm90a.
   # That adds an extra 17MB to compiled binary, so instead we selectively enable it.
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0)
+    list(APPEND VLLM_EXT_SRC
+      "csrc/quantization/cutlass_w8a8/scaled_mm_dq_entry.cu"
+      "csrc/quantization/cutlass_w8a8/scaled_mm_dq_c2x.cu"
+      "csrc/quantization/cutlass_w8a8/scaled_mm_dq_c3x.cu")
     set_source_files_properties(
           "csrc/quantization/cutlass_w8a8/scaled_mm_dq_c3x.cu"
           PROPERTIES
           COMPILE_FLAGS
           "-gencode arch=compute_90a,code=sm_90a")
+  else()
+    set_source_files_properties(
+          "csrc/pybind.cpp"
+          PROPERTIES
+          COMPILE_FLAGS
+          "-D DISABLE_CUTLASS_SCALED_MM")
+
   endif()
 
 endif()

--- a/csrc/pybind.cpp
+++ b/csrc/pybind.cpp
@@ -51,9 +51,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   ops.def("gptq_marlin_repack", &gptq_marlin_repack,
           "gptq_marlin repack from GPTQ");
   ops.def("awq_dequantize", &awq_dequantize, "Dequantization for AWQ");
+#ifndef DISABLE_CUTLASS_SCALED_MM
   ops.def("cutlass_scaled_mm_dq", &cutlass_scaled_mm_dq,
           "CUTLASS w8a8 GEMM, supporting symmetric per-tensor or "
           "per-row/column quantization.");
+#endif
 #endif
 
   ops.def("gptq_gemm", &gptq_gemm, "Quantized GEMM for GPTQ");


### PR DESCRIPTION
This PRs moves the cutlass kernel into a block that only compiles in CUDA 12. So we can avoid compilation issue in CUDA 11

https://github.com/vllm-project/vllm/actions/runs/9313161417/job/25635186169