### PR TITLE
[Bugfix] Fix `vocab_size` field access in LLaVA models

### DIFF
--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -155,7 +155,8 @@ class LlavaForConditionalGeneration(nn.Module, SupportsVision):
             quant_config=quant_config)
         logit_scale = getattr(config, "logit_scale", 1.0)
         self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
+                                                config.text_config.vocab_size,
+                                                logit_scale)
         self.sampler = Sampler()
 
     def _validate_pixel_values(self, data: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -248,8 +248,9 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsVision):
             org_num_embeddings=self.language_model.org_vocab_size,
             quant_config=quant_config)
         logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(
-            self.unpadded_vocab_size, config.text_config.vocab_size, logit_scale)
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.text_config.vocab_size,
+                                                logit_scale)
         self.sampler = Sampler()
 
         self.image_newline = nn.Parameter(

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -248,8 +248,8 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsVision):
             org_num_embeddings=self.language_model.org_vocab_size,
             quant_config=quant_config)
         logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
+        self.logits_processor = LogitsProcessor(
+            self.unpadded_vocab_size, config.text_config.vocab_size, logit_scale)
         self.sampler = Sampler()
 
         self.image_newline = nn.Parameter(


### PR DESCRIPTION
For VLMs, `config.vocab_size` is on its way to deprecation; now `config.text_config.vocab_size` should be used.
HuggingFace people went ahead and completely moved `vocab_size` into `text_config` in the configuration of `llava-hf/llama3-llava-next-8b-hf` ([ref](https://huggingface.co/llava-hf/llama3-llava-next-8b-hf/blob/2844b9a018f6eed5b773121d47590465c96b19fb/config.json#L45)), and vLLM hits an attribute access error when it's trying to load the model:

```
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/loader.py", line 104, in _initialize_model
[rank0]:     return model_class(config=model_config.hf_config,
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/llava_next.py", line 252, in __init__
[rank0]:     config.vocab_size, logit_scale)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformers/configuration_utils.py", line 264, in __getattribute__
[rank0]:     return super().__getattribute__(key)
[rank0]: AttributeError: 'LlavaNextConfig' object has no attribute 'vocab_size'
```