### PR TITLE
[Bugfix] Use templated datasource in grafana.json to allow automatic imports

### DIFF
--- a/examples/production_monitoring/grafana.json
+++ b/examples/production_monitoring/grafana.json
@@ -1,13 +1,5 @@
 {
   "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
   ],
   "__elements": {},
   "__requires": [
@@ -1215,11 +1207,21 @@
   "templating": {
     "list": [
       {
+        "type": "datasource",
+        "name": "DS_PROMETHEUS",
+        "label": "datasource",
         "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false
+      },
+      {
         "definition": "label_values(model_name)",
         "hide": 0,
         "includeAll": false,
@@ -1250,3 +1252,4 @@
   "version": 1,
   "weekStart": ""
 }
+


### PR DESCRIPTION
Use templated datasource in grafana.json to allow automatic imports

This is somewhat of a followup to #4711 which introducted a input variable to allow setting the datasource on import. Unfortunately this only works when the dashboard is imported via the Grafana UI.
It's common to e.g. import dashboard JSON files via ConfigMaps on Kubernetes, so there is no manual step to set the datasource name.

Switching to a template var for the datasource also should cover the issue #4711 fixed, but also works in setting the datasource when using automatic dashboard provisioning.


FIX https://github.com/vllm-project/vllm/discussions/4700#discussioncomment-9363725
(^ rather improve on the previous fix ^)