### PR TITLE
[core] Sampling controller interface

### DIFF
--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -147,10 +147,13 @@ class BlockTable:
 
         # Update the blocks with the new tokens
         first_block_idx = self._num_full_slots // self._block_size
-        token_blocks = self._chunk_token_blocks_for_append(token_ids)
 
-        for i, token_block in enumerate(token_blocks):
-            self._blocks.append_token_ids(first_block_idx + i, token_block)
+        # don't bother appending anything, if no new token_ids were generated
+        if token_ids:
+            token_blocks = self._chunk_token_blocks_for_append(token_ids)
+
+            for i, token_block in enumerate(token_blocks):
+                self._blocks.append_token_ids(first_block_idx + i, token_block)
 
         self._num_full_slots += len(token_ids)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -237,7 +237,8 @@ class _AsyncLLMEngine(LLMEngine):
                 virtual_engine=virtual_engine,
                 num_lookahead_slots=scheduler_outputs.num_lookahead_slots,
                 running_queue_size=scheduler_outputs.running_queue_size,
-                finished_requests_ids=finished_requests_ids)
+                finished_requests_ids=finished_requests_ids,
+                sampling_controller=self.sampling_controller)
             output = await self.model_executor.execute_model_async(
                 execute_model_req)
         else:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -258,6 +258,8 @@ class _AsyncLLMEngine(LLMEngine):
 
     async def stop_remote_worker_execution_loop_async(self) -> None:
         """Stop the remote worker execution loop."""
+        if ctrl := self.sampling_controller:
+            ctrl.empty_step()
         await self.model_executor.stop_remote_worker_execution_loop_async()
 
     async def process_model_inputs_async(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -29,8 +29,8 @@ from vllm.outputs import (EmbeddingRequestOutput, RequestOutput,
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import (EmbeddingSequenceGroupOutput, ExecuteModelRequest,
-                           PoolerOutput, SamplerOutput, Sequence,
-                           SequenceGroup, SequenceGroupMetadata,
+                           PoolerOutput, SamplerOutput, SamplingController,
+                           Sequence, SequenceGroup, SequenceGroupMetadata,
                            SequenceStatus)
 from vllm.tracing import (SpanAttributes, SpanKind, extract_trace_context,
                           init_tracer)
@@ -225,6 +225,7 @@ class LLMEngine:
         self.observability_config = observability_config or ObservabilityConfig(
         )
         self.log_stats = log_stats
+        self.sampling_controller: Optional[SamplingController] = None
 
         if not self.model_config.skip_tokenizer_init:
             self.tokenizer = self._init_tokenizer()
@@ -857,7 +858,8 @@ class LLMEngine:
                 blocks_to_copy=scheduler_outputs.blocks_to_copy,
                 num_lookahead_slots=scheduler_outputs.num_lookahead_slots,
                 running_queue_size=scheduler_outputs.running_queue_size,
-                finished_requests_ids=finished_requests_ids)
+                finished_requests_ids=finished_requests_ids,
+                sampling_controller=self.sampling_controller)
             output = self.model_executor.execute_model(
                 execute_model_req=execute_model_req)
         else:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -529,6 +529,8 @@ class LLMEngine:
         min_cost_scheduler.add_seq_group(seq_group)
 
     def stop_remote_worker_execution_loop(self) -> None:
