### PR TITLE
[Bugfix] OpenVINOExecutor abstractmethod error

### DIFF
--- a/vllm/executor/openvino_executor.py
+++ b/vllm/executor/openvino_executor.py
@@ -90,6 +90,22 @@ class OpenVINOExecutor(ExecutorBase):
     def list_loras(self) -> Set[int]:
         return self.driver_worker.list_loras()
 
+    def add_prompt_adapter(self, prompt_adapter_request) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the OPENVINO backend.")
+
+    def remove_prompt_adapter(self, prompt_adapter_id: int) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the OPENVINO backend.")
+
+    def pin_prompt_adapter(self, prompt_adapter_id: int) -> bool:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the OPENVINO backend.")
+
+    def list_prompt_adapters(self) -> Set[int]:
+        raise NotImplementedError(
+            "Soft prompt is currently not supported by the OPENVINO backend.")
+
     def check_health(self) -> None:
         # OpenVINOExecutor will always be healthy as long as
         # it's running.


### PR DESCRIPTION

`TypeError: Can't instantiate abstract class TPUExecutor with abstract methods add_prompt_adapter, list_prompt_adapters, pin_prompt_adapter, remove_prompt_adapter`

This is Simple PR to fix the abstractmethod error in OpenVINOExecutor.