### PR TITLE
[CI/Build] Disable LLaVA-NeXT CPU test

### DIFF
--- a/.buildkite/run-cpu-test.sh
+++ b/.buildkite/run-cpu-test.sh
@@ -20,4 +20,4 @@ docker exec cpu-test bash -c "python3 examples/offline_inference.py"
 docker exec cpu-test bash -c "cd tests;
   pip install pytest Pillow protobuf
   cd ../
-  pytest -v -s tests/models -m "not llava" --ignore=tests/models/test_embedding.py --ignore=tests/models/test_registry.py
+  pytest -v -s tests/models -m \"not llava\" --ignore=tests/models/test_embedding.py --ignore=tests/models/test_registry.py"

--- a/.buildkite/run-cpu-test.sh
+++ b/.buildkite/run-cpu-test.sh
@@ -19,6 +19,5 @@ docker exec cpu-test bash -c "python3 examples/offline_inference.py"
 # Run basic model test
 docker exec cpu-test bash -c "cd tests;
   pip install pytest Pillow protobuf
-  bash ../.buildkite/download-images.sh
   cd ../
-  pytest -v -s tests/models --ignore=tests/models/test_llava.py --ignore=tests/models/test_embedding.py --ignore=tests/models/test_registry.py"
+  pytest -v -s tests/models -m "not llava" --ignore=tests/models/test_embedding.py --ignore=tests/models/test_registry.py


### PR DESCRIPTION
As discussed in #5481, vision models are currently not optimized for CPU, so they incur significant load on tests.

Although LLaVA-1.5 is currently excluded from the CPU tests, the existing test script fails to exclude the newly-added LLaVA-NeXT. This PR fixes this by updating the filter.


