### PR TITLE
[Bugfix] Support cpu offloading with quant_method.process_weights_after_loading

### DIFF
--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -13,9 +13,11 @@ def test_cpu_offload():
 @pytest.mark.skipif(not is_quant_method_supported("fp8"),
                     reason="fp8 is not supported on this GPU type.")
 def test_cpu_offload_fp8():
+    # Test quantization of an unquantized checkpoint
     compare_two_settings("meta-llama/Meta-Llama-3-8B-Instruct",
                          ["--quantization", "fp8"],
                          ["--quantization", "fp8", "--cpu-offload-gb", "2"])
+    # Test loading a quantized checkpoint
     compare_two_settings("neuralmagic/Meta-Llama-3-8B-Instruct-FP8", [],
                          ["--cpu-offload-gb", "2"])
 
@@ -27,20 +29,16 @@ def test_cpu_offload_awq():
                          ["--cpu-offload-gb", "2"])
 
 
-@pytest.mark.skipif(not is_quant_method_supported("gptq_marlin_24"),
-                    reason="gptq_marlin_24 is not supported on this GPU type.")
-def test_cpu_offload_gptq_marlin_24():
+@pytest.mark.skipif(not is_quant_method_supported("gptq_marlin"),
+                    reason="gptq_marlin is not supported on this GPU type.")
+def test_cpu_offload_compressed_tensors():
+    # Test wNa16
+    compare_two_settings("nm-testing/tinyllama-oneshot-w4a16-channel-v2", [],
+                         ["--cpu-offload-gb", "1"])
+    # Test w4a16_marlin24
     compare_two_settings("nm-testing/llama7b-one-shot-2_4-w4a16-marlin24-t",
                          [], ["--cpu-offload-gb", "1"])
-
-
-@pytest.mark.skipif(not is_quant_method_supported("bitsandbytes"),
-                    reason="bitsandbytes is not supported on this GPU type.")
-def test_cpu_offload_bitsandbytes():
-    compare_two_settings("lllyasviel/omost-llama-3-8b-4bits", [
-        "quantization", "bitsandbytes", "load_format", "bitsandbytes",
-        "enforce_eager", "True"
-    ], [
-        "quantization", "bitsandbytes", "load_format", "bitsandbytes",
-        "enforce_eager", "True", "--cpu-offload-gb", "2"
-    ])
+    # Test w8a8
+    compare_two_settings(
+        "nm-testing/tinyllama-oneshot-w8w8-test-static-shape-change", [],
+        ["--cpu-offload-gb", "1"])

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -1,7 +1,6 @@
 import pytest
 
 from tests.quantization.utils import is_quant_method_supported
-from vllm.utils import is_hip
 
 from ..utils import compare_two_settings
 
@@ -9,14 +8,8 @@ from ..utils import compare_two_settings
 def test_cpu_offload():
     compare_two_settings("meta-llama/Llama-2-7b-hf", [],
                          ["--cpu-offload-gb", "4"])
-    if not is_hip():
-        # compressed-tensors quantization is currently not supported in ROCm.
-        compare_two_settings(
-            "nm-testing/llama7b-one-shot-2_4-w4a16-marlin24-t", [],
-            ["--cpu-offload-gb", "1"])
 
 
-@pytest.mark.skipif(is_hip(), reason="ROCm isn't supported")
 @pytest.mark.skipif(not is_quant_method_supported("fp8"),
                     reason="fp8 is not supported on this GPU type.")
 def test_cpu_offload_fp8():
@@ -27,9 +20,22 @@ def test_cpu_offload_fp8():
                          ["--cpu-offload-gb", "2"])
 
 
-@pytest.mark.skipif(is_hip(), reason="ROCm isn't supported")
 @pytest.mark.skipif(not is_quant_method_supported("awq"),
                     reason="awq is not supported on this GPU type.")
 def test_cpu_offload_awq():
     compare_two_settings("casperhansen/llama-3-8b-instruct-awq", [],
+                         ["--cpu-offload-gb", "2"])
+
+
+@pytest.mark.skipif(not is_quant_method_supported("gptq_marlin_24"),
+                    reason="gptq_marlin_24 is not supported on this GPU type.")
+def test_cpu_offload_gptq_marlin_24():
+    compare_two_settings("nm-testing/llama7b-one-shot-2_4-w4a16-marlin24-t",
+                         [], ["--cpu-offload-gb", "1"])
+
+
+@pytest.mark.skipif(not is_quant_method_supported("bitsandbytes"),
+                    reason="bitsandbytes is not supported on this GPU type.")
+def test_cpu_offload_bitsandbytes():
+    compare_two_settings("lllyasviel/omost-llama-3-8b-4bits", [],
                          ["--cpu-offload-gb", "2"])

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -37,5 +37,10 @@ def test_cpu_offload_gptq_marlin_24():
 @pytest.mark.skipif(not is_quant_method_supported("bitsandbytes"),
                     reason="bitsandbytes is not supported on this GPU type.")
 def test_cpu_offload_bitsandbytes():
