### PR TITLE
[WIP] [Speculative Decoding] Support draft model on different tensor-parallel size than target model (Extended)

### DIFF
--- a/tests/spec_decode/e2e/test_integration_dist_tp4.py
+++ b/tests/spec_decode/e2e/test_integration_dist_tp4.py
@@ -38,16 +38,14 @@ from .conftest import run_greedy_equality_correctness_test
     },
 ])
 @pytest.mark.parametrize("baseline_llm_kwargs", [{}])
-@pytest.mark.parametrize(
-    "test_llm_kwargs",
-    [
-        {
-            "speculative_draft_tensor_parallel_size": 2,
-        },
-        {
-            "speculative_draft_tensor_parallel_size": 1,
-        },
-    ])
+@pytest.mark.parametrize("test_llm_kwargs", [
+    {
+        "speculative_draft_tensor_parallel_size": 2,
+    },
+    {
+        "speculative_draft_tensor_parallel_size": 1,
+    },
+])
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("seed", [1])
 def test_draft_model_tp_lt_target_model_tp4(test_llm_generator,

--- a/tests/spec_decode/e2e/test_integration_dist_tp4.py
+++ b/tests/spec_decode/e2e/test_integration_dist_tp4.py
@@ -41,7 +41,9 @@ from .conftest import run_greedy_equality_correctness_test
 @pytest.mark.parametrize(
     "test_llm_kwargs",
     [
-        #TODO(wooyeon): add spec_draft_dp=2 case
+        {
+            "speculative_draft_tensor_parallel_size": 2,
+        },
         {
             "speculative_draft_tensor_parallel_size": 1,
         },

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1095,11 +1095,12 @@ class SpeculativeConfig:
         if speculative_draft_tensor_parallel_size is None:
             speculative_draft_tensor_parallel_size = \
                   target_parallel_config.tensor_parallel_size
-        elif speculative_draft_tensor_parallel_size != 1:
-            # TODO(wooyeon): allow tp values larger than 1
+
+        if speculative_draft_tensor_parallel_size > \
+            target_parallel_config.tensor_parallel_size:
             raise ValueError(
-                f"{speculative_draft_tensor_parallel_size=} cannot be"
-                f"other value than 1")
+                f"{speculative_draft_tensor_parallel_size=} cannot be "
+                f"larger than {target_parallel_config.tensor_parallel_size}")
 
         draft_parallel_config = ParallelConfig(
             pipeline_parallel_size=target_parallel_config.


### PR DESCRIPTION
This PR is to support spec_draft_tp larger than 1.
spec_draft_tp=1 has been enabled in #5414.

Note: To test the code in CI, I removed unrelated test cases temporarily.

What I've done in this PR:
- Changed config.py to allow tp values larger than 1 but not than the target model's tp value.
- Added a test case of spec_draft_tp=2 in test_integration_dist_tp4.py

Resolves #4632 further