### PR TITLE
[build][misc] limit numpy version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -2,7 +2,7 @@ cmake >= 3.21
 ninja  # For faster builds.
 psutil
 sentencepiece  # Required for LLaMA tokenizer.
-numpy
+numpy < 2.0.0
 requests
 py-cpuinfo
 transformers >= 4.40.0  # Required for StarCoder2 & Llava, Llama 3.


### PR DESCRIPTION
numpy 2.0 is just officially released. it has many breaking changes, as observed in https://buildkite.com/vllm/ci-aws/builds/1631#019022aa-6e00-4979-970c-20c73d4396d9 .