### PR TITLE
fix DbrxFusedNormAttention missing cache_config

### DIFF
--- a/vllm/model_executor/models/dbrx.py
+++ b/vllm/model_executor/models/dbrx.py
@@ -247,11 +247,12 @@ class DbrxFusedNormAttention(nn.Module):
     def __init__(
         self,
         config: DbrxConfig,
+        cache_config: Optional[CacheConfig] = None,
         quant_config: Optional[QuantizationConfig] = None,
     ):
         super().__init__()
         self.d_model = config.d_model
-        self.attn = DbrxAttention(config, quant_config)
+        self.attn = DbrxAttention(config, cache_config, quant_config)
         self.norm_1 = nn.LayerNorm(self.d_model)
         self.norm_2 = nn.LayerNorm(self.d_model)
 


### PR DESCRIPTION
Bug Description:

When running: `poetry run python vllm_server.py --disable-log-stats --host=localhost --port=8511 --model=/models/huggingface/dbrx-base --served-model-name=vllm_dbrx`, there will be error:

```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/team/calvinn/search/python/vllm/vllm_server.py", line 158, in <module>
[rank0]:     engine = AsyncLLMEngine.from_engine_args(
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 386, in from_engine_args
[rank0]:     engine = cls(
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 340, in __init__
[rank0]:     self.engine = self._init_engine(*args, **kwargs)
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 462, in _init_engine
[rank0]:     return engine_class(*args, **kwargs)
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/engine/llm_engine.py", line 222, in __init__
[rank0]:     self.model_executor = executor_class(
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/executor/executor_base.py", line 41, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/executor/gpu_executor.py", line 24, in _init_executor
[rank0]:     self.driver_worker.load_model()
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/worker/worker.py", line 121, in load_model
[rank0]:     self.model_runner.load_model()
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/worker/model_runner.py", line 134, in load_model
[rank0]:     self.model = get_model(
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/model_loader/__init__.py", line 21, in get_model
[rank0]:     return loader.load_model(model_config=model_config,
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/model_loader/loader.py", line 240, in load_model
[rank0]:     model = _initialize_model(model_config, self.load_config,
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/model_loader/loader.py", line 91, in _initialize_model
[rank0]:     return model_class(config=model_config.hf_config,
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/models/dbrx.py", line 366, in __init__
[rank0]:     self.transformer = DbrxModel(config, cache_config, quant_config)
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/models/dbrx.py", line 323, in __init__
[rank0]:     self.blocks = nn.ModuleList([
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/models/dbrx.py", line 324, in <listcomp>
[rank0]:     DbrxBlock(config, cache_config, quant_config)
[rank0]:   File "/home/team/.cache/pypoetry/virtualenvs/vllm-server-LZ2-Bccm-py3.9/lib/python3.9/site-packages/vllm/model_executor/models/dbrx.py", line 288, in __init__
[rank0]:     self.norm_attn_norm = DbrxFusedNormAttention(config, cache_config,
[rank0]: TypeError: __init__() takes from 2 to 3 positional arguments but 4 were given
```

It is a simple error of not adding `cache_config` argument in `DbrxFusedNormAttention` and then passing it to `DbrxAttention`. This PR fixes it. 