### PR TITLE
[CI/Build] Simplify model loading for `HfRunner`

### DIFF
--- a/tests/models/test_embedding.py
+++ b/tests/models/test_embedding.py
@@ -28,7 +28,7 @@ def test_models(
     model: str,
     dtype: str,
 ) -> None:
-    hf_model = hf_runner(model, dtype=dtype)
+    hf_model = hf_runner(model, dtype=dtype, is_embedding_model=True)
     hf_outputs = hf_model.encode(example_prompts)
     del hf_model
 

--- a/tests/models/test_llava.py
+++ b/tests/models/test_llava.py
@@ -94,7 +94,7 @@ def test_models(hf_runner, vllm_runner, hf_image_prompts, hf_images,
     """
     model_id, vision_language_config = model_and_config
 
-    hf_model = hf_runner(model_id, dtype=dtype)
+    hf_model = hf_runner(model_id, dtype=dtype, is_vision_model=True)
     hf_outputs = hf_model.generate_greedy(hf_image_prompts,
                                           max_tokens,
                                           images=hf_images)


### PR DESCRIPTION
This PR removes the need to manually register new models for loading HuggingFace models in tests. Instead, you should now pass `is_embedding_model` or `is_vision_model` to the `HfRunner` to indicate how to load the model.