### PR TITLE
[CI/Build] Cleanup VLM tests

### DIFF
--- a/tests/models/test_llava.py
+++ b/tests/models/test_llava.py
@@ -52,7 +52,6 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
     image_token_id = vlm_config.image_token_id
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    image_token_str = tokenizer.decode(image_token_id)
     eos_token_id = tokenizer.eos_token_id
 
     hf_output_ids = [
@@ -60,8 +59,7 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
         if token_id != image_token_id or output_ids[idx - 1] != image_token_id
     ]
 
-    hf_output_str = output_str \
-        .replace(image_token_str * vlm_config.image_feature_size, "")
+    hf_output_str = output_str
     assert hf_output_str[0] == " "
     hf_output_str = hf_output_str[1:]
     if hf_output_ids[-1] == eos_token_id:

--- a/tests/models/test_llava.py
+++ b/tests/models/test_llava.py
@@ -59,9 +59,8 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
         if token_id != image_token_id or output_ids[idx - 1] != image_token_id
     ]
 
-    hf_output_str = output_str
-    assert hf_output_str[0] == " "
-    hf_output_str = hf_output_str[1:]
+    assert output_str[0] == " "
+    hf_output_str = output_str[1:]
     if hf_output_ids[-1] == eos_token_id:
         hf_output_str = hf_output_str + tokenizer.decode(eos_token_id)
 

--- a/tests/models/test_llava_next.py
+++ b/tests/models/test_llava_next.py
@@ -67,9 +67,8 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
         if token_id != image_token_id or output_ids[idx - 1] != image_token_id
     ]
 
-    hf_output_str = output_str
-    assert hf_output_str[0] == " "
-    hf_output_str = hf_output_str[1:]
+    assert output_str[0] == " "
+    hf_output_str = output_str[1:]
     if hf_output_ids[-1] == eos_token_id:
         hf_output_str = hf_output_str + tokenizer.decode(eos_token_id)
 

--- a/tests/models/test_llava_next.py
+++ b/tests/models/test_llava_next.py
@@ -1,4 +1,3 @@
-import re
 from typing import List, Optional, Tuple
 
 import pytest
@@ -61,7 +60,6 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
     image_token_id = vlm_config.image_token_id
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    image_token_str = tokenizer.decode(image_token_id)
     eos_token_id = tokenizer.eos_token_id
 
     hf_output_ids = [
@@ -69,7 +67,7 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
         if token_id != image_token_id or output_ids[idx - 1] != image_token_id
     ]
 
-    hf_output_str = re.sub(fr"({image_token_str})+", "", output_str)
+    hf_output_str = output_str
     assert hf_output_str[0] == " "
     hf_output_str = hf_output_str[1:]
     if hf_output_ids[-1] == eos_token_id:

--- a/tests/models/test_phi3v.py
+++ b/tests/models/test_phi3v.py
@@ -57,8 +57,7 @@ def vllm_to_hf_output(vllm_output: Tuple[List[int], str,
     assert output_str_without_image[0] == " "
     output_str_without_image = output_str_without_image[1:]
 
-    hf_output_str = output_str_without_image.replace("<|user|>", "") \
-        .replace("<|end|>\n<|assistant|>", " ")
+    hf_output_str = output_str_without_image + "<|end|><|endoftext|>"
 
     tokenizer = AutoTokenizer.from_pretrained(model_id)
     hf_output_ids = tokenizer.encode(output_str_without_image)

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -77,6 +77,7 @@ def check_logprobs_close(
                 # Each predicted token must be in top N logprobs of the other
                 fail_msg = (
                     f"Test{prompt_idx}:"
+                    f"\nMatched tokens:\t{output_ids_0[:idx]}"
                     f"\n{name_0}:\t{output_str_0!r}\t{logprobs_elem_0}"
                     f"\n{name_1}:\t{output_str_1!r}\t{logprobs_elem_1}")
 

--- a/vllm/multimodal/image.py
+++ b/vllm/multimodal/image.py
@@ -115,7 +115,7 @@ class ImagePlugin(MultiModalPlugin):
         if isinstance(data, Image.Image):
             image_processor = self._get_hf_image_processor(model_config)
             if image_processor is None:
-                raise RuntimeError("No HuggingFace processor is available"
+                raise RuntimeError("No HuggingFace processor is available "
                                    "to process the image object")
             try:
                 batch_data = image_processor \


### PR DESCRIPTION
The text conversion from vLLM to HF format was not entirely correct, resulting in some false positive warnings in VLM tests.

(Note: Text mismatches don't cause CI failures since we're now comparing results by token IDs, but such mismatches still emit a warning)