### PR TITLE
[Misc] Missing error message for custom ops import

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2,13 +2,12 @@ from typing import Optional, Tuple, Type
 
 import torch
 
-from vllm.logger import init_logger
-logger = init_logger(__name__)
-
 try:
     from vllm._C import cache_ops as vllm_cache_ops
     from vllm._C import ops as vllm_ops
 except ImportError as e:
+    from vllm.logger import init_logger
+    logger = init_logger(__name__)
     logger.error("Failed to import from vllm._C with %r", e)
 
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2,11 +2,14 @@ from typing import Optional, Tuple, Type
 
 import torch
 
+from vllm.logger import init_logger
+logger = init_logger(__name__)
+
 try:
     from vllm._C import cache_ops as vllm_cache_ops
     from vllm._C import ops as vllm_ops
-except ImportError:
-    pass
+except ImportError as e:
+    logger.error("Failed to import from vllm._C with %r", e)
 
 
 # activation ops

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -8,7 +8,7 @@ try:
 except ImportError as e:
     from vllm.logger import init_logger
     logger = init_logger(__name__)
-    logger.error("Failed to import from vllm._C with %r", e)
+    logger.warning("Failed to import from vllm._C with %r", e)
 
 
 # activation ops


### PR DESCRIPTION
Hi all,

The error message is missing if there is something wrong with the custom ops import.

I had spent several hours to debug a bug called `NameError: name 'vllm_cache_ops' is not defined` today.
Finally, I got the reason (a bad `_C.cpython-310-x86_64-linux-gnu.so` compiled).

However, if we had dump the error message when the custom ops import fails, I could have fixed it in serveral minutes.

This kind of bugs seem to be happening from time to time (https://github.com/vllm-project/vllm/issues/4083).

It would be better to dump the error msg to help us fix it as soon as possible.

Thanks.
Best regards,
Jie