### PR TITLE
[Bugfix] Require triton >= 3.0.0 to resolve issue with MoE and TP>1

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -5,6 +5,8 @@
 ray >= 2.9
 nvidia-ml-py # for pynvml package
 torch == 2.3.0
+triton >= 3.0.0
+
 # These must be updated alongside torch
 torchvision == 0.18.0   # Required for phi3v processor, also see https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 xformers == 0.0.26.post1  # Requires PyTorch 2.3.0


### PR DESCRIPTION
Fixes #6103 via https://github.com/triton-lang/triton/pull/4295

This would make #6140 redundant but let's see if bumping Triton causes any issues in CI.