### PR TITLE
enforce eager mode with bnb quantization temporarily

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -282,6 +282,10 @@ class ModelConfig:
             raise ValueError(
                 "BitAndBytes quantization with TP or PP is not supported yet.")
 
+        if self.quantization == "bitsandbytes" and self.enforce_eager is False:
+            raise ValueError(
+                "BitAndBytes with enforce_eager = False is no supported yet.")
+
     def get_hf_config_sliding_window(self) -> Optional[int]:
         """Get the sliding window size, or None if disabled."""
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -284,7 +284,7 @@ class ModelConfig:
 
         if self.quantization == "bitsandbytes" and self.enforce_eager is False:
             raise ValueError(
-                "BitAndBytes with enforce_eager = False is no supported yet.")
+                "BitAndBytes with enforce_eager = False is not supported yet.")
 
     def get_hf_config_sliding_window(self) -> Optional[int]:
         """Get the sliding window size, or None if disabled."""


### PR DESCRIPTION
Temporarily enforce eager_mode in bitsandbytes quantization before the known issue (https://github.com/vllm-project/vllm/issues/5569) is fixed. 