### PR TITLE
[Bugfix] Multinode hang fix with PP

### DIFF
--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -224,16 +224,13 @@ class RayGPUExecutor(DistributedGPUExecutor):
         # broadcasted to.
         self.non_driver_workers: List[RayWorkerWrapper] = []
 
-        for pp_rank in range(self.parallel_config.pipeline_parallel_size):
-            for tp_rank in range(self.parallel_config.tensor_parallel_size):
-                rank = (pp_rank *
-                        self.parallel_config.tensor_parallel_size) + tp_rank
-                if rank == 0:
-                    pass
-                elif rank % self.parallel_config.tensor_parallel_size == 0:
-                    self.tp_driver_workers.append(self.workers[rank - 1])
-                else:
-                    self.non_driver_workers.append(self.workers[rank - 1])
+        for idx, rank in enumerate(worker_ranks[1:]):
+            if rank == 0:
+                pass
+            elif rank % self.parallel_config.tensor_parallel_size == 0:
+                self.tp_driver_workers.append(self.workers[idx])
+            else:
+                self.non_driver_workers.append(self.workers[idx])
 
     def _driver_execute_model(
         self, execute_model_req: Optional[ExecuteModelRequest]

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -225,9 +225,9 @@ class RayGPUExecutor(DistributedGPUExecutor):
         self.non_driver_workers: List[RayWorkerWrapper] = []
 
         for idx, rank in enumerate(worker_ranks[1:]):
-            if rank == 0:
-                pass
-            elif rank % self.parallel_config.tensor_parallel_size == 0:
+            # We need to skip the driver worker, which we
+            # do by skipping worker_ranks[0] which is always 0.
+            if rank % self.parallel_config.tensor_parallel_size == 0:
                 self.tp_driver_workers.append(self.workers[idx])
             else:
                 self.non_driver_workers.append(self.workers[idx])


### PR DESCRIPTION
We needed to merge https://github.com/vllm-project/vllm/pull/6235 to allow for correct TP/PP rank assignment within a node. However, this caused our driver worker assignment to be out of sync now.

For TP = 2/PP = 2 case we previously had the following correspondence between ranks and workers.

```
Ranks   [0,  1,  2,  3]
Workers [W1, W2, W3, W4] 
```

We would then iterate through and infer the rank based on the index of the worker in the list. Therefore we would have W1, W3 be assigned as driver workers, which is ok as they correspond to Ranks 0, 2.

Now the ranks might be switched, i.e we can have the following:
```
Ranks   [0,  1,  3,  2]
Workers [W1, W2, W3, W4] 
```

In this case, we cannot have W1, W3 still be drivers, as this would cause deadlock. Rank 2 would have a `None` `execute_model_req` which would cause the workers to stop executing. Instead, we have to use `worker_ranks` to assign the correct workers W1 and W4 to the driver list.

cc: @youkaichao @aurickq  