### PR TITLE
[bugfix][distributed] fix shm broadcast when the queue size is full

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -157,7 +157,10 @@ class ShmRingBufferIO:
                     # if this block is not ready to write,
                     # we need to wait until it is read by all readers
 
-                    # wait for a while (0.1 us)
+                    # wait for a while
+                    # if we sleep for too short, it will consume too much CPU
+                    # if we sleep for too long, it will slow down the writer
+                    # 0.1 us is a good balance
                     time.sleep(1e-7)
 
                     # if we wait for a long time, we should warn the user
@@ -211,7 +214,10 @@ class ShmRingBufferIO:
                     # if this block is not ready,
                     # we need to wait until it is written
 
-                    # wait for a while (0.1 us)
+                    # wait for a while
+                    # if we sleep for too short, it will consume too much CPU
+                    # if we sleep for too long, it will slow down the reader
+                    # 0.1 us is a good balance
                     time.sleep(1e-7)
 
                     # if we wait for a long time, we should warn the user

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -14,6 +14,12 @@ from vllm.logger import init_logger
 
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
 
+# time to wait if the queue is full or empty
+# if we sleep for too short, it will consume too much CPU
+# if we sleep for too long, it will slow down the writer/reader
+# 0.1 us is a good balance
+RINGBUFFER_SLEEP_INTERVAL = 1e-7
+
 logger = init_logger(__name__)
 
 
@@ -158,10 +164,7 @@ class ShmRingBufferIO:
                     # we need to wait until it is read by all readers
 
                     # wait for a while
-                    # if we sleep for too short, it will consume too much CPU
-                    # if we sleep for too long, it will slow down the writer
-                    # 0.1 us is a good balance
-                    time.sleep(1e-7)
+                    time.sleep(RINGBUFFER_SLEEP_INTERVAL)
 
                     # if we wait for a long time, we should warn the user
                     if time.monotonic(
@@ -215,10 +218,7 @@ class ShmRingBufferIO:
                     # we need to wait until it is written
 
                     # wait for a while
-                    # if we sleep for too short, it will consume too much CPU
-                    # if we sleep for too long, it will slow down the reader
-                    # 0.1 us is a good balance
-                    time.sleep(1e-7)
+                    time.sleep(RINGBUFFER_SLEEP_INTERVAL)
 
                     # if we wait for a long time, we should warn the user
                     if time.monotonic(

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -145,7 +145,7 @@ class ShmRingBufferIO:
     @contextmanager
     def acquire_write(self):
         assert self._is_writer, "Only writers can acquire write"
-        start_time = time.time()
+        start_time = time.monotonic()
         n_warning = 1
         while True:
             with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
@@ -161,7 +161,7 @@ class ShmRingBufferIO:
                     time.sleep(1e-7)
 
                     # if we wait for a long time, we should warn the user
-                    if time.time(
+                    if time.monotonic(
                     ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
                         logger.warning(
                             "No available block found in %s second. ",
@@ -196,7 +196,7 @@ class ShmRingBufferIO:
     @contextmanager
     def acquire_read(self):
         assert self._is_reader, "Only readers can acquire read"
-        start_time = time.time()
+        start_time = time.monotonic()
         n_warning = 1
         while True:
             with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
@@ -215,7 +215,7 @@ class ShmRingBufferIO:
                     time.sleep(1e-7)
 
                     # if we wait for a long time, we should warn the user
-                    if time.time(
+                    if time.monotonic(
                     ) - start_time > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning:  # noqa
                         logger.warning(
                             "No available block found in %s second. ",


### PR DESCRIPTION
The shm broadcast is meant to be a message queue, and `current_idx` points to the enqueue / dequeue position for writer/reader. We cannot go on to find another block when the current block is not ready for write/read.

This PR fixes the bug, and also borrow the stress test from https://github.com/vllm-project/vllm/pull/5768 .

somehow magically, I find this bug in an irrelevant test https://buildkite.com/vllm/ci-aws/builds/2452#01904c1a-10a8-4f4c-ace2-744082f5287b , where I can stably reproduce the bug. However, it is not caught by the current ci in the main branch.

FIX #5848