### PR TITLE
[Frontend] Add Usage data in each chunk for chat_serving. #6540

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -335,7 +335,8 @@ async def test_chat_completion_stream_options(
             stream_options={"include_usage": True},
         )
 
-    # Test stream=True, stream_options={"include_usage": False, "continuous_usage_stats": True}
+    # Test stream=True, stream_options={"include_usage": False,
+    #                           "continuous_usage_stats": True}
     stream = await client.chat.completions.create(
         model=model_name,
         messages=messages,
@@ -375,7 +376,8 @@ async def test_guided_choice_chat(
         {"role": "system", "content": "you are a helpful assistant"},
         {
             "role": "user",
-            "content": "The best language for type-safe systems programming is ",
+            "content": 
+            "The best language for type-safe systems programming is ",
         },
     ]
     chat_completion = await client.chat.completions.create(
@@ -470,7 +472,8 @@ async def test_guided_regex_chat(
         {"role": "system", "content": "you are a helpful assistant"},
         {
             "role": "user",
-            "content": f"Give an example IP address with this regex: {sample_regex}",
+            "content": 
+                f"Give an example IP address with this regex: {sample_regex}",
         },
     ]
     chat_completion = await client.chat.completions.create(
@@ -509,7 +512,8 @@ async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
         {"role": "system", "content": "you are a helpful assistant"},
         {
             "role": "user",
-            "content": "The best language for type-safe systems programming is ",
+            "content":
+            "The best language for type-safe systems programming is ",
         },
     ]
 
@@ -534,7 +538,8 @@ async def test_guided_choice_chat_logprobs(
         {"role": "system", "content": "you are a helpful assistant"},
         {
             "role": "user",
-            "content": "The best language for type-safe systems programming is ",
+            "content":
+                "The best language for type-safe systems programming is ",
         },
     ]
     chat_completion = await client.chat.completions.create(
@@ -802,7 +807,9 @@ async def test_complex_message_content(client: openai.AsyncOpenAI):
                 "content": [
                     {
                         "type": "text",
-                        "text": "what is 1+1? please provide the result without any other text.",
+                        "text":
+                        ("what is 1+1"
+                         "please provide the result without any other text."),
                     }
                 ],
             }

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -58,24 +58,19 @@ def client(server):
     [MODEL_NAME, "zephyr-lora", "zephyr-lora2"],
 )
 async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
-    chat_completion = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=5,
-        temperature=0.0,
-        logprobs=False,
-    )
+    chat_completion = await client.chat.completions.create(model=model_name,
+                                                           messages=messages,
+                                                           max_tokens=5,
+                                                           temperature=0.0,
+                                                           logprobs=False)
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is None
@@ -88,25 +83,20 @@ async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
-    chat_completion = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=5,
-        temperature=0.0,
-        logprobs=True,
-        top_logprobs=0,
-    )
+    chat_completion = await client.chat.completions.create(model=model_name,
+                                                           messages=messages,
+                                                           max_tokens=5,
+                                                           temperature=0.0,
+                                                           logprobs=True,
+                                                           top_logprobs=0)
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is not None
@@ -120,25 +110,20 @@ async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
-    chat_completion = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=5,
-        temperature=0.0,
-        logprobs=True,
-        top_logprobs=5,
-    )
+    chat_completion = await client.chat.completions.create(model=model_name,
+                                                           messages=messages,
+                                                           max_tokens=5,
+                                                           temperature=0.0,
+                                                           logprobs=True,
+                                                           top_logprobs=5)
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is not None
@@ -153,39 +138,32 @@ async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
 )
 async def test_too_many_chat_logprobs(client: openai.AsyncOpenAI,
                                       model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
     # Default max_logprobs is 20, so this should raise an error
     with pytest.raises((openai.BadRequestError, openai.APIError)):
-        stream = await client.chat.completions.create(
-            model=model_name,
-            messages=messages,
-            max_tokens=10,
-            logprobs=True,
-            top_logprobs=21,
-            stream=True,
-        )
+        stream = await client.chat.completions.create(model=model_name,
+                                                      messages=messages,
+                                                      max_tokens=10,
+                                                      logprobs=True,
+                                                      top_logprobs=21,
+                                                      stream=True)
         async for chunk in stream:
             ...
 
     with pytest.raises(openai.BadRequestError):
-        await client.chat.completions.create(
-            model=model_name,
-            messages=messages,
-            max_tokens=10,
-            logprobs=True,
-            top_logprobs=30,
-            stream=False,
-        )
+        await client.chat.completions.create(model=model_name,
+                                             messages=messages,
+                                             max_tokens=10,
+                                             logprobs=True,
+                                             top_logprobs=30,
+                                             stream=False)
 
     # the server should still work afterwards
     chat_completion = await client.chat.completions.create(model=model_name,
@@ -203,25 +181,20 @@ async def test_too_many_chat_logprobs(client: openai.AsyncOpenAI,
 )
 async def test_single_chat_session(client: openai.AsyncOpenAI,
                                    model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
     # test single completion
-    chat_completion = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=10,
-        logprobs=True,
-        top_logprobs=5,
-    )
+    chat_completion = await client.chat.completions.create(model=model_name,
+                                                           messages=messages,
+                                                           max_tokens=10,
+                                                           logprobs=True,
+                                                           top_logprobs=5)
     assert chat_completion.id is not None
     assert len(chat_completion.choices) == 1
 
@@ -253,16 +226,13 @@ async def test_single_chat_session(client: openai.AsyncOpenAI,
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content": "what is 1+1?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role": "user",
+        "content": "what is 1+1?"
+    }]
 
     # test single completion
     chat_completion = await client.chat.completions.create(
@@ -306,16 +276,13 @@ async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
 )
 async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
                                               model_name: str):
-    messages = [
-        {
-            "role": "system",
-            "content": "You are a helpful assistant."
-        },
-        {
-            "role": "user",
-            "content": "What is the capital of France?"
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "You are a helpful assistant."
+    }, {
+        "role": "user",
+        "content": "What is the capital of France?"
+    }]
 
     # Test stream=True, stream_options={"include_usage": False}
     stream = await client.chat.completions.create(
@@ -324,21 +291,23 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
         max_tokens=10,
         temperature=0.0,
         stream=True,
-        stream_options={"include_usage": False},
-    )
+        stream_options={"include_usage": False})
     async for chunk in stream:
         assert chunk.usage is None
 
     # Test stream=True, stream_options={"include_usage": True,
-    #                    "continuous_usage_stats": False}
-    stream = await client.chat.completions.create(
-        model=model_name,
-        messages=messages,
-        max_tokens=10,
-        temperature=0.0,
-        stream=True,
-        stream_options={"include_usage": True, "continuous_usage_stats": False},
-    )
+    #                                   "continuous_usage_stats": False}}
+    stream = await client.chat.completions.create(model=model_name,
+                                                  messages=messages,
+                                                  max_tokens=10,
+                                                  temperature=0.0,
+                                                  stream=True,
+                                                  stream_options={
+                                                      "include_usage":
+                                                      True,
+                                                      "continuous_usage_stats":
+                                                      False
+                                                  })
 
     async for chunk in stream:
         if chunk.choices[0].finish_reason is None:
@@ -362,8 +331,7 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             max_tokens=10,
             temperature=0.0,
             stream=False,
-            stream_options={"include_usage": None},
-        )
+            stream_options={"include_usage": None})
 
     # Test stream=False, stream_options={"include_usage": True}
     with pytest.raises(BadRequestError):
@@ -373,8 +341,7 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             max_tokens=10,
             temperature=0.0,
             stream=False,
-            stream_options={"include_usage": True},
-        )
+            stream_options={"include_usage": True})
 
     # Test stream=True, stream_options={"include_usage": True,
     #                           "continuous_usage_stats": True}
@@ -389,16 +356,11 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             "continuous_usage_stats": True
         },
     )
-    generated_tokens = 0
     async for chunk in stream:
-        assert list(chunk.usage.keys()) == [
-            "total_tokens",
-            "prompt_tokens",
-            "completion_tokens",
-        ]
-        assert (chunk.usage["total_tokens"] == generated_tokens +
-                chunk.choices[0].delta.completion_tokens)
-        generated_tokens += 1
+        assert chunk.usage.prompt_tokens >= 0
+        assert chunk.usage.completion_tokens >= 0
+        assert chunk.usage.total_tokens == (chunk.usage.prompt_tokens +
+                                            chunk.usage.completion_tokens)
 
 
 # NOTE: Not sure why, but when I place this after `test_guided_regex_chat`
@@ -408,31 +370,24 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend",
                          ["outlines", "lm-format-enforcer"])
