### PR TITLE
[Core][Distributed] improve p2p cache generation

### DIFF
--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -1,6 +1,7 @@
-# This file is a pure Python wrapper for the cudart library.
-# It avoids the need to compile a separate shared library, and is
-# convenient for use when we just need to call a few functions.
+"""This file is a pure Python wrapper for the cudart library.
+It avoids the need to compile a separate shared library, and is
+convenient for use when we just need to call a few functions.
+"""
 
 import ctypes
 from dataclasses import dataclass

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -1,6 +1,6 @@
 # This file is a pure Python wrapper for the cudart library.
 # It avoids the need to compile a separate shared library, and is
-# convienient for use when we just need to call a few functions.
+# convenient for use when we just need to call a few functions.
 
 import ctypes
 import platform
@@ -21,14 +21,17 @@ logger = init_logger(__name__)
 cudaError_t = ctypes.c_int
 cudaMemcpyKind = ctypes.c_int
 
+
 class cudaIpcMemHandle_t(ctypes.Structure):
     _fields_ = [("internal", ctypes.c_byte * 128)]
+
 
 @dataclass
 class Function:
     name: str
     restype: Any
     argtypes: List[Any]
+
 
 class CudaRTLibrary:
     exported_functions = [
@@ -41,18 +44,25 @@ class CudaRTLibrary:
         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
 
         # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
-        Function("cudaMalloc", cudaError_t, [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
+        Function("cudaMalloc", cudaError_t,
+                 [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
         # ​cudaError_t 	cudaFree ( void* devPtr )
         Function("cudaFree", cudaError_t, [ctypes.c_void_p]),
         # ​cudaError_t cudaMemset ( void* devPtr, int  value, size_t count )
-        Function("cudaMemset", cudaError_t, [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
+        Function("cudaMemset", cudaError_t,
+                 [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
         # ​cudaError_t cudaMemcpy ( void* dst, const void* src, size_t count, cudaMemcpyKind kind )
-        Function("cudaMemcpy", cudaError_t, [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, cudaMemcpyKind]),
+        Function("cudaMemcpy", cudaError_t, [
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, cudaMemcpyKind
+        ]),
 
         # cudaError_t cudaIpcGetMemHandle ( cudaIpcMemHandle_t* handle, void* devPtr )
-        Function("cudaIpcGetMemHandle", cudaError_t, [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p]),
+        Function("cudaIpcGetMemHandle", cudaError_t,
+                 [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p]),
         # ​cudaError_t cudaIpcOpenMemHandle ( void** devPtr, cudaIpcMemHandle_t handle, unsigned int  flags )
-        Function("cudaIpcOpenMemHandle", cudaError_t, [ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint]),
+        Function("cudaIpcOpenMemHandle", cudaError_t, [
+            ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint
+        ]),
     ]
 
     def __init__(self):
@@ -88,21 +98,27 @@ class CudaRTLibrary:
     def cudaFree(self, devPtr: ctypes.c_void_p) -> None:
         self.CUDART_CHECK(self.funcs["cudaFree"](devPtr))
 
-    def cudaMemset(self, devPtr: ctypes.c_void_p, value: int, count: int) -> None:
+    def cudaMemset(self, devPtr: ctypes.c_void_p, value: int,
+                   count: int) -> None:
         self.CUDART_CHECK(self.funcs["cudaMemset"](devPtr, value, count))
 
-    def cudaMemcpy(self, dst: ctypes.c_void_p, src: ctypes.c_void_p, count: int) -> None:
+    def cudaMemcpy(self, dst: ctypes.c_void_p, src: ctypes.c_void_p,
+                   count: int) -> None:
         cudaMemcpyDefault = 4
         kind = cudaMemcpyDefault
         self.CUDART_CHECK(self.funcs["cudaMemcpy"](dst, src, count, kind))
 
-    def cudaIpcGetMemHandle(self, devPtr: ctypes.c_void_p) -> cudaIpcMemHandle_t:
+    def cudaIpcGetMemHandle(self,
+                            devPtr: ctypes.c_void_p) -> cudaIpcMemHandle_t:
         handle = cudaIpcMemHandle_t()
-        self.CUDART_CHECK(self.funcs["cudaIpcGetMemHandle"](ctypes.byref(handle), devPtr))
+        self.CUDART_CHECK(self.funcs["cudaIpcGetMemHandle"](
+            ctypes.byref(handle), devPtr))
         return handle
-    
-    def cudaIpcOpenMemHandle(self, handle: cudaIpcMemHandle_t) -> ctypes.c_void_p:
+
+    def cudaIpcOpenMemHandle(self,
+                             handle: cudaIpcMemHandle_t) -> ctypes.c_void_p:
         cudaIpcMemLazyEnablePeerAccess = 1
         devPtr = ctypes.c_void_p()
-        self.CUDART_CHECK(self.funcs["cudaIpcOpenMemHandle"](ctypes.byref(devPtr), handle, cudaIpcMemLazyEnablePeerAccess))
+        self.CUDART_CHECK(self.funcs["cudaIpcOpenMemHandle"](
+            ctypes.byref(devPtr), handle, cudaIpcMemLazyEnablePeerAccess))
         return devPtr

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -38,6 +38,8 @@ class CudaRTLibrary:
         Function("cudaSetDevice", cudaError_t, [ctypes.c_int]),
         # cudaError_t 	cudaDeviceSynchronize ( void )
         Function("cudaDeviceSynchronize", cudaError_t, []),
+        # ​cudaError_t cudaDeviceReset ( void )
+        Function("cudaDeviceReset", cudaError_t, []),
 
         # const char* 	cudaGetErrorString ( cudaError_t error )
         Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
@@ -88,6 +90,9 @@ class CudaRTLibrary:
 
     def cudaDeviceSynchronize(self) -> None:
         self.CUDART_CHECK(self.funcs["cudaDeviceSynchronize"]())
+
+    def cudaDeviceReset(self) -> None:
+        self.CUDART_CHECK(self.funcs["cudaDeviceReset"]())
 
     def cudaMalloc(self, size: int) -> ctypes.c_void_p:
         devPtr = ctypes.c_void_p()

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -1,0 +1,108 @@
+# This file is a pure Python wrapper for the cudart library.
+# It avoids the need to compile a separate shared library, and is
+# convienient for use when we just need to call a few functions.
+
+import ctypes
+import platform
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+# this line makes it possible to directly load `libcudart.so` using `ctypes`
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# === export types and functions from cudart to Python ===
+# for the original cudart definition, please check
+# https://docs.nvidia.com/cuda/cuda-runtime-api/index.html
+
+cudaError_t = ctypes.c_int
+cudaMemcpyKind = ctypes.c_int
+
+class cudaIpcMemHandle_t(ctypes.Structure):
+    _fields_ = [("internal", ctypes.c_byte * 128)]
+
+@dataclass
+class Function:
+    name: str
+    restype: Any
+    argtypes: List[Any]
+
+class CudaRTLibrary:
+    exported_functions = [
+        # ​cudaError_t cudaSetDevice ( int  device )
+        Function("cudaSetDevice", cudaError_t, [ctypes.c_int]),
+        # cudaError_t 	cudaDeviceSynchronize ( void )
+        Function("cudaDeviceSynchronize", cudaError_t, []),
+
+        # const char* 	cudaGetErrorString ( cudaError_t error )
+        Function("cudaGetErrorString", ctypes.c_char_p, [cudaError_t]),
+
+        # ​cudaError_t 	cudaMalloc ( void** devPtr, size_t size )
+        Function("cudaMalloc", cudaError_t, [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]),
+        # ​cudaError_t 	cudaFree ( void* devPtr )
+        Function("cudaFree", cudaError_t, [ctypes.c_void_p]),
+        # ​cudaError_t cudaMemset ( void* devPtr, int  value, size_t count )
+        Function("cudaMemset", cudaError_t, [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
+        # ​cudaError_t cudaMemcpy ( void* dst, const void* src, size_t count, cudaMemcpyKind kind )
+        Function("cudaMemcpy", cudaError_t, [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, cudaMemcpyKind]),
+
+        # cudaError_t cudaIpcGetMemHandle ( cudaIpcMemHandle_t* handle, void* devPtr )
+        Function("cudaIpcGetMemHandle", cudaError_t, [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p]),
+        # ​cudaError_t cudaIpcOpenMemHandle ( void** devPtr, cudaIpcMemHandle_t handle, unsigned int  flags )
+        Function("cudaIpcOpenMemHandle", cudaError_t, [ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint]),
+    ]
+
+    def __init__(self):
+        so_file = "libcudart.so"
+        self.lib = ctypes.CDLL(so_file)
+        _funcs = {}
+        for func in CudaRTLibrary.exported_functions:
+            f = getattr(self.lib, func.name)
+            f.restype = func.restype
+            f.argtypes = func.argtypes
+            _funcs[func.name] = f
+        self.funcs = _funcs
+
+    def CUDART_CHECK(self, result: cudaError_t) -> None:
+        if result != 0:
+            error_str = self.cudaGetErrorString(result)
+            raise RuntimeError(f"CUDART error: {error_str}")
+
+    def cudaGetErrorString(self, error: cudaError_t) -> str:
+        return self.funcs["cudaGetErrorString"](error).decode("utf-8")
+
+    def cudaSetDevice(self, device: int) -> None:
+        self.CUDART_CHECK(self.funcs["cudaSetDevice"](device))
+
+    def cudaDeviceSynchronize(self) -> None:
+        self.CUDART_CHECK(self.funcs["cudaDeviceSynchronize"]())
+
+    def cudaMalloc(self, size: int) -> ctypes.c_void_p:
+        devPtr = ctypes.c_void_p()
+        self.CUDART_CHECK(self.funcs["cudaMalloc"](ctypes.byref(devPtr), size))
+        return devPtr
+
+    def cudaFree(self, devPtr: ctypes.c_void_p) -> None:
+        self.CUDART_CHECK(self.funcs["cudaFree"](devPtr))
+
+    def cudaMemset(self, devPtr: ctypes.c_void_p, value: int, count: int) -> None:
+        self.CUDART_CHECK(self.funcs["cudaMemset"](devPtr, value, count))
+
+    def cudaMemcpy(self, dst: ctypes.c_void_p, src: ctypes.c_void_p, count: int) -> None:
+        cudaMemcpyDefault = 4
+        kind = cudaMemcpyDefault
+        self.CUDART_CHECK(self.funcs["cudaMemcpy"](dst, src, count, kind))
+
+    def cudaIpcGetMemHandle(self, devPtr: ctypes.c_void_p) -> cudaIpcMemHandle_t:
+        handle = cudaIpcMemHandle_t()
+        self.CUDART_CHECK(self.funcs["cudaIpcGetMemHandle"](ctypes.byref(handle), devPtr))
+        return handle
+    
+    def cudaIpcOpenMemHandle(self, handle: cudaIpcMemHandle_t) -> ctypes.c_void_p:
+        cudaIpcMemLazyEnablePeerAccess = 1
+        devPtr = ctypes.c_void_p()
+        self.CUDART_CHECK(self.funcs["cudaIpcOpenMemHandle"](ctypes.byref(devPtr), handle, cudaIpcMemLazyEnablePeerAccess))
+        return devPtr

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -3,12 +3,11 @@
 # convenient for use when we just need to call a few functions.
 
 import ctypes
-import platform
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, List
 
 # this line makes it possible to directly load `libcudart.so` using `ctypes`
-import torch
+import torch  # noqa
 
 from vllm.logger import init_logger
 
@@ -51,15 +50,15 @@ class CudaRTLibrary:
         # ​cudaError_t cudaMemset ( void* devPtr, int  value, size_t count )
         Function("cudaMemset", cudaError_t,
                  [ctypes.c_void_p, ctypes.c_int, ctypes.c_size_t]),
-        # ​cudaError_t cudaMemcpy ( void* dst, const void* src, size_t count, cudaMemcpyKind kind )
+        # ​cudaError_t cudaMemcpy ( void* dst, const void* src, size_t count, cudaMemcpyKind kind ) # noqa
         Function("cudaMemcpy", cudaError_t, [
             ctypes.c_void_p, ctypes.c_void_p, ctypes.c_size_t, cudaMemcpyKind
         ]),
 
-        # cudaError_t cudaIpcGetMemHandle ( cudaIpcMemHandle_t* handle, void* devPtr )
+        # cudaError_t cudaIpcGetMemHandle ( cudaIpcMemHandle_t* handle, void* devPtr ) # noqa
         Function("cudaIpcGetMemHandle", cudaError_t,
                  [ctypes.POINTER(cudaIpcMemHandle_t), ctypes.c_void_p]),
-        # ​cudaError_t cudaIpcOpenMemHandle ( void** devPtr, cudaIpcMemHandle_t handle, unsigned int  flags )
+        # ​cudaError_t cudaIpcOpenMemHandle ( void** devPtr, cudaIpcMemHandle_t handle, unsigned int  flags ) # noqa
         Function("cudaIpcOpenMemHandle", cudaError_t, [
             ctypes.POINTER(ctypes.c_void_p), cudaIpcMemHandle_t, ctypes.c_uint
         ]),

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -33,8 +33,10 @@ def producer(batch_src: Sequence[int],
         producer_queue.put(handle)
         open_success = consumer_queue.get()
         if open_success:
+            # use two queues to simulate barrier
             producer_queue.put(0)
             consumer_queue.get()
+            # check if the memory is modified
             host_data = (ctypes.c_char * 1024)()
             lib.cudaMemcpy(host_data, pointer, 1024)  # type: ignore
             for i in range(1024):
@@ -67,9 +69,12 @@ def consumer(batch_tgt: Sequence[int],
             pass
         consumer_queue.put(open_success)
         if open_success:
+            # modify the memory
             lib.cudaMemset(pointer, 2, 1024)
+            # use two queues to simulate barrier
             producer_queue.get()
             consumer_queue.put(0)
+            # check if the memory is modified
             host_data = (ctypes.c_char * 1024)()
             lib.cudaMemcpy(host_data, pointer, 1024)  # type: ignore
             for i in range(1024):

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -1,3 +1,4 @@
+import ctypes
 import json
 import os
 import sys
@@ -57,6 +58,7 @@ def producer(i: int,
         else:
             raise RuntimeError("Failed to open the IPC handle")
 
+
 def consumer(j: int,
              init_method: str,
              cuda_visible_devices: Optional[str] = None):
@@ -76,7 +78,7 @@ def consumer(j: int,
         handle = recv[0]
         open_success = False
         try:
-            pointer = lib.cudaIpcOpenMemHandle(handle)
+            pointer = lib.cudaIpcOpenMemHandle(handle)  # type: ignore
             open_success = True
         except RuntimeError:
             # cannot error out here, because the producer process
@@ -87,11 +89,12 @@ def consumer(j: int,
             lib.cudaMemset(pointer, 2, 1024)
             dist.barrier()
             host_data = (ctypes.c_char * 1024)()
-            lib.cudaMemcpy(host_data, pointer, 1024)
+            lib.cudaMemcpy(host_data, pointer, 1024)  # type: ignore
             for i in range(1024):
                 assert host_data[i] == 2
         else:
             raise RuntimeError("Failed to open the IPC handle")
+
 
 def can_actually_p2p(i, j):
     """

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -79,7 +79,10 @@ def consumer(batch_js: List[int],
         lib.cudaDeviceReset()
 
 
-def can_actually_p2p(batch_is, batch_js):
+def can_actually_p2p(
+    batch_is: List[int],
+    batch_js: List[int],
+):
     """
     Usually, checking if P2P access is enabled can be done by
     `torch.cuda.can_device_access_peer(i, j)`. However, sometimes
@@ -103,7 +106,12 @@ def can_actually_p2p(batch_is, batch_js):
     tensor in process j will be reflected in the tensor in process i, because
     they are the same memory segment.
     It is important to note that process j accesses the tensor in GPU j, not
-    GPU i. That's why we need p2p access. # noqa
+    GPU i. That's why we need p2p access.
+
+    The most time-consuming part is the process creation. To avoid creating
+    processes for every pair of GPUs, we use batched testing. We create two
+    processes for testing all pairs of GPUs in batch. The trick is to reset
+    the device after each test (which is not available in PyTorch). # noqa
     """
     cuda_visible_devices = os.getenv('CUDA_VISIBLE_DEVICES', None)
     # pass the CUDA_VISIBLE_DEVICES to the child process

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -175,9 +175,15 @@ def gpu_p2p_access_check(i: int, j: int) -> bool:
         #  enter this block to calculate the cache
         logger.info("generating GPU P2P access cache in %s", path)
         cache = {}
+        batch_is = []
+        batch_js = []
         for _i in range(num_dev):
             for _j in range(num_dev):
-                cache[f"{_i}->{_j}"] = can_actually_p2p(_i, _j)
+                batch_is.append(_i)
+                batch_js.append(_j)
+        result = can_actually_p2p(batch_is, batch_js)
+        for _i, _j, r in zip(batch_is, batch_js, result):
+            cache[f"{_i}->{_j}"] = r
         with open(path, "w") as f:
             json.dump(cache, f, indent=4)
     if is_distributed:

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -5,16 +5,15 @@ import sys
 import tempfile
 import time
 from contextlib import contextmanager
-from typing import Callable, Dict, List, Optional
+from typing import Dict, Optional
 
-import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
 import vllm.envs as envs
+from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
 from vllm.utils import cuda_device_count_stateless
-from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 
 logger = init_logger(__name__)
 
@@ -54,7 +53,7 @@ def producer(i: int,
             host_data = (ctypes.c_char * 1024)()
             lib.cudaMemcpy(host_data, pointer, 1024)
             for i in range(1024):
-                assert host_data[i] == 2
+                assert ord(host_data[i]) == 2
         else:
             raise RuntimeError("Failed to open the IPC handle")
 
@@ -91,7 +90,7 @@ def consumer(j: int,
             host_data = (ctypes.c_char * 1024)()
             lib.cudaMemcpy(host_data, pointer, 1024)  # type: ignore
             for i in range(1024):
-                assert host_data[i] == 2
+                assert ord(host_data[i]) == 2
         else:
             raise RuntimeError("Failed to open the IPC handle")
 


### PR DESCRIPTION
fixes https://github.com/vllm-project/vllm/issues/5523

users report that generating p2p cache can be very slow. it requires about 11s for testing one pair, and for 8GPU machine it can take 8 x 8 x 11 ≈ 700 s, which is indeed quite long. The time is mainly spent on spawning processes, which takes quite a long time.

this pr removes pytorch for the test (which cannot reset device), so that we can test the p2p result in a batched fashion.

After this PR, the p2p cache generation time only slightly scale with the number of GPUs. e.g. it uses 19s for generating p2p cache in 4GPU machine, which used to take about 176s.