### PR TITLE
Pin sphinx-argparse version

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx==6.2.1
 sphinx-book-theme==1.0.1
 sphinx-copybutton==0.5.2
 myst-parser==2.0.0
-sphinx-argparse
+sphinx-argparse==0.4.0
 
 # packages to install to build the documentation
 pydantic


### PR DESCRIPTION
Pin to 0.4.0 due to 0.5.0 failing doc build on main: https://buildkite.com/vllm/ci-aws/builds/4946#0190b7c3-4ac2-41c4-9e11-c704a0830e08