### PR TITLE
[Bugfix] Fix torch.compile() error when using MultiprocessingGPUExecutor

### DIFF
--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -34,6 +34,9 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
         # Ensure that VLLM_INSTANCE_ID is set, to be inherited by workers
         os.environ["VLLM_INSTANCE_ID"] = get_vllm_instance_id()
 
+        # Disable torch async compiling which won't work with daemonic processes
+        os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
+
         from torch.cuda import device_count
         assert world_size <= device_count(), (
             "please set tensor_parallel_size to less than max local gpu count")


### PR DESCRIPTION
`torch.compile()` by default will use a process pool for async compiling which doesn't work with `MultiprocessingGPUExecutor`. Models uses `torch.compile()` like commandr therefore won't work:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/var/data/home/vllm-upstream/benchmarks/benchmark_latency.py", line 226, in <module>
[rank0]:     main(args)
[rank0]:   File "/var/data/home/vllm-upstream/benchmarks/benchmark_latency.py", line 22, in main
[rank0]:     llm = LLM(model=args.model,
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/entrypoints/llm.py", line 143, in __init__
[rank0]:     self.llm_engine = LLMEngine.from_engine_args(
[rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/engine/llm_engine.py", line 359, in from_engine_args
[rank0]:     engine = cls(
[rank0]:              ^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/engine/llm_engine.py", line 222, in __init__
[rank0]:     self.model_executor = executor_class(
[rank0]:                           ^^^^^^^^^^^^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/distributed_gpu_executor.py", line 25, in __init__
[rank0]:     super().__init__(*args, **kwargs)
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/executor_base.py", line 41, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/multiproc_gpu_executor.py", line 66, in _init_executor
[rank0]:     self._run_workers("load_model",
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/multiproc_gpu_executor.py", line 123, in _run_workers
[rank0]:     ] + [output.get() for output in worker_outputs]
[rank0]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/multiproc_gpu_executor.py", line 123, in <listcomp>
[rank0]:     ] + [output.get() for output in worker_outputs]
[rank0]:          ^^^^^^^^^^^^
[rank0]:   File "/var/data/home/vllm-upstream/vllm/executor/multiproc_worker_utils.py", line 58, in get
[rank0]:     raise self.result.exception
[rank0]: AssertionError: daemonic processes are not allowed to have children
ERROR 06-03 20:34:21 multiproc_worker_utils.py:119] Worker VllmWorkerProcess pid 114600 died, exit code: -15
```

Setting `TORCHINDUCTOR_COMPILE_THREADS` to 1 can disable the async compiling process pool.