### PR TITLE
[misc][distributed] use localhost for single-node

### DIFF
--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -10,7 +10,7 @@ from vllm.executor.multiproc_worker_utils import (ProcessWorkerWrapper,
 from vllm.logger import init_logger
 from vllm.sequence import ExecuteModelRequest, SamplerOutput
 from vllm.utils import (cuda_device_count_stateless,
-                        get_distributed_init_method, get_ip, get_open_port,
+                        get_distributed_init_method, get_open_port,
                         get_vllm_instance_id, make_async)
 
 logger = init_logger(__name__)
@@ -38,7 +38,7 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
             "please set tensor_parallel_size to less than max local gpu count")
 
         distributed_init_method = get_distributed_init_method(
-            get_ip(), get_open_port())
+            "127.0.0.1", get_open_port())
 
         if world_size == 1:
             self.workers = []

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -37,6 +37,9 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
         assert world_size <= cuda_device_count_stateless(), (
             "please set tensor_parallel_size to less than max local gpu count")
 
+        # Multiprocessing-based executor does not support multi-node setting.
+        # Since it only works for single node, we can use the loopback address
+        # 127.0.0.1 for communication.
         distributed_init_method = get_distributed_init_method(
             "127.0.0.1", get_open_port())
 

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -164,6 +164,12 @@ class RayGPUExecutor(DistributedGPUExecutor):
         if len(node_gpus) == 1:
             # in single node case, we don't need to get the IP address.
             # the loopback address is sufficient
+            # NOTE: a node may have several IP addresses, one for each
+            # network interface. `get_ip()` might return any of them,
+            # while they might not work for communication inside the node
+            # if the network setup is complicated. Using the loopback address
+            # solves this issue, as it always works for communication inside
+            # the node.
             driver_ip = "127.0.0.1"
         distributed_init_method = get_distributed_init_method(
             driver_ip, get_open_port())

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -81,7 +81,6 @@ class RayGPUExecutor(DistributedGPUExecutor):
 
         # Create the workers.
         driver_ip = get_ip()
-        is_inside_single_node = True
         for bundle_id, bundle in enumerate(placement_group.bundle_specs):
             if not bundle.get("GPU", 0):
                 continue
@@ -110,8 +109,6 @@ class RayGPUExecutor(DistributedGPUExecutor):
             )
 
             worker_ip = ray.get(worker.get_node_ip.remote())
-            if worker_ip != driver_ip:
-                is_inside_single_node = False
             if worker_ip == driver_ip and self.driver_dummy_worker is None:
                 # If the worker is on the same node as the driver, we use it
                 # as the resource holder for the driver process.
@@ -164,7 +161,6 @@ class RayGPUExecutor(DistributedGPUExecutor):
         self._run_workers("update_environment_variables",
                           all_args=all_args_to_update_environment_variables)
 
-        driver_ip = "127.0.0.1" if is_inside_single_node else driver_ip
         distributed_init_method = get_distributed_init_method(
             driver_ip, get_open_port())
 

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -161,6 +161,10 @@ class RayGPUExecutor(DistributedGPUExecutor):
         self._run_workers("update_environment_variables",
                           all_args=all_args_to_update_environment_variables)
 
+        if len(node_gpus) == 1:
+            # in single node case, we don't need to get the IP address.
+            # localhost is sufficient
+            driver_ip = "127.0.0.1"
         distributed_init_method = get_distributed_init_method(
             driver_ip, get_open_port())
 

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -81,6 +81,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
 
         # Create the workers.
         driver_ip = get_ip()
+        is_inside_single_node = True
         for bundle_id, bundle in enumerate(placement_group.bundle_specs):
             if not bundle.get("GPU", 0):
                 continue
@@ -109,6 +110,8 @@ class RayGPUExecutor(DistributedGPUExecutor):
             )
 
             worker_ip = ray.get(worker.get_node_ip.remote())
+            if worker_ip != driver_ip:
+                is_inside_single_node = False
             if worker_ip == driver_ip and self.driver_dummy_worker is None:
                 # If the worker is on the same node as the driver, we use it
                 # as the resource holder for the driver process.
@@ -161,6 +164,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
         self._run_workers("update_environment_variables",
                           all_args=all_args_to_update_environment_variables)
 
+        driver_ip = "127.0.0.1" if is_inside_single_node else driver_ip
         distributed_init_method = get_distributed_init_method(
             driver_ip, get_open_port())
 

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -163,7 +163,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
 
         if len(node_gpus) == 1:
             # in single node case, we don't need to get the IP address.
-            # localhost is sufficient
+            # the loopback address is sufficient
             driver_ip = "127.0.0.1"
         distributed_init_method = get_distributed_init_method(
             driver_ip, get_open_port())


### PR DESCRIPTION
We have received numerous report that sometimes the following code does not get the correct IP for TCP communication, e.g. https://github.com/vllm-project/vllm/issues/3644 .

https://github.com/vllm-project/vllm/blob/daef218b5595a8c744ee143223f4f0544619ea9f/vllm/utils.py#L281-L312

If we know we are inside a single node, there is no need to get the ip actually. We can just use the localhost IP.

- [x] tell if we are inside a single node in ray by counting `node_id` , thanks for @rkooo567 

cc @njhill 