-async def test_guided_choice_chat(
-    client: openai.AsyncOpenAI,
-    guided_decoding_backend: str,
-    sample_guided_choice,
-):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content":
-            "The best language for type-safe systems programming is ",
-        },
-    ]
+async def test_guided_choice_chat(client: openai.AsyncOpenAI,
+                                  guided_decoding_backend: str,
+                                  sample_guided_choice):
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        "The best language for type-safe systems programming is "
+    }]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
-        extra_body=dict(
-            guided_choice=sample_guided_choice,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_choice=sample_guided_choice,
+                        guided_decoding_backend=guided_decoding_backend))
     choice1 = chat_completion.choices[0].message.content
     assert choice1 in sample_guided_choice
 
@@ -445,11 +400,8 @@ async def test_guided_choice_chat(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
-        extra_body=dict(
-            guided_choice=sample_guided_choice,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_choice=sample_guided_choice,
+                        guided_decoding_backend=guided_decoding_backend))
     choice2 = chat_completion.choices[0].message.content
     assert choice2 in sample_guided_choice
     assert choice1 != choice2
@@ -461,28 +413,22 @@ async def test_guided_choice_chat(
 async def test_guided_json_chat(client: openai.AsyncOpenAI,
                                 guided_decoding_backend: str,
                                 sample_json_schema):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role":
-            "user",
-            "content":
-            f"Give an example JSON for an employee profile that "
-            f"fits this schema: {sample_json_schema}",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give an example JSON for an employee profile that "
+        f"fits this schema: {sample_json_schema}"
+    }]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        extra_body=dict(
-            guided_json=sample_json_schema,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_json=sample_json_schema,
+                        guided_decoding_backend=guided_decoding_backend))
     message = chat_completion.choices[0].message
     assert message.content is not None
     json1 = json.loads(message.content)
@@ -493,17 +439,14 @@ async def test_guided_json_chat(client: openai.AsyncOpenAI,
         "role":
         "user",
         "content":
-        "Give me another one with a different name and age",
+        "Give me another one with a different name and age"
     })
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        extra_body=dict(
-            guided_json=sample_json_schema,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_json=sample_json_schema,
+                        guided_decoding_backend=guided_decoding_backend))
     message = chat_completion.choices[0].message
     assert message.content is not None
     json2 = json.loads(message.content)
@@ -517,27 +460,21 @@ async def test_guided_json_chat(client: openai.AsyncOpenAI,
                          ["outlines", "lm-format-enforcer"])
 async def test_guided_regex_chat(client: openai.AsyncOpenAI,
                                  guided_decoding_backend: str, sample_regex):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role":
-            "user",
-            "content":
-            f"Give an example IP address with this regex: {sample_regex}",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give an example IP address with this regex: {sample_regex}"
+    }]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=20,
-        extra_body=dict(
-            guided_regex=sample_regex,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_regex=sample_regex,
+                        guided_decoding_backend=guided_decoding_backend))
     ip1 = chat_completion.choices[0].message.content
     assert ip1 is not None
     assert re.fullmatch(sample_regex, ip1) is not None
@@ -548,11 +485,8 @@ async def test_guided_regex_chat(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_tokens=20,
-        extra_body=dict(
-            guided_regex=sample_regex,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_regex=sample_regex,
+                        guided_decoding_backend=guided_decoding_backend))
     ip2 = chat_completion.choices[0].message.content
     assert ip2 is not None
     assert re.fullmatch(sample_regex, ip2) is not None
@@ -561,59 +495,48 @@ async def test_guided_regex_chat(client: openai.AsyncOpenAI,
 
 @pytest.mark.asyncio
 async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content":
-            "The best language for type-safe systems programming is ",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        "The best language for type-safe systems programming is "
+    }]
 
     with pytest.raises(openai.BadRequestError):
-        _ = await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=messages,
-            extra_body=dict(guided_regex={
-                1: "Python",
-                2: "C++"
-            }),
-        )
+        _ = await client.chat.completions.create(model=MODEL_NAME,
+                                                 messages=messages,
+                                                 extra_body=dict(guided_regex={
+                                                     1: "Python",
+                                                     2: "C++"
+                                                 }))
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend",
                          ["outlines", "lm-format-enforcer"])
-async def test_guided_choice_chat_logprobs(
-    client: openai.AsyncOpenAI,
-    guided_decoding_backend: str,
-    sample_guided_choice,
-):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role": "user",
-            "content":
-            "The best language for type-safe systems programming is ",
-        },
-    ]
+async def test_guided_choice_chat_logprobs(client: openai.AsyncOpenAI,
+                                           guided_decoding_backend: str,
+                                           sample_guided_choice):
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        "The best language for type-safe systems programming is "
+    }]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
         logprobs=True,
         top_logprobs=5,
-        extra_body=dict(
-            guided_choice=sample_guided_choice,
-            guided_decoding_backend=guided_decoding_backend,
-        ),
-    )
+        extra_body=dict(guided_choice=sample_guided_choice,
+                        guided_decoding_backend=guided_decoding_backend))
 
     assert chat_completion.choices[0].logprobs is not None
     assert chat_completion.choices[0].logprobs.content is not None
@@ -630,19 +553,16 @@ async def test_guided_choice_chat_logprobs(
 async def test_named_tool_use(client: openai.AsyncOpenAI,
                               guided_decoding_backend: str,
                               sample_json_schema):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role":
-            "user",
-            "content":
-            f"Give an example JSON for an employee profile that "
-            f"fits this schema: {sample_json_schema}",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give an example JSON for an employee profile that "
+        f"fits this schema: {sample_json_schema}"
+    }]
 
     # non-streaming
 
@@ -655,16 +575,15 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
             "function": {
                 "name": "dummy_function_name",
                 "description": "This is a dummy function",
-                "parameters": sample_json_schema,
-            },
+                "parameters": sample_json_schema
+            }
         }],
         tool_choice={
             "type": "function",
             "function": {
                 "name": "dummy_function_name"
-            },
-        },
-    )
+            }
+        })
     message = chat_completion.choices[0].message
     assert len(message.content) == 0
     json_string = message.tool_calls[0].function.arguments
@@ -676,7 +595,7 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
         "role":
         "user",
         "content":
-        "Give me another one with a different name and age",
+        "Give me another one with a different name and age"
     })
 
     # streaming
@@ -690,17 +609,16 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
             "function": {
                 "name": "dummy_function_name",
                 "description": "This is a dummy function",
-                "parameters": sample_json_schema,
-            },
+                "parameters": sample_json_schema
+            }
         }],
         tool_choice={
             "type": "function",
             "function": {
                 "name": "dummy_function_name"
-            },
+            }
         },
-        stream=True,
-    )
+        stream=True)
 
     output = []
     finish_reason_count = 0
@@ -726,19 +644,16 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
 async def test_required_tool_use_not_yet_supported(
         client: openai.AsyncOpenAI, guided_decoding_backend: str,
         sample_json_schema):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role":
-            "user",
-            "content":
-            f"Give an example JSON for an employee profile that "
-            f"fits this schema: {sample_json_schema}",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give an example JSON for an employee profile that "
+        f"fits this schema: {sample_json_schema}"
+    }]
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
@@ -750,11 +665,10 @@ async def test_required_tool_use_not_yet_supported(
                 "function": {
                     "name": "dummy_function_name",
                     "description": "This is a dummy function",
-                    "parameters": sample_json_schema,
-                },
+                    "parameters": sample_json_schema
+                }
             }],
-            tool_choice="required",
-        )
+            tool_choice="required")
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
@@ -766,11 +680,10 @@ async def test_required_tool_use_not_yet_supported(
                 "function": {
                     "name": "dummy_function_name",
                     "description": "This is a dummy function",
-                    "parameters": sample_json_schema,
-                },
+                    "parameters": sample_json_schema
+                }
             }],
-            tool_choice="auto",
-        )
+            tool_choice="auto")
 
 
 @pytest.mark.asyncio
@@ -778,32 +691,28 @@ async def test_required_tool_use_not_yet_supported(
 async def test_inconsistent_tool_choice_and_tools(client: openai.AsyncOpenAI,
                                                   guided_decoding_backend: str,
                                                   sample_json_schema):
-    messages = [
-        {
-            "role": "system",
-            "content": "you are a helpful assistant"
-        },
-        {
-            "role":
-            "user",
-            "content":
-            f"Give an example JSON for an employee profile that "
-            f"fits this schema: {sample_json_schema}",
-        },
-    ]
+    messages = [{
+        "role": "system",
+        "content": "you are a helpful assistant"
+    }, {
+        "role":
+        "user",
+        "content":
+        f"Give an example JSON for an employee profile that "
+        f"fits this schema: {sample_json_schema}"
+    }]
 
     with pytest.raises(openai.BadRequestError):
-        await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=messages,
-            max_tokens=1000,
-            tool_choice={
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name"
-                },
-            },
-        )
+        await client.chat.completions.create(model=MODEL_NAME,
+                                             messages=messages,
+                                             max_tokens=1000,
+                                             tool_choice={
+                                                 "type": "function",
+                                                 "function": {
+                                                     "name":
+                                                     "dummy_function_name"
+                                                 }
+                                             })
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
@@ -815,16 +724,15 @@ async def test_inconsistent_tool_choice_and_tools(client: openai.AsyncOpenAI,
                 "function": {
                     "name": "dummy_function_name",
                     "description": "This is a dummy function",
-                    "parameters": sample_json_schema,
-                },
+                    "parameters": sample_json_schema
+                }
             }],
             tool_choice={
                 "type": "function",
                 "function": {
                     "name": "nondefined_function_name"
-                },
-            },
-        )
+                }
+            })
 
 
 @pytest.mark.asyncio
