### PR TITLE
[BugFix] Ensure worker model loop is always stopped at the right time

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -248,7 +248,7 @@ class _AsyncLLMEngine(LLMEngine):
         # Tracing
         self.do_tracing(scheduler_outputs)
 
-        if not self.has_unfinished_requests():
+        if not request_outputs:
             # Stop the execute model loop in parallel workers until there are
             # more requests to process. This avoids waiting indefinitely in
             # torch.distributed ops which may otherwise timeout, and unblocks

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -248,7 +248,7 @@ class _AsyncLLMEngine(LLMEngine):
         # Tracing
         self.do_tracing(scheduler_outputs)
 
-        if not request_outputs:
+        if not self.has_unfinished_requests():
             # Stop the execute model loop in parallel workers until there are
             # more requests to process. This avoids waiting indefinitely in
             # torch.distributed ops which may otherwise timeout, and unblocks

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -838,7 +838,7 @@ class LLMEngine:
         # Tracing
         self.do_tracing(scheduler_outputs)
 
-        if not request_outputs:
+        if not self.has_unfinished_requests():
             # Stop the execute model loop in parallel workers until there are
             # more requests to process. This avoids waiting indefinitely in
             # torch.distributed ops which may otherwise timeout, and unblocks


### PR DESCRIPTION
The model loop in the worker processes is meant to stop when there are no more sequences to process but the condition being checked for this wasn't sufficient, meaning that the workers can incorrectly remain in an indefinite broadcast loop.

Resolves https://github.com/vllm-project/vllm/pull/5987