### PR TITLE
[Frontend] `request.tool_choice` is not completely exhausted in non-stream mode

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -525,7 +525,7 @@ class OpenAIServingChat(OpenAIServing):
                             name=request.tool_choice.function.name,
                             arguments=output.text))
                     ])
-            elif not request.tool_choice or request.tool_choice == "none":
+            else:
                 message = ChatMessage(role=role, content=output.text)
 
             choice_data = ChatCompletionResponseChoice(


### PR DESCRIPTION
`request.tool_choice` could be "auto" or others, in that cases message would not be defined.

In `chat_completion_stream_generator`, `request.tool_choice` is completely exhausted:

```Python
if request.tool_choice and type(
        request.tool_choice
) is ChatCompletionNamedToolChoiceParam:
    delta_message = DeltaMessage(tool_calls=[
        ToolCall(function=FunctionCall(
            name=request.tool_choice.function.name,
            arguments=delta_text))
    ])
else:
    delta_message = DeltaMessage(content=delta_text)
```

so this pr just follow the approach in `chat_completion_stream_generator`