### PR TITLE
[core][optimization] use a pool of numpy ndarray to hold seq data

### DIFF
--- a/vllm/array_pool.py
+++ b/vllm/array_pool.py
@@ -1,0 +1,13 @@
+import numpy as np
+from collections import defaultdict
+from typing import Dict, List
+
+_POOL: Dict[int, List[np.ndarray]] = defaultdict(list)
+
+def alloc_array(max_tokens: int) -> np.ndarray:
+    if max_tokens in _POOL and _POOL[max_tokens]:
+        return _POOL[max_tokens].pop()
+    return np.zeros((max_tokens, ), dtype=np.int64)
+
+def del_array(arr: np.ndarray) -> None:
+    _POOL[len(arr)].append(arr)

--- a/vllm/array_pool.py
+++ b/vllm/array_pool.py
@@ -1,13 +1,16 @@
-import numpy as np
 from collections import defaultdict
 from typing import Dict, List
 
+import numpy as np
+
 _POOL: Dict[int, List[np.ndarray]] = defaultdict(list)
+
 
 def alloc_array(max_tokens: int) -> np.ndarray:
     if max_tokens in _POOL and _POOL[max_tokens]:
         return _POOL[max_tokens].pop()
     return np.zeros((max_tokens, ), dtype=np.int64)
+
 
 def del_array(arr: np.ndarray) -> None:
     _POOL[len(arr)].append(arr)

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -348,6 +348,10 @@ class NullBlock(Block):
         return self._proxy.num_empty_slots
 
     @property
+    def num_tokens(self) -> BlockId:
+        return self._proxy.num_tokens
+
+    @property
     def is_full(self):
         return self._proxy.is_full
 

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -1,5 +1,7 @@
 from typing import Dict, FrozenSet, List, Optional, Tuple
 
+import numpy as np
+
 from vllm.core.block.interfaces import (Block, BlockAllocator, BlockId,
                                         DeviceAwareBlockAllocator)
 from vllm.core.block.naive_block import NaiveBlock, NaiveBlockAllocator
@@ -131,15 +133,15 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return self._allocators[device].allocate_mutable(prev_block)
 
     def allocate_immutable(self, prev_block: Optional[Block],
-                           token_ids: List[int], device: Device) -> Block:
+                           token_ids: np.ndarray, device: Device) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
 
         Args:
             prev_block (Optional[Block]): The previous block in the sequence.
                 Used for prefix hashing.
-            token_ids (List[int]): The list of token IDs to be stored in the new
-                block.
+            token_ids (np.ndarray): The list of token IDs to be stored in the
+                 new block.
             device (Device): The device on which to allocate the new block.
 
         Returns:
@@ -326,7 +328,7 @@ class NullBlock(Block):
         super().__init__()
         self._proxy = proxy
 
-    def append_token_ids(self, token_ids: List[BlockId]):
+    def append_token_ids(self, token_ids: np.ndarray):
         raise ValueError("null block should not be modified")
 
     @property
@@ -338,7 +340,7 @@ class NullBlock(Block):
         raise ValueError("null block should not be modified")
 
     @property
-    def token_ids(self) -> List[BlockId]:
+    def token_ids(self) -> np.ndarray:
         return self._proxy.token_ids
 
     @property

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Dict, FrozenSet, List, Optional, Protocol, Tuple
 
+import numpy as np
+
 from vllm.utils import Device
 
 BlockId = int
@@ -9,7 +11,7 @@ BlockId = int
 class Block(ABC):
 
     @abstractmethod
-    def append_token_ids(self, token_ids: List[int]) -> None:
+    def append_token_ids(self, token_ids: np.ndarray) -> None:
         pass
 
     @property
@@ -25,7 +27,7 @@ class Block(ABC):
 
     @property
     @abstractmethod
-    def token_ids(self) -> List[int]:
+    def token_ids(self) -> np.ndarray:
         pass
 
     @property
