### PR TITLE
[Kernel] Update Cutlass int8 kernel configs for SM80

### DIFF
--- a/csrc/quantization/cutlass_w8a8/common.hpp
+++ b/csrc/quantization/cutlass_w8a8/common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "cutlass/cutlass.h"
+#include <climits>
 
 /**
  * Helper function for checking CUTLASS errors
@@ -10,3 +11,9 @@
     TORCH_CHECK(status == cutlass::Status::kSuccess, \
                 cutlassGetStatusString(status))      \
   }
+
+inline uint32_t next_pow_2(uint32_t const num) {
+  if (num <= 1) return num;
+  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
+}
+

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -300,56 +300,58 @@ struct sm80_config<InType, OutType, Epilogue, 16> {
 
 }  // namespace
 
-template <typename InType, typename OutType>
-void cutlass_scaled_mm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
-                                     torch::Tensor const& b,
-                                     torch::Tensor const& a_scales,
-                                     torch::Tensor const& b_scales) {
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue,
+          typename... EpilogueArgs>
+void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
+                                torch::Tensor const& b,
+                                EpilogueArgs&&... args) {
   static_assert(std::is_same<InType, int8_t>());
   TORCH_CHECK(a.dtype() == torch::kInt8);
   TORCH_CHECK(b.dtype() == torch::kInt8);
-  TORCH_CHECK(a_scales.dtype() == torch::kFloat32);
-  TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
 
   static const int32_t MDimDontCare = 0;
 
   using Cutlass2xGemmDefault =
-      typename sm80_config<InType, OutType, ScaledEpilogue,
+      typename sm80_config<InType, OutType, Epilogue,
                            MDimDontCare>::Cutlass2xGemm;
   using Cutlass2xGemmM128BigN =
-      typename sm80_config<InType, OutType, ScaledEpilogue,
+      typename sm80_config<InType, OutType, Epilogue,
                            MDimDontCare>::Cutlass2xGemm;
   using Cutlass2xGemmM128SmallN =
-      typename sm80_config<InType, OutType, ScaledEpilogue, 64>::Cutlass2xGemm;
+      typename sm80_config<InType, OutType, Epilogue, 64>::Cutlass2xGemm;
   using Cutlass2xGemmM64 =
-      typename sm80_config<InType, OutType, ScaledEpilogue, 64>::Cutlass2xGemm;
+      typename sm80_config<InType, OutType, Epilogue, 64>::Cutlass2xGemm;
   using Cutlass2xGemmM32 =
-      typename sm80_config<InType, OutType, ScaledEpilogue, 32>::Cutlass2xGemm;
+      typename sm80_config<InType, OutType, Epilogue, 32>::Cutlass2xGemm;
   using Cutlass2xGemmM16 =
-      typename sm80_config<InType, OutType, ScaledEpilogue, 16>::Cutlass2xGemm;
+      typename sm80_config<InType, OutType, Epilogue, 16>::Cutlass2xGemm;
 
   uint32_t const m = a.size(0);
   uint32_t const mp2 =
       std::max(static_cast<uint32_t>(16), next_pow_2(m));  // next power of 2
   if (mp2 <= 16) {
-    return cutlass_gemm_caller<Cutlass2xGemmM16>(out, a, b, a_scales, b_scales);
+    return cutlass_gemm_caller<Cutlass2xGemmM16>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 32) {
-    return cutlass_gemm_caller<Cutlass2xGemmM32>(out, a, b, a_scales, b_scales);
+    return cutlass_gemm_caller<Cutlass2xGemmM32>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 64) {
-    return cutlass_gemm_caller<Cutlass2xGemmM64>(out, a, b, a_scales, b_scales);
+    return cutlass_gemm_caller<Cutlass2xGemmM64>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 128) {
     uint32_t const n = a.size(1);
     bool const small_n = n < 8192;
     if (small_n) {
-      return cutlass_gemm_caller<Cutlass2xGemmM128SmallN>(out, a, b, a_scales,
-                                                          b_scales);
+      return cutlass_gemm_caller<Cutlass2xGemmM128SmallN>(
+          out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
-      return cutlass_gemm_caller<Cutlass2xGemmM128BigN>(out, a, b, a_scales,
-                                                        b_scales);
+      return cutlass_gemm_caller<Cutlass2xGemmM128BigN>(
+          out, a, b, std::forward<EpilogueArgs>(args)...);
     }
   } else {
-    return cutlass_gemm_caller<Cutlass2xGemmDefault>(out, a, b, a_scales,
-                                                     b_scales);
+    return cutlass_gemm_caller<Cutlass2xGemmDefault>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   }
 }
 
@@ -390,11 +392,12 @@ void cutlass_scaled_mm_sm80(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
 
   if (out.dtype() == torch::kBFloat16) {
-    return cutlass_scaled_mm_sm80_dispatch<int8_t, cutlass::bfloat16_t>(
-        out, a, b, a_scales, b_scales);
+    return cutlass_gemm_sm80_dispatch<int8_t, cutlass::bfloat16_t,
+                                      ScaledEpilogue>(out, a, b, a_scales,
+                                                      b_scales);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return cutlass_scaled_mm_sm80_dispatch<int8_t, cutlass::half_t>(
+    return cutlass_gemm_sm80_dispatch<int8_t, cutlass::half_t, ScaledEpilogue>(
         out, a, b, a_scales, b_scales);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -250,7 +250,8 @@ void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
   CUTLASS_CHECK(status);
 }
 
-template <typename InType, typename OutType, int32_t M>
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue, int32_t M>
 struct sm80_config {
   static_assert(std::is_same<InType, int8_t>());
   using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
@@ -258,43 +259,99 @@ struct sm80_config {
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using Cutlass2xGemm =
       cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      TileShape, WarpShape, InstructionShape, 5>;
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
 };
 
-template <typename InType, typename OutType>
-struct sm80_config<InType, OutType, 64> {
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config<InType, OutType, Epilogue, 64> {
   static_assert(std::is_same<InType, int8_t>());
   using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using Cutlass2xGemm =
       cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      TileShape, WarpShape, InstructionShape, 5>;
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
 };
 
-template <typename InType, typename OutType>
-struct sm80_config<InType, OutType, 32> {
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config<InType, OutType, Epilogue, 32> {
   static_assert(std::is_same<InType, int8_t>());
   using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
   using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using Cutlass2xGemm =
       cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      TileShape, WarpShape, InstructionShape, 5>;
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
 };
 
-template <typename InType, typename OutType>
-struct sm80_config<InType, OutType, 16> {
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config<InType, OutType, Epilogue, 16> {
   static_assert(std::is_same<InType, int8_t>());
   using TileShape = typename cutlass::gemm::GemmShape<16, 64, 128>;
   using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using Cutlass2xGemm =
       cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      TileShape, WarpShape, InstructionShape, 5>;
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
 };
 
 }  // namespace
+
+template <typename InType, typename OutType>
+void cutlass_scaled_mm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
+                                     torch::Tensor const& b,
+                                     torch::Tensor const& a_scales,
+                                     torch::Tensor const& b_scales) {
+  static_assert(std::is_same<InType, int8_t>());
+  TORCH_CHECK(a.dtype() == torch::kInt8);
+  TORCH_CHECK(b.dtype() == torch::kInt8);
+  TORCH_CHECK(a_scales.dtype() == torch::kFloat32);
+  TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
+
+  static const int32_t MDimDontCare = 0;
+
+  using Cutlass2xGemmDefault =
+      typename sm80_config<InType, OutType, ScaledEpilogue,
+                           MDimDontCare>::Cutlass2xGemm;
+  using Cutlass2xGemmM128BigN =
+      typename sm80_config<InType, OutType, ScaledEpilogue,
+                           MDimDontCare>::Cutlass2xGemm;
+  using Cutlass2xGemmM128SmallN =
+      typename sm80_config<InType, OutType, ScaledEpilogue, 64>::Cutlass2xGemm;
+  using Cutlass2xGemmM64 =
+      typename sm80_config<InType, OutType, ScaledEpilogue, 64>::Cutlass2xGemm;
+  using Cutlass2xGemmM32 =
+      typename sm80_config<InType, OutType, ScaledEpilogue, 32>::Cutlass2xGemm;
+  using Cutlass2xGemmM16 =
+      typename sm80_config<InType, OutType, ScaledEpilogue, 16>::Cutlass2xGemm;
+
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 =
+      std::max(static_cast<uint32_t>(16), next_pow_2(m));  // next power of 2
+  if (mp2 <= 16) {
+    return cutlass_gemm_caller<Cutlass2xGemmM16>(out, a, b, a_scales, b_scales);
+  } else if (mp2 <= 32) {
+    return cutlass_gemm_caller<Cutlass2xGemmM32>(out, a, b, a_scales, b_scales);
+  } else if (mp2 <= 64) {
+    return cutlass_gemm_caller<Cutlass2xGemmM64>(out, a, b, a_scales, b_scales);
+  } else if (mp2 <= 128) {
+    uint32_t const n = a.size(1);
+    bool const small_n = n < 8192;
+    if (small_n) {
+      return cutlass_gemm_caller<Cutlass2xGemmM128SmallN>(out, a, b, a_scales,
+                                                          b_scales);
+    } else {
+      return cutlass_gemm_caller<Cutlass2xGemmM128BigN>(out, a, b, a_scales,
+                                                        b_scales);
+    }
+  } else {
+    return cutlass_gemm_caller<Cutlass2xGemmDefault>(out, a, b, a_scales,
+                                                     b_scales);
+  }
+}
 
 void cutlass_scaled_mm_sm75(torch::Tensor& out, torch::Tensor const& a,
                             torch::Tensor const& b,
@@ -333,15 +390,11 @@ void cutlass_scaled_mm_sm80(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
 
   if (out.dtype() == torch::kBFloat16) {
-    return cutlass_gemm_caller<cutlass_2x_gemm<
-        cutlass::arch::Sm80, enable_sm80_to_sm89, int8_t, cutlass::bfloat16_t,
-        ScaledEpilogue, TileShape, WarpShape, InstructionShape, 5>>(
+    return cutlass_scaled_mm_sm80_dispatch<int8_t, cutlass::bfloat16_t>(
         out, a, b, a_scales, b_scales);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return cutlass_gemm_caller<cutlass_2x_gemm<
-        cutlass::arch::Sm80, enable_sm80_to_sm89, int8_t, cutlass::half_t,
-        ScaledEpilogue, TileShape, WarpShape, InstructionShape, 5>>(
+    return cutlass_scaled_mm_sm80_dispatch<int8_t, cutlass::half_t>(
         out, a, b, a_scales, b_scales);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -348,7 +348,7 @@ void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
         out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 128) {
     // M in (64, 128]
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     bool const small_n = n < 8192;
     if (small_n) {
       return cutlass_gemm_caller<Cutlass2xGemmM128SmallN>(

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
@@ -44,11 +44,6 @@ using namespace cute;
 
 namespace {
 
-uint32_t next_pow_2(uint32_t const num) {
-  if (num <= 1) return num;
-  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
-}
-
 // A wrapper for the GEMM kernel that is used to guard against compilation on
 // architectures that will never use the kernel. The purpose of this is to
 // reduce the size of the compiled binary.


### PR DESCRIPTION
This PR:

-  Add 6 int8 Cutlass Kernel configurations for different Gemm shape regimes.
    -  M in [0, 16]
    - M in (16, 32]
    - M in (32, 64]
    - M in (64, 128] and N < 8192
    - M in (64, 128] and N >= 8192
    - M in (128, inf)
- Add dispatching to the correct configuration based on the Gemm problem shape.

The kernel configurations were selected from benchmark sweeps performed on an A100 GPU on a variety of commonly encountered GEMM shapes.

Numbers:
GPU A100.
Command: `python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype int8 model_bench --models {mistralai/Mistral-7B-v0.1,meta-llama/Llama-2-7b-hf,meta-llama/Llama-2-13b-hf,meta-llama/Llama-2-70b-hf}`

Model : meta-llama/Llama-2-7b-hf

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Shapes | cutlass_i8_i8_bf16_scaled_mm - PR (microseconds) | cutlass_i8_i8_bf16_scaled_mm -main (microseconds) | Speedup
-- | -- | -- | --
MKN=(1x4096x12288) | 42.8 | 48.7 | 1.137850467
MKN=(1x4096x4096) | 12.2 | 34.4 | 2.819672131
MKN=(1x4096x22016) | 75.1 | 80 | 1.065246338
MKN=(1x11008x4096) | 38 | 80 | 2.105263158
MKN=(16x4096x12288) | 43.3 | 48.9 | 1.129330254
MKN=(16x4096x4096) | 12.4 | 34.5 | 2.782258065
MKN=(16x4096x22016) | 77.7 | 81.1 | 1.043758044
MKN=(16x11008x4096) | 38.1 | 80 | 2.099737533
MKN=(32x4096x12288) | 44.5 | 49.3 | 1.107865169
MKN=(32x4096x4096) | 14.4 | 34.6 | 2.402777778
MKN=(32x4096x22016) | 74.4 | 82 | 1.102150538
MKN=(32x11008x4096) | 39.3 | 80.2 | 2.040712468
MKN=(64x4096x12288) | 46.7 | 50 | 1.070663812
MKN=(64x4096x4096) | 21.2 | 34.7 | 1.636792453
MKN=(64x4096x22016) | 78 | 83.6 | 1.071794872
MKN=(64x11008x4096) | 46.3 | 80.6 | 1.740820734
MKN=(128x4096x12288) | 49.9 | 51.5 | 1.032064128
MKN=(128x4096x4096) | 22 | 36.9 | 1.677272727
MKN=(128x4096x22016) | 87.1 | 86.6 | 0.9942594719
MKN=(128x11008x4096) | 47.7 | 85.7 | 1.796645702
MKN=(256x4096x12288) | 73.2 | 72.8 | 0.9945355191
MKN=(256x4096x4096) | 37.6 | 37.7 | 1.002659574
MKN=(256x4096x22016) | 132.7 | 132.8 | 1.00075358
MKN=(256x11008x4096) | 86 | 86.1 | 1.001162791
MKN=(512x4096x12288) | 126 | 125.7 | 0.9976190476
MKN=(512x4096x4096) | 64 | 64.1 | 1.0015625
MKN=(512x4096x22016) | 215.9 | 215.8 | 0.9995368226
MKN=(512x11008x4096) | 149.2 | 149.1 | 0.9993297587

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


