### PR TITLE
[Core] offload model weights to CPU conditionally

### DIFF
--- a/examples/offline_inference_with_cpu_offload.py
+++ b/examples/offline_inference_with_cpu_offload.py
@@ -1,0 +1,23 @@
+from vllm import LLM, SamplingParams
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+# Create an LLM.
+llm = LLM(model="meta-llama/Llama-2-7b-hf", cpu_offload_trigger_percent=0.4)
+#llm = LLM(model="facebook/opt-125m", cpu_offload_trigger_percent=1)
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -434,6 +434,7 @@ class CacheConfig:
         num_gpu_blocks_override: Optional[int] = None,
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
+        cpu_offload_trigger_percent: float = 1,
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -442,6 +443,7 @@ class CacheConfig:
         self.cache_dtype = cache_dtype
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
+        self.cpu_offload_trigger_percent = cpu_offload_trigger_percent
         self._verify_args()
         self._verify_cache_dtype()
         self._verify_prefix_caching()

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -79,6 +79,8 @@ class LLM:
             When a sequence has context length larger than this, we fall back
             to eager mode.
         disable_custom_all_reduce: See ParallelConfig
+        cpu_offload_trigger_percent: the percentage limit of GPU memory to hold
+            weights, extra weights will be offloaded to CPU memory.
         **kwargs: Arguments for :class:`~vllm.EngineArgs`. (See
             :ref:`engine_args`)
     
@@ -118,6 +120,7 @@ class LLM:
         max_context_len_to_capture: Optional[int] = None,
         max_seq_len_to_capture: int = 8192,
         disable_custom_all_reduce: bool = False,
+        cpu_offload_trigger_percent: float = 1,
         **kwargs,
     ) -> None:
         if "disable_log_stats" not in kwargs:
@@ -145,6 +148,7 @@ class LLM:
             max_context_len_to_capture=max_context_len_to_capture,
             max_seq_len_to_capture=max_seq_len_to_capture,
             disable_custom_all_reduce=disable_custom_all_reduce,
+            cpu_offload_trigger_percent=cpu_offload_trigger_percent,
             **kwargs,
         )
         self.llm_engine = LLMEngine.from_engine_args(

--- a/vllm/model_executor/models/opt.py
+++ b/vllm/model_executor/models/opt.py
@@ -75,18 +75,24 @@ class OPTAttention(nn.Module):
         self.head_dim = embed_dim // total_num_heads
         self.scaling = self.head_dim**-0.5
 
+        cpu_offload_trigger_percent = (
+            1 if cache_config is None else
+            cache_config.cpu_offload_trigger_percent)
+
         self.qkv_proj = QKVParallelLinear(
             embed_dim,
             self.head_dim,
             total_num_heads,
             bias=bias,
             quant_config=quant_config,
+            cpu_offload_trigger_percent=cpu_offload_trigger_percent,
         )
         self.out_proj = RowParallelLinear(
             embed_dim,
             embed_dim,
             bias=bias,
             quant_config=quant_config,
+            cpu_offload_trigger_percent=cpu_offload_trigger_percent,
         )
         self.attn = Attention(self.num_heads,
                               self.head_dim,


### PR DESCRIPTION
We are developing the "conditional cpu-offload-weight" feature for vLLM, which is comparable to Hugging Face's Accelerate device_map='auto'. This democratizes access to vLLM, empowering a broader community of learners and researchers to engage with cutting-edge AI models. This democratizes access to vLLM, empowering a broader community of learners and researchers to engage with cutting-edge AI models.

To achieve conditional CPU offload,  a new CLI parameter, **cpu_offload_trigger_percent**,  whose default value is 0, will be added. 
- When cpu_offload_trigger_percent == 1, the conditional cpu offload feature is turned off, vLLM behaves just as now.
- If 0<= cpu_offload_trigger_percent <1, vllm will try to load the weights to GPU until the memory percentage hits the limit of cpu_offload_trigger_percent. After that, the weight will be offloaded to CPU.

Test results show:
1. When the percentage specified by the user is enough to hold the weights, the performance will be the same as of now.
2. When the percentage specified by the user is insufficient to hold the weights, the vLLM will continue to work with higher latency. In cases of large models with very limited GPU resources, the latency could be very high. However, vLLM will still work and generate outputs.

A more detailed doc is given at https://docs.google.com/document/d/1qY9SJIRCLn6_p_2jHInW0E8qE2oukgOrH26v62jZy70/edit#heading=h.vrhc1mfm2tpm