### PR TITLE
[Nightly benchmarking suite] Remove pkill python from run benchmark suite

### DIFF
--- a/.buildkite/nightly-benchmarks/run-benchmarks-suite.sh
+++ b/.buildkite/nightly-benchmarks/run-benchmarks-suite.sh
@@ -73,11 +73,6 @@ kill_gpu_processes() {
       echo "All GPU processes have been killed."
   fi
 
-  # Sometimes kill with pid doesn't work properly, we can also kill all process running python or python3
-  # since we are in container anyway
-  pkill -9 -f python
-  pkill -9 -f python3
-
   # waiting for GPU processes to be fully killed
   # loop while nvidia-smi returns any processes
   while [ -n "$(nvidia-smi --query-compute-apps=pid --format=csv,noheader)" ]; do


### PR DESCRIPTION
The comment says sometimes `kill` does not work, so instead we do `pkill` on python. This doesn't quite right -- `kill -9 [gpu proc pid]` should be equivalent in signalling power to `pkill python`.

This allows me to run the benchmark locally while I have other python processes open, e.g. infrastructure monitoring tooling.