### PR TITLE
[Misc] add code to get git hash info for vllm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Target device: ${VLLM_TARGET_DEVICE}")
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/dep.cmake)
 
 #
 # Supported python versions.  These versions will be searched in order, the
@@ -206,7 +207,8 @@ define_gpu_extension_target(
   ARCHITECTURES ${VLLM_GPU_ARCHES}
   INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR};${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
   USE_SABI 3
-  WITH_SOABI)
+  WITH_SOABI
+  LIBRARIES cmake_git_version_tracking)
 
 #
 # _moe_C extension
@@ -224,7 +226,8 @@ define_gpu_extension_target(
   COMPILE_FLAGS ${VLLM_GPU_FLAGS}
   ARCHITECTURES ${VLLM_GPU_ARCHES}
   USE_SABI 3
-  WITH_SOABI)
+  WITH_SOABI
+  LIBRARIES cmake_git_version_tracking)
 
 #
 # _punica_C extension
@@ -276,7 +279,8 @@ if (VLLM_PUNICA_GPU_ARCHES)
     COMPILE_FLAGS ${VLLM_PUNICA_GPU_FLAGS}
     ARCHITECTURES ${VLLM_PUNICA_GPU_ARCHES}
     USE_SABI 3
-    WITH_SOABI)
+    WITH_SOABI
+    LIBRARIES cmake_git_version_tracking)
 else()
   message(WARNING "Unable to create _punica_C target because none of the "
     "requested architectures (${VLLM_GPU_ARCHES}) are supported, i.e. >= 8.0")

--- a/cmake/dep.cmake
+++ b/cmake/dep.cmake
@@ -1,0 +1,6 @@
+include(FetchContent)
+FetchContent_Declare(cmake_git_version_tracking                   
+  GIT_REPOSITORY https://github.com/andrew-hardin/cmake-git-version-tracking.git
+  GIT_TAG 6c0cb87edd029ddfb403a8e24577c144a03605a6
+)
+FetchContent_MakeAvailable(cmake_git_version_tracking)

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -2,10 +2,18 @@
 #include "ops.h"
 #include "registration.h"
 
+#include <git.h>
 #include <torch/library.h>
+
+std::string githash() { return std::string{git::CommitSHA1()}; }
 
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // vLLM custom ops
+
+  // git hash
+  // Show vllm git hash
+  ops.def("githash() -> ()");
+  ops.impl("githash", torch::kCPU, &githash);
 
   // Attention ops
   // Compute the attention between an input query and the cached keys/values

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -12,7 +12,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // git hash
   // Show vllm git hash
-  ops.def("githash() -> ()");
+  ops.def("githash", &githash);
   ops.impl("githash", torch::kCPU, &githash);
 
   // Attention ops

--- a/csrc/punica/torch_bindings.cpp
+++ b/csrc/punica/torch_bindings.cpp
@@ -1,14 +1,7 @@
 #include "registration.h"
 #include "punica_ops.h"
 
-#include <git.h>
-
-std::string githash() { return std::string{git::CommitSHA1()}; }
-
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
-  m.def("githash() -> ()");
-  m.impl("githash", torch::kCUDA, &githash);
-
   m.def(
       "dispatch_bgmv(Tensor! y, Tensor x, Tensor w, Tensor indicies, int "
       "layer_idx, float scale) -> ()");

--- a/csrc/punica/torch_bindings.cpp
+++ b/csrc/punica/torch_bindings.cpp
@@ -1,7 +1,14 @@
 #include "registration.h"
 #include "punica_ops.h"
 
+#include <git.h>
+
+std::string githash() { return std::string{git::CommitSHA1()}; }
+
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
+  m.def("githash() -> ()");
+  m.impl("githash", torch::kCUDA, &githash);
+
   m.def(
       "dispatch_bgmv(Tensor! y, Tensor x, Tensor w, Tensor indicies, int "
       "layer_idx, float scale) -> ()");

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -4,6 +4,7 @@
 #include "registration.h"
 
 #include <torch/library.h>
+#include <git.h>
 
 // Note on op signatures:
 // The X_meta signatures are for the meta functions corresponding to op X.
@@ -15,8 +16,15 @@
 // https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit#heading=h.ptttacy8y1u9
 // https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/README.md#annotations
 
+std::string githash() { return std::string{git::CommitSHA1()}; }
+
 TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // vLLM custom ops
+
+  // git hash
+  // Show vllm git hash
+  ops.def("githash() -> ()");
+  ops.impl("githash", torch::kCUDA, &githash);
 
   // Attention ops
   // Compute the attention between an input query and the cached

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -23,7 +23,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // git hash
   // Show vllm git hash
-  ops.def("githash() -> ()");
+  ops.def("githash", &githash);
   ops.impl("githash", torch::kCUDA, &githash);
 
   // Attention ops

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "PoolingParams",
 ]
 
+
 def githash():
     import torch
     return torch.ops._C.githash()

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -15,6 +15,7 @@ from vllm.sampling_params import SamplingParams
 __version__ = "0.5.0"
 
 __all__ = [
+    "githash",
     "LLM",
     "ModelRegistry",
     "PromptStrictInputs",
@@ -32,3 +33,7 @@ __all__ = [
     "initialize_ray_cluster",
     "PoolingParams",
 ]
+
+def githash():
+    import torch
+    return torch.ops._C.githash()


### PR DESCRIPTION
Add code to get git hash information for vllm so people can check which commit the vllm is built from. This will be useful for tracking wheels and reporting bugs.

Utilized cmake-git-version-tracking cmake package from: https://github.com/andrew-hardin/cmake-git-version-tracking

With the changes, we can check the git hash by calling:

```
import vllm
vllm.githash()
```
