### PR TITLE
[Bugfix][Core] Output sampling: heuristic to choose between candidates

### DIFF
--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -113,7 +113,7 @@ class RequestOutput:
                 sorting_key = lambda seq: seq.get_beam_search_score(
                     seq_group.sampling_params.length_penalty)
             else:
-                sorting_key = lambda seq: seq.get_cumulative_logprob()
+                sorting_key = lambda seq: seq.get_averaged_logprob()
             sorted_seqs = sorted(seqs, key=sorting_key, reverse=True)
             top_n_seqs = sorted_seqs[:n]
 

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -113,7 +113,7 @@ class RequestOutput:
                 sorting_key = lambda seq: seq.get_beam_search_score(
                     seq_group.sampling_params.length_penalty)
             else:
-                sorting_key = lambda seq: seq.get_averaged_logprob()
+                sorting_key = lambda seq: seq.get_average_logprob()
             sorted_seqs = sorted(seqs, key=sorting_key, reverse=True)
             top_n_seqs = sorted_seqs[:n]
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -354,6 +354,9 @@ class Sequence:
     def get_cumulative_logprob(self) -> float:
         return self.data.cumulative_logprob
 
+    def get_averaged_logprob(self) -> float:
+        return self.data.cumulative_logprob / self.get_len()
+
     def get_beam_search_score(self,
                               length_penalty: float = 1.0,
                               seq_len: Optional[int] = None,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -354,7 +354,7 @@ class Sequence:
     def get_cumulative_logprob(self) -> float:
         return self.data.cumulative_logprob
 
-    def get_averaged_logprob(self) -> float:
+    def get_average_logprob(self) -> float:
         return self.data.cumulative_logprob / self.get_len()
 
     def get_beam_search_score(self,


### PR DESCRIPTION
In the `RequestOutput` class in `outputs.py`, when beam search is not being used, VLLM samples from the best-of generated candidates with the `cumulative_logprob` heuristic. Given that log_probs are negative and then we sample from these candidates from highest (closest to zero) to smallest (farthest from zero), the chosen solutions would bias towards shorter sequences. A better heuristic would likely be to average out the cumulative log_probs by the sequence length as suggested in this PR.

Validation: running some quality-based benchmarks would be helpful in assessing the effectiveness of this change. Are there any which are already built into VLLM?