### PR TITLE
[Model] Implement DualChunkAttention for Qwen2 Models

### DIFF
--- a/vllm/attention/__init__.py
+++ b/vllm/attention/__init__.py
@@ -1,12 +1,15 @@
 from vllm.attention.backends.abstract import (AttentionBackend,
                                               AttentionMetadata)
-from vllm.attention.layer import Attention
-from vllm.attention.selector import get_attn_backend
+from vllm.attention.layer import Attention, DualChunkAttention
+from vllm.attention.selector import (get_attn_backend,
+                                     get_dual_chunk_attn_backend)
 
 __all__ = [
     "Attention",
     "AttentionBackend",
     "AttentionMetadata",
     "Attention",
+    "DualChunkAttention",
     "get_attn_backend",
+    "get_dual_chunk_attn_backend",
 ]

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -130,3 +130,132 @@ class AttentionImpl(ABC, Generic[T]):
         kv_scale: float = 1.0,
     ) -> torch.Tensor:
         raise NotImplementedError
+
+
+class DualChunkAttentionBackend(ABC):
+    """Abstract class for dual chunk attention backends."""
+
+    @staticmethod
+    @abstractmethod
+    def get_name() -> str:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def get_impl_cls() -> Type["DualChunkAttentionImpl"]:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def get_metadata_cls() -> Type["DualChunkAttentionMetadata"]:
+        raise NotImplementedError
+
+    @classmethod
+    def make_metadata(cls, *args, **kwargs) -> "DualChunkAttentionMetadata":
+        return cls.get_metadata_cls()(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> Tuple[int, ...]:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def swap_blocks(
+        src_kv_cache: torch.Tensor,
+        dst_kv_cache: torch.Tensor,
+        src_to_dst: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def copy_blocks(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+    ) -> None:
+        raise NotImplementedError
+
+
+@dataclass
+class DualChunkAttentionMetadata:
+    """DualChunkAttention metadata for prefill and decode batched together."""
+    # Total number of prefill requests.
+    num_prefills: int
+    # Number of prefill tokens.
+    num_prefill_tokens: int
+    # Number of decode tokens. Note that it is equivalent to the number of
+    # decode requests.
+    num_decode_tokens: int
+    # (num_tokens,). The indices of the token slots that input tokens will be
+    # stored into. E.g., if `slot_mapping` is [35, 2, 17] and the block size
+    # is 16, the three tokens are stored in the 3rd slot in block 2, 2nd slot
+    # in block 0, and 1st slot in block 1, respectively.
+    slot_mapping: torch.Tensor
+
+    @property
+    @abstractmethod
+    def prefill_metadata(self) -> Optional["DualChunkAttentionMetadata"]:
+        """Return the attention metadata that's required to run prefill
+        attention."""
+        pass
+
+    @property
+    @abstractmethod
+    def decode_metadata(self) -> Optional["DualChunkAttentionMetadata"]:
+        """Return the attention metadata that's required to run decode
+        attention."""
+        pass
+
+    def asdict_zerocopy(self,
+                        skip_fields: Optional[Set[str]] = None
+                        ) -> Dict[str, Any]:
+        """Similar to dataclasses.asdict, but avoids deepcopying."""
+        if skip_fields is None:
+            skip_fields = set()
+        # Note that if we add dataclasses as fields, they will need
+        # similar handling.
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self) if field.name not in skip_fields
+        }
+
+
+T2 = TypeVar("T2", bound=DualChunkAttentionMetadata)
+
+
+class DualChunkAttentionImpl(ABC, Generic[T2]):
+
+    @abstractmethod
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: Optional[int] = None,
+        alibi_slopes: Optional[List[float]] = None,
+        sliding_window: Optional[int] = None,
+        kv_cache_dtype: str = "auto",
+        blocksparse_params: Optional[Dict[str, Any]] = None,
+        dual_chunk_attention_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def forward(
+        self,
+        query: torch.Tensor,
+        query_succ: torch.Tensor,
+        query_inter: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: T2,
+        kv_scale: float = 1.0,
+    ) -> torch.Tensor:
+        raise NotImplementedError

