### PR TITLE
[BugFix] skip loading lm_head for llama if word embeddings are tied

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -496,10 +496,12 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA):
 
                 break
             else:
-                # lm_head is not used in vllm as it is tied with embed_token.
+                # if word embeddings are tied, 
+                # lm_head will not be used.
                 # To prevent errors, skip loading lm_head.
-                if "lm_head" in name:
-                    continue
+                if self.config.tie_word_embeddings:
+                    if "lm_head" in name:
+                        continue
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -496,6 +496,10 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA):
 
                 break
             else:
+                # lm_head is not used in vllm as it is tied with embed_token.
+                # To prevent errors, skip loading lm_head.
+                if "lm_head" in name:
+                    continue
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -496,12 +496,11 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA):
 
                 break
             else:
-                # if word embeddings are tied, 
+                # if word embeddings are tied,
                 # lm_head will not be used.
                 # To prevent errors, skip loading lm_head.
-                if self.config.tie_word_embeddings:
-                    if "lm_head" in name:
-                        continue
+                if self.config.tie_word_embeddings and "lm_head" in name:
+                    continue
                 # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue


### PR DESCRIPTION
Check if `tie_word_embeddings` is true, that means `lm_head` is tied to `embeddings` we should be able to skip loading `lm_head`

Similar to what was done for gemma here - https://github.com/vllm-project/vllm/pull/3553