### PR TITLE
[Core] Support sparse KV cache framework

### DIFF
--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -27,6 +27,15 @@ void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
                              torch::Tensor& slot_mapping,
                              const std::string& kv_cache_dtype);
 
+void sparse_cache_copy(std::vector<torch::Tensor> const& key_caches,
+                       std::vector<torch::Tensor> const& value_caches,
+                       const torch::Tensor& block_mapping_src_tensor,
+                       const torch::Tensor& block_mapping_dst_tensor,
+                       const torch::Tensor& selection_index_src_tensor,
+                       const torch::Tensor& selection_index_dst_tensor,
+                       const int64_t num_heads, const int64_t head_size,
+                       const int64_t block_size);
+
 // Just for unittest
 void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,
                  const double scale, const std::string& kv_cache_dtype);

--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -426,7 +426,8 @@ void paged_attention_v1(
     const std::string& kv_cache_dtype, double kv_scale, const int64_t tp_rank,
     const int64_t blocksparse_local_blocks,
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
-    const int64_t blocksparse_head_sliding_step) {
+    const int64_t blocksparse_head_sliding_step,
+    const std::string& sparse_cache_type, torch::Tensor& attention_scores) {
   TORCH_CHECK(kv_scale == 1.0f);
   TORCH_CHECK(blocksparse_vert_stride <= 1,
               "CPU backend does not support blocksparse attention yet.");
@@ -745,7 +746,8 @@ void paged_attention_v2(
     const std::string& kv_cache_dtype, double kv_scale, const int64_t tp_rank,
     const int64_t blocksparse_local_blocks,
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
-    const int64_t blocksparse_head_sliding_step) {
+    const int64_t blocksparse_head_sliding_step,
+    const std::string& sparse_cache_type, torch::Tensor& attention_scores) {
   TORCH_CHECK(kv_scale == 1.0f);
   TORCH_CHECK(blocksparse_vert_stride <= 1,
               "CPU backend does not support blocksparse attention yet.");

--- a/csrc/cpu/cache.cpp
+++ b/csrc/cpu/cache.cpp
@@ -135,3 +135,15 @@ void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
                  const torch::Tensor& block_mapping) {
   TORCH_CHECK(false, "swap_blocks is unsupported on CPU.")
 }
+
+void sparse_cache_copy(std::vector<torch::Tensor> const& key_caches,
+                       std::vector<torch::Tensor> const& value_caches,
+                       const torch::Tensor& block_mapping_src_tensor,
+                       const torch::Tensor& block_mapping_dst_tensor,
+                       const torch::Tensor& selection_index_src_tensor,
+                       const torch::Tensor& selection_index_dst_tensor,
+                       const int64_t num_heads, const int64_t head_size,
+                       const int64_t block_size) {
+  // CPU not supported yet.
+  return;
+}

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -19,7 +19,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    str kv_cache_dtype, float kv_scale, int tp_rank,"
       "    int blocksparse_local_blocks,"
       "    int blocksparse_vert_stride, int blocksparse_block_size,"
-      "    int blocksparse_head_sliding_step) -> ()");
+      "    int blocksparse_head_sliding_step, str sparse_cache_type, "
+      "    Tensor attention_scores) -> ()");
   ops.impl("paged_attention_v1", torch::kCPU, &paged_attention_v1);
 
   // PagedAttention V2.
@@ -33,7 +34,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    str kv_cache_dtype, float kv_scale, int tp_rank,"
       "    int blocksparse_local_blocks,"
       "    int blocksparse_vert_stride, int blocksparse_block_size,"
-      "    int blocksparse_head_sliding_step) -> ()");
+      "    int blocksparse_head_sliding_step, str sparse_cache_type, "
+      "    Tensor attention_scores) -> ()");
   ops.impl("paged_attention_v2", torch::kCPU, &paged_attention_v2);
 
   // Activation ops
@@ -101,6 +103,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "                  str kv_cache_dtype,"
       "                  float kv_scale) -> ()");
   cache_ops.impl("reshape_and_cache", torch::kCPU, &reshape_and_cache);
+
+  // Sparse copy KV cache items.
+  cache_ops.def(
+      "sparse_cache_copy(Tensor[]! key_caches, Tensor[]! value_caches,"
+      "Tensor block_mapping_src_tensor, Tensor block_mapping_dst_tensor,"
+      "Tensor selection_index_src_tensor, Tensor selection_index_dst_tensor,"
+      "int num_heads, int head_size, int block_size) -> ()");
+  cache_ops.impl("sparse_cache_copy", torch::kCUDA, &sparse_cache_copy);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -10,7 +10,8 @@ void paged_attention_v1(
     const std::string& kv_cache_dtype, double kv_scale, const int64_t tp_rank,
     const int64_t blocksparse_local_blocks,
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
-    const int64_t blocksparse_head_sliding_step);
+    const int64_t blocksparse_head_sliding_step,
+    const std::string& sparse_cache_type, torch::Tensor& attention_scores);
 
 void paged_attention_v2(
     torch::Tensor& out, torch::Tensor& exp_sums, torch::Tensor& max_logits,
@@ -21,7 +22,8 @@ void paged_attention_v2(
     const std::string& kv_cache_dtype, double kv_scale, const int64_t tp_rank,
     const int64_t blocksparse_local_blocks,
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
-    const int64_t blocksparse_head_sliding_step);
+    const int64_t blocksparse_head_sliding_step,
+    const std::string& sparse_cache_type, torch::Tensor& attention_scores);
 
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -30,7 +30,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    str kv_cache_dtype, float kv_scale, int tp_rank,"
       "    int blocksparse_local_blocks,"
       "    int blocksparse_vert_stride, int blocksparse_block_size,"