@@ -835,11 +743,10 @@ async def test_response_format_json_object(client: openai.AsyncOpenAI):
             messages=[{
                 "role":
                 "user",
-                "content": ("what is 1+1? please respond with a JSON object, "
-                            'the format is {"result": 2}'),
+                "content": ('what is 1+1? please respond with a JSON object, '
+                            'the format is {"result": 2}')
             }],
-            response_format={"type": "json_object"},
-        )
+            response_format={"type": "json_object"})
 
         content = resp.choices[0].message.content
         assert content is not None
@@ -859,8 +766,7 @@ async def test_extra_fields(client: openai.AsyncOpenAI):
                 "extra_field": "0",
             }],  # type: ignore
             temperature=0,
-            seed=0,
-        )
+            seed=0)
 
     assert "extra_forbidden" in exc_info.value.message
 
@@ -875,13 +781,12 @@ async def test_complex_message_content(client: openai.AsyncOpenAI):
             "content": [{
                 "type":
                 "text",
-                "text": ("what is 1+1"
-                         "please provide the result without any other text."),
-            }],
+                "text":
+                "what is 1+1? please provide the result without any other text."
+            }]
         }],
         temperature=0,
-        seed=0,
-    )
+        seed=0)
     content = resp.choices[0].message.content
     assert content == "2"
 
@@ -898,8 +803,7 @@ async def test_custom_role(client: openai.AsyncOpenAI):
             "content": "what is 1+1?",
         }],  # type: ignore
         temperature=0,
-        seed=0,
-    )
+        seed=0)
 
     resp2 = await client.chat.completions.create(
         model=MODEL_NAME,
@@ -908,11 +812,10 @@ async def test_custom_role(client: openai.AsyncOpenAI):
             "content": [{
                 "type": "text",
                 "text": "what is 1+1?"
-            }],
+            }]
         }],  # type: ignore
         temperature=0,
-        seed=0,
-    )
+        seed=0)
 
     content1 = resp1.choices[0].message.content
     content2 = resp2.choices[0].message.content
@@ -923,7 +826,7 @@ async def test_custom_role(client: openai.AsyncOpenAI):
 async def test_long_seed(client: openai.AsyncOpenAI):
     for seed in [
             torch.iinfo(torch.long).min - 1,
-            torch.iinfo(torch.long).max + 1,
+            torch.iinfo(torch.long).max + 1
     ]:
         with pytest.raises(BadRequestError) as exc_info:
             await client.chat.completions.create(
@@ -933,8 +836,7 @@ async def test_long_seed(client: openai.AsyncOpenAI):
                     "content": "You are a helpful assistant.",
                 }],
                 temperature=0,
-                seed=seed,
-            )
+                seed=seed)
 
         assert ("greater_than_equal" in exc_info.value.message
                 or "less_than_equal" in exc_info.value.message)

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -329,14 +329,15 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
     async for chunk in stream:
         assert chunk.usage is None
 
-    # Test stream=True, stream_options={"include_usage": True}
+    # Test stream=True, stream_options={"include_usage": True,
+    #                    "continuous_usage_stats": False}
     stream = await client.chat.completions.create(
         model=model_name,
         messages=messages,
         max_tokens=10,
         temperature=0.0,
         stream=True,
-        stream_options={"include_usage": True},
+        stream_options={"include_usage": True, "continuous_usage_stats": False},
     )
 
     async for chunk in stream:
@@ -375,7 +376,7 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             stream_options={"include_usage": True},
         )
 
-    # Test stream=True, stream_options={"include_usage": False,
+    # Test stream=True, stream_options={"include_usage": True,
     #                           "continuous_usage_stats": True}
     stream = await client.chat.completions.create(
         model=model_name,
@@ -384,7 +385,7 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
         temperature=0.0,
         stream=True,
         stream_options={
-            "include_usage": False,
+            "include_usage": True,
             "continuous_usage_stats": True
         },
     )

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -58,19 +58,18 @@ def client(server):
     [MODEL_NAME, "zephyr-lora", "zephyr-lora2"],
 )
 async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
-    chat_completion = await client.chat.completions.create(model=model_name,
-                                                           messages=messages,
-                                                           max_tokens=5,
-                                                           temperature=0.0,
-                                                           logprobs=False)
+    chat_completion = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=5,
+        temperature=0.0,
+        logprobs=False,
+    )
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is None
@@ -83,20 +82,19 @@ async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
-    chat_completion = await client.chat.completions.create(model=model_name,
-                                                           messages=messages,
-                                                           max_tokens=5,
-                                                           temperature=0.0,
-                                                           logprobs=True,
-                                                           top_logprobs=0)
+    chat_completion = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=5,
+        temperature=0.0,
+        logprobs=True,
+        top_logprobs=0,
+    )
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is not None
@@ -110,20 +108,19 @@ async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
-    chat_completion = await client.chat.completions.create(model=model_name,
-                                                           messages=messages,
-                                                           max_tokens=5,
-                                                           temperature=0.0,
-                                                           logprobs=True,
-                                                           top_logprobs=5)
+    chat_completion = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=5,
+        temperature=0.0,
+        logprobs=True,
+        top_logprobs=5,
+    )
 
     choice = chat_completion.choices[0]
     assert choice.logprobs is not None
@@ -136,40 +133,41 @@ async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     "model_name",
     [MODEL_NAME, "zephyr-lora"],
 )
-async def test_too_many_chat_logprobs(client: openai.AsyncOpenAI,
-                                      model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+async def test_too_many_chat_logprobs(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
     # Default max_logprobs is 20, so this should raise an error
     with pytest.raises((openai.BadRequestError, openai.APIError)):
-        stream = await client.chat.completions.create(model=model_name,
-                                                      messages=messages,
-                                                      max_tokens=10,
-                                                      logprobs=True,
-                                                      top_logprobs=21,
-                                                      stream=True)
+        stream = await client.chat.completions.create(
+            model=model_name,
+            messages=messages,
+            max_tokens=10,
+            logprobs=True,
+            top_logprobs=21,
+            stream=True,
+        )
         async for chunk in stream:
             ...
 
     with pytest.raises(openai.BadRequestError):
-        await client.chat.completions.create(model=model_name,
-                                             messages=messages,
-                                             max_tokens=10,
-                                             logprobs=True,
-                                             top_logprobs=30,
-                                             stream=False)
+        await client.chat.completions.create(
+            model=model_name,
+            messages=messages,
+            max_tokens=10,
+            logprobs=True,
+            top_logprobs=30,
+            stream=False,
+        )
 
     # the server should still work afterwards
-    chat_completion = await client.chat.completions.create(model=model_name,
-                                                           messages=messages,
-                                                           max_tokens=10,
-                                                           stream=False)
+    chat_completion = await client.chat.completions.create(
+        model=model_name, messages=messages, max_tokens=10, stream=False
+    )
     message = chat_completion.choices[0].message
     assert message.content is not None and len(message.content) >= 0
 
@@ -179,29 +177,28 @@ async def test_too_many_chat_logprobs(client: openai.AsyncOpenAI,
     "model_name",
     [MODEL_NAME, "zephyr-lora"],
 )
-async def test_single_chat_session(client: openai.AsyncOpenAI,
-                                   model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+async def test_single_chat_session(client: openai.AsyncOpenAI, model_name: str):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
     # test single completion
-    chat_completion = await client.chat.completions.create(model=model_name,
-                                                           messages=messages,
-                                                           max_tokens=10,
-                                                           logprobs=True,
-                                                           top_logprobs=5)
+    chat_completion = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=10,
+        logprobs=True,
+        top_logprobs=5,
+    )
     assert chat_completion.id is not None
     assert len(chat_completion.choices) == 1
 
     choice = chat_completion.choices[0]
     assert choice.finish_reason == "length"
     assert chat_completion.usage == openai.types.CompletionUsage(
-        completion_tokens=10, prompt_tokens=37, total_tokens=47)
+        completion_tokens=10, prompt_tokens=37, total_tokens=47
+    )
 
     message = choice.message
     assert message.content is not None and len(message.content) >= 10
@@ -226,13 +223,10 @@ async def test_single_chat_session(client: openai.AsyncOpenAI,
     [MODEL_NAME, "zephyr-lora"],
 )
 async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role": "user",
-        "content": "what is 1+1?"
-    }]
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is 1+1?"},
+    ]
 
     # test single completion
     chat_completion = await client.chat.completions.create(
@@ -274,15 +268,13 @@ async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
     "model_name",
     ["HuggingFaceH4/zephyr-7b-beta", "zephyr-lora"],
 )
