### PR TITLE
[CI/Build] bump minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.26)
 
 project(vllm_extensions LANGUAGES CXX)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Should be mirrored in requirements-build.txt
 requires = [
-    "cmake>=3.21",
+    "cmake>=3.26",
     "ninja",
     "packaging",
     "setuptools >= 49.4.0",

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,5 @@
 # Should be mirrored in pyproject.toml
-cmake>=3.21
+cmake>=3.26
 ninja
 packaging
 setuptools>=49.4.0

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,5 +1,3 @@
-cmake >= 3.21
-ninja  # For faster builds.
 psutil
 sentencepiece  # Required for LLaMA tokenizer.
 numpy < 2.0.0


### PR DESCRIPTION
- `find_python_from_executable` uses `find_package(PYTHON ... Development.SABIModule)`, which is only available [since cmake>=3.26](https://cmake.org/cmake/help/latest/module/FindPython.html)
- `cmake` and `ninja` are build-time requirements, so they should not be  in `requirements-common.txt` or `requirements-openvino.txt`
