### PR TITLE
compressed-tensors accuracy testing

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -21,4 +21,4 @@ aiohttp
 
 # quantization
 bitsandbytes==0.42.0
-sparseml-nightly
+sparseml[transformers]==1.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -21,3 +21,4 @@ aiohttp
 
 # quantization
 bitsandbytes==0.42.0
+sparseml-nightly

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -147,7 +147,7 @@ def _run_sparseml(model_path: str, prompts: List[str], n_tokens: int):
     from sparseml.transformers import (  # noqa: E501
         SparseAutoModelForCausalLM, SparseAutoTokenizer)
     model = SparseAutoModelForCausalLM.from_pretrained(model_path,
-                                                       device_map="cuda")
+                                                       device_map="auto")
     tokenizer = SparseAutoTokenizer.from_pretrained(model_path)
     inputs = tokenizer(prompts, return_tensors="pt").to("cuda")
     num_input_ids = inputs.get("input_ids").shape[-1]

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -2,6 +2,7 @@
 
 Run `pytest tests/quantization/test_compressed_tensors.py`.
 """
+from typing import List
 
 import pytest
 import torch
@@ -111,3 +112,63 @@ def test_compressed_tensors_w4a16_marlin24(vllm_runner):
         sampling_params = SamplingParams()
         output = llm.generate("Hello world!", sampling_params=sampling_params)
         assert output
+
+
+@pytest.mark.parametrize("model_path", [
+    "nm-testing/tinyllama-oneshot-w8-channel-a8-tensor",
+    "nm-testing/tinyllama-oneshot-w8a8-channel-dynamic-token-v2",
+    "nm-testing/tinyllama-oneshot-w4a16-channel-v2",
+    "nm-testing/tinyllama-oneshot-w4a16-group128-v2"
+])
+def test_accuracy_compressed_tensors(vllm_runner, model_path):
+    prompts = ["The capital of France is"]
+    n_tokens = 50
+    n_log_probs = 5
+
+    with vllm_runner(model_path, dtype=torch.bfloat16) as llm:
+        vllm_outputs = llm.generate_greedy_logprobs(prompts, n_tokens,
+                                                    n_log_probs)
+    sparseml_outputs = _run_sparseml(model_path, prompts, n_tokens)
+    _compare_ids_top_logprobs(vllm_outputs, sparseml_outputs)
+
+
+def _run_sparseml(model_path: str, prompts: List[str], n_tokens: int):
+    """
+    Run sparseml generation using a given model, prompt, and number 
+    of tokens to generate. Generations are modified to remove prompt_ids
+    from the generations.
+
+    :param model_path: model path
+    :param prompts: list of prompts
+    :param n_tokens: number of tokens to generate
+    :returns: a list of generations. Number of generations 
+        should be equal to number of prompts.
+    """
+    from sparseml.transformers import (  # noqa: E501
+        SparseAutoModelForCausalLM, SparseAutoTokenizer)
+    model = SparseAutoModelForCausalLM.from_pretrained(model_path,
+                                                       device_map="cuda")
+    tokenizer = SparseAutoTokenizer.from_pretrained(model_path)
+    inputs = tokenizer(prompts, return_tensors="pt").to("cuda")
+    num_input_ids = inputs.get("input_ids").shape[-1]
+    generations = model.generate(**inputs,
+                                 min_new_tokens=n_tokens,
+                                 max_new_tokens=n_tokens)
+    generations_concat = []
+    for i in range(len(generations)):
+        generations_concat.append(generations[i, num_input_ids:])
+    return generations_concat
+
+
+def _compare_ids_top_logprobs(vllm_outputs, sparseml_outputs):
+    """
+    Compare and verify if the sparseml generated token ids 
+    are in the top_n logprobs generated through vllm.
+
+    :param vllm_outputs: vllm generations
+    :param sparseml_outputs: sparseml generations
+    """
+    for vllm_output, sparseml_output in zip(vllm_outputs, sparseml_outputs):
+        logprobs = vllm_output[2]
+        for i in range(len(logprobs)):
+            assert sparseml_output[i].item() in logprobs[i]


### PR DESCRIPTION
# Summary
- Adds `sparseml[transformers]==1.8` as a dev/testing requirements
- Compares sparseml logprobs to vllm logprobs for compressed-tensors models now supported through vllm 
- Compare and verify if the sparseml generated token ids are in the top_n logprobs generated through vllm