### PR TITLE
bug fixed: cuda out of memory lead to 'AsyncEngineDeadError: Background loop has errored already.

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -526,10 +526,13 @@ class AsyncLLMEngine:
                 self.set_errored(exc)
                 raise
             except Exception as e:
-                # maybe cuda out of memory or other exception, this exception lead to AsyncEngineDeadError: Background loop has errored already.
-                logger.error(f"Engine iteration error: {str(e)}")
+                # maybe cuda out of memory or other exception 
+                # lead to AsyncEngineDeadError: Background 
+                # loop has errored already.
+                logger.error("Engine iteration error: %s .", str(e))
 
-                # abort all of request that impacted by this exception, then later request can be processed normally.
+                # abort all of request that impacted by this exception,
+                # then later request can be processed normally.
                 self._error_callback(e)
             await asyncio.sleep(0)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -525,6 +525,12 @@ class AsyncLLMEngine:
                     "Engine iteration timed out. This should never happen!")
                 self.set_errored(exc)
                 raise
+            except Exception as e:
+                # maybe cuda out of memory or other exception, this exception lead to AsyncEngineDeadError: Background loop has errored already.
+                logger.error(f"Engine iteration error: {str(e)}")
+
+                # abort all of request that impacted by this exception, then later request can be processed normally.
+                self._error_callback(e)
             await asyncio.sleep(0)
 
     async def add_request(


### PR DESCRIPTION
cuda out of memory lead to 'AsyncEngineDeadError: Background loop has errored already.', then later request can NOT  be processed, it means, async engine was dead and need to restart vllm engine for continue service.  

we can catch the cuda OOM exception (maybe other exception for AMD devices) and abort current and other running request, then later request can be processed normally. Of course, got an cuda OOM exception, other running request can not be continue, I hope vlmm should add an offload features.

the code I changed:
```diff
 async def run_engine_loop(self):
        has_requests_in_progress = False
        while True:
            if not has_requests_in_progress:
                logger.debug("Waiting for new requests...")
                await self._request_tracker.wait_for_new_requests()
                logger.debug("Got new requests!")

            # Abort if iteration takes too long due to unrecoverable errors
            # (eg. NCCL timeouts).
            try:
                has_requests_in_progress = await asyncio.wait_for(
                    self.engine_step(), ENGINE_ITERATION_TIMEOUT_S)
            except asyncio.TimeoutError as exc:
                logger.error(
                    "Engine iteration timed out. This should never happen!")
                self.set_errored(exc)
                raise
+           except Exception as e:
+               # maybe cuda out of memory or other exception 
+               # lead to AsyncEngineDeadError: Background 
+               # loop has errored already.
+               logger.error("Engine iteration error: %s .", str(e))
+
+               # abort all of request that impacted by this exception,
+               # then later request can be processed normally.
+               self._error_callback(e)
            await asyncio.sleep(0)
```

FIX #3310
FIX #3338
FIX #4879
FIX #5784
