### PR TITLE
[Core][Distributed] use device group for all broadcast

### DIFF
--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -257,7 +257,7 @@ def broadcast_tensor_dict(
         # all happening on CPU. Therefore, we can use the CPU group.
         torch.distributed.broadcast_object_list([metadata_list],
                                                 src=src,
-                                                group=metadata_group)
+                                                group=group)
         async_handles = []
         for tensor in tensor_list:
             if tensor.numel() == 0:
@@ -267,7 +267,7 @@ def broadcast_tensor_dict(
                 # use metadata_group for CPU tensors
                 handle = torch.distributed.broadcast(tensor,
                                                      src=src,
-                                                     group=metadata_group,
+                                                     group=group,
                                                      async_op=True)
             else:
                 # use group for GPU tensors
@@ -283,7 +283,7 @@ def broadcast_tensor_dict(
         recv_metadata_list = [None]
         torch.distributed.broadcast_object_list(recv_metadata_list,
                                                 src=src,
-                                                group=metadata_group)
+                                                group=group)
         assert recv_metadata_list[0] is not None
         tensor_dict = {}
         async_handles = []
@@ -300,7 +300,7 @@ def broadcast_tensor_dict(
                     # use metadata_group for CPU tensors
                     handle = torch.distributed.broadcast(tensor,
                                                          src=src,
-                                                         group=metadata_group,
+                                                         group=group,
                                                          async_op=True)
                 else:
                     # use group for GPU tensors

--- a/vllm/distributed/communication_op.py
+++ b/vllm/distributed/communication_op.py
@@ -267,7 +267,7 @@ def broadcast_tensor_dict(
                 # use metadata_group for CPU tensors
                 handle = torch.distributed.broadcast(tensor,
                                                      src=src,
-                                                     group=group,
+                                                     group=metadata_group,
                                                      async_op=True)
             else:
                 # use group for GPU tensors
@@ -300,7 +300,7 @@ def broadcast_tensor_dict(
                     # use metadata_group for CPU tensors
                     handle = torch.distributed.broadcast(tensor,
                                                          src=src,
-                                                         group=group,
+                                                         group=metadata_group,
                                                          async_op=True)
                 else:
                     # use group for GPU tensors


### PR DESCRIPTION
A fix to #4444 

That PR was originally tested on A100, and it showed some speedup.

However, later it seems to slow down on H100 and other machines. The hypothesis is that `gloo` performs poorly while nvlink is better in these high-end machines.

Before we find a good solution, we can just use device group for all the broadcast.

TODO:

investigate if it is possible and beneficial to only communicate cpu data, using mechanisms such as message queue.