### PR TITLE
[Bugfix][Kernel] Reduce GPU L1 cache pressure for act_order and tensor_parallel on smaller GPUs

### DIFF
--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -1503,6 +1503,15 @@ bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
     return false;
   }
 
+  // For act_order with is_k_full == False, we load a chunk of scales.
+  // If GPU L1 cache is small, then reduce the N thread size to ensure
+  // we load less data
+  if (has_act_order && !is_k_full && max_shared_mem < 1024 * 110) {
+    if (th_config.thread_n > 64) {
+      return false;
+    }
+  }
+
   //  Determine cache for scales
   int scales_cache_size =
       get_scales_cache_size(th_config, prob_m, prob_n, prob_k, num_bits,

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -1506,8 +1506,11 @@ bool is_valid_config(thread_config_t const& th_config, int max_m_blocks,
   // For act_order with is_k_full == False, we load a chunk of scales.
   // If GPU L1 cache is small, then reduce the N thread size to ensure
   // we load less data
-  if (has_act_order && !is_k_full && max_shared_mem < 1024 * 110) {
-    if (th_config.thread_n > 64) {
+  if (has_act_order && !is_k_full &&
+      max_shared_mem <
+          1024 * 110 /* Small GPUs have around 100K of L1 cache */) {
+    if (th_config.thread_n >
+        64 /* thread_n == 64 is the minimal one that we want to have */) {
       return false;
     }
   }


### PR DESCRIPTION
Attempts to fix the bug reported in https://github.com/vllm-project/vllm/issues/6258