### PR TITLE
[Build] Dockerfile revert to CUDA 12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@
 # docs/source/dev/dockerfile/dockerfile.rst and
 # docs/source/assets/dev/dockerfile-stages-dependency.png
 
-ARG CUDA_VERSION=12.4.1
+ARG CUDA_VERSION=12.1.0
 #################### BASE BUILD IMAGE ####################
 # prepare basic build environment
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu20.04 AS base
 
-ARG CUDA_VERSION=12.4.1
+ARG CUDA_VERSION=12.1.0
 ARG PYTHON_VERSION=3.10
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -109,6 +109,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             export SCCACHE_BUCKET=vllm-build-sccache; \
            fi \
         && export SCCACHE_REGION=us-west-2 \
+        && export SCCACHE_S3_NO_CREDENTIALS=1 \
         && export CMAKE_BUILD_TYPE=Release \
         && sccache --show-stats \
         && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38 \
@@ -157,7 +158,7 @@ RUN pip --verbose wheel -r requirements-mamba.txt \
 #################### vLLM installation IMAGE ####################
 # image with vLLM installed
 FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu20.04 AS vllm-base
-ARG CUDA_VERSION=12.4.1
+ARG CUDA_VERSION=12.1.0
 ARG PYTHON_VERSION=3.10
 WORKDIR /vllm-workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             export SCCACHE_BUCKET=vllm-build-sccache; \
            fi \
         && export SCCACHE_REGION=us-west-2 \
-        && export SCCACHE_S3_NO_CREDENTIALS=1 \
         && export CMAKE_BUILD_TYPE=Release \
         && sccache --show-stats \
         && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38 \


### PR DESCRIPTION
12.4 seems to be a bit more aggressive because it requires an up to date host. Now we have the base image to be ubuntu20, we don't need to worry about the base image deprecation anymore 