### PR TITLE
[core][distributed] support variable length object in shm broadcast

### DIFF
--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -57,7 +57,7 @@ def worker_fn_wrapper(fn):
 def worker_fn():
     writer_rank = 2
     broadcaster = ShmRingBufferIO.create_from_process_group(
-        dist.group.WORLD, 1024, 2, writer_rank)
+        dist.group.WORLD, writer_rank)
     # test broadcasting with about 400MB of data
     N = 10_000
     if dist.get_rank() == writer_rank:

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -13,7 +13,7 @@ from vllm.utils import update_environment_variables
 
 def get_arrays(n: int) -> List[np.ndarray]:
     np.random.seed(0)
-    sizes = np.random.randint(1, 10000, n)
+    sizes = np.random.randint(1, 10_000, n)
     # on average, each array will have 5k elements
     # with int64, each array will have 40kb
     return [np.random.randint(1, 100, i) for i in sizes]

--- a/tests/distributed/test_shm_broadcast.py
+++ b/tests/distributed/test_shm_broadcast.py
@@ -11,8 +11,8 @@ from vllm.distributed.device_communicators.shm_broadcast import (
 from vllm.utils import update_environment_variables
 
 
-def get_arrays(n: int) -> List[np.ndarray]:
-    np.random.seed(0)
+def get_arrays(n: int, seed: int = 0) -> List[np.ndarray]:
+    np.random.seed(seed)
     sizes = np.random.randint(1, 10_000, n)
     # on average, each array will have 5k elements
     # with int64, each array will have 40kb
@@ -58,15 +58,26 @@ def worker_fn():
     writer_rank = 2
     broadcaster = ShmRingBufferIO.create_from_process_group(
         dist.group.WORLD, writer_rank)
+    if dist.get_rank() == writer_rank:
+        seed = random.randint(0, 1000)
+        dist.broadcast_object_list([seed], writer_rank)
+    else:
+        recv = [None]
+        dist.broadcast_object_list(recv, writer_rank)
+        seed = recv[0]  # type: ignore
+    dist.barrier()
+    # in case we find a race condition
+    # print the seed so that we can reproduce the error
+    print(f"Rank {dist.get_rank()} got seed {seed}")
     # test broadcasting with about 400MB of data
     N = 10_000
     if dist.get_rank() == writer_rank:
-        arrs = get_arrays(N)
+        arrs = get_arrays(N, seed)
         for x in arrs:
             broadcaster.broadcast_object(x)
             time.sleep(random.random() / 1000)
     else:
-        arrs = get_arrays(N)
+        arrs = get_arrays(N, seed)
         for x in arrs:
             y = broadcaster.broadcast_object(None)
             assert np.array_equal(x, y)

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -1,8 +1,10 @@
+import itertools
 import pickle
+import sys
 import time
 from contextlib import contextmanager
 from multiprocessing import shared_memory
-from typing import Optional
+from typing import Generator, Iterable, Optional
 from unittest.mock import patch
 
 import torch
@@ -15,6 +17,52 @@ from vllm.logger import init_logger
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
 
 logger = init_logger(__name__)
+
+
+class _MetadataBuffer:
+
+    def __init__(self, buffer):
+        self.buffer = buffer
+        self.n_reader = len(buffer) - 9
+        self.written_flag = buffer[0]
+        self.read_count = sum(buffer[1:self.n_reader + 1])
+        self.start = int.from_bytes(
+            buffer[self.n_reader + 1:self.n_reader + 5], sys.byteorder)
+        self.end = int.from_bytes(buffer[self.n_reader + 5:self.n_reader + 9],
+                                  sys.byteorder)
+
+    def mark_ready_to_read(self):
+        # NOTE: order is important here
+        # (1) set the written flag to 0
+        # (2) set the read flags to 0
+        # (3) set the written flag to 1
+        # otherwise, the readers may think they already read the block
+
+        # mark the block as not written
+        self.buffer[0] = 0
+        for i in range(1, self.n_reader + 1):
+            # set read flag to 0, meaning it is not read yet
+            self.buffer[i] = 0
+        # mark the block as written
+        self.buffer[0] = 1
+
+    def mark_read(self, reader_rank):
+        self.buffer[reader_rank + 1] = 1
+
+    def write_start_end(self):
+        self.buffer[self.n_reader + 1:self.n_reader + 5] = self.start.to_bytes(
+            4, sys.byteorder)
+        self.buffer[self.n_reader + 5:self.n_reader + 9] = self.end.to_bytes(
+            4, sys.byteorder)
+
+    def can_write(self):
+        # this block is either
+        # (1) not written
+        # (2) read by all readers
+        return not self.written_flag or self.read_count == self.n_reader
+
+    def can_read(self, reader_rank):
+        return self.written_flag and not self.buffer[reader_rank + 1]
 
 
 class ShmRingBuffer:
@@ -35,20 +83,23 @@ class ShmRingBuffer:
         Buffer memory layout:
                   data                                 metadata
                     |                                      |
-                    | (current_idx)                        | (current_idx)
+                    | [current_start, current_end)         | (current_idx)
                     v                                      v
         +-------------------------------+----------------------------------------+
         | chunk0 | chunk1 | ... | chunk | metadata0 | metadata1 | ... | metadata |
         +-------------------------------+----------------------------------------+
-        | max_chunks x max_chunk_bytes  | max_chunks x (1 + n_reader) bytes      |
+        |         max_bytes             | max_chunks x (1 + n_reader + 8) bytes  |
 
-        metadata memory layout: each byte is a flag, the first byte is the written
-        flag, and the rest are reader flags. The flags are set to 0 by default.
-        +--------------+--------------+--------------+-----+--------------+
-        | written_flag | reader0_flag | reader1_flag | ... | readerN_flag |
-        +--------------+--------------+--------------+-----+--------------+
+        metadata memory layout:
+            the first bytes are flags (set to 0 by default):
+                the first byte is the written flag
+                the following bytes are reader flags.
+            the next 8 bytes are two int32 values, indicating the start (inclusive) and end (exclusive) of the data in the chunk.
+        +--------------+--------------+--------------+-----+--------------+--------------+--------------+
+        | written_flag | reader0_flag | reader1_flag | ... | readerN_flag | start_offset | end_offset   |
+        +--------------+--------------+--------------+-----+--------------+--------------+--------------+
 
-        The state of metadata is as follows:
+        The state of metadata (excluding the 8 bytes) is as follows:
 
         (case 1) 0???...???: the block is not written yet, cannot read, can write
         (case 2) 1000...000: the block is just written, can read, cannot write
@@ -63,9 +114,9 @@ class ShmRingBuffer:
 
         State transition for writer:
 
-        When the writer writes to a block (case 1 or 4), it first resets the written flag to 0, converting either case
-        to case 1. Then it can yield the block for caller to write. After the caller finishes writing the block, the writer
-        can reset the reader flags to 0, and mark the block as written (from 0 to 1).
+        When the writer writes to a block (case 1 or 4), it can yield the block for caller to write. 
+        After the caller finishes writing the block, the writer first resets the written flag to 0, converting either case
+        to case 1. Then it can reset the reader flags to 0, and mark the block as written (from 0 to 1).
         NOTE: the order is important here, first reset the reader flags (so that we are still in case 1), then mark the block as written. The state transition is atomic. If we do it in the reverse order, it will go through case 3 and then back to case 2, and readers might read the intermediate case 3, which is not correct.
 
         During creation, `name` is None and the buffer is created. We can pass the
@@ -73,14 +124,16 @@ class ShmRingBuffer:
         get the name of the shared memory and open it, so that they can access the
         same shared memory buffer.
         """# noqa
-        self.n_reader = n_reader
-        self.metadata_size = 1 + n_reader
+
         self.max_chunk_bytes = max_chunk_bytes
+        self.n_reader = n_reader
+        self.flags_size = 1 + n_reader
+        self.metadata_size = self.flags_size + 8
+        self.max_bytes = 10 * 1024 * 1024  # 10 MB
         self.max_chunks = max_chunks
-        self.total_bytes_of_buffer = (self.max_chunk_bytes +
-                                      self.metadata_size) * self.max_chunks
+        self.total_bytes_of_buffer = self.max_bytes + self.metadata_size * self.max_chunks  # noqa
         self.data_offset = 0
-        self.metadata_offset = self.max_chunk_bytes * self.max_chunks
+        self.metadata_offset = self.max_bytes
 
         if name is None:
             # we are creating a buffer
@@ -115,18 +168,17 @@ class ShmRingBuffer:
             self.shared_memory.unlink()
 
     @contextmanager
-    def get_data(self, current_idx: int):
-        start = self.data_offset + current_idx * self.max_chunk_bytes
-        end = start + self.max_chunk_bytes
+    def get_data(self, start: int, end: int):
         with memoryview(self.shared_memory.buf[start:end]) as buf:
             yield buf
 
     @contextmanager
-    def get_metadata(self, current_idx: int):
+    def get_metadata(
+            self, current_idx: int) -> Generator[_MetadataBuffer, None, None]:
         start = self.metadata_offset + current_idx * self.metadata_size
         end = start + self.metadata_size
         with memoryview(self.shared_memory.buf[start:end]) as buf:
-            yield buf
+            yield _MetadataBuffer(buf)
 
 
 class ShmRingBufferIO:
@@ -140,104 +192,197 @@ class ShmRingBufferIO:
             assert 0 <= self.reader_rank < buffer.n_reader, \
                 (f"Invalid reader rank {self.reader_rank} for buffer"
                 f" created with {buffer.n_reader} readers")
+        """
+        `current_idx` of the writer points to the next enqueue position.
+        `current_idx` of the readers points to the next dequeue position.
+        i.e.:
+        for reader, current_idx is the next block to read
+        for writer, current_idx is the next block to write.
+        """ # noqa
         self.current_idx = 0
 
+
+        """
+        `low_watermark` and `high_watermark` are used for the writer to know the available space in the buffer:
+        - if `low_watermark` == `high_watermark`, it is ambiguous whether the buffer is full or empty.
+            We reserve the case for the buffer is empty. In this case, we can safely reset the
+            `low_watermark` and `high_watermark` to 0. `[0, max_bytes - 1)` are available for writing.
+        - if `low_watermark` < `high_watermark`, both the range `[high_watermark, max_bytes - 1)`
+            and `[0, low_watermark -1)` are available for writing.
+        0           low_watermark       high_watermark    max_bytes
+                          |<--      data    -->|
+        |<-- can write -->|<-- cannot write -->|<-- can write -->|
+
+        - if `low_watermark` > `high_watermark`, the range `[high_watermark, low_watermark - 1)`
+            is available for writing.
+        0              high_watermark     low_watermark       max_bytes
+        |<--    data      -->|                 |<--       data   -->|
+        |<-- cannot write -->|<-- can write -->|<-- cannot write -->|
+
+        The following fields are only for writer.
+        `start_recycle_idx` points to the bottom of the queue
+
+        invariant:
+        just after finish writing,
+        self.buffer.get_metadata(self.current_idx).end == self.high_watermark
+        self.buffer.get_metadata(self.start_recycle_idx).start == self.low_watermark
+        """ # noqa
+        self.start_recycle_idx = 0
+        self.low_watermark = 0
+        self.high_watermark = 0
+
+    def recycle_memory(self):
+        # essentially this function sets `low_watermark`
+
+        recycle_range: Iterable
+        recycle_range = tuple()
+        if self.start_recycle_idx < self.current_idx:
+            recycle_range = range(self.start_recycle_idx, self.current_idx)
+        elif self.start_recycle_idx > self.current_idx:
+            recycle_range = itertools.chain(
+                range(self.start_recycle_idx, self.buffer.max_chunks),
+                range(0, self.current_idx))
+        for i in recycle_range:
+            with self.buffer.get_metadata(i) as metadata_buffer:
+                if metadata_buffer.can_write():
+                    self.start_recycle_idx = (self.start_recycle_idx +
+                                              1) % self.buffer.max_chunks
+                    self.low_watermark = metadata_buffer.end
+                else:
+                    self.low_watermark = metadata_buffer.start
+                    break
+        if self.start_recycle_idx == self.current_idx:
+            # the current block can also be recycled
+            self.low_watermark = 0
+            self.high_watermark = 0
+
     @contextmanager
-    def acquire_write(self):
+    def acquire_write(self, n_bytes: int = 0):
         assert self._is_writer, "Only writers can acquire write"
-        start_index = self.current_idx
+        assert 0 < n_bytes < self.buffer.max_bytes, \
+            f"bytes acquired for write should be in (0, {self.buffer.max_bytes})"  # noqa
         start_time = time.time()
         n_warning = 1
         while True:
             with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
-                read_count = sum(metadata_buffer[1:])
-                written_flag = metadata_buffer[0]
-                if written_flag and read_count != self.buffer.n_reader:
-                    # this block is written and not read by all readers
-                    # try to write to the next block
-                    self.current_idx = (self.current_idx +
-                                        1) % self.buffer.max_chunks
-                    if self.current_idx == start_index:
-                        # no empty block found
-                        if time.time(
-                        ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
-                            logger.warning(
-                                "No available block found in %s second. ",
-                                VLLM_RINGBUFFER_WARNING_INTERVAL)
-                            n_warning += 1
-                        # wait for a while (0.1 us)
-                        time.sleep(1e-7)
-                    continue
-                # found a block that is either
-                # (1) not written
-                # (2) read by all readers
+                if not metadata_buffer.can_write():
+                    # for writers, `self.current_idx` is the next block to write
+                    # if this block is not ready to write,
+                    # we need to wait until it is read by all readers
 
-                # mark the block as not written
-                metadata_buffer[0] = 0
+                    # wait for a while (0.1 us)
+                    time.sleep(1e-7)
+
+                    # if we wait for a long time, we should warn the user
+                    if time.time(
+                    ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
+                        logger.warning(
+                            "No available block found in %s second. ",
+                            VLLM_RINGBUFFER_WARNING_INTERVAL)
+                        n_warning += 1
+
+                    continue
+
+                # the block is ready to write now
+
+                # recycle memory
+                self.recycle_memory()
+
+                # find enough space to write
+                start_loc = None
+                if self.low_watermark == self.high_watermark:
+                    # the buffer is empty
+                    # reset to 0
+                    start_loc = 0
+                    self.low_watermark = 0
+                    self.high_watermark = n_bytes
+                elif self.low_watermark < self.high_watermark:
+                    right_space = self.buffer.max_bytes - 1 - self.high_watermark  # noqa
+                    left_space = self.low_watermark - 1
+                    if left_space < n_bytes and right_space < n_bytes:
+                        # not enough space
+                        # wait for a while (0.1 us)
+                        # readers may read the block and then
+                        # we can free the space
+                        time.sleep(1e-7)
+                        continue
+                    if right_space >= n_bytes:
+                        start_loc = self.high_watermark
+                        self.high_watermark += n_bytes
+                    else:
+                        start_loc = 0
+                        self.high_watermark = n_bytes
+                else:
+                    space = self.low_watermark - self.high_watermark - 1
+                    if space < n_bytes:
+                        # not enough space
+                        # wait for a while (0.1 us)
+                        # readers may read the block and then
+                        # we can free the space
+                        time.sleep(1e-7)
+                        continue
+                    start_loc = self.high_watermark
+                    self.high_watermark += n_bytes
+
+                metadata_buffer.start = start_loc
+                metadata_buffer.end = start_loc + n_bytes
+                metadata_buffer.write_start_end()
+
                 # let caller write to the buffer
-                with self.buffer.get_data(self.current_idx) as buf:
+                with self.buffer.get_data(metadata_buffer.start,
+                                          metadata_buffer.end) as buf:
                     yield buf
 
                 # caller has written to the buffer
-                # NOTE: order is important here
-                # first set the read flags to 0
-                # then set the written flag to 1
-                # otherwise, the readers may think they already read the block
-                for i in range(1, self.buffer.n_reader + 1):
-                    # set read flag to 0, meaning it is not read yet
-                    metadata_buffer[i] = 0
-                # mark the block as written
-                metadata_buffer[0] = 1
+                metadata_buffer.mark_ready_to_read()
+                self.current_idx = (self.current_idx +
+                                    1) % self.buffer.max_chunks
                 break
 
     @contextmanager
     def acquire_read(self):
         assert self._is_reader, "Only readers can acquire read"
-        start_index = self.current_idx
         start_time = time.time()
         n_warning = 1
         while True:
             with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
-                read_flag = metadata_buffer[self.reader_rank + 1]
-                written_flag = metadata_buffer[0]
-                if not written_flag or read_flag:
-                    # this block is either
-                    # (1) not written
-                    # (2) already read by this reader
-                    # try to read the next block
-                    self.current_idx = (self.current_idx +
-                                        1) % self.buffer.max_chunks
-                    if self.current_idx == start_index:
-                        # no block found
-                        if time.time(
-                        ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
-                            logger.warning(
-                                "No available block found in %s second. ",
-                                VLLM_RINGBUFFER_WARNING_INTERVAL)
-                            n_warning += 1
-                        # wait for a while (0.1 us)
-                        time.sleep(1e-7)
+                if not metadata_buffer.can_read(self.reader_rank):
+                    # for readers, `self.current_idx` is the next block to read
+                    # if this block is not ready,
+                    # we need to wait until it is written
+
+                    # wait for a while (0.1 us)
+                    time.sleep(1e-7)
+
+                    # if we wait for a long time, we should warn the user
+                    if time.time(
+                    ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
+                        logger.warning(
+                            "No available block found in %s second. ",
+                            VLLM_RINGBUFFER_WARNING_INTERVAL)
+                        n_warning += 1
+
                     continue
+
                 # found a block that is not read by this reader
                 # let caller read from the buffer
-                with self.buffer.get_data(self.current_idx) as buf:
+                with self.buffer.get_data(metadata_buffer.start,
+                                          metadata_buffer.end) as buf:
                     yield buf
 
                 # caller has read from the buffer
                 # set the read flag
-                metadata_buffer[self.reader_rank + 1] = 1
+                metadata_buffer.mark_read(self.reader_rank)
+                self.current_idx = (self.current_idx +
+                                    1) % self.buffer.max_chunks
                 break
 
     def enqueue(self, obj):
         assert self._is_writer, "Only writers can enqueue"
         serialized_obj = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
-        if len(serialized_obj) > self.buffer.max_chunk_bytes:
-            raise RuntimeError(
-                f"{len(serialized_obj)=} larger than the allowed value "
-                f"{self.buffer.max_chunk_bytes},"
-                "Please increase the max_chunk_bytes parameter.")
-        with self.acquire_write() as buf:
-            buf[:len(serialized_obj)] = serialized_obj
+        n_bytes = len(serialized_obj)
+        with self.acquire_write(n_bytes) as buf:
+            buf[:] = serialized_obj
 
     def dequeue(self):
         assert self._is_reader, "Only readers can dequeue"

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -130,7 +130,7 @@ class ShmRingBuffer:
         self.flags_size = 1 + n_reader
         self.metadata_size = self.flags_size + 8
         self.max_bytes = 10 * 1024 * 1024  # 10 MB
-        self.max_chunks = max_chunks
+        self.max_chunks = 1000
         self.total_bytes_of_buffer = self.max_bytes + self.metadata_size * self.max_chunks  # noqa
         self.data_offset = 0
         self.metadata_offset = self.max_bytes

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -168,7 +168,7 @@ class GroupCoordinator:
         self.shm_broadcaster: Optional[ShmRingBufferIO] = None
         if self.world_size > 1 and is_in_the_same_node(self.cpu_group):
             self.shm_broadcaster = ShmRingBufferIO.create_from_process_group(
-                self.cpu_group, 1 << 20, 6)
+                self.cpu_group)
 
     @property
     def first_rank(self):


### PR DESCRIPTION
The shm transport introduced in https://github.com/vllm-project/vllm/pull/5399 , reserve a fixed chunk size (1MB) for each object, which is not flexible, and waste share memory space.

This PR tries to add variable length support. The initialization argument is now, the max total bytes, and the max number of objects (basically queue size). Only when either is full, the enqueue operation will be blocking.

In most cases, it should not block, as we just have a few broadcast in vLLM, and the worker will read them before the next broadcast. The queue size will not grow dramatically.

The variable length support is more complicated than I thought. The high-watermark and low-watermark stuff is quite difficult to get it right. I added a stress test to send over 400MB data in 10K messages, which should give us enough confidence that this implementation is correct.