### PR TITLE
[misc][distributed] improve tests

### DIFF
--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -4,12 +4,14 @@ from ..utils import RemoteOpenAIServer
 
 
 @pytest.mark.parametrize(
-    "TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, MODEL_NAME", [
+    "TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, MODEL_NAME",
+    [
         (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B"),
         (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B"),
         (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B"),
-        (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B"),
-        (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B"),
+        # TODO: figure out why PP=4 tests are flaky
+        # (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B"),
+        # (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B"),
     ])
 def test_compare_tp(TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, MODEL_NAME):
     pp_args = [

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -170,7 +170,7 @@ class MessageQueue:
         self.n_remote_reader = n_remote_reader
 
         if connect_ip is None:
-            connect_ip = get_ip()
+            connect_ip = get_ip() if n_remote_reader > 0 else "127.0.0.1"
 
         context = Context()
 
@@ -229,6 +229,8 @@ class MessageQueue:
             remote_subscribe_port=remote_subscribe_port,
             remote_sync_port=remote_sync_port,
         )
+
+        logger.info("vLLM message queue communication handle: %s", self.handle)
 
     def export_handle(self) -> Handle:
         return self.handle


### PR DESCRIPTION
PP=4 tests tends to be quite flaky. before @andoorve fixes it, let's turn off the test first.

in addition, I get reports about zmq connection issue https://github.com/vllm-project/vllm/issues/6355#issuecomment-2231892582 , so let's add more info about this. possibly this is the cause of some test hangs.