### PR TITLE
[core][optimization] use a pool of numpy ndarray to hold seq data

### DIFF
--- a/vllm/block.py
+++ b/vllm/block.py
@@ -74,11 +74,16 @@ class LogicalTokenBlock:
     def is_full(self) -> bool:
         return self.num_tokens == self.block_size
 
-    def append_tokens(self, token_ids: List[int]) -> None:
+    def append_tokens(self, token_ids: np.ndarray) -> None:
         assert len(token_ids) <= self.get_num_empty_slots()
         curr_idx = self.num_tokens
         self.token_ids[curr_idx:curr_idx + len(token_ids)] = token_ids
         self.num_tokens += len(token_ids)
+
+    def append_token(self, token_id: int) -> None:
+        assert self.get_num_empty_slots() > 0
+        self.token_ids[self.num_tokens] = token_id
+        self.num_tokens += 1
 
     def get_token_ids(self) -> np.ndarray:
         return self.token_ids[:self.num_tokens]

--- a/vllm/block.py
+++ b/vllm/block.py
@@ -11,8 +11,6 @@ _BLANK_TOKEN_ID = -1
 
 DEFAULT_LAST_ACCESSED_TIME = -1
 
-TokensBlock = np.ndarray
-
 
 class BlockPool:
     """A pool of logical blocks.
@@ -27,14 +25,14 @@ class BlockPool:
 
     def __init__(self) -> None:
         # block size to list of token blocks
-        self.pool: Dict[int, List[TokensBlock]] = defaultdict(list)
+        self.pool: Dict[int, List[np.ndarray]] = defaultdict(list)
 
-    def alloc_block(self, block_size: int) -> TokensBlock:
+    def alloc_block(self, block_size: int) -> np.ndarray:
         if block_size in self.pool and self.pool[block_size]:
             return self.pool[block_size].pop()
         return np.full(block_size, _BLANK_TOKEN_ID, dtype=np.int64)
 
-    def del_block(self, block: TokensBlock) -> None:
+    def del_block(self, block: np.ndarray) -> None:
         self.pool[len(block)].append(block)
 
 

--- a/vllm/block.py
+++ b/vllm/block.py
@@ -1,94 +1,11 @@
 """Token blocks."""
-import weakref
-from collections import defaultdict
-from typing import Dict, List
-
-import numpy as np
+from typing import List
 
 from vllm.utils import Device
 
 _BLANK_TOKEN_ID = -1
 
 DEFAULT_LAST_ACCESSED_TIME = -1
-
-
-class BlockPool:
-    """A pool of logical blocks.
-    When requests come, we create a lot of logical blocks;
-    when requests are done, we destroy a lot of logical blocks.
-    It turns out that creating and destroying logical blocks can be expensive,
-    especially for the `token_ids` field, which is a list of integers.
-    To avoid this overhead, we use a pool to manage the logical blocks.
-    When an old request is done and a new request comes, we can reuse the
-    logical blocks from the old request to feed the new request.
-    """
-
-    def __init__(self) -> None:
-        # block size to list of token blocks
-        self.pool: Dict[int, List[np.ndarray]] = defaultdict(list)
-
-    def alloc_block(self, block_size: int) -> np.ndarray:
-        if block_size in self.pool and self.pool[block_size]:
-            return self.pool[block_size].pop()
-        return np.full(block_size, _BLANK_TOKEN_ID, dtype=np.int64)
-
-    def del_block(self, block: np.ndarray) -> None:
-        self.pool[len(block)].append(block)
-
-
-_BLOCK_POOL = BlockPool()
-
-
-class LogicalTokenBlock:
-    """A block that stores a contiguous chunk of tokens from left to right.
-
-    Logical blocks are used to represent the states of the corresponding
-    physical blocks in the KV cache.
-    """
-
-    def __init__(
-        self,
-        block_number: int,
-        block_size: int,
-    ) -> None:
-        self.block_number = block_number
-        self.block_size = block_size
-
-        self.token_ids = _BLOCK_POOL.alloc_block(block_size)
-        # this finalizer is used to return the block to the pool when the object is deleted # noqa
-        # NOTE: don't use __del__ because it cannot guarantee the order of finalization, # noqa
-        # i.e. `self.token_ids` may be deleted before `self`, and we lose
-        #  the opportunity to return the block to the pool
-        self._finalizer = weakref.finalize(self, _BLOCK_POOL.del_block,
-                                           self.token_ids)
-        self.num_tokens = 0
-
-    def is_empty(self) -> bool:
-        return self.num_tokens == 0
-
-    def get_num_empty_slots(self) -> int:
-        return self.block_size - self.num_tokens
-
-    def is_full(self) -> bool:
-        return self.num_tokens == self.block_size
-
-    def append_tokens(self, token_ids: np.ndarray) -> None:
-        assert len(token_ids) <= self.get_num_empty_slots()
-        curr_idx = self.num_tokens
-        self.token_ids[curr_idx:curr_idx + len(token_ids)] = token_ids
-        self.num_tokens += len(token_ids)
-
-    def append_token(self, token_id: int) -> None:
-        assert self.get_num_empty_slots() > 0
-        self.token_ids[self.num_tokens] = token_id
-        self.num_tokens += 1
-
-    def get_token_ids(self) -> np.ndarray:
-        return self.token_ids[:self.num_tokens]
-
-    def get_last_token_id(self) -> int:
-        assert self.num_tokens > 0
-        return int(self.token_ids[self.num_tokens - 1])
 
 
 class PhysicalTokenBlock:

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -263,7 +263,7 @@ class BlockSpaceManagerV1(BlockSpaceManager):
 
     def _get_seq_num_required_blocks(self, seq: Sequence) -> int:
         return 0 if seq is None \
-            else len(seq.logical_token_blocks)
+            else seq.n_blocks
 
     def can_allocate(self, seq_group: SequenceGroup) -> AllocStatus:
         # FIXME(woosuk): Here we assume that all sequences in the group share
@@ -298,7 +298,7 @@ class BlockSpaceManagerV1(BlockSpaceManager):
                            ref_count: int, \
                            is_encoder_decoder: bool = True) -> BlockTable:
         # Allocate new physical token blocks that will store the prompt tokens.
-        num_prompt_blocks = len(seq.logical_token_blocks)
+        num_prompt_blocks = seq.n_blocks
 
         block_table: BlockTable = []
         for logical_idx in range(num_prompt_blocks):
@@ -367,7 +367,7 @@ class BlockSpaceManagerV1(BlockSpaceManager):
 
         # Compute a new hash for the block so that it can be shared by other
         # Sequences
-        new_hash = seq.hash_of_block(len(seq.logical_token_blocks) - 1)
+        new_hash = seq.hash_of_block(seq.n_blocks - 1)
 
         # if new_hash is already in the cached table, then free last_block
         # and return the cached version
@@ -408,9 +408,8 @@ class BlockSpaceManagerV1(BlockSpaceManager):
             return self.gpu_allocator.allocate()
         block_hash: Optional[int] = None
         if (self._is_last_block_full(seq)):
-            block_hash = seq.hash_of_block(len(seq.logical_token_blocks) - 1)
-        num_hashed_tokens = seq.num_hashed_tokens_of_block(
-            len(seq.logical_token_blocks) - 1)
+            block_hash = seq.hash_of_block(seq.n_blocks - 1)
+        num_hashed_tokens = seq.num_hashed_tokens_of_block(seq.n_blocks - 1)
 
         # num_hashed_tokens is used to compute future hashes
         # (e.g. in the hashing function, it is used to ask the sequence for
@@ -429,12 +428,11 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         num_lookahead_slots: int = 0,
     ) -> List[Tuple[int, int]]:
         """Allocate a physical slot for a new token."""
-        logical_blocks = seq.logical_token_blocks
         block_table = self.block_tables[seq.seq_id]
         # If we need to allocate a new physical block
-        if len(block_table) < len(logical_blocks):
+        if len(block_table) < seq.n_blocks:
             # Currently this code only supports adding one physical block
-            assert len(block_table) == len(logical_blocks) - 1
+            assert len(block_table) == seq.n_blocks - 1
 
             if (self.block_sliding_window
                     and len(block_table) >= self.block_sliding_window):

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -30,7 +30,7 @@ class CompletionOutput:
 
     index: int
     text: str
-    token_ids: List[int]
+    token_ids: Union[List[int], np.ndarray]
     cumulative_logprob: float
     logprobs: Optional[SampleLogprobs]
     finish_reason: Optional[str] = None
@@ -128,7 +128,7 @@ class RequestOutput:
         outputs = [
             CompletionOutput(seqs.index(seq),
                              seq.get_output_text_to_return(text_buffer_length),
-                             seq.get_output_token_ids().tolist(),
+                             seq.get_output_token_ids(),
                              seq.get_cumulative_logprob(),
                              seq.output_logprobs if include_logprobs else None,
                              SequenceStatus.get_finished_reason(seq.status),

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -2,8 +2,6 @@ import time
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
-import numpy as np
-
 from vllm.lora.request import LoRARequest
 from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
                            SequenceGroup, SequenceStatus)
@@ -30,7 +28,7 @@ class CompletionOutput:
 
     index: int
     text: str
-    token_ids: Union[List[int], np.ndarray]
+    token_ids: List[int]
     cumulative_logprob: float
     logprobs: Optional[SampleLogprobs]
     finish_reason: Optional[str] = None
@@ -84,7 +82,7 @@ class RequestOutput:
         self,
         request_id: str,
         prompt: Optional[str],
-        prompt_token_ids: Union[List[int], np.ndarray],
+        prompt_token_ids: List[int],
         prompt_logprobs: Optional[PromptLogprobs],
         outputs: List[CompletionOutput],
         finished: bool,
@@ -174,8 +172,7 @@ class EmbeddingRequestOutput:
     """
 
     def __init__(self, request_id: str, outputs: "EmbeddingOutput",
-                 prompt_token_ids: Union[List[int],
-                                         np.ndarray], finished: bool):
+                 prompt_token_ids: List[int], finished: bool):
         self.request_id = request_id
         self.prompt_token_ids = prompt_token_ids
         self.finished = finished

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -142,7 +142,7 @@ class RequestOutput:
         seq_group.set_finished_time(finished_time)
         return cls(seq_group.request_id,
                    prompt,
-                   prompt_token_ids.tolist(),
+                   prompt_token_ids,
                    prompt_logprobs,
                    outputs,
                    finished,
@@ -185,7 +185,7 @@ class EmbeddingRequestOutput:
             raise ValueError(
                 "Embeddings are missing in seq_group for EmbeddingRequest.")
         output = EmbeddingOutput(seq_group.embeddings)
-        prompt_token_ids = seq_group.prompt_token_ids.tolist()
+        prompt_token_ids = seq_group.prompt_token_ids
         finished = seq_group.is_finished()
 
         return cls(seq_group.request_id, output, prompt_token_ids, finished)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -126,7 +126,7 @@ class RequestOutput:
         outputs = [
             CompletionOutput(seqs.index(seq),
                              seq.get_output_text_to_return(text_buffer_length),
-                             seq.get_output_token_ids(),
+                             seq.get_output_token_ids().tolist(),
                              seq.get_cumulative_logprob(),
                              seq.output_logprobs if include_logprobs else None,
                              SequenceStatus.get_finished_reason(seq.status),

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -126,7 +126,7 @@ class RequestOutput:
         outputs = [
             CompletionOutput(seqs.index(seq),
                              seq.get_output_text_to_return(text_buffer_length),
-                             seq.get_output_token_ids(),
+                             seq.get_output_token_ids().tolist(),
                              seq.get_cumulative_logprob(),
                              seq.output_logprobs if include_logprobs else None,
                              SequenceStatus.get_finished_reason(seq.status),
@@ -142,7 +142,7 @@ class RequestOutput:
         seq_group.set_finished_time(finished_time)
         return cls(seq_group.request_id,
                    prompt,
-                   prompt_token_ids,
+                   prompt_token_ids.tolist(),
                    prompt_logprobs,
                    outputs,
                    finished,
@@ -185,7 +185,7 @@ class EmbeddingRequestOutput:
             raise ValueError(
                 "Embeddings are missing in seq_group for EmbeddingRequest.")
         output = EmbeddingOutput(seq_group.embeddings)
-        prompt_token_ids = seq_group.prompt_token_ids
+        prompt_token_ids = seq_group.prompt_token_ids.tolist()
         finished = seq_group.is_finished()
 
         return cls(seq_group.request_id, output, prompt_token_ids, finished)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -2,6 +2,8 @@ import time
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
+import numpy as np
+
 from vllm.lora.request import LoRARequest
 from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
                            SequenceGroup, SequenceStatus)
@@ -82,7 +84,7 @@ class RequestOutput:
         self,
         request_id: str,
         prompt: Optional[str],
-        prompt_token_ids: List[int],
+        prompt_token_ids: Union[List[int], np.ndarray],
         prompt_logprobs: Optional[PromptLogprobs],
         outputs: List[CompletionOutput],
         finished: bool,
@@ -135,7 +137,7 @@ class RequestOutput:
 
         # Every sequence in the sequence group should have the same prompt.
         prompt = seq_group.prompt
-        prompt_token_ids = seq_group.prompt_token_ids.tolist()
+        prompt_token_ids = seq_group.prompt_token_ids
         prompt_logprobs = seq_group.prompt_logprobs
         finished = seq_group.is_finished()
         finished_time = time.time() if finished else None
@@ -172,7 +174,8 @@ class EmbeddingRequestOutput:
     """
 
     def __init__(self, request_id: str, outputs: "EmbeddingOutput",
-                 prompt_token_ids: List[int], finished: bool):
+                 prompt_token_ids: Union[List[int],
+                                         np.ndarray], finished: bool):
         self.request_id = request_id
         self.prompt_token_ids = prompt_token_ids
         self.finished = finished
@@ -185,7 +188,7 @@ class EmbeddingRequestOutput:
             raise ValueError(
                 "Embeddings are missing in seq_group for EmbeddingRequest.")
         output = EmbeddingOutput(seq_group.embeddings)
-        prompt_token_ids = seq_group.prompt_token_ids.tolist()
+        prompt_token_ids = seq_group.prompt_token_ids
         finished = seq_group.is_finished()
 
         return cls(seq_group.request_id, output, prompt_token_ids, finished)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -135,7 +135,7 @@ class RequestOutput:
 
         # Every sequence in the sequence group should have the same prompt.
         prompt = seq_group.prompt
-        prompt_token_ids = seq_group.prompt_token_ids
+        prompt_token_ids = seq_group.prompt_token_ids.tolist()
         prompt_logprobs = seq_group.prompt_logprobs
         finished = seq_group.is_finished()
         finished_time = time.time() if finished else None
@@ -185,7 +185,7 @@ class EmbeddingRequestOutput:
             raise ValueError(
                 "Embeddings are missing in seq_group for EmbeddingRequest.")
         output = EmbeddingOutput(seq_group.embeddings)
-        prompt_token_ids = seq_group.prompt_token_ids
+        prompt_token_ids = seq_group.prompt_token_ids.tolist()
         finished = seq_group.is_finished()
 
         return cls(seq_group.request_id, output, prompt_token_ids, finished)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -266,6 +266,8 @@ class Sequence:
         self.lora_request = lora_request
 
         self.data = SequenceData(self.inputs["prompt_token_ids"])
+        self.prompt_token_ids: np.ndarray = self.data.get_prompt_token_ids()
+        self.prompt: Optional[str] = self.inputs.get("prompt")
         self.output_logprobs: SampleLogprobs = []
         self.output_text = ""
 
@@ -280,14 +282,6 @@ class Sequence:
         self.read_offset = 0
         # Input + output tokens
         self.tokens: Optional[List[str]] = None
-
-    @property
-    def prompt(self) -> Optional[str]:
-        return self.inputs.get("prompt")
-
-    @property
-    def prompt_token_ids(self) -> np.ndarray:
-        return self.data.get_prompt_token_ids()
 
     @property
     def multi_modal_data(self) -> Optional["MultiModalData"]:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -183,7 +183,7 @@ class SequenceData:
 
     def hash_prefix_token_ids(self, num_tokens: int) -> bytes:
         """Get prefix tokens, and make the return value hashable"""
-        data = self.tokens[:self.num_prompt_tokens + self.num_output_tokens]
+        data = self.tokens[:num_tokens]
         # get a memory view of the underlying data
         buffer = memoryview(data)  # type: ignore
         # hash the memory view

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -266,7 +266,7 @@ class Sequence:
         self.lora_request = lora_request
 
         self.data = SequenceData(self.inputs["prompt_token_ids"])
-        self.prompt_token_ids: np.ndarray = self.data.get_prompt_token_ids()
+        self.prompt_token_ids: List[int] = self.inputs["prompt_token_ids"]
         self.prompt: Optional[str] = self.inputs.get("prompt")
         self.output_logprobs: SampleLogprobs = []
         self.output_text = ""
@@ -457,7 +457,7 @@ class SequenceGroup:
         return next(iter(self.seqs_dict.values())).prompt
 
     @property
-    def prompt_token_ids(self) -> np.ndarray:
+    def prompt_token_ids(self) -> List[int]:
         # All sequences in the group should have the same prompt.
         # We use the prompt of an arbitrary sequence.
         return next(iter(self.seqs_dict.values())).prompt_token_ids

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1,10 +1,13 @@
 """Sequence and its related classes."""
 import copy
 import enum
+import hashlib
+import weakref
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
+import numpy as np
 import torch
 
 from vllm.block import LogicalTokenBlock
@@ -100,6 +103,33 @@ class RequestMetrics:
     finished_time: Optional[float] = None
 
 
+class SequenceDataPool:
+    """A pool of numpy array to hold sequence data.
+    """
+
+    def __init__(self, max_tokens: int, initial_pool_size: int) -> None:
+        self.max_tokens = max_tokens
+        self.pool: List[np.ndarray] = []
+        if initial_pool_size > 0:
+            self.pool = [
+                np.zeros(max_tokens, dtype=np.int64)
+                for _ in range(initial_pool_size)
+            ]
+
+    def alloc_array(self) -> np.ndarray:
+        if self.pool:
+            return self.pool.pop()
+        return np.zeros(self.max_tokens, dtype=np.int64)
+
+    def del_array(self, arr: np.ndarray) -> None:
+        assert arr.size == self.max_tokens
+        self.pool.append(arr)
+
+
+# for 128k context size
+_SEQUENCE_DATA_POOL = SequenceDataPool(128 * 1024, 32)
+
+
 class SequenceData:
     """Data associated with a sequence.
 
@@ -119,43 +149,46 @@ class SequenceData:
         prompt_token_ids: List[int],
         output_token_ids: Optional[List[int]] = None,
     ) -> None:
+        self.tokens = _SEQUENCE_DATA_POOL.alloc_array()
+        self.num_prompt_tokens = len(prompt_token_ids)
+        self.tokens[:self.num_prompt_tokens] = prompt_token_ids
         if output_token_ids is None:
             output_token_ids = []
-
-        self.prompt_token_ids = prompt_token_ids
-        self._prompt_token_ids_tuple = tuple(prompt_token_ids)
-        self.output_token_ids = output_token_ids
+        self.num_output_tokens = len(output_token_ids)
+        self.tokens[self.num_prompt_tokens:self.num_prompt_tokens +
+                    self.num_output_tokens] = output_token_ids
         self.cumulative_logprob = 0.0
         # The number of tokens that are computed (that run against the model).
         self._num_computed_tokens = 0
         self._stage: SequenceStage = SequenceStage.PREFILL
+        self._finalizer = weakref.finalize(self, _SEQUENCE_DATA_POOL.del_array,
+                                           self.tokens)
 
     def append_token_id(self, token_id: int, logprob: float) -> None:
-        self.output_token_ids.append(token_id)
+        self.tokens[self.num_prompt_tokens + self.num_output_tokens] = token_id
+        self.num_output_tokens += 1
         self.cumulative_logprob += logprob
 
     def get_len(self) -> int:
-        return len(self.output_token_ids) + len(self.prompt_token_ids)
+        return self.num_prompt_tokens + self.num_output_tokens
 
     def get_prompt_len(self) -> int:
-        return len(self.prompt_token_ids)
+        return self.num_prompt_tokens
 
     def get_output_len(self) -> int:
-        return len(self.output_token_ids)
+        return self.num_output_tokens
 
-    def get_token_ids(self) -> List[int]:
-        return self.prompt_token_ids + self.output_token_ids
+    def get_token_ids(self) -> np.ndarray:
+        return self.tokens[:self.num_prompt_tokens + self.num_output_tokens]
 
-    def get_prefix_token_ids(
-            self, num_tokens: int
-    ) -> Tuple[Tuple[int, ...], Optional[Tuple[int, ...]]]:
+    def hash_prefix_token_ids(self, num_tokens: int) -> bytes:
         """Get prefix tokens, and make the return value hashable"""
-        prompt_length = len(self.prompt_token_ids)
-        if num_tokens > prompt_length:
-            return (self._prompt_token_ids_tuple,
-                    tuple(self.output_token_ids[:num_tokens - prompt_length]))
-        else:
-            return (self._prompt_token_ids_tuple[:num_tokens], None)
+        data = self.tokens[:self.num_prompt_tokens + self.num_output_tokens]
+        # get a memory view of the underlying data
+        buffer = memoryview(data)  # type: ignore
+        # hash the memory view
+        hash_value = hashlib.sha256(buffer).digest()
+        return hash_value
 
     def get_num_computed_tokens(self) -> int:
         """Return the number of prefill tokens that are already computed."""
@@ -186,15 +219,15 @@ class SequenceData:
         return self.get_len() - self.get_num_computed_tokens()
 
     def get_last_token_id(self) -> int:
-        if not self.output_token_ids:
-            return self.prompt_token_ids[-1]
-        return self.output_token_ids[-1]
+        return int(self.tokens[self.num_prompt_tokens +
+                               self.num_output_tokens - 1])
 
-    def get_prompt_token_ids(self) -> List[int]:
-        return self.prompt_token_ids
+    def get_prompt_token_ids(self) -> np.ndarray:
+        return self.tokens[:self.num_prompt_tokens]
 
-    def get_output_token_ids(self) -> List[int]:
-        return self.output_token_ids
+    def get_output_token_ids(self) -> np.ndarray:
+        return self.tokens[self.num_prompt_tokens:self.num_prompt_tokens +
+                           self.num_output_tokens]
 
     @property
     def stage(self) -> SequenceStage:
@@ -202,8 +235,8 @@ class SequenceData:
 
     def __repr__(self) -> str:
         return (f"SequenceData("
-                f"prompt_token_ids={self.prompt_token_ids}, "
-                f"output_token_ids={self.output_token_ids}, "
+                f"prompt_token_ids={self.get_prompt_token_ids().tolist()}, "
+                f"output_token_ids={self.get_output_token_ids().tolist()}, "
                 f"cumulative_logprob={self.cumulative_logprob})")
 
 
@@ -277,8 +310,8 @@ class Sequence:
         # TODO: The current hashing function is O(L^2). We should optimize
         # this in the future.
         num_tokens = self.num_hashed_tokens_of_block(logical_idx)
-        hashed_tokens = self.data.get_prefix_token_ids(num_tokens)
-        return hash((hashed_tokens, self.lora_int_id))
+        tokens_hash = self.data.hash_prefix_token_ids(num_tokens)
+        return hash((tokens_hash, self.lora_int_id))
 
     def num_hashed_tokens_of_block(self, logical_idx: int):
         return logical_idx * self.block_size + self.block_size
@@ -329,17 +362,17 @@ class Sequence:
     def get_output_len(self) -> int:
         return self.data.get_output_len()
 
-    def get_token_ids(self) -> List[int]:
+    def get_token_ids(self) -> np.ndarray:
         return self.data.get_token_ids()
 
-    def get_prompt_token_ids(self) -> List[int]:
+    def get_prompt_token_ids(self) -> np.ndarray:
         return self.data.get_prompt_token_ids()
 
     def get_last_token_id(self) -> int:
         return self.data.get_last_token_id()
 
-    def get_output_token_ids(self) -> List[int]:
-        return self.data.output_token_ids
+    def get_output_token_ids(self) -> np.ndarray:
+        return self.data.get_output_token_ids()
 
     def get_cumulative_logprob(self) -> float:
         return self.data.cumulative_logprob


### PR DESCRIPTION
similar to https://github.com/vllm-project/vllm/pull/5584

the same benchmark command:

`python benchmarks/benchmark_throughput.py --output-len 256 --input 256 --model meta-llama/Llama-2-7b-hf -tp 8`

the same machine: 8*H100

before (current main): Throughput: 38.07 requests/s, 19493.23 tokens/s

after (this PR): Throughput: 38.94 requests/s, 19939.65 tokens/s

let's see if it breaks anything. we need to make sure, we only use python list when receiving/sending user's request. elsewhere, we should keep numpy array, where slicing is only a view operation. Never copy the whole sequence.