### PR TITLE
[Bugfix] adding chunking mechanism to fused_moe to handle large inputs

### DIFF
--- a/tests/kernels/test_moe.py
+++ b/tests/kernels/test_moe.py
@@ -29,7 +29,7 @@ def torch_moe(a, w1, w2, score, topk):
             topk_weight.view(B, -1, 1).to(out.dtype)).sum(dim=1)
 
 
-@pytest.mark.parametrize("m", [512, 222, 33, 1])
+@pytest.mark.parametrize("m", [1024 * 128, 512, 222, 33, 1])
 @pytest.mark.parametrize("n", [2048, 256, 1024])
 @pytest.mark.parametrize("k", [128, 511, 1024])
 @pytest.mark.parametrize("e", [8, 64])

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     VLLM_OPENVINO_CPU_KV_CACHE_PRECISION: Optional[str] = None
     VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS: bool = False
     VLLM_XLA_CACHE_PATH: str = "~/.vllm/xla_cache/"
+    VLLM_FUSED_MOE_CHUNK_SIZE: int = 64 * 1024
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_WORKER_MULTIPROC_METHOD: str = "fork"
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
@@ -248,6 +249,9 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH":
     lambda: os.getenv("VLLM_XLA_CACHE_PATH", "~/.vllm/xla_cache/"),
+
+    "VLLM_FUSED_MOE_CHUNK_SIZE":
+    lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "65536")),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -249,7 +249,6 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Only used for XLA devices such as TPUs.
     "VLLM_XLA_CACHE_PATH":
     lambda: os.getenv("VLLM_XLA_CACHE_PATH", "~/.vllm/xla_cache/"),
-
     "VLLM_FUSED_MOE_CHUNK_SIZE":
     lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "65536")),
 }

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -8,9 +8,9 @@ import torch
 import triton
 import triton.language as tl
 
+import vllm.envs as envs
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
-import vllm.envs as envs
 
 logger = init_logger(__name__)
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -520,8 +520,8 @@ def fused_experts(hidden_states: torch.Tensor,
                                 use_fp8=use_fp8)
 
         torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
