### PR TITLE
[ci] Add A100 queue into AWS CI template

### DIFF
--- a/.buildkite/nightly-benchmarks/benchmark-pipeline.yaml
+++ b/.buildkite/nightly-benchmarks/benchmark-pipeline.yaml
@@ -17,6 +17,7 @@ steps:
     plugins:
     - kubernetes:
         podSpec:
+          priorityClassName: perf-benchmark
           containers:
           - image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:$BUILDKITE_COMMIT
             command:

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -24,6 +24,7 @@ steps:
 
 - label: Core Test
   mirror_hardwares: [amd]
+  gpu: a100
   command: pytest -v -s core
 
 - label: Distributed Comm Ops Test

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -15,7 +15,6 @@ steps:
 
 - label: Basic Correctness Test
   mirror_hardwares: [amd]
-  gpu: a100
   commands:
   - VLLM_ATTENTION_BACKEND=XFORMERS pytest -v -s basic_correctness/test_basic_correctness.py
   - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest -v -s basic_correctness/test_basic_correctness.py
@@ -25,7 +24,6 @@ steps:
 
 - label: Core Test
   mirror_hardwares: [amd]
-  gpu: a100
   command: pytest -v -s core
 
 - label: Distributed Comm Ops Test

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -175,4 +175,5 @@ steps:
 
 - label: A100 status
   gpu: a100
-  commands: nvidia-smi
+  commands: 
+  - nvidia-smi

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -15,6 +15,7 @@ steps:
 
 - label: Basic Correctness Test
   mirror_hardwares: [amd]
+  gpu: a100
   commands:
   - VLLM_ATTENTION_BACKEND=XFORMERS pytest -v -s basic_correctness/test_basic_correctness.py
   - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest -v -s basic_correctness/test_basic_correctness.py

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -172,3 +172,7 @@ steps:
   commands:
   - pip install -r requirements-docs.txt
   - SPHINXOPTS=\"-W\" make html
+
+- label: A100 status
+  gpu: a100
+  commands: nvidia-smi

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -2,6 +2,52 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 
 steps:
