### PR TITLE
[Kernel] Update Cutlass int8 kernel configs for SM90

### DIFF
--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -120,9 +120,8 @@ def bench_int8(dtype: torch.dtype, m: int, k: int, n: int, label: str,
 
     # cutlass impl
     timers.append(
-        bench_fn(a, b, scale_a.to(device="cpu"), scale_b.to(device="cpu"),
-                 torch.bfloat16, label, sub_label, cutlass_impl,
-                 "cutlass_i8_i8_bf16_scaled_mm"))
+        bench_fn(a, b, scale_a, scale_b, torch.bfloat16, label, sub_label,
+                 cutlass_impl, "cutlass_i8_i8_bf16_scaled_mm"))
 
     return timers
 
@@ -160,14 +159,12 @@ def bench_fp8(dtype: torch.dtype, m: int, k: int, n: int, label: str,
 
     # cutlass impl: bf16 output
     timers.append(
-        bench_fn(a, b, scale_a.to(device="cpu"), scale_b.to(device="cpu"),
-                 torch.bfloat16, label, sub_label, cutlass_impl,
-                 "cutlass_fp8_fp8_bf16_scaled_mm"))
+        bench_fn(a, b, scale_a, scale_b, torch.bfloat16, label, sub_label,
+                 cutlass_impl, "cutlass_fp8_fp8_bf16_scaled_mm"))
     # cutlass impl: fp16 output
     timers.append(
-        bench_fn(a, b, scale_a.to(device="cpu"), scale_b.to(device="cpu"),
-                 torch.float16, label, sub_label, cutlass_impl,
-                 "cutlass_fp8_fp8_fp16_scaled_mm"))
+        bench_fn(a, b, scale_a, scale_b, torch.float16, label, sub_label,
+                 cutlass_impl, "cutlass_fp8_fp8_fp16_scaled_mm"))
     return timers
 
 

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
@@ -414,7 +414,7 @@ void cutlass_gemm_sm90_int8_dispatch(torch::Tensor& out, torch::Tensor const& a,
       typename sm90_int8_config_M32_NSmall<InType, OutType,
                                            Epilogue>::Cutlass3xGemm;
 
-  uint32_t const n = a.size(1);
+  uint32_t const n = out.size(1);
   bool const is_small_n = n < 8192;
 
   uint32_t const m = a.size(0);

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
@@ -486,8 +486,8 @@ void cutlass_scaled_mm_sm90(torch::Tensor& out, torch::Tensor const& a,
           out, a, b, a_scales, b_scales);
     } else {
       TORCH_CHECK(out.dtype() == torch::kFloat16);
-      return cutlass_gemm_sm90_fp8_dispatch<
-          cutlass::float_e4m3_t, cutlass::half_t, ScaledEpilogue>(
+      return cutlass_gemm_sm90_fp8_dispatch<cutlass::float_e4m3_t,
+                                            cutlass::half_t, ScaledEpilogue>(
           out, a, b, a_scales, b_scales);
     }
   }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
@@ -486,8 +486,8 @@ void cutlass_scaled_mm_sm90(torch::Tensor& out, torch::Tensor const& a,
           out, a, b, a_scales, b_scales);
     } else {
       TORCH_CHECK(out.dtype() == torch::kFloat16);
-      return cutlass_gemm_sm90_fp8_dispatch<cutlass::float_e4m3_t,
-                                            cutlass::half_t, ScaledEpilogue>(
+      return cutlass_gemm_sm90_fp8_dispatch<
+          cutlass::float_e4m3_t, cutlass::half_t, ScaledEpilogue>(
           out, a, b, a_scales, b_scales);
     }
   }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c3x.cu