-    compare_two_settings("lllyasviel/omost-llama-3-8b-4bits", [],
-                         ["--cpu-offload-gb", "2"])
+    compare_two_settings("lllyasviel/omost-llama-3-8b-4bits", [
+        "quantization", "bitsandbytes", "load_format", "bitsandbytes",
+        "enforce_eager", "True"
+    ], [
+        "quantization", "bitsandbytes", "load_format", "bitsandbytes",
+        "enforce_eager", "True", "--cpu-offload-gb", "2"
+    ])

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -1,3 +1,6 @@
+import pytest
+
+from tests.quantization.utils import is_quant_method_supported
 from vllm.utils import is_hip
 
 from ..utils import compare_two_settings
@@ -11,3 +14,22 @@ def test_cpu_offload():
         compare_two_settings(
             "nm-testing/llama7b-one-shot-2_4-w4a16-marlin24-t", [],
             ["--cpu-offload-gb", "1"])
+
+
+@pytest.mark.skipif(is_hip(), reason="ROCm isn't supported")
+@pytest.mark.skipif(not is_quant_method_supported("fp8"),
+                    reason="fp8 is not supported on this GPU type.")
+def test_cpu_offload_fp8():
+    compare_two_settings("meta-llama/Meta-Llama-3-8B-Instruct",
+                         ["--quantization", "fp8"],
+                         ["--quantization", "fp8", "--cpu-offload-gb", "2"])
+    compare_two_settings("neuralmagic/Meta-Llama-3-8B-Instruct-FP8", [],
+                         ["--cpu-offload-gb", "2"])
+
+
+@pytest.mark.skipif(is_hip(), reason="ROCm isn't supported")
+@pytest.mark.skipif(not is_quant_method_supported("awq"),
+                    reason="awq is not supported on this GPU type.")
+def test_cpu_offload_awq():
+    compare_two_settings("casperhansen/llama-3-8b-instruct-awq", [],
+                         ["--cpu-offload-gb", "2"])

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -42,7 +42,8 @@ from vllm.utils import is_tpu
 
 
 @contextmanager
-def device_loading_context(module: torch.nn.Module, target_device: torch.device):
+def device_loading_context(module: torch.nn.Module,
+                           target_device: torch.device):
     if target_device.type == "cpu":
         # If target is CPU, no need to move anything
         yield module

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -46,15 +46,12 @@ def gpu_loading_context(module: torch.nn.Module):
     # TODO: change this
     target_device = torch.device("cuda")
     original_device_states: Dict[str, torch.device] = {}
-    moved_param_names: set = set()
-    original_param_names = set(dict(module.named_parameters()).keys())
 
     # Store original device states and move parameters to GPU if they're on CPU
     for name, param in module.named_parameters():
-        original_device_states[name] = param.device
         if param.device.type == 'cpu':
+            original_device_states[name] = param.device
             param.data = param.data.to(target_device)
-            moved_param_names.add(name)
         # Parameters already on CUDA devices are not touched
 
     try:
@@ -63,7 +60,7 @@ def gpu_loading_context(module: torch.nn.Module):
     finally:
         # Restore parameters to their original devices, ignoring new parameters
         for name, param in module.named_parameters():
