### PR TITLE
[Model] Support Qwen-VL and Qwen-VL-Chat models with text-only inputs

### DIFF
--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -291,6 +291,7 @@ class QWenLMHeadModel(nn.Module):
                     continue
                 # Skip loading visual weights to support Qwen-VL models
                 # in cases with text-only inputs
+                # TODO: add support for Qwen-VL
                 if (name not in params_dict
                         and name.startswith("transformer.visual.")):
                     print_warning_once(

--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import SamplerOutput
+from vllm.utils import print_warning_once
 
 
 class QWenMLP(nn.Module):
@@ -287,6 +288,14 @@ class QWenLMHeadModel(nn.Module):
             else:
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
+                    continue
+                # Skip loading visual weights to support Qwen-VL models
+                # in cases with text-only inputs
+                if (name not in params_dict
+                        and name.startswith("transformer.visual.")):
+                    print_warning_once(
+                        "Only text inputs are allowed. Images won't be handled "
+                        "until Qwen-VL models are fully supported.")
                     continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader",


### PR DESCRIPTION
Hi all,

Qwen-VL and Qwen-VL-Chat models are still not supported in vLLM.
I found this fact while I was developing a program which uses Qwen-VL-Chat with text-only inputs.
vLLM fails with KeyError, which had been described in https://github.com/vllm-project/vllm/issues/962 .

Fully supporting Qwen-VL and Qwen-VL-Chat models seems not easy.
However, running these models with text-only inputs just needs minor changes in vLLM.
This is because Qwen-VL and Qwen-VL-Chat are actually Qwen-7B models if there are no images.

To support text-only inputs, the patch just skips loading the visual transformer weights, which are used to handle input images.
I would be appreciated if vLLM could support Qwen-VL models with text-only inputs as soon as possible.

Testing:
  Qwen-VL and Qwen-VL-Chat passed with text-only inputs after this patch.

Thanks.
Best regards,
Jie