-      "    int blocksparse_head_sliding_step) -> ()");
+      "    int blocksparse_head_sliding_step, str sparse_cache_type,"
+      "    Tensor attention_scores) -> ()");
   ops.impl("paged_attention_v1", torch::kCUDA, &paged_attention_v1);
 
   // PagedAttention V2.
@@ -44,7 +45,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    str kv_cache_dtype, float kv_scale, int tp_rank,"
       "    int blocksparse_local_blocks,"
       "    int blocksparse_vert_stride, int blocksparse_block_size,"
-      "    int blocksparse_head_sliding_step) -> ()");
+      "    int blocksparse_head_sliding_step, str sparse_cache_type,"
+      "    Tensor attention_scores) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
   // Activation ops
@@ -231,6 +233,14 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _cache_ops), cache_ops) {
       "                        str kv_cache_dtype) -> ()");
   cache_ops.impl("reshape_and_cache_flash", torch::kCUDA,
                  &reshape_and_cache_flash);
+
+  // Sparse copy KV cache items.
+  cache_ops.def(
+      "sparse_cache_copy(Tensor[]! key_caches, Tensor[]! value_caches,"
+      "Tensor block_mapping_src_tensor, Tensor block_mapping_dst_tensor,"
+      "Tensor selection_index_src_tensor, Tensor selection_index_dst_tensor,"
+      "int num_heads, int head_size, int block_size) -> ()");
+  cache_ops.impl("sparse_cache_copy", torch::kCUDA, &sparse_cache_copy);
 
   // Convert the key and value cache to fp8 data type.
   cache_ops.def(

--- a/examples/sparse_kv_cache.py
+++ b/examples/sparse_kv_cache.py
@@ -1,0 +1,34 @@
+"""
+This example shows how to use sparse KV cache techniques for offline inference. 
+Currently, sparse KV cache is supported for opt model with eager mode.
+"""
+from vllm import LLM, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is Tony, and I'm thrilled to have the opportunity to "
+    "introduce myself to you. I am a motivated and enthusiastic individual "
+    "with a passion for technology, marketing, finance. ",
+    "The president of the United States is Donald Trump, who has been "
+    "involved in a lawsuit, and he has been regarded ",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+# Create an LLM.
+llm = LLM(model="facebook/opt-125m",
+          kv_cache_dtype='auto',
+          sparse_kv_cache_type='h2o',
+          enforce_eager=True)
+
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -90,12 +90,15 @@ def paged_attention_v1(
     blocksparse_vert_stride: int = 0,
     blocksparse_block_size: int = 64,
     blocksparse_head_sliding_step: int = 0,
+    sparse_cache_type: str = 'auto',
+    attention_scores: torch.Tensor = None,
 ) -> None:
     torch.ops._C.paged_attention_v1(
         out, query, key_cache, value_cache, num_kv_heads, scale, block_tables,
         seq_lens, block_size, max_seq_len, alibi_slopes, kv_cache_dtype,
         kv_scale, tp_rank, blocksparse_local_blocks, blocksparse_vert_stride,
-        blocksparse_block_size, blocksparse_head_sliding_step)
+        blocksparse_block_size, blocksparse_head_sliding_step,
+        sparse_cache_type, attention_scores)
 
 
 def paged_attention_v2(
@@ -120,13 +123,16 @@ def paged_attention_v2(
     blocksparse_vert_stride: int = 0,
     blocksparse_block_size: int = 64,
     blocksparse_head_sliding_step: int = 0,
+    sparse_cache_type: str = 'auto',
+    attention_scores: torch.Tensor = None,
 ) -> None:
     torch.ops._C.paged_attention_v2(
         out, exp_sum, max_logits, tmp_out, query, key_cache, value_cache,
         num_kv_heads, scale, block_tables, seq_lens, block_size, max_seq_len,
         alibi_slopes, kv_cache_dtype, kv_scale, tp_rank,
         blocksparse_local_blocks, blocksparse_vert_stride,
-        blocksparse_block_size, blocksparse_head_sliding_step)
+        blocksparse_block_size, blocksparse_head_sliding_step,
+        sparse_cache_type, attention_scores)
 
 
 # pos encoding ops
