### PR TITLE
[Kernel] Adding fused bias add to cutlass_scaled_mm_dq kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,15 +181,20 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     "csrc/custom_all_reduce.cu"
     "csrc/quantization/cutlass_w8a8/scaled_mm_entry.cu"
     "csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu"
-    "csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu")
+    "csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu"
+    "csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu")
 
   #
   # The CUTLASS kernels for Hopper require sm90a to be enabled.
   # This is done via the below gencode option, BUT that creates kernels for both sm90 and sm90a.
   # That adds an extra 17MB to compiled binary, so instead we selectively enable it.
   if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0)
+    list(APPEND HOPPER_KERNELS
+      "csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu"
+      "csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu"
+    )
     set_source_files_properties(
-          "csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu"
+          ${HOPPER_KERNELS}
           PROPERTIES
           COMPILE_FLAGS
           "-gencode arch=compute_90a,code=sm_90a")

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -92,7 +92,8 @@ torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
 
 void cutlass_scaled_mm(torch::Tensor& out, torch::Tensor const& a,
                        torch::Tensor const& b, torch::Tensor const& a_scales,
-                       torch::Tensor const& b_scales);
+                       torch::Tensor const& b_scales,
+                       const c10::optional<torch::Tensor>& bias);
 
 #endif
 

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu
@@ -1,0 +1,358 @@
+// clang-format will break include orders
+// clang-format off
+#include <cudaTypedefs.h>
+
+#if defined CUDA_VERSION && CUDA_VERSION >= 12000
+
+#include <torch/all.h>
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "cutlass/cutlass.h"
+
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cutlass/numeric_types.h"
+
+#include "cutlass/util/device_memory.h"
+
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+
+#include "broadcast_load_epilogue_c3x.hpp"
+#include "common.hpp"
+// clang-format on
+
+using namespace cute;
+
+/*
+   This defines a quantized GEMM operation with dequantized output, similar to
+   torch._scaled_mm. It is defined using the CUTLASS 3.x API, and is used for
+   NVIDIA GPUs with sm90a (Hopper) or later.
+
+   A and B may be both either int8 or fp8_e4m3. A can be quantized per-tensor or
+   per-row. B can be quantized per-tensor or per-column.
+   Any combination of per-tensor and per-row or column is supported.
+   A and B must have symmetric quantization (zero point == 0).
+
+   D = a_scales * (b_scales * (A*B)) + per-row bias
+
+   In the epilogue ACC stores the results of A*B and will be multiplied
+   by a_scales and b_scales before adding the per-row bias.
+
+   The epilogue computation can be composed with `multiplies` and `multiply_add`
+
+   ScaleA and ScaleB define the epilogue functions that apply the scales for
+   the A and B operands respectively. These scales may be either per-tensor or
+   per row or column.
+*/
+
+namespace {
+
+uint32_t next_pow_2(uint32_t const num) {
+  if (num <= 1) return num;
+  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
+}
+
+// A wrapper for the GEMM kernel that is used to guard against compilation on
+// architectures that will never use the kernel. The purpose of this is to
+// reduce the size of the compiled binary.
+// __CUDA_ARCH__ is not defined in host code, so this lets us smuggle the ifdef
+// into code that will be executed on the device where it is defined.
+template <typename Kernel>
+struct enable_sm90_or_later : Kernel {
+  template <typename... Args>
+  CUTLASS_DEVICE void operator()(Args&&... args) {
+  #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 900
+    Kernel::operator()(std::forward<Args>(args)...);
+  #endif
+  }
+};
+
+template <typename ElementAB_, typename ElementD_, typename TileShape,
+          typename ClusterShape, typename KernelSchedule,
+          typename EpilogueSchedule>
+struct cutlass_3x_gemm_bias {
+  using ElementAB = ElementAB_;
+  using ElementD = ElementD_;
+  using ElementAcc =
+      typename std::conditional<std::is_same_v<ElementAB, int8_t>, int32_t,
+                                float>::type;
+  //   using ElementBias = float;
+  using ElementBias =
+      typename std::conditional<std::is_same_v<ElementD, cutlass::half_t>,
+                                at::Half, at::BFloat16>::type;
+
+  using EpilogueDescriptor =
+      cutlass::epilogue::collective::detail::EpilogueDescriptor<
+          TileShape, cutlass::epilogue::collective::EpilogueTileAuto, ElementD,
+          ElementD, EpilogueSchedule>;
+
+  // D = a_scales * (b_scales * (A*B)) + per-row bias
+  using Accum = cutlass::epilogue::fusion::Sm90AccFetch;
+
+  using ScaleA = cutlass::epilogue::fusion::Sm90ColOrScalarBroadcast<
+      0 /*Stages*/, typename EpilogueDescriptor::TileShape, float,
+      Stride<Int<1>, Int<0>, Int<0>>>;
+
+  using ScaleBDescriptor =
+      cutlass::epilogue::collective::detail::RowBroadcastDescriptor<
+          EpilogueDescriptor, float>;
+
+  using ScaleB = cutlass::epilogue::fusion::Sm90RowOrScalarBroadcast<
+      ScaleBDescriptor::Stages, typename EpilogueDescriptor::TileShape,
+      typename ScaleBDescriptor::Element, Stride<Int<0>, Int<1>, Int<0>>>;
+
+  // binary op
+  using Compute0 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  // b_scales * (A*B)
+  using EVTCompute0 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute0, ScaleB, Accum>;
+
+  using Compute1 = cutlass::epilogue::fusion::Sm90Compute<
+      cutlass::multiply_add, ElementD /*ElementOutput*/,
+      float /*ElementCompute*/, cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using BiasDescriptor =
+      cutlass::epilogue::collective::detail::RowBroadcastDescriptor<
+          EpilogueDescriptor, ElementBias>;
+
+  using Bias = cutlass::epilogue::fusion::Sm90RowOrScalarBroadcast<
+      BiasDescriptor::Stages, typename EpilogueDescriptor::TileShape,
+      typename BiasDescriptor::Element, Stride<Int<0>, Int<1>, Int<0>>>;
+
+  // a_scales * (b_scales * (A*B)) + per-row bias
+  using EVTCompute1 =
+      cutlass::epilogue::fusion::Sm90EVT<Compute1, ScaleA, EVTCompute0, Bias>;
+
+  using StrideD = Stride<int64_t, Int<1>, Int<0>>;
+  using ElementC = void;
+  using StrideC = StrideD;
+
+  using CollectiveEpilogue =
+      typename cutlass::epilogue::collective::CollectiveBuilder<
+          cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp, TileShape,
+          ClusterShape, cutlass::epilogue::collective::EpilogueTileAuto,
+          ElementAcc, float, ElementC, StrideC, 4, ElementD, StrideD, 4,
+          EpilogueSchedule, EVTCompute1>::CollectiveOp;
+
+  static constexpr size_t CEStorageSize =
+      sizeof(typename CollectiveEpilogue::SharedStorage);
+  using Stages = typename cutlass::gemm::collective::StageCountAutoCarveout<
+      static_cast<int>(CEStorageSize)>;
+
+  // clang-format off
+  using CollectiveMainloop =
+      typename cutlass::gemm::collective::CollectiveBuilder<
+          cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp, 
+          ElementAB, cutlass::layout::RowMajor, 16, 
+          ElementAB, cutlass::layout::ColumnMajor, 16, 
+          ElementAcc, TileShape, ClusterShape,
+          Stages,
+          KernelSchedule>::CollectiveOp;
+  // clang-format on
+
+  using KernelType = enable_sm90_or_later<cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int, int, int, int>, CollectiveMainloop, CollectiveEpilogue,
+      cutlass::gemm::PersistentScheduler>>;
+
+  struct GemmKernel : public KernelType {};
+};
+
+template <typename Gemm>
+void cutlass_scaled_mm_dq_bias_dispatcher(torch::Tensor& out,
+                                          torch::Tensor const& a,
+                                          torch::Tensor const& b,
+                                          torch::Tensor const& a_scales,
+                                          torch::Tensor const& b_scales,
+                                          torch::Tensor const& bias) {
+  using ElementAB = typename Gemm::ElementAB;
+  using ElementD = typename Gemm::ElementD;
+  using ElementBias = typename Gemm::ElementBias;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+
+  int64_t lda = a.stride(0);
+  int64_t ldb = b.stride(1);
+  int64_t ldc = out.stride(0);
+
+  using StrideA = Stride<int64_t, Int<1>, Int<0>>;
+  using StrideB = Stride<int64_t, Int<1>, Int<0>>;
+  using StrideC = typename Gemm::StrideC;
+
+  StrideA a_stride{lda, Int<1>{}, Int<0>{}};
+  StrideB b_stride{ldb, Int<1>{}, Int<0>{}};
+  StrideC c_stride{ldc, Int<1>{}, Int<0>{}};
+
+  using GemmKernel = typename Gemm::GemmKernel;
+  typename GemmKernel::ProblemShape prob_shape{m, n, k, 1};
+
+  auto a_ptr = static_cast<ElementAB*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementAB*>(b.data_ptr());
+  typename GemmKernel::MainloopArguments mainloop_args{a_ptr, a_stride, b_ptr,
+                                                       b_stride};
+
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+  typename GemmKernel::EpilogueArguments epilogue_args{
+      {} /* epilogue.thread */, c_ptr, c_stride, c_ptr, c_stride};
+
+  typename GemmKernel::Arguments args{cutlass::gemm::GemmUniversalMode::kGemm,
+                                      prob_shape, mainloop_args, epilogue_args};
+
+  using ScaleA_Args = typename Gemm::ScaleA::Arguments;
+  using ScaleB_Args = typename Gemm::ScaleB::Arguments;
+  using Bias_Args = typename Gemm::Bias::Arguments;
+  ScaleA_Args a_args{a_scales.data_ptr<float>(), a_scales.numel() != 1, {}};
+  ScaleB_Args b_args{b_scales.data_ptr<float>(), b_scales.numel() != 1, {}};
+  Bias_Args bias_args =
+      Bias_Args{bias.data_ptr<ElementBias>(), bias.numel() != 1, {}};
+
+  args.epilogue.thread = {
+      // ternary op: a_scales * (b_scales * (A*B)) + per-row bias
+      a_args,  // a_scales
+      {
+          // binary op: b_scales * (A*B)
+          b_args,  // b_scales
+          {},      // acc
+          {}       // binary args: multiplies
+      },
+      bias_args,  // bias
+      {}          // ternary args: multiply_add
+  };
+
+  // Launch the CUTLASS GEMM kernel.
+  using GemmOp = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  GemmOp gemm_op;
+  CUTLASS_CHECK(gemm_op.can_implement(args));
+
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  cutlass::Status status = gemm_op.run(args, workspace.get(), stream);
+  CUTLASS_CHECK(status);
+}
+
+template <typename InType, typename OutType, int32_t M>
+struct sm90_fp8_config {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule =
+      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+  using EpilogueSchedule = typename cutlass::epilogue::TmaWarpSpecialized;
+  using TileShape = Shape<_128, _128, _128>;
+  using ClusterShape = Shape<_2, _1, _1>;
+
+  using Cutlass3xGemm =
+      cutlass_3x_gemm_bias<InType, OutType, TileShape, ClusterShape,
+                           KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType>
+struct sm90_fp8_config<InType, OutType, 128> {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule =
+      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+  using EpilogueSchedule = typename cutlass::epilogue::TmaWarpSpecialized;
+  using TileShape = Shape<_64, _128, _128>;
+  using ClusterShape = Shape<_2, _1, _1>;
+
+  using Cutlass3xGemm =
+      cutlass_3x_gemm_bias<InType, OutType, TileShape, ClusterShape,
+                           KernelSchedule, EpilogueSchedule>;
+};
+
+template <typename InType, typename OutType>
+struct sm90_fp8_config<InType, OutType, 64> {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  using KernelSchedule =
+      cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
+  using EpilogueSchedule = typename cutlass::epilogue::TmaWarpSpecialized;
+  using TileShape = Shape<_64, _64, _128>;
+  using ClusterShape = Shape<_1, _8, _1>;
+
+  using Cutlass3xGemm =
+      cutlass_3x_gemm_bias<InType, OutType, TileShape, ClusterShape,
+                           KernelSchedule, EpilogueSchedule>;
+};
+
+}  // namespace
+
+template <typename InType, typename OutType>
+void cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch(torch::Tensor& out,
+                                                 torch::Tensor const& a,
+                                                 torch::Tensor const& b,
+                                                 torch::Tensor const& a_scales,
+                                                 torch::Tensor const& b_scales,
+                                                 torch::Tensor const& bias) {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+  TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
+  TORCH_CHECK(a_scales.dtype() == torch::kFloat32);
+  TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
+  TORCH_CHECK((std::is_same_v<OutType, cutlass::half_t> &&
+               (bias.dtype() == torch::kFloat16)) ||
+              (std::is_same_v<OutType, cutlass::bfloat16_t> &&
+               (bias.dtype() == torch::kBFloat16)));
+
+  using Cutlass3xGemmDefault =
+      typename sm90_fp8_config<InType, OutType, 0>::Cutlass3xGemm;
+  using Cutlass3xGemmM64 =
+      typename sm90_fp8_config<InType, OutType, 64>::Cutlass3xGemm;
+  using Cutlass3xGemmM128 =
+      typename sm90_fp8_config<InType, OutType, 128>::Cutlass3xGemm;
+
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 =
+      std::max(static_cast<uint32_t>(64), next_pow_2(m));  // next power of 2
+
+  if (mp2 <= 64) {
+    // m in [1, 64]
+    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmM64>(
+        out, a, b, a_scales, b_scales, bias);
+  } else if (mp2 <= 128) {
+    // m in (64, 128]
+    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmM128>(
+        out, a, b, a_scales, b_scales, bias);
+  } else {
+    // m in (128, inf)
+    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmDefault>(
+        out, a, b, a_scales, b_scales, bias);
+  }
+}
+
+void cutlass_scaled_mm_dq_bias_sm90(torch::Tensor& out, torch::Tensor const& a,
+                                    torch::Tensor const& b,
+                                    torch::Tensor const& a_scales,
+                                    torch::Tensor const& b_scales,
+                                    torch::Tensor const& bias) {
+  TORCH_CHECK(a_scales.dtype() == torch::kFloat32);
+  TORCH_CHECK(b_scales.dtype() == torch::kFloat32);
+  TORCH_CHECK(out.dtype() == bias.dtype());
+  TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+  TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
+
+  if (out.dtype() == torch::kBFloat16) {
+    return cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
+                                                       cutlass::bfloat16_t>(
+        out, a, b, a_scales, b_scales, bias);
+  } else {
+    TORCH_CHECK(out.dtype() == torch::kFloat16);
+    return cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
+                                                       cutlass::half_t>(
+        out, a, b, a_scales, b_scales, bias);
+  }
+}
+
+#endif

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_bias_c3x.cu
@@ -169,7 +169,7 @@ struct cutlass_3x_gemm_bias {
 };
 
 template <typename Gemm>
-void cutlass_scaled_mm_dq_bias_dispatcher(torch::Tensor& out,
+void cutlass_scaled_mm_bias_dispatcher(torch::Tensor& out,
                                           torch::Tensor const& a,
                                           torch::Tensor const& b,
                                           torch::Tensor const& a_scales,
@@ -290,7 +290,7 @@ struct sm90_fp8_config<InType, OutType, 64> {
 }  // namespace
 
 template <typename InType, typename OutType>
-void cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch(torch::Tensor& out,
+void cutlass_scaled_mm_bias_sm90_fp8_dispatch(torch::Tensor& out,
                                                  torch::Tensor const& a,
                                                  torch::Tensor const& b,
                                                  torch::Tensor const& a_scales,
@@ -319,20 +319,20 @@ void cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch(torch::Tensor& out,
 
   if (mp2 <= 64) {
     // m in [1, 64]
-    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmM64>(
+    return cutlass_scaled_mm_bias_dispatcher<Cutlass3xGemmM64>(
         out, a, b, a_scales, b_scales, bias);
   } else if (mp2 <= 128) {
     // m in (64, 128]
-    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmM128>(
+    return cutlass_scaled_mm_bias_dispatcher<Cutlass3xGemmM128>(
         out, a, b, a_scales, b_scales, bias);
   } else {
     // m in (128, inf)
-    return cutlass_scaled_mm_dq_bias_dispatcher<Cutlass3xGemmDefault>(
+    return cutlass_scaled_mm_bias_dispatcher<Cutlass3xGemmDefault>(
         out, a, b, a_scales, b_scales, bias);
   }
 }
 
-void cutlass_scaled_mm_dq_bias_sm90(torch::Tensor& out, torch::Tensor const& a,
+void cutlass_scaled_mm_bias_sm90(torch::Tensor& out, torch::Tensor const& a,
                                     torch::Tensor const& b,
                                     torch::Tensor const& a_scales,
                                     torch::Tensor const& b_scales,
@@ -344,12 +344,12 @@ void cutlass_scaled_mm_dq_bias_sm90(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
 
   if (out.dtype() == torch::kBFloat16) {
-    return cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
+    return cutlass_scaled_mm_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
                                                        cutlass::bfloat16_t>(
         out, a, b, a_scales, b_scales, bias);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return cutlass_scaled_mm_dq_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
+    return cutlass_scaled_mm_bias_sm90_fp8_dispatch<cutlass::float_e4m3_t,
                                                        cutlass::half_t>(
         out, a, b, a_scales, b_scales, bias);
   }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_entry.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_entry.cu
@@ -24,10 +24,10 @@ void cutlass_scaled_mm_sm90(torch::Tensor& c, torch::Tensor const& a,
                             torch::Tensor const& a_scales,
                             torch::Tensor const& b_scales);
 void cutlass_scaled_mm_bias_sm90(torch::Tensor& c, torch::Tensor const& a,
-                                    torch::Tensor const& b,
-                                    torch::Tensor const& a_scales,
-                                    torch::Tensor const& b_scales,
-                                    torch::Tensor const& bias);
+                                 torch::Tensor const& b,
+                                 torch::Tensor const& a_scales,
+                                 torch::Tensor const& b_scales,
+                                 torch::Tensor const& bias);
 #endif
 
 void cutlass_scaled_mm(torch::Tensor& c, torch::Tensor const& a,
@@ -65,13 +65,13 @@ void cutlass_scaled_mm(torch::Tensor& c, torch::Tensor const& a,
     // Guard against compilation issues for sm90 kernels
 #if defined CUDA_VERSION && CUDA_VERSION >= 12000
     cutlass_scaled_mm_bias_sm90(c, a, b, a_scales, b_scales,
-                                    reinterpret_cast<const at::Tensor&>(bias));
+                                reinterpret_cast<const at::Tensor&>(bias));
 #else
-      TORCH_CHECK(0);
+    TORCH_CHECK(0);
 #endif
   } else {
     if (version_num >= 90) {
-#if defined CUDA_VERSION && CUDA_VERSION >= 12000      
+#if defined CUDA_VERSION && CUDA_VERSION >= 12000
       cutlass_scaled_mm_sm90(c, a, b, a_scales, b_scales);
 #else
       cutlass_scaled_mm_sm80(c, a, b, a_scales, b_scales);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -138,7 +138,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def(
       "cutlass_scaled_mm(Tensor! out, Tensor a,"
       "                  Tensor b, Tensor a_scales,"
-      "                  Tensor b_scales) -> ()");
+      "                  Tensor b_scales, Tensor? bias) -> ()");
   ops.impl("cutlass_scaled_mm", torch::kCUDA, &cutlass_scaled_mm);
 #endif
 

--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -54,6 +54,35 @@ def cutlass_fp8_gemm_helper(m: int,
     assert torch.allclose(out, baseline, rtol=1e-2, atol=1e-1)
 
 
+def cutlass_fp8_gemm_bias_helper(m: int,
+                                 n: int,
+                                 k: int,
+                                 per_token_act_quant: bool,
+                                 per_out_channel_weight_quant: bool,
+                                 out_dtype: Type[torch.dtype] = torch.bfloat16,
+                                 device: str = "cuda"):
+    # Test for a cutlass kernel with per-token activation quantization
+    # and per-output channel weight quantization.
+    a = to_fp8(torch.randn((m, k), device=device))
+    b = to_fp8(torch.randn((n, k), device=device).t())
+    bias = torch.randn((n, ), device=device, dtype=out_dtype)
+
+    m_a_scales = m if per_token_act_quant else 1
+    n_b_scales = n if per_out_channel_weight_quant else 1
+
+    scale_a = (torch.randn(
+        (m_a_scales, 1), device=device, dtype=torch.float32) / 10)
+    scale_b = (torch.randn(
+        (1, n_b_scales), device=device, dtype=torch.float32) / 10)
+
+    out = ops.cutlass_scaled_mm_dq(a, b, scale_a, scale_b, out_dtype, bias)
+    baseline = (torch.mm(scale_a * a.to(dtype=torch.float32),
+                         scale_b * b.to(dtype=torch.float32)) +
+                bias).to(out_dtype)
+
+    assert torch.allclose(out, baseline, rtol=1e-2, atol=1e-1)
+
+
 def cutlass_int8_gemm_helper(m: int,
                              n: int,
                              k: int,
@@ -80,6 +109,18 @@ def cutlass_int8_gemm_helper(m: int,
                         b.to(dtype=torch.float32)).to(dtype=out_dtype)
 
     assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
+
+
+@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
+@pytest.mark.parametrize("n", [2048, 256, 1024])
+@pytest.mark.parametrize("k", [128, 496, 1024])
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.skipif(capability < 89,
+                    reason="FP8 is not supported on this GPU type.")
+def test_cutlass_fp8_gemm_bias(m: int, n: int, k: int, per_act_token: bool,
+                               per_out_ch: bool):
+    cutlass_fp8_gemm_bias_helper(m, n, k, per_act_token, per_out_ch)
 
 
 @pytest.mark.parametrize("m", [512, 222, 100, 33, 1])

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -212,12 +212,13 @@ def gptq_marlin_24_gemm(a: torch.Tensor, b_q_weight: torch.Tensor,
 
 
 # cutlass
-def cutlass_scaled_mm(a: torch.Tensor,
-                      b: torch.Tensor,
-                      scale_a: torch.Tensor,
-                      scale_b: torch.Tensor,
-                      out_dtype: Type[torch.dtype],
-                      bias: Optional[Type[torch.Tensor]] = None) -> torch.Tensor:
+def cutlass_scaled_mm(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        scale_a: torch.Tensor,
+        scale_b: torch.Tensor,
+        out_dtype: Type[torch.dtype],
+        bias: Optional[Type[torch.Tensor]] = None) -> torch.Tensor:
     assert (b.shape[0] % 16 == 0 and b.shape[1] % 16 == 0)
     assert (out_dtype is torch.bfloat16 or out_dtype is torch.float16)
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -212,9 +212,12 @@ def gptq_marlin_24_gemm(a: torch.Tensor, b_q_weight: torch.Tensor,
 
 
 # cutlass
-def cutlass_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor,
+def cutlass_scaled_mm(a: torch.Tensor,
+                      b: torch.Tensor,
+                      scale_a: torch.Tensor,
                       scale_b: torch.Tensor,
-                      out_dtype: Type[torch.dtype]) -> torch.Tensor:
+                      out_dtype: Type[torch.dtype],
+                      bias: Optional[Type[torch.Tensor]] = None) -> torch.Tensor:
     assert (b.shape[0] % 16 == 0 and b.shape[1] % 16 == 0)
     assert (out_dtype is torch.bfloat16 or out_dtype is torch.float16)
 
@@ -222,7 +225,7 @@ def cutlass_scaled_mm(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor,
     n = b.shape[1]
     out = torch.empty((m, n), dtype=out_dtype, device=a.device)
 
-    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b)
+    torch.ops._C.cutlass_scaled_mm(out, a, b, scale_a, scale_b, bias)
     return out
 
 


### PR DESCRIPTION
This PR adds support of bias add to `cutlass_scaled_mm_dq` op, which is required for optimized performance of W8A8 linear layer with bias.

I added the support for fp8, **but not the int8 path yet**, as my use case is fp8 only. 

Microbenchmarking results show that it performs similarly to `cutlass_scaled_mm_dq`. Times are in microseconds (us). Columns represent different m (batch_size*seq_len). The kernels being compared are:
- `torch_mm:f16` :  fp16 pytorch (using cublas)
- `cutlass_scaled_mm_bias0:f8e4`: original `cutlass_scaled_mm_dq` fp8 without bias add support
- `cutlass_scaled_mm_bias1:f8e4`: original `cutlass_scaled_mm_dq` fp8 with bias add support

cc @njhill 
```

[-------------------------------------------------------- llama-3-8b_n=4096_k=4096 --------------------------------------------------------]
                                           |   1    |   2    |   4    |   8    |   16   |   32   |   64   |  128   |  256   |  512   |  1024
1 threads: ---------------------------------------------------------------------------------------------------------------------------------
      torch_mm:f16                         |  11.5  |  11.7  |  11.6  |  11.8  |  11.7  |  11.7  |  14.4  |  16.6  |  24.9  |  35.6  |  55.0
      cutlass_scaled_mm_bias0:f8e4         |   8.0  |   8.0  |   8.0  |   8.0  |   8.1  |   8.2  |   8.0  |  10.0  |  14.6  |  16.0  |  30.8
      cutlass_scaled_mm_bias1:f8e4         |   8.3  |   8.3  |   8.3  |   8.3  |   8.3  |   8.4  |   8.3  |  10.2  |  14.9  |  16.3  |  31.2

[-------------------------------------------------------- llama-3-8b_n=4096_k=6144 --------------------------------------------------------]
                                           |   1    |   2    |   4    |   8    |   16   |   32   |   64   |  128   |  256   |  512   |  1024
1 threads: ---------------------------------------------------------------------------------------------------------------------------------
      torch_mm:f16                         |  24.9  |  25.6  |  25.3  |  26.1  |  26.0  |  25.0  |  25.9  |  29.7  |  34.0  |  52.1  |  83.6
      cutlass_scaled_mm_bias0:f8e4         |   9.8  |   9.8  |  13.8  |   9.8  |   9.8  |   9.9  |   9.8  |  12.8  |  19.4  |  23.5  |  45.9
      cutlass_scaled_mm_bias1:f8e4         |  10.2  |  10.1  |  10.1  |  10.2  |  10.2  |  10.2  |  10.2  |  13.1  |  19.7  |  23.6  |  46.2

[------------------------------------------------------------ llama-3-8b_n=4096_k=28672 ------------------------------------------------------------]
                                           |    1    |    2    |    4    |    8    |    16   |   32   |   64   |   128   |   256   |   512   |   1024
1 threads: ------------------------------------------------------------------------------------------------------------------------------------------
      torch_mm:f16                         |   95.2  |   85.0  |   84.7  |   85.7  |   85.9  |  88.8  |  89.8  |  100.4  |  140.2  |  202.3  |  370.8
      cutlass_scaled_mm_bias0:f8e4         |   44.8  |   44.8  |   44.9  |   45.0  |   45.2  |  45.5  |  46.0  |   54.3  |   76.6  |   98.1  |  190.6
      cutlass_scaled_mm_bias1:f8e4         |   45.1  |   45.1  |   45.1  |   45.3  |   45.4  |  45.7  |  46.2  |   54.7  |   76.8  |   97.8  |  190.1

[-------------------------------------------------------- llama-3-8b_n=14336_k=4096 ---------------------------------------------------------]
                                           |   1    |   2    |   4    |   8    |   16   |   32   |   64   |  128   |  256   |   512   |   1024
1 threads: -----------------------------------------------------------------------------------------------------------------------------------
      torch_mm:f16                         |  45.3  |  45.4  |  45.6  |  45.7  |  48.0  |  48.5  |  46.6  |  48.8  |  59.3  |  124.2  |  199.9
      cutlass_scaled_mm_bias0:f8e4         |  24.6  |  24.8  |  25.2  |  25.2  |  25.7  |  25.7  |  25.8  |  27.0  |  33.9  |   51.8  |   98.5
      cutlass_scaled_mm_bias1:f8e4         |  25.0  |  25.0  |  25.5  |  25.5  |  25.9  |  25.9  |  26.0  |  27.3  |  34.3  |   52.8  |   98.8
```

It would be helpful for the vLLM team to provide feedback on getting this PR accepted. Thanks!


---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


