### PR TITLE
[Model] Changes to MLPSpeculator to support tie_weights and input_scale

### DIFF
--- a/vllm/model_executor/models/mlp_speculator.py
+++ b/vllm/model_executor/models/mlp_speculator.py
@@ -180,10 +180,8 @@ class MLPSpeculator(nn.Module):
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         params_dict = dict(self.named_parameters())
         for name, loaded_weight in weights:
-            try:
-                param = params_dict[name.replace("speculator.", "")]
+            param = params_dict.get(name.replace("speculator.", ""))
+            if param is not None:
                 weight_loader = getattr(param, "weight_loader",
                                         default_weight_loader)
                 weight_loader(param, loaded_weight)
-            except:
-                pass

--- a/vllm/transformers_utils/configs/mlp_speculator.py
+++ b/vllm/transformers_utils/configs/mlp_speculator.py
@@ -17,7 +17,7 @@ class MLPSpeculatorConfig(PretrainedConfig):
                  n_predict: int = 3,
                  top_k_tokens_per_head: Optional[List[int]] = None,
                  n_candidates: int = 5,
-                 tie_wts: bool = False,
+                 tie_weights: bool = False,
                  scale_input: bool = False,
                  **kwargs):
         """
@@ -40,6 +40,11 @@ class MLPSpeculatorConfig(PretrainedConfig):
                 NOTE: This parameter is currently unused.
             n_candidates: int
                 number of child candidates to create per sequence
+            tie_weights: bool
+                If true, use a single set of weights for every model head/stage after the first. The initial projection
+                from the base model may have a different size, so that stays separate.
+            scale_input: bool
+                if True, will scale the initial hidden states from the base model
         """
         if top_k_tokens_per_head is None:
             top_k_tokens_per_head = [5, 4, 3]
@@ -51,7 +56,7 @@ class MLPSpeculatorConfig(PretrainedConfig):
         self.top_k_tokens_per_head = top_k_tokens_per_head
         self.n_candidates = n_candidates
         self.num_lookahead_tokens = n_predict
-        self.tie_wts = tie_wts
+        self.tie_weights = tie_weights
         self.scale_input = scale_input
 
         super().__init__(**kwargs)

--- a/vllm/transformers_utils/configs/mlp_speculator.py
+++ b/vllm/transformers_utils/configs/mlp_speculator.py
@@ -41,10 +41,13 @@ class MLPSpeculatorConfig(PretrainedConfig):
             n_candidates: int
                 number of child candidates to create per sequence
             tie_weights: bool
-                If true, use a single set of weights for every model head/stage after the first. The initial projection
-                from the base model may have a different size, so that stays separate.
+                If true, use a single set of weights for every model
+                head/stage after the first. The initial projection
+                from the base model may have a different size, so that
+                stays separate.
             scale_input: bool
-                if True, will scale the initial hidden states from the base model
+                if True, will scale the initial hidden states from
+                the base model.
         """
         if top_k_tokens_per_head is None:
             top_k_tokens_per_head = [5, 4, 3]

--- a/vllm/transformers_utils/configs/mlp_speculator.py
+++ b/vllm/transformers_utils/configs/mlp_speculator.py
@@ -17,6 +17,8 @@ class MLPSpeculatorConfig(PretrainedConfig):
                  n_predict: int = 3,
                  top_k_tokens_per_head: Optional[List[int]] = None,
                  n_candidates: int = 5,
+                 tie_wts: bool = False,
+                 scale_input: bool = False,
                  **kwargs):
         """
         Initialize an MLPSpeculatorConfig
@@ -49,5 +51,7 @@ class MLPSpeculatorConfig(PretrainedConfig):
         self.top_k_tokens_per_head = top_k_tokens_per_head
         self.n_candidates = n_candidates
         self.num_lookahead_tokens = n_predict
+        self.tie_wts = tie_wts
+        self.scale_input = scale_input
 
         super().__init__(**kwargs)


### PR DESCRIPTION
New versions of the MLPSpeculator models have two new features:
```
tie_weights
input_scale
```
In particular, the former allows us to significantly reduce the size of the speculator model.

This PR adds support in vLLM for these new features.

