### PR TITLE
Add FlashInfer to default Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,9 @@ RUN --mount=type=bind,from=build,src=/workspace/dist,target=/vllm-workspace/dist
 RUN --mount=type=bind,from=mamba-builder,src=/usr/src/mamba,target=/usr/src/mamba \
     --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install /usr/src/mamba/*.whl --no-cache-dir
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install https://github.com/flashinfer-ai/flashinfer/releases/download/v0.0.8/flashinfer-0.0.8+cu121torch2.3-cp310-cp310-linux_x86_64.whl
 #################### vLLM installation IMAGE ####################
 
 


### PR DESCRIPTION
Closes #6169 

Testing with 
```
docker run --gpus all -p 8000:8000 -e HF_TOKEN --ipc=host --env "VLLM_ATTENTION_BACKEND=FLASHINFER" -v /data/xmo/hub:/root/.cache/huggingface vllm/vllm-openai --model google/gemma-2-9b-it
```

```
$ curl http://localhost:8000/v1/completions  -H "Content-Type: application/json"      -d '{
"model": "google/gemma-2-9b-it",
"prompt":"Who won the world series in 2020?",
"max_tokens": 100,
"ignore_eos": true
}'
{"id":"cmpl-8ce64ceae52449e2b04988b08f3f42f9","object":"text_completion","created":1720253967,"model":"google/gemma-2-9b-it","choices":[{"index":0,"text":"\n\nThe **Los Angeles Dodgers** won the World Series in 2020. \n\\\\\n  \\\\\n\n\n\\\\\n\\\\\n\\\n\n\\\\\n\\\\\n\n\n\n\n.\n\n\n'.\n\n\n\n\n\n **\n\n\n\n\n。","logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":13,"total_tokens":113,"completion_tokens":100}}(miniconda3) (base) [xmo@flow-matic:/data/xmo/vllm]$ 
```

The docker image for `vllm/vllm-openai:latest` and `vllm/vllm-openai:v0.5.1` has been built and updated. This doesn't effect the wheel build. 