### PR TITLE
[Core] Remove duplicate processing in async engine

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -580,21 +580,9 @@ class AsyncLLMEngine:
         if arrival_time is None:
             arrival_time = time.time()
 
-        if self.engine_use_ray:
-            processed_inputs = await self.engine.process_model_inputs_async \
-                .remote(  # type: ignore
-                    request_id=request_id,
-                    inputs=inputs,
-                    lora_request=lora_request)
-        else:
-            processed_inputs = await self.engine.process_model_inputs_async(
-                request_id=request_id,
-                inputs=inputs,
-                lora_request=lora_request)
-
         stream = self._request_tracker.add_request(
             request_id,
-            inputs=processed_inputs,
+            inputs=inputs,
             params=params,
             arrival_time=arrival_time,
             lora_request=lora_request,


### PR DESCRIPTION
`_AsyncLLMEngine.process_model_inputs` is called in both `_AsyncLLMEngine` and `AsyncLLMEngine`. However, it is unnecessary to call the method inside `AsyncLLMEngine` because `AsyncLLMEngine.engine_step` will pass the request to the inner `_AsyncLLMEngine` anyways, which in turn calls `_AsyncLLMEngine.process_model_inputs` internally.