@@ -70,7 +72,7 @@ class Block(ABC):
         def __call__(
             self,
             prev_block: Optional["Block"],
-            token_ids: List[int],
+            token_ids: np.ndarray,
             block_size: int,
             allocator: "BlockAllocator",
             block_id: Optional[int] = None,
@@ -97,7 +99,7 @@ class BlockAllocator(ABC):
 
     @abstractmethod
     def allocate_immutable(self, prev_block: Optional[Block],
-                           token_ids: List[int]) -> Block:
+                           token_ids: np.ndarray) -> Block:
         pass
 
     @abstractmethod
@@ -180,7 +182,7 @@ class DeviceAwareBlockAllocator(ABC):
 
     @abstractmethod
     def allocate_immutable(self, prev_block: Optional[Block],
-                           token_ids: List[int], device: Device) -> Block:
+                           token_ids: np.ndarray, device: Device) -> Block:
         pass
 
     @abstractmethod

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -37,6 +37,11 @@ class Block(ABC):
 
     @property
     @abstractmethod
+    def num_tokens(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
     def is_full(self) -> bool:
         pass
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -373,6 +373,10 @@ class NaiveBlock(Block):
         return self._block_size - self._num_tokens
 
     @property
+    def num_tokens(self) -> int:
+        return self._num_tokens
+
+    @property
     def token_ids(self) -> np.ndarray:
         return self._token_ids
 

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -600,6 +600,10 @@ class PrefixCachingBlock(Block):
         return self._block.num_empty_slots
 
     @property
+    def num_tokens(self) -> int:
+        return self._block._num_tokens
+
+    @property
     def num_tokens_total(self) -> int:
         """return the total tokens so far.
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -464,8 +464,12 @@ class LLMEngine:
         seq_id = next(self.seq_counter)
         eos_token_id = self._get_eos_token_id(lora_request)
 
-        seq = Sequence(seq_id, processed_inputs, block_size, eos_token_id,
-                       lora_request)
+        seq = Sequence(seq_id,
+                       processed_inputs,
+                       block_size,
+                       eos_token_id,
+                       lora_request,
+                       max_seq_len=self.model_config.max_model_len)
 
         # Create a SequenceGroup based on SamplingParams or PoolingParams
         if isinstance(params, SamplingParams):

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -126,7 +126,7 @@ class RequestOutput:
         outputs = [
             CompletionOutput(seqs.index(seq),
                              seq.get_output_text_to_return(text_buffer_length),
-                             seq.get_output_token_ids(),
+                             seq.get_output_token_ids().tolist(),
                              seq.get_cumulative_logprob(),
                              seq.output_logprobs if include_logprobs else None,
                              SequenceStatus.get_finished_reason(seq.status),

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -126,7 +126,7 @@ class RequestOutput:
         outputs = [
             CompletionOutput(seqs.index(seq),
                              seq.get_output_text_to_return(text_buffer_length),
-                             seq.get_output_token_ids().tolist(),
+                             seq.get_output_token_ids(),
                              seq.get_cumulative_logprob(),
                              seq.output_logprobs if include_logprobs else None,
                              SequenceStatus.get_finished_reason(seq.status),

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -5,7 +5,6 @@ import hashlib
 import math
 import weakref
 from abc import ABC, abstractmethod
-from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -156,9 +156,9 @@ class SequenceData:
         self,
         prompt_token_ids: List[int],
         output_token_ids: Optional[List[int]] = None,
-        max_seq_len: int = 16 * 1024,
+        max_seq_len: Optional[int] = None,
     ) -> None:
-        self.max_seq_len = max_seq_len
+        self.max_seq_len = max_seq_len or 16 * 1024
         self.tokens = _SEQUENCE_DATA_POOL.alloc_array(max_seq_len)
         self.prompt_token_ids_list = prompt_token_ids
         self.num_prompt_tokens = len(prompt_token_ids)
@@ -270,6 +270,7 @@ class Sequence:
         block_size: int,
         eos_token_id: Optional[int] = None,
         lora_request: Optional[LoRARequest] = None,
+        max_seq_len: Optional[int] = None,
     ) -> None:
         self.seq_id = seq_id
         self.inputs = inputs
@@ -277,7 +278,9 @@ class Sequence:
         self.eos_token_id = eos_token_id
         self.lora_request = lora_request
 
-        self.data = SequenceData(self.inputs["prompt_token_ids"])
+        self.max_seq_len = max_seq_len
+        self.data = SequenceData(self.inputs["prompt_token_ids"],
+                                 max_seq_len=max_seq_len)
         self.prompt_token_ids: List[int] = self.inputs["prompt_token_ids"]
         self.prompt: Optional[str] = self.inputs.get("prompt")
         self.output_logprobs: SampleLogprobs = []

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -111,10 +111,10 @@ class SequenceDataPool:
     def __init__(self) -> None:
         self.pool: Dict[int, List[np.ndarray]] = defaultdict(list)
 
-    def alloc_array(self, max_tokens) -> np.ndarray:
+    def alloc_array(self, max_tokens: int) -> np.ndarray:
         if max_tokens in self.pool and self.pool[max_tokens]:
             return self.pool[max_tokens].pop()
-        return np.zeros(max_tokens, dtype=np.int64)
+        return np.zeros((max_tokens, ), dtype=np.int64)
 
     def del_array(self, arr: np.ndarray) -> None:
         self.pool[len(arr)].append(arr)
@@ -159,7 +159,7 @@ class SequenceData:
         max_seq_len: Optional[int] = None,
     ) -> None:
         self.max_seq_len = max_seq_len or 16 * 1024
-        self.tokens = _SEQUENCE_DATA_POOL.alloc_array(max_seq_len)
+        self.tokens = _SEQUENCE_DATA_POOL.alloc_array(self.max_seq_len)
         self.prompt_token_ids_list = prompt_token_ids
         self.num_prompt_tokens = len(prompt_token_ids)
         self.tokens[:self.num_prompt_tokens] = prompt_token_ids

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -142,6 +142,16 @@ class SequenceData:
         prompt_token_ids: The token IDs of the prompt.
         output_token_ids: The token IDs of the output.
         cumulative_logprob: The cumulative log probability of the output.
+        tokens: array of all the tokens (prompt + output)
+    
+    NOTE: special care must be taken regarding data copy and returning `list`
+        or `np.ndarray` from this class. `get_prompt_token_ids` and 
+        `get_output_token_ids` return `list`. They are used to construct
+        request output that will be returned to the user. They need to be
+        Python lists. And they are actually quite cheap, because the function
+        returns a reference to the list that is already stored in the object.
+        `get_token_ids` returns a view of `np.ndarray`. It avoids data copy,
+        and also allows array operations to be performed on the data.
     """
 
     def __init__(

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -156,6 +156,7 @@ class SequenceData:
         if output_token_ids is None:
             output_token_ids = []
         self.num_output_tokens = len(output_token_ids)
+        self.output_token_ids_list = output_token_ids
         self.tokens[self.num_prompt_tokens:self.num_prompt_tokens +
                     self.num_output_tokens] = output_token_ids
         self.cumulative_logprob = 0.0
@@ -167,6 +168,7 @@ class SequenceData:
 
     def append_token_id(self, token_id: int, logprob: float) -> None:
         self.tokens[self.num_prompt_tokens + self.num_output_tokens] = token_id
+        self.output_token_ids_list.append(token_id)
         self.num_output_tokens += 1
         self.cumulative_logprob += logprob
 
@@ -226,9 +228,8 @@ class SequenceData:
     def get_prompt_token_ids(self) -> List[int]:
         return self.prompt_token_ids_list
 
-    def get_output_token_ids(self) -> np.ndarray:
-        return self.tokens[self.num_prompt_tokens:self.num_prompt_tokens +
-                           self.num_output_tokens]
+    def get_output_token_ids(self) -> List[int]:
+        return self.output_token_ids_list
 
     @property
     def stage(self) -> SequenceStage:
@@ -237,7 +238,7 @@ class SequenceData:
     def __repr__(self) -> str:
         return (f"SequenceData("
                 f"prompt_token_ids={self.get_prompt_token_ids()}, "
-                f"output_token_ids={self.get_output_token_ids().tolist()}, "
+                f"output_token_ids={self.get_output_token_ids()}, "
                 f"cumulative_logprob={self.cumulative_logprob})")
 
 
@@ -344,7 +345,7 @@ class Sequence:
     def get_last_token_id(self) -> int:
         return self.data.get_last_token_id()
 
-    def get_output_token_ids(self) -> np.ndarray:
+    def get_output_token_ids(self) -> List[int]:
         return self.data.get_output_token_ids()
 
     def get_cumulative_logprob(self) -> float:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -131,6 +131,10 @@ class SequenceData:
         prompt_token_ids: The token IDs of the prompt.
         output_token_ids: The token IDs of the output. Set to an empty list if
             None.
+        max_seq_len: The maximum sequence length. A buffer of this size is
+            allocated for the tokens. By default, it is set to 16k for test
+            purposes. During inference, it should be set to the maximum
+            sequence length of the model.
 
     Attributes:
         prompt_token_ids: The token IDs of the prompt.
@@ -152,8 +156,9 @@ class SequenceData:
         self,
         prompt_token_ids: List[int],
         output_token_ids: Optional[List[int]] = None,
-        max_seq_len: int = 1024,
+        max_seq_len: int = 16 * 1024,
     ) -> None:
+        self.max_seq_len = max_seq_len
         self.tokens = _SEQUENCE_DATA_POOL.alloc_array(max_seq_len)
         self.prompt_token_ids_list = prompt_token_ids
         self.num_prompt_tokens = len(prompt_token_ids)

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -283,6 +283,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             SequenceData(
                 prompt_token_ids=prompt_token_ids,
                 output_token_ids=new_output_token_ids,
+                max_seq_len=seq_data.max_seq_len,
             ),
         }
         # This is a hack. Technically, spec decoding should compute

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -393,6 +393,11 @@ def chunk_list(lst: List[T], chunk_size: int) -> List[List[T]]:
     return [lst[i:i + chunk_size] for i in range(0, len(lst), chunk_size)]
 
 