+        if ctrl := self.sampling_controller:
+            ctrl.empty_step()
         self.model_executor.stop_remote_worker_execution_loop()
 
     def process_model_inputs(
@@ -863,6 +865,8 @@ class LLMEngine:
             output = self.model_executor.execute_model(
                 execute_model_req=execute_model_req)
         else:
+            if ctrl := self.sampling_controller:
+                ctrl.empty_step()
             output = []
 
         request_outputs = self._process_model_outputs(

--- a/vllm/engine/output_processor/single_step.py
+++ b/vllm/engine/output_processor/single_step.py
@@ -102,15 +102,13 @@ class SingleStepOutputProcessor(SequenceGroupOutputProcessor):
             for child_sample in child_samples[:-1]:
                 new_child_seq_id: int = next(self.seq_counter)
                 child = parent.fork(new_child_seq_id)
-                child.append_token_id(child_sample.output_token,
-                                      child_sample.logprobs)
+                child_sample.append_to(child)
                 child_seqs.append((child, parent))
             # Continue the parent sequence for the last child sample.
             # We reuse the parent sequence here to reduce redundant memory
             # copies, especially when using non-beam search sampling methods.
             last_child_sample = child_samples[-1]
-            parent.append_token_id(last_child_sample.output_token,
-                                   last_child_sample.logprobs)
+            last_child_sample.append_to(parent)
             child_seqs.append((parent, parent))
 
         for seq, _ in child_seqs:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -42,7 +42,8 @@ TIMEOUT_KEEP_ALIVE = 5  # seconds
 openai_serving_chat: OpenAIServingChat
 openai_serving_completion: OpenAIServingCompletion
 openai_serving_embedding: OpenAIServingEmbedding
-engine_args: AsyncEngineArgs
+_engine_args: AsyncEngineArgs
+_engine: AsyncLLMEngine
 
 logger = init_logger('vllm.entrypoints.openai.api_server')
 
@@ -55,9 +56,9 @@ async def lifespan(app: fastapi.FastAPI):
     async def _force_log():
         while True:
             await asyncio.sleep(10)
-            await engine.do_log_stats()
+            await _engine.do_log_stats()
 
-    if not engine_args.disable_log_stats:
+    if not _engine_args.disable_log_stats:
         task = asyncio.create_task(_force_log())
         _running_tasks.add(task)
         task.add_done_callback(_running_tasks.remove)
@@ -205,21 +206,19 @@ def create_engine(args):
     logger.info("vLLM API server version %s", VLLM_VERSION)
     logger.info("args: %s", args)
 
-    global engine_args
     engine_args = AsyncEngineArgs.from_cli_args(args)
 
     engine = AsyncLLMEngine.from_engine_args(
         engine_args, usage_context=UsageContext.OPENAI_API_SERVER)
+    
+    global _engine_args, _engine
+    _engine_args = engine_args
+    _engine = engine
 
     return engine
 
 
-def start_engine(args, engine):
-    if args.served_model_name is not None:
-        served_model_names = args.served_model_name
-    else:
-        served_model_names = [args.model]
-
+def get_model_config(args, engine: AsyncLLMEngine):
     event_loop: Optional[asyncio.AbstractEventLoop]
     try:
         event_loop = asyncio.get_running_loop()
@@ -233,6 +232,17 @@ def start_engine(args, engine):
     else:
         # When using single vLLM without engine_use_ray
         model_config = asyncio.run(engine.get_model_config())
+
+    if args.served_model_name is not None:
+        served_model_names = args.served_model_name
+    else:
+        served_model_names = [args.model]
+
+    return model_config, served_model_names
+
+
+def start_engine(args, engine: AsyncLLMEngine):
+    model_config, served_model_names = get_model_config(args, engine)
 
     global openai_serving_chat, openai_serving_completion
     global openai_serving_embedding
@@ -258,7 +268,11 @@ def start_engine(args, engine):
                 ssl_cert_reqs=args.ssl_cert_reqs)
 
 
+def _main():
+    _args = parse_args()
+    _engine = create_engine(_args)
+    start_engine(_args, _engine)
+
+
 if __name__ == "__main__":
-    args = parse_args()
-    engine = create_engine(args)
-    start_engine(args, engine)
+    _main()

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -24,6 +24,7 @@ class SequenceGroupToSample:
     #                                   |-- query_len ---|
 
     # Sequence ids for the sequence group in a previous step.
+    request_id: str
     seq_ids: List[int]
     sampling_params: SamplingParams
     # seq_id -> sequence data.
@@ -273,6 +274,7 @@ def _prepare_seq_groups(
 
         seq_groups.append(
             SequenceGroupToSample(
+                request_id=seq_group_metadata.request_id,
                 seq_ids=seq_ids,
                 sampling_params=sampling_params,
                 seq_data=seq_group_metadata.seq_data,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -912,6 +912,17 @@ class HiddenStates:
             self.seq_ids = seq_ids
 
 
+class SamplingController:
+
+    def prepare(self, seq_group_metadata_list: List[SequenceGroupMetadata]):
+        """Prepare the sampling controller for the next step."""
+        pass
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        """Apply the sampling controller to the logits."""
+        return logits
+
+
 @dataclass
 class ExecuteModelRequest:
     """The model execution request, containing CPU metadata only. The LLM
@@ -936,6 +947,8 @@ class ExecuteModelRequest:
     num_steps: int = 1
     # Finished request ids since last step.
     finished_requests_ids: List[str] = field(default_factory=list)
+    # Sampling controller to use for this step.
+    sampling_controller: Optional[SamplingController] = None
 
     def clone(
         self, seq_group_metadata_list: List[SequenceGroupMetadata]
@@ -951,4 +964,5 @@ class ExecuteModelRequest:
             running_queue_size=self.running_queue_size,
             previous_hidden_states=self.previous_hidden_states,
             num_steps=self.num_steps,
-            finished_requests_ids=self.finished_requests_ids)
+            finished_requests_ids=self.finished_requests_ids,
+            sampling_controller=self.sampling_controller)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -942,6 +942,11 @@ class SamplingController:
         """Prepare the sampling controller for the next step."""
         pass
 
+    def empty_step(self):
+        """Called instead of prepare() when the scheduler found no sequences
+        to run."""
+        pass
+
     def transform_logits(self, logits: torch.Tensor) -> torch.Tensor:
         """Apply the sampling controller to the logits."""
         return logits

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -712,14 +712,17 @@ class SequenceOutput:
             for token in self.fast_forward_tokens:
                 # On first iteration, use the existing self.logprobs, provided
                 # they contain the token.
-                # On subsequent iterations, logprobs is cleared, so always use
-                # artificially created logprobs.
                 if token not in logprobs:
                     logprobs = {
                         token: Logprob(logprob=0.0, rank=1, decoded_token=None)
                     }
                 seq.append_token_id(token, logprobs)
+                # On subsequent iterations always use artificially created
+                # logprobs.
                 logprobs = {}
+            # If more than one token was appended, switch to prefill stage.
+            if seq.data.get_num_uncomputed_tokens() > 1:
+                seq.data._stage = SequenceStage.PREFILL
         else:
             seq.append_token_id(self.output_token, self.logprobs)
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -186,9 +186,14 @@ class SequenceData:
 
     def update_num_computed_tokens(self, num_new_computed_tokens: int):
         """Update number of tokens computed so far."""
+        seq_len = self.get_len()
         self._num_computed_tokens += num_new_computed_tokens
-        assert self._num_computed_tokens <= self.get_len(), (
-            self._num_computed_tokens, self.get_len())
+        # We can overflow by 1 if previous sampling was updated by
+        # SamplingController to generate an empty sequence of tokens.
+        if self._num_computed_tokens == seq_len + 1:
+            self._num_computed_tokens = seq_len
+        assert self._num_computed_tokens <= seq_len, (
+            self._num_computed_tokens, seq_len)
         # If all tokens are computed, it means it is in decoding phase.
         if self.get_num_uncomputed_tokens() == 0:
             self._stage = SequenceStage.DECODE

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -469,8 +469,8 @@ class SequenceGroup:
 
     def get_last_latency(self, now: float) -> Optional[float]:
         """Sets the last token time for Request level timings."""
-        # If still in prefill phase, raise Error.
-        if self.is_prefill():
+        # If still in initial prefill phase, raise Error.
+        if self.is_prefill() and self.get_seqs()[0].get_output_len() == 0:
             raise ValueError(
                 "seq_group.get_last_latency() should not be called "
                 "if the seq_group is in prefill phase.")

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from vllm.inputs import LLMInputs
     from vllm.multimodal import MultiModalDataDict
     from vllm.spec_decode.metrics import SpecDecodeWorkerMetrics
+    from vllm.model_executor.sampling_metadata import SamplingMetadata
 
 
 @dataclass
@@ -914,7 +915,7 @@ class HiddenStates:
 
 class SamplingController:
 
-    def prepare(self, seq_group_metadata_list: List[SequenceGroupMetadata]):
+    def prepare(self, sampling_metadata: "SamplingMetadata"):
         """Prepare the sampling controller for the next step."""
         pass
 

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -124,7 +124,7 @@ class Detokenizer:
          )
 
         # Decode logprobs
-        logprobs = seq.output_logprobs[-1]
+        logprobs = seq.output_logprobs[-1] if seq.output_logprobs else None
         if logprobs:
             previous_tokens = all_input_ids[:-1]
             for token_id, sample_logprob in logprobs.items():

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1265,13 +1265,16 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             return []
 
         if ctrl is not None:
-            logits = ctrl.apply(logits)
+            logits = ctrl.transform_logits(logits)
 
         # Sample the next token.
         output: SamplerOutput = self.model.sample(
             logits=logits,
             sampling_metadata=model_input.sampling_metadata,
         )
+
+        if ctrl is not None:
+            ctrl.transform_sampler_output(output)
 
         if self.return_hidden_states:
             # we only need to pass hidden states of most recent token

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1274,7 +1274,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         )
 
         if ctrl is not None:
-            ctrl.transform_sampler_output(output)
+            output = ctrl.transform_sampler_output(output)
 
         if self.return_hidden_states:
             # we only need to pass hidden states of most recent token

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1259,6 +1259,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         if not self.is_driver_worker:
             return []
 
+        if (ctrl := model_input.sampling_controller) is not None:
+            logits = ctrl.apply(logits)
+
         # Sample the next token.
         output: SamplerOutput = self.model.sample(
             logits=logits,

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -6,7 +6,7 @@ from typing import (TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type,
 import torch
 
 from vllm.sequence import (IntermediateTensors, SamplerOutput,
-                           SequenceGroupMetadata)
+                           SamplingController, SequenceGroupMetadata)
 
 if TYPE_CHECKING:
     from vllm.attention import AttentionMetadata
@@ -91,6 +91,8 @@ class ModelRunnerInputBase(ABC):
     ModelRunnerInputBase subclass, add their required fields, and specify how to
     serialize/deserialize a ModelInput for broadcast between workers.
     """
+
+    sampling_controller: Optional[SamplingController] = None
 
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         """

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -236,6 +236,11 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     execute_model_req.seq_group_metadata_list,
                     execute_model_req.virtual_engine,
                     execute_model_req.finished_requests_ids))
+            ctrl = execute_model_req.sampling_controller
+            if ctrl is not None:
+                ctrl.prepare(execute_model_req.seq_group_metadata_list)
+                model_input = dataclasses.replace(model_input,
+                                                  sampling_controller=ctrl)
             num_steps = execute_model_req.num_steps
 
             if self.do_metadata_broadcast:

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -236,11 +236,6 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     execute_model_req.seq_group_metadata_list,
                     execute_model_req.virtual_engine,
                     execute_model_req.finished_requests_ids))
-            ctrl = execute_model_req.sampling_controller
-            if ctrl is not None:
-                ctrl.prepare(execute_model_req.seq_group_metadata_list)
-                model_input = dataclasses.replace(model_input,
-                                                  sampling_controller=ctrl)
             num_steps = execute_model_req.num_steps
 
             if self.do_metadata_broadcast:
@@ -249,6 +244,13 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     model_input.as_broadcastable_tensor_dict())
                 broadcast_data["num_steps"] = num_steps
                 broadcast_tensor_dict(broadcast_data, src=0)
+
+            # SamplingController is only used in the driver worker, so it
+            # doesn't need to be broadcasted.
+            ctrl = execute_model_req.sampling_controller
+            if ctrl is not None:
+                model_input = dataclasses.replace(model_input,
+                                                  sampling_controller=ctrl)
         else:
             assert self.do_metadata_broadcast
             broadcast_data = broadcast_tensor_dict(src=0)


### PR DESCRIPTION
This patch adds `SamplingController` object on `LLMEngine`. It subsumes `LogitsProcessor` functions in `SamplingParams` as suggested in #5423. Instead of calling the class `LogitPostProcessor` I used `SamplingController` since it's a bit broader than just dealing with logits (in particular it allows for fast forward tokens, see below). I'm happy to rename if needed.

The basic idea is that the engine holds an instance of `SamplingController` and calls methods on it to influence the sampling process. In every step the following methods are called:
* `prepare(sampling_metadata: SamplingMetadata)`: this is meant to start computation of logit biases for sequences in the batch; the controller will likely need to store mapping from sequences to indices in logit tensor
* model forward pass is started
* `transform_logits(logits: torch.Tensor) -> torch.Tensor` is called on the entire logit tensor (for all sequences in the batch)
* sampling is performed as usual
* `transform_sampler_output(output: SamplerOutput) -> SamplerOutput` is called on the output of the sampler

In case of an empty step (where no sequences are scheduled to run), the `empty_step()` method is called, instead of the three methods mentioned above. This is to allow the controller to perform cleanup.

To be clear, the only way to use this right now, is to derive from `SamplingController` and use `vllm` as a library.

The transformation of sampler output is primary useful in conjunction with the newly added `SequenceOutput.fast_forward_tokens` field. If this is set, these tokens are to be added to the sequence instead of the sampled token.

An example, where fast forward tokens are useful is generating data adhering to a certain JSON schema. The controller first forces `{"name":"` to be generated, then the model generates `John"`, the controller forces `,\n"age":`, model generates `42`, and so on. Another example is chain-of-thought reasoning, where after the model generated a sentence, the controller forces more instructions for the model, the model generates more text, and so on. If used, these greatly speed up generation process.

The `SamplingController` is passed from `LLMEngine` to worker/executor via `ExecuteModelRequest` and `ModelRunnerInputBase`. Only driver worker receives the controller (as it's the only one that does sampling).

I also added `request_id` to `SequenceGroupToSample` (which is referenced from `SamplingMetadata`) to allow the controller to identify the sequences in the batch.

There are two places where I had to make changes to allow empty fast forward tokens:
- `SequenceData.update_num_computed_tokens`
- `BlockTable.append_token_ids`
The main reason to support empty tokens is for the cases when the computation of the next token mask did not complete in time. Instead of waiting for it to finish, or aborting the sequence, the controller can instead do an "empty pass" on that particular sequence and try it again in the next step, without holding up the rest of the batch. Of course, if this happens several times, the controller is free to terminate the sequence.

Status: I have this working with AICI. I think this is good to go, though it may need some tests.

CC @rkooo567 @simon-mo @GindaChen @cadedaniel @njhill 

FIX #5423

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


