### PR TITLE
[Misc] Remove unused cuda_utils.h in CPU backend

### DIFF
--- a/csrc/cpu/pybind.cpp
+++ b/csrc/cpu/pybind.cpp
@@ -1,5 +1,4 @@
 #include "cache.h"
-#include "cuda_utils.h"
 #include "ops.h"
 #include <torch/extension.h>
 


### PR DESCRIPTION
Hi all,

May I get reviews for this trivial change?

`cuda_utils.h` was included in the CPU backend, which seems to be unreasonable.
Fortunately, it can be removed without regression, which is actually unused.

Thanks.
Best regards,
Jie