### PR TITLE
[Bugfix] Support `eos_token_id` from `config.json`

### DIFF
--- a/tests/tokenization/test_get_eos.py
+++ b/tests/tokenization/test_get_eos.py
@@ -1,0 +1,29 @@
+"""
+This test file includes some cases where it is inappropriate to
+only get the `eos_token_id` from the tokenizer as defined by
+:meth:`vllm.LLMEngine._get_eos_token_id`.
+"""
+from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.tokenizer import get_tokenizer
+
+
+def test_get_llama3_eos_token():
+    MODEL_NAME = "meta-llama/Meta-Llama-3-8B-Instruct"
+
+    tokenizer = get_tokenizer(MODEL_NAME)
+    assert tokenizer.eos_token_id == 128009
+
+    generation_config = try_get_generation_config(MODEL_NAME)
+    assert generation_config is not None
+    assert generation_config.eos_token_id == [128001, 128009]
+
+
+def test_get_blip2_eos_token():
+    MODEL_NAME = "Salesforce/blip2-opt-2.7b"
+
+    tokenizer = get_tokenizer(MODEL_NAME)
+    assert tokenizer.eos_token_id == 2
+
+    generation_config = try_get_generation_config(MODEL_NAME)
+    assert generation_config is not None
+    assert generation_config.eos_token_id == 50118

--- a/tests/tokenization/test_get_eos.py
+++ b/tests/tokenization/test_get_eos.py
@@ -8,22 +8,24 @@ from vllm.transformers_utils.tokenizer import get_tokenizer
 
 
 def test_get_llama3_eos_token():
-    MODEL_NAME = "meta-llama/Meta-Llama-3-8B-Instruct"
+    model_name = "meta-llama/Meta-Llama-3-8B-Instruct"
 
-    tokenizer = get_tokenizer(MODEL_NAME)
+    tokenizer = get_tokenizer(model_name)
     assert tokenizer.eos_token_id == 128009
 
-    generation_config = try_get_generation_config(MODEL_NAME)
+    generation_config = try_get_generation_config(model_name,
+                                                  trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == [128001, 128009]
 
 
 def test_get_blip2_eos_token():
-    MODEL_NAME = "Salesforce/blip2-opt-2.7b"
+    model_name = "Salesforce/blip2-opt-2.7b"
 
-    tokenizer = get_tokenizer(MODEL_NAME)
+    tokenizer = get_tokenizer(model_name)
     assert tokenizer.eos_token_id == 2
 
-    generation_config = try_get_generation_config(MODEL_NAME)
+    generation_config = try_get_generation_config(model_name,
+                                                  trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -49,6 +49,7 @@ _LOCAL_LOGGING_INTERVAL_SEC = 5
 def _load_generation_config_dict(model_config: ModelConfig) -> Dict[str, Any]:
     config = try_get_generation_config(
         model_config.model,
+        trust_remote_code=model_config.trust_remote_code,
         revision=model_config.revision,
     )
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1,10 +1,10 @@
 import time
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, ClassVar, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, Iterable, List, Optional
 from typing import Sequence as GenericSequence
 from typing import Set, Type, TypeVar, Union
 
-from transformers import GenerationConfig, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 from vllm.config import (CacheConfig, DecodingConfig, DeviceConfig, LoadConfig,
                          LoRAConfig, ModelConfig, ObservabilityConfig,
@@ -33,6 +33,7 @@ from vllm.sequence import (EmbeddingSequenceGroupOutput, ExecuteModelRequest,
                            SequenceStatus)
 from vllm.tracing import (SpanAttributes, SpanKind, extract_trace_context,
                           init_tracer)
+from vllm.transformers_utils.config import try_get_generation_config
 from vllm.transformers_utils.detokenizer import Detokenizer
 from vllm.transformers_utils.tokenizer_group import (BaseTokenizerGroup,
                                                      get_tokenizer_group)
@@ -45,15 +46,16 @@ logger = init_logger(__name__)
 _LOCAL_LOGGING_INTERVAL_SEC = 5
 
 
-def _load_generation_config_dict(model_config: ModelConfig):
-    try:
-        return GenerationConfig.from_pretrained(
-            model_config.model,
-            revision=model_config.revision,
-        ).to_diff_dict()
-    except OSError:
-        # Not found.
+def _load_generation_config_dict(model_config: ModelConfig) -> Dict[str, Any]:
+    config = try_get_generation_config(
+        model_config.model,
+        revision=model_config.revision,
+    )
+
+    if config is None:
         return {}
+
+    return config.to_diff_dict()
 
 
 _O = TypeVar("_O", RequestOutput, EmbeddingRequestOutput)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -84,6 +84,7 @@ def get_hf_text_config(config: PretrainedConfig):
 
 def try_get_generation_config(
     model: str,
+    trust_remote_code: bool,
     revision: Optional[str] = None,
 ) -> Optional[GenerationConfig]:
     try:
@@ -93,10 +94,11 @@ def try_get_generation_config(
         )
     except OSError:  # Not found
         try:
-            return GenerationConfig.from_model_config(
-                AutoConfig.from_pretrained(
-                    model,
-                    revision=revision,
-                ), )
+            config = get_config(
+                model,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+            )
+            return GenerationConfig.from_model_config(config)
         except OSError:  # Not found
             return None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -1,7 +1,7 @@
 import contextlib
 from typing import Dict, Optional, Type
 
-from transformers import PretrainedConfig
+from transformers import GenerationConfig, PretrainedConfig
 
 from vllm.envs import VLLM_USE_MODELSCOPE
 from vllm.logger import init_logger
@@ -80,3 +80,23 @@ def get_hf_text_config(config: PretrainedConfig):
         return config.text_config
     else:
         return config
+
+
+def try_get_generation_config(
+    model: str,
+    revision: Optional[str] = None,
+) -> Optional[GenerationConfig]:
+    try:
+        return GenerationConfig.from_pretrained(
+            model,
+            revision=revision,
+        )
+    except OSError:  # Not found
+        try:
+            return GenerationConfig.from_model_config(
+                AutoConfig.from_pretrained(
+                    model,
+                    revision=revision,
+                ), )
+        except OSError:  # Not found
+            return None


### PR DESCRIPTION
While working on BLIP-2 in #5920, I found that the model kept repeating the output in a fashion similar to Llama 3 when it was first released. It turns out that this is because vLLM failed to consider the extra EOS token (`\n`) which is only specified in `config.json` rather than `generation_config.json` or `tokenizer_config.json`.

Building on #4182, this PR adds another fallback when loading EOS tokens from the generation config. I have tested this on a local copy of #5920 and it successfully resolves my issue.
