### PR TITLE
[Kernel] Add dynamic asymmetric quantization kernel

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -149,7 +149,8 @@ void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor const& scale);
 
 void dynamic_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
-                               torch::Tensor& scales, c10::optional<torch::Tensor> const& azp);
+                               torch::Tensor& scales,
+                               c10::optional<torch::Tensor> const& azp);
 
 void squeezellm_gemm(torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
                      torch::Tensor lookup_table);

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -146,7 +146,8 @@ torch::Tensor marlin_qqq_gemm(torch::Tensor const& a,
 #endif
 
 void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
-                              torch::Tensor const& scale);
+                              torch::Tensor const& scale,
+                              c10::optional<torch::Tensor> const& azp);
 
 void dynamic_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
                                torch::Tensor& scales,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -149,7 +149,7 @@ void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor const& scale);
 
 void dynamic_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
-                               torch::Tensor& scales);
+                               torch::Tensor& scales, c10::optional<torch::Tensor> const& azp);
 
 void squeezellm_gemm(torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
                      torch::Tensor lookup_table);

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -134,7 +134,7 @@ __global__ void dynamic_scaled_int8_azp_quant_kernel(
   if (threadIdx.x == 0) {
     float const scale_val = (max_val - min_val) / 255.0f;
     // Use rounding to even (same as torch.round)
-    auto const azp_float = std::nearbyint(min_val / scale_val + 128.0f);
+    auto const azp_float = std::nearbyint(-128.0f - min_val / scale_val);
     auto const azp_val = static_cast<azp_type>(azp_float);
 
     // Store the scale and azp into shared and global
@@ -152,7 +152,7 @@ __global__ void dynamic_scaled_int8_azp_quant_kernel(
   for (int i = threadIdx.x; i < hidden_size; i += blockDim.x) {
     auto const val = static_cast<float>(input[token_idx * hidden_size + i]);
     auto const quant_val =
-        int32_to_int8(float_to_int32_rn(val / scale_val) - azp_val);
+        int32_to_int8(float_to_int32_rn(val / scale_val) + azp_val);
     out[token_idx * hidden_size + i] = quant_val;
   }
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -239,7 +239,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Compute int8 quantized tensor and scaling factor
   ops.def(
-      "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale) -> "
+      "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, Tensor!? azp) -> "
       "()");
   ops.impl("dynamic_scaled_int8_quant", torch::kCUDA,
            &dynamic_scaled_int8_quant);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -233,15 +233,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Compute int8 quantized tensor for given scaling factor.
   ops.def(
-      "static_scaled_int8_quant(Tensor! out, Tensor input, Tensor scale) -> "
-      "()");
+      "static_scaled_int8_quant(Tensor! out, Tensor input, Tensor scale,"
+      "Tensor? azp) -> ()");
   ops.impl("static_scaled_int8_quant", torch::kCUDA, &static_scaled_int8_quant);
 
   // Compute int8 quantized tensor and scaling factor
   ops.def(
       "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, "
-      "Tensor!? azp) -> "
-      "()");
+      "Tensor!? azp) -> ()");
   ops.impl("dynamic_scaled_int8_quant", torch::kCUDA,
            &dynamic_scaled_int8_quant);
 }

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -239,7 +239,8 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // Compute int8 quantized tensor and scaling factor
   ops.def(
-      "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, Tensor!? azp) -> "
+      "dynamic_scaled_int8_quant(Tensor! out, Tensor input, Tensor! scale, "
+      "Tensor!? azp) -> "
       "()");
   ops.impl("dynamic_scaled_int8_quant", torch::kCUDA,
            &dynamic_scaled_int8_quant);

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -5,7 +5,7 @@ from tests.kernels.quant_utils import ref_dynamic_per_token_quant
 from vllm._custom_ops import scaled_int8_quant
 
 DTYPES = [torch.float]
