### PR TITLE
[Misc] Remove VLLM_BUILD_WITH_NEURON env variable

### DIFF
--- a/Dockerfile.neuron
+++ b/Dockerfile.neuron
@@ -28,7 +28,7 @@ COPY ./requirements-neuron.txt /app/vllm/requirements-neuron.txt
 RUN cd /app/vllm \
     && python3 -m pip install -U -r requirements-neuron.txt
 
-ENV VLLM_BUILD_WITH_NEURON 1
+ENV VLLM_TARGET_DEVICE neuron
 RUN cd /app/vllm \
     && pip install -e . \
     && cd ..

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ def _is_neuron() -> bool:
         subprocess.run(["neuron-ls"], capture_output=True, check=True)
     except (FileNotFoundError, PermissionError, subprocess.CalledProcessError):
         torch_neuronx_installed = False
-    return torch_neuronx_installed or envs.VLLM_BUILD_WITH_NEURON
+    return torch_neuronx_installed or VLLM_TARGET_DEVICE == "neuron"
 
 
 def _is_cpu() -> bool:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     VLLM_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None
-    VLLM_BUILD_WITH_NEURON: bool = False
     VLLM_USE_PRECOMPILED: bool = False
     VLLM_INSTALL_PUNICA_KERNELS: bool = False
     CMAKE_BUILD_TYPE: Optional[str] = None
@@ -62,10 +61,6 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # If set, `MAX_JOBS` will be reduced to avoid oversubscribing the CPU.
     "NVCC_THREADS":
     lambda: os.getenv("NVCC_THREADS", None),
-
-    # If set, vllm will build with Neuron support
-    "VLLM_BUILD_WITH_NEURON":
-    lambda: bool(os.environ.get("VLLM_BUILD_WITH_NEURON", False)),
 
     # If set, vllm will use precompiled binaries (*.so)
     "VLLM_USE_PRECOMPILED":


### PR DESCRIPTION
Use `VLLM_TARGET_DEVICE` instead of `VLLM_BUILD_WITH_NEURON`.