### PR TITLE
[Bugfix][TPU] Add prompt adapter methods to TPUExecutor

### DIFF
--- a/vllm/executor/tpu_executor.py
+++ b/vllm/executor/tpu_executor.py
@@ -81,8 +81,7 @@ class TPUExecutor(ExecutorBase):
 
     def determine_num_available_blocks(self) -> Tuple[int, int]:
         """Determine the number of available KV blocks by invoking the
-        underlying worker.
-        """
+        underlying worker."""
         return self.driver_worker.determine_num_available_blocks()
 
     def execute_model(
@@ -93,16 +92,36 @@ class TPUExecutor(ExecutorBase):
         return output
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
-        raise NotImplementedError("LoRA is not implemented for TPU backend.")
+        raise NotImplementedError(
+            "LoRA is currently not supported by the TPU backend.")
 
     def remove_lora(self, lora_id: int) -> bool:
-        raise NotImplementedError("LoRA is not implemented for TPU backend.")
+        raise NotImplementedError(
+            "LoRA is currently not supported by the TPU backend.")
 
     def pin_lora(self, lora_id: int) -> bool:
-        raise NotImplementedError("LoRA is not implemented for TPU backend.")
+        raise NotImplementedError(
+            "LoRA is currently not supported by the TPU backend.")
 
     def list_loras(self) -> Set[int]:
-        raise NotImplementedError("LoRA is not implemented for TPU backend.")
+        raise NotImplementedError(
+            "LoRA is currently not supported by the TPU backend.")
+
+    def add_prompt_adapter(self, prompt_adapter_request) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the TPU backend.")
+
+    def remove_prompt_adapter(self, prompt_adapter_id: int) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the TPU backend.")
+
+    def pin_prompt_adapter(self, prompt_adapter_id: int) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the TPU backend.")
+
+    def list_prompt_adapters(self) -> Set[int]:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the TPU backend.")
 
     def check_health(self) -> None:
         # TPUExecutor will always be healthy as long as it's running.


### PR DESCRIPTION
After PR #4645 was merged today, the TPU backend has been broken with the following error:
```
TypeError: Can't instantiate abstract class TPUExecutor with abstract methods add_prompt_adapter, list_prompt_adapters, pin_prompt_adapter, remove_prompt_adapter
```

This PR fixes the bug by adding the prompt adapter methods that simply raise `NotImplementedError`.