### PR TITLE
fix cuda118 can't find libcudart.so error

### DIFF
--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -80,6 +80,7 @@ class CudaRTLibrary:
             assert torch.version.cuda is not None
             major_version = torch.version.cuda.split(".")[0]
             so_file = f"libcudart.so.{major_version}"
+            so_file = so_file + ".0" if major_version == "11" else so_file
         if so_file not in CudaRTLibrary.path_to_library_cache:
             lib = ctypes.CDLL(so_file)
             CudaRTLibrary.path_to_library_cache[so_file] = lib


### PR DESCRIPTION
 **CudaRTLibrary()** can't find **libcudart.so.11** because it's **libcudart.so.11.0**
cuda12 can find so normally because it's file is:
`/usr/local/lib/python3.10/dist-packages/nvidia/cuda_runtime/lib/libcudart.so.12`
cuda11 can't find so, because it's file is:
`/usr/local/lib/python3.8/dist-packages/nvidia/cuda_runtime/lib/libcudart.so.11.0`
#6299