-HIDDEN_SIZES = [16, 32, 64, 67, 128, 768, 2048, 5120, 5137, 8192,
+HIDDEN_SIZES = [16, 67, 768, 2048, 5120, 5137, 8192,
                 8193]  # Arbitrary values for testing
 NUM_TOKENS = [1, 7, 83, 4096, 16384]  # Arbitrary values for testing
 SEEDS = [0]

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -52,11 +52,6 @@ def test_dynamic_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
     # calculate scale and azp, and adjust the range
     scales = (x_token_max - x_token_min) / torch.tensor(255.0)
     azps = torch.round(x_token_min / scales + 128.0).to(torch.int32)
-    min_nozp, max_nozp = azps - 128.0, azps + 127.0
-
-    # for all elements that are 0, make result equal to scale
-    no_div_by_zero = lambda x, div: torch.where(div == 0, scales, x / div)
-    scales = torch.max(no_div_by_zero(x_token_max, max_nozp), no_div_by_zero(x_token_min, min_nozp))
 
     torch_out = (x / scales - azps).round().to(torch.int8)
     assert torch_out.min() >= int8_traits.min and torch_out.max() <= int8_traits.max

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -112,7 +112,7 @@ def test_static_scaled_int8_quant(num_tokens: int, hidden_size: int,
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("seed", SEEDS)
-@pytest.mark.parametrize("scale", SCALE[2:]) # Fewer scales to reduce test time
+@pytest.mark.parametrize("scale", SCALE[2:])  # Reduce test time
 @pytest.mark.parametrize("azp", [-255, 54])
 @torch.inference_mode()
 def test_static_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -62,7 +62,7 @@ def test_dynamic_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
     scales = (x_token_max - x_token_min) / torch.tensor(255.0)
     azps = torch.round(x_token_min / scales + 128.0).to(torch.int32)
 
-    torch_out = (x / scales - azps).round().to(torch.int8)
+    torch_out = (x / scales - azps).round().clamp(int8_traits.min, int8_traits.max).to(torch.int8)
     assert torch_out.min() >= int8_traits.min and torch_out.max() <= int8_traits.max
 
     ops_out = torch.empty_like(x, dtype=torch.int8)

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -65,9 +65,9 @@ def test_dynamic_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
 
     # calculate scale and azp, and adjust the range
     scales = (x_token_max - x_token_min) / torch.tensor(255.0)
-    azps = torch.round(x_token_min / scales + 128.0).to(torch.int32)
+    azps = torch.round(-128.0 - x_token_min / scales).to(torch.int32)
 
-    torch_out = (x / scales - azps).round().clamp(
+    torch_out = (x / scales + azps).round().clamp(
         int8_traits.min, int8_traits.max).to(torch.int8)
     assert torch_out.min() >= int8_traits.min and torch_out.max(
     ) <= int8_traits.max

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -64,9 +64,8 @@ def test_dynamic_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
     if (not torch.allclose(scales_out, scales)):
         print(torch.argmax(torch.abs(scales_out - scales)))
     assert torch.allclose(scales_out, scales)
-    assert torch.allclose(azp_out, azps)
-    assert torch.allclose(torch_out, ops_out,
-                          atol=1)  # big atol to account for rounding errors
+    assert torch.allclose(azp_out, azps, atol=1)  # azp rounding error
+    assert torch.allclose(torch_out, ops_out, atol=1)  # azp rounding error
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -67,7 +67,7 @@ def test_dynamic_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
     scales = (x_token_max - x_token_min) / torch.tensor(255.0)
     azps = torch.round(-128.0 - x_token_min / scales).to(torch.int32)
 
-    torch_out = (x / scales + azps).round().clamp(
+    torch_out = ((x / scales).round() + azps).clamp(
         int8_traits.min, int8_traits.max).to(torch.int8)
     assert torch_out.min() >= int8_traits.min and torch_out.max(
     ) <= int8_traits.max

--- a/tests/kernels/test_int8_quant.py
+++ b/tests/kernels/test_int8_quant.py
@@ -134,4 +134,3 @@ def test_static_scaled_int8_azp_quant(num_tokens: int, hidden_size: int,
     torch.ops._C.static_scaled_int8_quant(out2, x, scale_argument,
                                           azp_argument)
     assert torch.allclose(out1, out2, atol=1)  # atol for rounding
-

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -423,7 +423,8 @@ def scaled_int8_quant(
                                dtype=torch.float32)
     input_azp = None if symmetric else torch.empty_like(input_scales,
                                                         dtype=torch.int32)
-    torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales)
+    torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales,
+                                           input_azp)
     return output, input_scales, input_azp
 
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -392,15 +392,20 @@ def scaled_fp8_quant(
 # int8
 def scaled_int8_quant(
         input: torch.Tensor,
-        scale: Optional[torch.Tensor] = None
-) -> Tuple[torch.Tensor, torch.Tensor]:
+        scale: Optional[torch.Tensor] = None,
+        azp : Optional[torch.Tensor] = None,
+        symmetric: bool = True
+) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """
-    Quantize the input tensor to int8 and return the quantized tensor and scale.
+    Quantize the input tensor to int8 and return the quantized tensor and scale, and maybe azp.
 
     Args:
         input: The input tensor to be quantized to int8.
         scale: Optional scaling factor for the int8 quantization.
             When not provided, we invoke dynamic-per-token quantization.
+        azp: Optional zero-point for the int8 quantization.
+            Must be provided for asymmetric quantization if `scale` is provided.
+        symmetric: Whether to use symmetric quantization (scale only, azp ignored).
 
     Returns:
       Tuple[Torch.Tensor, Torch.Tensor] : Output int8 tensor and scales.
@@ -408,15 +413,17 @@ def scaled_int8_quant(
     output = torch.empty_like(input, dtype=torch.int8)
     if scale is not None:
         # static-per-tensor quantization.
+        assert not symmetric, "Asymmetric quantization per-tensor not supported yet."
         torch.ops._C.static_scaled_int8_quant(output, input, scale)
-        return output, scale
+        return output, scale, None
 
     # dynamic-per-token quantization.
     input_scales = torch.empty((input.numel() // input.shape[-1], 1),
                                device=input.device,
                                dtype=torch.float32)
+    input_azp = None if symmetric else torch.empty_like(input_scales, dtype=torch.int32)
     torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales)
-    return output, input_scales
+    return output, input_scales, input_azp
 
 
 # qqq ops

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -391,10 +391,10 @@ def scaled_fp8_quant(
 
 # int8
 def scaled_int8_quant(
-        input: torch.Tensor,
-        scale: Optional[torch.Tensor] = None,
-        azp : Optional[torch.Tensor] = None,
-        symmetric: bool = True
+    input: torch.Tensor,
+    scale: Optional[torch.Tensor] = None,
+    azp: Optional[torch.Tensor] = None,
+    symmetric: bool = True
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """
     Quantize the input tensor to int8 and return the quantized tensor and scale, and maybe azp.
@@ -421,7 +421,8 @@ def scaled_int8_quant(
     input_scales = torch.empty((input.numel() // input.shape[-1], 1),
                                device=input.device,
                                dtype=torch.float32)
-    input_azp = None if symmetric else torch.empty_like(input_scales, dtype=torch.int32)
+    input_azp = None if symmetric else torch.empty_like(input_scales,
+                                                        dtype=torch.int32)
     torch.ops._C.dynamic_scaled_int8_quant(output, input, input_scales)
     return output, input_scales, input_azp
 

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -413,8 +413,8 @@ def scaled_int8_quant(
     output = torch.empty_like(input, dtype=torch.int8)
     if scale is not None:
         # static-per-tensor quantization.
-        assert not symmetric, "Asymmetric quantization per-tensor not supported yet."
-        torch.ops._C.static_scaled_int8_quant(output, input, scale)
+        assert symmetric == azp is None, "azp must be only be provided for asymmetric quantization."
+        torch.ops._C.static_scaled_int8_quant(output, input, scale, azp)
         return output, scale, None
 
     # dynamic-per-token quantization.

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -199,7 +199,7 @@ def apply_int8_linear(
     # ops.scaled_int8_quant supports both dynamic and static quant.
     # * dynamic, layer.input_scale is None and x_scale computed from x.
     # * static, layer.input_scale is scalar and x_scale is input_scale.
-    x_q, x_scale = ops.scaled_int8_quant(input, input_scale)
+    x_q, x_scale, _ = ops.scaled_int8_quant(input, input_scale)
 
     return ops.cutlass_scaled_mm(x_q,
                                  weight,


### PR DESCRIPTION
Added a dynamic quantization kernel with support for asymmetric quantization with zero points.

Currently failing the unit test non-deterministically on certain tokens. When debugging with print statements, that token always seems to pass, making a race even more likely to be the reason.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


