### PR TITLE
[Docs] [Spec decode] Fix docs error in code example

### DIFF
--- a/docs/source/models/spec_decode.rst
+++ b/docs/source/models/spec_decode.rst
@@ -17,6 +17,7 @@ Speculating with a draft model
 The following code configures vLLM to use speculative decoding with a draft model, speculating 5 tokens at a time.
 
 .. code-block:: python
+
     from vllm import LLM, SamplingParams
     
     prompts = [
@@ -45,6 +46,7 @@ The following code configures vLLM to use speculative decoding where proposals a
 matching n-grams in the prompt. For more information read `this thread. <https://x.com/joao_gante/status/1747322413006643259>`_
 
 .. code-block:: python
+
     from vllm import LLM, SamplingParams
     
     prompts = [


### PR DESCRIPTION
```
Warning, treated as error:
[2024-06-11T01:15:20Z] /vllm-workspace/test_docs/docs/source/models/spec_decode.rst:19:Error in "code-block" directive:
[2024-06-11T01:15:20Z] maximum 1 argument(s) allowed, 6 supplied.
```