### PR TITLE
Add Nemotron to PP_SUPPORTED_MODELS

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -39,6 +39,7 @@ _PP_SUPPORTED_MODELS = [
     "Phi3ForCausalLM",
     "GPT2LMHeadModel",
     "MixtralForCausalLM",
+    "NemotronForCausalLM",
 ]
 
 


### PR DESCRIPTION
Followup to https://github.com/vllm-project/vllm/pull/6611#discussion_r1693716156

Tested TP=2 + PP=2 with server:
```
vllm serve nvidia/Minitron-4B-Base --tensor-parallel-size 2 --pipeline-parallel-size 2
```

Client request and result:
```
curl http://0.0.0.0:8000/v1/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer OPENAI_API_KEY" \
  -d '{
    "model": "nvidia/Minitron-4B-Base",
    "prompt": "The capital of the USA is" 
  }'
 
{"id":"cmpl-7029ed6cf71347c999a01361418bc6e2","object":"text_completion","created":1722094724,"model":"nvidia/Minitron-4B-Base","choices":[{"index":0,"text":" Washington D. C. which is a Fictional World. It was first mentioned in","logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":6,"total_tokens":22,"completion_tokens":16}}%  
```