### PR TITLE
[ci][test] fix ca test in main

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -197,6 +197,9 @@ steps:
   gpu: a100
   num_gpus: 4
   commands: 
+  # FIXIT: find out which code initialize cuda before running the test
+  # before the fix, we need to use spawn to test it
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   # NOTE: don't test llama model here, it seems hf implementation is buggy
   # see https://github.com/vllm-project/vllm/pull/5689 for details
   - pytest -v -s distributed/test_custom_all_reduce.py


### PR DESCRIPTION
As observed in https://buildkite.com/vllm/ci-aws/builds/2187#01903b64-42da-4470-b31d-67de70140802 , custom allreduce test in A100 fails, because of a merge race from https://github.com/vllm-project/vllm/pull/5669 .