+  - label: ":docker: build image"
+    agents:
+      queue: cpu_queue
+    commands:
+      - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+      - "docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --tag {{ docker_image }} --target test --progress plain ."
+      - "docker push {{ docker_image }}"
+    env:
+      DOCKER_BUILDKIT: "1"
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 5
+        - exit_status: -10  # Agent was lost
+          limit: 5
+  - wait
+
+  - group: "AMD Tests"
+    depends_on: ~
+    steps:
+    {% for step in steps %}
+    {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
+      - label: "AMD: {{ step.label }}"
+        agents:
+          queue: amd
+        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
+        env:
+          DOCKER_BUILDKIT: "1"
+        priority: 100
+        soft_fail: true
+    {% endif %}
+    {% endfor %}
+
+  - label: "Neuron Test"
+    depends_on: ~
+    agents:
+      queue: neuron
+    command: bash .buildkite/run-neuron-test.sh
+    soft_fail: false
+
+  - label: "Intel Test"
+    depends_on: ~
+    agents:
+      queue: intel
+    command: bash .buildkite/run-cpu-test.sh
+
   {% for step in steps %}
   {% if step.gpu == "a100" %}
   - label: "{{ step.label }}"
@@ -21,7 +67,7 @@ steps:
     - kubernetes:
         podSpec:
           containers:
-          - image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:13db4369d9ab3158a01192d60c744c6523961824
+          - image: {{ docker_image }}
             command: ["bash"]
             args:
             - '-c'
@@ -71,7 +117,7 @@ steps:
           limit: 5
     plugins:
       - docker#v5.2.0:
-          image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:13db4369d9ab3158a01192d60c744c6523961824
+          image: {{ docker_image }}
           always-pull: true
           propagate-environment: true
           {% if not step.no_gpu %}

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -2,23 +2,58 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 
 steps:
-  - label: "user check"
+  {% for step in steps %}
+  {% if step.gpu == "a100" %}
+  - label: "{{ step.label }}"
     agents:
       queue: a100-queue
-    commands:
-      - whoami
-      - cat /etc/os-release
-      - nvidia-smi
-  - wait
-  {% for step in steps %}
+    soft_fail: {{ step.soft_fail or false }}
+    {% if step.parallelism %}
+    parallelism: {{ step.parallelism }}
+    {% endif %}
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 5
+        - exit_status: -10  # Agent was lost
+          limit: 5
+    plugins:
+    - kubernetes:
+        podSpec:
+          containers:
+          - image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:13db4369d9ab3158a01192d60c744c6523961824
+            command: ["bash"]
+            args:
+            - '-c'
+            - "'cd {{ (step.working_dir or default_working_dir) | safe }} && {{ step.command or (step.commands | join(' && ')) | safe }}'"
+            resources:
+              limits:
+                nvidia.com/gpu: 8
+            volumeMounts:
+            - name: devshm
+              mountPath: /dev/shm
+            env:
+            - name: VLLM_USAGE_SOURCE
+              value: ci-test
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token-secret
+                  key: token
+          nodeSelector:
+            nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
+          volumes:
+          - name: devshm
+            emptyDir:
+              medium: Memory
+  {% endif %}
+  {% if step.gpu != "a100" %}
   - label: "{{ step.label }}"
     agents:
       {% if step.label == "Documentation Build" %}
       queue: small_cpu_queue
       {% elif step.no_gpu %}
       queue: cpu_queue
-      {% elif step.gpu == "a100" %}
-      queue: a100-queue
       {% elif step.num_gpus == 2 or step.num_gpus == 4 %}
       queue: gpu_4_queue
       {% else %}
@@ -54,4 +89,5 @@ steps:
             {% endif %}
           volumes:
             - /dev/shm:/dev/shm
+  {% endif %}
   {% endfor %}

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -7,9 +7,8 @@ steps:
       queue: a100-queue
     commands:
       - whoami
-      - yum update -y
-      - amazon-linux-extras install docker
-      - service docker start
+      - cat /etc/os-release
+      - nvidia-smi
   - wait
   {% for step in steps %}
   - label: "{{ step.label }}"

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -66,6 +66,7 @@ steps:
     plugins:
     - kubernetes:
         podSpec:
+          priorityClassName: ci
           containers:
           - image: {{ docker_image }}
             command: ["bash"]

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -7,6 +7,9 @@ steps:
       queue: a100-queue
     commands:
       - whoami
+      - sudo yum update -y
+      - sudo amazon-linux-extras install docker
+      - sudo service docker start
   - wait
   {% for step in steps %}
   - label: "{{ step.label }}"

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -92,8 +92,7 @@ steps:
           - name: devshm
             emptyDir:
               medium: Memory
-  {% endif %}
-  {% if step.gpu != "a100" %}
+  {% else %}
   - label: "{{ step.label }}"
     agents:
       {% if step.label == "Documentation Build" %}

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -2,52 +2,6 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 
 steps:
-  - label: ":docker: build image"
-    agents:
-      queue: cpu_queue
-    commands:
-      - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - "docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --tag {{ docker_image }} --target test --progress plain ."
-      - "docker push {{ docker_image }}"
-    env:
-      DOCKER_BUILDKIT: "1"
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 5
-        - exit_status: -10  # Agent was lost
-          limit: 5
-  - wait
-
-  - group: "AMD Tests"
-    depends_on: ~
-    steps:
-    {% for step in steps %}
-    {% if step.mirror_hardwares and "amd" in step.mirror_hardwares %}
-      - label: "AMD: {{ step.label }}"
-        agents:
-          queue: amd
-        command: bash .buildkite/run-amd-test.sh "cd {{ (step.working_dir or default_working_dir) | safe  }} ; {{ step.command  or (step.commands | join(" ; ")) | safe }}"
-        env:
-          DOCKER_BUILDKIT: "1"
-        priority: 100
-        soft_fail: true
-    {% endif %}
-    {% endfor %}
-
-  - label: "Neuron Test"
-    depends_on: ~
-    agents:
-      queue: neuron
-    command: bash .buildkite/run-neuron-test.sh
-    soft_fail: false
-
-  - label: "Intel Test"
-    depends_on: ~
-    agents:
-      queue: intel
-    command: bash .buildkite/run-cpu-test.sh
-
   {% for step in steps %}
   - label: "{{ step.label }}"
     agents:
@@ -55,6 +9,8 @@ steps:
       queue: small_cpu_queue
       {% elif step.no_gpu %}
       queue: cpu_queue
+      {% elif step.gpu == "a100" %}
+      queue: a100-queue
       {% elif step.num_gpus == 2 or step.num_gpus == 4 %}
       queue: gpu_4_queue
       {% else %}
@@ -72,7 +28,7 @@ steps:
           limit: 5
     plugins:
       - docker#v5.2.0:
-          image: {{ docker_image }}
+          image: public.ecr.aws/q9t5s3a7/vllm-ci-test-repo:13db4369d9ab3158a01192d60c744c6523961824
           always-pull: true
           propagate-environment: true
           {% if not step.no_gpu %}

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -7,9 +7,9 @@ steps:
       queue: a100-queue
     commands:
       - whoami
-      - sudo yum update -y
-      - sudo amazon-linux-extras install docker
-      - sudo service docker start
+      - yum update -y
+      - amazon-linux-extras install docker
+      - service docker start
   - wait
   {% for step in steps %}
   - label: "{{ step.label }}"

--- a/.buildkite/test-template-aws.j2
+++ b/.buildkite/test-template-aws.j2
@@ -2,6 +2,12 @@
 {% set default_working_dir = "/vllm-workspace/tests" %}
 
 steps:
+  - label: "user check"
+    agents:
+      queue: a100-queue
+    commands:
+      - whoami
+  - wait
   {% for step in steps %}
   - label: "{{ step.label }}"
     agents:


### PR DESCRIPTION
Enable steps defined in `test-pipeline.yaml` with key `gpu: a100` to run with A100 GPUs