### PR TITLE
[Bugfix] Use torch.set_num_threads() to configure parallelism in multiproc_gpu_executor

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -1,5 +1,20 @@
 """vLLM: a high-throughput and memory-efficient inference engine for LLMs"""
 
+import os
+
+# Set OMP_NUM_THREADS to 1 if it is not already set
+# Helps to avoid CPU contention, particularly when running in a container and
+# when using multiprocessing.
+#
+# This must be set before importing torch to have the full effect. It seems that
+# torch determines the number of threads it will use when it is imported.
+if "OMP_NUM_THREADS" not in os.environ:
+    print(
+        "WARNING: Setting OMP_NUM_THREADS env var to 1 by default to avoid "
+        "unnecessary CPU contention. Set in the external environment to tune "
+        "this value for optimal performance.")
+    os.environ["OMP_NUM_THREADS"] = "1"
+
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.engine.llm_engine import LLMEngine

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -1,20 +1,5 @@
 """vLLM: a high-throughput and memory-efficient inference engine for LLMs"""
 
-import os
-
-# Set OMP_NUM_THREADS to 1 if it is not already set
-# Helps to avoid CPU contention, particularly when running in a container and
-# when using multiprocessing.
-#
-# This must be set before importing torch to have the full effect. It seems that
-# torch determines the number of threads it will use when it is imported.
-if "OMP_NUM_THREADS" not in os.environ:
-    print(
-        "WARNING: Setting OMP_NUM_THREADS env var to 1 by default to avoid "
-        "unnecessary CPU contention. Set in the external environment to tune "
-        "this value for optimal performance.")
-    os.environ["OMP_NUM_THREADS"] = "1"
-
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.engine.llm_engine import LLMEngine

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -44,11 +44,6 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
         # Disable torch async compiling which won't work with daemonic processes
         os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 
-        # Set OMP_NUM_THREADS to 1 if it is not set explicitly, avoids CPU
-        # contention amongst the shards
-        if "OMP_NUM_THREADS" not in os.environ:
-            os.environ["OMP_NUM_THREADS"] = "1"
-
         # workaround for https://github.com/vllm-project/vllm/issues/6103
         if world_size > 1:
             maybe_set_triton_cache_manager()

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -5,6 +5,8 @@ import weakref
 from functools import partial
 from typing import Any, List, Optional
 
+import torch
+
 from vllm.executor.distributed_gpu_executor import (  # yapf: disable
     DistributedGPUExecutor, DistributedGPUExecutorAsync)
 from vllm.executor.gpu_executor import create_worker
@@ -43,6 +45,24 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
 
         # Disable torch async compiling which won't work with daemonic processes
         os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
+
+        # Configure thread parallelism if OMP_NUM_THREADS isn't set
+        #
+        # Helps to avoid CPU contention. The default of spawning a thread per
+        # core combined with multiprocessing for each GPU can have a negative
+        # impact on performance. The contention is amplified when running in a
+        # container where CPU limits can cause throttling.
+        default_omp_num_threads = 1
+        if "OMP_NUM_THREADS" not in os.environ and (
+                current_parallelism :=
+                torch.get_num_threads()) > default_omp_num_threads:
+            logger.warning(
+                "Reducing Torch parallelism from %d threads to %d to avoid "
+                "unnecessary CPU contention. Set OMP_NUM_THREADS in the "
+                "external environment to tune this value as needed.",
+                current_parallelism, default_omp_num_threads)
+            os.environ["OMP_NUM_THREADS"] = str(default_omp_num_threads)
+            torch.set_num_threads(default_omp_num_threads)
 
         # workaround for https://github.com/vllm-project/vllm/issues/6103
         if world_size > 1:


### PR DESCRIPTION
OMP_NUM_THREADS must be set before `import torch` in order for it to have an effect on the CPU thread parallelization of torch operations, such as when loading tensors to RAM.

I thought that I had resolved this issue with https://github.com/vllm-project/vllm/pull/6109, but, after further investigation, I it was not actually the right fix. The code and profiling on that issue are accurate, but the code change does not resolve the problem. In the test script I was setting OMP_NUM_THREADS before the import of torch, but that is not the case for setting OMP_NUM_THREADS in `multiproc_gpu_executor.py`..

Instead of relying on OMP_NUM_THREADS, this PR uses `torch.set_num_threads()` to configure the parallelism. This can be done after torch is imported (https://pytorch.org/docs/stable/torch.html#parallelism).

These are the issues that were closed without being fixed due to my previous PR 😬 
FIX https://github.com/vllm-project/vllm/issues/6072
FIX https://github.com/vllm-project/vllm/issues/5564
FIX https://github.com/vllm-project/vllm/issues/5532