### PR TITLE
[Kernel] Fix identical branches

### DIFF
--- a/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
+++ b/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
@@ -289,17 +289,10 @@ __global__ void Marlin_24(
   }
 
   int s_sh_wr = threadIdx.x;
-  int s_sh_rd;
-  // We use a different scale layout for grouped and column-wise quantization as
-  // we scale a `half2` tile in column-major layout in the former and in
-  // row-major in the latter case.
-  if (group_blocks != -1) {
-    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
+
+  // Sparse marlin computes grouped and column-wise quantization the same way
+  int s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
               (threadIdx.x % 32) / 4;
-  } else {
-    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
-              (threadIdx.x % 32) / 4;
-  }
 
   // Precompute which thread should not read memory in which iterations; this is
   // needed if there are more threads than required for a certain tilesize or


### PR DESCRIPTION
Static analysis detected that an 'if; statement with an 'else' are the same. Issue #6030 was opened to report this. Conversation there suggested that they can be consolidated into 1 line of code.

FIX #6030

This was tested with test_marlin_gemm.py as suggested in the issue.
