### PR TITLE
[Kernel] Raise an exception in MoE kernel if the batch size is larger then 65k

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -392,6 +392,11 @@ def fused_experts(hidden_states: torch.Tensor,
     M, _ = hidden_states.shape
     E, N, _ = w1.shape
 
+    if M > 65536:
+        # https://github.com/vllm-project/vllm/issues/5938
+        raise ValueError("MoE kernel does not support more than 65536 tokens, "
+                         f"but got {M}")
+
     if override_config:
         config = override_config
     else:


### PR DESCRIPTION
See #5938 for details.
This PR raises an exception in the MoE kernel when the batch size is too large, which likely causes illegal memory access.