### PR TITLE
do not exclude `object` field in CompletionStreamResponse

### DIFF
--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -301,7 +301,7 @@ class OpenAIServingCompletion(OpenAIServing):
                         else:
                             chunk.usage = None
 
-                    response_json = chunk.model_dump_json(exclude_unset=True)
+                    response_json = chunk.model_dump_json(exclude_unset=False)
                     yield f"data: {response_json}\n\n"
 
             if (request.stream_options
@@ -314,7 +314,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     usage=usage,
                 )
                 final_usage_data = (final_usage_chunk.model_dump_json(
-                    exclude_unset=True, exclude_none=True))
+                    exclude_unset=False, exclude_none=True))
                 yield f"data: {final_usage_data}\n\n"
 
         except ValueError as e:


### PR DESCRIPTION
The [CompletionStreamResponse](https://github.com/vllm-project/vllm/blob/abfe705a02160db53f4b0cf90c7b016f04291b9c/vllm/entrypoints/openai/protocol.py#L593) contains the required `object` field but is subsequently [removed when serializing to JSON](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/serving_completion.py#L304C37-L304C78).

This PR retains the required `object` field.