### PR TITLE
[CI/Build] Each PR only uses 1 Machine (AMD)

### DIFF
--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -22,17 +22,19 @@ steps:
   - group: "AMD Tests"
     depends_on: ~
     steps:
-    {% for step in steps %}
-    {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
-      - label: "AMD: {{ step.label }}"
+      - label: "AMD Tests: {$BUILDKITE_COMMIT}"
         agents:
           queue: amd
-        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        commands:
+        {% for step in steps %}
+        {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
+          - bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        {% endif %}
+        {% endfor %}
         env:
           DOCKER_BUILDKIT: "1"
+        priority: 100
         soft_fail: true
-    {% endif %}
-    {% endfor %}
 
   - label: "Neuron Test"
     depends_on: ~

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -31,6 +31,7 @@ steps:
         {% endfor %}
         env:
           DOCKER_BUILDKIT: "1"
+        priority: 100
         soft_fail: true
 
   - label: "Neuron Test"

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -20,19 +20,17 @@ steps:
   - group: "AMD Tests"
     depends_on: ~
     steps:
-      - label: "AMD Tests: {$BUILDKITE_COMMIT}"
+    {% for step in steps %}
+    {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
+      - label: "AMD: {{ step.label }}"
         agents:
           queue: amd
-        commands: 
-        {% for step in steps %}
-        {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
-          - bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
-        {% endif %}
-        {% endfor %}
+        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
         env:
           DOCKER_BUILDKIT: "1"
-        priority: 100
         soft_fail: true
+    {% endif %}
+    {% endfor %}
 
   - label: "Neuron Test"
     depends_on: ~

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -20,19 +20,18 @@ steps:
   - group: "AMD Tests"
     depends_on: ~
     steps:
-    {% for step in steps %}
-    {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
-      - label: "AMD: {{ step.label }}"
+      - label: "AMD Tests: {$BUILDKITE_COMMIT}"
         agents:
           queue: amd
-        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
-        concurrency: 1
-        concurrency_group: "{$BUILDKITE_COMMIT}"
+        commands: 
+        {% for step in steps %}
+        {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
+          - bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        {% endif %}
+        {% endfor %}
         env:
           DOCKER_BUILDKIT: "1"
         soft_fail: true
-    {% endif %}
-    {% endfor %}
 
   - label: "Neuron Test"
     depends_on: ~

--- a/.buildkite/test-template.j2
+++ b/.buildkite/test-template.j2
@@ -26,6 +26,8 @@ steps:
         agents:
           queue: amd
         command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        concurrency: 1
+        concurrency_group: "{$BUILDKITE_COMMIT}"
         env:
           DOCKER_BUILDKIT: "1"
         soft_fail: true

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     nvidia-cuda-toolkit \
     tmux \
+    ccache \
  && rm -rf /var/lib/apt/lists/*
 
 ### Mount Point ###
@@ -102,7 +103,9 @@ ENV RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
 
 ENV VLLM_NCCL_SO_PATH=/opt/rocm/lib/librccl.so
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+ENV CCACHE_DIR=/root/.cache/ccache
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    --mount=type=cache,target=/root/.cache/pip \
     pip install -U -r requirements-rocm.txt \
     && patch /opt/rocm/include/hip/amd_detail/amd_hip_bf16.h ./rocm_patch/rocm_bf16.patch \
     && python3 setup.py install \


### PR DESCRIPTION
* Each PR is assigned a unique `concurrency_group`, which is limited to `concurrency: 1` machines
* This means the docker container is only built once
* Will increase speed when facing a large queue
