### PR TITLE
[Kernel] Tuned int8 Cutlass Kernels for SM75 (T4)

### DIFF
--- a/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
+++ b/benchmarks/cutlass_benchmarks/w8a8_benchmarks.py
@@ -112,12 +112,19 @@ def bench_int8(dtype: torch.dtype, m: int, k: int, n: int, label: str,
     scale_b = torch.tensor(1.0, device="cuda", dtype=torch.float32)
 
     timers = []
-    # pytorch impl
+    # pytorch impl - bfloat16
     timers.append(
         bench_fn(a.to(dtype=torch.bfloat16, device="cuda"),
                  b.to(dtype=torch.bfloat16, device="cuda"), scale_a, scale_b,
                  torch.bfloat16, label, sub_label, pytorch_mm_impl,
                  "pytorch_bf16_bf16_bf16_matmul-no-scales"))
+
+    # pytorch impl - float16
+    timers.append(
+        bench_fn(a.to(dtype=torch.float16, device="cuda"),
+                 b.to(dtype=torch.float16, device="cuda"), scale_a, scale_b,
+                 torch.float16, label, sub_label, pytorch_mm_impl,
+                 "pytorch_fp16_fp16_fp16_matmul-no-scales"))
 
     # cutlass impl
     timers.append(

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -3,6 +3,7 @@
 #include "cutlass/cutlass.h"
 
 #include "scaled_mm_c2x.cuh"
+#include "scaled_mm_c2x_sm75_dispatch.cuh"
 #include "scaled_mm_c2x_sm80_dispatch.cuh"
 #include "scaled_mm_c2x_sm89_fp8_dispatch.cuh"
 #include "scaled_mm_c2x_sm89_int8_dispatch.cuh"
@@ -20,21 +21,14 @@ void cutlass_scaled_mm_sm75_epilogue(torch::Tensor& out, torch::Tensor const& a,
   TORCH_CHECK(a.dtype() == torch::kInt8);
   TORCH_CHECK(b.dtype() == torch::kInt8);
 
-  using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
-  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
-  using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
-
   if (out.dtype() == torch::kBFloat16) {
-    return vllm::cutlass_gemm_caller<
-        vllm::cutlass_2x_gemm<cutlass::arch::Sm75, vllm::enable_sm75_to_sm80,
-                              int8_t, cutlass::bfloat16_t, Epilogue, TileShape,
-                              WarpShape, InstructionShape, 2>>(
+    return vllm::cutlass_gemm_sm75_dispatch<int8_t, cutlass::bfloat16_t,
+                                            Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return vllm::cutlass_gemm_caller<vllm::cutlass_2x_gemm<
-        cutlass::arch::Sm75, vllm::enable_sm75_to_sm80, int8_t, cutlass::half_t,
-        Epilogue, TileShape, WarpShape, InstructionShape, 2>>(
+    return vllm::cutlass_gemm_sm75_dispatch<int8_t, cutlass::half_t,
+                                            Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x.cu
@@ -27,8 +27,7 @@ void cutlass_scaled_mm_sm75_epilogue(torch::Tensor& out, torch::Tensor const& a,
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   } else {
     TORCH_CHECK(out.dtype() == torch::kFloat16);
-    return vllm::cutlass_gemm_sm75_dispatch<int8_t, cutlass::half_t,
-                                            Epilogue>(
+    return vllm::cutlass_gemm_sm75_dispatch<int8_t, cutlass::half_t, Epilogue>(
         out, a, b, std::forward<EpilogueArgs>(epilogue_args)...);
   }
 }

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm75_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm75_dispatch.cuh
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "scaled_mm_c2x.cuh"
+
+/**
+ * This file defines Gemm kernel configurations for SM75 based on the Gemm
+ * shape.
+ */
+
+namespace vllm {
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm75_config_default {
+  // TODO (varun) : figure out shared mem usage
+  // This config is used in 2 cases,
+  // - M in (256, inf]
+  // - M in (64, 128]
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<128, 128, 64>;
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm75, enable_sm75_to_sm80, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 2>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm75_config_M256 {
+  // M in (128, 256]
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<128, 128, 128>;
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm75, enable_sm75_to_sm80, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 2>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm75_config_M64 {
+  // M in (32, 64]
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<64, 128, 128>;
+  using WarpShape = typename cutlass::gemm::GemmShape<64, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm75, enable_sm75_to_sm80, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 2>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue>
+struct sm75_config_M32 {
+  // M in [1, 32]
+  static_assert(std::is_same<InType, int8_t>());
+  using TileShape = typename cutlass::gemm::GemmShape<32, 128, 64>;
+  using WarpShape = typename cutlass::gemm::GemmShape<32, 64, 64>;
+  using InstructionShape = typename cutlass::gemm::GemmShape<8, 8, 16>;
+  using Cutlass2xGemm =
+      cutlass_2x_gemm<cutlass::arch::Sm75, enable_sm75_to_sm80, InType, OutType,
+                      Epilogue, TileShape, WarpShape, InstructionShape, 2>;
+};
+
+template <typename InType, typename OutType,
+          template <typename, typename> typename Epilogue,
+          typename... EpilogueArgs>
+inline void cutlass_gemm_sm75_dispatch(torch::Tensor& out,
+                                       torch::Tensor const& a,
+                                       torch::Tensor const& b,
+                                       EpilogueArgs&&... args) {
+  static_assert(std::is_same<InType, int8_t>());
+  TORCH_CHECK(a.dtype() == torch::kInt8);
+  TORCH_CHECK(b.dtype() == torch::kInt8);
+
+  using Cutlass2xGemmDefault =
+      typename sm75_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM256 = 
+      typename sm75_config_M256<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM128 = Cutlass2xGemmDefault;
+  using Cutlass2xGemmM64 = 
+      typename sm75_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM32 = 
+      typename sm75_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
+
+  // Due to shared memory requirements, some Gemms may fail to run on some
+  // GPUs. As the name indicates, the Fallback Gemm is used as an alternative
+  // in such cases.
+  // sm75_config_M16 has the least shared-memory requirement. However,
+  // based on some profiling, we select sm75_config_M32 as a better alternative
+  // performance wise.
+  // TODO (varun) : fix fallback gemm
+  using FallbackGemm = Cutlass2xGemmDefault;
+
+  uint32_t const m = a.size(0);
+  uint32_t const mp2 =
+      std::max(static_cast<uint32_t>(32), next_pow_2(m));  // next power of 2
+  if (mp2 <= 32) {
+    // M in [1, 32]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM32, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 64) {
+    // M in (32, 64]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM64, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 128) {
+    // M in (64, 128]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM128, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else if (mp2 <= 256) {
+    // M in (128, 256]
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmM256, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  } else {
+    // M in (256, inf)
+    return fallback_cutlass_gemm_caller<Cutlass2xGemmDefault, FallbackGemm>(
+        out, a, b, std::forward<EpilogueArgs>(args)...);
+  }
+}
+
+}  // namespace vllm

--- a/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm75_dispatch.cuh
+++ b/csrc/quantization/cutlass_w8a8/scaled_mm_c2x_sm75_dispatch.cuh
@@ -80,13 +80,13 @@ inline void cutlass_gemm_sm75_dispatch(torch::Tensor& out,
 
   using Cutlass2xGemmDefault =
       typename sm75_config_default<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM256 = 
+  using Cutlass2xGemmM256 =
       typename sm75_config_M256<InType, OutType, Epilogue>::Cutlass2xGemm;
   using Cutlass2xGemmM128 = Cutlass2xGemmDefault;
-  using Cutlass2xGemmM64 = 
+  using Cutlass2xGemmM64 =
       typename sm75_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
-  using Cutlass2xGemmM32 = 
-      typename sm75_config_M64<InType, OutType, Epilogue>::Cutlass2xGemm;
+  using Cutlass2xGemmM32 =
+      typename sm75_config_M32<InType, OutType, Epilogue>::Cutlass2xGemm;
 
   // Due to shared memory requirements, some Gemms may fail to run on some
   // GPUs. As the name indicates, the Fallback Gemm is used as an alternative


### PR DESCRIPTION
Add tuned Int8 kernels for SM75 (T4) 

 - Added 4 unique Gemm configs to stratify Gemm shapes along the M dimensions.
 - Perf. Takeaways:
   - M in [1, 64] - 20% speedup
   - M in (64, 128] - Same as main
   - M in (128, 256] - You will see upto 3% perf. drop for some Gemm shapes. But the PR chooses a better holistic config based on the perf. runs. 
   - M in (256, inf) - Same as main 

Numbers:
Machine : T4 x 1 
Command : `python3 benchmarks/cutlass_benchmarks/w8a8_benchmarks.py --dtype int8 model_bench --batch-sizes {116,32,64,128,256,512}`

<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
torch.int8 meta-llama/Llama-2-7b-hf-TP1 |   |   |   |   |  
-- | -- | -- | -- | -- | --
  | cutlass_i8_i8_bf16_scaled_mm - main (us) | cutlass_i8_i8_bf16_scaled_mm - pr (us) | pytorch_f16_f16_f16_matmul-no-scales - main (us) | speedup vs cutlass main | speedup vs pytorch fp16
MKN=(1x4096x12288) | 349.3 | 276.7 | 388.4 | 1.26 | 1.40
MKN=(1x4096x4096) | 123.8 | 99.4 | 133 | 1.25 | 1.34
MKN=(1x4096x22016) | 591.7 | 493.5 | 692.3 | 1.20 | 1.40
MKN=(1x11008x4096) | 287.4 | 248.9 | 356.2 | 1.15 | 1.43
MKN=(16x4096x12288) | 358.4 | 281.7 | 433.8 | 1.27 | 1.54
MKN=(16x4096x4096) | 125.6 | 101.3 | 160.9 | 1.24 | 1.59
MKN=(16x4096x22016) | 610.3 | 503.2 | 759.1 | 1.21 | 1.51
MKN=(16x11008x4096) | 301.9 | 252.7 | 412 | 1.19 | 1.63
MKN=(32x4096x12288) | 365.3 | 285.3 | 566.8 | 1.28 | 1.99
MKN=(32x4096x4096) | 127.9 | 103.6 | 172.1 | 1.23 | 1.66
MKN=(32x4096x22016) | 629.5 | 513.5 | 951.8 | 1.23 | 1.85
MKN=(32x11008x4096) | 314.8 | 255.7 | 477.5 | 1.23 | 1.87
MKN=(64x4096x12288) | 388 | 338.1 | 552.4 | 1.15 | 1.63
MKN=(64x4096x4096) | 132.3 | 111.9 | 176.2 | 1.18 | 1.57
MKN=(64x4096x22016) | 682.2 | 595.5 | 953.2 | 1.15 | 1.60
MKN=(64x11008x4096) | 338.6 | 277.1 | 488.1 | 1.22 | 1.76
MKN=(128x4096x12288) | 445.6 | 444.9 | 691.8 | 1.00 | 1.55
MKN=(128x4096x4096) | 147.9 | 147.7 | 218.4 | 1.00 | 1.48
MKN=(128x4096x22016) | 807 | 797.9 | 1194.5 | 1.01 | 1.50
MKN=(128x11008x4096) | 396.8 | 398.7 | 630.5 | 1.00 | 1.58
MKN=(256x4096x12288) | 746.1 | 765.2 | 1033.5 | 0.98 | 1.35
MKN=(256x4096x4096) | 250.8 | 256.7 | 472.5 | 0.98 | 1.84
MKN=(256x4096x22016) | 1357.4 | 1394.2 | 1861.8 | 0.97 | 1.34
MKN=(256x11008x4096) | 673.5 | 672.9 | 1259.9 | 1.00 | 1.87
MKN=(512x4096x12288) | 1349.6 | 1357.4 | 1813.5 | 0.99 | 1.34
MKN=(512x4096x4096) | 448 | 448.2 | 761 | 1.00 | 1.70
MKN=(512x4096x22016) | 2416.9 | 2439.7 | 3285 | 0.99 | 1.35
MKN=(512x11008x4096) | 1259.4 | 1256.3 | 2040.8 | 1.00 | 1.62
  |   |   |   |   |  
torch.int8 meta-llama/Llama-3-8b-TP1 |   |   |   |   |  
MKN=(1x4096x6144) | 194.3 | 155.5 | 197.5 | 1.25 | 1.27
MKN=(1x4096x4096) | 123.9 | 99.6 | 133.5 | 1.24 | 1.34
MKN=(1x4096x28672) | 750.3 | 624.1 | 902 | 1.20 | 1.45
MKN=(1x14336x4096) | 373.2 | 335.8 | 459.6 | 1.11 | 1.37
MKN=(16x4096x6144) | 196.5 | 158.2 | 228.2 | 1.24 | 1.44
MKN=(16x4096x4096) | 125.6 | 101.2 | 159.6 | 1.24 | 1.58
MKN=(16x4096x28672) | 790.9 | 634.5 | 975.4 | 1.25 | 1.54
MKN=(16x14336x4096) | 390.3 | 338.2 | 535.4 | 1.15 | 1.58
MKN=(32x4096x6144) | 199.5 | 160.2 | 266.1 | 1.25 | 1.66
MKN=(32x4096x4096) | 127.6 | 104.2 | 171.9 | 1.22 | 1.65
MKN=(32x4096x28672) | 822.2 | 646.2 | 1151.7 | 1.27 | 1.78
MKN=(32x14336x4096) | 404.8 | 341.3 | 623.2 | 1.19 | 1.83
MKN=(64x4096x6144) | 206.1 | 191.5 | 262.8 | 1.08 | 1.37
MKN=(64x4096x4096) | 133.5 | 112.2 | 176.4 | 1.19 | 1.57
MKN=(64x4096x28672) | 898.6 | 752.9 | 1171.4 | 1.19 | 1.56
MKN=(64x14336x4096) | 451.2 | 363.7 | 637 | 1.24 | 1.75
MKN=(128x4096x6144) | 224.3 | 223.3 | 331.2 | 1.00 | 1.48
MKN=(128x4096x4096) | 149.1 | 148.9 | 222.1 | 1.00 | 1.49
MKN=(128x4096x28672) | 1055.1 | 1059.6 | 1495.4 | 1.00 | 1.41
MKN=(128x14336x4096) | 526.8 | 523.2 | 835.8 | 1.01 | 1.60
MKN=(256x4096x6144) | 376.4 | 385.4 | 604.2 | 0.98 | 1.57
MKN=(256x4096x4096) | 250.5 | 255.6 | 474.9 | 0.98 | 1.86
MKN=(256x4096x28672) | 1756.5 | 1796.8 | 2444.3 | 0.98 | 1.36
MKN=(256x14336x4096) | 886.2 | 882.7 | 1642.9 | 1.00 | 1.86
MKN=(512x4096x6144) | 667.2 | 669.1 | 1026.8 | 1.00 | 1.53
MKN=(512x4096x4096) | 449.5 | 448.7 | 753.7 | 1.00 | 1.68
MKN=(512x4096x28672) | 3170.6 | 3148.1 | 4217.1 | 1.01 | 1.34
MKN=(512x14336x4096) | 1698.9 | 1656.8 | 2633.5 | 1.03 | 1.59
  |   |   |   |   |  
torch.int8 meta-llama/Llama-2-13b-hf-TP1 |   |   |   |   |  
MKN=(1x5120x15360) | 512.8 | 434.1 | 607.3 | 1.18 | 1.40
MKN=(1x5120x5120) | 182 | 159.3 | 206.2 | 1.14 | 1.29
MKN=(1x5120x27648) | 928.6 | 769.8 | 1087.6 | 1.21 | 1.41
MKN=(1x13824x5120) | 441.8 | 396.4 | 566.8 | 1.11 | 1.43
MKN=(16x5120x15360) | 536.3 | 438.8 | 668.1 | 1.22 | 1.52
MKN=(16x5120x5120) | 185.7 | 161.6 | 283.9 | 1.15 | 1.76
MKN=(16x5120x27648) | 973.3 | 782.1 | 1205.8 | 1.24 | 1.54
MKN=(16x13824x5120) | 468.3 | 397.9 | 641.9 | 1.18 | 1.61
MKN=(32x5120x15360) | 564.3 | 447.1 | 847.4 | 1.26 | 1.90
MKN=(32x5120x5120) | 189.9 | 162.4 | 287.5 | 1.17 | 1.77
MKN=(32x5120x27648) | 1032 | 801.3 | 1455.5 | 1.29 | 1.82
MKN=(32x13824x5120) | 483.8 | 401 | 763.2 | 1.21 | 1.90
MKN=(64x5120x15360) | 612.7 | 512.7 | 843.3 | 1.20 | 1.64
MKN=(64x5120x5120) | 201.3 | 173.6 | 294.7 | 1.16 | 1.70
MKN=(64x5120x27648) | 1121.7 | 932.1 | 1474.8 | 1.20 | 1.58
MKN=(64x13824x5120) | 531.9 | 433.7 | 775 | 1.23 | 1.79
MKN=(128x5120x15360) | 727.1 | 721.2 | 1105.2 | 1.01 | 1.53
MKN=(128x5120x5120) | 237.1 | 235.9 | 367.6 | 1.01 | 1.56
MKN=(128x5120x27648) | 1306.1 | 1303.7 | 1929.9 | 1.00 | 1.48
MKN=(128x13824x5120) | 635.7 | 632.1 | 986.2 | 1.01 | 1.56
MKN=(256x5120x15360) | 1238.9 | 1227.5 | 1681.8 | 1.01 | 1.37
MKN=(256x5120x5120) | 414 | 407.7 | 558.8 | 1.02 | 1.37
MKN=(256x5120x27648) | 2222.7 | 2234.7 | 3065.4 | 0.99 | 1.37
MKN=(256x13824x5120) | 1064.4 | 1036.1 | 1504.5 | 1.03 | 1.45
MKN=(512x5120x15360) | 2178 | 2178.5 | 2924.6 | 1.00 | 1.34
MKN=(512x5120x5120) | 722.8 | 720 | 961.8 | 1.00 | 1.34
MKN=(512x5120x27648) | 3938 | 3958.4 | 5241 | 0.99 | 1.32
MKN=(512x13824x5120) | 1835.7 | 1829.7 | 2569.6 | 1.00 | 1.40
  |   |   |   |   |  
torch.int8 meta-llama/Llama-2-70b-hf-TP1 |   |   |   |   |  
MKN=(1x8192x10240) | 512.2 | 437.4 | 647.9 | 1.17 | 1.48
MKN=(1x8192x8192) | 417.1 | 358.6 | 519.6 | 1.16 | 1.45
MKN=(1x8192x57344) | 2888.6 | 2413.7 | 3588.9 | 1.20 | 1.49
MKN=(1x28672x8192) | 1474.8 | 1239.6 | 1811.4 | 1.19 | 1.46
MKN=(16x8192x10240) | 536.5 | 444 | 815.9 | 1.21 | 1.84
MKN=(16x8192x8192) | 436.1 | 360.8 | 583.2 | 1.21 | 1.62
MKN=(16x8192x57344) | 3040.2 | 2448.4 | 3864.1 | 1.24 | 1.58
MKN=(16x28672x8192) | 1533.7 | 1258.2 | 1980.1 | 1.22 | 1.57
MKN=(32x8192x10240) | 567.9 | 448.7 | 823.8 | 1.27 | 1.84
MKN=(32x8192x8192) | 450.5 | 367.6 | 661.7 | 1.23 | 1.80
MKN=(32x8192x57344) | 3203.7 | 2486.8 | 4537.4 | 1.29 | 1.82
MKN=(32x28672x8192) | 1625.5 | 1275.4 | 2377.7 | 1.27 | 1.86
MKN=(64x8192x10240) | 621.2 | 488.2 | 834.3 | 1.27 | 1.71
MKN=(64x8192x8192) | 492.9 | 409.2 | 668.6 | 1.20 | 1.63
MKN=(64x8192x57344) | 3526.1 | 2796.2 | 4622 | 1.26 | 1.65
MKN=(64x28672x8192) | 1778.4 | 1454.9 | 2422.1 | 1.22 | 1.66
MKN=(128x8192x10240) | 738.9 | 741.6 | 1058.4 | 1.00 | 1.43
MKN=(128x8192x8192) | 585.1 | 587.8 | 925 | 1.00 | 1.57
MKN=(128x8192x57344) | 4129 | 4139 | 6021.1 | 1.00 | 1.45
MKN=(128x28672x8192) | 2115.6 | 2115.7 | 3245.8 | 1.00 | 1.53
MKN=(256x8192x10240) | 1240.6 | 1207.9 | 1723.2 | 1.03 | 1.43
MKN=(256x8192x8192) | 1000.7 | 966.4 | 1381.5 | 1.04 | 1.43
MKN=(256x8192x57344) | 6998.6 | 6851.5 | 9810.8 | 1.02 | 1.43
MKN=(256x28672x8192) | 3728.9 | 3424.2 | 5068.4 | 1.09 | 1.48
MKN=(512x8192x10240) | 2235.7 | 2247.3 | 2989.4 | 0.99 | 1.33
MKN=(512x8192x8192) | 1808.5 | 1800.7 | 2568.7 | 1.00 | 1.43
MKN=(512x8192x57344) | 12533.3 | 12475.2 | 16607.1 | 1.00 | 1.33
MKN=(512x28672x8192) | 6233.3 | 6201.8 | 8923.9 | 1.01 | 1.44




---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


