### PR TITLE
[CI/Build] Add tqdm to dependencies

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -4,6 +4,7 @@ psutil
 sentencepiece  # Required for LLaMA tokenizer.
 numpy < 2.0.0
 requests
+tqdm
 py-cpuinfo
 transformers >= 4.40.0  # Required for StarCoder2 & Llava, Llama 3.
 tokenizers >= 0.19.1  # Required for Llama 3.


### PR DESCRIPTION
`tqdm` is currently used in `vllm/entrypoints/llm.py` but fails to be included in the dependencies. This PR fixes that.

https://github.com/vllm-project/vllm/blob/3eea74889fe29534808bae41fca251e0e74c0962/vllm/entrypoints/llm.py#L4
