### PR TITLE
[Bugfix] Fix pin_lora error in TPU executor

### DIFF
--- a/vllm/executor/tpu_executor.py
+++ b/vllm/executor/tpu_executor.py
@@ -82,6 +82,9 @@ class TPUExecutor(ExecutorBase):
     def remove_lora(self, lora_id: int) -> bool:
         raise NotImplementedError("LoRA is not implemented for TPU backend.")
 
+    def pin_lora(self, lora_id: int) -> bool:
+        raise NotImplementedError("LoRA is not implemented for TPU backend.")
+
     def list_loras(self) -> Set[int]:
         raise NotImplementedError("LoRA is not implemented for TPU backend.")
 


### PR DESCRIPTION
Currently, the TPU backend is broken with the following error:
```
TypeError: Can't instantiate abstract class TPUExecutor with abstract method pin_lora
```

This PR is a simple fix for the error.