-                      dim=1,
-                      out=out_hidden_states[begin_chunk_idx:end_chunk_idx])
+                  dim=1,
+                  out=out_hidden_states[begin_chunk_idx:end_chunk_idx])
     return out_hidden_states
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -458,7 +458,8 @@ def fused_experts(hidden_states: torch.Tensor,
 
     states_acc = []
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
-        begin_chunk_idx, end_chunk_idx = chunk * CHUNK_SIZE, min((chunk + 1) * CHUNK_SIZE, num_tokens)
+        begin_chunk_idx, end_chunk_idx = (chunk * CHUNK_SIZE,
+                                          min((chunk + 1) * CHUNK_SIZE, num_tokens))
         curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
         tokens_in_chunk, _ = curr_hidden_states.shape
 
@@ -474,8 +475,8 @@ def fused_experts(hidden_states: torch.Tensor,
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
 
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(curr_topk_ids,
-                                                                                    config['BLOCK_SIZE_M'], E)
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+            curr_topk_ids, config['BLOCK_SIZE_M'], E)
 
         invoke_fused_moe_kernel(curr_hidden_states,
                                 w1,
@@ -516,7 +517,8 @@ def fused_experts(hidden_states: torch.Tensor,
                       dim=1,
                       out=hidden_states[begin_chunk_idx:end_chunk_idx])
         else:
-            states_acc.append(torch.sum(intermediate_cache3.view(*intermediate_cache3.shape), dim=1))
+            states_acc.append(torch.sum(intermediate_cache3.view(
+                *intermediate_cache3.shape), dim=1))
     if inplace:
         return hidden_states
     else:

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -461,7 +461,7 @@ def fused_experts(hidden_states: torch.Tensor,
     if inplace:
         out_hidden_states = hidden_states
     else:
-        out_hidden_states = torch.zeros_like(hidden_states)
+        out_hidden_states = torch.empty_like(hidden_states)
 
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
         begin_chunk_idx, end_chunk_idx = (chunk * CHUNK_SIZE,
@@ -482,8 +482,8 @@ def fused_experts(hidden_states: torch.Tensor,
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
 
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(  # noqa: E501
-            curr_topk_ids, config['BLOCK_SIZE_M'], E)
+        sorted_token_ids, expert_ids, num_tokens_post_padded = (
+            moe_align_block_size(curr_topk_ids, config['BLOCK_SIZE_M'], E))
 
         invoke_fused_moe_kernel(curr_hidden_states,
                                 w1,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -476,7 +476,7 @@ def fused_experts(hidden_states: torch.Tensor,
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
 
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size( # noqa: E501
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(  # noqa: E501
             curr_topk_ids, config['BLOCK_SIZE_M'], E)
 
         invoke_fused_moe_kernel(curr_hidden_states,
@@ -518,8 +518,9 @@ def fused_experts(hidden_states: torch.Tensor,
                       dim=1,
                       out=hidden_states[begin_chunk_idx:end_chunk_idx])
         else:
-            states_acc.append(torch.sum(intermediate_cache3.view(
-                *intermediate_cache3.shape), dim=1))
+            states_acc.append(
+                torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
+                          dim=1))
     if inplace:
         return hidden_states
     else:

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -10,6 +10,7 @@ import triton.language as tl
 
 from vllm import _custom_ops as ops
 from vllm.logger import init_logger
+import vllm.envs as envs
 
 logger = init_logger(__name__)
 
@@ -420,13 +421,10 @@ def fused_experts(hidden_states: torch.Tensor,
         torch.float32, torch.float16, torch.bfloat16
     ]
 
-    M, _ = hidden_states.shape
+    num_tokens, _ = hidden_states.shape
     E, N, _ = w1.shape
-
-    if M > 65536:
-        # https://github.com/vllm-project/vllm/issues/5938
-        raise ValueError("MoE kernel does not support more than 65536 tokens, "
-                         f"but got {M}")
+    CHUNK_SIZE = envs.VLLM_FUSED_MOE_CHUNK_SIZE
+    M = min(num_tokens, CHUNK_SIZE)
 
     if override_config:
         config = override_config
@@ -455,51 +453,74 @@ def fused_experts(hidden_states: torch.Tensor,
                                       device=hidden_states.device,
                                       dtype=hidden_states.dtype)
 
-    sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-        topk_ids, config['BLOCK_SIZE_M'], E)
     compute_type = (tl.bfloat16
                     if hidden_states.dtype == torch.bfloat16 else tl.float16)
 
-    invoke_fused_moe_kernel(hidden_states,
-                            w1,
-                            intermediate_cache1,
-                            a1_scale,
-                            w1_scale,
-                            topk_weights,
-                            topk_ids,
-                            sorted_token_ids,
-                            expert_ids,
-                            num_tokens_post_padded,
-                            False,
-                            topk_ids.shape[1],
-                            config,
-                            compute_type=compute_type,
-                            use_fp8=use_fp8)
+    states_acc = []
+    for chunk in range((num_tokens // CHUNK_SIZE) + 1):
+        begin_chunk_idx, end_chunk_idx = chunk * CHUNK_SIZE, min((chunk + 1) * CHUNK_SIZE, num_tokens)
+        curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
+        tokens_in_chunk, _ = curr_hidden_states.shape
 
-    ops.silu_and_mul(intermediate_cache2, intermediate_cache1.view(-1, N))
+        if tokens_in_chunk == 0:
+            break
 
-    invoke_fused_moe_kernel(intermediate_cache2,
-                            w2,
-                            intermediate_cache3,
-                            a2_scale,
-                            w2_scale,
-                            topk_weights,
-                            topk_ids,
-                            sorted_token_ids,
-                            expert_ids,
-                            num_tokens_post_padded,
-                            True,
-                            1,
-                            config,
-                            compute_type=compute_type,
-                            use_fp8=use_fp8)
+        if tokens_in_chunk < CHUNK_SIZE:
+            # will only happen in the last chunk
+            intermediate_cache1 = intermediate_cache1[:tokens_in_chunk]
+            intermediate_cache2 = intermediate_cache2[:tokens_in_chunk]
+            intermediate_cache3 = intermediate_cache3[:tokens_in_chunk]
 
+        curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
+        curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
+
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(curr_topk_ids,
+                                                                                    config['BLOCK_SIZE_M'], E)
+
+        invoke_fused_moe_kernel(curr_hidden_states,
+                                w1,
+                                intermediate_cache1,
+                                a1_scale,
+                                w1_scale,
+                                curr_topk_weights,
+                                curr_topk_ids,
+                                sorted_token_ids,
+                                expert_ids,
+                                num_tokens_post_padded,
+                                False,
+                                topk_ids.shape[1],
+                                config,
+                                compute_type=compute_type,
+                                use_fp8=use_fp8)
+
+        ops.silu_and_mul(intermediate_cache2, intermediate_cache1.view(-1, N))
+
+        invoke_fused_moe_kernel(intermediate_cache2,
+                                w2,
+                                intermediate_cache3,
+                                a2_scale,
+                                w2_scale,
+                                curr_topk_weights,
+                                curr_topk_ids,
+                                sorted_token_ids,
+                                expert_ids,
+                                num_tokens_post_padded,
+                                True,
+                                1,
+                                config,
+                                compute_type=compute_type,
+                                use_fp8=use_fp8)
+
+        if inplace:
+            torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
+                      dim=1,
+                      out=hidden_states[begin_chunk_idx:end_chunk_idx])
+        else:
+            states_acc.append(torch.sum(intermediate_cache3.view(*intermediate_cache3.shape), dim=1))
     if inplace:
-        return torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
-                         dim=1,
-                         out=hidden_states)
-    return torch.sum(intermediate_cache3.view(*intermediate_cache3.shape),
-                     dim=1)
+        return hidden_states
+    else:
+        return torch.cat(states_acc, dim=0)
 
 
 def fused_moe(

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -459,7 +459,8 @@ def fused_experts(hidden_states: torch.Tensor,
     states_acc = []
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
         begin_chunk_idx, end_chunk_idx = (chunk * CHUNK_SIZE,
-                                          min((chunk + 1) * CHUNK_SIZE, num_tokens))
+                                          min((chunk + 1) * CHUNK_SIZE,
+                                              num_tokens))
         curr_hidden_states = hidden_states[begin_chunk_idx:end_chunk_idx]
         tokens_in_chunk, _ = curr_hidden_states.shape
 
@@ -475,7 +476,7 @@ def fused_experts(hidden_states: torch.Tensor,
         curr_topk_ids = topk_ids[begin_chunk_idx:end_chunk_idx]
         curr_topk_weights = topk_weights[begin_chunk_idx:end_chunk_idx]
 
-        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
+        sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size( # noqa: E501
             curr_topk_ids, config['BLOCK_SIZE_M'], E)
 
         invoke_fused_moe_kernel(curr_hidden_states,


### PR DESCRIPTION
This fix provides a hotfix for issue [5938](https://github.com/vllm-project/vllm/issues/5938) where the fused_moe kernel crashes on long inputs (> 64k tokens).
Instead of asserting as suggested in [this](https://github.com/vllm-project/vllm/commit/f7dac83d95ae38973b425a8bb2d3a3df9fe9a9c2) commit, we execute the kernel in chunks and aggregate the outputs. This enables us to process very large inputs (batched or single prompt) without crashing.
Obviously, the complete fix would be to debug the kernel and find the underlying memory issue, but this serves as a fix until the RCA is found and the issue is fixed.