@@ -390,6 +396,20 @@ def copy_blocks(key_caches: List[torch.Tensor],
 def swap_blocks(src: torch.Tensor, dst: torch.Tensor,
                 block_mapping: torch.Tensor) -> None:
     torch.ops._C_cache_ops.swap_blocks(src, dst, block_mapping)
+
+
+def sparse_cache_copy(key_caches: torch.Tensor, value_caches: torch.Tensor,
+                      block_mapping_src: torch.Tensor,
+                      block_mapping_dst: torch.Tensor,
+                      selection_index_src_tensor: torch.Tensor,
+                      selection_index_dst_tensor: torch.Tensor, num_heads: int,
+                      head_size: int, block_size: int) -> None:
+    torch.ops._C_cache_ops.sparse_cache_copy(key_caches, value_caches,
+                                             block_mapping_src,
+                                             block_mapping_dst,
+                                             selection_index_src_tensor,
+                                             selection_index_dst_tensor,
+                                             num_heads, head_size, block_size)
 
 
 def convert_fp8(output: torch.Tensor,

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -51,6 +51,18 @@ class AttentionBackend(ABC):
     ) -> None:
         raise NotImplementedError
 
+    @staticmethod
+    @abstractmethod
+    def sparse_cache_copy(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+        sparse_condition: torch.Tensor,
+        num_heads: int,
+        head_size: int,
+        block_size: int,
+    ) -> None:
+        raise NotImplementedError
+
 
 @dataclass
 class AttentionMetadata:
@@ -67,6 +79,11 @@ class AttentionMetadata:
     # is 16, the three tokens are stored in the 3rd slot in block 2, 2nd slot
     # in block 0, and 1st slot in block 1, respectively.
     slot_mapping: torch.Tensor
+    # The kv cache sparse type.
+    sparse_cache_type: str
+    sparse_interval: Optional[int]
+    sparse_percentage: Optional[float]
+    sparse_condition: Optional[torch.Tensor]
 
     @property
     @abstractmethod
@@ -124,5 +141,6 @@ class AttentionImpl(ABC, Generic[T]):
         kv_cache: torch.Tensor,
         attn_metadata: T,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         raise NotImplementedError

--- a/vllm/attention/backends/blocksparse_attn.py
+++ b/vllm/attention/backends/blocksparse_attn.py
@@ -212,6 +212,10 @@ class BlocksparseFlashAttentionMetadata(AttentionMetadata):
             context_lens_tensor=self.context_lens_tensor[:self.num_prefills],
             block_tables=self.block_tables[:self.num_prefills],
             use_cuda_graph=False,
+            sparse_cache_type='',
+            sparse_interval=None,
+            sparse_percentage=None,
+            sparse_condition=None,
         )
         return self._cached_prefill_metadata
 
@@ -240,6 +244,10 @@ class BlocksparseFlashAttentionMetadata(AttentionMetadata):
             context_lens_tensor=None,
             block_tables=self.block_tables[self.num_prefills:],
             use_cuda_graph=self.use_cuda_graph,
+            sparse_cache_type='',
+            sparse_interval=None,
+            sparse_percentage=None,
+            sparse_condition=None,
         )
         return self._cached_decode_metadata
 
@@ -328,6 +336,7 @@ class BlocksparseFlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: BlocksparseFlashAttentionMetadata,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention and PagedAttention.
 

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -152,6 +152,10 @@ class FlashAttentionMetadata(AttentionMetadata):
             context_lens_tensor=self.context_lens_tensor[:self.num_prefills],
             block_tables=self.block_tables[:self.num_prefills],
             use_cuda_graph=False,
+            sparse_cache_type='',
+            sparse_interval=None,
+            sparse_percentage=None,
+            sparse_condition=None,
         )
         return self._cached_prefill_metadata
 
@@ -180,6 +184,10 @@ class FlashAttentionMetadata(AttentionMetadata):
             context_lens_tensor=None,
             block_tables=self.block_tables[self.num_prefills:],
             use_cuda_graph=self.use_cuda_graph,
+            sparse_cache_type='',
+            sparse_interval=None,
+            sparse_percentage=None,
+            sparse_condition=None,
         )
         return self._cached_decode_metadata
 
@@ -257,6 +265,7 @@ class FlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashAttentionMetadata,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention.
 

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -192,6 +192,7 @@ class FlashInferImpl(AttentionImpl):
         kv_cache: Optional[torch.Tensor],
         attn_metadata: FlashInferMetadata,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         assert kv_scale == 1.0
         num_tokens, hidden_size = query.shape

--- a/vllm/attention/backends/ipex_attn.py
+++ b/vllm/attention/backends/ipex_attn.py
@@ -157,6 +157,7 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
         kv_cache: Optional[torch.Tensor],
         attn_metadata: IpexAttnMetadata,  # type: ignore
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with IPEX varlen_attention and PagedAttention.
 

