### PR TITLE
[Misc] Log spec decode metrics

### DIFF
--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -192,8 +192,8 @@ def test_metric_spec_decode(
         # metrics instead of functional correctness, so the expected values
         # are intended to be loose.
         metric_name_to_expected_fn = {
-            "gauge_spec_decode_draft_acceptance_rate": lambda v: 0 < v <= 1,
-            "gauge_spec_decode_efficiency": lambda v: 0 < v <= 1,
+            "gauge_spec_decode_draft_acceptance_rate": lambda v: 0 <= v <= 1,
+            "gauge_spec_decode_efficiency": lambda v: 0 <= v <= 1,
             "counter_spec_decode_num_accepted_tokens": lambda v: 0 <= v <= k,
             "counter_spec_decode_num_draft_tokens": lambda v: v == k,
             "counter_spec_decode_num_emitted_tokens":

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -168,6 +168,52 @@ def test_engine_log_metrics_regression(
     assert_metrics(engine, disable_log_stats, len(example_prompts))
 
 
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("dtype", ["float"])
+@pytest.mark.parametrize("max_tokens", [10])
+def test_metric_spec_decode(
+    vllm_runner,
+    example_prompts,
+    model: str,
+    dtype: str,
+    max_tokens: int,
+) -> None:
+    k = 5
+
+    with vllm_runner(model,
+                     dtype=dtype,
+                     disable_log_stats=False,
+                     gpu_memory_utilization=0.4,
+                     speculative_model=model,
+                     num_speculative_tokens=k,
+                     use_v2_block_manager=True) as vllm_model:
+
+        # Note that the purpose of this test is to verify spec decode
+        # metrics instead of functional correctness, so the expected values
+        # are intended to be loose.
+        metric_name_to_expected_fn = {
+            "gauge_spec_decode_draft_acceptance_rate": lambda v: 0 < v <= 1,
+            "gauge_spec_decode_efficiency": lambda v: 0 < v <= 1,
+            "counter_spec_decode_num_accepted_tokens": lambda v: 0 <= v <= k,
+            "counter_spec_decode_num_draft_tokens": lambda v: v == k,
+            "counter_spec_decode_num_emitted_tokens":
+            lambda v: 0 <= v <= k + 1,
+        }
+
+        # Use one request to better inspect the metrics.
+        prompts = example_prompts[:1]
+
+        _ = vllm_model.generate_greedy(prompts, max_tokens)
+        stat_logger = vllm_model.model.llm_engine.stat_loggers['prometheus']
+        for metric_name, is_expected in metric_name_to_expected_fn.items():
+            metric_val = getattr(
+                stat_logger.metrics,
+                metric_name).labels(**stat_logger.labels)._value.get()
+            assert is_expected(metric_val), (
+                f"the value of metric {metric_name} ({metric_val}) "
+                "does not meet expectation")
+
+
 def assert_metrics(engine: LLMEngine, disable_log_stats: bool,
                    num_requests: int) -> None:
     if disable_log_stats:

--- a/tests/spec_decode/e2e/conftest.py
+++ b/tests/spec_decode/e2e/conftest.py
@@ -257,7 +257,7 @@ def run_greedy_equality_correctness_test(baseline_llm_generator,
                                          max_output_len,
                                          force_output_len: bool,
                                          print_tokens: bool = False,
-                                         encure_all_accepted: bool = False):
+                                         ensure_all_accepted: bool = False):
     """Helper method that compares the outputs of both the baseline LLM and
     the test LLM. It asserts greedy equality, e.g. that the outputs are exactly
     the same when temperature is zero.
@@ -309,5 +309,5 @@ def run_greedy_equality_correctness_test(baseline_llm_generator,
         print(f'{i=}     {spec_token_ids=}')
         assert baseline_token_ids == spec_token_ids
 
-    if encure_all_accepted:
+    if ensure_all_accepted:
         assert acceptance_rate == 1.0

--- a/tests/spec_decode/e2e/conftest.py
+++ b/tests/spec_decode/e2e/conftest.py
@@ -231,8 +231,8 @@ def get_output_from_llm_generator(
         tokens = [output.outputs[0].text for output in outputs]
 
         # Fetch acceptance rate if logging is enabled.
-        if llm.llm_engine.log_stats:
-            stat_logger = llm.llm_engine.stat_loggers["prometheus"]
+        if stat_loggers := getattr(llm.llm_engine, "stat_loggers", None):
+            stat_logger = stat_loggers["prometheus"]
             acceptance_rate = (stat_logger.metrics.
                                gauge_spec_decode_draft_acceptance_rate.labels(
                                    **stat_logger.labels)._value.get())

--- a/tests/spec_decode/e2e/test_multistep_correctness.py
+++ b/tests/spec_decode/e2e/test_multistep_correctness.py
@@ -151,8 +151,7 @@ def test_spec_decode_e2e_with_async_engine(test_llm_generator,
                                          test_llm_generator,
                                          batch_size,
                                          max_output_len=32,
-                                         force_output_len=True,
-                                         encure_all_accepted=True)
+                                         force_output_len=True)
 
 
 @pytest.mark.parametrize(
@@ -202,12 +201,14 @@ def test_spec_decode_e2e_greedy_correctness_tiny_model_bs1(
     Since this test is cheaper than other e2e correctness tests, we generate
     with a higher output_len.
     """
-    run_greedy_equality_correctness_test(baseline_llm_generator,
-                                         test_llm_generator,
-                                         batch_size,
-                                         max_output_len=output_len,
-                                         force_output_len=True,
-                                         encure_all_accepted=True)
+    encure_all_accepted = test_llm_generator.same_draft_target_model
+    run_greedy_equality_correctness_test(
+        baseline_llm_generator,
+        test_llm_generator,
+        batch_size,
+        max_output_len=output_len,
+        force_output_len=True,
+        encure_all_accepted=encure_all_accepted)
 
 
 @pytest.mark.parametrize(

--- a/tests/spec_decode/e2e/test_multistep_correctness.py
+++ b/tests/spec_decode/e2e/test_multistep_correctness.py
@@ -200,15 +200,18 @@ def test_spec_decode_e2e_greedy_correctness_tiny_model_bs1(
 
     Since this test is cheaper than other e2e correctness tests, we generate
     with a higher output_len.
+
+    When the draft model is the same as the target model, we further check
+    whether all speculative tokens are accepted.
     """
-    encure_all_accepted = test_llm_generator.same_draft_target_model
+    ensure_all_accepted = test_llm_generator.same_draft_target_model
     run_greedy_equality_correctness_test(
         baseline_llm_generator,
         test_llm_generator,
         batch_size,
         max_output_len=output_len,
         force_output_len=True,
-        encure_all_accepted=encure_all_accepted)
+        ensure_all_accepted=ensure_all_accepted)
 
 
 @pytest.mark.parametrize(

--- a/tests/spec_decode/e2e/test_multistep_correctness.py
+++ b/tests/spec_decode/e2e/test_multistep_correctness.py
@@ -97,7 +97,7 @@ def test_spec_decode_e2e_with_detokenization(test_llm_generator,
         temperature=temperature,
     )
 
-    batch_tokens, batch_token_ids = get_output_from_llm_generator(
+    batch_tokens, batch_token_ids, _ = get_output_from_llm_generator(
         test_llm_generator, prompts, sampling_params)
 
     # Expect a generation for each prompt in the batch.
@@ -151,7 +151,8 @@ def test_spec_decode_e2e_with_async_engine(test_llm_generator,
                                          test_llm_generator,
                                          batch_size,
                                          max_output_len=32,
-                                         force_output_len=True)
+                                         force_output_len=True,
+                                         encure_all_accepted=True)
 
 
 @pytest.mark.parametrize(
@@ -205,7 +206,8 @@ def test_spec_decode_e2e_greedy_correctness_tiny_model_bs1(
                                          test_llm_generator,
                                          batch_size,
                                          max_output_len=output_len,
-                                         force_output_len=True)
+                                         force_output_len=True,
+                                         encure_all_accepted=True)
 
 
 @pytest.mark.parametrize(

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -478,21 +478,21 @@ class PrometheusStatLogger(StatLoggerBase):
             self.num_generation_tokens = []
             self.last_local_log = stats.now
 
-        if stats.spec_decode_metrics is not None:
-            self._log_gauge(
-                self.metrics.gauge_spec_decode_draft_acceptance_rate,
-                stats.spec_decode_metrics.draft_acceptance_rate)
-            self._log_gauge(self.metrics.gauge_spec_decode_efficiency,
-                            stats.spec_decode_metrics.system_efficiency)
-            self._log_counter(
-                self.metrics.counter_spec_decode_num_accepted_tokens,
-                stats.spec_decode_metrics.accepted_tokens)
-            self._log_counter(
-                self.metrics.counter_spec_decode_num_draft_tokens,
-                stats.spec_decode_metrics.draft_tokens)
-            self._log_counter(
-                self.metrics.counter_spec_decode_num_emitted_tokens,
-                stats.spec_decode_metrics.emitted_tokens)
+            if stats.spec_decode_metrics is not None:
+                self._log_gauge(
+                    self.metrics.gauge_spec_decode_draft_acceptance_rate,
+                    stats.spec_decode_metrics.draft_acceptance_rate)
+                self._log_gauge(self.metrics.gauge_spec_decode_efficiency,
+                                stats.spec_decode_metrics.system_efficiency)
+                self._log_counter(
+                    self.metrics.counter_spec_decode_num_accepted_tokens,
+                    stats.spec_decode_metrics.accepted_tokens)
+                self._log_counter(
+                    self.metrics.counter_spec_decode_num_draft_tokens,
+                    stats.spec_decode_metrics.draft_tokens)
+                self._log_counter(
+                    self.metrics.counter_spec_decode_num_emitted_tokens,
+                    stats.spec_decode_metrics.emitted_tokens)
 
 
 class RayPrometheusStatLogger(PrometheusStatLogger):

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -133,6 +133,30 @@ class Metrics:
             documentation="Count of successfully processed requests.",
             labelnames=labelnames + [Metrics.labelname_finish_reason])
 
+        # Speculatie decoding stats
+        self.gauge_spec_decode_draft_acceptance_rate = self._base_library.Gauge(
+            name="vllm:spec_decode_draft_acceptance_rate",
+            documentation="Speulative token acceptance rate.",
+            labelnames=labelnames)
+        self.gauge_spec_decode_efficiency = self._base_library.Gauge(
+            name="vllm:spec_decode_efficiency",
+            documentation="Speculative decoding system efficiency.",
+            labelnames=labelnames)
+        self.counter_spec_decode_num_accepted_tokens = (
+            self._base_library.Counter(
+                name="vllm:spec_decode_num_accepted_tokens_total",
+                documentation="Number of accepted tokens.",
+                labelnames=labelnames))
+        self.counter_spec_decode_num_draft_tokens = self._base_library.Counter(
+            name="vllm:spec_decode_num_draft_tokens_total",
+            documentation="Number of draft tokens.",
+            labelnames=labelnames)
+        self.counter_spec_decode_num_emitted_tokens = (
+            self._base_library.Counter(
+                name="vllm:spec_decode_num_emitted_tokens_total",
+                documentation="Number of emitted tokens.",
+                labelnames=labelnames))
+
         # Deprecated in favor of vllm:prompt_tokens_total
         self.gauge_avg_prompt_throughput = self._base_library.Gauge(
             name="vllm:avg_prompt_throughput_toks_per_s",
@@ -453,6 +477,22 @@ class PrometheusStatLogger(StatLoggerBase):
             self.num_prompt_tokens = []
             self.num_generation_tokens = []
             self.last_local_log = stats.now
+
+        if stats.spec_decode_metrics is not None:
+            self._log_gauge(
+                self.metrics.gauge_spec_decode_draft_acceptance_rate,
+                stats.spec_decode_metrics.draft_acceptance_rate)
+            self._log_gauge(self.metrics.gauge_spec_decode_efficiency,
+                            stats.spec_decode_metrics.system_efficiency)
+            self._log_counter(
+                self.metrics.counter_spec_decode_num_accepted_tokens,
+                stats.spec_decode_metrics.accepted_tokens)
+            self._log_counter(
+                self.metrics.counter_spec_decode_num_draft_tokens,
+                stats.spec_decode_metrics.draft_tokens)
+            self._log_counter(
+                self.metrics.counter_spec_decode_num_emitted_tokens,
+                stats.spec_decode_metrics.emitted_tokens)
 
 
 class RayPrometheusStatLogger(PrometheusStatLogger):


### PR DESCRIPTION
This PR adds speculative decoding metrics to engine metrics so that they can be dumped and evaluated. Two unit tests were added accordingly:
1. In `test_metrics.py`, added a unit test to verify theres metrics are correctly logged.
2. In spec decode conftest, override log interval to 0 (log per request) to log all metrics, and check the acceptance rate to be 100% when target and draft morel are the same.

cc @cadedaniel @alexm-neuralmagic 