### PR TITLE
[Bugfix] [SpecDecode] AsyncMetricsCollector: update time since last collection

### DIFF
--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -145,6 +145,10 @@ class AsyncMetricsCollector:
         """
 
         ready_event.synchronize()
+
+        # update time of last collection
+        self._last_metrics_collect_time = self._timer()
+
         accepted_tokens = self._aggregate_num_accepted_tokens.item()
         emitted_tokens = self._aggregate_num_emitted_tokens.item()
         draft_tokens = self._aggregate_num_draft_tokens


### PR DESCRIPTION
Fix #6577 

IDK if I misunderstood something here, but looks like we basically sync the metrics every time (unless one is in-flight) and don't respect the `collect_interval_s` after the very first collection. 

cc @cadedaniel @njhill 


