### PR TITLE
Add FP8 quantization `ignored_layers` support in llama

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -32,6 +32,7 @@ class Fp8Config(QuantizationConfig):
         self,
         is_checkpoint_fp8_serialized: bool = False,
         activation_scheme: str = "dynamic",
+        ignored_layers: Optional[List[str]] = None,
     ) -> None:
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         if is_checkpoint_fp8_serialized:
@@ -41,6 +42,7 @@ class Fp8Config(QuantizationConfig):
             raise ValueError(
                 f"Unsupported activation scheme {activation_scheme}")
         self.activation_scheme = activation_scheme
+        self.ignored_layers = ignored_layers or []
 
     @classmethod
     def get_name(cls) -> str:
@@ -63,8 +65,9 @@ class Fp8Config(QuantizationConfig):
         quant_method = cls.get_from_keys(config, ["quant_method"])
         is_checkpoint_fp8_serialized = ("fp8" in quant_method)
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
+        ignored_layers = cls.get_from_keys(config, ["ignored_layers"])
         return cls(is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
-                   activation_scheme=activation_scheme)
+                   activation_scheme=activation_scheme, ignored_layers=ignored_layers)
 
     def get_quant_method(
             self, layer: torch.nn.Module) -> Optional["QuantizeMethodBase"]:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -67,7 +67,8 @@ class Fp8Config(QuantizationConfig):
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
         ignored_layers = cls.get_from_keys(config, ["ignored_layers"])
         return cls(is_checkpoint_fp8_serialized=is_checkpoint_fp8_serialized,
-                   activation_scheme=activation_scheme, ignored_layers=ignored_layers)
+                   activation_scheme=activation_scheme,
+                   ignored_layers=ignored_layers)
 
     def get_quant_method(
             self, layer: torch.nn.Module) -> Optional["QuantizeMethodBase"]:

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -65,7 +65,9 @@ class LlamaMLP(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
-        ignored_gate_up_proj = all(p in quant_config.ignored_layers for p in [f"{prefix}.gate_proj", f"{prefix}.up_proj"])
+        ignored_gate_up_proj = all(
+            p in quant_config.ignored_layers
+            for p in [f"{prefix}.gate_proj", f"{prefix}.up_proj"])
         self.gate_up_proj = MergedColumnParallelLinear(
             input_size=hidden_size,
             output_sizes=[intermediate_size] * 2,
@@ -73,11 +75,12 @@ class LlamaMLP(nn.Module):
             quant_config=quant_config if not ignored_gate_up_proj else None,
             prefix=f"{prefix}.gate_up_proj")
         ignore_down_proj = f"{prefix}.down_proj" in quant_config.ignored_layers
-        self.down_proj = RowParallelLinear(input_size=intermediate_size,
-                                           output_size=hidden_size,
-                                           bias=bias,
-                                           quant_config=quant_config if not ignore_down_proj else None,
-                                           prefix=f"{prefix}.down_proj")
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            bias=bias,
+            quant_config=quant_config if not ignore_down_proj else None,
+            prefix=f"{prefix}.down_proj")
         if hidden_act != "silu":
             raise ValueError(f"Unsupported activation: {hidden_act}. "
                              "Only silu is supported for now.")
@@ -130,7 +133,9 @@ class LlamaAttention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
-        ignore_qkv_proj = all(p in quant_config.ignored_layers for p in [f"{prefix}.q_proj",  f"{prefix}.k_proj", f"{prefix}.v_proj"]) 
+        ignore_qkv_proj = all(
+            p in quant_config.ignored_layers for p in
+            [f"{prefix}.q_proj", f"{prefix}.k_proj", f"{prefix}.v_proj"])
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size=hidden_size,
@@ -141,7 +146,7 @@ class LlamaAttention(nn.Module):
             quant_config=quant_config if not ignore_qkv_proj else None,
             prefix=f"{prefix}.qkv_proj",
         )
-        ignore_o_proj = f"{prefix}.o_proj" in quant_config.ignored_layers 
+        ignore_o_proj = f"{prefix}.o_proj" in quant_config.ignored_layers
         self.o_proj = RowParallelLinear(
             input_size=self.total_num_heads * self.head_dim,
             output_size=hidden_size,
@@ -149,7 +154,7 @@ class LlamaAttention(nn.Module):
             quant_config=quant_config if not ignore_o_proj else None,
             prefix=f"{prefix}.o_proj",
         )
-        
+
         self.rotary_emb = get_rope(
             self.head_dim,
             rotary_dim=self.head_dim,


### PR DESCRIPTION
Summary:
https://github.com/neuralmagic/AutoFP8 supports "ignored_layers" in quantization and the saved out "quantization_config" has the information. E.g., 
```  
"quantization_config": {
    "activation_scheme": "dynamic",
    "ignored_layers": [
        "model.layers.0.self_attn.q_proj",
        "model.layers.0.self_attn.k_proj",
        "model.layers.0.self_attn.v_proj",
        "model.layers.0.self_attn.o_proj"
      ],
     "quant_method": "fp8"
 },
```
does not quantize the self attention module in the first layer.

However vLLM currently does not respect the  "ignored_layers" field and applies uniform quantization to all the modules in all layers. 
https://github.com/vllm-project/vllm/pull/6515 added non-uniform support for quantization through `compressed-tensors`. This PR adds the support for  "ignored_layers" in Llama models and leverage the `prefix` params added in  https://github.com/vllm-project/vllm/pull/6515.