### PR TITLE
[Bugfix] [Easy] Fixed a bug in the multiprocessing GPU executor.

### DIFF
--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import signal
+import threading
 import weakref
 from functools import partial
 from typing import Any, List, Optional
@@ -115,8 +116,9 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
             if executor := ref():
                 executor.shutdown()
 
-        signal.signal(signal.SIGINT, shutdown)
-        signal.signal(signal.SIGTERM, shutdown)
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(signal.SIGINT, shutdown)
+            signal.signal(signal.SIGTERM, shutdown)
 
         self.driver_worker = self._create_worker(
             distributed_init_method=distributed_init_method)


### PR DESCRIPTION
This was broken in the `0.5.3` release when these signal calls were introduced. It results in the following error when deploying on our machines:

```
ValueError: signal only works in main thread of the main interpreter
```

The fix is borrowed from [here](https://github.com/Lightning-AI/pytorch-lightning/pull/10610).

It would be great if you could cut a `0.5.3.post2` release after this is merged to unblock us (and I assume others as well) from using vLLM with Llama 3.1. Thank you!