### PR TITLE
[Bugfix] GPTBigCodeForCausalLM: Remove lm_head from supported_lora_modules.

### DIFF
--- a/vllm/model_executor/models/gpt_bigcode.py
+++ b/vllm/model_executor/models/gpt_bigcode.py
@@ -235,7 +235,7 @@ class GPTBigCodeModel(nn.Module):
 class GPTBigCodeForCausalLM(nn.Module, SupportsLoRA):
     packed_modules_mapping = {"c_attn": ["c_attn"]}
 
-    supported_lora_modules = ["c_fc", "c_proj", "wte", "lm_head", "c_attn"]
+    supported_lora_modules = ["c_fc", "c_proj", "wte", "c_attn"]
 
     embedding_modules = {
         "wte": "input_embeddings",


### PR DESCRIPTION
Fix #6314 

This PR implements the workaround suggested by @tjohnson31415 [here](https://github.com/vllm-project/vllm/issues/6314#issuecomment-2221628179).

I have also confirmed this resolves the failure at startup. 

cc @robertgshaw2-neuralmagic 


