### PR TITLE
Correct alignment in the seq_len diagram.

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -83,7 +83,7 @@ class FlashAttentionMetadata(AttentionMetadata):
     # |---------------- N iteration ---------------------|
     # |- tokenA -|......................|-- newTokens ---|
     # |---------- context_len ----------|
-    # |-------------------- seq_len ----------------------|
+    # |-------------------- seq_len ---------------------|
     #                                   |-- query_len ---|
 
     # Maximum query length in the batch. None for decoding.


### PR DESCRIPTION
This PR corrects a minor formatting issue in the documentation for context_len, query_len, and seq_len. There is seemingly an extra dash in the `seq_len` line, causing a slight misalignment in the diagram. This misalignment could potentially confuse users trying to understand the definitions.