### PR TITLE
[Doc] Add "Suggest edit" button to doc pages

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,7 @@ html_theme_options = {
     'path_to_docs': 'docs/source',
     'repository_url': 'https://github.com/vllm-project/vllm',
     'use_repository_button': True,
+    'use_edit_page_button': True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Adds a shortcut for editing doc pages that will take you directly to the source to propose a change.

<img width="1422" alt="Screenshot 2024-06-24 at 11 25 08 AM" src="https://github.com/vllm-project/vllm/assets/3195154/7802470d-b410-43ab-9d88-ef7040053da6">


Leads you straight to source in the edit page:

<img width="1336" alt="Screenshot 2024-06-24 at 11 30 02 AM" src="https://github.com/vllm-project/vllm/assets/3195154/3313ddf0-66e4-4f3d-bb97-515c5c0aa92d">
