### PR TITLE
[Misc] Add a wrapper for torch.inference_mode

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -2,7 +2,9 @@ from typing import Optional
 
 import torch
 
-from .interface import Platform, PlatformEnum
+from vllm.utils import is_tpu
+
+from .interface import Platform, PlatformEnum, UnspecifiedPlatform
 
 current_platform: Optional[Platform]
 
@@ -12,7 +14,10 @@ if torch.version.cuda is not None:
 elif torch.version.hip is not None:
     from .rocm import RocmPlatform
     current_platform = RocmPlatform()
+elif is_tpu():
+    from .tpu import TpuPlatform
+    current_platform = TpuPlatform()
 else:
-    current_platform = None
+    current_platform = UnspecifiedPlatform()
 
 __all__ = ['Platform', 'PlatformEnum', 'current_platform']

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1,10 +1,14 @@
 import enum
 from typing import Tuple
 
+import torch
+
 
 class PlatformEnum(enum.Enum):
     CUDA = enum.auto()
     ROCM = enum.auto()
+    TPU = enum.auto()
+    UNSPECIFIED = enum.auto()
 
 
 class Platform:
@@ -16,6 +20,23 @@ class Platform:
     def is_rocm(self) -> bool:
         return self._enum == PlatformEnum.ROCM
 
+    def is_tpu(self) -> bool:
+        return self._enum == PlatformEnum.TPU
+
     @staticmethod
     def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
         raise NotImplementedError
+
+    @staticmethod
+    def inference_mode():
+        """A device-specific wrapper of `torch.inference_mode`.
+
+        This wrapper is recommended because some hardware backends such as TPU
+        do not support `torch.inference_mode`. In such a case, this class falls
+        back to `torch.no_grad`.
+        """
+        return torch.inference_mode(mode=True)
+
+
+class UnspecifiedPlatform(Platform):
+    _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -32,8 +32,8 @@ class Platform:
         """A device-specific wrapper of `torch.inference_mode`.
 
         This wrapper is recommended because some hardware backends such as TPU
-        do not support `torch.inference_mode`. In such a case, this class falls
-        back to `torch.no_grad`.
+        do not support `torch.inference_mode`. In such a case, they will fall
+        back to `torch.no_grad` by overriding this method.
         """
         return torch.inference_mode(mode=True)
 

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -1,0 +1,17 @@
+from typing import Tuple
+
+import torch
+
+from .interface import Platform, PlatformEnum
+
+
+class TpuPlatform(Platform):
+    _enum = PlatformEnum.TPU
+
+    @staticmethod
+    def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
+        raise RuntimeError("TPU does not have device capability.")
+
+    @staticmethod
+    def inference_mode():
+        return torch.no_grad()

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -897,20 +897,6 @@ def error_on_invalid_device_count_status():
                 "CUDA_VISIBLE_DEVICES to the GPUs you want to use.")
 
 
-def inference_mode():
-    """A device-agnostic wrapper of `torch.inference_mode`.
-
-    This wrapper is recommended because some hardware backends such as TPU
-    do not support `torch.inference_mode`. In such a case, this class falls
-    back to `torch.no_grad`.
-    """
-    if is_tpu():
-        # Fall back to `torch.no_grad()`.
-        return torch.no_grad()
-    else:
-        return torch.inference_mode(mode=True)
-
-
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,
 # all the related functions work on real physical device ids.

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -923,7 +923,7 @@ class inference_mode(torch.inference_mode):
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if self.use_inference_mode:
-            super().__init__(exc_type, exc_value, traceback)
+            super().__exit__(exc_type, exc_value, traceback)
         else:
             torch.set_grad_enabled(self.prev)
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -897,6 +897,37 @@ def error_on_invalid_device_count_status():
                 "CUDA_VISIBLE_DEVICES to the GPUs you want to use.")
 
 
+class inference_mode(torch.inference_mode):
+    """A device-agnostic wrapper of `torch.inference_mode`.
+
+    This wrapper is recommended because some hardware backends such as TPU
+    do not support `torch.inference_mode`. In such as case, this class falls
+    back to `torch.no_grad`.
+    """
+
+    def __init__(self, mode: bool = True) -> None:
+        self.use_inference_mode = not is_tpu()
+        if self.use_inference_mode:
+            super().__init__(mode)
+        else:
+            # Fall back to torch.no_grad().
+            self.prev = False
+            self.mode = mode
+
+    def __enter__(self) -> None:
+        if self.use_inference_mode:
+            super().__enter__()
+        else:
+            self.prev = torch.is_grad_enabled()
+            torch.set_grad_enabled(False)
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        if self.use_inference_mode:
+            super().__init__(exc_type, exc_value, traceback)
+        else:
+            torch.set_grad_enabled(self.prev)
+
+
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,
 # all the related functions work on real physical device ids.

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -897,35 +897,18 @@ def error_on_invalid_device_count_status():
                 "CUDA_VISIBLE_DEVICES to the GPUs you want to use.")
 
 
