### PR TITLE
feat: adds user information to the input of the scheduler

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -317,7 +317,8 @@ class Scheduler:
         """The number of new tokens."""
         return 1
 
-    def add_seq_group(self, seq_group: SequenceGroup) -> None:
+    def add_seq_group(self, seq_group: SequenceGroup, user_id: Optional[str] = None) -> None:
+        logger.debug(f"Received new seq group {seq_group.request_id} from user {user_id}")
         # Add sequence groups to the waiting queue.
         self.waiting.append(seq_group)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -285,6 +285,7 @@ class _AsyncLLMEngine(LLMEngine):
         params: Union[SamplingParams, PoolingParams],
         arrival_time: Optional[float] = None,
         lora_request: Optional[LoRARequest] = None,
+        user_id: Optional[str] = None,
     ) -> None:
         if lora_request is not None and not self.lora_config:
             raise ValueError(f"Got lora_request {lora_request} but LoRA is "
@@ -301,6 +302,7 @@ class _AsyncLLMEngine(LLMEngine):
             params=params,
             arrival_time=arrival_time,
             lora_request=lora_request,
+            user_id=user_id,
         )
 
     async def check_health_async(self) -> None:
@@ -556,6 +558,7 @@ class AsyncLLMEngine:
         params: Union[SamplingParams, PoolingParams],
         arrival_time: Optional[float] = None,
         lora_request: Optional[LoRARequest] = None,
+        user_id: Optional[str] = None,
     ) -> AsyncStream:
         if self.log_requests:
             if isinstance(inputs, str):
@@ -597,6 +600,7 @@ class AsyncLLMEngine:
             params=params,
             arrival_time=arrival_time,
             lora_request=lora_request,
+            user_id=user_id,
         )
 
         return stream
@@ -607,6 +611,7 @@ class AsyncLLMEngine:
         sampling_params: SamplingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
+        user_id: Optional[str] = None,
     ) -> AsyncIterator[RequestOutput]:
         """Generate outputs for a request.
 
@@ -621,6 +626,7 @@ class AsyncLLMEngine:
             sampling_params: The sampling parameters of the request.
             request_id: The unique id of the request.
             lora_request: LoRA request to use for generation, if any.
+            user_id: User identifier of the request, if any.
 
         Yields:
             The output `RequestOutput` objects from the LLMEngine
@@ -674,6 +680,7 @@ class AsyncLLMEngine:
                 inputs,
                 sampling_params,
                 lora_request=lora_request,
+                user_id=user_id,
         ):
             yield LLMEngine.validate_output(output, RequestOutput)
 
@@ -758,6 +765,7 @@ class AsyncLLMEngine:
         params: Union[SamplingParams, PoolingParams],
         *,
         lora_request: Optional[LoRARequest] = None,
+        user_id: Optional[str] = None,
     ) -> AsyncIterator[Union[RequestOutput, EmbeddingRequestOutput]]:
         """Common logic to process requests with SamplingParams or
         PoolingParams."""
@@ -769,6 +777,7 @@ class AsyncLLMEngine:
             params,
             arrival_time=arrival_time,
             lora_request=lora_request,
+            user_id=user_id,
         )
 
         try:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -444,6 +444,7 @@ class LLMEngine:
         params: Union[SamplingParams, PoolingParams],
         arrival_time: float,
         lora_request: Optional[LoRARequest],
+        user_id: Optional[str] = None,
     ) -> None:
         # Create the sequences.
         block_size = self.cache_config.block_size
@@ -475,7 +476,7 @@ class LLMEngine:
                 "Either SamplingParams or PoolingParams must be provided.")
 
         # Add the sequence group to the scheduler.
-        self.scheduler.add_seq_group(seq_group)
+        self.scheduler.add_seq_group(seq_group, user_id)
 
     def process_model_inputs(
         self,

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -133,6 +133,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     sampling_params,
                     f"{request_id}-{i}",
                     lora_request=lora_request,
+                    user_id=request.user,
                 )
 
                 generators.append(generator)


### PR DESCRIPTION
SOLVES #5605

This PR includes as input the user identifier corresponding to the input _SequenceGroup_ in the method _add_seq_group_ of the scheduler. In case that no user is provided, the scheduler receives the None value.

The change is only done for the OpenAI Completions API when not using Ray, other PRs can incorporate other scenarios.

In order to test:
1. Initialize server with debug log level `VLLM_LOGGING_LEVEL=DEBUG python3 -m vllm.entrypoints.openai.api_server --model ../models/llama/llama-2-7b`
2. Send request including user identifier `curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{ "model": "../models/llama/llama-2-7b", "prompt": "San Francisco is a", "max_tokens": 7, "temperature": 0, "user": "Pere" }'`
3. The logs of the server should contain the following line that is printed by the scheduler in its method _add_seq_group_ `Received new seq group cmpl-1b05ca776f1c4d7e85b84a7c216b36f7-0 from user Pere`, confirming that it received the user identifier

All new parameters in the methods are added as optional to avoid any conflict with other files or libraries.

