### PR TITLE
Fix doc error

### DIFF
--- a/docs/source/dev/dockerfile/dockerfile.rst
+++ b/docs/source/dev/dockerfile/dockerfile.rst
@@ -1,7 +1,7 @@
 Dockerfile
 ====================
 
-See `here <https://github.com/vllm-project/vllm/blob/main/Dockerfile>`_ for the main Dockerfile to construct 
+See `vLLM main Dockerfile <https://github.com/vllm-project/vllm/blob/main/Dockerfile>`_ to construct 
 the image for running an OpenAI compatible server with vLLM. More information about deploying with Docker can be found `here <https://docs.vllm.ai/en/stable/serving/deploying_with_docker.html>`_.
 
 Below is a visual representation of the multi-stage Dockerfile. The build graph contains the following nodes:


### PR DESCRIPTION
Reword the intro and change target name since RST file doesn't allow 2 targets (see error: https://buildkite.com/vllm/ci-aws/builds/2024#01903368-c886-4817-977a-36045f5a4da6/184-321)