### PR TITLE
[Doc] Add missing mock import to docs `conf.py`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ build:
 
 sphinx:
    configuration: docs/source/conf.py
+   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,7 @@ def setup(app):
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
 autodoc_mock_imports = [
-    # "aiohttp",
+    "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,6 +93,7 @@ def setup(app):
 
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
+nitpicky = True
 autodoc_mock_imports = [
     "aiohttp",
     "cpuinfo",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,9 +93,8 @@ def setup(app):
 
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
-nitpicky = True
 autodoc_mock_imports = [
-    "aiohttp",
+    # "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,6 +94,7 @@ def setup(app):
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
 autodoc_mock_imports = [
+    "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,7 @@ def setup(app):
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
 nitpicky = True
 autodoc_mock_imports = [
-    "aiohttp",
+    # "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -143,5 +143,6 @@ intersphinx_mapping = {
 }
 
 autodoc_preserve_defaults = True
+autodoc_warningiserror = True
 
 navigation_with_keys = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,7 +95,7 @@ def setup(app):
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.
 nitpicky = True
 autodoc_mock_imports = [
-    # "aiohttp",
+    "aiohttp",
     "cpuinfo",
     "torch",
     "transformers",


### PR DESCRIPTION
Fixes the issue identified in https://github.com/vllm-project/vllm/pull/6600#issuecomment-2252739458

FIX #6853