### PR TITLE
[Bugfix][TPU] Fix megacore setting for v5e-litepod

### DIFF
--- a/vllm/attention/backends/pallas.py
+++ b/vllm/attention/backends/pallas.py
@@ -116,7 +116,7 @@ class PallasAttentionBackendImpl(AttentionImpl):
 
         self.megacore_mode = None
         tpu_type = torch_xla.tpu.get_tpu_env()["TYPE"].lower()
-        if not tpu_type.endswith("lite"):
+        if "lite" not in tpu_type:
             if self.num_kv_heads % 2 == 0:
                 self.megacore_mode = "kv_head"
             else:


### PR DESCRIPTION
The current code does not correctly set the megacore for TPU-v5e-litepod. This PR fixes the bug. 