### PR TITLE
[Bugfix] Fix empty (nullptr) channelwise  scales when loading wNa16 using compressed tensors

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -54,7 +54,12 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
         output_size_per_partition = sum(output_partition_sizes)
 
         # If group_size is -1, we are in channelwise case.
-        group_size = input_size if self.group_size == -1 else self.group_size
+        channelwise = (self.group_size == -1)
+        group_size = input_size if channelwise else self.group_size
+        row_parallel = (input_size != input_size_per_partition)
+        # In the case of channelwise quantization, we need to replicate the
+        # scales across all gpus.
+        partition_scales = (row_parallel and not channelwise)
 
         verify_marlin_supports_shape(
             output_size_per_partition=output_size_per_partition,
@@ -65,8 +70,8 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
         weight_scale_dim = None
         scales_and_zp_size = input_size // group_size
 
-        if (input_size != input_size_per_partition
-                and self.group_size is not None):
+        if partition_scales:
+            assert input_size_per_partition % group_size == 0
             weight_scale_dim = 1
             scales_and_zp_size = input_size_per_partition // group_size
 


### PR DESCRIPTION
When running row parallel with channelwise scales, the integer divide in:
```
// in vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py:
scales_and_zp_size = input_size_per_partition // group_size
```
would result in a 0 sized tensor (with shape `(0, 8192)`, i.e. `tensor([], device='cuda:2', size=(0, 8192), dtype=torch.bfloat16)`) leading to a nullptr getting passed into marlin.

This is because when its channelwise `group_size` was getting set to `input_size` which is greater than `input_size_per_partition` in the row parallel case when tp > 1

Now for channelwise scales when running row parallel with a tp > 1 we replicate the scales to all gpus. 


This issue was present for the model: "nm-testing/Meta-Llama-3.1-70B-Instruct-quantized.w8a16"
