### PR TITLE
[Bugfix][CI/Build][Hardware][AMD] Install matching torchvision to fix AMD tests

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -55,16 +55,22 @@ RUN apt-get purge -y sccache; pip uninstall -y sccache; rm -f "$(which sccache)"
 # Install torch == 2.4.0 on ROCm
 RUN case "$(ls /opt | grep -Po 'rocm-[0-9]\.[0-9]')" in \
         *"rocm-5.7"*) \
-            pip uninstall -y torch \
-            && pip install --no-cache-dir --pre torch==2.4.0.dev20240612 \
+            pip uninstall -y torch torchaudio torchvision \
+            && pip install --no-cache-dir --pre \
+                torch==2.4.0.dev20240612 torchaudio==2.4.0.dev20240612 \
+                torchvision==0.19.0.dev20240612 \
                --index-url https://download.pytorch.org/whl/nightly/rocm5.7;; \
         *"rocm-6.0"*) \
-            pip uninstall -y torch \
-            && pip install --no-cache-dir --pre torch==2.4.0.dev20240612 \
+            pip uninstall -y torch torchaudio torchvision \
+            && pip install --no-cache-dir --pre \
+                torch==2.4.0.dev20240612 torchaudio==2.4.0.dev20240612 \
+                torchvision==0.19.0.dev20240612 \
                --index-url https://download.pytorch.org/whl/nightly/rocm6.0;; \
         *"rocm-6.1"*) \
-            pip uninstall -y torch \
-            && pip install --no-cache-dir --pre torch==2.4.0.dev20240612 \
+            pip uninstall -y torch torchaudio torchvision \
+            && pip install --no-cache-dir --pre \
+                torch==2.4.0.dev20240612 torchaudio==2.4.0.dev20240612 \
+                torchvision==0.19.0.dev20240612 \
                --index-url https://download.pytorch.org/whl/nightly/rocm6.1;; \
         *) ;; esac
 

--- a/tests/entrypoints/test_openai_chat.py
+++ b/tests/entrypoints/test_openai_chat.py
@@ -14,7 +14,7 @@ import torch
 from huggingface_hub import snapshot_download
 from openai import BadRequestError
 
-from ..utils import VLLM_PATH, RemoteOpenAIServer
+from ..utils import RemoteOpenAIServer
 
 # any model with a chat template should work here
 MODEL_NAME = "HuggingFaceH4/zephyr-7b-beta"
@@ -79,7 +79,7 @@ def zephyr_lora_files():
 
 @pytest.fixture(scope="module")
 def ray_ctx():
-    ray.init(runtime_env={"working_dir": VLLM_PATH})
+    ray.init()
     yield
     ray.shutdown()
 


### PR DESCRIPTION
PR https://github.com/vllm-project/vllm/pull/5908 installs `transformers >= 4.42.0` for Gemma-2 support. This broke the AMD container and **all AMD tests** because certain `torchvision` features are used that are not yet supported by the container's version of `torchvision`.

This PR resolves the issue by installing a matching updated version of `torchvision`.

FIX [#5908](https://github.com/vllm-project/vllm/pull/5908)

An example of the error:

```ImportError while loading conftest '/vllm-workspace/tests/conftest.py'.
/vllm-workspace/tests/conftest.py:16: in <module>
    from transformers import (AutoModelForCausalLM, AutoModelForVision2Seq,
/opt/conda/envs/py_3.9/lib/python3.9/site-packages/transformers/utils/import_utils.py:1551: in __getattr__
value = getattr(module, name)
/opt/conda/envs/py_3.9/lib/python3.9/site-packages/transformers/utils/import_utils.py:1550: in __getattr__
module = self._get_module(self._class_to_module[name])
/opt/conda/envs/py_3.9/lib/python3.9/site-packages/transformers/utils/import_utils.py:1562: in _get_module
raise RuntimeError(
E   RuntimeError: Failed to import transformers.models.auto.processing_auto because of the following error (look up to see its traceback):
E   operator torchvision::nms does not exist