-async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
-                                              model_name: str):
-    messages = [{
-        "role": "system",
-        "content": "You are a helpful assistant."
-    }, {
-        "role": "user",
-        "content": "What is the capital of France?"
-    }]
+async def test_chat_completion_stream_options(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is the capital of France?"},
+    ]
 
     # Test stream=True, stream_options={"include_usage": False}
     stream = await client.chat.completions.create(
@@ -291,7 +283,8 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
         max_tokens=10,
         temperature=0.0,
         stream=True,
-        stream_options={"include_usage": False})
+        stream_options={"include_usage": False},
+    )
     async for chunk in stream:
         assert chunk.usage is None
 
@@ -302,7 +295,8 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
         max_tokens=10,
         temperature=0.0,
         stream=True,
-        stream_options={"include_usage": True})
+        stream_options={"include_usage": True},
+    )
 
     async for chunk in stream:
         if chunk.choices[0].finish_reason is None:
@@ -314,8 +308,9 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             assert final_chunk.usage.prompt_tokens > 0
             assert final_chunk.usage.completion_tokens > 0
             assert final_chunk.usage.total_tokens == (
-                final_chunk.usage.prompt_tokens +
-                final_chunk.usage.completion_tokens)
+                final_chunk.usage.prompt_tokens
+                + final_chunk.usage.completion_tokens
+            )
             assert final_chunk.choices == []
 
     # Test stream=False, stream_options={"include_usage": None}
@@ -326,7 +321,8 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             max_tokens=10,
             temperature=0.0,
             stream=False,
-            stream_options={"include_usage": None})
+            stream_options={"include_usage": None},
+        )
 
     # Test stream=False, stream_options={"include_usage": True}
     with pytest.raises(BadRequestError):
@@ -336,7 +332,30 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
             max_tokens=10,
             temperature=0.0,
             stream=False,
-            stream_options={"include_usage": True})
+            stream_options={"include_usage": True},
+        )
+
+    # Test stream=True, stream_options={"include_usage": False, "continuous_usage_stats": True}
+    stream = await client.chat.completions.create(
+        model=model_name,
+        messages=messages,
+        max_tokens=10,
+        temperature=0.0,
+        stream=True,
+        stream_options={"include_usage": False, "continuous_usage_stats": True},
+    )
+    generated_tokens = 0
+    async for chunk in stream:
+        assert list(chunk.usage.keys()) == [
+            "total_tokens",
+            "prompt_tokens",
+            "completion_tokens",
+        ]
+        assert (
+            chunk.usage["total_tokens"]
+            == generated_tokens + chunk.choices[0].delta.completion_tokens
+        )
+        generated_tokens += 1
 
 
 # NOTE: Not sure why, but when I place this after `test_guided_regex_chat`
@@ -344,85 +363,94 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
 # will fail on the second `guided_decoding_backend` even when I swap their order
 # (ref: https://github.com/vllm-project/vllm/pull/5526#issuecomment-2173772256)
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guided_decoding_backend",
-                         ["outlines", "lm-format-enforcer"])
-async def test_guided_choice_chat(client: openai.AsyncOpenAI,
-                                  guided_decoding_backend: str,
-                                  sample_guided_choice):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        "The best language for type-safe systems programming is "
-    }]
+@pytest.mark.parametrize(
+    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
+)
+async def test_guided_choice_chat(
+    client: openai.AsyncOpenAI,
+    guided_decoding_backend: str,
+    sample_guided_choice,
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": "The best language for type-safe systems programming is ",
+        },
+    ]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
-        extra_body=dict(guided_choice=sample_guided_choice,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_choice=sample_guided_choice,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     choice1 = chat_completion.choices[0].message.content
     assert choice1 in sample_guided_choice
 
     messages.append({"role": "assistant", "content": choice1})
-    messages.append({
-        "role": "user",
-        "content": "I disagree, pick another one"
-    })
+    messages.append({"role": "user", "content": "I disagree, pick another one"})
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
-        extra_body=dict(guided_choice=sample_guided_choice,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_choice=sample_guided_choice,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     choice2 = chat_completion.choices[0].message.content
     assert choice2 in sample_guided_choice
     assert choice1 != choice2
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guided_decoding_backend",
-                         ["outlines", "lm-format-enforcer"])
-async def test_guided_json_chat(client: openai.AsyncOpenAI,
-                                guided_decoding_backend: str,
-                                sample_json_schema):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        f"Give an example JSON for an employee profile that "
-        f"fits this schema: {sample_json_schema}"
-    }]
+@pytest.mark.parametrize(
+    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
+)
+async def test_guided_json_chat(
+    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": f"Give an example JSON for an employee profile that "
+            f"fits this schema: {sample_json_schema}",
+        },
+    ]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        extra_body=dict(guided_json=sample_json_schema,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_json=sample_json_schema,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     message = chat_completion.choices[0].message
     assert message.content is not None
     json1 = json.loads(message.content)
     jsonschema.validate(instance=json1, schema=sample_json_schema)
 
     messages.append({"role": "assistant", "content": message.content})
-    messages.append({
-        "role":
-        "user",
-        "content":
-        "Give me another one with a different name and age"
-    })
+    messages.append(
+        {
+            "role": "user",
+            "content": "Give me another one with a different name and age",
+        }
+    )
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        extra_body=dict(guided_json=sample_json_schema,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_json=sample_json_schema,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     message = chat_completion.choices[0].message
     assert message.content is not None
     json2 = json.loads(message.content)
@@ -432,25 +460,28 @@ async def test_guided_json_chat(client: openai.AsyncOpenAI,
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guided_decoding_backend",
-                         ["outlines", "lm-format-enforcer"])
-async def test_guided_regex_chat(client: openai.AsyncOpenAI,
-                                 guided_decoding_backend: str, sample_regex):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        f"Give an example IP address with this regex: {sample_regex}"
-    }]
+@pytest.mark.parametrize(
+    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
+)
+async def test_guided_regex_chat(
+    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_regex
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": f"Give an example IP address with this regex: {sample_regex}",
+        },
+    ]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=20,
-        extra_body=dict(guided_regex=sample_regex,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_regex=sample_regex,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     ip1 = chat_completion.choices[0].message.content
     assert ip1 is not None
     assert re.fullmatch(sample_regex, ip1) is not None
@@ -461,8 +492,11 @@ async def test_guided_regex_chat(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_tokens=20,
-        extra_body=dict(guided_regex=sample_regex,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_regex=sample_regex,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
     ip2 = chat_completion.choices[0].message.content
     assert ip2 is not None
     assert re.fullmatch(sample_regex, ip2) is not None
@@ -471,48 +505,49 @@ async def test_guided_regex_chat(client: openai.AsyncOpenAI,
 
 @pytest.mark.asyncio
 async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        "The best language for type-safe systems programming is "
-    }]
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": "The best language for type-safe systems programming is ",
+        },
+    ]
 
     with pytest.raises(openai.BadRequestError):
-        _ = await client.chat.completions.create(model=MODEL_NAME,
-                                                 messages=messages,
-                                                 extra_body=dict(guided_regex={
-                                                     1: "Python",
-                                                     2: "C++"
-                                                 }))
+        _ = await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=messages,
+            extra_body=dict(guided_regex={1: "Python", 2: "C++"}),
+        )
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guided_decoding_backend",
-                         ["outlines", "lm-format-enforcer"])
-async def test_guided_choice_chat_logprobs(client: openai.AsyncOpenAI,
-                                           guided_decoding_backend: str,
-                                           sample_guided_choice):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        "The best language for type-safe systems programming is "
-    }]
+@pytest.mark.parametrize(
+    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
+)
+async def test_guided_choice_chat_logprobs(
+    client: openai.AsyncOpenAI,
+    guided_decoding_backend: str,
+    sample_guided_choice,
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": "The best language for type-safe systems programming is ",
+        },
+    ]
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=10,
         logprobs=True,
         top_logprobs=5,
-        extra_body=dict(guided_choice=sample_guided_choice,
-                        guided_decoding_backend=guided_decoding_backend))
+        extra_body=dict(
+            guided_choice=sample_guided_choice,
+            guided_decoding_backend=guided_decoding_backend,
+        ),
+    )
 
     assert chat_completion.choices[0].logprobs is not None
     assert chat_completion.choices[0].logprobs.content is not None
