### PR TITLE
[CI/Build] Remove "boardwalk" image asset

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ def _read_prompts(filename: str) -> List[str]:
 class _ImageAssetPrompts(TypedDict):
     stop_sign: str
     cherry_blossom: str
-    boardwalk: str
 
 
 if sys.version_info < (3, 9):
@@ -58,7 +57,6 @@ class _ImageAssets(_ImageAssetsBase):
         super().__init__([
             ImageAsset("stop_sign"),
             ImageAsset("cherry_blossom"),
-            ImageAsset("boardwalk")
         ])
 
     def prompts(self, prompts: _ImageAssetPrompts) -> List[str]:
@@ -68,10 +66,7 @@ class _ImageAssets(_ImageAssetsBase):
         The order of the returned prompts matches the order of the
         assets when iterating through this object.
         """
-        return [
-            prompts["stop_sign"], prompts["cherry_blossom"],
-            prompts["boardwalk"]
-        ]
+        return [prompts["stop_sign"], prompts["cherry_blossom"]]
 
 
 IMAGE_ASSETS = _ImageAssets()

--- a/tests/models/test_fuyu.py
+++ b/tests/models/test_fuyu.py
@@ -12,8 +12,10 @@ from .utils import check_logprobs_close
 pytestmark = pytest.mark.vlm
 
 HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
-    "stop_sign": "What's the content of the image?\n",
-    "cherry_blossom": "What is the season?\n",
+    "stop_sign":
+    "What's the content of the image?\n",
+    "cherry_blossom":
+    "What is the season?\n",
 })
 
 models = ["adept/fuyu-8b"]

--- a/tests/models/test_fuyu.py
+++ b/tests/models/test_fuyu.py
@@ -12,9 +12,8 @@ from .utils import check_logprobs_close
 pytestmark = pytest.mark.vlm
 
 HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
-    "stop_sign": "What's the content of the image?\n",  # noqa: E501
+    "stop_sign": "What's the content of the image?\n",
     "cherry_blossom": "What is the season?\n",
-    "boardwalk": "What's in this image?\n",
 })
 
 models = ["adept/fuyu-8b"]

--- a/tests/models/test_llava.py
+++ b/tests/models/test_llava.py
@@ -16,8 +16,6 @@ HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
     "USER: <image>\nWhat's the content of the image?\nASSISTANT:",
     "cherry_blossom":
     "USER: <image>\nWhat is the season?\nASSISTANT:",
-    "boardwalk":
-    "USER: <image>\nWhat's in this image?\nASSISTANT:",
 })
 
 IMAGE_TOKEN_ID = 32000

--- a/tests/models/test_llava_next.py
+++ b/tests/models/test_llava_next.py
@@ -23,8 +23,6 @@ HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
     f"{_PREFACE} USER: <image>\nWhat's the content of the image? ASSISTANT:",
     "cherry_blossom":
     f"{_PREFACE} USER: <image>\nWhat is the season? ASSISTANT:",
-    "boardwalk":
-    f"{_PREFACE} USER: <image>\nWhat's in this image? ASSISTANT:",
 })
 
 IMAGE_TOKEN_ID = 32000

--- a/tests/models/test_paligemma.py
+++ b/tests/models/test_paligemma.py
@@ -14,7 +14,6 @@ pytestmark = pytest.mark.vlm
 HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
     "stop_sign": "caption es",
     "cherry_blossom": "What is in the picture?",
-    "boardwalk": "What is in the picture?",
 })
 
 IMAGE_TOKEN_ID = 257152

--- a/tests/models/test_paligemma.py
+++ b/tests/models/test_paligemma.py
@@ -12,8 +12,10 @@ from .utils import check_logprobs_close
 pytestmark = pytest.mark.vlm
 
 HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
-    "stop_sign": "caption es",
-    "cherry_blossom": "What is in the picture?",
+    "stop_sign":
+    "caption es",
+    "cherry_blossom":
+    "What is in the picture?",
 })
 
 IMAGE_TOKEN_ID = 257152

--- a/tests/models/test_phi3v.py
+++ b/tests/models/test_phi3v.py
@@ -18,8 +18,6 @@ HF_IMAGE_PROMPTS = IMAGE_ASSETS.prompts({
     "<|user|>\n<|image_1|>\nWhat's the content of the image?<|end|>\n<|assistant|>\n",  # noqa: E501
     "cherry_blossom":
     "<|user|>\n<|image_1|>\nWhat is the season?<|end|>\n<|assistant|>\n",
-    "boardwalk":
-    "<|user|>\n<|image_1|>\nWhat's in this image?<|end|>\n<|assistant|>\n",
 })
 
 models = ["microsoft/Phi-3-vision-128k-instruct"]

--- a/vllm/assets/image.py
+++ b/vllm/assets/image.py
@@ -1,12 +1,10 @@
 import shutil
 from dataclasses import dataclass
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from typing import Literal
 
 import requests
 from PIL import Image
-
-from vllm.multimodal.utils import fetch_image
 
 from .base import get_cache_dir
 
@@ -35,13 +33,8 @@ def get_air_example_data_2_asset(filename: str) -> Image.Image:
 
 @dataclass(frozen=True)
 class ImageAsset:
-    name: Literal["stop_sign", "cherry_blossom", "boardwalk"]
+    name: Literal["stop_sign", "cherry_blossom"]
 
-    @cached_property
+    @property
     def pil_image(self) -> Image.Image:
-        if self.name == "boardwalk":
-            return fetch_image(
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
-            )
-
         return get_air_example_data_2_asset(f"{self.name}.jpg")


### PR DESCRIPTION
Following #6339, it is no longer necessary to test the "boardwalk" image asset (it was originally added due to causing errors in feature size calculations). This should reduce the running time of related tests by around a third.

cc @xwjiang2010 