### PR TITLE
[Bugfix] Fix null `modules_to_not_convert`  in FBGEMM Fp8 quantization

### DIFF
--- a/vllm/model_executor/layers/quantization/fbgemm_fp8.py
+++ b/vllm/model_executor/layers/quantization/fbgemm_fp8.py
@@ -31,7 +31,7 @@ class FBGEMMFp8Config(QuantizationConfig):
     """Config class for FBGEMM Fp8."""
 
     def __init__(self, ignore_list: List[str], input_scale_ub: float):
-        self.ignore_list = ignore_list
+        self.ignore_list = ignore_list if ignore_list else []
         self.input_scale_ub = input_scale_ub
 
         # For GPUs that lack FP8 hardware support, we can leverage the Marlin


### PR DESCRIPTION
Summary:

This PR fixes the bug in the FBGEMM Fp8 quantization where `"modules_to_not_convert": null`. Without this fix, the current check on layer skipping results in error due to `in self.ignore_list`.