@@ -233,11 +233,10 @@ void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
   CUTLASS_CHECK(status);
 }
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_fp8_config_default {
-  // M in (128, inf) 
+  // M in (128, inf)
   static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
   using KernelSchedule =
       cutlass::gemm::KernelTmaWarpSpecializedPingpongFP8FastAccum;
@@ -249,8 +248,7 @@ struct sm90_fp8_config_default {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_fp8_config_M128 {
   // M in (64, 128]
@@ -265,8 +263,7 @@ struct sm90_fp8_config_M128 {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_fp8_config_M64 {
   // M in [1, 64]
@@ -282,8 +279,7 @@ struct sm90_fp8_config_M64 {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_int8_config_default {
   // For M > 128 and any N
@@ -298,8 +294,7 @@ struct sm90_int8_config_default {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_int8_config_M128 {
   // For M in (64, 128] and any N
@@ -314,8 +309,7 @@ struct sm90_int8_config_M128 {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_int8_config_M64 {
   // For M in (32, 64] and any N
@@ -329,8 +323,7 @@ struct sm90_int8_config_M64 {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_int8_config_M32_NBig {
   // For M in [1, 32] and N >= 8192
@@ -344,8 +337,7 @@ struct sm90_int8_config_M32_NBig {
                       KernelSchedule, EpilogueSchedule>;
 };
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue>
 struct sm90_int8_config_M32_NSmall {
   // For M in [1, 32] and N < 8192
@@ -361,12 +353,10 @@ struct sm90_int8_config_M32_NSmall {
 
 }  // namespace
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue,
           typename... EpilogueArgs>
-void cutlass_gemm_sm90_fp8_dispatch(torch::Tensor& out,
-                                    torch::Tensor const& a,
+void cutlass_gemm_sm90_fp8_dispatch(torch::Tensor& out, torch::Tensor const& a,
                                     torch::Tensor const& b,
                                     EpilogueArgs&&... args) {
   static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
@@ -374,7 +364,8 @@ void cutlass_gemm_sm90_fp8_dispatch(torch::Tensor& out,
   TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
 
   using Cutlass3xGemmDefault =
-      typename sm90_fp8_config_default<InType, OutType, Epilogue>::Cutlass3xGemm;
+      typename sm90_fp8_config_default<InType, OutType,
+                                       Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM64 =
       typename sm90_fp8_config_M64<InType, OutType, Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM128 =
@@ -399,12 +390,10 @@ void cutlass_gemm_sm90_fp8_dispatch(torch::Tensor& out,
   }
 }
 
-template <typename InType,
-          typename OutType,
+template <typename InType, typename OutType,
           template <typename, typename, typename> typename Epilogue,
           typename... EpilogueArgs>
-void cutlass_gemm_sm90_int8_dispatch(torch::Tensor& out,
-                                     torch::Tensor const& a,
+void cutlass_gemm_sm90_int8_dispatch(torch::Tensor& out, torch::Tensor const& a,
                                      torch::Tensor const& b,
                                      EpilogueArgs&&... args) {
   static_assert(std::is_same<InType, int8_t>());
@@ -412,15 +401,18 @@ void cutlass_gemm_sm90_int8_dispatch(torch::Tensor& out,
   TORCH_CHECK(b.dtype() == torch::kInt8);
 
   using Cutlass3xGemmDefault =
-      typename sm90_int8_config_default<InType, OutType, Epilogue>::Cutlass3xGemm;
+      typename sm90_int8_config_default<InType, OutType,
+                                        Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM128 =
       typename sm90_int8_config_M128<InType, OutType, Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM64 =
       typename sm90_int8_config_M64<InType, OutType, Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM32NBig =
-      typename sm90_int8_config_M32_NBig<InType, OutType, Epilogue>::Cutlass3xGemm;
+      typename sm90_int8_config_M32_NBig<InType, OutType,
+                                         Epilogue>::Cutlass3xGemm;
   using Cutlass3xGemmM32NSmall =
-      typename sm90_int8_config_M32_NSmall<InType, OutType, Epilogue>::Cutlass3xGemm;
+      typename sm90_int8_config_M32_NSmall<InType, OutType,
+                                           Epilogue>::Cutlass3xGemm;
 
   uint32_t const n = a.size(1);
   bool const is_small_n = n < 8192;
@@ -453,8 +445,7 @@ void cutlass_gemm_sm90_int8_dispatch(torch::Tensor& out,
   }
 }
 
-void cutlass_scaled_mm_sm90(torch::Tensor& out,
-                            torch::Tensor const& a,
+void cutlass_scaled_mm_sm90(torch::Tensor& out, torch::Tensor const& a,
                             torch::Tensor const& b,
                             torch::Tensor const& a_scales,
                             torch::Tensor const& b_scales) {


### PR DESCRIPTION
This PR:
 - Add 5 int8 Cutlass Kernel configurations for different Gemm shape regimes.
M in [1, 32] && N < 8192
M in [1, 32] && N >= 8192
M in (32, 64]
M in (64, 128]
M in (128, inf)

Add dispatching to the correct configuration based on the Gemm problem shape.
The kernel configurations were selected from benchmark sweeps performed on an H100 GPU on a variety of commonly encountered GEMM shapes.

Numbers:
GPU : H100
Command: `python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype int8 model_bench --models meta-llama/Llama-2-7b-hf`

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Gemm Shapes | Main (micro-seconds) | This PR (micro-seconds) | Speedup
-- | -- | -- | --
MKN=(1x4096x12288) | 29.7 | 23.5 | 1.263829787
MKN=(1x4096x4096) | 17.1 | 7.5 | 2.28
MKN=(1x4096x22016) | 46.7 | 40 | 1.1675
MKN=(1x11008x4096) | 34.2 | 20.9 | 1.636363636
MKN=(16x4096x12288) | 24.6 | 23.8 | 1.033613445
MKN=(16x4096x4096) | 15.5 | 7.3 | 2.123287671
MKN=(16x4096x22016) | 42.5 | 40.4 | 1.051980198
MKN=(16x11008x4096) | 33.4 | 21.1 | 1.582938389
MKN=(32x4096x12288) | 27.5 | 22.8 | 1.206140351
MKN=(32x4096x4096) | 15.6 | 7.2 | 2.166666667
MKN=(32x4096x22016) | 42.7 | 38.5 | 1.109090909
MKN=(32x11008x4096) | 33.5 | 21.3 | 1.572769953
MKN=(64x4096x12288) | 28 | 24.7 | 1.133603239
MKN=(64x4096x4096) | 15.6 | 8.9 | 1.752808989
MKN=(64x4096x22016) | 43.8 | 39.1 | 1.120204604
MKN=(64x11008x4096) | 33.1 | 21.3 | 1.55399061
MKN=(128x4096x12288) | 26.2 | 25.4 | 1.031496063
MKN=(128x4096x4096) | 14.8 | 10.2 | 1.450980392
MKN=(128x4096x22016) | 42 | 38.6 | 1.088082902
MKN=(128x11008x4096) | 32.9 | 24 | 1.370833333
MKN=(256x4096x12288) | 32.8 | 31.6 | 1.037974684
MKN=(256x4096x4096) | 16.1 | 14.2 | 1.133802817
MKN=(256x4096x22016) | 50.3 | 47.8 | 1.052301255
MKN=(256x11008x4096) | 35.1 | 32.9 | 1.066869301
MKN=(512x4096x12288) | 48.5 | 44 | 1.102272727
MKN=(512x4096x4096) | 19 | 14.8 | 1.283783784
MKN=(512x4096x22016) | 87.8 | 80.3 | 1.093399751
MKN=(512x11008x4096) | 42.7 | 37.7 | 1.132625995



Command: `python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype int8 model_bench --models mistralai/Mistral-7B-v0.1`

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Gemm Shapes | Main | This PR | Speedup
-- | -- | -- | --
MKN=(1x4096x6144) | 20.4 | 10.1 | 2.01980198
MKN=(1x4096x4096) | 17.3 | 7.6 | 2.276315789
MKN=(1x4096x28672) | 56.2 | 45.7 | 1.2297593
MKN=(1x14336x4096) | 42.4 | 25.9 | 1.637065637
MKN=(16x4096x6144) | 18.2 | 9.8 | 1.857142857
MKN=(16x4096x4096) | 15.7 | 7.4 | 2.121621622
MKN=(16x4096x28672) | 49.3 | 46.4 | 1.0625
MKN=(16x14336x4096) | 41.3 | 26.3 | 1.570342205
MKN=(32x4096x6144) | 18.4 | 9.5 | 1.936842105
MKN=(32x4096x4096) | 15.8 | 7.3 | 2.164383562
MKN=(32x4096x28672) | 50.1 | 46.5 | 1.077419355
MKN=(32x14336x4096) | 41.5 | 26.5 | 1.566037736
MKN=(64x4096x6144) | 18.9 | 9.2 | 2.054347826
MKN=(64x4096x4096) | 15.9 | 9 | 1.766666667
MKN=(64x4096x28672) | 50.9 | 49.3 | 1.032454361
MKN=(64x14336x4096) | 40.7 | 26.8 | 1.518656716
MKN=(128x4096x6144) | 16.4 | 10.4 | 1.576923077
MKN=(128x4096x4096) | 15 | 10.5 | 1.428571429
MKN=(128x4096x28672) | 49.3 | 49.9 | 0.9879759519
MKN=(128x14336x4096) | 41 | 29.9 | 1.371237458
MKN=(256x4096x6144) | 18.1 | 14.5 | 1.248275862
MKN=(256x4096x4096) | 16.2 | 14.3 | 1.132867133
MKN=(256x4096x28672) | 64.9 | 61.4 | 1.057003257
MKN=(256x14336x4096) | 43.4 | 41.2 | 1.053398058
MKN=(512x4096x6144) | 31.4 | 26.3 | 1.19391635
MKN=(512x4096x4096) | 18.9 | 15 | 1.26
MKN=(512x4096x28672) | 106.7 | 97.3 | 1.096608428
MKN=(512x14336x4096) | 54.4 | 47.4 | 1.147679325



---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


