### PR TITLE
[Bugfix] Add a more helpful load model OOM message

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -25,7 +25,8 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig, is_vllm_tensorized, load_with_tensorizer,
     serialize_vllm_model, tensorizer_weights_iterator)
-from vllm.model_executor.model_loader.utils import (get_model_architecture,
+from vllm.model_executor.model_loader.utils import (handle_oom,
+                                                    get_model_architecture,
                                                     set_default_torch_dtype)
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf, download_weights_from_hf,
@@ -249,6 +250,7 @@ class DefaultModelLoader(BaseModelLoader):
             weights_iterator = _xla_weights_iterator(weights_iterator)
         return weights_iterator
 
+    @handle_oom("DefaultModelLoader.load_model")
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
                    lora_config: Optional[LoRAConfig],

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -25,8 +25,8 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.model_loader.tensorizer import (
     TensorizerConfig, is_vllm_tensorized, load_with_tensorizer,
     serialize_vllm_model, tensorizer_weights_iterator)
-from vllm.model_executor.model_loader.utils import (handle_oom,
-                                                    get_model_architecture,
+from vllm.model_executor.model_loader.utils import (get_model_architecture,
+                                                    handle_oom,
                                                     set_default_torch_dtype)
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf, download_weights_from_hf,

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -53,7 +53,7 @@ def handle_oom(section_name: str) -> Callable:
             except torch.cuda.OutOfMemoryError as e:
                 msg = f"CUDA OutOfMemoryError occurred in: {section_name}\n"
                 msg += "Possible solutions:\n"
-                msg += "1. Use more devices by with tensor_parallel_size\n"
+                msg += "1. Use more devices with tensor_parallel_size\n"
                 msg += "2. Use a quantized checkpoint to reduce memory usage\n"
                 msg += "3. Use a machine with more device memory\n"
                 raise torch.cuda.OutOfMemoryError(msg) from e


### PR DESCRIPTION
We should strive to be more helpful in telling the user why vLLM went out of memory. We can start with the easy case of failing to initialize or load the model. This message simply notes that it failed during load model and adds a few suggestions for next steps. It is possible that we could measure the memory available before loading the model and report that as a more accurate assessment.

FIX https://github.com/vllm-project/vllm/issues/5711

Here is the new message when trying to load Llama 3 70B on a single 80GB GPU:
```
python -c 'from vllm import LLM;LLM("meta-llama/Meta-Llama-3-70B-Instruct")'
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
INFO 06-20 16:09:23 llm_engine.py:164] Initializing an LLM engine (v0.5.0.post1) with config: model='meta-llama/Meta-Llama-3-70B-Instruct', speculative_config=None, tokenizer='meta-llama/Meta-Llama-3-70B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=8192, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None), seed=0, served_model_name=meta-llama/Meta-Llama-3-70B-Instruct)
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/utils.py", line 52, in wrapper
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/loader.py", line 263, in load_model
[rank0]:     model = _initialize_model(model_config, self.load_config,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/loader.py", line 99, in _initialize_model
[rank0]:     return model_class(config=model_config.hf_config,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/llama.py", line 340, in __init__
[rank0]:     self.model = LlamaModel(config,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/llama.py", line 262, in __init__
[rank0]:     self.layers = nn.ModuleList([
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/llama.py", line 263, in <listcomp>
[rank0]:     LlamaDecoderLayer(config=config,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/llama.py", line 188, in __init__
[rank0]:     self.self_attn = LlamaAttention(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/llama.py", line 122, in __init__
[rank0]:     self.qkv_proj = QKVParallelLinear(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/linear.py", line 533, in __init__
[rank0]:     super().__init__(input_size=input_size,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/linear.py", line 252, in __init__
[rank0]:     self.quant_method.create_weights(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/linear.py", line 94, in create_weights
[rank0]:     weight = Parameter(torch.empty(sum(output_partition_sizes),
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/utils/_device.py", line 78, in __torch_function__
[rank0]:     return func(*args, **kwargs)
[rank0]: torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 160.00 MiB. GPU 

[rank0]: The above exception was the direct cause of the following exception:

[rank0]: Traceback (most recent call last):
[rank0]:   File "<string>", line 1, in <module>
[rank0]:   File "/home/mgoin/code/vllm/vllm/entrypoints/llm.py", line 144, in __init__
[rank0]:     self.llm_engine = LLMEngine.from_engine_args(
[rank0]:   File "/home/mgoin/code/vllm/vllm/engine/llm_engine.py", line 384, in from_engine_args
[rank0]:     engine = cls(
[rank0]:   File "/home/mgoin/code/vllm/vllm/engine/llm_engine.py", line 230, in __init__
[rank0]:     self.model_executor = executor_class(
[rank0]:   File "/home/mgoin/code/vllm/vllm/executor/executor_base.py", line 41, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/home/mgoin/code/vllm/vllm/executor/gpu_executor.py", line 24, in _init_executor
[rank0]:     self.driver_worker.load_model()
[rank0]:   File "/home/mgoin/code/vllm/vllm/worker/worker.py", line 122, in load_model
[rank0]:     self.model_runner.load_model()
[rank0]:   File "/home/mgoin/code/vllm/vllm/worker/model_runner.py", line 148, in load_model
[rank0]:     self.model = get_model(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/__init__.py", line 21, in get_model
[rank0]:     return loader.load_model(model_config=model_config,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/utils.py", line 59, in wrapper
[rank0]:     raise torch.cuda.OutOfMemoryError(msg) from e
[rank0]: torch.cuda.OutOfMemoryError: CUDA OutOfMemoryError occurred in: DefaultModelLoader.load_model
[rank0]: Possible solutions:
[rank0]: 1. Use more devices with tensor_parallel_size
[rank0]: 2. Use a quantized checkpoint to reduce memory usage
[rank0]: 3. Use a machine with more device memory
```