--- a/vllm/attention/backends/pallas.py
+++ b/vllm/attention/backends/pallas.py
@@ -127,6 +127,7 @@ class PallasAttentionBackendImpl(AttentionImpl):
         kv_cache: Tuple[Optional[torch.Tensor], Optional[torch.Tensor]],
         attn_metadata: PallasMetadata,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with Pallas attention.
 

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -266,6 +266,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: ROCmFlashAttentionMetadata,
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention and PagedAttention.
 

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -145,6 +145,7 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
         kv_cache: Optional[torch.Tensor],
         attn_metadata: TorchSDPAMetadata,  # type: ignore
         kv_scale: float = 1.0,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with torch SDPA and PagedAttention.
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -85,9 +85,10 @@ class Attention(nn.Module):
         value: torch.Tensor,
         kv_cache: Optional[torch.Tensor],
         attn_metadata: AttentionMetadata,
+        sparse_condition: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return self.impl.forward(query, key, value, kv_cache, attn_metadata,
-                                 self._kv_scale)
+                                 self._kv_scale, sparse_condition)
 
     def extra_repr(self) -> str:
         s = f"head_size={self.impl.head_size}"  # type: ignore

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -364,7 +364,6 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         last_block: PhysicalTokenBlock,
     ) -> PhysicalTokenBlock:
         assert self.enable_caching
-
         # Compute a new hash for the block so that it can be shared by other
         # Sequences
         new_hash = seq.hash_of_block(len(seq.logical_token_blocks) - 1)
@@ -401,7 +400,6 @@ class BlockSpaceManagerV1(BlockSpaceManager):
     ) -> PhysicalTokenBlock:
         # Called before a new block is appended.
         # This is in charge of allocating a new physical block (to be appended).
-
         # None if the last block is not full. Otherwise, we set it to the
         # content hash.
         if not self.enable_caching:
@@ -423,6 +421,33 @@ class BlockSpaceManagerV1(BlockSpaceManager):
             assert new_block.ref_count == 1
         return new_block
 
