### PR TITLE
Adding f-string to validation error which is missing

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -107,7 +107,7 @@ def _image_token_str(model_config: ModelConfig,
         return tokenizer.decode(model_config.hf_config.image_token_index)
     if model_type == "chameleon":
         return "<image>"
-    raise TypeError("Unknown model type: {model_type}")
+    raise TypeError(f"Unknown model type: {model_type}")
 
 
 # TODO: Let user specify how to insert image tokens into prompt


### PR DESCRIPTION
FIX #6747

Very minor fix on missing string interpolation.
This will avoid plain non-sense string being returned on API servers implementations.

Before
```
{
  "object": "error",
  "message": "Unknown model type: {model_type}",
  "type": "BadRequestError",
  "param": null,
  "code": 400
}
```

After:
```
{
  "object": "error",
  "message": "Unknown model type: <whatever model type actually is>",
  "type": "BadRequestError",
  "param": null,
  "code": 400
}
```