### PR TITLE
[Bugfix] Fix for inconsistent behaviour related to sampling and repetition penalties 

### DIFF
--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -419,13 +419,11 @@ class SamplingTensors:
         if do_penalties:
             for seq_group in sampling_metadata.seq_groups:
                 seq_ids = seq_group.seq_ids
-
                 if (seq_group.is_prompt
                         and sampling_params.prompt_logprobs is not None):
                     prefill_len = len(seq_group.prompt_logprob_indices)
                     prompt_tokens.extend([] for _ in range(prefill_len))
                     output_tokens.extend([] for _ in range(prefill_len))
-
                 if seq_group.do_sample:
                     for seq_id in seq_ids:
                         seq_data = seq_group.seq_data[seq_id]

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -343,14 +343,14 @@ class SamplingTensors:
 
         # first pass through to determine do_penalties
         for seq_group in sampling_metadata.seq_groups:
-             sampling_params = seq_group.sampling_params
-             p = sampling_params.presence_penalty
-             f = sampling_params.frequency_penalty
-             r = sampling_params.repetition_penalty
-             if not do_penalties and (abs(p) >= _SAMPLING_EPS
-                                 or abs(f) >= _SAMPLING_EPS
-                                 or abs(r - 1.0) >= _SAMPLING_EPS):
-                 do_penalties = True
+            sampling_params = seq_group.sampling_params
+            p = sampling_params.presence_penalty
+            f = sampling_params.frequency_penalty
+            r = sampling_params.repetition_penalty
+            if not do_penalties and (abs(p) >= _SAMPLING_EPS
+                                     or abs(f) >= _SAMPLING_EPS
+                                     or abs(r - 1.0) >= _SAMPLING_EPS):
+                do_penalties = True
 
         for seq_group in sampling_metadata.seq_groups:
             seq_ids = seq_group.seq_ids

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -340,6 +340,18 @@ class SamplingTensors:
                              get_num_triton_sampler_splits(vocab_size))
 
         assert sampling_metadata.seq_groups is not None
+
+        # first pass through to determine do_penalties
+        for seq_group in sampling_metadata.seq_groups:
+             sampling_params = seq_group.sampling_params
+             p = sampling_params.presence_penalty
+             f = sampling_params.frequency_penalty
+             r = sampling_params.repetition_penalty
+             if not do_penalties and (abs(p) >= _SAMPLING_EPS
+                                 or abs(f) >= _SAMPLING_EPS
+                                 or abs(r - 1.0) >= _SAMPLING_EPS):
+                 do_penalties = True
+
         for seq_group in sampling_metadata.seq_groups:
             seq_ids = seq_group.seq_ids
             sampling_params = seq_group.sampling_params
@@ -366,10 +378,6 @@ class SamplingTensors:
                 do_top_p_top_k = True
             if not do_min_p and min_p > _SAMPLING_EPS:
                 do_min_p = True
-            if not do_penalties and (abs(p) >= _SAMPLING_EPS
-                                     or abs(f) >= _SAMPLING_EPS
-                                     or abs(r - 1.0) >= _SAMPLING_EPS):
-                do_penalties = True
 
             is_prompt = seq_group.is_prompt
             if (seq_group.is_prompt


### PR DESCRIPTION
Fixes #5607 

I tracked this down to the `prompt_tokens` and `output_tokens` within `SamplingTensors` having the wrong shape, and determined that the correct/incorrect behaviour depends on the order of the requests within the batch. I found that it was enough to reproduce this with just two concurrent requests hitting the server with sampling params:
```python
sampling_params = []
    sampling_params.append(
        {
            "prompt": prompt,
            "temperature": 0.0,
            "max_tokens": 5,
            "repetition_penalty": 2,
        }
    )
    sampling_params.append(
        {
            "prompt": prompt,
            "seed": 99,
            "max_tokens": 4,
            "top_k": 1,
        }
    )
```
The bug relates to how we compute `do_penalties` on the fly inside `from_sampling_metadata`. If we hit the request with `repetition_penalty=2` first, then `do_penalties=True` also for the second request which results in `prompt_tokens` and `output_tokens` having length 2 (see [this line](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/sampling_metadata.py#L399-L400)) and we have the correct behaviour. On the other hand, if we hit the request without `repetition_penalty` first, then this results in `prompt_tokens` and `output_tokens` having length 1, which leads to incorrect sampling behaviour. 

A simple fix is just to do a quick pass through to compute `do_penalties` upfront, thus making it independent of the order of requests. 