### PR TITLE
[Model] Support Mistral-Nemo

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -89,6 +89,7 @@ class LlamaAttention(nn.Module):
 
     def __init__(
         self,
+        config: LlamaConfig,
         hidden_size: int,
         num_heads: int,
         num_kv_heads: int,
@@ -115,7 +116,9 @@ class LlamaAttention(nn.Module):
             # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
         self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
-        self.head_dim = hidden_size // self.total_num_heads
+        # MistralConfig has an optional head_dim introduced by Mistral-Nemo
+        self.head_dim = getattr(config, "head_dim",
+                                self.hidden_size // self.total_num_heads)
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
@@ -189,6 +192,7 @@ class LlamaDecoderLayer(nn.Module):
         attention_bias = getattr(config, "attention_bias", False) or getattr(
             config, "bias", False)
         self.self_attn = LlamaAttention(
+            config=config,
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
             num_kv_heads=getattr(config, "num_key_value_heads",


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/6545

Patch was ported from https://github.com/huggingface/transformers/pull/32050

Essentially there was a new `head_dim` override added to MistralConfig. We will look for that optional argument in the config and default to the previous `self.hidden_size // self.total_num_heads` behavior.

We have also produced and validated a FP8 quantized checkpoint: https://huggingface.co/neuralmagic/Mistral-Nemo-Instruct-2407-FP8

```python
>>> from vllm import LLM
>>> model = LLM("mistralai/Mistral-Nemo-Instruct-2407", max_model_len=4096)
>>> model.generate("Hello!")
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  4.79it/s, est. speed input: 19.19 toks/s, output: 76.75 toks/s]
[RequestOutput(request_id=0, prompt='Hello!', prompt_token_ids=[1, 22177, 1033, 2], prompt_logprobs=None, outputs=[CompletionOutput(index=0, text='Hello! How can I assist you today? Let me know if you have any', token_ids=(22177, 1033, 3075, 1710, 1362, 10410, 1636, 9406, 1063, 9246, 1639, 2840, 1693, 1636, 1736, 2258), cumulative_logprob=-1.838211446563946, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=RequestMetrics(arrival_time=1721321536.0599637, last_token_time=1721321536.0599637, first_scheduled_time=1721321536.0735824, first_token_time=1721321536.111321, time_in_queue=0.013618707656860352, finished_time=1721321536.2816722), lora_request=None)]
```

Note that by default it will use a very large model length (128k) and may need `max_model_len` to be specified.