+def chunk_array(lst: np.ndarray, chunk_size: int) -> List[np.ndarray]:
+    """Yield successive chunk_size chunks from lst."""
+    return [lst[i:i + chunk_size] for i in range(0, len(lst), chunk_size)]
+
+
 def cdiv(a: int, b: int) -> int:
     """Ceiling division."""
     return -(a // -b)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -476,7 +476,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                 query_len = sliding_seq_len - sliding_context_len
                 query_lens.append(query_len)
                 input_tokens.append(tokens)
-                batch_size += len(tokens)
+                batch_size += seq_len - context_len
                 input_positions.append(np.arange(context_len, seq_len))
                 lora_id = seq_group_metadata.lora_int_id
 
@@ -614,10 +614,10 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
 
         input_tokens_array = np.concatenate(input_tokens)
         input_tokens_tensor = torch.from_numpy(input_tokens_array).to(
-            device=self.device, non_blocking=True)
+            device=self.device)
         input_positions_array = np.concatenate(input_positions)
         input_positions_tensor = torch.from_numpy(input_positions_array).to(
-            device=self.device, non_blocking=True)
+            device=self.device)
         slot_mapping_tensor = torch.tensor(slot_mapping,
                                            dtype=torch.long,
                                            device=self.device)


### PR DESCRIPTION
The remaining part of https://github.com/vllm-project/vllm/pull/5877 after separating https://github.com/vllm-project/vllm/pull/5882 out.

the same benchmark command:

`python benchmarks/benchmark_throughput.py --output-len 256 --input 256 --model meta-llama/Llama-2-7b-hf -tp 8`

the same machine: 8*H100

before (current main): Throughput: 38.89 requests/s, 19909.29 tokens/s

after (this PR): Throughput: 40.12 requests/s, 20541.11 tokens/s

