### PR TITLE
[CI/Build] bump Dockerfile.neuron image base, use public ECR

### DIFF
--- a/Dockerfile.neuron
+++ b/Dockerfile.neuron
@@ -1,5 +1,5 @@
 # default base image
-ARG BASE_IMAGE="763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference-neuronx:2.1.1-neuronx-py310-sdk2.17.0-ubuntu20.04"
+ARG BASE_IMAGE="public.ecr.aws/neuron/pytorch-inference-neuronx:2.1.2-neuronx-py310-sdk2.19.1-ubuntu20.04"
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
The current Neuron base image [fails to build in CI](https://github.com/vllm-project/vllm/pull/4738#issuecomment-2189335981) due to a malformed requirements string.

It also seems that the current image is not public. I switched over to the image provided in https://github.com/aws-neuron/deep-learning-containers?tab=readme-ov-file#pytorch-inference-neuronx
