### PR TITLE
[Bugfix] use float32 precision in samplers/test_logprobs.py for comparing with HF 

### DIFF
--- a/tests/samplers/test_logprobs.py
+++ b/tests/samplers/test_logprobs.py
@@ -11,7 +11,8 @@ MODELS = ["facebook/opt-125m"]
 
 
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("dtype",
+                         ["float"])  # needed for comparing logprobs with HF
 @pytest.mark.parametrize("chunked_prefill_token_size", [1, 4, 16, -1])
 @pytest.mark.parametrize("num_top_logprobs", [6])  # 32000 == vocab_size
 @pytest.mark.parametrize("detokenize", [True, False])

--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -687,6 +687,12 @@ if triton.__version__ >= "2.1.0":
 
         cap = current_platform.get_device_capability()
         BLOCK = 128 if cap[0] >= 8 else 64
+
+        # need to reduce num. blocks when using fp32
+        # due to increased use of GPU shared memory
+        if q.dtype == torch.float32:
+            BLOCK = BLOCK // 2
+
         # shape constraints
         Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
         assert Lq == Lk and Lk == Lv

--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -690,7 +690,7 @@ if triton.__version__ >= "2.1.0":
 
         # need to reduce num. blocks when using fp32
         # due to increased use of GPU shared memory
-        if q.dtype == torch.float32:
+        if q.dtype is torch.float32:
             BLOCK = BLOCK // 2
 
         # shape constraints


### PR DESCRIPTION
Fixes #6408 

This PR changes the precision in `tests/samplers/test_logprobs.py` from `half` to `float`. 

This is needed because the test is comparing the actual values of the logprobs against the equivalent outputs from HF. There is precedent established for doing this in other tests (see e.g., [here](https://github.com/vllm-project/vllm/blob/d80aef37764feda51e21065de9c669785fe1d94a/tests/models/test_models.py#L27) or [here](https://github.com/vllm-project/vllm/blob/d80aef37764feda51e21065de9c669785fe1d94a/tests/basic_correctness/test_preemption.py#L72)). 

This change ensures that the test does not fail on an H100 GPU. 