### PR TITLE
update setup.py to also build for CPU wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -381,9 +381,11 @@ def get_requirements() -> List[str]:
 
 
 ext_modules = []
+cmd_class = {}
 
 if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
+    cmd_class = {"build_ext": cmake_build_ext}
 
 if not _is_neuron():
     ext_modules.append(CMakeExtension(name="vllm._C"))
@@ -428,6 +430,6 @@ setup(
     extras_require={
         "tensorizer": ["tensorizer>=2.9.0"],
     },
-    cmdclass={"build_ext": cmake_build_ext} if not _is_neuron() else {},
+    cmdclass=cmd_class,
     package_data=package_data,
 )


### PR DESCRIPTION
This PR aimed to fix the bug for CPU wheel build.

Before the fix, if you try to do

```
VLLM_TARGET_DEVICE=cpu pip3 wheel . --no-deps
```

Will still trigger the extension build for GPU and hence cause failure. The following PR addressed the issue through
- Explicit check if CUDA or HIP (RocM) environment enabled to run the extension build
- AWS Neuron and CPU is skipped from the build

Tested locally and see it works:

```
# VLLM_TARGET_DEVICE=cpu pip3 wheel . --no-deps
Processing /workspace/vllm
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: vllm
  Building wheel for vllm (pyproject.toml) ... done
  Created wheel for vllm: filename=vllm-0.4.3+cpu-cp310-cp310-linux_x86_64.whl size=617069 sha256=1a106e3aba64963fa2f1beb46b47bc1631940f0989b611e1605c86d4994f7d72
  Stored in directory: /tmp/pip-ephem-wheel-cache-hc3l8oop/wheels/17/3e/94/a775b439b762a13c499e485f8d7299b6a897e6162642ee6e88
Successfully built vllm
```


