### PR TITLE
test spec decode verify tokens

### DIFF
--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -534,6 +534,11 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         # metadata.
         accepted_token_ids[original_indices] = accepted_token_ids.clone()
 
+        matched_num = torch.sum(torch.where(accepted_token_ids > -0.5, 1, 0)).item() - 1
+        predict_num = proposal_token_ids.shape[-1]
+        print(f"predict tokens: {predict_num}")
+        print(f"matched tokens: {matched_num}")
+
         hidden_states = proposal_scores.hidden_states
         if hidden_states is not None:
             # Contract hidden states based on accepted tokens


### PR DESCRIPTION
Just for testing.

`>-0.5` (same like `>-1`) means it has been matched. `-1` is for the target model's token (it will always generate 1 token by the target model).