@@ -524,21 +559,20 @@ async def test_guided_choice_chat_logprobs(client: openai.AsyncOpenAI,
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("guided_decoding_backend",
-                         ["outlines", "lm-format-enforcer"])
-async def test_named_tool_use(client: openai.AsyncOpenAI,
-                              guided_decoding_backend: str,
-                              sample_json_schema):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        f"Give an example JSON for an employee profile that "
-        f"fits this schema: {sample_json_schema}"
-    }]
+@pytest.mark.parametrize(
+    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
+)
+async def test_named_tool_use(
+    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": f"Give an example JSON for an employee profile that "
+            f"fits this schema: {sample_json_schema}",
+        },
+    ]
 
     # non-streaming
 
@@ -546,20 +580,21 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        tools=[{
-            "type": "function",
-            "function": {
-                "name": "dummy_function_name",
-                "description": "This is a dummy function",
-                "parameters": sample_json_schema
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema,
+                },
             }
-        }],
+        ],
         tool_choice={
             "type": "function",
-            "function": {
-                "name": "dummy_function_name"
-            }
-        })
+            "function": {"name": "dummy_function_name"},
+        },
+    )
     message = chat_completion.choices[0].message
     assert len(message.content) == 0
     json_string = message.tool_calls[0].function.arguments
@@ -567,12 +602,12 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
     jsonschema.validate(instance=json1, schema=sample_json_schema)
 
     messages.append({"role": "assistant", "content": json_string})
-    messages.append({
-        "role":
-        "user",
-        "content":
-        "Give me another one with a different name and age"
-    })
+    messages.append(
+        {
+            "role": "user",
+            "content": "Give me another one with a different name and age",
+        }
+    )
 
     # streaming
 
@@ -580,21 +615,22 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        tools=[{
-            "type": "function",
-            "function": {
-                "name": "dummy_function_name",
-                "description": "This is a dummy function",
-                "parameters": sample_json_schema
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema,
+                },
             }
-        }],
+        ],
         tool_choice={
             "type": "function",
-            "function": {
-                "name": "dummy_function_name"
-            }
+            "function": {"name": "dummy_function_name"},
         },
-        stream=True)
+        stream=True,
+    )
 
     output = []
     finish_reason_count = 0
@@ -618,97 +654,99 @@ async def test_named_tool_use(client: openai.AsyncOpenAI,
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend", ["outlines"])
 async def test_required_tool_use_not_yet_supported(
-        client: openai.AsyncOpenAI, guided_decoding_backend: str,
-        sample_json_schema):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        f"Give an example JSON for an employee profile that "
-        f"fits this schema: {sample_json_schema}"
-    }]
+    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": f"Give an example JSON for an employee profile that "
+            f"fits this schema: {sample_json_schema}",
+        },
+    ]
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[{
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name",
-                    "description": "This is a dummy function",
-                    "parameters": sample_json_schema
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "dummy_function_name",
+                        "description": "This is a dummy function",
+                        "parameters": sample_json_schema,
+                    },
                 }
-            }],
-            tool_choice="required")
+            ],
+            tool_choice="required",
+        )
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[{
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name",
-                    "description": "This is a dummy function",
-                    "parameters": sample_json_schema
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "dummy_function_name",
+                        "description": "This is a dummy function",
+                        "parameters": sample_json_schema,
+                    },
                 }
-            }],
-            tool_choice="auto")
+            ],
+            tool_choice="auto",
+        )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend", ["outlines"])
-async def test_inconsistent_tool_choice_and_tools(client: openai.AsyncOpenAI,
-                                                  guided_decoding_backend: str,
-                                                  sample_json_schema):
-    messages = [{
-        "role": "system",
-        "content": "you are a helpful assistant"
-    }, {
-        "role":
-        "user",
-        "content":
-        f"Give an example JSON for an employee profile that "
-        f"fits this schema: {sample_json_schema}"
-    }]
-
-    with pytest.raises(openai.BadRequestError):
-        await client.chat.completions.create(model=MODEL_NAME,
-                                             messages=messages,
-                                             max_tokens=1000,
-                                             tool_choice={
-                                                 "type": "function",
-                                                 "function": {
-                                                     "name":
-                                                     "dummy_function_name"
-                                                 }
-                                             })
+async def test_inconsistent_tool_choice_and_tools(
+    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
+):
+    messages = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "user",
+            "content": f"Give an example JSON for an employee profile that "
+            f"fits this schema: {sample_json_schema}",
+        },
+    ]
 
     with pytest.raises(openai.BadRequestError):
         await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[{
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name",
-                    "description": "This is a dummy function",
-                    "parameters": sample_json_schema
-                }
-            }],
             tool_choice={
                 "type": "function",
-                "function": {
-                    "name": "nondefined_function_name"
+                "function": {"name": "dummy_function_name"},
+            },
+        )
+
+    with pytest.raises(openai.BadRequestError):
+        await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=messages,
+            max_tokens=1000,
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "dummy_function_name",
+                        "description": "This is a dummy function",
+                        "parameters": sample_json_schema,
+                    },
                 }
-            })
+            ],
+            tool_choice={
+                "type": "function",
+                "function": {"name": "nondefined_function_name"},
+            },
+        )
 
 
 @pytest.mark.asyncio
@@ -716,13 +754,17 @@ async def test_response_format_json_object(client: openai.AsyncOpenAI):
     for _ in range(2):
         resp = await client.chat.completions.create(
             model=MODEL_NAME,
-            messages=[{
-                "role":
-                "user",
-                "content": ('what is 1+1? please respond with a JSON object, '
-                            'the format is {"result": 2}')
-            }],
-            response_format={"type": "json_object"})
+            messages=[
+                {
+                    "role": "user",
+                    "content": (
+                        "what is 1+1? please respond with a JSON object, "
+                        'the format is {"result": 2}'
+                    ),
+                }
+            ],
+            response_format={"type": "json_object"},
+        )
 
         content = resp.choices[0].message.content
         assert content is not None
@@ -736,13 +778,16 @@ async def test_extra_fields(client: openai.AsyncOpenAI):
     with pytest.raises(BadRequestError) as exc_info:
         await client.chat.completions.create(
             model=MODEL_NAME,
-            messages=[{
-                "role": "system",
-                "content": "You are a helpful assistant.",
-                "extra_field": "0",
-            }],  # type: ignore
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant.",
+                    "extra_field": "0",
+                }
+            ],  # type: ignore
             temperature=0,
-            seed=0)
+            seed=0,
+        )
 
     assert "extra_forbidden" in exc_info.value.message
 
@@ -751,18 +796,20 @@ async def test_extra_fields(client: openai.AsyncOpenAI):
 async def test_complex_message_content(client: openai.AsyncOpenAI):
     resp = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[{
-            "role":
-            "user",
-            "content": [{
-                "type":
-                "text",
-                "text":
-                "what is 1+1? please provide the result without any other text."
-            }]
-        }],
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "what is 1+1? please provide the result without any other text.",
+                    }
+                ],
+            }
+        ],
         temperature=0,
-        seed=0)
+        seed=0,
+    )
     content = resp.choices[0].message.content
     assert content == "2"
 
@@ -774,24 +821,27 @@ async def test_custom_role(client: openai.AsyncOpenAI):
 
     resp1 = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[{
-            "role": "my-custom-role",
-            "content": "what is 1+1?",
-        }],  # type: ignore
+        messages=[
+            {
+                "role": "my-custom-role",
+                "content": "what is 1+1?",
+            }
+        ],  # type: ignore
         temperature=0,
-        seed=0)
+        seed=0,
+    )
 
     resp2 = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[{
-            "role": "my-custom-role",
-            "content": [{
-                "type": "text",
-                "text": "what is 1+1?"
-            }]
-        }],  # type: ignore
+        messages=[
+            {
+                "role": "my-custom-role",
+                "content": [{"type": "text", "text": "what is 1+1?"}],
+            }
+        ],  # type: ignore
         temperature=0,
-        seed=0)
+        seed=0,
+    )
 
     content1 = resp1.choices[0].message.content
     content2 = resp2.choices[0].message.content
@@ -801,18 +851,23 @@ async def test_custom_role(client: openai.AsyncOpenAI):
 @pytest.mark.asyncio
 async def test_long_seed(client: openai.AsyncOpenAI):
     for seed in [
-            torch.iinfo(torch.long).min - 1,
-            torch.iinfo(torch.long).max + 1
+        torch.iinfo(torch.long).min - 1,
+        torch.iinfo(torch.long).max + 1,
     ]:
         with pytest.raises(BadRequestError) as exc_info:
             await client.chat.completions.create(
                 model=MODEL_NAME,
-                messages=[{
-                    "role": "system",
-                    "content": "You are a helpful assistant.",
-                }],
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "You are a helpful assistant.",
+                    }
+                ],
                 temperature=0,
-                seed=seed)
+                seed=seed,
+            )
 
