### PR TITLE
[Kernel] Tuned FP8 Kernels for Ada Lovelace

### DIFF
--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -13,7 +13,7 @@ from weight_shapes import WEIGHT_SHAPES
 from vllm import _custom_ops as ops
 from vllm.utils import FlexibleArgumentParser
 
-DEFAULT_MODELS = list(WEIGHT_SHAPES.keys())[1:]
+DEFAULT_MODELS = list(WEIGHT_SHAPES.keys())
 DEFAULT_BATCH_SIZES = [1, 16, 32, 64, 128, 256, 512]
 DEFAULT_TP_SIZES = [1]
 

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -124,11 +124,13 @@ void cutlass_scaled_mm_sm89_epilogue(torch::Tensor& out, torch::Tensor const& a,
     TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
 
     if (out.dtype() == torch::kBFloat16) {
-      return vllm::cutlass_gemm_sm89_dispatch<cutlass::float_e4m3_t, cutlass::bfloat16_t, Epilogue>(
+      return vllm::cutlass_gemm_sm89_dispatch<cutlass::float_e4m3_t,
+                                              cutlass::bfloat16_t, Epilogue>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     } else {
       TORCH_CHECK(out.dtype() == torch::kFloat16);
-      return vllm::cutlass_gemm_sm89_dispatch<cutlass::float_e4m3_t, cutlass::half_t, Epilogue>(
+      return vllm::cutlass_gemm_sm89_dispatch<cutlass::float_e4m3_t,
+                                              cutlass::half_t, Epilogue>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     }
   }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -1,469 +1,10 @@
-#include <stddef.h>
-#include <torch/all.h>
-
-#include <ATen/cuda/CUDAContext.h>
-
-// clang-format will break include orders
-// clang-format off
-#include "cute/tensor.hpp"
-#include "cute/atom/mma_atom.hpp"
-#include "cutlass/numeric_types.h"
-
-#include "cutlass/util/device_memory.h"
-
-#include "cutlass/cutlass.h"
-#include "cutlass/gemm_coord.h"
-#include "cutlass/arch/mma_sm75.h"
-#include "cutlass/arch/arch.h"
-#include "cutlass/arch/mma.h"
-#include "cutlass/gemm/device/gemm.h"
-#include "cutlass/gemm/device/gemm_universal_adapter.h"
-
-#include "cutlass/epilogue/threadblock/fusion/visitors.hpp"
-#include "cutlass/gemm/kernel/default_gemm_universal_with_visitor.h"
-
-#include "broadcast_load_epilogue_c2x.hpp"
-#include "common.hpp"
-// clang-format on
-
-using namespace cute;
+#include "scaled_mm_c2x.cuh"
+#include "scaled_mm_c2x_sm80_dispatch.cuh"
 
 /*
    This file defines quantized GEMM operations using the CUTLASS 2.x API, for
    NVIDIA GPUs with SM versions prior to sm90 (Hopper).
-
-   Epilogue functions can be defined to post-process the output before it is
-   written to GPU memory.
-   Epilogues must contain a public type named EVTCompute of type Sm80EVT,
-   as well as a static prepare_args function that constructs an
-   EVTCompute::Arguments struct.
 */
-
-namespace {
-
-// Wrappers for the GEMM kernel that is used to guard against compilation on
-// architectures that will never use the kernel. The purpose of this is to
-// reduce the size of the compiled binary.
-// __CUDA_ARCH__ is not defined in host code, so this lets us smuggle the ifdef
-// into code that will be executed on the device where it is defined.
-template <typename Kernel>
-struct enable_sm75_to_sm80 : Kernel {
-  template <typename... Args>
-  CUTLASS_DEVICE static void invoke(Args&&... args) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 750 && __CUDA_ARCH__ < 800
-    Kernel::invoke(std::forward<Args>(args)...);
-#endif
-  }
-};
-
-template <typename Kernel>
-struct enable_sm80_to_sm89 : Kernel {
-  template <typename... Args>
-  CUTLASS_DEVICE static void invoke(Args&&... args) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 800 && __CUDA_ARCH__ < 890
-    Kernel::invoke(std::forward<Args>(args)...);
-#endif
-  }
-};
-
-template <typename Kernel>
-struct enable_sm89_to_sm90 : Kernel {
-  template <typename... Args>
-  CUTLASS_DEVICE static void invoke(Args&&... args) {
-#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 890 && __CUDA_ARCH__ < 900
-    Kernel::invoke(std::forward<Args>(args)...);
-#endif
-  }
-};
-
-/*
- * This class provides the common ScaleA and ScaleB descriptors for the
- * ScaledEpilogue and ScaledEpilogueBias classes.
- */
-template <typename ElementD, typename OutputTileThreadMap>
-struct ScaledEpilogueBase {
- protected:
-  using Accum = cutlass::epilogue::threadblock::VisitorAccFetch;
-
-  using ScaleA = cutlass::epilogue::threadblock::VisitorColOrScalarBroadcast<
-      OutputTileThreadMap, float, Stride<Int<1>, Int<0>, Int<0>>>;
-
-  using ScaleB = cutlass::epilogue::threadblock::VisitorRowOrScalarBroadcast<
-      OutputTileThreadMap, float, Stride<Int<0>, Int<1>, Int<0>>>;
-};
-
-/*
- This epilogue function defines a quantized GEMM operation similar to
- torch._scaled_mm.
-
- A and B may be both either int8 or fp8_e4m3. A can be quantized per-tensor or
- per-row. B can be quantized per-tensor or per-column.
- Any combination of per-tensor and per-row or column is supported.
- A and B must have symmetric quantization (zero point == 0).
-
- So the GEMM operation is D = (a_scales * A) (b_scales * B), where the
- scales are applied elementwise with numpy-style broadcasting.
-
- ScaleA and ScaleB define the epilogue functions that apply the scales for
- the A and B operands respectively. These scales may be either per-tensor or
- per row or column.
-*/
-template <typename ElementD, typename OutputTileThreadMap>
-struct ScaledEpilogue
-    : private ScaledEpilogueBase<ElementD, OutputTileThreadMap> {
- private:
-  using SUPER = ScaledEpilogueBase<ElementD, OutputTileThreadMap>;
-  using Accum = typename SUPER::Accum;
-  using ScaleA = typename SUPER::ScaleA;
-  using ScaleB = typename SUPER::ScaleB;
-
-  using Compute0 = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiplies, float, float,
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute0 =
-      cutlass::epilogue::threadblock::Sm80EVT<Compute0, ScaleB, Accum>;
-
-  using Compute1 = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiplies, ElementD, float,
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
- public:
-  using EVTCompute =
-      cutlass::epilogue::threadblock::Sm80EVT<Compute1, ScaleA, EVTCompute0>;
-  using ArgumentType = typename EVTCompute::Arguments;
-
-  static ArgumentType prepare_args(torch::Tensor const& a_scales,
-                                   torch::Tensor const& b_scales) {
-    using ScaleAArgs = typename ScaleA::Arguments;
-    using ScaleBArgs = typename ScaleB::Arguments;
-
-    ScaleBArgs b_args{b_scales.data_ptr<float>(), b_scales.numel() != 1, {}};
-    ScaleAArgs a_args{a_scales.data_ptr<float>(), a_scales.numel() != 1, {}};
-
-    typename EVTCompute0::Arguments evt0_compute_args{b_args};
-
-    typename EVTCompute::Arguments evt_compute_args{a_args, evt0_compute_args};
-    return evt_compute_args;
-  }
-};
-
-template <typename ElementD, typename OutputTileThreadMap>
-struct ScaledEpilogueBias
-    : private ScaledEpilogueBase<ElementD, OutputTileThreadMap> {
- private:
-  using SUPER = ScaledEpilogueBase<ElementD, OutputTileThreadMap>;
-  using Accum = typename SUPER::Accum;
-  using ScaleA = typename SUPER::ScaleA;
-  using ScaleB = typename SUPER::ScaleB;
-
-  using Compute0 = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiplies, float, float,
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using EVTCompute0 =
-      cutlass::epilogue::threadblock::Sm80EVT<Compute0, ScaleB, Accum>;
-
-  using Compute1 = cutlass::epilogue::threadblock::VisitorCompute<
-      cutlass::multiply_add, ElementD, float,
-      cutlass::FloatRoundStyle::round_to_nearest>;
-
-  using Bias = cutlass::epilogue::threadblock::VisitorRowBroadcast<
-      OutputTileThreadMap, ElementD, Stride<Int<0>, Int<1>, Int<0>>>;
-
- public:
-  using EVTCompute = cutlass::epilogue::threadblock::Sm80EVT<Compute1, ScaleA,
-                                                             EVTCompute0, Bias>;
-  using ArgumentType = typename EVTCompute::Arguments;
-
-  static ArgumentType prepare_args(torch::Tensor const& a_scales,
-                                   torch::Tensor const& b_scales,
-                                   torch::Tensor const& bias) {
-    using ScaleAArgs = typename ScaleA::Arguments;
-    using ScaleBArgs = typename ScaleB::Arguments;
-    using BiasArgs = typename Bias::Arguments;
-
-    ScaleBArgs b_args{b_scales.data_ptr<float>(), b_scales.numel() != 1, {}};
-    ScaleAArgs a_args{a_scales.data_ptr<float>(), a_scales.numel() != 1, {}};
-    BiasArgs bias_args{static_cast<ElementD*>(bias.data_ptr()), {}};
-
-    typename EVTCompute0::Arguments evt0_compute_args{b_args};
-
-    typename EVTCompute::Arguments evt_compute_args{a_args, evt0_compute_args,
-                                                    bias_args};
-    return evt_compute_args;
-  }
-};
-
-template <typename Arch, template <typename> typename ArchGuard,
-          typename ElementAB_, typename ElementD_,
-          template <typename, typename> typename Epilogue_, typename TileShape,
-          typename WarpShape, typename InstructionShape, int32_t MainLoopStages>
-struct cutlass_2x_gemm {
-  using ElementAB = ElementAB_;
-  using ElementD = ElementD_;
-
-  using ElementAcc =
-      typename std::conditional<std::is_same_v<ElementAB, int8_t>, int32_t,
-                                float>::type;
-
-  using Operator =
-      typename std::conditional<std::is_same_v<ElementAB, int8_t>,
-                                cutlass::arch::OpMultiplyAddSaturate,
-                                cutlass::arch::OpMultiplyAdd>::type;
-
-  using OutputTileThreadMap =
-      cutlass::epilogue::threadblock::OutputTileThreadLayout<
-          TileShape, WarpShape, float, 4, 1 /* epilogue stages */
-          >;
-
-  using Epilogue = Epilogue_<ElementD, OutputTileThreadMap>;
-  using EVTCompute = typename Epilogue::EVTCompute;
-
-  using D = cutlass::epilogue::threadblock::VisitorAuxStore<
-      OutputTileThreadMap, ElementD, cutlass::FloatRoundStyle::round_to_nearest,
-      Stride<int64_t, Int<1>, Int<0>>>;
-
-  using EVTD = cutlass::epilogue::threadblock::Sm80EVT<D, EVTCompute>;
-
-  // clang-format off
-  using RowMajor = typename cutlass::layout::RowMajor;
-  using ColumnMajor = typename cutlass::layout::ColumnMajor;
-  using KernelType =
-    ArchGuard<typename cutlass::gemm::kernel::DefaultGemmWithVisitor<
-      ElementAB, RowMajor, cutlass::ComplexTransform::kNone, 16,
-      ElementAB, ColumnMajor, cutlass::ComplexTransform::kNone, 16,
-      float, cutlass::layout::RowMajor, 4,
-      ElementAcc, float, cutlass::arch::OpClassTensorOp,
-      Arch,
-      TileShape, WarpShape, InstructionShape,
-      EVTD,
-      cutlass::gemm::threadblock::ThreadblockSwizzleStreamK,
-      MainLoopStages, Operator,
-      1 /* epilogue stages */
-      >::GemmKernel>;
-  // clang-format on
-
-  using Op = cutlass::gemm::device::GemmUniversalAdapter<KernelType>;
-};
-
-template <typename Gemm, typename... EpilogueArgs>
-void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
-                         torch::Tensor const& b,
-                         EpilogueArgs&&... epilogue_params) {
-  using ElementAB = typename Gemm::ElementAB;
-  using ElementD = typename Gemm::ElementD;
-
-  int32_t m = a.size(0);
-  int32_t n = b.size(1);
-  int32_t k = a.size(1);
-  cutlass::gemm::GemmCoord problem_size{m, n, k};
-
-  int64_t lda = a.stride(0);
-  int64_t ldb = b.stride(1);
-  int64_t ldc = out.stride(0);
-
-  using StrideC = Stride<int64_t, Int<1>, Int<0>>;
-  StrideC c_stride{ldc, Int<1>{}, Int<0>{}};
-
-  auto a_ptr = static_cast<ElementAB const*>(a.data_ptr());
-  auto b_ptr = static_cast<ElementAB const*>(b.data_ptr());
-  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
-
-  typename Gemm::D::Arguments d_args{c_ptr, c_stride};
-
-  using Epilogue = typename Gemm::Epilogue;
-  auto evt_args =
-      Epilogue::prepare_args(std::forward<EpilogueArgs>(epilogue_params)...);
-
-  typename Gemm::EVTD::Arguments epilogue_args{
-      evt_args,
-      d_args,
-  };
-
-  typename Gemm::Op::Arguments args{
-      cutlass::gemm::GemmUniversalMode::kGemmSplitKParallel,  // universal mode
-      problem_size,                                           // problem size
-      1,                                                      // batch count
-      epilogue_args,
-      a_ptr,
-      b_ptr,
-      nullptr,
-      nullptr,
-      0,
-      0,
-      0,
-      0,
-      lda,
-      ldb,
-      ldc,
-      ldc};
-
-  // Launch the CUTLASS GEMM kernel.
-  typename Gemm::Op gemm_op;
-  size_t workspace_size = gemm_op.get_workspace_size(args);
-  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
-
-  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
-
-  CUTLASS_CHECK(gemm_op.can_implement(args));
-  cutlass::Status status = gemm_op(args, workspace.get(), stream);
-  CUTLASS_CHECK(status);
-}
-
-template <typename Gemm, typename FallbackGemm, typename... EpilogueArgs>
-void fallback_cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
-                                  torch::Tensor const& b,
-                                  EpilogueArgs&&... args) {
-  // In some cases, the GPU isn't able to accommodate the
-  // shared memory requirements of the Gemm. In such cases, use
-  // the FallbackGemm instead.
-  static const int max_shared_mem_per_block_opt_in =
-      get_cuda_max_shared_memory_per_block_opt_in(0);
-
-  size_t const gemm_shared_mem_size =
-      sizeof(typename Gemm::KernelType::SharedStorage);
-  size_t const fallback_gemm_shared_mem_size =
-      sizeof(typename FallbackGemm::KernelType::SharedStorage);
-
-  if (gemm_shared_mem_size <= max_shared_mem_per_block_opt_in) {
-    return cutlass_gemm_caller<Gemm>(out, a, b,
-                                     std::forward<EpilogueArgs>(args)...);
-  } else {
-    TORCH_CHECK(fallback_gemm_shared_mem_size <=
-                max_shared_mem_per_block_opt_in);
-    return cutlass_gemm_caller<FallbackGemm>(
-        out, a, b, std::forward<EpilogueArgs>(args)...);
-  }
-}
-
-template <typename InType, typename OutType,
-          template <typename, typename> typename Epilogue>
-struct sm80_config_default {
-  // This config is used in 2 cases,
-  //  - M in (128, inf)
-  //  - M in (64, 128] and N >= 8192
-  // Shared Memory required by this Gemm - 81920 bytes
-  static_assert(std::is_same<InType, int8_t>());
-  using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
-  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using Cutlass2xGemm =
-      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
-};
-
-template <typename InType, typename OutType,
-          template <typename, typename> typename Epilogue>
-struct sm80_config_M64 {
-  // This config is used in 2 cases,
-  // - M in (32, 64]
-  // - M in (64, 128] and N < 8192
-  // Shared Memory required by this Gemm - 122880 bytes
-  static_assert(std::is_same<InType, int8_t>());
-  using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
-  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using Cutlass2xGemm =
-      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
-};
-
-template <typename InType, typename OutType,
-          template <typename, typename> typename Epilogue>
-struct sm80_config_M32 {
-  // M in (16, 32]
-  // Shared Memory required by this Gemm - 61440 bytes
-  static_assert(std::is_same<InType, int8_t>());
-  using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
-  using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using Cutlass2xGemm =
-      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
-};
-
-template <typename InType, typename OutType,
-          template <typename, typename> typename Epilogue>
-struct sm80_config_M16 {
-  // M in [1, 16]
-  // Shared Memory required by this Gemm - 51200 bytes
-  static_assert(std::is_same<InType, int8_t>());
-  using TileShape = typename cutlass::gemm::GemmShape<16, 64, 128>;
-  using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using Cutlass2xGemm =
-      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
-                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
-};
-
-}  // namespace
-
-template <typename InType, typename OutType,
-          template <typename, typename> typename Epilogue,
-          typename... EpilogueArgs>
-void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
-                                torch::Tensor const& b,
-                                EpilogueArgs&&... args) {
-  static_assert(std::is_same<InType, int8_t>());
-  TORCH_CHECK(a.dtype() == torch::kInt8);
-  TORCH_CHECK(b.dtype() == torch::kInt8);
-
-  using Cutlass2xGemmDefault =
-      typename sm80_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM128BigN =
-      typename sm80_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM128SmallN =
-      typename sm80_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM64 =
-      typename sm80_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM32 =
-      typename sm80_config_M32<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM16 =
-      typename sm80_config_M16<InType, OutType, Epilogue>::Cutlass2xGemm;
-
-  // Due to shared memory requirements, some Gemms may fail to run on some
-  // GPUs. As the name indicates, the Fallback Gemm is used as an alternative
-  // in such cases.
-  // sm80_config_M16 has the least shared-memory requirement. However,
-  // based on some profiling, we select sm80_config_M32 as a better alternative
-  // performance wise.
-  using FallbackGemm =
-      typename sm80_config_M32<InType, OutType, Epilogue>::Cutlass2xGemm;
-
-  uint32_t const m = a.size(0);
-  uint32_t const mp2 =
-      std::max(static_cast<uint32_t>(16), next_pow_2(m));  // next power of 2
-  if (mp2 <= 16) {
-    // M in [1, 16]
-    return fallback_cutlass_gemm_caller<Cutlass2xGemmM16, FallbackGemm>(
-        out, a, b, std::forward<EpilogueArgs>(args)...);
-  } else if (mp2 <= 32) {
-    // M in (16, 32]
-    return fallback_cutlass_gemm_caller<Cutlass2xGemmM32, FallbackGemm>(
-        out, a, b, std::forward<EpilogueArgs>(args)...);
-  } else if (mp2 <= 64) {
-    // M in (32, 64]
-    return fallback_cutlass_gemm_caller<Cutlass2xGemmM64, FallbackGemm>(
-        out, a, b, std::forward<EpilogueArgs>(args)...);
-  } else if (mp2 <= 128) {
-    // M in (64, 128]
-    uint32_t const n = out.size(1);
-    bool const small_n = n < 8192;
-    if (small_n) {
-      return fallback_cutlass_gemm_caller<Cutlass2xGemmM128SmallN,
-                                          FallbackGemm>(
-          out, a, b, std::forward<EpilogueArgs>(args)...);
-    } else {
-      return fallback_cutlass_gemm_caller<Cutlass2xGemmM128BigN, FallbackGemm>(
-          out, a, b, std::forward<EpilogueArgs>(args)...);
-    }
-  } else {
-    // M in (128, inf)
-    return fallback_cutlass_gemm_caller<Cutlass2xGemmDefault, FallbackGemm>(
-        out, a, b, std::forward<EpilogueArgs>(args)...);
-  }
-}
 
 template <template <typename, typename> typename Epilogue,
           typename... EpilogueArgs>
