### PR TITLE
[build] relax wheel size limit

### DIFF
--- a/.buildkite/check-wheel-size.py
+++ b/.buildkite/check-wheel-size.py
@@ -1,7 +1,7 @@
 import os
 import zipfile
 
-MAX_SIZE_MB = 200
+MAX_SIZE_MB = 250
 
 
 def print_top_10_largest_files(zip_file):


### PR DESCRIPTION
fixes https://github.com/vllm-project/vllm/issues/6647

NOTE: per https://github.com/pypi/support/issues/3792 , our wheel size limit is 400 MB. We should only increase the wheel size sparsely and gradually.