+    def create_new_slots(
+            self, seq: Sequence,
+            percentage: float) -> Tuple[List[List[int]], List[int]]:
+        # Called when sparse KV cache is applied to generate new blocks.
+        ret: List[List[int]] = []
+        block_table = self.block_tables[seq.seq_id].copy()
+        for block in block_table:
+            if not ret:
+                ret.append([])
+            ret[0].append(block.block_number)
+        new_block_number = math.ceil(len(block_table) * percentage)
+        if len(ret) == 1:
+            ret.append([])
+        new_block_table: BlockTable = []
+        for i in range(new_block_number):
+            assert len(ret) == 2
+            if (self.block_sliding_window
+                    and len(block_table) >= self.block_sliding_window):
+                block_table.append(block_table[len(block_table) %
+                                               self.block_sliding_window])
+            else:
+                new_block = self.gpu_allocator.allocate()
+                new_block_table.append(new_block)
+                ret[1].append(new_block.block_number)
+        self.block_tables[seq.seq_id] = new_block_table.copy()
+        return (ret, block_table)
+
     def append_slots(
         self,
         seq: Sequence,
@@ -431,11 +456,12 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         """Allocate a physical slot for a new token."""
         logical_blocks = seq.logical_token_blocks
         block_table = self.block_tables[seq.seq_id]
+        block_size = 0
+        if logical_blocks:
+            block_size = logical_blocks[0].block_size
         # If we need to allocate a new physical block
-        if len(block_table) < len(logical_blocks):
+        if seq.data.last_token_block_offset == block_size - 1:
             # Currently this code only supports adding one physical block
-            assert len(block_table) == len(logical_blocks) - 1
-
             if (self.block_sliding_window
                     and len(block_table) >= self.block_sliding_window):
                 # reuse a block
@@ -497,6 +523,18 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         if seq_group.is_encoder_decoder():
             blocks.update(self.cross_block_tables[request_id])
         return list(blocks)
+
+    def can_append_slots_sparse_cache(self,
+                                      seq_group: SequenceGroup,
+                                      percentage: float,
+                                      num_lookahead_slots: int = 0) -> bool:
+        assert (num_lookahead_slots == 0
+                ), "lookahead allocation not supported in BlockSpaceManagerV1"
+        new_physical_block_number = len(
+            self._get_physical_blocks(seq_group)) * percentage
+        num_free_gpu_blocks = self.gpu_allocator.get_num_free_blocks()
+        num_seqs = seq_group.num_seqs(status=SequenceStatus.RUNNING)
+        return num_seqs + new_physical_block_number <= num_free_gpu_blocks
 
     def can_swap_in(self,
                     seq_group: SequenceGroup,

--- a/vllm/core/interfaces.py
+++ b/vllm/core/interfaces.py
@@ -56,6 +56,12 @@ class BlockSpaceManager(ABC):
         pass
 
     @abstractmethod
+    def can_append_slots_sparse_cache(self, seq_group: SequenceGroup,
+                                      percentage: float,
+                                      num_lookahead_slots: int) -> bool:
+        pass
+
+    @abstractmethod
     def append_slots(
         self,
         seq: Sequence,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -123,6 +123,8 @@ class SchedulerOutputs:
     blocks_to_swap_out: List[Tuple[int, int]]
     # Blocks to copy. Source to dest block.
     blocks_to_copy: List[Tuple[int, int]]
+    # Blocks to sparse copy. Source blocks and dest blocks.
+    blocks_to_sparse_copy: List[List[List[int]]]
     # Sequence groups that are going to be ignored.
     ignored_seq_groups: List[SequenceGroup]
     # The number of slots for lookahead decoding.
@@ -178,6 +180,8 @@ class SchedulerRunningOutputs:
     blocks_to_swap_out: List[Tuple[int, int]]
     # The blocks to copy.
     blocks_to_copy: List[Tuple[int, int]]
+    # The blocks to sparse copy.
+    blocks_to_sparse_copy: List[List[List[int]]]
     # The number of slots for lookahead decoding.
     num_lookahead_slots: int
 
@@ -190,6 +194,7 @@ class SchedulerRunningOutputs:
             swapped_out=[],
             blocks_to_swap_out=[],
             blocks_to_copy=[],
+            blocks_to_sparse_copy=[],
             num_lookahead_slots=0,
         )
 
@@ -210,6 +215,8 @@ class SchedulerSwappedInOutputs:
     blocks_to_swap_in: List[Tuple[int, int]]
     # The blocks to copy.
     blocks_to_copy: List[Tuple[int, int]]
+    # The blocks to sparse copy.
+    blocks_to_sparse_copy: List[List[List[int]]]
     # The number of slots for lookahead decoding.
     num_lookahead_slots: int
     # Infeasible sequence groups.
@@ -222,6 +229,7 @@ class SchedulerSwappedInOutputs:
             prefill_seq_groups=[],
             blocks_to_swap_in=[],
             blocks_to_copy=[],
+            blocks_to_sparse_copy=[],
             num_lookahead_slots=0,
             infeasible_seq_groups=[],
         )
@@ -396,11 +404,13 @@ class Scheduler:
         # Blocks that need to be swapped or copied before model execution.
         blocks_to_swap_out: List[Tuple[int, int]] = []
         blocks_to_copy: List[Tuple[int, int]] = []
+        blocks_to_sparse_copy: List[List[List[int]]] = []
 
         decode_seq_groups: List[ScheduledSequenceGroup] = []
         prefill_seq_groups: List[ScheduledSequenceGroup] = []
         preempted: List[SequenceGroup] = []
         swapped_out: List[SequenceGroup] = []
+        blocks_to_free: List[int] = []
 
         # NOTE(woosuk): Preemption happens only when there is no available slot
         # to keep all the sequence groups in the RUNNING state.
@@ -448,7 +458,9 @@ class Scheduler:
                         swapped_out.append(seq_group)
                     break
             else:
-                self._append_slots(seq_group, blocks_to_copy)
+                blocks_to_free.extend(
+                    self._append_slots(seq_group, blocks_to_copy,
+                                       blocks_to_sparse_copy))
                 is_prefill = seq_group.is_prefill()
                 if is_prefill:
                     prefill_seq_groups.append(
@@ -470,7 +482,8 @@ class Scheduler:
                     budget.add_num_seqs(seq_group.request_id, num_running_seqs)
                 if curr_loras is not None and seq_group.lora_int_id > 0:
                     curr_loras.add(seq_group.lora_int_id)
-
+        for free_block in blocks_to_free:
+            self.block_manager.gpu_allocator.free(free_block)
         return running_queue, SchedulerRunningOutputs(
             decode_seq_groups=decode_seq_groups,
             prefill_seq_groups=prefill_seq_groups,
@@ -478,6 +491,7 @@ class Scheduler:
             swapped_out=swapped_out,
             blocks_to_swap_out=blocks_to_swap_out,
             blocks_to_copy=blocks_to_copy,
+            blocks_to_sparse_copy=blocks_to_sparse_copy,
             num_lookahead_slots=self._get_num_lookahead_slots(
                 is_prefill=False))
 
@@ -515,8 +529,10 @@ class Scheduler:
         # Blocks that need to be swapped or copied before model execution.
         blocks_to_swap_in: List[Tuple[int, int]] = []
         blocks_to_copy: List[Tuple[int, int]] = []
+        blocks_to_sparse_copy: List[List[List[int]]] = []
         decode_seq_groups: List[ScheduledSequenceGroup] = []
         prefill_seq_groups: List[ScheduledSequenceGroup] = []
+        blocks_to_free: List[int] = []
         now = time.time()
         swapped_queue = policy.sort_by_priority(now, swapped_queue)
         infeasible_seq_groups: List[SequenceGroup] = []
@@ -571,7 +587,9 @@ class Scheduler:
                 curr_loras.add(lora_int_id)
             swapped_queue.popleft()
             self._swap_in(seq_group, blocks_to_swap_in)
-            self._append_slots(seq_group, blocks_to_copy)
+            blocks_to_free.extend(
+                self._append_slots(seq_group, blocks_to_copy,
+                                   blocks_to_sparse_copy))
             is_prefill = seq_group.is_prefill()
             if is_prefill:
                 prefill_seq_groups.append(
@@ -585,11 +603,15 @@ class Scheduler:
 
         swapped_queue.extendleft(leftover_swapped)
 
+        for free_block in blocks_to_free:
+            self.block_manager.gpu_allocator.free(free_block)
+
         return swapped_queue, SchedulerSwappedInOutputs(
             decode_seq_groups=decode_seq_groups,
             prefill_seq_groups=prefill_seq_groups,
             blocks_to_swap_in=blocks_to_swap_in,
             blocks_to_copy=blocks_to_copy,
+            blocks_to_sparse_copy=blocks_to_sparse_copy,
             num_lookahead_slots=self._get_num_lookahead_slots(
                 is_prefill=False),
             infeasible_seq_groups=infeasible_seq_groups,
@@ -818,6 +840,7 @@ class Scheduler:
             blocks_to_swap_out=running_scheduled.blocks_to_swap_out,
             blocks_to_copy=running_scheduled.blocks_to_copy +
             swapped_in.blocks_to_copy,
+            blocks_to_sparse_copy=running_scheduled.blocks_to_sparse_copy,
             ignored_seq_groups=prefills.ignored_seq_groups +
             swapped_in.infeasible_seq_groups,
             num_lookahead_slots=running_scheduled.num_lookahead_slots,
@@ -907,6 +930,7 @@ class Scheduler:
             blocks_to_swap_out=running_scheduled.blocks_to_swap_out,
             blocks_to_copy=running_scheduled.blocks_to_copy +
             swapped_in.blocks_to_copy,
+            blocks_to_sparse_copy=running_scheduled.blocks_to_sparse_copy,
             ignored_seq_groups=prefills.ignored_seq_groups +
             swapped_in.infeasible_seq_groups,
             num_lookahead_slots=running_scheduled.num_lookahead_slots,
@@ -935,6 +959,14 @@ class Scheduler:
 
         # Appending slots only occurs in decoding.
         is_prefill = False
+
+        if (self.cache_config.sparse_cache_type == "h2o" and
+                seq_group.n_times % self.cache_config.sparse_interval == 0):
+            return self.block_manager.can_append_slots_sparse_cache(
+                seq_group=seq_group,
+                percentage=self.cache_config.sparse_percentage,
+                num_lookahead_slots=self._get_num_lookahead_slots(is_prefill),
+            )
 
         return self.block_manager.can_append_slots(
             seq_group=seq_group,
@@ -1006,8 +1038,10 @@ class Scheduler:
                 # `multi_modal_data` will be None.
                 multi_modal_data=seq_group.multi_modal_data
                 if scheduler_outputs.num_prefill_groups > 0 else None,
+                n_times=seq_group.n_times,
             )
             seq_group_metadata_list.append(seq_group_metadata)
+            seq_group.n_times += 1
 
         # Now that the batch has been created, we can assume all blocks in the
         # batch will have been computed before the next scheduling invocation.
@@ -1039,7 +1073,8 @@ class Scheduler:
         self,
         seq_group: SequenceGroup,
         blocks_to_copy: List[Tuple[int, int]],
-    ) -> None:
+        blocks_to_sparse_copy: List[List[List[int]]],
+    ) -> List[int]:
         """Appends new slots to the sequences in the given sequence group.
 
         Args:
@@ -1050,12 +1085,24 @@ class Scheduler:
                 int is the destination block index. This list is updated with
                 the new source and destination block indices for the appended
                 slots.
+        Return:
+            a list of free blocks.
         """
         num_lookahead_slots = self._get_num_lookahead_slots(is_prefill=False)
 
+        free_blocks: List = []
         for seq in seq_group.get_seqs(status=SequenceStatus.RUNNING):
             cows = self.block_manager.append_slots(seq, num_lookahead_slots)
             blocks_to_copy.extend(cows)
+
+            if (self.cache_config.sparse_cache_type == "h2o"
+                    and seq_group.n_times % self.cache_config.sparse_interval
+                    == 0):
+                sparse_cows, free_block = self.block_manager.create_new_slots(
+                    seq, self.cache_config.sparse_percentage)
+                free_blocks.extend(free_block)
+                blocks_to_sparse_copy.append(sparse_cows)
+        return free_blocks
 
     def _preempt(
         self,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -33,6 +33,7 @@ class EngineArgs:
     load_format: str = 'auto'
     dtype: str = 'auto'
     kv_cache_dtype: str = 'auto'
+    sparse_kv_cache_type: str = 'auto'
     quantization_param_path: Optional[str] = None
     seed: int = 0
     max_model_len: Optional[int] = None
@@ -270,6 +271,12 @@ class EngineArgs:
             'FP8_E5M2 (without scaling) is only supported on cuda version'
             'greater than 11.8. On ROCm (AMD GPU), FP8_E4M3 is instead '
             'supported for common inference criteria.')
+        parser.add_argument('--sparse-kv-cache-type',
+                            type=str,
+                            choices=['auto', 'h2o'],
+                            default=EngineArgs.sparse_kv_cache_type,
+                            help='Sparse kv cache storage type. If "auto", '
+                            'will not use any sparse kv cache.')
         parser.add_argument('--max-model-len',
                             type=int,
                             default=EngineArgs.max_model_len,
@@ -666,7 +673,8 @@ class EngineArgs:
             cache_dtype=self.kv_cache_dtype,
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=model_config.get_sliding_window(),
-            enable_prefix_caching=self.enable_prefix_caching)
+            enable_prefix_caching=self.enable_prefix_caching,
+            sparse_cache_type=self.sparse_kv_cache_type)
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -169,7 +169,7 @@ class LLMEngine:
             "trust_remote_code=%s, dtype=%s, max_seq_len=%d, "
             "download_dir=%r, load_format=%s, tensor_parallel_size=%d, "
             "disable_custom_all_reduce=%s, quantization=%s, "
-            "enforce_eager=%s, kv_cache_dtype=%s, "
+            "enforce_eager=%s, kv_cache_dtype=%s, sparse_cache_type=%s, "
             "quantization_param_path=%s, device_config=%s, "
             "decoding_config=%r, observability_config=%r, "
             "seed=%d, served_model_name=%s)",
@@ -193,6 +193,7 @@ class LLMEngine:
             model_config.quantization,
             model_config.enforce_eager,
             cache_config.cache_dtype,
+            cache_config.sparse_cache_type,
             model_config.quantization_param_path,
             device_config.device,
             decoding_config,
@@ -265,6 +266,8 @@ class LLMEngine:
                     model_config.quantization,
                     "kv_cache_dtype":
                     cache_config.cache_dtype,
+                    "sparse_cache_type":
+                    cache_config.sparse_cache_type,
 
                     # Feature flags
                     "enable_lora":
@@ -800,6 +803,7 @@ class LLMEngine:
                 blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
                 blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
                 blocks_to_copy=scheduler_outputs.blocks_to_copy,
+                blocks_to_sparse_copy=scheduler_outputs.blocks_to_sparse_copy,
                 num_lookahead_slots=scheduler_outputs.num_lookahead_slots,
                 running_queue_size=scheduler_outputs.running_queue_size,
             )

