### PR TITLE
[BugFix]Fix the problem that StopChecker assumes a single token produ…

### DIFF
--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -57,16 +57,16 @@ class StopChecker:
             return
 
         # Check if a stop token was encountered.
-        # This assumes a single token produced per step.
-        last_token_id = seq.get_last_token_id()
-        if last_token_id in sampling_params.stop_token_ids:
-            if new_char_count and (
-                    not sampling_params.include_stop_str_in_output):
-                # Remove last token
-                seq.output_text = seq.output_text[:-new_char_count]
-            seq.status = SequenceStatus.FINISHED_STOPPED
-            seq.stop_reason = last_token_id
-            return
+        last_token_ids = seq.get_last_few_token_ids(new_char_count)
+        for last_token_id in last_token_ids:
+            if last_token_id in sampling_params.stop_token_ids:
+                if new_char_count and (
+                        not sampling_params.include_stop_str_in_output):
+                    # Remove last token
+                    seq.output_text = seq.output_text[:-new_char_count]
+                seq.status = SequenceStatus.FINISHED_STOPPED
+                seq.stop_reason = last_token_id
+                return
 
         # Check if any stop strings are matched.
         stop_str = self._check_stop_strings(seq, new_char_count,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -189,6 +189,11 @@ class SequenceData:
         if not self.output_token_ids:
             return self.prompt_token_ids[-1]
         return self.output_token_ids[-1]
+    
+    def get_last_few_token_ids(self, num: int) -> List[int]:
+        if not self.output_token_ids:
+            return self.prompt_token_ids[-num:]
+        return self.output_token_ids[-num:]
 
     def get_prompt_token_ids(self) -> List[int]:
         return self.prompt_token_ids
@@ -337,6 +342,9 @@ class Sequence:
 
     def get_last_token_id(self) -> int:
         return self.data.get_last_token_id()
+    
+    def get_last_few_token_ids(self, num) -> List[int]:
+        return self.data.get_last_few_token_ids(num)
 
     def get_output_token_ids(self) -> List[int]:
         return self.data.output_token_ids


### PR DESCRIPTION
FIX the problem that StopChecker assumes a single token produced per step.

In https://github.com/vllm-project/vllm/blob/main/vllm/engine/output_processor/stop_checker.py#L60, the stop checker assumes a single token produced per step, however, it's common that there will be a few tokens produced per step.

If the generated tokens happen to be: `end_token_id, id_1, id_2` some time, then `last_token_id = seq.get_last_token_id()` would capture `id_2`, thereby missing the check for `sampling_params.stop_token_ids`.

I add a function `get_last_few_token_ids()`, and corresponding `get_last_few_token_ids` to solve this problem.