-        assert ("greater_than_equal" in exc_info.value.message
-                or "less_than_equal" in exc_info.value.message)
+        assert (
+            "greater_than_equal" in exc_info.value.message
+            or "less_than_equal" in exc_info.value.message
+        )

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -59,8 +59,14 @@ def client(server):
 )
 async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     chat_completion = await client.chat.completions.create(
@@ -83,8 +89,14 @@ async def test_no_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
 )
 async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     chat_completion = await client.chat.completions.create(
@@ -109,8 +121,14 @@ async def test_zero_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
 )
 async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     chat_completion = await client.chat.completions.create(
@@ -133,12 +151,17 @@ async def test_some_logprobs_chat(client: openai.AsyncOpenAI, model_name: str):
     "model_name",
     [MODEL_NAME, "zephyr-lora"],
 )
-async def test_too_many_chat_logprobs(
-    client: openai.AsyncOpenAI, model_name: str
-):
+async def test_too_many_chat_logprobs(client: openai.AsyncOpenAI,
+                                      model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     # Default max_logprobs is 20, so this should raise an error
@@ -165,9 +188,10 @@ async def test_too_many_chat_logprobs(
         )
 
     # the server should still work afterwards
-    chat_completion = await client.chat.completions.create(
-        model=model_name, messages=messages, max_tokens=10, stream=False
-    )
+    chat_completion = await client.chat.completions.create(model=model_name,
+                                                           messages=messages,
+                                                           max_tokens=10,
+                                                           stream=False)
     message = chat_completion.choices[0].message
     assert message.content is not None and len(message.content) >= 0
 
@@ -177,10 +201,17 @@ async def test_too_many_chat_logprobs(
     "model_name",
     [MODEL_NAME, "zephyr-lora"],
 )
-async def test_single_chat_session(client: openai.AsyncOpenAI, model_name: str):
+async def test_single_chat_session(client: openai.AsyncOpenAI,
+                                   model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     # test single completion
@@ -197,8 +228,7 @@ async def test_single_chat_session(client: openai.AsyncOpenAI, model_name: str):
     choice = chat_completion.choices[0]
     assert choice.finish_reason == "length"
     assert chat_completion.usage == openai.types.CompletionUsage(
-        completion_tokens=10, prompt_tokens=37, total_tokens=47
-    )
+        completion_tokens=10, prompt_tokens=37, total_tokens=47)
 
     message = choice.message
     assert message.content is not None and len(message.content) >= 10
@@ -224,8 +254,14 @@ async def test_single_chat_session(client: openai.AsyncOpenAI, model_name: str):
 )
 async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
-        {"role": "user", "content": "what is 1+1?"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role": "user",
+            "content": "what is 1+1?"
+        },
     ]
 
     # test single completion
@@ -268,12 +304,17 @@ async def test_chat_streaming(client: openai.AsyncOpenAI, model_name: str):
     "model_name",
     ["HuggingFaceH4/zephyr-7b-beta", "zephyr-lora"],
 )
-async def test_chat_completion_stream_options(
-    client: openai.AsyncOpenAI, model_name: str
-):
+async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
+                                              model_name: str):
     messages = [
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "What is the capital of France?"},
+        {
+            "role": "system",
+            "content": "You are a helpful assistant."
+        },
+        {
+            "role": "user",
+            "content": "What is the capital of France?"
+        },
     ]
 
     # Test stream=True, stream_options={"include_usage": False}
@@ -308,9 +349,8 @@ async def test_chat_completion_stream_options(
             assert final_chunk.usage.prompt_tokens > 0
             assert final_chunk.usage.completion_tokens > 0
             assert final_chunk.usage.total_tokens == (
-                final_chunk.usage.prompt_tokens
-                + final_chunk.usage.completion_tokens
-            )
+                final_chunk.usage.prompt_tokens +
+                final_chunk.usage.completion_tokens)
             assert final_chunk.choices == []
 
     # Test stream=False, stream_options={"include_usage": None}
@@ -343,7 +383,10 @@ async def test_chat_completion_stream_options(
         max_tokens=10,
         temperature=0.0,
         stream=True,
-        stream_options={"include_usage": False, "continuous_usage_stats": True},
+        stream_options={
+            "include_usage": False,
+            "continuous_usage_stats": True
+        },
     )
     generated_tokens = 0
     async for chunk in stream:
@@ -352,10 +395,8 @@ async def test_chat_completion_stream_options(
             "prompt_tokens",
             "completion_tokens",
         ]
-        assert (
-            chunk.usage["total_tokens"]
-            == generated_tokens + chunk.choices[0].delta.completion_tokens
-        )
+        assert (chunk.usage["total_tokens"] == generated_tokens +
+                chunk.choices[0].delta.completion_tokens)
         generated_tokens += 1
 
 
@@ -364,19 +405,21 @@ async def test_chat_completion_stream_options(
 # will fail on the second `guided_decoding_backend` even when I swap their order
 # (ref: https://github.com/vllm-project/vllm/pull/5526#issuecomment-2173772256)
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
-)
+@pytest.mark.parametrize("guided_decoding_backend",
+                         ["outlines", "lm-format-enforcer"])
 async def test_guided_choice_chat(
     client: openai.AsyncOpenAI,
     guided_decoding_backend: str,
     sample_guided_choice,
 ):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
         {
             "role": "user",
-            "content": 
+            "content":
             "The best language for type-safe systems programming is ",
         },
     ]
@@ -393,7 +436,10 @@ async def test_guided_choice_chat(
     assert choice1 in sample_guided_choice
 
     messages.append({"role": "assistant", "content": choice1})
-    messages.append({"role": "user", "content": "I disagree, pick another one"})
+    messages.append({
+        "role": "user",
+        "content": "I disagree, pick another one"
+    })
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
@@ -409,17 +455,21 @@ async def test_guided_choice_chat(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
-)
-async def test_guided_json_chat(
-    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
-):
+@pytest.mark.parametrize("guided_decoding_backend",
+                         ["outlines", "lm-format-enforcer"])
+async def test_guided_json_chat(client: openai.AsyncOpenAI,
+                                guided_decoding_backend: str,
+                                sample_json_schema):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
         {
-            "role": "user",
-            "content": f"Give an example JSON for an employee profile that "
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role":
+            "user",
+            "content":
+            f"Give an example JSON for an employee profile that "
             f"fits this schema: {sample_json_schema}",
         },
     ]
@@ -438,12 +488,12 @@ async def test_guided_json_chat(
     jsonschema.validate(instance=json1, schema=sample_json_schema)
 
     messages.append({"role": "assistant", "content": message.content})
-    messages.append(
-        {
-            "role": "user",
-            "content": "Give me another one with a different name and age",
-        }
-    )
+    messages.append({
+        "role":
+        "user",
+        "content":
+        "Give me another one with a different name and age",
+    })
     chat_completion = await client.chat.completions.create(
         model=MODEL_NAME,
         messages=messages,
@@ -462,18 +512,20 @@ async def test_guided_json_chat(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
-)
-async def test_guided_regex_chat(
-    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_regex
-):
+@pytest.mark.parametrize("guided_decoding_backend",
+                         ["outlines", "lm-format-enforcer"])
+async def test_guided_regex_chat(client: openai.AsyncOpenAI,
+                                 guided_decoding_backend: str, sample_regex):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
         {
-            "role": "user",
-            "content": 
-                f"Give an example IP address with this regex: {sample_regex}",
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role":
+            "user",
+            "content":
+            f"Give an example IP address with this regex: {sample_regex}",
         },
     ]
     chat_completion = await client.chat.completions.create(
@@ -509,7 +561,10 @@ async def test_guided_regex_chat(
 @pytest.mark.asyncio
 async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
         {
             "role": "user",
             "content":
@@ -521,25 +576,30 @@ async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
         _ = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
-            extra_body=dict(guided_regex={1: "Python", 2: "C++"}),
+            extra_body=dict(guided_regex={
+                1: "Python",
+                2: "C++"
+            }),
         )
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
-)
+@pytest.mark.parametrize("guided_decoding_backend",
+                         ["outlines", "lm-format-enforcer"])
 async def test_guided_choice_chat_logprobs(
     client: openai.AsyncOpenAI,
     guided_decoding_backend: str,
     sample_guided_choice,
 ):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
+        {
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
         {
             "role": "user",
             "content":
-                "The best language for type-safe systems programming is ",
+            "The best language for type-safe systems programming is ",
         },
     ]
     chat_completion = await client.chat.completions.create(
@@ -564,17 +624,21 @@ async def test_guided_choice_chat_logprobs(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "guided_decoding_backend", ["outlines", "lm-format-enforcer"]
-)
-async def test_named_tool_use(
-    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
-):
+@pytest.mark.parametrize("guided_decoding_backend",
+                         ["outlines", "lm-format-enforcer"])
+async def test_named_tool_use(client: openai.AsyncOpenAI,
+                              guided_decoding_backend: str,
+                              sample_json_schema):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
         {
-            "role": "user",
-            "content": f"Give an example JSON for an employee profile that "
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role":
+            "user",
+            "content":
+            f"Give an example JSON for an employee profile that "
             f"fits this schema: {sample_json_schema}",
         },
     ]
@@ -585,19 +649,19 @@ async def test_named_tool_use(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name",
-                    "description": "This is a dummy function",
-                    "parameters": sample_json_schema,
-                },
-            }
-        ],
+        tools=[{
+            "type": "function",
+            "function": {
+                "name": "dummy_function_name",
+                "description": "This is a dummy function",
+                "parameters": sample_json_schema,
+            },
+        }],
         tool_choice={
             "type": "function",
-            "function": {"name": "dummy_function_name"},
+            "function": {
+                "name": "dummy_function_name"
+            },
         },
     )
     message = chat_completion.choices[0].message
