### PR TITLE
[BugFix] Avoid secondary error in ShmRingBuffer destructor

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -119,9 +119,10 @@ class ShmRingBuffer:
         )
 
     def __del__(self):
-        self.shared_memory.close()
-        if self.is_creator:
-            self.shared_memory.unlink()
+        if hasattr(self, "shared_memory"):
+            self.shared_memory.close()
+            if self.is_creator:
+                self.shared_memory.unlink()
 
     @contextmanager
     def get_data(self, current_idx: int):
@@ -428,7 +429,6 @@ class MessageQueue:
 
     def dequeue(self):
         if self._is_local_reader:
-            overflow = False
             with self.acquire_read() as buf:
                 overflow = buf[0] == 1
                 if not overflow:


### PR DESCRIPTION
If there is an error setting up the shared memory in the ShmRingBuffer initializer, the destructor will raise an additional error:
```
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m Exception ignored in: <function ShmRingBuffer.__del__ at 0x7f6ce44258a0>
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m Traceback (most recent call last):
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m   File "/opt/vllm/lib64/python3.11/site-packages/vllm/distributed/device_communicators/shm_broadcast.py", line 122, in __del__
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m     self.shared_memory.close()
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m     ^^^^^^^^^^^^^^^^^^
[36m(RayWorkerWrapper pid=371, ip=10.128.21.6)[0m AttributeError: 'ShmRingBuffer' object has no attribute 'shared_memory'
```

