### PR TITLE
[TPU] Support collective communications in XLA devices

### DIFF
--- a/vllm/distributed/device_communicators/tpu_communicator.py
+++ b/vllm/distributed/device_communicators/tpu_communicator.py
@@ -1,0 +1,35 @@
+from typing import Union
+
+import torch
+from torch.distributed import ProcessGroup
+
+from vllm.platforms import current_platform
+
+if current_platform.is_tpu():
+    import torch_xla.core.xla_model as xm
+    from torch_xla._internal import pjrt
+
+
+class TpuCommunicator:
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        local_rank: int,
+        world_size: int,
+    ):
+        del group  # Unused.
+        if not current_platform.is_tpu():
+            self.disabled = True
+            return
+        self.disabled = False
+
+        pjrt.initialize_multiprocess(local_rank, world_size)
+        xm._init_world_size_ordinal()
+
+    def all_reduce(self, x: torch.Tensor) -> torch.Tensor:
+        return xm.all_reduce(xm.REDUCE_SUM, x)
+
+    def all_gather(self, x: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        assert dim == -1, "TPUs only support dim=-1 for all-gather."
+        return xm.all_gather(x, dim=dim)

--- a/vllm/distributed/device_communicators/tpu_communicator.py
+++ b/vllm/distributed/device_communicators/tpu_communicator.py
@@ -1,4 +1,5 @@
 import torch
+import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 from vllm.platforms import current_platform
@@ -10,18 +11,14 @@ if current_platform.is_tpu():
 
 class TpuCommunicator:
 
-    def __init__(
-        self,
-        group: ProcessGroup,
-        local_rank: int,
-        world_size: int,
-    ):
-        del group  # Unused.
+    def __init__(self, group: ProcessGroup):
         if not current_platform.is_tpu():
             self.disabled = True
             return
         self.disabled = False
 
+        local_rank = dist.get_rank(group)
+        world_size = dist.get_world_size(group)
         pjrt.initialize_multiprocess(local_rank, world_size)
         xm._init_world_size_ordinal()
 

--- a/vllm/distributed/device_communicators/tpu_communicator.py
+++ b/vllm/distributed/device_communicators/tpu_communicator.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import torch
 from torch.distributed import ProcessGroup
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -36,7 +36,7 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
-if current_platform.is_xla():
+if current_platform.is_tpu():
     import torch_xla.core.xla_model as xm
 
 
@@ -145,7 +145,7 @@ class GroupCoordinator:
         self.local_rank = local_rank
         self.device_group = None
         self.cpu_group = None
-        self.use_xla = current_platform.is_xla()
+        self.use_xla = current_platform.is_tpu()
 
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -196,11 +196,7 @@ class GroupCoordinator:
             TpuCommunicator)
         self.tpu_communicator: Optional[TpuCommunicator]
         if use_tpu_communicator and self.world_size > 1:
-            self.tpu_communicator = TpuCommunicator(
-                group=self.cpu_group,
-                local_rank=local_rank,
-                world_size=self.world_size,
-            )
+            self.tpu_communicator = TpuCommunicator(group=self.cpu_group)
 
         from vllm.distributed.device_communicators.shm_broadcast import (
             MessageQueue)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -34,9 +34,9 @@ from torch.distributed import Backend, ProcessGroup
 
 import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.utils import is_tpu
+from vllm.platforms import current_platform
 
-if is_tpu():
+if current_platform.is_xla():
     import torch_xla.core.xla_model as xm
 
 
@@ -145,7 +145,7 @@ class GroupCoordinator:
         self.local_rank = local_rank
         self.device_group = None
         self.cpu_group = None
-        self.use_xla = is_tpu()
+        self.use_xla = current_platform.is_xla()
 
         for ranks in group_ranks:
             device_group = torch.distributed.new_group(

--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -1068,6 +1068,10 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         return self.base_layer.soft_cap
 
     @property
+    def use_gather(self):
+        return self.base_layer.use_gather
+
+    @property
     def org_vocab_size(self):
         return self.base_layer.org_vocab_size
 

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -42,7 +42,7 @@ class LogitsProcessor(nn.Module):
         # Soft cap the logits. Used in Gemma 2.
         self.soft_cap = soft_cap
         # Whether to use gather or all-gather to gather the logits.
-        self.use_gather = not current_platform.is_xla()
+        self.use_gather = not current_platform.is_tpu()
 
     def forward(
         self,

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -10,7 +10,7 @@ from vllm.distributed import (tensor_model_parallel_all_gather,
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
-from vllm.utils import is_tpu
+from vllm.platforms import current_platform
 
 
 class LogitsProcessor(nn.Module):
@@ -42,7 +42,7 @@ class LogitsProcessor(nn.Module):
         # Soft cap the logits. Used in Gemma 2.
         self.soft_cap = soft_cap
         # Whether to use gather or all-gather to gather the logits.
-        self.use_gather = not is_tpu()
+        self.use_gather = not current_platform.is_xla()
 
     def forward(
         self,

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -5,10 +5,12 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from vllm.distributed import tensor_model_parallel_gather
+from vllm.distributed import (tensor_model_parallel_all_gather,
+                              tensor_model_parallel_gather)
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.utils import is_tpu
 
 
 class LogitsProcessor(nn.Module):
@@ -39,6 +41,8 @@ class LogitsProcessor(nn.Module):
         self.org_vocab_size = org_vocab_size or vocab_size
         # Soft cap the logits. Used in Gemma 2.
         self.soft_cap = soft_cap
+        # Whether to use gather or all-gather to gather the logits.
+        self.use_gather = not is_tpu()
 
     def forward(
         self,
@@ -76,7 +80,15 @@ class LogitsProcessor(nn.Module):
         logits = lm_head.linear_method.apply(lm_head,
                                              hidden_states,
                                              bias=embedding_bias)
-        logits = tensor_model_parallel_gather(logits)
+        if self.use_gather:
+            logits = tensor_model_parallel_gather(logits)
+        else:
+            # Gather is not supported for some devices such as TPUs.
+            # Use all-gather instead.
+            # NOTE(woosuk): Here, the outputs of every device should not be None
+            # because XLA requires strict SPMD among all devices. Every device
+            # should execute the same operations after gathering the logits.
+            logits = tensor_model_parallel_all_gather(logits)
         # Remove paddings in vocab (if any).
         if logits is not None:
             logits = logits[:, :self.org_vocab_size]

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -23,9 +23,6 @@ class Platform:
     def is_tpu(self) -> bool:
         return self._enum == PlatformEnum.TPU
 
-    def is_xla(self) -> bool:
-        return self.is_tpu()
-
     @staticmethod
     def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
         raise NotImplementedError

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -23,6 +23,9 @@ class Platform:
     def is_tpu(self) -> bool:
         return self._enum == PlatformEnum.TPU
 
+    def is_xla(self) -> bool:
+        return self.is_tpu()
+
     @staticmethod
     def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
         raise NotImplementedError


### PR DESCRIPTION
This PR adds support for collective communications in XLA devices (TPU). It is simply implemented by falling back to `xm.all_reduce` and `xm.all_gather` for TPU devices. One difference is the gather operation in logits processor, where `gather` is replaced by `all-gather` to meet the SPMD restriction in XLA.