### PR TITLE
[ci] Add GHA workflows to enable full CI run

### DIFF
--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -1,6 +1,6 @@
 name: Add label on auto-merge enabled
 on:
-    pull_request:
+    pull_request_target:
         types:
             - auto_merge_enabled
 jobs:

--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -17,3 +17,5 @@ jobs:
                             issue_number: context.issue.number,
                             labels: ['ready']
                         })
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -1,0 +1,19 @@
+name: Add label on auto-merge enabled
+on:
+    pull_request:
+        types:
+            - auto_merge_enabled
+jobs:
+    add-label-on-auto-merge:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Add label
+                uses: actions/github-script@v5
+                with:
+                    script: |
+                        github.rest.issues.addLabels({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            labels: ['ready']
+                        })

--- a/.github/workflows/add_label_ready_comment.yml
+++ b/.github/workflows/add_label_ready_comment.yml
@@ -1,0 +1,21 @@
+name: Add Ready Label on Ready Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add-ready-label:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/ready')
+    steps:
+        -   name: Add label
+            uses: actions/github-script@v5
+            with:
+                script: |
+                    github.rest.issues.addLabels({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                        labels: ['ready']
+                    })

--- a/.github/workflows/add_label_ready_comment.yml
+++ b/.github/workflows/add_label_ready_comment.yml
@@ -19,3 +19,5 @@ jobs:
                         issue_number: context.issue.number,
                         labels: ['ready']
                     })
+            env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -1,0 +1,19 @@
+name: PR Reminder Comment Bot
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr_reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remind to run full CI on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '👋 Hi! Thank you for contributing to the vLLM project.\n Just a reminder: PRs would not trigger full CI run by default. Instead, it would only trigger `fastcheck` CI to run, which consists only a small and essential subset of tests to quickly catch small errors.\n\nFull CI run is still required to merge this PR so please make sure that you run full CI before merging or if you need more test signals.\n\n To run full CI, you can do one of these:\n- Add `ready` label to the PR\n- Comment `/ready` on the PR\n- Enable auto-merge.\n\n🚀'
+            })

--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -17,3 +17,5 @@ jobs:
               issue_number: context.issue.number,
               body: '👋 Hi! Thank you for contributing to the vLLM project.\n Just a reminder: PRs would not trigger full CI run by default. Instead, it would only trigger `fastcheck` CI to run, which consists only a small and essential subset of tests to quickly catch small errors.\n\nFull CI run is still required to merge this PR so please make sure that you run full CI before merging or if you need more test signals.\n\n To run full CI, you can do one of these:\n- Add `ready` label to the PR\n- Comment `/ready` on the PR\n- Enable auto-merge.\n\n🚀'
             })
+        env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -1,6 +1,6 @@
 name: PR Reminder Comment Bot
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Add GHA workflows that:
- Add `ready` label to PR when auto-merge is enabled
- Add `ready` label to PR when a `/ready` comment is posted in the PR
- Send a comment when PR is opened to remind PR authors to run full CI before merging or if more test signal is needed. 