### PR TITLE
[doc][misc] bump up py version in installation doc

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -20,7 +20,7 @@ You can install vLLM using pip:
 .. code-block:: console
 
     $ # (Recommended) Create a new conda environment.
-    $ conda create -n myenv python=3.9 -y
+    $ conda create -n myenv python=3.10 -y
     $ conda activate myenv
 
     $ # Install vLLM with CUDA 12.1.
@@ -35,7 +35,7 @@ You can install vLLM using pip:
 
         $ # Install vLLM with CUDA 11.8.
         $ export VLLM_VERSION=0.4.0
-        $ export PYTHON_VERSION=39
+        $ export PYTHON_VERSION=310
         $ pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cu118-cp${PYTHON_VERSION}-cp${PYTHON_VERSION}-manylinux1_x86_64.whl --extra-index-url https://download.pytorch.org/whl/cu118
 
     In order to be performant, vLLM has to compile many cuda kernels. The compilation unfortunately introduces binary incompatibility with other CUDA versions and PyTorch versions, even for the same PyTorch version with different building configurations.


### PR DESCRIPTION
many people (including me) just copy-paste the command from doc. we should recommend the most extensively tested python version (python 3.10, used in ci), so that users' environment is more aligned with our ci, and we can catch more bugs there.

in addition, pipeline parallel currently requires python 3.10, as there are some more work to do to support python 3.8/3.9 in terms of asyncio default event loop.

@andoorve is trying to fix it. orthogonally, we can bump up the recommended python version so that users have better experience with pipeline parallel.