### PR TITLE
[CI][BugFix] Flip is_quant_method_supported condition

### DIFF
--- a/tests/quantization/utils.py
+++ b/tests/quantization/utils.py
@@ -10,5 +10,5 @@ def is_quant_method_supported(quant_method: str) -> bool:
 
     capability = torch.cuda.get_device_capability()
     capability = capability[0] * 10 + capability[1]
-    return (capability <
+    return (capability >=
             QUANTIZATION_METHODS[quant_method].get_min_capability())


### PR DESCRIPTION
The CUDA capability check was reversed and causing several quantization tests to be disabled.