### PR TITLE
[Frontend] support only use linear lora modules in attention

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1042,6 +1042,7 @@ class LoRAConfig:
     max_lora_rank: int
     max_loras: int
     fully_sharded_loras: bool = False
+    linear_lora_attn_only: bool = False
     max_cpu_loras: Optional[int] = None
     lora_dtype: Optional[torch.dtype] = None
     lora_extra_vocab_size: int = 256

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -67,6 +67,7 @@ class EngineArgs:
     max_loras: int = 1
     max_lora_rank: int = 16
     fully_sharded_loras: bool = False
+    linear_lora_attn_only: bool = False
     lora_extra_vocab_size: int = 256
     long_lora_scaling_factors: Optional[Tuple[float]] = None
     lora_dtype: str = 'auto'
@@ -501,6 +502,12 @@ class EngineArgs:
                   'Enabling this will use the fully sharded layers. '
                   'At high sequence length, max rank or '
                   'tensor parallel size, this is likely faster.'))
+        parser.add_argument(
+            '--linear-lora-attn-only',
+            action='store_true',
+            help=('By default, vLLM create LoRA modules for all linear modules. '
+                  'When enabling this, vLLM would not create LoRA modules for linear modules '
+                  'that is not in attention module.'))
         parser.add_argument("--device",
                             type=str,
                             default=EngineArgs.device,
@@ -703,6 +710,7 @@ class EngineArgs:
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,
             fully_sharded_loras=self.fully_sharded_loras,
+            linear_lora_attn_only=self.linear_lora_attn_only,
             lora_extra_vocab_size=self.lora_extra_vocab_size,
             long_lora_scaling_factors=self.long_lora_scaling_factors,
             lora_dtype=self.lora_dtype,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -505,9 +505,10 @@ class EngineArgs:
         parser.add_argument(
             '--linear-lora-attn-only',
             action='store_true',
-            help=('By default, vLLM create LoRA modules for all linear modules. '
-                  'When enabling this, vLLM would not create LoRA modules for linear modules '
-                  'that is not in attention module.'))
+            help=('By default, vLLM create LoRA modules for all linear '
+                  'modules. When enabling this, vLLM would not create '
+                  'LoRA modules for linear modules that is not in '
+                  'attention module.'))
         parser.add_argument("--device",
                             type=str,
                             default=EngineArgs.device,

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -679,10 +679,11 @@ class LoRAModelManager:
                 self._attn_modules[name] = module
 
     def _match_target_modules(self, module_name: str, module: nn.Module):
-        if self.lora_config.linear_lora_attn_only:
-            if not any(module_name.startswith(x + ".") for x in self._attn_modules):
-                if "Linear" in module.__class__.__name__:
-                    return False
+        is_attn_child = any(module_name.startswith(x + ".")
+                            for x in self._attn_modules)
+        if self.lora_config.linear_lora_attn_only and not is_attn_child and \
+                "Linear" in module.__class__.__name__:
+            return False
         return any(
             re.match(
                 r".*\.{target_module}$".format(target_module=target_module),

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -679,8 +679,8 @@ class LoRAModelManager:
                 self._attn_modules[name] = module
 
     def _match_target_modules(self, module_name: str, module: nn.Module):
-        is_attn_child = any(module_name.startswith(x + ".")
-                            for x in self._attn_modules)
+        is_attn_child = any(
+            module_name.startswith(x + ".") for x in self._attn_modules)
         if self.lora_config.linear_lora_attn_only and not is_attn_child and \
                 "Linear" in module.__class__.__name__:
             return False

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -675,7 +675,7 @@ class LoRAModelManager:
     def _find_attn_modules(self):
         self._attn_modules = {}
         for name, module in self.model.named_modules(remove_duplicate=False):
-            if module.__name__.endswith("Attention"):
+            if module.__class__.__name__.endswith("Attention"):
                 self._attn_modules[name] = module
 
     def _match_target_modules(self, module_name: str, module: nn.Module):

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -1,4 +1,3 @@
-
 import copy
 import json
 import math


### PR DESCRIPTION
The vLLM create LoRA modules for all linear modules and use punica kernel for lora forward. So we need to precompile all possible linear dimensions. If a model with new intermediate size is published, we cannot use it with lora before adding the new intermediate size to the c++ code.

However, many lora models only use linear modules in attention module (e.g. qkv_proj and o_proj). This PR add a argument 
 `--linear-lora-attn-only` to support only use linear modules in attention module.

