### PR TITLE
[Doc] xpu backend requires running setvars.sh

### DIFF
--- a/docs/source/getting_started/xpu-installation.rst
+++ b/docs/source/getting_started/xpu-installation.rst
@@ -40,12 +40,13 @@ Quick start using Dockerfile
 Build from source
 -----------------
 
-- First, install required driver and intel OneAPI 2024.1.
+- First, install required driver and intel OneAPI 2024.1 or later.
 
 - Second, install Python packages for vLLM XPU backend building:
 
 .. code-block:: console
 
+    $ source /opt/intel/oneapi/setvars.sh
     $ pip install --upgrade pip
     $ pip install -v -r requirements-xpu.txt 
 


### PR DESCRIPTION
IPEX depends on MKL, and you need to do `setvars.sh` to setup the `LD_LIBRARY_PATH` to find it. It works fine with with setvars.sh and 2024.2 oneapi.

@jikunshang: Thanks for adding XPU support!

Here is the error message:
```
(.venv) rscohn1@gkdse-dnp-23:~/projects/cutlass/vllm$ python examples/offline_inference.py 
WARNING 07-12 23:25:17 _custom_ops.py:14] Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
WARNING 07-12 23:25:17 utils.py:218] Import Error for IPEX: libmkl_intel_lp64.so.2: cannot open shared object file: No such file or directory
WARNING 07-12 23:25:17 utils.py:222] not found ipex lib
```