--- a/vllm/executor/cpu_executor.py
+++ b/vllm/executor/cpu_executor.py
@@ -49,6 +49,7 @@ class CPUExecutor(ExecutorBase):
             vision_language_config=self.vision_language_config,
             kv_cache_dtype=self.cache_config.cache_dtype,
             is_driver_worker=True,
+            sparse_cache_type=self.cache_config.sparse_cache_type,
         )
         self.driver_worker.init_device()
         self.driver_worker.load_model()

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -95,6 +95,13 @@ class CacheEngine:
     def copy(self, src_to_dsts: torch.Tensor) -> None:
         self.attn_backend.copy_blocks(self.gpu_cache, src_to_dsts)
 
+    def sparse_cache_copy(self, src_to_dsts: torch.Tensor,
+                          sparse_condition: torch.Tensor) -> None:
+        self.attn_backend.sparse_cache_copy(self.gpu_cache, src_to_dsts,
+                                            sparse_condition,
+                                            self.num_kv_heads, self.head_size,
+                                            self.block_size)
+
     @staticmethod
     def get_cache_block_size(
         cache_config: CacheConfig,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -35,6 +35,7 @@ class CPUModelRunner:
         vision_language_config: Optional[VisionLanguageConfig],
         kv_cache_dtype: Optional[str] = "auto",
         is_driver_worker: bool = False,
+        sparse_cache_type: Optional[str] = "auto",
         *args,
         **kwargs,
     ):
