### PR TITLE
[Docs] Fix readthedocs for tag build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,10 @@ if READTHEDOCS_VERSION_TYPE == "tag":
     # remove the warning banner if the version is a tagged release
     header_file = os.path.join(os.path.dirname(__file__),
                                "_templates/sections/header.html")
-    os.remove(header_file)
+    # The file might be removed already if the build is triggered multiple times
+    # (readthedocs build both HTML and PDF versions separately)
+    if os.path.exists(header_file):
+        os.remove(header_file)
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
https://readthedocs.org/projects/vllm/builds/24917886/

<img width="888" alt="image" src="https://github.com/vllm-project/vllm/assets/21118851/6c34ec9c-e0ea-4179-ba7c-a22562ee5477">


Readthedocs will first build html successfully on tag, then run into file not found when building pdf, because template is already remvoed. 