@@ -607,12 +671,12 @@ async def test_named_tool_use(
     jsonschema.validate(instance=json1, schema=sample_json_schema)
 
     messages.append({"role": "assistant", "content": json_string})
-    messages.append(
-        {
-            "role": "user",
-            "content": "Give me another one with a different name and age",
-        }
-    )
+    messages.append({
+        "role":
+        "user",
+        "content":
+        "Give me another one with a different name and age",
+    })
 
     # streaming
 
@@ -620,19 +684,19 @@ async def test_named_tool_use(
         model=MODEL_NAME,
         messages=messages,
         max_tokens=1000,
-        tools=[
-            {
-                "type": "function",
-                "function": {
-                    "name": "dummy_function_name",
-                    "description": "This is a dummy function",
-                    "parameters": sample_json_schema,
-                },
-            }
-        ],
+        tools=[{
+            "type": "function",
+            "function": {
+                "name": "dummy_function_name",
+                "description": "This is a dummy function",
+                "parameters": sample_json_schema,
+            },
+        }],
         tool_choice={
             "type": "function",
-            "function": {"name": "dummy_function_name"},
+            "function": {
+                "name": "dummy_function_name"
+            },
         },
         stream=True,
     )
@@ -659,13 +723,18 @@ async def test_named_tool_use(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend", ["outlines"])
 async def test_required_tool_use_not_yet_supported(
-    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
-):
+        client: openai.AsyncOpenAI, guided_decoding_backend: str,
+        sample_json_schema):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
         {
-            "role": "user",
-            "content": f"Give an example JSON for an employee profile that "
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role":
+            "user",
+            "content":
+            f"Give an example JSON for an employee profile that "
             f"fits this schema: {sample_json_schema}",
         },
     ]
@@ -675,16 +744,14 @@ async def test_required_tool_use_not_yet_supported(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "dummy_function_name",
-                        "description": "This is a dummy function",
-                        "parameters": sample_json_schema,
-                    },
-                }
-            ],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema,
+                },
+            }],
             tool_choice="required",
         )
 
@@ -693,30 +760,33 @@ async def test_required_tool_use_not_yet_supported(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "dummy_function_name",
-                        "description": "This is a dummy function",
-                        "parameters": sample_json_schema,
-                    },
-                }
-            ],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema,
+                },
+            }],
             tool_choice="auto",
         )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("guided_decoding_backend", ["outlines"])
-async def test_inconsistent_tool_choice_and_tools(
-    client: openai.AsyncOpenAI, guided_decoding_backend: str, sample_json_schema
-):
+async def test_inconsistent_tool_choice_and_tools(client: openai.AsyncOpenAI,
+                                                  guided_decoding_backend: str,
+                                                  sample_json_schema):
     messages = [
-        {"role": "system", "content": "you are a helpful assistant"},
         {
-            "role": "user",
-            "content": f"Give an example JSON for an employee profile that "
+            "role": "system",
+            "content": "you are a helpful assistant"
+        },
+        {
+            "role":
+            "user",
+            "content":
+            f"Give an example JSON for an employee profile that "
             f"fits this schema: {sample_json_schema}",
         },
     ]
@@ -728,7 +798,9 @@ async def test_inconsistent_tool_choice_and_tools(
             max_tokens=1000,
             tool_choice={
                 "type": "function",
-                "function": {"name": "dummy_function_name"},
+                "function": {
+                    "name": "dummy_function_name"
+                },
             },
         )
 
@@ -737,19 +809,19 @@ async def test_inconsistent_tool_choice_and_tools(
             model=MODEL_NAME,
             messages=messages,
             max_tokens=1000,
-            tools=[
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "dummy_function_name",
-                        "description": "This is a dummy function",
-                        "parameters": sample_json_schema,
-                    },
-                }
-            ],
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema,
+                },
+            }],
             tool_choice={
                 "type": "function",
-                "function": {"name": "nondefined_function_name"},
+                "function": {
+                    "name": "nondefined_function_name"
+                },
             },
         )
 
@@ -759,15 +831,12 @@ async def test_response_format_json_object(client: openai.AsyncOpenAI):
     for _ in range(2):
         resp = await client.chat.completions.create(
             model=MODEL_NAME,
-            messages=[
-                {
-                    "role": "user",
-                    "content": (
-                        "what is 1+1? please respond with a JSON object, "
-                        'the format is {"result": 2}'
-                    ),
-                }
-            ],
+            messages=[{
+                "role":
+                "user",
+                "content": ("what is 1+1? please respond with a JSON object, "
+                            'the format is {"result": 2}'),
+            }],
             response_format={"type": "json_object"},
         )
 
@@ -783,13 +852,11 @@ async def test_extra_fields(client: openai.AsyncOpenAI):
     with pytest.raises(BadRequestError) as exc_info:
         await client.chat.completions.create(
             model=MODEL_NAME,
-            messages=[
-                {
-                    "role": "system",
-                    "content": "You are a helpful assistant.",
-                    "extra_field": "0",
-                }
-            ],  # type: ignore
+            messages=[{
+                "role": "system",
+                "content": "You are a helpful assistant.",
+                "extra_field": "0",
+            }],  # type: ignore
             temperature=0,
             seed=0,
         )
@@ -801,19 +868,16 @@ async def test_extra_fields(client: openai.AsyncOpenAI):
 async def test_complex_message_content(client: openai.AsyncOpenAI):
     resp = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text":
-                        ("what is 1+1"
+        messages=[{
+            "role":
+            "user",
+            "content": [{
+                "type":
+                "text",
+                "text": ("what is 1+1"
                          "please provide the result without any other text."),
-                    }
-                ],
-            }
-        ],
+            }],
+        }],
         temperature=0,
         seed=0,
     )
@@ -828,24 +892,23 @@ async def test_custom_role(client: openai.AsyncOpenAI):
 
     resp1 = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[
-            {
-                "role": "my-custom-role",
-                "content": "what is 1+1?",
-            }
-        ],  # type: ignore
+        messages=[{
+            "role": "my-custom-role",
+            "content": "what is 1+1?",
+        }],  # type: ignore
         temperature=0,
         seed=0,
     )
 
     resp2 = await client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[
-            {
-                "role": "my-custom-role",
-                "content": [{"type": "text", "text": "what is 1+1?"}],
-            }
-        ],  # type: ignore
+        messages=[{
+            "role": "my-custom-role",
+            "content": [{
+                "type": "text",
+                "text": "what is 1+1?"
+            }],
+        }],  # type: ignore
         temperature=0,
         seed=0,
     )
@@ -858,23 +921,19 @@ async def test_custom_role(client: openai.AsyncOpenAI):
 @pytest.mark.asyncio
 async def test_long_seed(client: openai.AsyncOpenAI):
     for seed in [
-        torch.iinfo(torch.long).min - 1,
-        torch.iinfo(torch.long).max + 1,
+            torch.iinfo(torch.long).min - 1,
+            torch.iinfo(torch.long).max + 1,
     ]:
         with pytest.raises(BadRequestError) as exc_info:
             await client.chat.completions.create(
                 model=MODEL_NAME,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": "You are a helpful assistant.",
-                    }
-                ],
+                messages=[{
+                    "role": "system",
+                    "content": "You are a helpful assistant.",
+                }],
                 temperature=0,
                 seed=seed,
             )
 
-        assert (
-            "greater_than_equal" in exc_info.value.message
-            or "less_than_equal" in exc_info.value.message
-        )
+        assert ("greater_than_equal" in exc_info.value.message
+                or "less_than_equal" in exc_info.value.message)

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -222,18 +222,11 @@ class OpenAIServingChat(OpenAIServing):
                             model=model_name)
                         if (request.stream_options
                                 and request.stream_options.include_usage):
-                            if (request.stream_options.continuous_usage_stats
-                                    or res.outputs[i].finish_reason
-                                    is not None):
+                            if (request.stream_options.continuous_usage_stats):
                                 prompt_tokens = len(res.prompt_token_ids)