@@ -53,6 +54,7 @@ class CPUModelRunner:
         self.device = self.device_config.device
 
         self.kv_cache_dtype = kv_cache_dtype
+        self.sparse_cache_type = sparse_cache_type
         self.sliding_window = model_config.get_sliding_window()
         self.block_size = cache_config.block_size
         self.attn_backend = get_attn_backend(
@@ -182,6 +184,7 @@ class CPUModelRunner:
             num_decode_tokens=0,
             block_tables=torch.tensor([]),
             slot_mapping=slot_mapping,
+            sparse_cache_type=self.sparse_cache_type,
         )
         return (input_tokens, input_positions, attn_metadata, seq_lens,
                 multi_modal_kwargs)
@@ -263,6 +266,7 @@ class CPUModelRunner:
             num_decode_tokens=len(input_tokens),
             num_prefills=0,
             block_tables=block_tables,
+            sparse_cache_type=self.sparse_cache_type,
         )
         return (
             input_tokens,

--- a/vllm/worker/cpu_worker.py
+++ b/vllm/worker/cpu_worker.py
@@ -134,6 +134,7 @@ class CPUWorker(LoraNotSupportedWorkerBase):
         vision_language_config: Optional[VisionLanguageConfig] = None,
         kv_cache_dtype: Optional[str] = "auto",
         is_driver_worker: bool = False,
+        sparse_cache_type: Optional[str] = "auto",
     ) -> None:
         self.model_config = model_config
         self.parallel_config = parallel_config
