### PR TITLE
[Bugfix] Fix a log error in chunked prefill

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -814,7 +814,7 @@ class SchedulerConfig:
         if enable_chunked_prefill:
             logger.info(
                 "Chunked prefill is enabled with max_num_batched_tokens=%d.",
-                max_num_batched_tokens)
+                self.max_num_batched_tokens)
 
         self.max_num_seqs = max_num_seqs
         self.max_model_len = max_model_len


### PR DESCRIPTION
Fixes the error
```
Message: 'Chunked prefill is enabled with max_num_batched_tokens=%d.'
Arguments: (None,)
```