### PR TITLE
[Docs] Add RunLLM chat widget

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var script = document.createElement("script");
+    script.type = "module";
+    script.id = "runllm-widget-script"
+  
+    script.src = "https://widget.runllm.com";
+  
+    script.setAttribute("version", "stable");
+    script.setAttribute("runllm-keyboard-shortcut", "Mod+j"); // cmd-j or ctrl-j to open the widget.
+    script.setAttribute("runllm-name", "vLLM");
+    script.setAttribute("runllm-position", "BOTTOM_RIGHT");
+    script.setAttribute("runllm-assistant-id", "207");
+  
+    script.async = true;
+    document.head.appendChild(script);
+  });

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,8 @@ html_theme_options = {
     'use_repository_button': True,
     'use_edit_page_button': True,
 }
+html_static_path = ["_static"]
+html_js_files = ["custom.js"]
 
 # see https://docs.readthedocs.io/en/stable/reference/environment-variables.html # noqa
 READTHEDOCS_VERSION_TYPE = os.environ.get('READTHEDOCS_VERSION_TYPE')


### PR DESCRIPTION
This PR adds the RunLLM chat widget to the vLLM documentation site. Please see the attached screenshot for how it looks like.

![Screenshot 2024-07-26 at 10 24 45 PM](https://github.com/user-attachments/assets/a05ba218-db80-4d66-b4a6-9635eeb605fa)
