### PR TITLE
[Bugfix] Fix off-by-one bug in decode_prompt_logprobs_inplace()

### DIFF
--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -138,10 +138,12 @@ def create_dummy_logprobs(
         token_id + 1: Logprob(logprob=0.1)
     } for token_id in complete_sequence_token_ids]
 
+
 def create_dummy_prompt_logprobs(
         complete_sequence_token_ids: List[int]) -> List[Dict[int, Logprob]]:
     # logprob for the first prompt token is not defined.
     return create_dummy_logprobs(complete_sequence_token_ids)[1:]
+
 
 @pytest.mark.parametrize("complete_sequence", TRUTH)
 @pytest.mark.parametrize("tokenizer_name", TOKENIZERS)
@@ -204,15 +206,16 @@ def test_decode_prompt_logprobs(complete_sequence: str,
         # decoded_prompt_logprobs doesn't contain the first token.
         token_ids = complete_sequence_token_ids[1:]
         tokenzier = detokenizer.get_tokenizer_for_seq(seq)
-        text = tokenzier.decode(token_ids, skip_special_tokens=skip_special_tokens)
+        text = tokenzier.decode(token_ids,
+                                skip_special_tokens=skip_special_tokens)
         # Text for logprobs for the chosen token should be the same as the
         # prompt text. Note that this will only be true if we skip
         # special tokens.
         assert text == "".join([
-            logprobs[token_id].decoded_token for token_id, logprobs in zip(
-                token_ids, decoded_prompt_logprobs)
+            logprobs[token_id].decoded_token
+            for token_id, logprobs in zip(token_ids, decoded_prompt_logprobs)
         ])
         assert text != "".join([
-            logprobs[token_id + 1].decoded_token for token_id, logprobs in zip(
-                token_ids, decoded_prompt_logprobs)
+            logprobs[token_id + 1].decoded_token
+            for token_id, logprobs in zip(token_ids, decoded_prompt_logprobs)
         ])

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -222,8 +222,8 @@ def test_decode_prompt_logprobs(complete_sequence: str,
 
 
 @pytest.mark.parametrize("tokenizer_name", ["facebook/opt-125m"])
-def test_decode_prompt_logprobs_5846(detokenizer: Detokenizer):
-    """ Regression test for #5846. """
+def test_decode_prompt_logprobs_pr_5846(detokenizer: Detokenizer):
+    """ Regression test for PR #5846. """
 
     # This set of random input will generate incorrect output before #5846.
     prompt_token_ids = [3290, 1562, 8652, 3123, 1838, 9660]

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -37,7 +37,8 @@ class Detokenizer:
         # We can pick any sequence for the prompt.
         seq = next(iter(seq_group.seqs_dict.values()))
         # Only prompt, without the generated token.
-        all_token_ids = seq.get_token_ids()
+        # Skip the first token as its logprob is not defined.
+        all_token_ids = seq.get_token_ids()[1:]
         prompt_token_ids = all_token_ids[:-1]
         tokenizer = self.get_tokenizer_for_seq(seq)
         prefix_offset = 0
@@ -46,7 +47,6 @@ class Detokenizer:
         next_iter_read_offset = 0
         next_iter_tokens: List[str] = []
         prev_tokens = None
-
         for token_position, prompt_logprobs_for_token in enumerate(
                 prompt_logprobs):
             if not prompt_logprobs_for_token:

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -47,6 +47,7 @@ class Detokenizer:
         next_iter_read_offset = 0
         next_iter_tokens: List[str] = []
         prev_tokens = None
+
         for token_position, prompt_logprobs_for_token in enumerate(
                 prompt_logprobs):
             if not prompt_logprobs_for_token:


### PR DESCRIPTION
 Skip the first token in sequence as its logprob is not defined and not computed. Otherwise, this [`token_id == all_token_ids[token_position]`](https://github.com/vllm-project/vllm/blob/d7a816835ad2ec7af36229603a7d40535a9d82f0/vllm/transformers_utils/detokenizer.py#L77) check won't work properly and cause `detokenize_incrementally` to generate incorrect results.

FIX #4904
FIX #4772
FIX #5334
FIX #5872
