### PR TITLE
[core][misc] improve free_finished_seq_groups

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -566,6 +566,7 @@ class Scheduler:
                     "Failing the request %s because there's not enough kv "
                     "cache blocks to run the entire sequence.",
                     seq_group.request_id)
+                self._finished_requests_ids.append(seq_group.request_id)
                 for seq in seq_group.get_seqs():
                     seq.status = SequenceStatus.FINISHED_IGNORED
                 infeasible_seq_groups.append(seq_group)
@@ -699,6 +700,7 @@ class Scheduler:
                 logger.warning(
                     "Input prompt (%d tokens) is too long"
                     " and exceeds limit of %d", num_new_tokens, prompt_limit)
+                self._finished_requests_ids.append(seq_group.request_id)
                 for seq in waiting_seqs:
                     seq.status = SequenceStatus.FINISHED_IGNORED
                 ignored_seq_groups.append(seq_group)
@@ -714,6 +716,7 @@ class Scheduler:
                     "Input prompt (%d tokens) is too long"
                     " and exceeds the capacity of block_manager",
                     num_new_tokens)
+                self._finished_requests_ids.append(seq_group.request_id)
                 for seq in waiting_seqs:
                     seq.status = SequenceStatus.FINISHED_IGNORED
                 ignored_seq_groups.append(seq_group)
@@ -1058,13 +1061,16 @@ class Scheduler:
         self.block_manager.free(seq)
 
     def free_finished_seq_groups(self) -> None:
-        for queue in [self.running, self.swapped, self.waiting]:
-            self._finished_requests_ids += [
-                seq_group.request_id for seq_group in queue
-                if seq_group.is_finished()
-            ]
-        self.running = deque(seq_group for seq_group in self.running
-                             if not seq_group.is_finished())
+        # finished requests in self.waiting and self.swapped are already
+        # appended to self._finished_requests_ids during the scheduling.
+        # the only new finished requests are in self.running.
+        remaining: Deque[SequenceGroup] = deque()
+        for seq_group in self.running:
+            if seq_group.is_finished():
+                self._finished_requests_ids.append(seq_group.request_id)
+            else:
+                remaining.append(seq_group)
+        self.running = remaining
 
     def _allocate_and_set_running(self, seq_group: SequenceGroup) -> None:
         self.block_manager.allocate(seq_group)


### PR DESCRIPTION
`free_finished_seq_groups` is in the critical path, because the engine calls it after every model step.

the main branch searchs for all the requests to find finished requests, while new finished requests should only appear in running queue.

this simple optimization, turns out to be important, when we process large amount of offline batch inference, e.g. when users give `100k` prompts to the LLM engine. In this case, we are iterating all 100k data at every step.

I have heard users complaining that sending the whole dataset to `LLM` is slow, and he has to chunk the data into small batches (25 requests each) to make it fast. This PR might fix it.

Some micro benchmark to demonstrate the benefit when number of prompts are long and the model becomes small (thus overhead in scheduler becomes significant):

Note: main branch is commit https://github.com/vllm-project/vllm/commit/925de97e05dd4709fcd80691cb37da5e582c22e8

```shell
$ python benchmarks/benchmark_throughput.py --output-len 16 --input 16 --model facebook/opt-125m --num-prompts 10000

# main branch:
Throughput: 577.63 requests/s, 18484.31 tokens/s

# this PR:
Throughput: 674.46 requests/s, 21582.66 tokens/s

$ python benchmarks/benchmark_throughput.py --output-len 16 --input 16 --model facebook/opt-125m --num-prompts 100000

# main branch:
Throughput: 211.18 requests/s, 6757.85 tokens/s

# this PR:
Throughput: 522.91 requests/s, 16733.13 tokens/s
```

Conclusion:

When I increase the number of prompts from  10k to 100k, the main branch is slowed down by almost 3x. Improving the `free_finished_seq_groups` helps a lot, the slow down is about 40%. Apparently there are some other factors, but I think this might be the largest factor in processing with large datasets.