### PR TITLE
[Misc] Add transformers version to collect_env.py

### DIFF
--- a/collect_env.py
+++ b/collect_env.py
@@ -64,6 +64,7 @@ DEFAULT_CONDA_PATTERNS = {
     "triton",
     "optree",
     "nccl",
+    "transformers",
 }
 
 DEFAULT_PIP_PATTERNS = {
@@ -75,6 +76,7 @@ DEFAULT_PIP_PATTERNS = {
     "optree",
     "onnx",
     "nccl",
+    "transformers",
 }
 
 


### PR DESCRIPTION
It would be useful to know the version of transformers installed as it is directly related to model support. Specifically this would have been nice to have in resolving this issue with Phi-3 https://github.com/vllm-project/vllm/issues/5244