### PR TITLE
[Optimization] use a pool to reuse LogicalTokenBlock.token_ids

### DIFF
--- a/vllm/block.py
+++ b/vllm/block.py
@@ -20,7 +20,7 @@ class BlockPool:
         self.pool: Dict[int, List[TOKEN_BLOCKS]] = defaultdict(list)
 
     def alloc_block(self, block_size: int) -> TOKEN_BLOCKS:
-        if block_size in self.pool:
+        if block_size in self.pool and self.pool[block_size]:
             return self.pool[block_size].pop()
         return [_BLANK_TOKEN_ID] * block_size
 

--- a/vllm/block.py
+++ b/vllm/block.py
@@ -14,6 +14,13 @@ TokensBlock = List[int]
 
 class BlockPool:
     """A pool of physical blocks.
+    When requests come, we create a lot of logical blocks;
+    when requests are done, we destroy a lot of logical blocks.
+    It turns out that creating and destroying logical blocks can be expensive,
+    especially for the `token_ids` field, which is a list of integers.
+    To avoid this overhead, we use a pool to manage the logical blocks.
+    When an old request is done and a new request comes, we can reuse the
+    logical blocks from the old request to feed the new request.
     """
 
     def __init__(self) -> None:

--- a/vllm/block.py
+++ b/vllm/block.py
@@ -9,7 +9,7 @@ _BLANK_TOKEN_ID = -1
 
 DEFAULT_LAST_ACCESSED_TIME = -1
 
-TOKEN_BLOCKS = List[int]
+TokensBlock = List[int]
 
 
 class BlockPool:
@@ -18,14 +18,14 @@ class BlockPool:
 
     def __init__(self) -> None:
         # block size to list of token blocks
-        self.pool: Dict[int, List[TOKEN_BLOCKS]] = defaultdict(list)
+        self.pool: Dict[int, List[TokensBlock]] = defaultdict(list)
 
-    def alloc_block(self, block_size: int) -> TOKEN_BLOCKS:
+    def alloc_block(self, block_size: int) -> TokensBlock:
         if block_size in self.pool and self.pool[block_size]:
             return self.pool[block_size].pop()
         return [_BLANK_TOKEN_ID] * block_size
 
-    def del_block(self, block: TOKEN_BLOCKS) -> None:
+    def del_block(self, block: TokensBlock) -> None:
         self.pool[len(block)].append(block)
 
 


### PR DESCRIPTION
It is surprisingly effective.

Before:

Throughput: 32.37 requests/s, 16574.05 tokens/s

After:

Throughput: 35.64 requests/s, 18250.05 tokens/s

benchmark command: `python benchmarks/benchmark_throughput.py --output-len 256 --input 256 --model meta-llama/Llama-2-7b-hf -tp 8`

machine: 8*H100