### PR TITLE
[Misc][Utils] allow get_open_port to be called for multiple times

### DIFF
--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -1,12 +1,9 @@
-import os
-import socket
 from unittest.mock import MagicMock
 
 import pytest
 
 from vllm.sequence import SequenceGroupMetadata
 from vllm.spec_decode.util import get_all_seq_ids, split_batch_by_proposal_len
-from vllm.utils import get_open_port
 
 
 def test_get_all_seq_ids():
@@ -112,15 +109,3 @@ def test_all_non_zero_with_zero_filter(fake_sequence_group_metadata):
 
     assert filtered_groups == []
     assert indices == []
-
-
-def test_get_open_port():
-    os.environ["VLLM_PORT"] = "5678"
-    # make sure we can get multiple ports, even if the env var is set
-    ports = [get_open_port() for _ in range(3)]
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,\
-         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2,\
-         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
-        s1.bind(("localhost", ports[0]))
-        s2.bind(("localhost", ports[1]))
-        s3.bind(("localhost", ports[2]))

--- a/tests/spec_decode/test_utils.py
+++ b/tests/spec_decode/test_utils.py
@@ -1,9 +1,12 @@
+import os
+import socket
 from unittest.mock import MagicMock
 
 import pytest
 
 from vllm.sequence import SequenceGroupMetadata
 from vllm.spec_decode.util import get_all_seq_ids, split_batch_by_proposal_len
+from vllm.utils import get_open_port
 
 
 def test_get_all_seq_ids():
@@ -109,3 +112,15 @@ def test_all_non_zero_with_zero_filter(fake_sequence_group_metadata):
 
     assert filtered_groups == []
     assert indices == []
+
+
+def test_get_open_port():
+    os.environ["VLLM_PORT"] = "5678"
+    # make sure we can get multiple ports, even if the env var is set
+    ports = [get_open_port() for _ in range(3)]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,\
+         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2,\
+         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
+        s1.bind(("localhost", ports[0]))
+        s2.bind(("localhost", ports[1]))
+        s3.bind(("localhost", ports[2]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,13 @@
 import asyncio
+import os
+import socket
 import sys
 from typing import (TYPE_CHECKING, Any, AsyncIterator, Awaitable, Protocol,
                     Tuple, TypeVar)
 
 import pytest
 
-from vllm.utils import deprecate_kwargs, merge_async_iterators
+from vllm.utils import deprecate_kwargs, get_open_port, merge_async_iterators
 
 from .utils import error_on_warning
 
@@ -116,3 +118,16 @@ def test_deprecate_kwargs_additional_message():
 
     with pytest.warns(DeprecationWarning, match="abcd"):
         dummy(old_arg=1)
+
+
+def test_get_open_port():
+    os.environ["VLLM_PORT"] = "5678"
+    # make sure we can get multiple ports, even if the env var is set
+    ports = [get_open_port() for _ in range(3)]
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,\
+         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2,\
+         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
+        s1.bind(("localhost", ports[0]))
+        s2.bind(("localhost", ports[1]))
+        s3.bind(("localhost", ports[2]))
+    os.environ.pop("VLLM_PORT")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,11 +123,10 @@ def test_deprecate_kwargs_additional_message():
 def test_get_open_port():
     os.environ["VLLM_PORT"] = "5678"
     # make sure we can get multiple ports, even if the env var is set
-    ports = [get_open_port() for _ in range(3)]
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1,\
-         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2,\
-         socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
-        s1.bind(("localhost", ports[0]))
-        s2.bind(("localhost", ports[1]))
-        s3.bind(("localhost", ports[2]))
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1:
+        s1.bind(("localhost", get_open_port()))
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s2:
+            s2.bind(("localhost", get_open_port()))
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
+                s3.bind(("localhost", get_open_port()))
     os.environ.pop("VLLM_PORT")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -99,6 +99,9 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: os.getenv('VLLM_HOST_IP', "") or os.getenv("HOST_IP", ""),
 
     # used in distributed environment to manually set the communication port
+    # Note: if VLLM_PORT is set, and some code asks for multiple ports, the
+    # VLLM_PORT will be used as the first port, and the rest will be generated
+    # by incrementing the VLLM_PORT value.
     # '0' is used to make mypy happy
     'VLLM_PORT':
     lambda: int(os.getenv('VLLM_PORT', '0'))

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -289,7 +289,13 @@ def get_distributed_init_method(ip: str, port: int) -> str:
 def get_open_port() -> int:
     port = envs.VLLM_PORT
     if port is not None:
-        return port
+        while True:
+            try:
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                    s.bind(("", port))
+                    return port
+            except OSError:
+                port += 1  # Increment port number if already in use
     # try ipv4
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -296,6 +296,8 @@ def get_open_port() -> int:
                     return port
             except OSError:
                 port += 1  # Increment port number if already in use
+                logger.info("Port %d is already in use, trying port %d",
+                            port - 1, port)
     # try ipv4
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/4914 allows users to specify a port to use, but is restricted to one port. When we want to use multiple ports (e.g. multiple LLM instances in offline inference for interactive playing), it will cause a problem.

This PR makes it possible to call `get_open_port` multiple times, and return different ports. In a safety-constrained system, the admin can open a port range for vLLM to use.