### PR TITLE
[mis][ci/test] fix flaky test in tests/test_sharded_state_loader.py

### DIFF
--- a/tests/test_sharded_state_loader.py
+++ b/tests/test_sharded_state_loader.py
@@ -39,7 +39,8 @@ def test_filter_subtensors():
     filtered_state_dict = ShardedStateLoader._filter_subtensors(state_dict)
     assert tuple(filtered_state_dict.keys()) == ("a", "b", "c")
     for key, tensor in filtered_state_dict.items():
-        assert tensor.equal(state_dict[key])
+        # NOTE: don't use `euqal` here, as the tensor might contain NaNs
+        assert tensor is state_dict[key]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This flaky test is observed in https://buildkite.com/vllm/ci/builds/9517#018ff9e8-1c4b-4fac-b3c5-af50946523d8 . `torch.empty` tensor can contain NaN values.