### PR TITLE
[Bugfix] Fix usage stats logging exception warning with OpenVINO

### DIFF
--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -4,6 +4,6 @@
 # OpenVINO dependencies
 torch >= 2.1.2
 openvino ~= 2024.3.0.dev
-optimum-intel[openvino] >= 1.17.2
+optimum-intel[openvino] >= 1.18.1
 
 triton >= 2.2.0  # FIXME(woosuk): This is a hack to avoid import error.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -284,7 +284,7 @@ class LLMEngine:
                     "quantization":
                     model_config.quantization,
                     "kv_cache_dtype":
-                    cache_config.cache_dtype,
+                    str(cache_config.cache_dtype),
 
                     # Feature flags
                     "enable_lora":


### PR DESCRIPTION
- Fix usage stats logging exception with OpenVINO. kv_cache_dtype is of type openvino.Type, which is not json serializable. Casting to string is the easiest fix that doesn't require an "if openvino". 
- Update minimum optimum-intel version to 1.18.1 for transformers 4.42 compatibility, which is the minimum version of transformers in requirements-common.txt

FIX #6340 

cc @ilya-lavrenov 