### PR TITLE
[Bugfix] MLPSpeculator: Use ParallelLMHead in tie_weights=False case.

### DIFF
--- a/vllm/model_executor/models/mlp_speculator.py
+++ b/vllm/model_executor/models/mlp_speculator.py
@@ -110,7 +110,7 @@ class MLPSpeculator(nn.Module):
             ])
 
             self.head = nn.ModuleList([
-                nn.Linear(self.inner_dim, self.vocab_size, bias=False)
+                ParallelLMHead(self.vocab_size, self.inner_dim, bias=False)
                 for _ in range(self.max_speculative_tokens)
             ])
             self.ln = nn.ModuleList([


### PR DESCRIPTION
Fixes #6302 

cc @robertgshaw2-neuralmagic 
