### PR TITLE
[Bugfix] Lower gemma's unloaded_params exception to warning

### DIFF
--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -405,5 +405,5 @@ class GemmaForCausalLM(nn.Module, SupportsLoRA):
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
             logger.warning(
-                "Some weights are not initialized from checkpoints: "
-                f"{unloaded_params}")
+                "Some weights are not initialized from checkpoints: %s",
+                unloaded_params)

--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -404,6 +404,6 @@ class GemmaForCausalLM(nn.Module, SupportsLoRA):
             loaded_params.add(name)
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
-            raise RuntimeError(
+            logger.warning(
                 "Some weights are not initialized from checkpoints: "
                 f"{unloaded_params}")

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -23,6 +23,7 @@ from transformers import Gemma2Config
 from vllm.attention import Attention, AttentionMetadata
 from vllm.config import CacheConfig, LoRAConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import GeluAndMul
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
@@ -40,6 +41,8 @@ from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors, SamplerOutput
 
 from .interfaces import SupportsLoRA
+
+logger = init_logger(__name__)
 
 
 class Gemma2MLP(nn.Module):
@@ -391,5 +394,5 @@ class Gemma2ForCausalLM(nn.Module, SupportsLoRA):
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
             logger.warning(
-                "Some weights are not initialized from checkpoints: "
-                f"{unloaded_params}")
+                "Some weights are not initialized from checkpoints: %s",
+                unloaded_params)

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -390,6 +390,6 @@ class Gemma2ForCausalLM(nn.Module, SupportsLoRA):
 
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
-            raise RuntimeError(
+            logger.warning(
                 "Some weights are not initialized from checkpoints: "
                 f"{unloaded_params}")

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -342,6 +342,6 @@ class PaliGemmaForConditionalGeneration(nn.Module, SupportsVision):
 
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
-            raise RuntimeError(
+            logger.warning(
                 "Some weights are not initialized from checkpoints: "
                 f"{unloaded_params}")

--- a/vllm/model_executor/models/paligemma.py
+++ b/vllm/model_executor/models/paligemma.py
@@ -343,5 +343,5 @@ class PaliGemmaForConditionalGeneration(nn.Module, SupportsVision):
         unloaded_params = params_dict.keys() - loaded_params
         if unloaded_params:
             logger.warning(
-                "Some weights are not initialized from checkpoints: "
-                f"{unloaded_params}")
+                "Some weights are not initialized from checkpoints: %s",
+                unloaded_params)


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/6957

Sometimes we add extra tensors when constructing quantized models in order to cover all permutations of checkpoints. In the linked issue, Gemma currently fails when loading FP8 quantization because we add k/v_scale parameters to be loaded in the case that calibrated kv cache scales are available. Since Gemma has a strict "no unloaded parameters" check, it fails in this case. To quickly unblock, I propose making this exception a warning. Eventually we can be more strict in allowing or disallowing unloaded parameters for all models, rather than just some.