### PR TITLE
Llama3 Inference Optimization 

### DIFF
--- a/vllm/model_executor/layers/quantization/deepspeedfp.py
+++ b/vllm/model_executor/layers/quantization/deepspeedfp.py
@@ -9,6 +9,8 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 from vllm.model_executor.utils import set_weight_attrs
 
+from vllm.distributed import get_tensor_model_parallel_world_size
+g_matmul_fp8 = None
 
 class DeepSpeedFPConfig(QuantizationConfig):
     """Config for DeepSpeed FP quantizer. It supports fp6 and fp8.
@@ -83,9 +85,10 @@ class DeepSpeedFPLinearMethod(LinearMethodBase):
         quant_config: the DeepSpeedFP quantization config.
     """
 
-    def __init__(self, quant_config: DeepSpeedFPConfig):
+    def __init__(self, quant_config: DeepSpeedFPConfig, enable_fused_kernel=True):
         self.quant_config = quant_config
         self.weight = None
+        self.enable_fused_kernel = enable_fused_kernel
 
     def create_weights(self,
                        layer: torch.nn.Module,
@@ -111,14 +114,21 @@ class DeepSpeedFPLinearMethod(LinearMethodBase):
         layer.register_parameter("weight", weight)
 
         def quant_weight_loader(param, loaded_weight, *args, **kwargs):
-            # Calls the original weight loader (if any), quantizes the result,
-            # and then loads the quantized parameter.
             if weight_loader is not None:
-                orig_param_data = param.data
-                param.data = param.ds_dequantize()
-                weight_loader(param, loaded_weight, *args, **kwargs)
-                param.data, loaded_weight = orig_param_data, param.data
-            param.ds_quantize_(loaded_weight.cuda())
+                if not hasattr(param, 'shadow_data'):
+                    param.shadow_data = torch.empty(
+                        param.orig_shape, 
+                        dtype=loaded_weight.dtype, 
+                        device=loaded_weight.device)
+                    param.shadow_data.input_dim = param.input_dim
+                    param.shadow_data.output_dim = param.output_dim
+                    tp_size = get_tensor_model_parallel_world_size()
+                weight_loader(param.shadow_data, loaded_weight, *args, **kwargs)
+                loaded_weight = param.shadow_data
+
+            param.ds_quantize_(
+                loaded_weight.transpose(-1, -2).contiguous().cuda() if self.enable_fused_kernel else loaded_weight.cuda()
+            )
 
         extra_weight_attrs["weight_loader"] = quant_weight_loader
         set_weight_attrs(weight, extra_weight_attrs)
@@ -128,8 +138,18 @@ class DeepSpeedFPLinearMethod(LinearMethodBase):
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
         weight = layer.weight
-        y = weight.ds_dequantize()
-        return F.linear(x, y, bias)
+        if self.enable_fused_kernel:
+            y = g_matmul_fp8(
+                x, 
+                weight, 
+                weight.quantization_scales(), 
+                weight.fp_quantizer.group_size
+            )
+            return y if bias is None else (y + bias)
+        else:
+            weight = layer.weight
+            y = weight.ds_dequantize()
+            return F.linear(x, y, bias)
 
 
 class DeepSpeedFPParameter(nn.Parameter):
@@ -140,13 +160,15 @@ class DeepSpeedFPParameter(nn.Parameter):
     """
 
     def __new__(cls, orig_shape: torch.Size, params_dtype: torch.dtype,
-                quant_config: DeepSpeedFPConfig):
+                quant_config: DeepSpeedFPConfig, use_meta_tensor=True):
         try:
             import deepspeed
             if deepspeed.__version__ < "0.14.2":
                 raise ImportError("deepspeed version is wrong. Please "
                                   "install deepspeed>=0.14.2.")
-            from deepspeed.ops.fp_quantizer import FP_Quantize
+            global g_matmul_fp8
+            from deepspeed.ops.fp_quantizer import FP_Quantize, matmul_fp8
+            g_matmul_fp8 = matmul_fp8
         except ImportError as err:
             raise ImportError("Please install deepspeed>=0.14.2 via "
                               "`pip install deepspeed>=0.14.2` to use "
@@ -162,15 +184,25 @@ class DeepSpeedFPParameter(nn.Parameter):
         self.fp_quantizer = FP_Quantize(group_size=quant_config.group_size)
         self.fp_quantizer.orig_shape = orig_shape
         self.fp_quantizer.orig_dtype = params_dtype
+        self.scale = None
+        self.use_meta_tensor = use_meta_tensor
         return self
 
     def ds_quantize_(self, tensor: torch.Tensor):
         assert tensor.device.type == "cuda" and tensor.dtype != torch.int8
-        return self.data.copy_(
-            self.fp_quantizer.quantize(
-                tensor.data,
-                q_bits=self.quant_config.weight_bits,
-            ))
+        q_data = self.fp_quantizer.quantize(
+            tensor.data,
+            q_bits=self.quant_config.weight_bits,
+            return_meta_tensor=self.use_meta_tensor
+        )
+        if use_meta_tensor:
+            q_data, self.scale = q_data
+        self.data.copy_(q_data)
+        del q_data
+        return self.data
+
+    def quantization_scales(self):
+        return self.fp_quantizer.get_scales()
 
     def ds_dequantize(self, fp_out=None) -> torch.Tensor:
         """
@@ -178,7 +210,11 @@ class DeepSpeedFPParameter(nn.Parameter):
         """
         assert self.data.device.type == "cuda" and self.data.dtype == torch.int8
         return self.fp_quantizer.dequantize(
-            self.data, fp_out=fp_out, q_bits=self.quant_config.weight_bits)
+            self.data, 
+            fp_out=fp_out, 
+            q_bits=self.quant_config.weight_bits
+            scale=self.scale,
+        )
 
     def ds_selective_dequantize(self, indices, fp_out=None) -> torch.Tensor:
         """
@@ -190,4 +226,5 @@ class DeepSpeedFPParameter(nn.Parameter):
             self.data,
             indices,
             fp_out=fp_out,
-            q_bits=self.quant_config.weight_bits)
+            q_bits=self.quant_config.weight_bits
+            scale=self.scale,)

--- a/vllm/model_executor/models/arctic.py
+++ b/vllm/model_executor/models/arctic.py
@@ -112,19 +112,21 @@ class ArcticMoE(nn.Module):
                                          self.num_experts,
                                          bias=False,
                                          params_dtype=self.params_dtype,
-                                         quant_config=quant_config)
+                                         quant_config=None) # gate's projection is cheap and should not be quantized!
             if self.is_quant:
                 self.ws = DeepSpeedFPParameter(
                     torch.Size((self.num_experts, 2 * self.intermediate_size,
                                 self.hidden_size)),
                     params_dtype=params_dtype,
                     quant_config=quant_config,
+                    use_meta_tensor=False
                 )
                 self.w2s = DeepSpeedFPParameter(
                     torch.Size((self.num_experts, self.hidden_size,
                                 self.intermediate_size)),
                     params_dtype=params_dtype,
                     quant_config=quant_config,
+                    use_meta_tensor=False
                 )
             else:
                 self.ws = nn.Parameter(


### PR DESCRIPTION
This PR adds a series of optimization from the pipeline parallelism to kernel optimization for the quantized model, to make the inference stack run large-scale models such as Llama3 on lower number of devices or being able to get the highest throughput when using more GPUs and adding more parallelization degrees (combining pipeline and tensor parallelism).