### PR TITLE
[misc][frontend] log all available endpoints

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -21,7 +21,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import FlexibleArgumentParser, random_uuid
 
-logger = init_logger(__name__)
+logger = init_logger("vllm.entrypoints.api_server")
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 app = FastAPI()

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -16,9 +16,12 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import FlexibleArgumentParser, random_uuid
+
+logger = init_logger(__name__)
 
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 app = FastAPI()
@@ -107,6 +110,13 @@ if __name__ == "__main__":
         engine_args, usage_context=UsageContext.API_SERVER)
 
     app.root_path = args.root_path
+
+    logger.info("Available endpoints are:")
+    for route in app.routes:
+        methods = ', '.join(route.methods) if hasattr(
+            route, 'methods') else 'No methods'
+        logger.info("Path: %s, Methods: %s", route.path, methods)
+
     uvicorn.run(app,
                 host=args.host,
                 port=args.port,

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
 
     app.root_path = args.root_path
 
-    logger.info("Available endpoints are:")
+    logger.info("Available routes are:")
     for route in app.routes:
         methods = ', '.join(route.methods) if hasattr(
             route, 'methods') else 'No methods'

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -113,9 +113,10 @@ if __name__ == "__main__":
 
     logger.info("Available routes are:")
     for route in app.routes:
-        methods = ', '.join(route.methods) if hasattr(
-            route, 'methods') else 'No methods'
-        logger.info("Path: %s, Methods: %s", route.path, methods)
+        if not hasattr(route, 'methods'):
+            continue
+        methods = ', '.join(route.methods)
+        logger.info("Route: %s, Methods: %s", route.path, methods)
 
     uvicorn.run(app,
                 host=args.host,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -243,9 +243,10 @@ if __name__ == "__main__":
 
     logger.info("Available routes are:")
     for route in app.routes:
-        methods = ', '.join(route.methods) if hasattr(
-            route, 'methods') else 'No methods'
-        logger.info("Path: %s, Methods: %s", route.path, methods)
+        if not hasattr(route, 'methods'):
+            continue
+        methods = ', '.join(route.methods)
+        logger.info("Route: %s, Methods: %s", route.path, methods)
 
     uvicorn.run(app,
                 host=args.host,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -240,6 +240,13 @@ if __name__ == "__main__":
     openai_serving_embedding = OpenAIServingEmbedding(engine, model_config,
                                                       served_model_names)
     app.root_path = args.root_path
+
+    logger.info("Available endpoints are:")
+    for route in app.routes:
+        methods = ', '.join(route.methods) if hasattr(
+            route, 'methods') else 'No methods'
+        logger.info("Path: %s, Methods: %s", route.path, methods)
+
     uvicorn.run(app,
                 host=args.host,
                 port=args.port,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
                                                       served_model_names)
     app.root_path = args.root_path
 
-    logger.info("Available endpoints are:")
+    logger.info("Available routes are:")
     for route in app.routes:
         methods = ', '.join(route.methods) if hasattr(
             route, 'methods') else 'No methods'


### PR DESCRIPTION
fixes https://github.com/vllm-project/vllm/issues/6194

quite a lot users don't know the difference between simple api server and openai api server. I got several issue reports recently, that users are manually getting `/generate` from openai api server, or getting `/v1/models` from simple api server, and then complain about 404 response.

logging all available endpoints should help users clearly know what endpoints they can test.

example output:

simple api server: `python -m vllm.entrypoints.api_server`

```text
INFO 07-07 13:50:36 api_server.py:116] Available endpoints are:
INFO 07-07 13:50:36 api_server.py:120] Path: /openapi.json, Methods: GET, HEAD
INFO 07-07 13:50:36 api_server.py:120] Path: /docs, Methods: GET, HEAD
INFO 07-07 13:50:36 api_server.py:120] Path: /docs/oauth2-redirect, Methods: GET, HEAD
INFO 07-07 13:50:36 api_server.py:120] Path: /redoc, Methods: GET, HEAD
INFO 07-07 13:50:36 api_server.py:120] Path: /health, Methods: GET
INFO 07-07 13:50:36 api_server.py:120] Path: /generate, Methods: POST
```

openai api server: `python -m vllm.entrypoints.openai.api_server`

```text
INFO 07-07 13:53:48 api_server.py:244] Available endpoints are:
INFO 07-07 13:53:48 api_server.py:248] Path: /openapi.json, Methods: HEAD, GET
INFO 07-07 13:53:48 api_server.py:248] Path: /docs, Methods: HEAD, GET
INFO 07-07 13:53:48 api_server.py:248] Path: /docs/oauth2-redirect, Methods: HEAD, GET
INFO 07-07 13:53:48 api_server.py:248] Path: /redoc, Methods: HEAD, GET
INFO 07-07 13:53:48 api_server.py:248] Path: /metrics, Methods: No methods
INFO 07-07 13:53:48 api_server.py:248] Path: /health, Methods: GET
INFO 07-07 13:53:48 api_server.py:248] Path: /tokenize, Methods: POST
INFO 07-07 13:53:48 api_server.py:248] Path: /detokenize, Methods: POST
INFO 07-07 13:53:48 api_server.py:248] Path: /v1/models, Methods: GET
INFO 07-07 13:53:48 api_server.py:248] Path: /version, Methods: GET
INFO 07-07 13:53:48 api_server.py:248] Path: /v1/chat/completions, Methods: POST
INFO 07-07 13:53:48 api_server.py:248] Path: /v1/completions, Methods: POST
INFO 07-07 13:53:48 api_server.py:248] Path: /v1/embeddings, Methods: POST
```