### PR TITLE
[Bugfix] Fix a bug caused by pip install setuptools>=49.4.0 for CPU backend

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -7,7 +7,7 @@ RUN apt-get update  -y \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 10 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 
 RUN pip install --upgrade pip \
-    && pip install wheel packaging ninja setuptools>=49.4.0 numpy
+    && pip install wheel packaging ninja "setuptools>=49.4.0" numpy
 
 FROM cpu-test-1 AS build
 

--- a/docs/source/getting_started/cpu-installation.rst
+++ b/docs/source/getting_started/cpu-installation.rst
@@ -54,7 +54,7 @@ Build from source
 .. code-block:: console
 
     $ pip install --upgrade pip
-    $ pip install wheel packaging ninja setuptools>=49.4.0 numpy
+    $ pip install wheel packaging ninja "setuptools>=49.4.0" numpy
     $ pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
 
 - Finally, build and install vLLM CPU backend: 


### PR DESCRIPTION
Hi all,

When I use `docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=4g .` to build a cpu docker, I find a file named `=49.4.0` in the CPU docker instance. Please see the following picture for this bug.
<img width="774" alt="WeChatWorkScreenshot_3492a09e-b8e8-4e32-a5f8-0e27f922e51c" src="https://github.com/vllm-project/vllm/assets/19923746/654f7e1e-d225-4d83-95ee-0ffeeea435cb">

It is caused by 
```
RUN pip install --upgrade pip \
    && pip install wheel packaging ninja setuptools>=49.4.0 numpy
```
in the Dockerfile.cpu

Actually, `pip install setuptools>=49.4.0` is incorrect to install the expected setuptools, which can be fixed by
```
pip install "setuptools>=49.4.0"
```

It would be better to fix it.

Thanks.
Best regards,
Jie
