### PR TITLE
[ROCm] add some utility apis and fix some unit test based on torch version

### DIFF
--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -14,6 +14,7 @@ TEST_DIST_MODEL=meta-llama/Llama-2-7b-hf \
 """
 import os
 
+from vllm.utils import is_hip, is_hip_version_less_than
 import pytest
 import torch
 
@@ -40,7 +41,8 @@ def test_models(
     distributed_executor_backend = os.getenv(DISTRIBUTED_EXECUTOR_BACKEND)
 
     backend_by_env_var = os.getenv(VLLM_ATTENTION_BACKEND)
-    enforce_eager = backend_by_env_var == "FLASHINFER"
+    rocm_use_eager = is_hip() and is_hip_version_less_than((6, 1))
+    enforce_eager = backend_by_env_var == "FLASHINFER" or rocm_use_eager
 
     with hf_runner(model, dtype=dtype) as hf_model:
         hf_outputs = hf_model.generate_greedy(example_prompts, max_tokens)

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -14,9 +14,10 @@ TEST_DIST_MODEL=meta-llama/Llama-2-7b-hf \
 """
 import os
 
-from vllm.utils import is_hip, is_hip_version_less_than
 import pytest
 import torch
+
+from vllm.utils import is_hip, is_hip_version_less_than
 
 MODELS = [
     os.environ["TEST_DIST_MODEL"],

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -1,7 +1,7 @@
 import os
-
+import pytest
 import ray
-
+import torch
 from vllm.utils import cuda_device_count_stateless
 
 
@@ -21,6 +21,10 @@ class _CUDADeviceCountStatelessTestActor:
 def test_cuda_device_count_stateless():
     """Test that cuda_device_count_stateless changes return value if
     CUDA_VISIBLE_DEVICES is changed."""
+
+    # skip this test if rocm does not support this yet
+    if torch.version.hip and not hasattr(torch.cuda, "_device_count_amdsmi"):
+        pytest.skip("no support to _device_count_amdsmi yet")
 
     actor = _CUDADeviceCountStatelessTestActor.options(  # type: ignore
         num_gpus=2).remote()

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import ray
 import torch
-
+from vllm.utils import is_hip
 from vllm.utils import cuda_device_count_stateless
 
 
@@ -25,7 +25,8 @@ def test_cuda_device_count_stateless():
     CUDA_VISIBLE_DEVICES is changed."""
 
     # skip this test if rocm does not support this yet
-    if torch.version.hip and not hasattr(torch.cuda, "_device_count_amdsmi"):
+    if is_hip() and (not hasattr(torch.cuda, "_device_count_amdsmi")
+                     or not torch.cuda._HAS_PYNVML):
         pytest.skip("no support to _device_count_amdsmi yet")
 
     actor = _CUDADeviceCountStatelessTestActor.options(  # type: ignore

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -1,7 +1,9 @@
 import os
+
 import pytest
 import ray
 import torch
+
 from vllm.utils import cuda_device_count_stateless
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -748,7 +748,8 @@ def deprecate_kwargs(
 
 
 @lru_cache(maxsize=8)
-def _cuda_device_count_stateless() -> int:
+def _cuda_device_count_stateless(
+        cuda_visible_devices: Optional[str] = None) -> int:
     # Note: cuda_visible_devices is not used, but we keep it as an argument for
     # LRU Cache purposes.
 
@@ -763,11 +764,9 @@ def _cuda_device_count_stateless() -> int:
         return 0
 
     # for rocm torch 2.4 or later, torch.cuda.device_count() calls
-    # _device_count_amdsmi, equivalent to _device_count_nvml().
-    # Requires amdsmi installed
+    # _device_count_amdsmi, equivalent to _device_count_nvml()
     if is_hip():
-        if hasattr(torch.cuda,
-                   "_device_count_amdsmi") and torch.cuda._HAS_PYNVML:
+        if hasattr(torch.cuda, "_device_count_amdsmi"):
             return torch.cuda._device_count_amdsmi()
         else:
             return torch._C._cuda_getDeviceCount()
@@ -785,7 +784,7 @@ def cuda_device_count_stateless() -> int:
     # This can be removed and simply replaced with torch.cuda.get_device_count
     # after https://github.com/pytorch/pytorch/pull/122815 is released.
 
-    return _cuda_device_count_stateless()
+    return _cuda_device_count_stateless(envs.CUDA_VISIBLE_DEVICES)
 
 
 #From: https://stackoverflow.com/a/4104188/2749989

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -748,8 +748,7 @@ def deprecate_kwargs(
 
 
 @lru_cache(maxsize=8)
-def _cuda_device_count_stateless(
-        cuda_visible_devices: Optional[str] = None) -> int:
+def _cuda_device_count_stateless() -> int:
     # Note: cuda_visible_devices is not used, but we keep it as an argument for
     # LRU Cache purposes.
 
@@ -764,14 +763,15 @@ def _cuda_device_count_stateless(
         return 0
 
     # for rocm torch 2.4 or later, torch.cuda.device_count() calls
-    # _device_count_amdsmi, equivalent to _device_count_nvml()
+    # _device_count_amdsmi, equivalent to _device_count_nvml().
+    # Requires amdsmi installed
     if is_hip():
-        if hasattr(torch.cuda, "_device_count_amdsmi"):
+        if hasattr(torch.cuda,
+                   "_device_count_amdsmi") and torch.cuda._HAS_PYNVML:
             return torch.cuda._device_count_amdsmi()
         else:
             return torch._C._cuda_getDeviceCount()
     return torch.cuda._device_count_nvml()
-
 
 def cuda_device_count_stateless() -> int:
     """Get number of CUDA devices, caching based on the value of
@@ -784,7 +784,7 @@ def cuda_device_count_stateless() -> int:
     # This can be removed and simply replaced with torch.cuda.get_device_count
     # after https://github.com/pytorch/pytorch/pull/122815 is released.
 
-    return _cuda_device_count_stateless(envs.CUDA_VISIBLE_DEVICES)
+    return _cuda_device_count_stateless()
 
 
 #From: https://stackoverflow.com/a/4104188/2749989

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -132,19 +132,23 @@ class LRUCache(Generic[T]):
 def is_hip() -> bool:
     return torch.version.hip is not None
 
+
 def get_hip_version() -> tuple:
     # call this function for ROCm only
     hip_version = str(torch.version.hip)
-    hip_version = hip_version.split("-")[0]    # ignore git sha
+    hip_version = hip_version.split("-")[0]  # ignore git sha
     return tuple(int(x) for x in hip_version.split("."))
+
 
 def is_hip_version_less_than(version: tuple) -> bool:
     # check whether hip version is less than the version
     return get_hip_version() < version
 
+
 def is_hip_version_equals(version: tuple) -> bool:
     # check whether hip version is equals to the version
     return get_hip_version() == version
+
 
 @lru_cache(maxsize=None)
 def is_cpu() -> bool:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -773,6 +773,7 @@ def _cuda_device_count_stateless() -> int:
             return torch._C._cuda_getDeviceCount()
     return torch.cuda._device_count_nvml()
 
+
 def cuda_device_count_stateless() -> int:
     """Get number of CUDA devices, caching based on the value of
     CUDA_VISIBLE_DEVICES at the time of call.


### PR DESCRIPTION
Add some utility api and fix some unit test based on torch version

About unittest test_utils.py. The equivalent of _device_count_nvml in AMD to get the device count would be _device_count_amdsmi, and the wrapper is torch.cuda.device_count() which will direct to the above call. But for torch.cuda.device_count() to work to get a new value after the environment variable's value changes during the same process, it needs to wait for rocm6.2/pytorch2.4 official release, though rocm/pytorch-nightly image works under the condition to use HIP_VISIBLE_DEVICES environment variable instead. Discussed with @jataylo and we plan to support CUDA_VISIBLE_DEVICES in pytorch for this API right now so that vllm does not need to change code.


FIX #xxxx (*link existing issues this PR will resolve*)

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


