### PR TITLE
[Bugfix][Model]Solve the problem of inability to infer on vllm after minicpm training or awq

### DIFF
--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -500,6 +500,8 @@ class MiniCPMForCausalLM(nn.Module):
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
+            if "lm_head" in name:
+                continue
             if ("rotary_emb.cos_cached" in name
                     or "rotary_emb.sin_cached" in name):
                 # Models trained using ColossalAI may include these tensors in

--- a/vllm/model_executor/models/minicpm.py
+++ b/vllm/model_executor/models/minicpm.py
@@ -500,8 +500,8 @@ class MiniCPMForCausalLM(nn.Module):
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
-            if "lm_head" in name:
-                continue
+            if self.config.tie_word_embeddings and "lm_head.weight" in name:
+                 continue
             if ("rotary_emb.cos_cached" in name
                     or "rotary_emb.sin_cached" in name):
                 # Models trained using ColossalAI may include these tensors in


### PR DESCRIPTION

FILL IN THE PR DESCRIPTION HERE

FIX #4641 (*link existing issues this PR will resolve*)

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>



<h3><code>[Bugfix]</code><code>[Model]</code> inference on minicpm trained model will error，and minicpm will support awq soon，but awq model don't work on vllm now， This pr will solve this problem</h3>