@@ -164,7 +165,8 @@ class CPUWorker(LoraNotSupportedWorkerBase):
             lora_config=self.lora_config,
             vision_language_config=self.vision_language_config,
             kv_cache_dtype=kv_cache_dtype,
-            is_driver_worker=is_driver_worker)
+            is_driver_worker=is_driver_worker,
+            sparse_cache_type=sparse_cache_type)
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.
         self.cache_engine: CPUCacheEngine

--- a/vllm/worker/embedding_model_runner.py
+++ b/vllm/worker/embedding_model_runner.py
@@ -32,6 +32,7 @@ class EmbeddingModelRunner(ModelRunner):
         kv_cache_dtype: Optional[str] = "auto",
         is_driver_worker: bool = False,
         vision_language_config: Optional[VisionLanguageConfig] = None,
+        sparse_cache_type: Optional[str] = "auto",
     ):
         super().__init__(model_config,
                          parallel_config,
@@ -42,7 +43,8 @@ class EmbeddingModelRunner(ModelRunner):
                          lora_config=lora_config,
                          kv_cache_dtype=kv_cache_dtype,
                          is_driver_worker=is_driver_worker,
-                         vision_language_config=vision_language_config)
+                         vision_language_config=vision_language_config,
+                         sparse_cache_type=sparse_cache_type)
 
     @torch.inference_mode()
     def execute_model(


### PR DESCRIPTION
### Motivation

For current large model inference, KV cache occupies a significant portion of GPU memory, so reducing the size of KV cache is an important direction for improvement. Recently, several papers have approached this issue from different angles, detailed comparison in the table, including:

- FastDecode: This method offloads all computation of KV cache to the CPU. The computation and storage of KV cache occurs on CPU.

- Compression methods based on quantization (GEAR, Mixed Precision): By applying various quantization techniques, the size of individual token KV caches is reduced without decreasing the number of tokens stored in the KV cache. This method may also result in corresponding residual and outlier matrices, which need to be stored in memory but not in the KV cache. It may also involve quantizing unimportant token KV caches to reduce the memory footprint of the KV cache.

- Partial KV cache eviction (H2O, SnapKV, LESS, Adaptive Compression, Scissorhands, Dynamic Memory Compression, StreamingLLM): By removing some relatively useless KV cache entries, the memory footprint of the KV cache is reduced. Essentially, this reduces the number of tokens stored in the KV cache without reducing the size of individual token KV caches.

When addressing the sparse KV cache issue, we have previously considered supporting quantization (VLLM has already implemented this), implementing quantization + outlier + residual like GEAR (not widely applicable as it requires generating outlier and residual for each token generation, which is costly), and implementing KV cache accumulation + appendix (not widely applicable as it requires models to be trained using the same method). Finally, the idea is to implement partial KV cache eviction, primarily aiming for generality and abstraction rather than being specific to one or two approaches. Considering that six of the sparse KV cache methods we found are based on evicting cache entries, this method is also suitable for modification as part of a framework to be integrated into VLLM.


### Sparse KV Cache Workflow
First, let's clarify the required parameters, including:

- An optional flag "--sparse-kv-cache-type" indicating if we want to specify any sparse KV cache type. Default is ‘auto’ without using any sparse KV cache type, otherwise, there could be various methods, such as attention scores for H2O.

- Compression ratio for evicting KV cache entries: 20% if we want to achieve 80% reduction of KV cache usage. We can calculate the value of 'n' for recreating KV cache every 'n' step based on the compression ratio.

The entire workflow includes:

- During the first decoding pass, besides computing the KV values for all input tokens, we also need to calculate and retain information about the priority ranking of all token pairs, such as attention scores in H2O.

- During each scheduling of VLLM, we need to check whether 'n' steps have been completed, indicating the necessity for KV cache compression. If necessary, based on the priority ranking of tokens, one or more new KV cache blocks will be allocated, modifying the position information of input positions. The block manager will then manage the transfer of corresponding KV blocks from the original sequence group to the latest KV block. Finally, the reference count of the original KV block will be decremented, and the corresponding original KV blocks may even be released.

- The corresponding KV values are added to the KV cache until the next compression of the KV cache after 'n' steps, repeating this process until the entire process is completed.

### How to Run
`python3 examples/sparse_kv_cache.py `

### Limitation

- More tests will be added and some refactoring on model support will be implemented after collecting the feedback from RFC. 

- Now sparse KV cache is only supported for opt models with eager mode. Moreover, only block_manager_v1 and GPU worker are supported in functionality. The CPU worker, block_manager_v2 and other related models will be supported in the near future. 

### Links

- RFC link: https://github.com/vllm-project/vllm/issues/5751

- Design doc: https://docs.google.com/document/d/13_cpb31P9VOmPGa_tZ70s7z1vXGP_UenXf1WVuIppCk