@@ -478,14 +19,14 @@ void cutlass_scaled_mm_sm75_epilogue(torch::Tensor& out, torch::Tensor const& a,
   using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
 
   if (out.dtype() == torch::kBFloat16) {
-    return cutlass_gemm_caller<cutlass_2x_gemm<
-        cutlass::arch::Sm75, enable_sm75_to_sm80, int8_t, cutlass::bfloat16_t,
+    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+        cutlass::arch::Sm75, vllm::enable_sm75_to_sm80, int8_t, cutlass::bfloat16_t,
         Epilogue, TileShape, WarpShape, InstructionShape, 2>>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return cutlass_gemm_caller<cutlass_2x_gemm<
-        cutlass::arch::Sm75, enable_sm75_to_sm80, int8_t, cutlass::half_t,
+    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+        cutlass::arch::Sm75, vllm::enable_sm75_to_sm80, int8_t, cutlass::half_t,
         Epilogue, TileShape, WarpShape, InstructionShape, 2>>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   }
@@ -501,10 +42,10 @@ void cutlass_scaled_mm_sm75(torch::Tensor& out, torch::Tensor const& a,
   if (bias) {
     TORCH_CHECK(bias->dtype() == out.dtype(),
                 "currently bias dtype must match output dtype ", out.dtype());
-    return cutlass_scaled_mm_sm75_epilogue<ScaledEpilogueBias>(
+    return cutlass_scaled_mm_sm75_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm75_epilogue<ScaledEpilogue>(out, a, b, a_scales,
+    return cutlass_scaled_mm_sm75_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
                                                            b_scales);
   }
 }
@@ -518,11 +59,11 @@ void cutlass_scaled_mm_sm80_epilogue(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(b.dtype() == torch::kInt8);
 
   if (out.dtype() == torch::kBFloat16) {
-    return cutlass_gemm_sm80_dispatch<int8_t, cutlass::bfloat16_t, Epilogue>(
+    return vllm::cutlass_gemm_sm80_dispatch<int8_t, cutlass::bfloat16_t, Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return cutlass_gemm_sm80_dispatch<int8_t, cutlass::half_t, Epilogue>(
+    return vllm::cutlass_gemm_sm80_dispatch<int8_t, cutlass::half_t, Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   }
 }
@@ -537,10 +78,10 @@ void cutlass_scaled_mm_sm80(torch::Tensor& out, torch::Tensor const& a,
   if (bias) {
     TORCH_CHECK(bias->dtype() == out.dtype(),
                 "currently bias dtype must match output dtype ", out.dtype());
-    return cutlass_scaled_mm_sm80_epilogue<ScaledEpilogueBias>(
+    return cutlass_scaled_mm_sm80_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm80_epilogue<ScaledEpilogue>(out, a, b, a_scales,
+    return cutlass_scaled_mm_sm80_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
                                                            b_scales);
   }
 }
@@ -558,14 +99,14 @@ void cutlass_scaled_mm_sm89_epilogue(torch::Tensor& out, torch::Tensor const& a,
     TORCH_CHECK(b.dtype() == torch::kInt8);
 
     if (out.dtype() == torch::kBFloat16) {
-      return cutlass_gemm_caller<cutlass_2x_gemm<
-          cutlass::arch::Sm89, enable_sm89_to_sm90, int8_t, cutlass::bfloat16_t,
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, int8_t, cutlass::bfloat16_t,
           Epilogue, TileShape, WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     } else {
       assert(out.dtype() == torch::kFloat16);
-      return cutlass_gemm_caller<cutlass_2x_gemm<
-          cutlass::arch::Sm89, enable_sm89_to_sm90, int8_t, cutlass::half_t,
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, int8_t, cutlass::half_t,
           Epilogue, TileShape, WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     }
@@ -574,15 +115,15 @@ void cutlass_scaled_mm_sm89_epilogue(torch::Tensor& out, torch::Tensor const& a,
     TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
 
     if (out.dtype() == torch::kBFloat16) {
-      return cutlass_gemm_caller<
-          cutlass_2x_gemm<cutlass::arch::Sm89, enable_sm89_to_sm90,
+      return vllm::cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
                           cutlass::float_e4m3_t, cutlass::bfloat16_t, Epilogue,
                           TileShape, WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     } else {
       TORCH_CHECK(out.dtype() == torch::kFloat16);
-      return cutlass_gemm_caller<
-          cutlass_2x_gemm<cutlass::arch::Sm89, enable_sm89_to_sm90,
+      return vllm::cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
                           cutlass::float_e4m3_t, cutlass::half_t, Epilogue,
                           TileShape, WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
@@ -600,10 +141,10 @@ void cutlass_scaled_mm_sm89(torch::Tensor& out, torch::Tensor const& a,
   if (bias) {
     TORCH_CHECK(bias->dtype() == out.dtype(),
                 "currently bias dtype must match output dtype ", out.dtype());
-    return cutlass_scaled_mm_sm89_epilogue<ScaledEpilogueBias>(
+    return cutlass_scaled_mm_sm89_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm89_epilogue<ScaledEpilogue>(out, a, b, a_scales,
+    return cutlass_scaled_mm_sm89_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
                                                            b_scales);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -19,9 +19,10 @@ void cutlass_scaled_mm_sm75_epilogue(torch::Tensor& out, torch::Tensor const& a,
   using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
 
   if (out.dtype() == torch::kBFloat16) {
-    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-        cutlass::arch::Sm75, vllm::enable_sm75_to_sm80, int8_t, cutlass::bfloat16_t,
-        Epilogue, TileShape, WarpShape, InstructionShape, 2>>(
+    return vllm::cutlass_gemm_caller<
+        vllm::cutlass_2x_gemm<cutlass::arch::Sm75, vllm::enable_sm75_to_sm80,
+                              int8_t, cutlass::bfloat16_t, Epilogue, TileShape,
+                              WarpShape, InstructionShape, 2>>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
@@ -45,8 +46,8 @@ void cutlass_scaled_mm_sm75(torch::Tensor& out, torch::Tensor const& a,
     return cutlass_scaled_mm_sm75_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm75_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
-                                                           b_scales);
+    return cutlass_scaled_mm_sm75_epilogue<vllm::ScaledEpilogue>(
+        out, a, b, a_scales, b_scales);
   }
 }
 
@@ -59,7 +60,8 @@ void cutlass_scaled_mm_sm80_epilogue(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(b.dtype() == torch::kInt8);
 
   if (out.dtype() == torch::kBFloat16) {
-    return vllm::cutlass_gemm_sm80_dispatch<int8_t, cutlass::bfloat16_t, Epilogue>(
+    return vllm::cutlass_gemm_sm80_dispatch<int8_t, cutlass::bfloat16_t,
+                                            Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
@@ -81,8 +83,8 @@ void cutlass_scaled_mm_sm80(torch::Tensor& out, torch::Tensor const& a,
     return cutlass_scaled_mm_sm80_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm80_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
-                                                           b_scales);
+    return cutlass_scaled_mm_sm80_epilogue<vllm::ScaledEpilogue>(
+        out, a, b, a_scales, b_scales);
   }
 }
 
@@ -99,15 +101,17 @@ void cutlass_scaled_mm_sm89_epilogue(torch::Tensor& out, torch::Tensor const& a,
     TORCH_CHECK(b.dtype() == torch::kInt8);
 
     if (out.dtype() == torch::kBFloat16) {
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, int8_t, cutlass::bfloat16_t,
-          Epilogue, TileShape, WarpShape, InstructionShape, 5>>(
+      return vllm::cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                int8_t, cutlass::bfloat16_t, Epilogue,
+                                TileShape, WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     } else {
       assert(out.dtype() == torch::kFloat16);
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, int8_t, cutlass::half_t,
-          Epilogue, TileShape, WarpShape, InstructionShape, 5>>(
+      return vllm::cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                int8_t, cutlass::half_t, Epilogue, TileShape,
+                                WarpShape, InstructionShape, 5>>(
           out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     }
   } else {
@@ -115,18 +119,16 @@ void cutlass_scaled_mm_sm89_epilogue(torch::Tensor& out, torch::Tensor const& a,
     TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
 
     if (out.dtype() == torch::kBFloat16) {
-      return vllm::cutlass_gemm_caller<
-          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
-                          cutlass::float_e4m3_t, cutlass::bfloat16_t, Epilogue,
-                          TileShape, WarpShape, InstructionShape, 5>>(
-          out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, cutlass::float_e4m3_t,
+          cutlass::bfloat16_t, Epilogue, TileShape, WarpShape, InstructionShape,
+          5>>(out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     } else {
       TORCH_CHECK(out.dtype() == torch::kFloat16);
-      return vllm::cutlass_gemm_caller<
-          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
-                          cutlass::float_e4m3_t, cutlass::half_t, Epilogue,
-                          TileShape, WarpShape, InstructionShape, 5>>(
-          out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, cutlass::float_e4m3_t,
+          cutlass::half_t, Epilogue, TileShape, WarpShape, InstructionShape,
+          5>>(out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
     }
   }
 }
@@ -144,7 +146,7 @@ void cutlass_scaled_mm_sm89(torch::Tensor& out, torch::Tensor const& a,
     return cutlass_scaled_mm_sm89_epilogue<vllm::ScaledEpilogueBias>(
         out, a, b, a_scales, b_scales, *bias);
   } else {
-    return cutlass_scaled_mm_sm89_epilogue<vllm::ScaledEpilogue>(out, a, b, a_scales,
-                                                           b_scales);
+    return cutlass_scaled_mm_sm89_epilogue<vllm::ScaledEpilogue>(
+        out, a, b, a_scales, b_scales);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
@@ -247,8 +247,8 @@ struct cutlass_2x_gemm {
 
 template <typename Gemm, typename... EpilogueArgs>
 inline void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
-                         torch::Tensor const& b,
-                         EpilogueArgs&&... epilogue_params) {
+                                torch::Tensor const& b,
+                                EpilogueArgs&&... epilogue_params) {
   using ElementAB = typename Gemm::ElementAB;
   using ElementD = typename Gemm::ElementD;
 
@@ -310,9 +310,10 @@ inline void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
 }
 
 template <typename Gemm, typename FallbackGemm, typename... EpilogueArgs>
-inline void fallback_cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
-                                  torch::Tensor const& b,
-                                  EpilogueArgs&&... args) {
+inline void fallback_cutlass_gemm_caller(torch::Tensor& out,
+                                         torch::Tensor const& a,
+                                         torch::Tensor const& b,
+                                         EpilogueArgs&&... args) {
   // In some cases, the GPU isn't able to accommodate the
   // shared memory requirements of the Gemm. In such cases, use
   // the FallbackGemm instead.

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
@@ -1,0 +1,338 @@
+#pragma once
+#include <stddef.h>
+#include <torch/all.h>
+
+#include <ATen/cuda/CUDAContext.h>
+
+// clang-format will break include orders
+// clang-format off
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+#include "cutlass/numeric_types.h"
+
+#include "cutlass/util/device_memory.h"
+
+#include "cutlass/cutlass.h"
+#include "cutlass/gemm_coord.h"
+#include "cutlass/arch/mma_sm75.h"
+#include "cutlass/arch/arch.h"
+#include "cutlass/arch/mma.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+
+#include "cutlass/epilogue/threadblock/fusion/visitors.hpp"
+#include "cutlass/gemm/kernel/default_gemm_universal_with_visitor.h"
+
+#include "broadcast_load_epilogue_c2x.hpp"
+#include "common.hpp"
+// clang-format on
+
+using namespace cute;
+
+/*
+   Epilogue functions can be defined to post-process the output before it is
+   written to GPU memory.
+   Epilogues must contain a public type named EVTCompute of type Sm80EVT,
+   as well as a static prepare_args function that constructs an
+   EVTCompute::Arguments struct.
+*/
+
+namespace vllm {
+
+// Wrappers for the GEMM kernel that is used to guard against compilation on
+// architectures that will never use the kernel. The purpose of this is to
+// reduce the size of the compiled binary.
+// __CUDA_ARCH__ is not defined in host code, so this lets us smuggle the ifdef
+// into code that will be executed on the device where it is defined.
+template <typename Kernel>
+struct enable_sm75_to_sm80 : Kernel {
+  template <typename... Args>
+  CUTLASS_DEVICE static void invoke(Args&&... args) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 750 && __CUDA_ARCH__ < 800
+    Kernel::invoke(std::forward<Args>(args)...);
+#endif
+  }
+};
+
+template <typename Kernel>
+struct enable_sm80_to_sm89 : Kernel {
+  template <typename... Args>
+  CUTLASS_DEVICE static void invoke(Args&&... args) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 800 && __CUDA_ARCH__ < 890
+    Kernel::invoke(std::forward<Args>(args)...);
+#endif
+  }
+};
+
+template <typename Kernel>
+struct enable_sm89_to_sm90 : Kernel {
+  template <typename... Args>
+  CUTLASS_DEVICE static void invoke(Args&&... args) {
+#if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 890 && __CUDA_ARCH__ < 900
+    Kernel::invoke(std::forward<Args>(args)...);
+#endif
+  }
+};
+
+/*
+ * This class provides the common ScaleA and ScaleB descriptors for the
+ * ScaledEpilogue and ScaledEpilogueBias classes.
+ */
+template <typename ElementD, typename OutputTileThreadMap>
+struct ScaledEpilogueBase {
+ protected:
+  using Accum = cutlass::epilogue::threadblock::VisitorAccFetch;
+
+  using ScaleA = cutlass::epilogue::threadblock::VisitorColOrScalarBroadcast<
+      OutputTileThreadMap, float, Stride<Int<1>, Int<0>, Int<0>>>;
+
+  using ScaleB = cutlass::epilogue::threadblock::VisitorRowOrScalarBroadcast<
+      OutputTileThreadMap, float, Stride<Int<0>, Int<1>, Int<0>>>;
+};
+
+/*
+ This epilogue function defines a quantized GEMM operation similar to
+ torch._scaled_mm.
+
+ A and B may be both either int8 or fp8_e4m3. A can be quantized per-tensor or
+ per-row. B can be quantized per-tensor or per-column.
+ Any combination of per-tensor and per-row or column is supported.
+ A and B must have symmetric quantization (zero point == 0).
+
+ So the GEMM operation is D = (a_scales * A) (b_scales * B), where the
+ scales are applied elementwise with numpy-style broadcasting.
+
+ ScaleA and ScaleB define the epilogue functions that apply the scales for
+ the A and B operands respectively. These scales may be either per-tensor or
+ per row or column.
+*/
+template <typename ElementD, typename OutputTileThreadMap>
+struct ScaledEpilogue
+    : private ScaledEpilogueBase<ElementD, OutputTileThreadMap> {
+ private:
+  using SUPER = ScaledEpilogueBase<ElementD, OutputTileThreadMap>;
+  using Accum = typename SUPER::Accum;
+  using ScaleA = typename SUPER::ScaleA;
+  using ScaleB = typename SUPER::ScaleB;
+
+  using Compute0 = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::threadblock::Sm80EVT<Compute0, ScaleB, Accum>;
+
+  using Compute1 = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiplies, ElementD, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+ public:
+  using EVTCompute =
+      cutlass::epilogue::threadblock::Sm80EVT<Compute1, ScaleA, EVTCompute0>;
+  using ArgumentType = typename EVTCompute::Arguments;
+
+  static ArgumentType prepare_args(torch::Tensor const& a_scales,
+                                   torch::Tensor const& b_scales) {
+    using ScaleAArgs = typename ScaleA::Arguments;
+    using ScaleBArgs = typename ScaleB::Arguments;
+
+    ScaleBArgs b_args{b_scales.data_ptr<float>(), b_scales.numel() != 1, {}};
+    ScaleAArgs a_args{a_scales.data_ptr<float>(), a_scales.numel() != 1, {}};
+
+    typename EVTCompute0::Arguments evt0_compute_args{b_args};
+
+    typename EVTCompute::Arguments evt_compute_args{a_args, evt0_compute_args};
+    return evt_compute_args;
+  }
+};
+
+template <typename ElementD, typename OutputTileThreadMap>
+struct ScaledEpilogueBias
+    : private ScaledEpilogueBase<ElementD, OutputTileThreadMap> {
+ private:
+  using SUPER = ScaledEpilogueBase<ElementD, OutputTileThreadMap>;
+  using Accum = typename SUPER::Accum;
+  using ScaleA = typename SUPER::ScaleA;
+  using ScaleB = typename SUPER::ScaleB;
+
+  using Compute0 = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiplies, float, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using EVTCompute0 =
+      cutlass::epilogue::threadblock::Sm80EVT<Compute0, ScaleB, Accum>;
+
+  using Compute1 = cutlass::epilogue::threadblock::VisitorCompute<
+      cutlass::multiply_add, ElementD, float,
+      cutlass::FloatRoundStyle::round_to_nearest>;
+
+  using Bias = cutlass::epilogue::threadblock::VisitorRowBroadcast<
+      OutputTileThreadMap, ElementD, Stride<Int<0>, Int<1>, Int<0>>>;
+
+ public:
+  using EVTCompute = cutlass::epilogue::threadblock::Sm80EVT<Compute1, ScaleA,
+                                                             EVTCompute0, Bias>;
+  using ArgumentType = typename EVTCompute::Arguments;
+
+  static ArgumentType prepare_args(torch::Tensor const& a_scales,
+                                   torch::Tensor const& b_scales,
+                                   torch::Tensor const& bias) {
+    using ScaleAArgs = typename ScaleA::Arguments;
+    using ScaleBArgs = typename ScaleB::Arguments;
+    using BiasArgs = typename Bias::Arguments;
+
+    ScaleBArgs b_args{b_scales.data_ptr<float>(), b_scales.numel() != 1, {}};
+    ScaleAArgs a_args{a_scales.data_ptr<float>(), a_scales.numel() != 1, {}};
+    BiasArgs bias_args{static_cast<ElementD*>(bias.data_ptr()), {}};
+
+    typename EVTCompute0::Arguments evt0_compute_args{b_args};
+
+    typename EVTCompute::Arguments evt_compute_args{a_args, evt0_compute_args,
+                                                    bias_args};
+    return evt_compute_args;
+  }
+};
+
+template <typename Arch, template <typename> typename ArchGuard,
+          typename ElementAB_, typename ElementD_,
+          template <typename, typename> typename Epilogue_, typename TileShape,
+          typename WarpShape, typename InstructionShape, int32_t MainLoopStages>
+struct cutlass_2x_gemm {
+  using ElementAB = ElementAB_;
+  using ElementD = ElementD_;
+
+  using ElementAcc =
+      typename std::conditional<std::is_same_v<ElementAB, int8_t>, int32_t,
+                                float>::type;
+
+  using Operator =
+      typename std::conditional<std::is_same_v<ElementAB, int8_t>,
+                                cutlass::arch::OpMultiplyAddSaturate,
+                                cutlass::arch::OpMultiplyAdd>::type;
+
+  using OutputTileThreadMap =
+      cutlass::epilogue::threadblock::OutputTileThreadLayout<
+          TileShape, WarpShape, float, 4, 1 /* epilogue stages */
+          >;
+
+  using Epilogue = Epilogue_<ElementD, OutputTileThreadMap>;
+  using EVTCompute = typename Epilogue::EVTCompute;
+
+  using D = cutlass::epilogue::threadblock::VisitorAuxStore<
+      OutputTileThreadMap, ElementD, cutlass::FloatRoundStyle::round_to_nearest,
+      Stride<int64_t, Int<1>, Int<0>>>;
+
+  using EVTD = cutlass::epilogue::threadblock::Sm80EVT<D, EVTCompute>;
+
+  // clang-format off
+  using RowMajor = typename cutlass::layout::RowMajor;
+  using ColumnMajor = typename cutlass::layout::ColumnMajor;
+  using KernelType =
+    ArchGuard<typename cutlass::gemm::kernel::DefaultGemmWithVisitor<
+      ElementAB, RowMajor, cutlass::ComplexTransform::kNone, 16,
+      ElementAB, ColumnMajor, cutlass::ComplexTransform::kNone, 16,
+      float, cutlass::layout::RowMajor, 4,
+      ElementAcc, float, cutlass::arch::OpClassTensorOp,
+      Arch,
+      TileShape, WarpShape, InstructionShape,
+      EVTD,
+      cutlass::gemm::threadblock::ThreadblockSwizzleStreamK,
+      MainLoopStages, Operator,
+      1 /* epilogue stages */
+      >::GemmKernel>;
+  // clang-format on
+
+  using Op = cutlass::gemm::device::GemmUniversalAdapter<KernelType>;
+};
+
+template <typename Gemm, typename... EpilogueArgs>
+inline void cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
+                         torch::Tensor const& b,
+                         EpilogueArgs&&... epilogue_params) {
+  using ElementAB = typename Gemm::ElementAB;
+  using ElementD = typename Gemm::ElementD;
+
+  int32_t m = a.size(0);
+  int32_t n = b.size(1);
+  int32_t k = a.size(1);
+  cutlass::gemm::GemmCoord problem_size{m, n, k};
+
+  int64_t lda = a.stride(0);
+  int64_t ldb = b.stride(1);
+  int64_t ldc = out.stride(0);
+
+  using StrideC = Stride<int64_t, Int<1>, Int<0>>;
+  StrideC c_stride{ldc, Int<1>{}, Int<0>{}};
+
+  auto a_ptr = static_cast<ElementAB const*>(a.data_ptr());
+  auto b_ptr = static_cast<ElementAB const*>(b.data_ptr());
+  auto c_ptr = static_cast<ElementD*>(out.data_ptr());
+
+  typename Gemm::D::Arguments d_args{c_ptr, c_stride};
+
+  using Epilogue = typename Gemm::Epilogue;
+  auto evt_args =
+      Epilogue::prepare_args(std::forward<EpilogueArgs>(epilogue_params)...);
+
+  typename Gemm::EVTD::Arguments epilogue_args{
+      evt_args,
+      d_args,
+  };
+
+  typename Gemm::Op::Arguments args{
+      cutlass::gemm::GemmUniversalMode::kGemmSplitKParallel,  // universal mode
+      problem_size,                                           // problem size
+      1,                                                      // batch count
+      epilogue_args,
+      a_ptr,
+      b_ptr,
+      nullptr,
+      nullptr,
+      0,
+      0,
+      0,
+      0,
+      lda,
+      ldb,
+      ldc,
+      ldc};
+
+  // Launch the CUTLASS GEMM kernel.
+  typename Gemm::Op gemm_op;
+  size_t workspace_size = gemm_op.get_workspace_size(args);
+  cutlass::device_memory::allocation<uint8_t> workspace(workspace_size);
+
+  auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+  CUTLASS_CHECK(gemm_op.can_implement(args));
+  cutlass::Status status = gemm_op(args, workspace.get(), stream);
+  CUTLASS_CHECK(status);
+}
+
+template <typename Gemm, typename FallbackGemm, typename... EpilogueArgs>
+inline void fallback_cutlass_gemm_caller(torch::Tensor& out, torch::Tensor const& a,
+                                  torch::Tensor const& b,
+                                  EpilogueArgs&&... args) {
+  // In some cases, the GPU isn't able to accommodate the
+  // shared memory requirements of the Gemm. In such cases, use
+  // the FallbackGemm instead.
+  static const int max_shared_mem_per_block_opt_in =
+      get_cuda_max_shared_memory_per_block_opt_in(0);
+
+  size_t const gemm_shared_mem_size =
+      sizeof(typename Gemm::KernelType::SharedStorage);
+  size_t const fallback_gemm_shared_mem_size =
+      sizeof(typename FallbackGemm::KernelType::SharedStorage);
+
+  if (gemm_shared_mem_size <= max_shared_mem_per_block_opt_in) {
+    return cutlass_gemm_caller<Gemm>(out, a, b,
+                                     std::forward<EpilogueArgs>(args)...);
+  } else {
+    TORCH_CHECK(fallback_gemm_shared_mem_size <=
+                max_shared_mem_per_block_opt_in);
+    return cutlass_gemm_caller<FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  }
+}
+
+}  // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cuh
@@ -196,7 +196,8 @@ struct ScaledEpilogueBias
 template <typename Arch, template <typename> typename ArchGuard,
           typename ElementAB_, typename ElementD_,
           template <typename, typename> typename Epilogue_, typename TileShape,
-          typename WarpShape, typename InstructionShape, int32_t MainLoopStages>
+          typename WarpShape, typename InstructionShape, int32_t MainLoopStages,
+          typename FP8MathOperator = cutlass::arch::OpMultiplyAdd>
 struct cutlass_2x_gemm {
   using ElementAB = ElementAB_;
   using ElementD = ElementD_;
@@ -208,7 +209,7 @@ struct cutlass_2x_gemm {
   using Operator =
       typename std::conditional<std::is_same_v<ElementAB, int8_t>,
                                 cutlass::arch::OpMultiplyAddSaturate,
-                                cutlass::arch::OpMultiplyAdd>::type;
+                                FP8MathOperator>::type;
 
   using OutputTileThreadMap =
       cutlass::epilogue::threadblock::OutputTileThreadLayout<

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm80_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm80_dispatch.cuh
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "scaled_mm_c2x.cuh"
+
+/**
+ * This file defines Gemm kernel configurations for SM80 based on the Gemm shape.
+ */
+
+ namespace vllm {
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config_default {
+  // This config is used in 2 cases,
+  //  - M in (128, inf)
+  //  - M in (64, 128] and N >= 8192
+  // Shared Memory required by this Gemm - 81920 bytes
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config_M64 {
+  // This config is used in 2 cases,
+  // - M in (32, 64]
+  // - M in (64, 128] and N < 8192
+  // Shared Memory required by this Gemm - 122880 bytes
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config_M32 {
+  // M in (16, 32]
+  // Shared Memory required by this Gemm - 61440 bytes
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
+  using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm80_config_M16 {
+  // M in [1, 16]
+  // Shared Memory required by this Gemm - 51200 bytes
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<16, 64, 128>;
+  using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm80, enable_sm80_to_sm89, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 5>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue,
+          typename... EpilogueArgs>
+inline void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
+                                torch::Tensor const& b,
+                                EpilogueArgs&&... args) {
+  static_assert(std::is_same<InType, int8_t>());
+  TORCH_CHECK(a.dtype() == torch::kInt8);
+  TORCH_CHECK(b.dtype() == torch::kInt8);
+
+  using Cutlass2xGemmDefault =
+      typename sm80_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM128BigN =
+      typename sm80_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM128SmallN =
+      typename sm80_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM64 =
+      typename sm80_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM32 =
+      typename sm80_config_M32<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM16 =
+      typename sm80_config_M16<InType, OutType, Epilogue>::Cutlass2xGemm;
+
+  // Due to shared memory requirements, some Gemms may fail to run on some
+  // GPUs. As the name indicates, the Fallback Gemm is used as an alternative
+  // in such cases.
+  // sm80_config_M16 has the least shared-memory requirement. However,
+  // based on some profiling, we select sm80_config_M32 as a better alternative
+  // performance wise.
+  using FallbackGemm =
+      typename sm80_config_M32<InType, OutType, Epilogue>::Cutlass2xGemm;
+
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 =
+      std::max(static_cast<uint32_t>(16), next_pow_2(m));  // next power of 2
+  if (mp2 <= 16) {
+    // M in [1, 16]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM16, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 32) {
+    // M in (16, 32]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM32, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 64) {
+    // M in (32, 64]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM64, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 128) {
+    // M in (64, 128]
+    uint32_t const n = out.size(1);
+    bool const small_n = n < 8192;
+    if (small_n) {
+      return fallback_cutlass_gemm_caller<Cutlass2xGemmM128SmallN,
+                                          FallbackGemm>(
+          out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      return fallback_cutlass_gemm_caller<Cutlass2xGemmM128BigN, FallbackGemm>(
+          out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  } else {
+    // M in (128, inf)
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmDefault, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  }
+}
+
+} // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm80_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm80_dispatch.cuh
@@ -3,10 +3,11 @@
 #include "scaled_mm_c2x.cuh"
 
 /**
- * This file defines Gemm kernel configurations for SM80 based on the Gemm shape.
+ * This file defines Gemm kernel configurations for SM80 based on the Gemm
+ * shape.
  */
 
- namespace vllm {
+namespace vllm {
 
 template <typename InType, typename OutType,
           template <typename, typename> typename Epilogue>
@@ -71,9 +72,10 @@ struct sm80_config_M16 {
 template <typename InType, typename OutType,
           template <typename, typename> typename Epilogue,
           typename... EpilogueArgs>
-inline void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& a,
-                                torch::Tensor const& b,
-                                EpilogueArgs&&... args) {
+inline void cutlass_gemm_sm80_dispatch(torch::Tensor& out,
+                                       torch::Tensor const& a,
+                                       torch::Tensor const& b,
+                                       EpilogueArgs&&... args) {
   static_assert(std::is_same<InType, int8_t>());
   TORCH_CHECK(a.dtype() == torch::kInt8);
   TORCH_CHECK(b.dtype() == torch::kInt8);
@@ -134,4 +136,4 @@ inline void cutlass_gemm_sm80_dispatch(torch::Tensor& out, torch::Tensor const& 
   }
 }
 
-} // namespace vllm
+}  // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
@@ -13,11 +13,9 @@ namespace vllm {
 struct sm89_config_default {
 
   // M in (256, inf)
-
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  static const int32_t MainLoopStages = 1;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -31,30 +29,28 @@ struct sm89_config_default {
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
-#if 0
-    using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
-    using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
-    using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-    static const int32_t MainLoopStages = 3;
-    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-        cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-        Epilogue, TileShape, WarpShape, InstructionShape,
-        MainLoopStages, cutlass::arch::OpMultiplyAdd>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-#endif
-
     if (np2 <= 4096) {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else if (np2 <= 8192) {
+      using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          3, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
 
     } else {
-      using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
+      using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
   }
 };
@@ -62,10 +58,9 @@ struct sm89_config_default {
 struct sm89_config_M256 {
 
   // M in (128, 256]
-
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  static const int32_t MainLoopStages = 1;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -80,92 +75,29 @@ struct sm89_config_M256 {
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 4096) {
-      using TileShape = typename cutlass::gemm::GemmShape<128, 64, 64>;
-      using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+      using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-
-    } else if (np2 <= 8192) {
+          3, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else  {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
-      using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-
-    } else {
-      using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
-      using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
-
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-
-    }
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } 
   }
 };
 
 struct sm89_config_M128 {
 
   // M in (64, 128]
-
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  static const int32_t MainLoopStages = 1;
-
-  template <typename InType, typename OutType,
-            template <typename, typename> typename Epilogue,
-            typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
-    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
-    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
-    uint32_t const n = a.size(1);
-    uint32_t const np2 = next_pow_2(n);
-
-    if (np2 <= 4096) {
-      using TileShape = cutlass::gemm::GemmShape<64, 64, 128>;
-      using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
-
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    } else if (np2 <= 8192) {
-      using TileShape = cutlass::gemm::GemmShape<128, 64, 64>;
-      using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
-
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    } else {
-      using TileShape = cutlass::gemm::GemmShape<128, 128, 128>;
-      using WarpShape = cutlass::gemm::GemmShape<64, 64, 64>;
-
-      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    }
-  }
-};
-
-struct sm89_config_M64 {
-
-  // M in (32, 64]
-
-  using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  static const int32_t MainLoopStages = 1;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -180,30 +112,85 @@ struct sm89_config_M64 {
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 8192) {
-      using TileShape = cutlass::gemm::GemmShape<64, 64, 128>;
+      using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+          3, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else if (np2 <= 16384) {
+      using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
-      using TileShape = cutlass::gemm::GemmShape<64, 128, 128>;
+      using TileShape = typename cutlass::gemm::GemmShape<128, 64, 128>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+          3, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
+
+  }
+};
+
+struct sm89_config_M64 {
+
+  // M in (32, 64]
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 8196) {
+      using TileShape = typename cutlass::gemm::GemmShape<64, 64, 128>;
+      using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+      using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }  else if (np2 <= 16384) {
+      using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
+      using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+      using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          3, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      using TileShape = typename cutlass::gemm::GemmShape<64, 64, 128>;
+      using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+      using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+
   }
 };
 
 struct sm89_config_M32 {
 
-  // M in [1, 32]
-
-  using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+  // M in (16, 32]
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  static const int32_t MainLoopStages = 1;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -219,15 +206,68 @@ struct sm89_config_M32 {
 
     if (np2 <= 8192) {
       using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
-      using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+      using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else if (np2 <= 16384) {
+      using TileShape = typename cutlass::gemm::GemmShape<32, 128, 128>;
+      using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          4, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
+      using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          5, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  }
+};
+
+struct sm89_config_M16 {
+
+  // M in [1, 16]
+  using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+  static const int32_t MainLoopStages = 5; 
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 8192) {
+      using TileShape = typename cutlass::gemm::GemmShape<16, 64, 128>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else if (np2 <= 24576) {
+      using TileShape = typename cutlass::gemm::GemmShape<16, 128, 64>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
           Epilogue, TileShape, WarpShape, InstructionShape,
           MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
-      using TileShape = typename cutlass::gemm::GemmShape<32, 128, 128>;
-      using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
+      using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
 
       return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
           cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
@@ -254,11 +294,11 @@ inline void cutlass_gemm_sm89_dispatch(torch::Tensor& out,
   uint32_t const mp2 =
       std::max(static_cast<uint32_t>(32), next_pow_2(m));  // next power of 2
 
-  //return sm89_config_default::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
-
-#if 1
-  if (mp2 <= 32) {
-    // M in [1, 32]
+  if (mp2 <= 16) {
+    // M in [1, 16]
+    return sm89_config_M16::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 32) {
+    // M in (16, 32]
     return sm89_config_M32::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 64) {
     // M in (32, 64]
@@ -273,7 +313,6 @@ inline void cutlass_gemm_sm89_dispatch(torch::Tensor& out,
     // M in (256, inf)
     return sm89_config_default::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
   }
-#endif
 }
 
 }  // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
@@ -1,0 +1,279 @@
+#pragma once
+
+#include "scaled_mm_c2x.cuh"
+#include "cutlass/float8.h"
+
+/**
+ * This file defines Gemm kernel configurations for SM89 based on the Gemm
+ * shape.
+ */
+
+namespace vllm {
+
+struct sm89_config_default {
+
+  // M in (256, inf)
+
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+  static const int32_t MainLoopStages = 1;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+#if 0
+    using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+    using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+    using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+    static const int32_t MainLoopStages = 3;
+    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+        cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+        Epilogue, TileShape, WarpShape, InstructionShape,
+        MainLoopStages, cutlass::arch::OpMultiplyAdd>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+#endif
+
+    if (np2 <= 4096) {
+      using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+
+    } else {
+      using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  }
+};
+
+struct sm89_config_M256 {
+
+  // M in (128, 256]
+
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+  static const int32_t MainLoopStages = 1;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 4096) {
+      using TileShape = typename cutlass::gemm::GemmShape<128, 64, 64>;
+      using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+
+    } else if (np2 <= 8192) {
+      using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+      using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+
+    } else {
+      using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
+      using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+
+    }
+  }
+};
+
+struct sm89_config_M128 {
+
+  // M in (64, 128]
+
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+  static const int32_t MainLoopStages = 1;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 4096) {
+      using TileShape = cutlass::gemm::GemmShape<64, 64, 128>;
+      using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else if (np2 <= 8192) {
+      using TileShape = cutlass::gemm::GemmShape<128, 64, 64>;
+      using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      using TileShape = cutlass::gemm::GemmShape<128, 128, 128>;
+      using WarpShape = cutlass::gemm::GemmShape<64, 64, 64>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  }
+};
+
+struct sm89_config_M64 {
+
+  // M in (32, 64]
+
+  using WarpShape = cutlass::gemm::GemmShape<32, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+  static const int32_t MainLoopStages = 1;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 8192) {
+      using TileShape = cutlass::gemm::GemmShape<64, 64, 128>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      using TileShape = cutlass::gemm::GemmShape<64, 128, 128>;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  }
+};
+
+struct sm89_config_M32 {
+
+  // M in [1, 32]
+
+  using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
+  static const int32_t MainLoopStages = 1;
+
+  template <typename InType, typename OutType,
+            template <typename, typename> typename Epilogue,
+            typename... EpilogueArgs>
+  static void dispatch(torch::Tensor& out,
+                       torch::Tensor const& a,
+                       torch::Tensor const& b,
+                       EpilogueArgs&&... args) {
+    static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+    TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+    uint32_t const n = a.size(1);
+    uint32_t const np2 = next_pow_2(n);
+
+    if (np2 <= 8192) {
+      using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
+      using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    } else {
+      using TileShape = typename cutlass::gemm::GemmShape<32, 128, 128>;
+      using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
+
+      return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
+          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
+          Epilogue, TileShape, WarpShape, InstructionShape,
+          MainLoopStages, FP8MathOperator>>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    }
+  }
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue,
+          typename... EpilogueArgs>
+inline void cutlass_gemm_sm89_dispatch(torch::Tensor& out,
+                                       torch::Tensor const& a,
+                                       torch::Tensor const& b,
+                                       EpilogueArgs&&... args) {
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
+  TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+  TORCH_CHECK(b.dtype() == torch::kFloat8_e4m3fn);
+
+  // TODO check shared memory requirements
+
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 =
+      std::max(static_cast<uint32_t>(32), next_pow_2(m));  // next power of 2
+
+  //return sm89_config_default::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+
+#if 1
+  if (mp2 <= 32) {
+    // M in [1, 32]
+    return sm89_config_M32::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 64) {
+    // M in (32, 64]
+    return sm89_config_M64::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 128) {
+    // M in (64, 128]
+    return sm89_config_M128::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 256) {
+    // M in (128, 256]
+    return sm89_config_M256::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else {
+    // M in (256, inf)
+    return sm89_config_default::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+  }
+#endif
+}
+
+}  // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
@@ -14,7 +14,7 @@ template <typename InType, typename OutType,
           template <typename, typename> typename Epilogue>
 struct sm89_fallback_gemm {
   // Shared Memory required by this Gemm - 61440 bytes
-  static_assert(std::is_same<InType, int8_t>());
+  static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
   using TileShape = typename cutlass::gemm::GemmShape<64, 128, 64>;
   using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
@@ -31,7 +31,6 @@ struct sm89_config_default {
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -42,6 +41,9 @@ struct sm89_config_default {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
@@ -80,7 +82,6 @@ struct sm89_config_M256 {
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -91,6 +92,9 @@ struct sm89_config_M256 {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
@@ -120,7 +124,6 @@ struct sm89_config_M128 {
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -131,6 +134,9 @@ struct sm89_config_M128 {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
@@ -168,7 +174,6 @@ struct sm89_config_M64 {
 
   // M in (32, 64]
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -179,6 +184,9 @@ struct sm89_config_M64 {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
@@ -222,7 +230,6 @@ struct sm89_config_M32 {
   // M in (16, 32]
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
@@ -233,6 +240,9 @@ struct sm89_config_M32 {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 
@@ -273,7 +283,6 @@ struct sm89_config_M16 {
   using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  using FallbackGemm = sm89_fallback_gemm::Cutlass2xGemm; 
   static const int32_t MainLoopStages = 5; 
 
   template <typename InType, typename OutType,
@@ -285,6 +294,9 @@ struct sm89_config_M16 {
                        EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
+
+    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
 

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
@@ -26,7 +26,6 @@ struct sm89_fallback_gemm {
 };
 
 struct sm89_config_default {
-
   // M in (256, inf)
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
@@ -35,14 +34,13 @@ struct sm89_config_default {
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -50,34 +48,33 @@ struct sm89_config_default {
     if (np2 <= 4096) {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else if (np2 <= 8192) {
       using TileShape = typename cutlass::gemm::GemmShape<256, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          3, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 3, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
 
     } else {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
   }
 };
 
 struct sm89_config_M256 {
-
   // M in (128, 256]
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
@@ -86,14 +83,13 @@ struct sm89_config_M256 {
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -101,25 +97,24 @@ struct sm89_config_M256 {
     if (np2 <= 4096) {
       using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          3, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 3, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    } else  {
+    } else {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    } 
+    }
   }
 };
 
 struct sm89_config_M128 {
-
   // M in (64, 128]
   using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
@@ -128,14 +123,13 @@ struct sm89_config_M128 {
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -143,49 +137,46 @@ struct sm89_config_M128 {
     if (np2 <= 8192) {
       using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          3, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 3, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
 
     } else if (np2 <= 16384) {
       using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
       using TileShape = typename cutlass::gemm::GemmShape<128, 64, 128>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          3, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 3, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
-
   }
 };
 
 struct sm89_config_M64 {
-
   // M in (32, 64]
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -195,38 +186,36 @@ struct sm89_config_M64 {
       using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
       using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
-    }  else if (np2 <= 16384) {
+    } else if (np2 <= 16384) {
       using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
       using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
       using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          3, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 3, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
       using TileShape = typename cutlass::gemm::GemmShape<64, 64, 128>;
       using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
       using FP8MathOperator = typename cutlass::arch::OpMultiplyAdd;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
-
   }
 };
 
 struct sm89_config_M32 {
-
   // M in (16, 32]
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
@@ -234,14 +223,13 @@ struct sm89_config_M32 {
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -250,52 +238,50 @@ struct sm89_config_M32 {
       using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
       using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else if (np2 <= 16384) {
       using TileShape = typename cutlass::gemm::GemmShape<32, 128, 128>;
       using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          4, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 4, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
       using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
       using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          5, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, 5, FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
   }
 };
 
 struct sm89_config_M16 {
-
   // M in [1, 16]
   using WarpShape = typename cutlass::gemm::GemmShape<16, 64, 64>;
   using InstructionShape = typename cutlass::gemm::GemmShape<16, 8, 32>;
   using FP8MathOperator = typename cutlass::arch::OpMultiplyAddFastAccum;
-  static const int32_t MainLoopStages = 5; 
+  static const int32_t MainLoopStages = 5;
 
   template <typename InType, typename OutType,
             template <typename, typename> typename Epilogue,
             typename... EpilogueArgs>
-  static void dispatch(torch::Tensor& out,
-                       torch::Tensor const& a,
-                       torch::Tensor const& b,
-                       EpilogueArgs&&... args) {
+  static void dispatch(torch::Tensor& out, torch::Tensor const& a,
+                       torch::Tensor const& b, EpilogueArgs&&... args) {
     static_assert(std::is_same<InType, cutlass::float_e4m3_t>());
     TORCH_CHECK(a.dtype() == torch::kFloat8_e4m3fn);
 
-    using FallbackGemm = typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm; 
+    using FallbackGemm =
+        typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
     uint32_t const n = a.size(1);
     uint32_t const np2 = next_pow_2(n);
@@ -303,26 +289,29 @@ struct sm89_config_M16 {
     if (np2 <= 8192) {
       using TileShape = typename cutlass::gemm::GemmShape<16, 64, 128>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, MainLoopStages,
+                                FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else if (np2 <= 24576) {
       using TileShape = typename cutlass::gemm::GemmShape<16, 128, 64>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, MainLoopStages,
+                                FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     } else {
       using TileShape = typename cutlass::gemm::GemmShape<32, 64, 128>;
 
-      return vllm::fallback_cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-          cutlass::arch::Sm89, vllm::enable_sm89_to_sm90, InType, OutType,
-          Epilogue, TileShape, WarpShape, InstructionShape,
-          MainLoopStages, FP8MathOperator>,
+      return vllm::fallback_cutlass_gemm_caller<
+          vllm::cutlass_2x_gemm<cutlass::arch::Sm89, vllm::enable_sm89_to_sm90,
+                                InType, OutType, Epilogue, TileShape, WarpShape,
+                                InstructionShape, MainLoopStages,
+                                FP8MathOperator>,
           FallbackGemm>(out, a, b, std::forward<EpilogueArgs>(args)...);
     }
   }
@@ -345,22 +334,28 @@ inline void cutlass_gemm_sm89_dispatch(torch::Tensor& out,
 
   if (mp2 <= 16) {
     // M in [1, 16]
-    return sm89_config_M16::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_M16::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 32) {
     // M in (16, 32]
-    return sm89_config_M32::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_M32::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 64) {
     // M in (32, 64]
-    return sm89_config_M64::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_M64::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 128) {
     // M in (64, 128]
-    return sm89_config_M128::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_M128::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else if (mp2 <= 256) {
     // M in (128, 256]
-    return sm89_config_M256::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_M256::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   } else {
     // M in (256, inf)
-    return sm89_config_default::dispatch<InType, OutType, Epilogue>(out, a, b, std::forward<EpilogueArgs>(args)...);
+    return sm89_config_default::dispatch<InType, OutType, Epilogue>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
   }
 }
 

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm89_dispatch.cuh
@@ -42,7 +42,7 @@ struct sm89_config_default {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 4096) {
@@ -91,7 +91,7 @@ struct sm89_config_M256 {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 4096) {
@@ -131,7 +131,7 @@ struct sm89_config_M128 {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 8192) {
@@ -178,7 +178,7 @@ struct sm89_config_M64 {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 8196) {
@@ -231,7 +231,7 @@ struct sm89_config_M32 {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 8192) {
@@ -283,7 +283,7 @@ struct sm89_config_M16 {
     using FallbackGemm =
         typename sm89_fallback_gemm<InType, OutType, Epilogue>::Cutlass2xGemm;
 
-    uint32_t const n = a.size(1);
+    uint32_t const n = out.size(1);
     uint32_t const np2 = next_pow_2(n);
 
     if (np2 <= 8192) {

--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -106,8 +106,8 @@ def cutlass_int8_gemm_helper(m: int,
     assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
 
 
-@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
-@pytest.mark.parametrize("n", [2048, 256, 1024])
+@pytest.mark.parametrize("m", [1, 16, 32, 64, 128, 256, 512, 222, 100, 33])
+@pytest.mark.parametrize("n", [2048, 4096, 8192, 16384, 24576, 256, 1024])
 @pytest.mark.parametrize("k", [128, 496, 1024])
 @pytest.mark.parametrize("per_act_token", [True, False])
 @pytest.mark.parametrize("per_out_ch", [True, False])
@@ -117,19 +117,6 @@ def cutlass_int8_gemm_helper(m: int,
 def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
                           per_out_ch: bool, use_bias: bool):
     cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-
-@pytest.mark.parametrize("m", [16, 32, 64, 128, 256, 512])
-@pytest.mark.parametrize("n", [1024, 8192, 10240])
-@pytest.mark.parametrize("k", [128])
-@pytest.mark.parametrize("per_act_token", [False])
-@pytest.mark.parametrize("per_out_ch", [False])
-@pytest.mark.parametrize("use_bias", [False])
-@pytest.mark.skipif(capability < 89,
-                    reason="FP8 is not supported on this GPU type.")
-def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
-                          per_out_ch: bool, use_bias: bool):
-    cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-
 
 @pytest.mark.parametrize("m", [512, 222, 33, 1])
 @pytest.mark.parametrize("n", [2048, 256, 1024])

--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -106,17 +106,17 @@ def cutlass_int8_gemm_helper(m: int,
     assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
 
 
-#@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
-#@pytest.mark.parametrize("n", [2048, 256, 1024])
-#@pytest.mark.parametrize("k", [128, 496, 1024])
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#@pytest.mark.skipif(capability < 89,
-#                    reason="FP8 is not supported on this GPU type.")
-#def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
-#                          per_out_ch: bool, use_bias: bool):
-#    cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
+@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
+@pytest.mark.parametrize("n", [2048, 256, 1024])
+@pytest.mark.parametrize("k", [128, 496, 1024])
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.skipif(capability < 89,
+                    reason="FP8 is not supported on this GPU type.")
+def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
+                          per_out_ch: bool, use_bias: bool):
+    cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
 
 @pytest.mark.parametrize("m", [16, 32, 64, 128, 256, 512])
 @pytest.mark.parametrize("n", [1024, 8192, 10240])
@@ -129,180 +129,180 @@ def cutlass_int8_gemm_helper(m: int,
 def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
                           per_out_ch: bool, use_bias: bool):
     cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-#
-#
-#@pytest.mark.parametrize("m", [512, 222, 33, 1])
-#@pytest.mark.parametrize("n", [2048, 256, 1024])
-#@pytest.mark.parametrize("k", [128, 496, 1024])
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#def test_cutlass_int8_gemm(m: int, n: int, k: int, per_act_token: bool,
-#                           per_out_ch: bool, use_bias: bool):
-#    cutlass_int8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#def test_cutlass_int8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
-#                                        out_dtype: Type[torch.dtype],
-#                                        use_bias: bool):
-#    cutlass_int8_gemm_helper(512,
-#                             512,
-#                             512,
-#                             per_act_token,
-#                             per_out_ch,
-#                             use_bias,
-#                             out_dtype=out_dtype)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#@pytest.mark.skipif(capability < 89,
-#                    reason="FP8 is not supported on this GPU type.")
-#def test_cutlass_fp8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
-#                                       out_dtype: Type[torch.dtype],
-#                                       use_bias: bool):
-#    cutlass_fp8_gemm_helper(512,
-#                            512,
-#                            512,
-#                            per_act_token,
-#                            per_out_ch,
-#                            use_bias,
-#                            out_dtype=out_dtype)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#@pytest.mark.parametrize("device", CUDA_DEVICES)
-#@pytest.mark.skipif(capability < 89,
-#                    reason="FP8 is not supported on this GPU type.")
-#def test_cutlass_fp8_gemm_devices(per_act_token: bool, per_out_ch: bool,
-#                                  use_bias: bool, device: str):
-#    cutlass_fp8_gemm_helper(512, 512, 512, per_act_token, per_out_ch, use_bias,
-#                            torch.bfloat16, device)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#@pytest.mark.parametrize("device", CUDA_DEVICES)
-#def test_cutlass_int8_gemm_devices(per_act_token: bool, per_out_ch: bool,
-#                                   use_bias: bool, device: str):
-#    cutlass_int8_gemm_helper(512,
-#                             512,
-#                             512,
-#                             per_act_token,
-#                             per_out_ch,
-#                             use_bias,
-#                             out_dtype=torch.bfloat16,
-#                             device=device)
-#
-#
-## For the following two tests:
-## N and K correspond to the size of the weight matrix and likely to be multiples
-## of a large power of two. In any case, the kernel will have a naive fallback
-## when N and K are not divisible by 16. But M is the number of tokens and the
-## kernel must handle any M thrown at it.
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#@pytest.mark.skipif(capability < 89,
-#                    reason="FP8 is not supported on this GPU type.")
-#def test_cutlass_fp8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
-#                                  use_bias: bool):
-#    for nk in range(32, 128, 32):
-#        for m in range(1, 128):
-#            cutlass_fp8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
-#                                    use_bias)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#@pytest.mark.parametrize("use_bias", [True, False])
-#def test_cutlass_int8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
-#                                   use_bias: bool):
-#    for nk in range(32, 128, 32):
-#        for m in range(1, 128):
-#            cutlass_int8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
-#                                     use_bias)
-#
-#
-## Test working with a subset of A and B
-#def test_cutlass_subset():
-#    big_m, big_n, big_k = 1024, 1024, 1024
-#    m, n, k = 512, 512, 512
-#
-#    whole_a = to_int8(torch.randn((big_m, big_k), device="cuda") * 5)
-#    whole_b = to_int8(torch.randn((big_n, big_k), device="cuda").t() * 5)
-#    a = whole_a[0:m, 0:k]
-#    b = whole_b[0:k, 0:n]
-#
-#    scale_a = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
-#    scale_b = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
-#
-#    out = ops.cutlass_scaled_mm(a,
-#                                b,
-#                                scale_a,
-#                                scale_b,
-#                                out_dtype=torch.bfloat16)
-#    baseline = baseline_scaled_mm(a,
-#                                  b,
-#                                  scale_a,
-#                                  scale_b,
-#                                  out_dtype=torch.bfloat16)
-#
-#    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
-#
-#
-## Test to make sure cuda graphs work
-#class CutlassLayer(torch.nn.Module):
-#
-#    def __init__(self, b, scale_a, scale_b, out_dtype):
-#        super().__init__()
-#        self.b = b
-#        self.scale_a = scale_a
-#        self.scale_b = scale_b
-#        self.out_dtype = out_dtype
-#
-#    def forward(self, a):
-#        return ops.cutlass_scaled_mm(a, self.b, self.scale_a, self.scale_b,
-#                                     self.out_dtype)
-#
-#
-#@pytest.mark.parametrize("per_act_token", [True, False])
-#@pytest.mark.parametrize("per_out_ch", [True, False])
-#def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
-#    m, n, k = 512, 512, 512
-#
-#    a = to_int8(torch.randn((m, k), device="cuda"))
-#    b = to_int8(torch.randn((n, k), device="cuda").t())
-#
-#    m_a_scales = m if per_act_token else 1
-#    n_b_scales = n if per_out_ch else 1
-#
-#    scale_a = (torch.randn(
-#        (m_a_scales, 1), device="cuda", dtype=torch.float32) / 10)
-#    scale_b = (torch.randn(
-#        (1, n_b_scales), device="cuda", dtype=torch.float32) / 10)
-#
-#    # Construct a trivial model with a single layer that calls a CUTLASS kernel
-#    model = CutlassLayer(b, scale_a, scale_b, torch.bfloat16)
-#
-#    # Run the model with a cuda graph
-#    stream = torch.cuda.Stream()
-#    with torch.cuda.stream(stream):
-#        g = torch.cuda.CUDAGraph()
-#        with torch.cuda.graph(g):
-#            out = model(a)
-#    out.zero_()
-#    g.replay()
-#
-#    baseline = torch.mm(scale_a * a.to(dtype=torch.float32),
-#                        scale_b * b.to(dtype=torch.float32)).to(torch.bfloat16)
-#    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
+
+
+@pytest.mark.parametrize("m", [512, 222, 33, 1])
+@pytest.mark.parametrize("n", [2048, 256, 1024])
+@pytest.mark.parametrize("k", [128, 496, 1024])
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_cutlass_int8_gemm(m: int, n: int, k: int, per_act_token: bool,
+                           per_out_ch: bool, use_bias: bool):
+    cutlass_int8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_cutlass_int8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
+                                        out_dtype: Type[torch.dtype],
+                                        use_bias: bool):
+    cutlass_int8_gemm_helper(512,
+                             512,
+                             512,
+                             per_act_token,
+                             per_out_ch,
+                             use_bias,
+                             out_dtype=out_dtype)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.skipif(capability < 89,
+                    reason="FP8 is not supported on this GPU type.")
+def test_cutlass_fp8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
+                                       out_dtype: Type[torch.dtype],
+                                       use_bias: bool):
+    cutlass_fp8_gemm_helper(512,
+                            512,
+                            512,
+                            per_act_token,
+                            per_out_ch,
+                            use_bias,
+                            out_dtype=out_dtype)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.skipif(capability < 89,
+                    reason="FP8 is not supported on this GPU type.")
+def test_cutlass_fp8_gemm_devices(per_act_token: bool, per_out_ch: bool,
+                                  use_bias: bool, device: str):
+    cutlass_fp8_gemm_helper(512, 512, 512, per_act_token, per_out_ch, use_bias,
+                            torch.bfloat16, device)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+def test_cutlass_int8_gemm_devices(per_act_token: bool, per_out_ch: bool,
+                                   use_bias: bool, device: str):
+    cutlass_int8_gemm_helper(512,
+                             512,
+                             512,
+                             per_act_token,
+                             per_out_ch,
+                             use_bias,
+                             out_dtype=torch.bfloat16,
+                             device=device)
+
+
+# For the following two tests:
+# N and K correspond to the size of the weight matrix and likely to be multiples
+# of a large power of two. In any case, the kernel will have a naive fallback
+# when N and K are not divisible by 16. But M is the number of tokens and the
+# kernel must handle any M thrown at it.
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+@pytest.mark.skipif(capability < 89,
+                    reason="FP8 is not supported on this GPU type.")
+def test_cutlass_fp8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
+                                  use_bias: bool):
+    for nk in range(32, 128, 32):
+        for m in range(1, 128):
+            cutlass_fp8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
+                                    use_bias)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+@pytest.mark.parametrize("use_bias", [True, False])
+def test_cutlass_int8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
+                                   use_bias: bool):
+    for nk in range(32, 128, 32):
+        for m in range(1, 128):
+            cutlass_int8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
+                                     use_bias)
+
+
+# Test working with a subset of A and B
+def test_cutlass_subset():
+    big_m, big_n, big_k = 1024, 1024, 1024
+    m, n, k = 512, 512, 512
+
+    whole_a = to_int8(torch.randn((big_m, big_k), device="cuda") * 5)
+    whole_b = to_int8(torch.randn((big_n, big_k), device="cuda").t() * 5)
+    a = whole_a[0:m, 0:k]
+    b = whole_b[0:k, 0:n]
+
+    scale_a = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
+    scale_b = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
+
+    out = ops.cutlass_scaled_mm(a,
+                                b,
+                                scale_a,
+                                scale_b,
+                                out_dtype=torch.bfloat16)
+    baseline = baseline_scaled_mm(a,
+                                  b,
+                                  scale_a,
+                                  scale_b,
+                                  out_dtype=torch.bfloat16)
+
+    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
+
+
+# Test to make sure cuda graphs work
+class CutlassLayer(torch.nn.Module):
+
+    def __init__(self, b, scale_a, scale_b, out_dtype):
+        super().__init__()
+        self.b = b
+        self.scale_a = scale_a
+        self.scale_b = scale_b
+        self.out_dtype = out_dtype
+
+    def forward(self, a):
+        return ops.cutlass_scaled_mm(a, self.b, self.scale_a, self.scale_b,
+                                     self.out_dtype)
+
+
+@pytest.mark.parametrize("per_act_token", [True, False])
+@pytest.mark.parametrize("per_out_ch", [True, False])
+def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
+    m, n, k = 512, 512, 512
+
+    a = to_int8(torch.randn((m, k), device="cuda"))
+    b = to_int8(torch.randn((n, k), device="cuda").t())
+
+    m_a_scales = m if per_act_token else 1
+    n_b_scales = n if per_out_ch else 1
+
+    scale_a = (torch.randn(
+        (m_a_scales, 1), device="cuda", dtype=torch.float32) / 10)
+    scale_b = (torch.randn(
+        (1, n_b_scales), device="cuda", dtype=torch.float32) / 10)
+
+    # Construct a trivial model with a single layer that calls a CUTLASS kernel
+    model = CutlassLayer(b, scale_a, scale_b, torch.bfloat16)
+
+    # Run the model with a cuda graph
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g):
+            out = model(a)
+    out.zero_()
+    g.replay()
+
+    baseline = torch.mm(scale_a * a.to(dtype=torch.float32),
+                        scale_b * b.to(dtype=torch.float32)).to(torch.bfloat16)
+    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)

--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -106,191 +106,203 @@ def cutlass_int8_gemm_helper(m: int,
     assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
 
 
-@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
-@pytest.mark.parametrize("n", [2048, 256, 1024])
-@pytest.mark.parametrize("k", [128, 496, 1024])
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.parametrize("m", [512, 222, 100, 33, 1])
+#@pytest.mark.parametrize("n", [2048, 256, 1024])
+#@pytest.mark.parametrize("k", [128, 496, 1024])
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.skipif(capability < 89,
+#                    reason="FP8 is not supported on this GPU type.")
+#def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
+#                          per_out_ch: bool, use_bias: bool):
+#    cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
+
+@pytest.mark.parametrize("m", [16, 32, 64, 128, 256, 512])
+@pytest.mark.parametrize("n", [1024, 8192, 10240])
+@pytest.mark.parametrize("k", [128])
+@pytest.mark.parametrize("per_act_token", [False])
+@pytest.mark.parametrize("per_out_ch", [False])
+@pytest.mark.parametrize("use_bias", [False])
 @pytest.mark.skipif(capability < 89,
                     reason="FP8 is not supported on this GPU type.")
 def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
                           per_out_ch: bool, use_bias: bool):
     cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-
-
-@pytest.mark.parametrize("m", [512, 222, 33, 1])
-@pytest.mark.parametrize("n", [2048, 256, 1024])
-@pytest.mark.parametrize("k", [128, 496, 1024])
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
-def test_cutlass_int8_gemm(m: int, n: int, k: int, per_act_token: bool,
-                           per_out_ch: bool, use_bias: bool):
-    cutlass_int8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("use_bias", [True, False])
-def test_cutlass_int8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
-                                        out_dtype: Type[torch.dtype],
-                                        use_bias: bool):
-    cutlass_int8_gemm_helper(512,
-                             512,
-                             512,
-                             per_act_token,
-                             per_out_ch,
-                             use_bias,
-                             out_dtype=out_dtype)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("use_bias", [True, False])
-@pytest.mark.skipif(capability < 89,
-                    reason="FP8 is not supported on this GPU type.")
-def test_cutlass_fp8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
-                                       out_dtype: Type[torch.dtype],
-                                       use_bias: bool):
-    cutlass_fp8_gemm_helper(512,
-                            512,
-                            512,
-                            per_act_token,
-                            per_out_ch,
-                            use_bias,
-                            out_dtype=out_dtype)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
-@pytest.mark.parametrize("device", CUDA_DEVICES)
-@pytest.mark.skipif(capability < 89,
-                    reason="FP8 is not supported on this GPU type.")
-def test_cutlass_fp8_gemm_devices(per_act_token: bool, per_out_ch: bool,
-                                  use_bias: bool, device: str):
-    cutlass_fp8_gemm_helper(512, 512, 512, per_act_token, per_out_ch, use_bias,
-                            torch.bfloat16, device)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
-@pytest.mark.parametrize("device", CUDA_DEVICES)
-def test_cutlass_int8_gemm_devices(per_act_token: bool, per_out_ch: bool,
-                                   use_bias: bool, device: str):
-    cutlass_int8_gemm_helper(512,
-                             512,
-                             512,
-                             per_act_token,
-                             per_out_ch,
-                             use_bias,
-                             out_dtype=torch.bfloat16,
-                             device=device)
-
-
-# For the following two tests:
-# N and K correspond to the size of the weight matrix and likely to be multiples
-# of a large power of two. In any case, the kernel will have a naive fallback
-# when N and K are not divisible by 16. But M is the number of tokens and the
-# kernel must handle any M thrown at it.
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
-@pytest.mark.skipif(capability < 89,
-                    reason="FP8 is not supported on this GPU type.")
-def test_cutlass_fp8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
-                                  use_bias: bool):
-    for nk in range(32, 128, 32):
-        for m in range(1, 128):
-            cutlass_fp8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
-                                    use_bias)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-@pytest.mark.parametrize("use_bias", [True, False])
-def test_cutlass_int8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
-                                   use_bias: bool):
-    for nk in range(32, 128, 32):
-        for m in range(1, 128):
-            cutlass_int8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
-                                     use_bias)
-
-
-# Test working with a subset of A and B
-def test_cutlass_subset():
-    big_m, big_n, big_k = 1024, 1024, 1024
-    m, n, k = 512, 512, 512
-
-    whole_a = to_int8(torch.randn((big_m, big_k), device="cuda") * 5)
-    whole_b = to_int8(torch.randn((big_n, big_k), device="cuda").t() * 5)
-    a = whole_a[0:m, 0:k]
-    b = whole_b[0:k, 0:n]
-
-    scale_a = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
-    scale_b = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
-
-    out = ops.cutlass_scaled_mm(a,
-                                b,
-                                scale_a,
-                                scale_b,
-                                out_dtype=torch.bfloat16)
-    baseline = baseline_scaled_mm(a,
-                                  b,
-                                  scale_a,
-                                  scale_b,
-                                  out_dtype=torch.bfloat16)
-
-    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
-
-
-# Test to make sure cuda graphs work
-class CutlassLayer(torch.nn.Module):
-
-    def __init__(self, b, scale_a, scale_b, out_dtype):
-        super().__init__()
-        self.b = b
-        self.scale_a = scale_a
-        self.scale_b = scale_b
-        self.out_dtype = out_dtype
-
-    def forward(self, a):
-        return ops.cutlass_scaled_mm(a, self.b, self.scale_a, self.scale_b,
-                                     self.out_dtype)
-
-
-@pytest.mark.parametrize("per_act_token", [True, False])
-@pytest.mark.parametrize("per_out_ch", [True, False])
-def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
-    m, n, k = 512, 512, 512
-
-    a = to_int8(torch.randn((m, k), device="cuda"))
-    b = to_int8(torch.randn((n, k), device="cuda").t())
-
-    m_a_scales = m if per_act_token else 1
-    n_b_scales = n if per_out_ch else 1
-
-    scale_a = (torch.randn(
-        (m_a_scales, 1), device="cuda", dtype=torch.float32) / 10)
-    scale_b = (torch.randn(
-        (1, n_b_scales), device="cuda", dtype=torch.float32) / 10)
-
-    # Construct a trivial model with a single layer that calls a CUTLASS kernel
-    model = CutlassLayer(b, scale_a, scale_b, torch.bfloat16)
-
-    # Run the model with a cuda graph
-    stream = torch.cuda.Stream()
-    with torch.cuda.stream(stream):
-        g = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(g):
-            out = model(a)
-    out.zero_()
-    g.replay()
-
-    baseline = torch.mm(scale_a * a.to(dtype=torch.float32),
-                        scale_b * b.to(dtype=torch.float32)).to(torch.bfloat16)
-    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
+#
+#
+#@pytest.mark.parametrize("m", [512, 222, 33, 1])
+#@pytest.mark.parametrize("n", [2048, 256, 1024])
+#@pytest.mark.parametrize("k", [128, 496, 1024])
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#def test_cutlass_int8_gemm(m: int, n: int, k: int, per_act_token: bool,
+#                           per_out_ch: bool, use_bias: bool):
+#    cutlass_int8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#def test_cutlass_int8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
+#                                        out_dtype: Type[torch.dtype],
+#                                        use_bias: bool):
+#    cutlass_int8_gemm_helper(512,
+#                             512,
+#                             512,
+#                             per_act_token,
+#                             per_out_ch,
+#                             use_bias,
+#                             out_dtype=out_dtype)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("out_dtype", [torch.bfloat16, torch.float16])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.skipif(capability < 89,
+#                    reason="FP8 is not supported on this GPU type.")
+#def test_cutlass_fp8_gemm_output_dtype(per_act_token: bool, per_out_ch: bool,
+#                                       out_dtype: Type[torch.dtype],
+#                                       use_bias: bool):
+#    cutlass_fp8_gemm_helper(512,
+#                            512,
+#                            512,
+#                            per_act_token,
+#                            per_out_ch,
+#                            use_bias,
+#                            out_dtype=out_dtype)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.parametrize("device", CUDA_DEVICES)
+#@pytest.mark.skipif(capability < 89,
+#                    reason="FP8 is not supported on this GPU type.")
+#def test_cutlass_fp8_gemm_devices(per_act_token: bool, per_out_ch: bool,
+#                                  use_bias: bool, device: str):
+#    cutlass_fp8_gemm_helper(512, 512, 512, per_act_token, per_out_ch, use_bias,
+#                            torch.bfloat16, device)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.parametrize("device", CUDA_DEVICES)
+#def test_cutlass_int8_gemm_devices(per_act_token: bool, per_out_ch: bool,
+#                                   use_bias: bool, device: str):
+#    cutlass_int8_gemm_helper(512,
+#                             512,
+#                             512,
+#                             per_act_token,
+#                             per_out_ch,
+#                             use_bias,
+#                             out_dtype=torch.bfloat16,
+#                             device=device)
+#
+#
+## For the following two tests:
+## N and K correspond to the size of the weight matrix and likely to be multiples
+## of a large power of two. In any case, the kernel will have a naive fallback
+## when N and K are not divisible by 16. But M is the number of tokens and the
+## kernel must handle any M thrown at it.
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#@pytest.mark.skipif(capability < 89,
+#                    reason="FP8 is not supported on this GPU type.")
+#def test_cutlass_fp8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
+#                                  use_bias: bool):
+#    for nk in range(32, 128, 32):
+#        for m in range(1, 128):
+#            cutlass_fp8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
+#                                    use_bias)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#@pytest.mark.parametrize("use_bias", [True, False])
+#def test_cutlass_int8_gemm_m_sweep(per_act_token: bool, per_out_ch: bool,
+#                                   use_bias: bool):
+#    for nk in range(32, 128, 32):
+#        for m in range(1, 128):
+#            cutlass_int8_gemm_helper(m, nk, nk, per_act_token, per_out_ch,
+#                                     use_bias)
+#
+#
+## Test working with a subset of A and B
+#def test_cutlass_subset():
+#    big_m, big_n, big_k = 1024, 1024, 1024
+#    m, n, k = 512, 512, 512
+#
+#    whole_a = to_int8(torch.randn((big_m, big_k), device="cuda") * 5)
+#    whole_b = to_int8(torch.randn((big_n, big_k), device="cuda").t() * 5)
+#    a = whole_a[0:m, 0:k]
+#    b = whole_b[0:k, 0:n]
+#
+#    scale_a = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
+#    scale_b = torch.randn((1, 1), device="cuda", dtype=torch.float32) / 10
+#
+#    out = ops.cutlass_scaled_mm(a,
+#                                b,
+#                                scale_a,
+#                                scale_b,
+#                                out_dtype=torch.bfloat16)
+#    baseline = baseline_scaled_mm(a,
+#                                  b,
+#                                  scale_a,
+#                                  scale_b,
+#                                  out_dtype=torch.bfloat16)
+#
+#    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)
+#
+#
+## Test to make sure cuda graphs work
+#class CutlassLayer(torch.nn.Module):
+#
+#    def __init__(self, b, scale_a, scale_b, out_dtype):
+#        super().__init__()
+#        self.b = b
+#        self.scale_a = scale_a
+#        self.scale_b = scale_b
+#        self.out_dtype = out_dtype
+#
+#    def forward(self, a):
+#        return ops.cutlass_scaled_mm(a, self.b, self.scale_a, self.scale_b,
+#                                     self.out_dtype)
+#
+#
+#@pytest.mark.parametrize("per_act_token", [True, False])
+#@pytest.mark.parametrize("per_out_ch", [True, False])
+#def test_cutlass_cuda_graph(per_act_token: bool, per_out_ch: bool):
+#    m, n, k = 512, 512, 512
+#
+#    a = to_int8(torch.randn((m, k), device="cuda"))
+#    b = to_int8(torch.randn((n, k), device="cuda").t())
+#
+#    m_a_scales = m if per_act_token else 1
+#    n_b_scales = n if per_out_ch else 1
+#
+#    scale_a = (torch.randn(
+#        (m_a_scales, 1), device="cuda", dtype=torch.float32) / 10)
+#    scale_b = (torch.randn(
+#        (1, n_b_scales), device="cuda", dtype=torch.float32) / 10)
+#
+#    # Construct a trivial model with a single layer that calls a CUTLASS kernel
+#    model = CutlassLayer(b, scale_a, scale_b, torch.bfloat16)
+#
+#    # Run the model with a cuda graph
+#    stream = torch.cuda.Stream()
+#    with torch.cuda.stream(stream):
+#        g = torch.cuda.CUDAGraph()
+#        with torch.cuda.graph(g):
+#            out = model(a)
+#    out.zero_()
+#    g.replay()
+#
+#    baseline = torch.mm(scale_a * a.to(dtype=torch.float32),
+#                        scale_b * b.to(dtype=torch.float32)).to(torch.bfloat16)
+#    assert torch.allclose(out, baseline, rtol=1e-1, atol=1e0)

--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -118,6 +118,7 @@ def test_cutlass_fp8_gemm(m: int, n: int, k: int, per_act_token: bool,
                           per_out_ch: bool, use_bias: bool):
     cutlass_fp8_gemm_helper(m, n, k, per_act_token, per_out_ch, use_bias)
 
+
 @pytest.mark.parametrize("m", [512, 222, 33, 1])
 @pytest.mark.parametrize("n", [2048, 256, 1024])
 @pytest.mark.parametrize("k", [128, 496, 1024])


### PR DESCRIPTION
- Tune SM89 cutlass FP8 kernels for performance. 
- Refactor/Cleanup cutlass2x kernel code.
- High-level performance takeaways
  - Good performance speedups for M <= 16
  - `llama2-7b` :
      - min speedup 0.77x. max speed up 4.8x.
      - Number of Gemm shapes with perf. under 1.0x  - 11 / 28
      - Number of Gemm shapes with perf. under 0.9x  - 2 / 28
  
  - `llama3-8b` :
      -  min speedup 0.88x. max speedup 5.13x.
      - Number of Gemm shapes with perf. under 1.0x - 8 / 28
      - Number of Gemm shapes with perf. under 0.9x - 1 / 28

  - `llama2-13b`:
      - min speedup 0.4x. max speedup 4.74x. Until M <= 128, cutlass kernels are almost always over 1.0x faster.  
      - Number of Gemm shapes with perf. under 1.0x - 9 / 28
      - Number of Gemm shapes with perf. under 0.9x - 3 / 28
     
  - `llama2-70b` :
     -  min speedup 0.82x. max speedup 3.0x. Until M <= 128, cutlass kernels are almost always over 1.0x faster.
     -  Number of Gemm shapes with perf. under 1.0x - 7 / 28
     - Number of Gemm shapes with perf. under 0.9x - 2 / 28
 
Numbers: 

`Benchmark Serving`:

Machine : L40S x 1

Command : 
`python3 -m vllm.entrypoints.openai.api_server --model neuralmagic/Meta-Llama-3-8B-Instruct-FP8`
```
python benchmarks/benchmark_serving.py \
    --backend openai \
    --model neuralmagic/Meta-Llama-3-8B-Instruct-FP8 \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --request-rate 1 \
    --num-prompts 200 \
    --port 8000
```

Cutlass Kernels:
```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  201.75    
Total input tokens:                      42659     
Total generated tokens:                  40376     
Request throughput (req/s):              0.99      
Input token throughput (tok/s):          211.44    
Output token throughput (tok/s):         200.13    
---------------Time to First Token----------------
Mean TTFT (ms):                          28.72     
Median TTFT (ms):                        28.00     
P99 TTFT (ms):                           58.57     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.63     
Median TPOT (ms):                        15.57     
P99 TPOT (ms):                           18.71     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.57     
Median ITL (ms):                         15.19     
P99 ITL (ms):                            31.91     
==================================================
```

Pytorch Kernels:

```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  202.11    
Total input tokens:                      42659     
Total generated tokens:                  40817     
Request throughput (req/s):              0.99      
Input token throughput (tok/s):          211.07    
Output token throughput (tok/s):         201.95    
---------------Time to First Token----------------
Mean TTFT (ms):                          30.49     
Median TTFT (ms):                        28.90     
P99 TTFT (ms):                           60.36     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          16.68     
Median TPOT (ms):                        16.57     
P99 TPOT (ms):                           20.22     
---------------Inter-token Latency----------------
Mean ITL (ms):                           16.61     
Median ITL (ms):                         16.17     
P99 ITL (ms):                            34.07     
==================================================
```

`Gemm benchmarks`

- L40S x 1
- command : `python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py  --dtype fp8 model_bench --batch-sizes {1,16,32,64,128,256,512}`

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
float8_e4m3fn meta-llama/Llama-2-7b-hf-TP1 |   |   |  
-- | -- | -- | --
shapes | pytorch with and without fp8 fast accum best time (us) | cutlass_fp8_fp8_bf16_scaled_mm (us) | speedup
MKN=(1x4096x12288) | 33.00 | 15.40 | 2.14
MKN=(1x4096x4096) | 31.30 | 8.60 | 3.64
MKN=(1x4096x22016) | 71.30 | 44.90 | 1.59
MKN=(1x11008x4096) | 76.40 | 15.70 | 4.87
MKN=(16x4096x12288) | 33.20 | 16.60 | 2.00
MKN=(16x4096x4096) | 31.40 | 8.80 | 3.57
MKN=(16x4096x22016) | 72.00 | 49.50 | 1.45
MKN=(16x11008x4096) | 76.40 | 16.70 | 4.57
MKN=(32x4096x12288) | 19.80 | 18.10 | 1.09
MKN=(32x4096x4096) | 11.40 | 9.70 | 1.18
MKN=(32x4096x22016) | 44.00 | 57.20 | 0.77
MKN=(32x11008x4096) | 20.30 | 19.40 | 1.05
MKN=(64x4096x12288) | 22.30 | 22.80 | 0.98
MKN=(64x4096x4096) | 14.20 | 12.70 | 1.12
MKN=(64x4096x22016) | 56.10 | 72.10 | 0.78
MKN=(64x11008x4096) | 33.50 | 26.50 | 1.26
MKN=(128x4096x12288) | 47.50 | 37.90 | 1.25
MKN=(128x4096x4096) | 18.40 | 19.70 | 0.93
MKN=(128x4096x22016) | 94.80 | 105.90 | 0.90
MKN=(128x11008x4096) | 43.90 | 45.30 | 0.97
MKN=(256x4096x12288) | 85.20 | 91.40 | 0.93
MKN=(256x4096x4096) | 26.50 | 28.00 | 0.95
MKN=(256x4096x22016) | 169.40 | 183.60 | 0.92
MKN=(256x11008x4096) | 75.40 | 70.10 | 1.08
MKN=(512x4096x12288) | 139.60 | 140.20 | 1.00
MKN=(512x4096x4096) | 45.50 | 42.60 | 1.07
MKN=(512x4096x22016) | 300.50 | 318.50 | 0.94
MKN=(512x11008x4096) | 122.40 | 114.30 | 1.07
  |   |   |  
torch.float8_e4m3fn meta-llama/Llama-3-8b-TP1 |   |   |  
  |   |   |  
MKN=(1x4096x6144) | 31.40 | 10.30 | 3.05
MKN=(1x4096x4096) | 31.30 | 8.60 | 3.64
MKN=(1x4096x28672) | 181.90 | 170.40 | 1.07
MKN=(1x14336x4096) | 98.00 | 19.10 | 5.13
MKN=(16x4096x6144) | 31.40 | 11.40 | 2.75
MKN=(16x4096x4096) | 31.30 | 8.80 | 3.56
MKN=(16x4096x28672) | 186.80 | 176.00 | 1.06
MKN=(16x14336x4096) | 98.10 | 20.90 | 4.69
MKN=(32x4096x6144) | 13.20 | 12.40 | 1.06
MKN=(32x4096x4096) | 11.50 | 9.70 | 1.19
MKN=(32x4096x28672) | 188.10 | 180.80 | 1.04
MKN=(32x14336x4096) | 27.50 | 26.00 | 1.06
MKN=(64x4096x6144) | 15.30 | 16.10 | 0.95
MKN=(64x4096x4096) | 14.20 | 12.70 | 1.12
MKN=(64x4096x28672) | 199.90 | 190.40 | 1.05
MKN=(64x14336x4096) | 36.20 | 35.00 | 1.03
MKN=(128x4096x6144) | 21.90 | 22.80 | 0.96
MKN=(128x4096x4096) | 18.40 | 19.80 | 0.93
MKN=(128x4096x28672) | 200.60 | 202.10 | 0.99
MKN=(128x14336x4096) | 58.20 | 57.80 | 1.01
MKN=(256x4096x6144) | 36.30 | 38.20 | 0.95
MKN=(256x4096x4096) | 26.60 | 27.90 | 0.95
MKN=(256x4096x28672) | 224.00 | 253.70 | 0.88
MKN=(256x14336x4096) | 96.70 | 90.70 | 1.07
MKN=(512x4096x6144) | 85.10 | 69.30 | 1.23
MKN=(512x4096x4096) | 45.20 | 42.70 | 1.06
MKN=(512x4096x28672) | 402.00 | 435.50 | 0.92
MKN=(512x14336x4096) | 158.70 | 149.50 | 1.06
  |   |   |  
torch.float8_e4m3fn meta-llama/Llama-2-13b-hf-TP1 |   |   |  
  |   |   |  
MKN=(1x5120x15360) | 42.80 | 22.50 | 1.90
MKN=(1x5120x5120) | 38.00 | 10.50 | 3.62
MKN=(1x5120x27648) | 219.60 | 206.00 | 1.07
MKN=(1x13824x5120) | 94.80 | 20.00 | 4.74
MKN=(16x5120x15360) | 43.10 | 24.80 | 1.74
MKN=(16x5120x5120) | 38.00 | 11.60 | 3.28
MKN=(16x5120x27648) | 224.10 | 213.00 | 1.05
MKN=(16x13824x5120) | 94.80 | 24.30 | 3.90
MKN=(32x5120x15360) | 33.10 | 27.20 | 1.22
MKN=(32x5120x5120) | 13.10 | 12.60 | 1.04
MKN=(32x5120x27648) | 224.00 | 218.40 | 1.03
MKN=(32x13824x5120) | 29.40 | 27.80 | 1.06
MKN=(64x5120x15360) | 41.50 | 35.70 | 1.16
MKN=(64x5120x5120) | 16.60 | 16.80 | 0.99
MKN=(64x5120x27648) | 234.50 | 229.50 | 1.02
MKN=(64x13824x5120) | 39.40 | 38.50 | 1.02
MKN=(128x5120x15360) | 85.60 | 60.50 | 1.41
MKN=(128x5120x5120) | 24.80 | 25.50 | 0.97
MKN=(128x5120x27648) | 241.70 | 243.10 | 0.99
MKN=(128x13824x5120) | 61.00 | 59.90 | 1.02
MKN=(256x5120x15360) | 103.30 | 126.50 | 0.82
MKN=(256x5120x5120) | 41.60 | 43.70 | 0.95
MKN=(256x5120x27648) | 263.10 | 311.00 | 0.85
MKN=(256x13824x5120) | 108.50 | 108.20 | 1.00
MKN=(512x5120x15360) | 201.40 | 274.00 | 0.74
MKN=(512x5120x5120) | 102.20 | 80.00 | 1.28
MKN=(512x5120x27648) | 468.00 | 515.80 | 0.91
MKN=(512x13824x5120) | 199.80 | 212.90 | 0.94
  |   |   |  
float8_e4m3fn meta-llama/Llama-2-70b-hf-TP1 |   |   |  
  |   |   |  
MKN=(1x8192x10240) | 58.30 | 22.40 | 2.60
MKN=(1x8192x8192) | 58.10 | 19.30 | 3.01
MKN=(1x8192x57344) | 725.50 | 692.60 | 1.05
MKN=(1x28672x8192) | 367.30 | 353.90 | 1.04
MKN=(16x8192x10240) | 58.40 | 24.70 | 2.36
MKN=(16x8192x8192) | 58.20 | 22.10 | 2.63
MKN=(16x8192x57344) | 738.20 | 702.50 | 1.05
MKN=(16x28672x8192) | 370.70 | 357.60 | 1.04
MKN=(32x8192x10240) | 38.50 | 27.30 | 1.41
MKN=(32x8192x8192) | 25.40 | 25.70 | 0.99
MKN=(32x8192x57344) | 748.50 | 713.30 | 1.05
MKN=(32x28672x8192) | 357.80 | 361.90 | 0.99
MKN=(64x8192x10240) | 48.90 | 39.90 | 1.23
MKN=(64x8192x8192) | 35.20 | 35.20 | 1.00
MKN=(64x8192x57344) | 761.40 | 739.40 | 1.03
MKN=(64x28672x8192) | 356.50 | 370.40 | 0.96
MKN=(128x8192x10240) | 88.10 | 69.30 | 1.27
MKN=(128x8192x8192) | 70.60 | 51.30 | 1.38
MKN=(128x8192x57344) | 771.30 | 763.40 | 1.01
MKN=(128x28672x8192) | 388.10 | 389.10 | 1.00
MKN=(256x8192x10240) | 147.60 | 179.50 | 0.82
MKN=(256x8192x8192) | 90.00 | 86.40 | 1.04
MKN=(256x8192x57344) | 878.70 | 915.00 | 0.96
MKN=(256x28672x8192) | 470.20 | 448.40 | 1.05
MKN=(512x8192x10240) | 280.60 | 301.10 | 0.93
MKN=(512x8192x8192) | 153.20 | 184.90 | 0.83
MKN=(512x8192x57344) | 1,485.00 | 1,604.00 | 0.93
MKN=(512x28672x8192) | 710.50 | 728.40 | 0.98


---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