-class inference_mode(torch.inference_mode):
+def inference_mode():
     """A device-agnostic wrapper of `torch.inference_mode`.
 
     This wrapper is recommended because some hardware backends such as TPU
-    do not support `torch.inference_mode`. In such as case, this class falls
+    do not support `torch.inference_mode`. In such a case, this class falls
     back to `torch.no_grad`.
     """
-
-    def __init__(self, mode: bool = True) -> None:
-        self.use_inference_mode = not is_tpu()
-        if self.use_inference_mode:
-            super().__init__(mode)
-        else:
-            # Fall back to torch.no_grad().
-            self.prev = False
-            self.mode = mode
-
-    def __enter__(self) -> None:
-        if self.use_inference_mode:
-            super().__enter__()
-        else:
-            self.prev = torch.is_grad_enabled()
-            torch.set_grad_enabled(False)
-
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        if self.use_inference_mode:
-            super().__exit__(exc_type, exc_value, traceback)
-        else:
-            torch.set_grad_enabled(self.prev)
+    if is_tpu():
+        # Fall back to `torch.no_grad()`.
+        return torch.no_grad()
+    else:
+        return torch.inference_mode(mode=True)
 
 
 # NVML utils

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -5,9 +5,9 @@ from typing import (TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type,
 
 import torch
 
+from vllm.platforms import current_platform
 from vllm.sequence import (IntermediateTensors, SamplerOutput,
                            SequenceGroupMetadata)
-from vllm.utils import inference_mode
 
 if TYPE_CHECKING:
     from vllm.attention import AttentionMetadata
@@ -164,7 +164,7 @@ class ModelRunnerBase(ABC, Generic[T]):
         """
         raise NotImplementedError
 
-    @inference_mode()
+    @current_platform.inference_mode()
     def execute_model(
         self,
         model_input: T,

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -7,6 +7,7 @@ import torch
 
 from vllm.sequence import (IntermediateTensors, SamplerOutput,
                            SequenceGroupMetadata)
+from vllm.utils import inference_mode
 
 if TYPE_CHECKING:
     from vllm.attention import AttentionMetadata
@@ -163,7 +164,7 @@ class ModelRunnerBase(ABC, Generic[T]):
         """
         raise NotImplementedError
 
-    @torch.inference_mode()
+    @inference_mode()
     def execute_model(
         self,
         model_input: T,

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -9,9 +9,10 @@ import torch
 from vllm.distributed import broadcast_tensor_dict, get_pp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
 from vllm.sequence import (ExecuteModelRequest, IntermediateTensors,
                            SamplerOutput)
-from vllm.utils import (enable_trace_function_call_for_thread, inference_mode,
+from vllm.utils import (enable_trace_function_call_for_thread,
                         update_environment_variables)
 from vllm.worker.model_runner_base import ModelRunnerBase, ModelRunnerInputBase
 
@@ -53,7 +54,7 @@ class WorkerBase(ABC):
         """
         raise NotImplementedError
 
-    @inference_mode()
+    @current_platform.inference_mode()
     def start_worker_execution_loop(self) -> None:
         """Execute model loop in parallel worker.
 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -11,7 +11,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.sequence import (ExecuteModelRequest, IntermediateTensors,
                            SamplerOutput)
-from vllm.utils import (enable_trace_function_call_for_thread,
+from vllm.utils import (enable_trace_function_call_for_thread, inference_mode,
                         update_environment_variables)
 from vllm.worker.model_runner_base import ModelRunnerBase, ModelRunnerInputBase
 
@@ -53,7 +53,7 @@ class WorkerBase(ABC):
         """
         raise NotImplementedError
 
-    @torch.inference_mode()
+    @inference_mode()
     def start_worker_execution_loop(self) -> None:
         """Execute model loop in parallel worker.
 


### PR DESCRIPTION
`torch.inference_mode` is not supported by some hardware backends such as TPU. To address this, this PR introduces a wrapper class that falls back to `torch.no_grad` for the unsupported backends.