### PR TITLE
[BugFix] Don't start a Ray cluster when not using Ray

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -616,9 +616,14 @@ class ParallelConfig:
                                      "required for multi-node inference")
                 backend = "ray"
             elif ray_found:
-                from ray.util import get_current_placement_group
-                if self.placement_group or get_current_placement_group():
+                if self.placement_group:
                     backend = "ray"
+                else:
+                    from ray import is_initialized as ray_is_initialized
+                    if ray_is_initialized():
+                        from ray.util import get_current_placement_group
+                        if get_current_placement_group():
+                            backend = "ray"
             self.distributed_executor_backend = backend
             logger.info("Defaulting to use %s for distributed inference",
                         backend)


### PR DESCRIPTION
The logic to auto-select the distributed executor backend uses `ray.util.get_current_placement_group()` to check whether it's already running in a Ray placement group, but this function has a side effect of starting a Ray cluster if it's not already started.

The result is that a Ray cluster gets started even when defaulting to the multiprocessing distributed backend.