### PR TITLE
[ci] Use small_cpu_queue for doc build

### DIFF
--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -22,7 +22,9 @@ steps:
   {% for step in steps %}
   - label: "{{ step.label }}"
     agents:
-      {% if step.no_gpu %}
+      {% if step.label == "Documentation Build" %}
+      queue: small_cpu_queue
+      {% elif step.no_gpu %}
       queue: cpu_queue
       {% elif step.num_gpus == 2 or step.num_gpus == 4 %}
       queue: gpu_4_queue


### PR DESCRIPTION
Doc build doesn't need the heavy CPU instance to build: https://buildkite.com/vllm/ci-aws/builds/571#_
Let's use the small one to cut a bit on cost & save space for other image build steps