-                                completion_tokens = 0
-                                usage = UsageInfo(
-                                    prompt_tokens=prompt_tokens,
-                                    completion_tokens=completion_tokens,
-                                    total_tokens=prompt_tokens +
-                                    completion_tokens,
-                                )
-                            if request.stream_options.continuous_usage_stats:
+                                usage = UsageInfo(prompt_tokens=prompt_tokens,
+                                                  completion_tokens=0,
+                                                  total_tokens=prompt_tokens)
                                 chunk.usage = usage
                             else:
                                 chunk.usage = None
@@ -268,21 +261,13 @@ class OpenAIServingChat(OpenAIServing):
                                 if (request.stream_options and
                                         request.stream_options.include_usage):
                                     if (request.stream_options.
-                                            continuous_usage_stats
-                                            or res.outputs[i].finish_reason
-                                            is not None):
+                                            continuous_usage_stats):
                                         prompt_tokens = len(
                                             res.prompt_token_ids)
-                                        completion_tokens = len(
-                                            res.outputs[i].token_ids)
                                         usage = UsageInfo(
                                             prompt_tokens=prompt_tokens,
-                                            completion_tokens=completion_tokens,
-                                            total_tokens=prompt_tokens +
-                                            completion_tokens,
-                                        )
-                                    if (request.stream_options.
-                                            continuous_usage_stats):
+                                            completion_tokens=0,
+                                            total_tokens=prompt_tokens)
                                         chunk.usage = usage
                                     else:
                                         chunk.usage = None
@@ -354,7 +339,6 @@ class OpenAIServingChat(OpenAIServing):
                                     total_tokens=prompt_tokens +
                                     completion_tokens,
                                 )
-                            if request.stream_options.continuous_usage_stats:
                                 chunk.usage = usage
                             else:
                                 chunk.usage = None
@@ -387,11 +371,9 @@ class OpenAIServingChat(OpenAIServing):
                                     total_tokens=prompt_tokens +
                                     completion_tokens,
                                 )
-                            if request.stream_options.continuous_usage_stats:
                                 chunk.usage = usage
                             else:
                                 chunk.usage = None
-
                         data = chunk.model_dump_json(exclude_unset=True)
                         yield f"data: {data}\n\n"
                         finish_reason_sent[i] = True

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -223,13 +223,15 @@ class OpenAIServingChat(OpenAIServing):
                         if (request.stream_options
                                 and request.stream_options.include_usage):
                             if (request.stream_options.continuous_usage_stats
-                                    or output.finish_reason is not None):
+                                    or res.outputs[i].finish_reason
+                                    is not None):
                                 prompt_tokens = len(res.prompt_token_ids)
                                 completion_tokens = 0
                                 usage = UsageInfo(
                                     prompt_tokens=prompt_tokens,
                                     completion_tokens=completion_tokens,
-                                    total_tokens=prompt_tokens + completion_tokens,
+                                    total_tokens=prompt_tokens +
+                                    completion_tokens,
                                 )
                             if request.stream_options.continuous_usage_stats:
                                 chunk.usage = usage
@@ -265,16 +267,22 @@ class OpenAIServingChat(OpenAIServing):
                                     model=model_name)
                                 if (request.stream_options and
                                         request.stream_options.include_usage):
-                                    if (request.stream_options.continuous_usage_stats
-                                            or output.finish_reason is not None):
-                                        prompt_tokens = len(res.prompt_token_ids)
-                                        completion_tokens = len(res.outputs[i].token_ids)
+                                    if (request.stream_options.
+                                            continuous_usage_stats
+                                            or res.outputs[i].finish_reason
+                                            is not None):
+                                        prompt_tokens = len(
+                                            res.prompt_token_ids)
+                                        completion_tokens = len(
+                                            res.outputs[i].token_ids)
                                         usage = UsageInfo(
                                             prompt_tokens=prompt_tokens,
                                             completion_tokens=completion_tokens,
-                                            total_tokens=prompt_tokens + completion_tokens,
+                                            total_tokens=prompt_tokens +
+                                            completion_tokens,
                                         )
-                                    if request.stream_options.continuous_usage_stats:
+                                    if (request.stream_options.
+                                            continuous_usage_stats):
                                         chunk.usage = usage
                                     else:
                                         chunk.usage = None
@@ -343,7 +351,8 @@ class OpenAIServingChat(OpenAIServing):
                                 usage = UsageInfo(
                                     prompt_tokens=prompt_tokens,
                                     completion_tokens=completion_tokens,
-                                    total_tokens=prompt_tokens + completion_tokens,
+                                    total_tokens=prompt_tokens +
+                                    completion_tokens,
                                 )
                             if request.stream_options.continuous_usage_stats:
                                 chunk.usage = usage
@@ -375,7 +384,8 @@ class OpenAIServingChat(OpenAIServing):
                                 usage = UsageInfo(
                                     prompt_tokens=prompt_tokens,
                                     completion_tokens=completion_tokens,
-                                    total_tokens=prompt_tokens + completion_tokens,
+                                    total_tokens=prompt_tokens +
+                                    completion_tokens,
                                 )
                             if request.stream_options.continuous_usage_stats:
                                 chunk.usage = usage

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -222,7 +222,20 @@ class OpenAIServingChat(OpenAIServing):
                             model=model_name)
                         if (request.stream_options
                                 and request.stream_options.include_usage):
-                            chunk.usage = None
+                            if (request.stream_options.continuous_usage_stats
+                                    or output.finish_reason is not None):
+                                prompt_tokens = len(res.prompt_token_ids)
+                                completion_tokens = 0
+                                usage = UsageInfo(
+                                    prompt_tokens=prompt_tokens,
+                                    completion_tokens=completion_tokens,
+                                    total_tokens=prompt_tokens + completion_tokens,
+                                )
+                            if request.stream_options.continuous_usage_stats:
+                                chunk.usage = usage
+                            else:
+                                chunk.usage = None
+
                         data = chunk.model_dump_json(exclude_unset=True)
                         yield f"data: {data}\n\n"
 
@@ -252,7 +265,20 @@ class OpenAIServingChat(OpenAIServing):
                                     model=model_name)
                                 if (request.stream_options and
                                         request.stream_options.include_usage):
-                                    chunk.usage = None
+                                    if (request.stream_options.continuous_usage_stats
+                                            or output.finish_reason is not None):
+                                        prompt_tokens = len(res.prompt_token_ids)
+                                        completion_tokens = len(res.outputs[i].token_ids)
+                                        usage = UsageInfo(
+                                            prompt_tokens=prompt_tokens,
+                                            completion_tokens=completion_tokens,
+                                            total_tokens=prompt_tokens + completion_tokens,
+                                        )
+                                    if request.stream_options.continuous_usage_stats:
+                                        chunk.usage = usage
+                                    else:
+                                        chunk.usage = None
+
                                 data = chunk.model_dump_json(
                                     exclude_unset=True)
                                 yield f"data: {data}\n\n"
@@ -311,7 +337,19 @@ class OpenAIServingChat(OpenAIServing):
                             model=model_name)
                         if (request.stream_options
                                 and request.stream_options.include_usage):
-                            chunk.usage = None
+                            if (request.stream_options.continuous_usage_stats):
+                                prompt_tokens = len(res.prompt_token_ids)
+                                completion_tokens = len(output.token_ids)
+                                usage = UsageInfo(
+                                    prompt_tokens=prompt_tokens,
+                                    completion_tokens=completion_tokens,
+                                    total_tokens=prompt_tokens + completion_tokens,
+                                )
+                            if request.stream_options.continuous_usage_stats:
+                                chunk.usage = usage
+                            else:
+                                chunk.usage = None
+
                         data = chunk.model_dump_json(exclude_unset=True)
                         yield f"data: {data}\n\n"
                     else:
@@ -331,7 +369,19 @@ class OpenAIServingChat(OpenAIServing):
                             model=model_name)
                         if (request.stream_options
                                 and request.stream_options.include_usage):
-                            chunk.usage = None
+                            if (request.stream_options.continuous_usage_stats):
+                                prompt_tokens = len(res.prompt_token_ids)
+                                completion_tokens = len(output.token_ids)
+                                usage = UsageInfo(
+                                    prompt_tokens=prompt_tokens,
+                                    completion_tokens=completion_tokens,
+                                    total_tokens=prompt_tokens + completion_tokens,
+                                )
+                            if request.stream_options.continuous_usage_stats:
+                                chunk.usage = usage
+                            else:
+                                chunk.usage = None
+
                         data = chunk.model_dump_json(exclude_unset=True)
                         yield f"data: {data}\n\n"
                         finish_reason_sent[i] = True


### PR DESCRIPTION
PR for issue #6540 

I added a some logic to return usage data on each chunk when flag `stream_options.continuous_usage_stats` is set. 