-            if name in original_param_names and name in moved_param_names:
+            if name in original_device_states:
                 param.data = param.data.to(original_device_states[name])
         # New parameters or parameters already on CUDA are untouched
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -69,11 +69,12 @@ def device_loading_context(module: torch.nn.Module,
                 original_device: torch.device = original_device_states[name]
                 if original_device.type == "cpu":
                     # `torch.empty_like` does not support `pin_memory` argument
-                    cpu_data = torch.empty(size=param.data.size(),
-                                           dtype=param.data.dtype,
-                                           layout=param.data.layout,
-                                           device="cpu",
-                                           pin_memory=pin_memory)
+                    cpu_data = torch.empty_strided(size=param.data.size(),
+                                                   stride=param.data.stride(),
+                                                   dtype=param.data.dtype,
+                                                   layout=param.data.layout,
+                                                   device="cpu",
+                                                   pin_memory=pin_memory)
                     cpu_data.copy_(param.data)
                     param.data = cpu_data
                 else:

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -52,10 +52,10 @@ def device_loading_context(module: torch.nn.Module,
     original_device_states: Dict[str, torch.device] = {}
 
     # Store original device states and move parameters to GPU if they're on CPU
-    for name, param in module.named_parameters():
-        if param.device.type == "cpu":
-            original_device_states[name] = param.device
-            param.data = param.data.to(target_device)
+    for name, p in module.named_parameters():
+        if p.device.type == "cpu":
+            original_device_states[name] = p.device
+            p.data = p.data.to(target_device)
         # Parameters already on target device are not touched
 
     try:
@@ -64,21 +64,21 @@ def device_loading_context(module: torch.nn.Module,
     finally:
         # Restore parameters to their original devices, ignoring new parameters
         pin_memory = is_pin_memory_available()
-        for name, param in module.named_parameters():
+        for name, p in module.named_parameters():
             if name in original_device_states:
                 original_device: torch.device = original_device_states[name]
                 if original_device.type == "cpu":
                     # `torch.empty_like` does not support `pin_memory` argument
-                    cpu_data = torch.empty_strided(size=param.data.size(),
-                                                   stride=param.data.stride(),
-                                                   dtype=param.data.dtype,
-                                                   layout=param.data.layout,
+                    cpu_data = torch.empty_strided(size=p.data.size(),
+                                                   stride=p.data.stride(),
+                                                   dtype=p.data.dtype,
+                                                   layout=p.data.layout,
                                                    device="cpu",
                                                    pin_memory=pin_memory)
-                    cpu_data.copy_(param.data)
-                    param.data = cpu_data
+                    cpu_data.copy_(p.data)
+                    p.data = cpu_data
                 else:
-                    param.data = param.data.to(original_device)
+                    p.data = p.data.to(original_device)
         # New parameters or parameters already on target device are untouched
 
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -87,6 +87,7 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
 
     # offload parameters to CPU
     # use pin_memory if possible, which helps cudagraph capture speed
+    offloaded_parameters = False
     for p in module.parameters():
         if _CPU_OFFLOAD_BYTES >= _CPU_OFFLOAD_MAX_BYTES:
             # we use per-parameter offloading
@@ -102,27 +103,27 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
         cpu_data.copy_(p.data)
         p.data = cpu_data
         _CPU_OFFLOAD_BYTES += p.data.numel() * p.data.element_size()
+        offloaded_parameters = True
 
-    state_dict: Dict[str, torch.Tensor] = module.state_dict()
+    if offloaded_parameters:
+        original_forward = module.forward
 
-    original_forward = module.forward
+        def forward(*args, **kwargs):
+            module.forward = original_forward
+            device_state = {
+                # here we blindly call `to(device)`
+                # if the parameter is already on the device, it will be a no-op
+                k: v.to(device, non_blocking=True)
+                for k, v in module.state_dict().items()
+            }
+            output = functional_call(module,
+                                     device_state,
+                                     args=args,
+                                     kwargs=kwargs)
+            module.forward = forward
+            return output
 
-    def forward(*args, **kwargs):
-        module.forward = original_forward
-        device_state = {
-            # here we blindly call `to(device)`
-            # if the parameter is already on the device, it will be a no-op
-            k: v.to(device, non_blocking=True)
-            for k, v in state_dict.items()
-        }
-        output = functional_call(module,
-                                 device_state,
-                                 args=args,
-                                 kwargs=kwargs)
         module.forward = forward
-        return output
-
-    module.forward = forward
 
     return module
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -95,11 +95,12 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
             break
 
         # `torch.empty_like` does not support `pin_memory` argument
-        cpu_data = torch.empty(size=p.data.size(),
-                               dtype=p.data.dtype,
-                               layout=p.data.layout,
-                               device='cpu',
-                               pin_memory=pin_memory)
+        cpu_data = torch.empty_strided(size=p.data.size(),
+                                       stride=p.data.stride(),
+                                       dtype=p.data.dtype,
+                                       layout=p.data.layout,
+                                       device='cpu',
+                                       pin_memory=pin_memory)
         cpu_data.copy_(p.data)
         p.data = cpu_data
         _CPU_OFFLOAD_BYTES += p.data.numel() * p.data.element_size()


### PR DESCRIPTION
Adds compatibility for cpu offloading for common quantization methods that use `process_weights_after_loading` (marlin, fp8, compressed-tensors). This PR adds a new wrapper `device_loading_context` that looks for parameters that may be offloaded, moves them to the device for `process_weights_after_loading`, and moves them back to cpu afterwards

FIX https://github.com/vllm-project/vllm/issues/6765
FIX https://github.com/vllm-project/vllm/issues/6952

Note that BNB is still not supported with this PR due to issues preserving attributes on the weight tensor. This seems tricky and should be resolved in another PR since it is unrelated to process_weights_after_loading. Currently it will fail here:
```
[rank0]:   File "~/vllm/vllm/model_executor/layers/quantization/bitsandbytes.py", line 129, in apply
[rank0]:     quant_states = qweight.bnb_quant_state
[rank0]: AttributeError: 'Tensor' object has no attribute 'bnb_quant_state'
```