### PR TITLE
[Bugfix][TPU] Fix pad slot id

### DIFF
--- a/vllm/worker/tpu_model_runner.py
+++ b/vllm/worker/tpu_model_runner.py
@@ -19,7 +19,7 @@ from vllm.utils import make_tensor_with_pad
 
 logger = init_logger(__name__)
 
-_PAD_SLOT_ID = 0  # FIXME(woosuk)
+_PAD_SLOT_ID = -1  # NOTE(woosuk): In PyTorch XLA, index -1 is ignored.
 # FIXME(woosuk): Temporarily disabled top-p sampling since it's too slow.
 _ENABLE_TOP_P = False
 # FIXME(woosuk): A temporary hack to support `n > 1`.


### PR DESCRIPTION
This PR changes the TPU backend's `_PAD_SLOT_ID` from 0 to -1. The constant is used to discard padding tokens when inserting the attention KV into the KV cache. In PyTorch XLA, it seems the index -1 can be used with the `index_copy_` API to let XLA ignore the corresponding slice of tensors.