--- a/vllm/attention/backends/dual_chunk_flash_attn.py
+++ b/vllm/attention/backends/dual_chunk_flash_attn.py
@@ -1,0 +1,877 @@
+"""Attention layer with Flash and PagedAttention.
+
+NOTE(woosuk): At the moment, this file includes a lot of duplicated code from
+XFormers backend. The duplicated code will be removed once we use flash-attn or
+flashinfer for all the attention operations.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Type
+
+import torch
+from vllm_flash_attn import flash_attn_varlen_func, flash_attn_with_kvcache
+
+from vllm import _custom_ops as ops
+from vllm.attention.backends.abstract import (DualChunkAttentionBackend,
+                                              DualChunkAttentionImpl,
+                                              DualChunkAttentionMetadata)
+
+
+class DualChunkFlashAttentionBackend(DualChunkAttentionBackend):
+
+    @staticmethod
+    def get_supported_head_sizes() -> List[int]:
+        return [32, 64, 96, 128, 160, 192, 224, 256]
+
+    @staticmethod
+    def get_name() -> str:
+        return "dual-chunk-flash-attn"
+
+    @staticmethod
+    def get_impl_cls() -> Type["DualChunkFlashAttentionImpl"]:
+        return DualChunkFlashAttentionImpl
+
+    @staticmethod
+    def get_metadata_cls() -> Type["DualChunkAttentionMetadata"]:
+        return DualChunkFlashAttentionMetadata
+
+    @staticmethod
+    def swap_blocks(
+        src_kv_cache: torch.Tensor,
+        dst_kv_cache: torch.Tensor,
+        src_to_dst: torch.Tensor,
+    ) -> None:
+        src_key_cache = src_kv_cache[0]
+        dst_key_cache = dst_kv_cache[0]
+        ops.swap_blocks(src_key_cache, dst_key_cache, src_to_dst)
+
+        src_value_cache = src_kv_cache[1]
+        dst_value_cache = dst_kv_cache[1]
+        ops.swap_blocks(src_value_cache, dst_value_cache, src_to_dst)
+
+    @staticmethod
+    def copy_blocks(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+    ) -> None:
+        key_caches = [kv_cache[0] for kv_cache in kv_caches]
+        value_caches = [kv_cache[1] for kv_cache in kv_caches]
+        ops.copy_blocks(key_caches, value_caches, src_to_dists)
+
+
+@dataclass
+class DualChunkFlashAttentionMetadata(DualChunkAttentionMetadata):
+    """Metadata for DualChunkFlashAttentionBackend.
+
+    NOTE: Any python object stored here is not updated when it is
+    cuda-graph replayed. If you have values that need to be changed
+    dynamically, it should be stored in tensor. The tensor has to be
+    updated from `CUDAGraphRunner.forward` API.
+    """
+
+    # (batch_size,). The sequence length per sequence. Sequence length means
+    # the computed tokens + new tokens None if it is a decoding.
+    seq_lens: Optional[List[int]]
+    # seq_lens stored as a tensor.
+    seq_lens_tensor: Optional[torch.Tensor]
+
+    # (batch_size,). The original prefill length per sequence.
+    # None if it is decoding.
+    prefill_original_seq_lens_tensor: Optional[torch.Tensor]
+
+    # NOTE(sang): Definition of context_len, query_len, and seq_len.
+    # |---------- N-1 iteration --------|
+    # |---------------- N iteration ---------------------|
+    # |- tokenA -|......................|-- newTokens ---|
+    # |---------- context_len ----------|
+    # |-------------------- seq_len ----------------------|
+    #                                   |-- query_len ---|
+
+    # Maximum query length in the batch. None for decoding.
+    max_query_len: Optional[int]
+    # Maximum sequence length among prefill batch. 0 if there are decoding
+    # requests only.
+    max_prefill_seq_len: int
+    # Maximum sequence length among decode batch. 0 if there are prefill
+    # requests only.
+    max_decode_seq_len: int
+    # (batch_size + 1,). The cumulative subquery lengths of the sequences in
+    # the batch, used to index into subquery. E.g., if the subquery length
+    # is [4, 6], it is [0, 4, 10].
+    query_start_loc: Optional[torch.Tensor]
+    # (batch_size + 1,). The cumulative sequence lengths of the sequences in
+    # the batch, used to index into sequence. E.g., if the sequence length is
+    # [4, 6], it is [0, 4, 10].
+    seq_start_loc: Optional[torch.Tensor]
+    # (batch_size,) A tensor of context lengths (tokens that are computed
+    # so far).
+    context_lens_tensor: Optional[torch.Tensor]
+
+    # (batch_size, max_blocks_per_seq).
+    # Block addresses per sequence. (Seq id -> list of physical block)
+    # E.g., [0, 1, 2] means tokens are stored in 0th, 1st, and 2nd blocks
+    # in the kv cache. Each block can contain up to block_size tokens.
+    # 2nd dimensions are padded up to max_blocks_per_seq if it is cuda-graph
+    # captured.
+    block_tables: Optional[torch.Tensor]
+
+    # Whether or not if cuda graph is enabled.
+    # Cuda-graph is currently enabled for decoding only.
+    # TODO(woosuk): Move `use_cuda_graph` out since it's unrelated to attention.
+    use_cuda_graph: bool
+
+    _cached_prefill_metadata: Optional[
+        "DualChunkFlashAttentionMetadata"] = None
+    _cached_decode_metadata: Optional["DualChunkFlashAttentionMetadata"] = None
+
+    @property
+    def prefill_metadata(self) -> Optional["DualChunkFlashAttentionMetadata"]:
+        if self.num_prefills == 0:
+            return None
+
+        if self._cached_prefill_metadata is not None:
+            return self._cached_prefill_metadata
+
+        assert self.seq_lens is not None
+        assert self.seq_lens_tensor is not None
+        assert self.prefill_original_seq_lens_tensor is not None
+        assert self.query_start_loc is not None
+        assert self.context_lens_tensor is not None
+        assert self.block_tables is not None
+        assert self.seq_start_loc is not None
+
+        self._cached_prefill_metadata = DualChunkFlashAttentionMetadata(
+            num_prefills=self.num_prefills,
+            num_prefill_tokens=self.num_prefill_tokens,
+            num_decode_tokens=0,
+            slot_mapping=self.slot_mapping[:self.num_prefill_tokens],
+            seq_lens=self.seq_lens[:self.num_prefills],
+            seq_lens_tensor=self.seq_lens_tensor[:self.num_prefills],
+            prefill_original_seq_lens_tensor=self.
+            prefill_original_seq_lens_tensor[:self.num_prefill_tokens],
+            max_query_len=self.max_query_len,
+            max_prefill_seq_len=self.max_prefill_seq_len,
+            max_decode_seq_len=0,
+            query_start_loc=self.query_start_loc[:self.num_prefills + 1],
+            seq_start_loc=self.seq_start_loc[:self.num_prefills + 1],
+            context_lens_tensor=self.context_lens_tensor[:self.num_prefills],
+            block_tables=self.block_tables[:self.num_prefills],
+            use_cuda_graph=False,
+        )
+        return self._cached_prefill_metadata
+
+    @property
+    def decode_metadata(self) -> Optional["DualChunkFlashAttentionMetadata"]:
+        if self.num_decode_tokens == 0:
+            return None
+
+        if self._cached_decode_metadata is not None:
+            return self._cached_decode_metadata
+        assert self.block_tables is not None
+        assert self.seq_lens_tensor is not None
+
+        self._cached_decode_metadata = DualChunkFlashAttentionMetadata(
+            num_prefills=0,
+            num_prefill_tokens=0,
+            num_decode_tokens=self.num_decode_tokens,
+            slot_mapping=self.slot_mapping[self.num_prefill_tokens:],
+            seq_lens=None,
+            seq_lens_tensor=self.seq_lens_tensor[self.num_prefills:],
+            prefill_original_seq_lens_tensor=None,
+            max_query_len=None,
+            max_prefill_seq_len=0,
+            max_decode_seq_len=self.max_decode_seq_len,
+            query_start_loc=None,
+            seq_start_loc=None,
+            context_lens_tensor=None,
+            block_tables=self.block_tables[self.num_prefills:],
+            use_cuda_graph=self.use_cuda_graph,
+        )
+        return self._cached_decode_metadata
+
+
+class DualChunkFlashAttentionImpl(DualChunkAttentionImpl):
+    """
+    If the input tensors contain prompt tokens, the layout is as follows:
+    |<--------------- num_prefill_tokens ----------------->|
+    |<--prefill_0-->|<--prefill_1-->|...|<--prefill_N-1--->|
+
+    Otherwise, the layout is as follows:
+    |<----------------- num_decode_tokens ------------------>|
+    |<--decode_0-->|..........|<--decode_M-1-->|<--padding-->|
+
+    Generation tokens can contain padding when cuda-graph is used.
+    Currently, prompt tokens don't contain any padding.
+
+    The prompts might have different lengths, while the generation tokens
+    always have length 1.
+
+    If chunked prefill is enabled, prefill tokens and decode tokens can be
+    batched together in a flattened 1D query.
+
+    |<----- num_prefill_tokens ---->|<------- num_decode_tokens --------->|
+    |<-prefill_0->|...|<-prefill_N-1->|<--decode_0-->|...|<--decode_M-1-->|
+
+    Currently, cuda graph is disabled for chunked prefill, meaning there's no
+    padding between prefill and decode tokens.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: Optional[List[float]],
+        sliding_window: Optional[int],
+        kv_cache_dtype: str,
+        blocksparse_params: Optional[Dict[str, Any]] = None,
+        dual_chunk_attention_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if blocksparse_params is not None:
+            raise ValueError(
+                "FlashAttention does not support block-sparse attention.")
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_kv_heads
+        if alibi_slopes is not None:
+            alibi_slopes = torch.tensor(alibi_slopes, dtype=torch.float32)
+        self.alibi_slopes = alibi_slopes
+        self.sliding_window = ((sliding_window, sliding_window)
+                               if sliding_window is not None else (-1, -1))
+        self.kv_cache_dtype = kv_cache_dtype
+
+        assert self.num_heads % self.num_kv_heads == 0
+        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
+
+        if sliding_window is not None:
+            # NOTE(woosuk): flash-attn's sliding window does not work with
+            # paged KV cache.
+            raise ValueError(
+                "Sliding window is not supported in FlashAttention.")
+
+        support_head_sizes = (
+            DualChunkFlashAttentionBackend.get_supported_head_sizes())
+        if head_size not in support_head_sizes:
+            raise ValueError(
+                f"Head size {head_size} is not supported by FlashAttention. "
+                f"Supported head sizes are: {support_head_sizes}.")
+
+        assert dual_chunk_attention_config is not None
+        self.chunk_size = dual_chunk_attention_config.get("chunk_size", 8192)
+        self.local_size = dual_chunk_attention_config.get("local_size", 1024)
+        self.original_max_position_embeddings = dual_chunk_attention_config.get(
+            "original_max_position_embeddings", 0)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        query_succ: torch.Tensor,
+        query_inter: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: DualChunkFlashAttentionMetadata,
+        kv_scale: float = 1.0,
+    ) -> torch.Tensor:
+        """Forward pass with DualChunkFlashAttention.
+
+        Args:
+            query: shape = [num_tokens, num_heads * head_size]
+            query_succ: shape = [num_tokens, num_heads * head_size]
+            query_inter: shape = [num_tokens, num_heads * head_size]
+            key: shape = [num_tokens, num_kv_heads * head_size]
+            value: shape = [num_tokens, num_kv_heads * head_size]
+            kv_cache = [2, num_blocks, block_size, num_kv_heads * head_size]
+            attn_metadata: Metadata for attention.
+        Returns:
+            shape = [num_tokens, num_heads * head_size]
+        """
+        # NOTE(woosuk): FlashAttention does not support FP8 KV cache.
+        assert kv_scale == 1.0, "kv_scale is not supported in FlashAttention."
+
+        assert (
+            query_succ is not None and query_inter is not None
+        ), "query_succ and query_inter are required in Dual Chunk Attention."
+
+        num_tokens, hidden_size = query.shape
+        # Reshape the query, key, and value tensors.
+        query = query.view(-1, self.num_heads, self.head_size)
+        query_succ = query_succ.view(-1, self.num_heads, self.head_size)
+        query_inter = query_inter.view(-1, self.num_heads, self.head_size)
+        key = key.view(-1, self.num_kv_heads, self.head_size)
+        value = value.view(-1, self.num_kv_heads, self.head_size)
+
+        if self.original_max_position_embeddings > 0:
+            if prefill_meta := attn_metadata.prefill_metadata:
+                assert prefill_meta.query_start_loc is not None
+                assert prefill_meta.prefill_original_seq_lens_tensor is not None
+
+                current_start = 0
+                query_start_loc_cpu = prefill_meta.query_start_loc.cpu()
+                for i in range(
+                        0, prefill_meta.prefill_original_seq_lens_tensor.
+                        shape[0]):
+                    current_end = (current_start +
+                                   (query_start_loc_cpu[i + 1] -
+                                    query_start_loc_cpu[i]).item())
+                    mscale = (
+                        0.1 *
+                        (prefill_meta.prefill_original_seq_lens_tensor[i] /
+                         self.original_max_position_embeddings).log() +
+                        1.0).clip(min=1)
+                    key[current_start:current_end].mul_(mscale)
+                    current_start = current_end
+                assert current_end <= attn_metadata.num_prefill_tokens
+            if decode_meta := attn_metadata.decode_metadata:
+                mscale = (
+                    0.1 * torch.log(decode_meta.seq_lens_tensor /
+                                    self.original_max_position_embeddings) +
+                    1.0).clip(min=1)
+                key[attn_metadata.num_prefill_tokens:].mul_(
+                    mscale.unsqueeze(-1).unsqueeze(-1))
+
+        if kv_cache is not None:
+            key_cache = kv_cache[0]
+            value_cache = kv_cache[1]
+
+            # Reshape the input keys and values and store them in the cache.
+            # If kv_cache is not provided, the new key and value tensors are
+            # not cached. This happens during the initial memory profiling run.
+            ops.reshape_and_cache_flash(
+                key,
+                value,
+                key_cache,
+                value_cache,
+                attn_metadata.slot_mapping.flatten(),
+                self.kv_cache_dtype,
+            )
+
+        num_prefill_tokens = attn_metadata.num_prefill_tokens
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        assert key.shape[0] == num_prefill_tokens + num_decode_tokens
+        assert value.shape[0] == num_prefill_tokens + num_decode_tokens
+
+        output = torch.empty_like(query)
+        # Query for decode. KV is not needed because it is already cached.
+        decode_query = query[num_prefill_tokens:]
+        decode_query_succ = query_succ[num_prefill_tokens:]
+        decode_query_inter = query_inter[num_prefill_tokens:]
+
+        # QKV for prefill.
+        query = query[:num_prefill_tokens]
+        query_succ = query_succ[:num_prefill_tokens]
+        query_inter = query_inter[:num_prefill_tokens]
+        key = key[:num_prefill_tokens]
+        value = value[:num_prefill_tokens]
+
+        assert query.shape[0] == num_prefill_tokens
+        assert decode_query.shape[0] == num_decode_tokens
+
+        if prefill_meta := attn_metadata.prefill_metadata:
+            # Prompt run.
+            if (kv_cache is None or prefill_meta.block_tables is None
+                    or prefill_meta.block_tables.numel() == 0):
+                # normal attention
+                # When block_tables are not filled, it means q and k are the
+                # prompt, and they have the same length.
+                out = self._bruteforce_dynamic_chunk_flash_attn_varlen_func(
+                    q=query,
+                    q_succ=query_succ,
+                    q_inter=query_inter,
+                    k=key,
+                    v=value,
+                    cu_seqlens_q=prefill_meta.seq_start_loc,
+                    cu_seqlens_k=prefill_meta.seq_start_loc,
+                    max_seqlen_q=prefill_meta.max_prefill_seq_len,
+                    max_seqlen_k=prefill_meta.max_prefill_seq_len,
+                    softmax_scale=self.scale,
+                    causal=True,
+                    window_size=self.sliding_window,
+                    alibi_slopes=self.alibi_slopes,
+                    block_table=None,
+                    chunk_size=self.chunk_size,
+                    local_size=self.local_size,
+                    original_max_position_embeddings=self.
+                    original_max_position_embeddings,
+                    prefill_original_seq_lens_tensor=prefill_meta.
+                    prefill_original_seq_lens_tensor,
+                )
+                assert output[:num_prefill_tokens].shape == out.shape
+                output[:num_prefill_tokens] = out
+            else:
+                # prefix-enabled attention
+                assert prefill_meta.seq_lens is not None
+                max_seq_len = max(prefill_meta.seq_lens)
+                output[:num_prefill_tokens] = (
+                    self._bruteforce_dynamic_chunk_flash_attn_varlen_func(
+                        q=query,
+                        q_succ=query_succ,
+                        q_inter=query_inter,
+                        k=key_cache,
+                        v=value_cache,
+                        cu_seqlens_q=prefill_meta.query_start_loc,
+                        max_seqlen_q=prefill_meta.max_query_len,
+                        cu_seqlens_k=prefill_meta.seq_start_loc,
+                        max_seqlen_k=max_seq_len,
+                        softmax_scale=self.scale,
+                        causal=True,
+                        window_size=(-1, -1),
+                        alibi_slopes=self.alibi_slopes,
+                        block_table=prefill_meta.block_tables,
+                        chunk_size=self.chunk_size,
+                        local_size=self.local_size,
+                        original_max_position_embeddings=self.
+                        original_max_position_embeddings,
+                        prefill_original_seq_lens_tensor=prefill_meta.
+                        prefill_original_seq_lens_tensor,
+                    ))
+        if decode_meta := attn_metadata.decode_metadata:
+            # Decoding run.
+            output[num_prefill_tokens:] = (
+                self._bruteforce_dynamic_chunk_pageattention_forward_decode(
+                    decode_query.unsqueeze(1),
+                    decode_query_succ.unsqueeze(1),
+                    decode_query_inter.unsqueeze(1),
+                    key_cache,
+                    value_cache,
+                    block_table=decode_meta.block_tables,
+                    cache_seqlens=decode_meta.seq_lens_tensor,
+                    softmax_scale=self.scale,
+                    causal=True,
+                    alibi_slopes=self.alibi_slopes,
+                    chunk_size=self.chunk_size,
+                    local_size=self.local_size,
+                    original_max_position_embeddings=self.
+                    original_max_position_embeddings,
+                ).squeeze(1))
+
+        # Reshape the output tensor.
+        return output.view(num_tokens, hidden_size)
+
+    def _bruteforce_dynamic_chunk_flash_attn_func(
+        self,
+        q,
+        q_succ,
+        q_inter,
+        k,
+        v,
+        block_table,
+        softmax_scale,
+        chunk_size,
+        local_size,
+        original_max_position_embeddings,
+        current_prefill_original_seq_lens_tensor,
+        k_length,
+    ):
+
+        def do_flash_attn(
+            query_states,
+            key_states,
+            value_states,
+            causal=True,
+            block_table=None,
+            max_seqlen_k=None,
+        ):
+            if max_seqlen_k is None:
+                max_seqlen_k = key_states.shape[0]
+
+            output, softmax_lse, _ = flash_attn_varlen_func(
+                q=query_states,
+                k=key_states,
+                v=value_states,
+                softmax_scale=softmax_scale,
+                cu_seqlens_q=torch.tensor(
+                    [0, query_states.shape[0]],
+                    dtype=torch.int32,
+                    device=query_states.device,
+                ),
+                max_seqlen_q=query_states.shape[0],
+                cu_seqlens_k=torch.tensor(
+                    [0, max_seqlen_k],
+                    dtype=torch.int32,
+                    device=query_states.device,
+                ),
+                max_seqlen_k=max_seqlen_k,
+                causal=causal,
+                block_table=block_table,
+                return_attn_probs=True,
+            )
+            return output, softmax_lse
+
+        def merge_attn_outputs(flash_results):
+            attn_outputs_all = []
+            for flash_per_chunk in flash_results:
+                if len(flash_per_chunk) == 1:
+                    attn_outputs_all.append(flash_per_chunk[0][0])
+                    continue
+                attn_outputs = torch.stack([
+                    flash_attn_output[0]
+                    for flash_attn_output in flash_per_chunk
+                ])
+                logits = torch.stack([
+                    flash_attn_output[1]
+                    for flash_attn_output in flash_per_chunk
+                ]).to(torch.float32)
+                max_logits = torch.max(logits, dim=0).values
+                stable_logits = logits - max_logits.unsqueeze(0)
+                lse_s = torch.exp(stable_logits).detach()
+                lse_sum = torch.sum(lse_s, dim=0)
+                lse_s /= lse_sum
+                attn_outputs *= lse_s.unsqueeze(-1).transpose(2, 3).squeeze(1)
+                attn_outputs_all.append(attn_outputs.sum(dim=0))
+            return torch.cat(attn_outputs_all, dim=0)
+
+        def get_block(begin, end):
+            return block_table[:,
+                               begin // block_size:(end - 1) // block_size + 1]
+
+        flash_results = []
+        chunk_len = chunk_size - local_size
+        if block_table is not None:
+            block_size = v.shape[1]
+            if chunk_len % block_size != 0:
+                raise ValueError("chunk_len must be divisible by block_size.")
+        else:
+            block_size = 1
+
+        if original_max_position_embeddings > 0:
+            mscale = max(
+                0.1 * (current_prefill_original_seq_lens_tensor[0] /
+                       original_max_position_embeddings).log() + 1.0,
+                1.0,
+            )
+            softmax_scale = softmax_scale * mscale
+
+        begin = k_length - q.shape[0]
+
+        while begin < k_length:
+            flash_per_chunk = []
+
+            prev_chunk_end_pos = (begin // chunk_len) * chunk_len
+            next_chunk_end_pos = prev_chunk_end_pos + chunk_len
+            end = min(next_chunk_end_pos, k_length)
+            qbegin = begin - (k_length - q.shape[0])
+            qend = end - (k_length - q.shape[0])
+
+            q_states_intra = q[qbegin:qend]
+            if block_table is not None:
+                block_table_intra = get_block(prev_chunk_end_pos, end)
+                flash_result = do_flash_attn(
+                    q_states_intra,
+                    k,
+                    v,
+                    block_table=block_table_intra,
+                    max_seqlen_k=end - prev_chunk_end_pos,
+                )
+            else:
+                k_states_intra = k[prev_chunk_end_pos:end]
+                v_states_intra = v[prev_chunk_end_pos:end]
+                flash_result = do_flash_attn(q_states_intra, k_states_intra,
+                                             v_states_intra)
+            flash_per_chunk.append(flash_result)
+
+            if prev_chunk_end_pos - chunk_len >= 0:
+                q_states_succ = q_succ[qbegin:qend]
+                if block_table is not None:
+                    block_table_succ = get_block(
+                        prev_chunk_end_pos - chunk_len, prev_chunk_end_pos)
+                    flash_result = do_flash_attn(
+                        q_states_succ,
+                        k,
+                        v,
+                        False,
+                        block_table=block_table_succ,
+                        max_seqlen_k=chunk_len,
+                    )
+                else:
+                    k_states_succ = k[prev_chunk_end_pos -
+                                      chunk_len:prev_chunk_end_pos]
+                    v_states_succ = v[prev_chunk_end_pos -
+                                      chunk_len:prev_chunk_end_pos]
+                    flash_result = do_flash_attn(q_states_succ, k_states_succ,
+                                                 v_states_succ, False)
+                flash_per_chunk.append(flash_result)
+
+            if prev_chunk_end_pos - chunk_len * 2 >= 0:
+                q_states_inter = q_inter[qbegin:qend]
+
+                if block_table is not None:
+                    block_table_inter = get_block(
+                        0, prev_chunk_end_pos - chunk_len)
+                    flash_result = do_flash_attn(
+                        q_states_inter,
+                        k,
+                        v,
+                        False,
+                        block_table=block_table_inter,
+                        max_seqlen_k=prev_chunk_end_pos - chunk_len,
+                    )
+                else:
+                    k_states_inter = k[:prev_chunk_end_pos - chunk_len]
+                    v_states_inter = v[:prev_chunk_end_pos - chunk_len]
+                    flash_result = do_flash_attn(q_states_inter,
+                                                 k_states_inter,
+                                                 v_states_inter, False)
+                flash_per_chunk.append(flash_result)
+
+            begin = end
+            flash_results.append(flash_per_chunk)
+
+        attn_output = merge_attn_outputs(flash_results)
+
+        return attn_output
+
+    def _bruteforce_dynamic_chunk_flash_attn_varlen_func(
+        self,
+        q,
+        q_succ,
+        q_inter,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        softmax_scale,
+        causal,
+        window_size,
+        alibi_slopes,
+        block_table,
+        chunk_size,
+        local_size,
+        original_max_position_embeddings,
+        prefill_original_seq_lens_tensor,
+    ):
+
+        if alibi_slopes is not None:
+            raise ValueError(
+                "Native Dynamic Chunk Attention does not support alibi_slopes")
+        if not causal:
+            raise ValueError(
+                "Native Dynamic Chunk Attention does not support causal=False")
+        if window_size != (-1, -1):
+            raise ValueError(
+                "Native Dynamic Chunk Attention does not support window_size")
+
+        cu_seqlens_q_cpu = cu_seqlens_q.cpu().tolist()
+        cu_seqlens_k_cpu = cu_seqlens_k.cpu().tolist()
+
+        all_outputs = []
+        for i in range(0, len(cu_seqlens_q_cpu) - 1):
+            qs = cu_seqlens_q_cpu[i]
+            qe = cu_seqlens_q_cpu[i:i + 2][-1]
+            ks = cu_seqlens_k_cpu[i]
+            ke = cu_seqlens_k_cpu[i:i + 2][-1]
+
+            current_q = q[qs:qe]
+            current_q_succ = q_succ[qs:qe]
+            current_q_inter = q_inter[qs:qe]
+            if block_table is None:
+                current_k = k[ks:ke]
+                current_v = v[ks:ke]
+                current_block_table = None
+                current_prefill_original_seq_lens_tensor = (
+                    prefill_original_seq_lens_tensor[i:i + 1])
+            else:
+                current_block_table = block_table[i:i + 1]
+                current_prefill_original_seq_lens_tensor = (
+                    prefill_original_seq_lens_tensor[i:i + 1])
+                current_k = k
+                current_v = v
+
+            if current_q.shape[0] == 0:
+                continue
+            if current_k.shape[0] == 0:
+                all_outputs.append(
+                    torch.zeros(
+                        (current_q.shape[0], current_q.shape[1], v.shape[2]),
+                        device=q.device,
+                        dtype=q.dtype,
+                    ))
+                continue
+
+            current_output = self._bruteforce_dynamic_chunk_flash_attn_func(
+                current_q,
+                current_q_succ,
+                current_q_inter,
+                current_k,
+                current_v,
+                current_block_table,
+                softmax_scale,
+                chunk_size,
+                local_size,
+                original_max_position_embeddings,
+                current_prefill_original_seq_lens_tensor,
+                ke - ks,
+            )
+            all_outputs.append(current_output)
+
+        return torch.cat(all_outputs, dim=0)
+
+    def _bruteforce_dynamic_chunk_pageattention_forward_decode(
+        self,
+        query: torch.Tensor,
+        query_succ: torch.Tensor,
+        query_inter: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        softmax_scale: float,
+        causal: bool,
+        alibi_slopes: Optional[torch.Tensor],
+        chunk_size: int,
+        local_size: int,
+        original_max_position_embeddings: int,
+    ):
+        assert causal
+        batch_size = block_table.shape[0]
+        block_size = value_cache.shape[1]
+        chunk_len = chunk_size - local_size
+        if chunk_len % block_size != 0:
+            raise ValueError("chunk_len must be divisible by block_size.")
+        chunk_num_curr = (cache_seqlens - 1) // chunk_len
+
+        if original_max_position_embeddings > 0:
+            mscale = (
+                0.1 *
+                torch.log(cache_seqlens / original_max_position_embeddings) +
+                1.0).clip(min=1)
+            query = (query * mscale.view(-1, 1, 1, 1)).to(
+                query.dtype
+            )  # possible for numerical issue, need to fused in the kernel
+            query_succ = (query_succ * mscale.view(-1, 1, 1, 1)).to(
+                query.dtype)
+            query_inter = (query_inter * mscale.view(-1, 1, 1, 1)).to(
+                query.dtype)
+
+        outputs_list = []
+        softmax_lses_list = []
+
+        # intra-attention
+        seq_lens_intra = cache_seqlens - chunk_num_curr * chunk_len
+        max_seq_len_intra = seq_lens_intra.max().item()
+        block_table_intra = torch.zeros(
+            batch_size,
+            (max_seq_len_intra - 1) // block_size + 1,
+            dtype=block_table.dtype,
+            device=block_table.device,
+        )
+        for i in range(batch_size):
+            st = chunk_num_curr[i] * chunk_len // block_size
+            ed = min(
+                st + (max_seq_len_intra - 1) // block_size + 1,
+                (cache_seqlens[i] - 1) // block_size + 1,
+            )
+            block_table_intra[i, :ed - st] = block_table[i, st:ed]
+        intra_output, intra_softmax_lse = (
+            self._pagedattention_forward_decode_with_exp_sums(
+                query,
+                key_cache,
+                value_cache,
+                block_table_intra,
+                seq_lens_intra,
+                softmax_scale,
+                alibi_slopes,
+                causal=False,
+            ))
+        outputs_list.append(intra_output)
+        softmax_lses_list.append(intra_softmax_lse)
+
+        # succ-attention
+        seq_lens_succ = (chunk_num_curr -
+                         (chunk_num_curr - 1).clip(min=0)) * chunk_len
+        max_seq_len_succ = seq_lens_succ.max().item()
+        if max_seq_len_succ:
+            block_table_succ = torch.zeros(
+                batch_size,
+                (max_seq_len_succ - 1) // block_size + 1,
+                dtype=block_table.dtype,
+                device=block_table.device,
+            )
+            for i in range(batch_size):
+                st = ((chunk_num_curr[i] - 1).clip(min=0) * chunk_len //
+                      block_size)
+                ed = min(
+                    st + (max_seq_len_succ - 1) // block_size + 1,
+                    (cache_seqlens[i] - 1) // block_size + 1,
+                )
+                block_table_succ[i, :ed - st] = block_table[i, st:ed]
+            succ_output, succ_softmax_lse = (
+                self._pagedattention_forward_decode_with_exp_sums(
+                    query_succ,
+                    key_cache,
+                    value_cache,
+                    block_table_succ,
+                    seq_lens_succ,
+                    softmax_scale,
+                    alibi_slopes,
+                    causal=False,
+                ))
+            outputs_list.append(succ_output)
+            softmax_lses_list.append(succ_softmax_lse)
+
+        # inter-attention
+        seq_lens_inter = (chunk_num_curr - 1).clip(min=0) * chunk_len
+        max_seq_len_inter = seq_lens_inter.max().item()
+        if max_seq_len_inter:
+            inter_output, succ_softmax_lse = (
+                self._pagedattention_forward_decode_with_exp_sums(
+                    query_inter,
+                    key_cache,
+                    value_cache,
+                    block_table[:, :max_seq_len_inter],
+                    seq_lens_inter,
+                    softmax_scale,
+                    alibi_slopes,
+                    causal=False,
+                ))
+            outputs_list.append(inter_output)
+            softmax_lses_list.append(succ_softmax_lse)
+
+        outputs = torch.stack(outputs_list, dim=0)
+        del outputs_list
+        softmax_lses = torch.stack(softmax_lses_list, dim=0).to(torch.float32)
+        del softmax_lses_list
+
+        max_logits = torch.max(softmax_lses, dim=0).values
+        stable_logits = softmax_lses - max_logits.unsqueeze(0)
+        lse_s = torch.exp(stable_logits).detach()
+        lse_sum = torch.sum(lse_s, dim=0)
+        lse_s /= lse_sum
+        outputs *= lse_s.unsqueeze(-1).transpose(2, 3)
+
+        return outputs.sum(0)
+
+    def _pagedattention_forward_decode_with_exp_sums(
+        self,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        block_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        softmax_scale: float,
+        alibi_slopes: Optional[torch.Tensor],
+        causal: bool,
+    ):
+
+        out, softmax_lse = flash_attn_with_kvcache(
+            query,
+            key_cache,
+            value_cache,
+            block_table=block_table,
+            cache_seqlens=cache_seqlens,
+            softmax_scale=softmax_scale,
+            alibi_slopes=alibi_slopes,
+            causal=causal,
+            return_softmax=True,
+        )
+        cache_seqlens_cpu = cache_seqlens.cpu()
+        for i in range(cache_seqlens.shape[0]):
+            if cache_seqlens_cpu[i] == 0:
+                softmax_lse[i].fill_(-float("inf"))
+                out[i].fill_(0)
+
+        return out, softmax_lse

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -55,8 +55,8 @@ class Attention(nn.Module):
         # with the model weights.
         self.kv_cache_dtype = kv_cache_dtype
         self._kv_scale = 1.0
-        quant_method = (quant_config.get_quant_method(self)
-                        if quant_config else None)
+        quant_method = quant_config.get_quant_method(
+            self) if quant_config else None
         if quant_method is not None:
             assert isinstance(quant_method, Fp8KVCacheMethod)
             # TODO (mgoin): kv cache dtype should be specified in the FP8
@@ -75,27 +75,14 @@ class Attention(nn.Module):
         # During model initialization, the default dtype is set as the model
         # weight and activation dtype.
         dtype = torch.get_default_dtype()
-        attn_backend = get_attn_backend(
-            num_heads,
-            head_size,
-            num_kv_heads,
-            sliding_window,
-            dtype,
-            kv_cache_dtype,
-            block_size,
-            blocksparse_params is not None,
-        )
+        attn_backend = get_attn_backend(num_heads, head_size, num_kv_heads,
+                                        sliding_window, dtype, kv_cache_dtype,
+                                        block_size, blocksparse_params
+                                        is not None)
         impl_cls = attn_backend.get_impl_cls()
-        self.impl = impl_cls(
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            blocksparse_params,
-        )
+        self.impl = impl_cls(num_heads, head_size, scale, num_kv_heads,
+                             alibi_slopes, sliding_window, kv_cache_dtype,
+                             blocksparse_params)
 
     def forward(
         self,

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -5,7 +5,8 @@ import torch
 import torch.nn as nn
 
 from vllm.attention.backends.abstract import AttentionMetadata
-from vllm.attention.selector import get_attn_backend
+from vllm.attention.selector import (get_attn_backend,
+                                     get_dual_chunk_attn_backend)
 from vllm.config import CacheConfig
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
@@ -54,8 +55,8 @@ class Attention(nn.Module):
         # with the model weights.
         self.kv_cache_dtype = kv_cache_dtype
         self._kv_scale = 1.0
-        quant_method = quant_config.get_quant_method(
-            self) if quant_config else None
+        quant_method = (quant_config.get_quant_method(self)
+                        if quant_config else None)
         if quant_method is not None:
             assert isinstance(quant_method, Fp8KVCacheMethod)
             # TODO (mgoin): kv cache dtype should be specified in the FP8
@@ -74,14 +75,27 @@ class Attention(nn.Module):
         # During model initialization, the default dtype is set as the model
         # weight and activation dtype.
         dtype = torch.get_default_dtype()
-        attn_backend = get_attn_backend(num_heads, head_size, num_kv_heads,
-                                        sliding_window, dtype, kv_cache_dtype,
-                                        block_size, blocksparse_params
-                                        is not None)
+        attn_backend = get_attn_backend(
+            num_heads,
+            head_size,
+            num_kv_heads,
+            sliding_window,
+            dtype,
+            kv_cache_dtype,
+            block_size,
+            blocksparse_params is not None,
+        )
         impl_cls = attn_backend.get_impl_cls()
-        self.impl = impl_cls(num_heads, head_size, scale, num_kv_heads,
-                             alibi_slopes, sliding_window, kv_cache_dtype,
-                             blocksparse_params)
+        self.impl = impl_cls(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            blocksparse_params,
+        )
 
     def forward(
         self,
@@ -100,4 +114,116 @@ class Attention(nn.Module):
         s += f", num_kv_heads={self.impl.num_kv_heads}"  # type: ignore
         s += f", scale={self.impl.scale}"  # type: ignore
         s += f", backend={self.impl.__class__.__name__}"
+        return s
+
+
+class DualChunkAttention(nn.Module):
+    """Dual Chunk Attention layer.
+
+    This class takes query, query_succ, query_inter, key, and
+    value tensors as input.
+    The input tensors can either contain prompt tokens or generation tokens.
+    The class does the following:
+
+    1. Store the input key and value tensors in the KV cache.
+    2. Perform (multi-head/multi-query/grouped-query) dual chunk attention.
+    3. Return the output tensor.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: Optional[int] = None,
+        alibi_slopes: Optional[List[float]] = None,
+        cache_config: Optional[CacheConfig] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        blocksparse_params: Optional[Dict[str, Any]] = None,
+        dual_chunk_attention_config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        if cache_config is not None:
+            kv_cache_dtype = cache_config.cache_dtype
+            block_size = cache_config.block_size
+            sliding_window = cache_config.sliding_window
+        else:
+            kv_cache_dtype = "auto"
+            block_size = 16
+            sliding_window = None
+        if num_kv_heads is None:
+            num_kv_heads = num_heads
+
+        # The default kv_scale is set to 1.0. This is ignored
+        # when kv-cache is not fp8, and should be used with
+        # kv-cache in fp8_e5m2. For kv-cache in fp8_e4m3, we
+        # expect the pre-quantized kv_scale to be loaded along
+        # with the model weights.
+        self.kv_cache_dtype = kv_cache_dtype
+        self._kv_scale = 1.0
+        quant_method = (quant_config.get_quant_method(self)
+                        if quant_config else None)
+        if quant_method is not None:
+            if self.kv_cache_dtype == "fp8_e5m2":
+                raise ValueError("fp8_e5m2 kv-cache is not supported with "
+                                 "fp8 checkpoints.")
+            # When FP8 quantization is enabled, we make a parameter
+            # "kv_scale" so that it can be loaded from FP8 checkpoint.
+            # The kv_scale will then be converted back
+            # to self._kv_scale in a native float32 value after weight loading.
+            self.quant_method = quant_method
+            self.quant_method.create_weights(self)
+
+        # During model initialization, the default dtype is set as the model
+        # weight and activation dtype.
+        dtype = torch.get_default_dtype()
+        attn_backend = get_dual_chunk_attn_backend(
+            num_heads,
+            head_size,
+            num_kv_heads,
+            sliding_window,
+            dtype,
+            kv_cache_dtype,
+            block_size,
+            blocksparse_params is not None,
+        )
+        impl_cls = attn_backend.get_impl_cls()
+        self.impl = impl_cls(
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            blocksparse_params,
+            dual_chunk_attention_config,
+        )
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        query_succ: torch.Tensor,
+        query_inter: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: Optional[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        return self.impl.forward(
+            query,
+            query_succ,
+            query_inter,
+            key,
+            value,
+            kv_cache,
+            attn_metadata,
+            self._kv_scale,
+        )
+
+    def extra_repr(self) -> str:
+        s = f"head_size={self.impl.head_size}"  # type: ignore
+        s += f", num_heads={self.impl.num_heads}"  # type: ignore
+        s += f", num_kv_heads={self.impl.num_kv_heads}"  # type: ignore
+        s += f", scale={self.impl.scale}"  # type: ignore
         return s

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -21,7 +21,8 @@ except ImportError:
     BatchPrefillWithPagedKVCacheWrapper = None
     FLASHINFER_WORKSPACE_BUFFER_SIZE = 0
 
-from vllm.attention import AttentionMetadata, get_attn_backend
+from vllm.attention import (AttentionMetadata, get_attn_backend,
+                            get_dual_chunk_attn_backend)
 from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, LoRAConfig,
                          ModelConfig, ParallelConfig, SchedulerConfig,
                          VisionLanguageConfig)
@@ -193,15 +194,27 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             dtype=np.int32)
         num_attn_heads = self.model_config.get_num_attention_heads(
             self.parallel_config)
-        self.attn_backend = get_attn_backend(
-            num_attn_heads,
-            self.model_config.get_head_size(),
-            self.model_config.get_num_kv_heads(self.parallel_config),
-            self.model_config.get_sliding_window(),
-            self.model_config.dtype,
-            self.kv_cache_dtype,
-            self.block_size,
-        ) if num_attn_heads else None
+        if getattr(self.model_config.hf_config, "dual_chunk_attention_config",
+                   None):
+            self.attn_backend = get_dual_chunk_attn_backend(
+                num_attn_heads,
+                self.model_config.get_head_size(),
+                self.model_config.get_num_kv_heads(self.parallel_config),
+                self.model_config.get_sliding_window(),
+                self.model_config.dtype,
+                self.kv_cache_dtype,
+                self.block_size,
+            ) if num_attn_heads else None
+        else:
+            self.attn_backend = get_attn_backend(
+                num_attn_heads,
+                self.model_config.get_head_size(),
+                self.model_config.get_num_kv_heads(self.parallel_config),
+                self.model_config.get_sliding_window(),
+                self.model_config.dtype,
+                self.kv_cache_dtype,
+                self.block_size,
+            ) if num_attn_heads else None
 
         # Multi-modal data support
         self.multi_modal_input_mapper = MULTIMODAL_REGISTRY \
@@ -332,6 +345,9 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
 
         seq_lens: List[int] = []
         prefill_seq_lens: List[int] = []
+        # The length of the whole prefill sequence. Different from
+        # prefill_seq_lens when chunked prefill is enable.
+        prefill_original_seq_lens: List[int] = []
         decode_seq_lens: List[int] = []
         context_lens: List[int] = []
         query_lens: List[int] = []
@@ -486,6 +502,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                     num_prefill_tokens += len(tokens)
                     decode_only = False
                     prefill_seq_lens.append(seq_len)
+                    prefill_original_seq_lens.append(seq_data.get_len())
                 else:
                     assert query_len == 1, (
                         "seq_len: {}, context_len: {}, query_len: {}".format(
@@ -658,6 +675,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         slot_mapping_tensor = torch.tensor(slot_mapping,
                                            dtype=torch.long,
                                            device=self.device)
+        prefill_original_seq_lens_tensor = torch.tensor(
+            prefill_original_seq_lens, dtype=torch.long, device=self.device)
 
         if self.attn_backend.get_name() == "flashinfer":
             if len(paged_kv_indptr) > 0:
@@ -699,6 +718,25 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                 data_type=kv_cache_dtype,
                 use_cuda_graph=use_captured_graph)
 
+        elif self.attn_backend.get_name() == "dual-chunk-flash-attn":
+            attn_metadata = self.attn_backend.make_metadata(
+                num_prefills=num_prefills,
+                slot_mapping=slot_mapping_tensor,
+                num_prefill_tokens=num_prefill_tokens,
+                num_decode_tokens=num_decode_tokens,
+                seq_lens=seq_lens,
+                seq_lens_tensor=seq_lens_tensor,
+                max_query_len=max_query_len,
+                prefill_original_seq_lens_tensor=
+                prefill_original_seq_lens_tensor,
+                max_prefill_seq_len=max_prefill_seq_len,
+                max_decode_seq_len=max_decode_seq_len,
+                query_start_loc=query_start_loc,
+                seq_start_loc=seq_start_loc,
+                context_lens_tensor=context_lens_tensor,
+                block_tables=block_tables,
+                use_cuda_graph=use_captured_graph,
+            )
         else:
             attn_metadata = self.attn_backend.make_metadata(
                 num_prefills=num_prefills,


### PR DESCRIPTION
## Overview

[Dual Chunk Attention](https://arxiv.org/pdf/2402.17463.pdf) is a training-free method to extend model context length. It splits the entire sequence into chunks and uses three distinct query vectors to capture relative information within the same chunk, between successive chunks, and between distant chunks. The original implementation (using Hugging Face's Transformers) can be found [here](https://github.com/HKUNLP/ChunkLlama).

Qwen2 models now integrate this method, supporting 1M context length processing on 8x H100-80G GPUs. Qwen2-72B-Instruct achieves ~75% accuracy in the [Needle in A Haystack](https://github.com/gkamradt/LLMTest_NeedleInAHaystack) test with 1M tokens input.

**Features**:

* Brute-force implementation of Dual Chunk Attention (calling flash-attention ``3*chunk_num`` times).
* Chunked prefill support. (Recommended, otherwise OOM may happen.)

**Limitations**:

* Only Flash-Attention backend is available. Quantized KV Cache is not currently supported.
* No CUDA kernel for performance optimization. Processing a 1M sample with Qwen2-72B-Instruct takes approximately 10 minutes on 8x H100-80G GPUs.
* ``enforce_eager`` must be set to True due to the dynamic graph created by the brute-force implementation.

## Changes

* Add ``DualChunkRotaryEmbedding`` in ``vllm/model_executor/layers/rotary_embedding.py``. The function ``DualChunkRotaryEmbedding.forward`` returns ``query, query_succ, query_inter`` instead of a single ``query``. These three query vectors are used for computing intra-/succ-/inter-attention in Dual Chunk Attention.
* Add an abstract class ``DualChunkAttentionBackend`` in ``vllm/attention/backends/abstract.py`` and implement ``DualChunkFlashAttentionBackend`` in ``vllm/attention/backends/dual_chunk_flash_attn.py``. Note that we add an extra variable ``prefill_original_seq_lens_tensor`` in ``DualChunkFlashAttentionMetadata``, which stores the whole prefill sequences' lengths. To obtain the value, we insert a few lines in ``vllm/model_runner.py``.
* Add ``DualChunkAttention`` in ``vllm/vllm/attention/layer.py``, which simply calls ``DualChunkAttentionBackend``.
* Introduce ``dual_chunk_attention_config`` in ``Qwen2Model`` and ``Qwen2MoeModel``.

## How to use

1. After downloading the model weights, modify the ``config.json`` file following:

```json5
    {
        "architectures": [
            "Qwen2ForCausalLM" // or Qwen2MoeForCausalLM
        ],
        // ...
        "max_position_embeddings": 1000000, // Modify the max model length

        // adding the following snippets
        "dual_chunk_attention_config": {
            "chunk_size": 32768, // specify the chunk and local size of Dual Chunk Attention
            "local_size": 2048,
            "original_max_position_embeddings": 32768 // used for YARN in Dual Chunk Attention
        }
    }
```

2. Run the following codes:

```python
from vllm import LLM, SamplingParams

path = "/path/to/model"

llm = LLM(model=path, tensor_parallel_size=4, enforce_eager=True, enable_chunked_prefill=True, max_num_batched_tokens=32768)

prompt = "There is an important info hidden inside a lot of irrelevant text. Find it and memorize them. I will quiz you about the important information there.\n\nThe pass key is 28884. Remember it. 28884 is the pass key.\n " + \
    "The grass is green. The sky is blue. The sun is yellow. Here we go. There and back again. " * 8000 + \
    "\nWhat is the pass key?" # The prompt is 192k long. You can try longer prompt by replacing 8000 by 40000.

prompts = [
    f"<|im_start|>user\n{prompt1}<|im_end|>\n<|im_start|>assistant\n",
]
sampling_params = SamplingParams(top_p=0.8, temperature=0.7, repetition_penalty=1.05, top_k=20, max_tokens=100)

outputs = llm.generate(prompts, sampling_params)

# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Generated text: {generated_text!r}")

```

You will see outputs like: 

```
Generated text: 'The pass key is 28884.'
```