### PR TITLE
[TPU] Add Load-time W8A16 quantization for TPU Backend

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -244,6 +244,7 @@ class ModelConfig:
             "fp8", "marlin", "gptq_marlin_24", "gptq_marlin", "awq_marlin",
             "fbgemm_fp8", "compressed_tensors", "compressed-tensors"
         ]
+        tpu_supported_quantization = ["tpu_int8"]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
 
@@ -282,6 +283,10 @@ class ModelConfig:
                 raise ValueError(
                     f"{self.quantization} quantization is currently not "
                     f"supported in ROCm.")
+            if is_tpu() and self.quantization not in tpu_supported_quantization:
+                raise ValueError(
+                    f"{self.quantization} quantization is currently not "
+                    f"supported in TPU Backend.")
             if self.quantization not in optimized_quantization_methods:
                 logger.warning(
                     "%s quantization is not fully "

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -283,7 +283,8 @@ class ModelConfig:
                 raise ValueError(
                     f"{self.quantization} quantization is currently not "
                     f"supported in ROCm.")
-            if is_tpu() and self.quantization not in tpu_supported_quantization:
+            if is_tpu(
+            ) and self.quantization not in tpu_supported_quantization:
                 raise ValueError(
                     f"{self.quantization} quantization is currently not "
                     f"supported in TPU Backend.")

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -22,7 +22,6 @@ from vllm.model_executor.layers.quantization.gptq_marlin_24 import (
 from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.layers.quantization.qqq import QQQConfig
 from vllm.model_executor.layers.quantization.squeezellm import SqueezeLLMConfig
-
 from vllm.model_executor.layers.quantization.tpu_int8 import Int8TpuConfig
 
 QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -23,10 +23,13 @@ from vllm.model_executor.layers.quantization.marlin import MarlinConfig
 from vllm.model_executor.layers.quantization.qqq import QQQConfig
 from vllm.model_executor.layers.quantization.squeezellm import SqueezeLLMConfig
 
+from vllm.model_executor.layers.quantization.tpu_int8 import Int8TpuConfig
+
 QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "aqlm": AQLMConfig,
     "awq": AWQConfig,
     "deepspeedfp": DeepSpeedFPConfig,
+    "tpu_int8": Int8TpuConfig,
     "fp8": Fp8Config,
     "fbgemm_fp8": FBGEMMFp8Config,
     # The order of gptq methods is important for config.py iteration over

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -4,14 +4,13 @@ import torch
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
-from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase)
+from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 from vllm.model_executor.utils import set_weight_attrs
 
-import torch_xla.experimental.xla_quantized_matmul
-
 ACTIVATION_SCHEMES = ["none"]
+
 
 class Int8TpuConfig(QuantizationConfig):
     """Int8 Quantization Config class for TPU Backend.
@@ -32,10 +31,10 @@ class Int8TpuConfig(QuantizationConfig):
     def get_supported_act_dtypes(self) -> List[torch.dtype]:
         return [torch.float16, torch.bfloat16]
 
-
     @classmethod
     def get_min_capability(cls) -> int:
-        raise NotImplementedError("This function should not be called with TPU Backend")
+        raise NotImplementedError(
+            "This function should not be called with TPU Backend")
 
     @staticmethod
     def get_config_filenames() -> List[str]:
@@ -46,9 +45,8 @@ class Int8TpuConfig(QuantizationConfig):
         activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
         return cls(activation_scheme=activation_scheme)
 
-    def get_quant_method(
-            self, layer: Module,
-            prefix: str) -> Optional["TPUInt8LinearMethod"]:
+    def get_quant_method(self, layer: Module,
+                         prefix: str) -> Optional["TPUInt8LinearMethod"]:
         if isinstance(layer, LinearBase):
             return TPUInt8LinearMethod(self)
         return None
@@ -56,7 +54,7 @@ class Int8TpuConfig(QuantizationConfig):
     def get_scaled_act_names(self) -> List[str]:
         return []
 
-    
+
 class TPUInt8LinearMethod(LinearMethodBase):
     """Int8 Linear method for TPU Quant.
 
@@ -65,11 +63,18 @@ class TPUInt8LinearMethod(LinearMethodBase):
     def __init__(self, quant_config: Int8TpuConfig):
         self.quant_config = quant_config
 
-    def create_weights(self, layer: Module,
-                       input_size_per_partition: int,
+    def create_weights(self, layer: Module, input_size_per_partition: int,
                        output_partition_sizes: List[int], input_size: int,
                        output_size: int, params_dtype: torch.dtype,
                        **extra_weight_attrs):
+        try:
+            import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
+        except ImportError as err:
+            raise ImportError(
+                "Please install torch_xla by following the instructions at "
+                "https://docs.vllm.ai/en/latest/getting_started/tpu-installation.html "  # noqa: E501
+                "to run vLLM on TPU.") from err
+
         weight = Parameter(torch.empty(sum(output_partition_sizes),
                                        input_size_per_partition,
                                        dtype=params_dtype),
@@ -81,22 +86,22 @@ class TPUInt8LinearMethod(LinearMethodBase):
             "output_dim": 0,
         })
 
-    def quantize_weight(self, weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def quantize_weight(
+            self, weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         weight_dtype = weight.dtype
         weight = weight.cpu().to(torch.float32)
         n_bit = 8
         eps = 1e-5
-        max_int = 2 ** (n_bit - 1) - 1
-        min_int = -(2 ** (n_bit - 1))
+        max_int = 2**(n_bit - 1) - 1
+        min_int = -(2**(n_bit - 1))
         max_val = weight.abs().amax(dim=-1, keepdim=True)
         max_val = max_val.clamp(min=eps)
         qscale = max_val / max_int
-        qweight = torch.clamp(
-                        torch.round(weight * (1.0 / qscale)), min_int, max_int
-                    ).to(torch.int8)
+        qweight = torch.clamp(torch.round(weight * (1.0 / qscale)), min_int,
+                              max_int).to(torch.int8)
         qscale = qscale.squeeze().to(weight_dtype)
         return qweight, qscale
-    
+
     def process_weights_after_loading(self, layer: Module) -> None:
         device = layer.weight.device
         qweight, qscale = self.quantize_weight(layer.weight)
@@ -104,7 +109,7 @@ class TPUInt8LinearMethod(LinearMethodBase):
         qscale = qscale.to(device)
         layer.weight = Parameter(qweight, requires_grad=False)
         layer.scale = Parameter(qscale, requires_grad=False)
-    
+
     def apply(self,
               layer: torch.nn.Module,
               x: torch.Tensor,

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -86,7 +86,7 @@ class TPUInt8LinearMethod(LinearMethodBase):
             "output_dim": 0,
         })
 
-    def quantize_weight(
+    def _quantize_weight(
             self, weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         weight_dtype = weight.dtype
         weight = weight.cpu().to(torch.float32)
@@ -104,7 +104,7 @@ class TPUInt8LinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: Module) -> None:
         device = layer.weight.device
-        qweight, qscale = self.quantize_weight(layer.weight)
+        qweight, qscale = self._quantize_weight(layer.weight)
         qweight = qweight.to(device)
         qscale = qscale.to(device)
         layer.weight = Parameter(qweight, requires_grad=False)

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -55,9 +55,7 @@ class Int8TpuConfig(QuantizationConfig):
 
 
 class TPUInt8LinearMethod(LinearMethodBase):
-    """Int8 Linear method for TPU Quant.
-
-    """
+    """Int8 Linear method for TPU Quant. """
 
     def __init__(self, quant_config: Int8TpuConfig):
         self.quant_config = quant_config

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -13,8 +13,7 @@ ACTIVATION_SCHEMES = ["none"]
 
 
 class Int8TpuConfig(QuantizationConfig):
-    """Int8 Quantization Config class for TPU Backend.
-    """
+    """Int8 Quantization Config class for TPU Backend."""
 
     def __init__(
         self,

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -112,4 +112,7 @@ class TPUInt8LinearMethod(LinearMethodBase):
                 "to run vLLM on TPU.") from err
         weight = layer.weight
         scale = layer.scale
-        return torch.ops.xla.quantized_matmul(x, weight, scale)
+        out = torch.ops.xla.quantized_matmul(x, weight, scale)
+        if bias is not None:
+            out = out + bias
+        return out

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -67,14 +67,6 @@ class TPUInt8LinearMethod(LinearMethodBase):
                        output_partition_sizes: List[int], input_size: int,
                        output_size: int, params_dtype: torch.dtype,
                        **extra_weight_attrs):
-        try:
-            import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
-        except ImportError as err:
-            raise ImportError(
-                "Please install torch_xla by following the instructions at "
-                "https://docs.vllm.ai/en/latest/getting_started/tpu-installation.html "  # noqa: E501
-                "to run vLLM on TPU.") from err
-
         weight = Parameter(torch.empty(sum(output_partition_sizes),
                                        input_size_per_partition,
                                        dtype=params_dtype),
@@ -114,6 +106,13 @@ class TPUInt8LinearMethod(LinearMethodBase):
               layer: torch.nn.Module,
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        try:
+            import torch_xla.experimental.xla_quantized_matmul  # noqa: F401
+        except ImportError as err:
+            raise ImportError(
+                "Please install torch_xla by following the instructions at "
+                "https://docs.vllm.ai/en/latest/getting_started/tpu-installation.html "  # noqa: E501
+                "to run vLLM on TPU.") from err
         weight = layer.weight
         scale = layer.scale
         return torch.ops.xla.quantized_matmul(x, weight, scale)

--- a/vllm/model_executor/layers/quantization/tpu_int8.py
+++ b/vllm/model_executor/layers/quantization/tpu_int8.py
@@ -1,0 +1,114 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
+from vllm.model_executor.layers.linear import (LinearBase, LinearMethodBase)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig)
+from vllm.model_executor.utils import set_weight_attrs
+
+import torch_xla.experimental.xla_quantized_matmul
+
+ACTIVATION_SCHEMES = ["none"]
+
+class Int8TpuConfig(QuantizationConfig):
+    """Int8 Quantization Config class for TPU Backend.
+    """
+
+    def __init__(
+        self,
+        activation_scheme: str = "none",
+    ) -> None:
+        if activation_scheme not in ACTIVATION_SCHEMES:
+            raise ValueError(
+                f"Unsupported activation scheme {activation_scheme}")
+        self.activation_scheme = activation_scheme
+
+    def get_name(self) -> str:
+        return "tpu_int8"
+
+    def get_supported_act_dtypes(self) -> List[torch.dtype]:
+        return [torch.float16, torch.bfloat16]
+
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        raise NotImplementedError("This function should not be called with TPU Backend")
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "Int8TpuConfig":
+        activation_scheme = cls.get_from_keys(config, ["activation_scheme"])
+        return cls(activation_scheme=activation_scheme)
+
+    def get_quant_method(
+            self, layer: Module,
+            prefix: str) -> Optional["TPUInt8LinearMethod"]:
+        if isinstance(layer, LinearBase):
+            return TPUInt8LinearMethod(self)
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+    
+class TPUInt8LinearMethod(LinearMethodBase):
+    """Int8 Linear method for TPU Quant.
+
+    """
+
+    def __init__(self, quant_config: Int8TpuConfig):
+        self.quant_config = quant_config
+
+    def create_weights(self, layer: Module,
+                       input_size_per_partition: int,
+                       output_partition_sizes: List[int], input_size: int,
+                       output_size: int, params_dtype: torch.dtype,
+                       **extra_weight_attrs):
+        weight = Parameter(torch.empty(sum(output_partition_sizes),
+                                       input_size_per_partition,
+                                       dtype=params_dtype),
+                           requires_grad=False)
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, {
+            **extra_weight_attrs,
+            "input_dim": 1,
+            "output_dim": 0,
+        })
+
+    def quantize_weight(self, weight: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        weight_dtype = weight.dtype
+        weight = weight.cpu().to(torch.float32)
+        n_bit = 8
+        eps = 1e-5
+        max_int = 2 ** (n_bit - 1) - 1
+        min_int = -(2 ** (n_bit - 1))
+        max_val = weight.abs().amax(dim=-1, keepdim=True)
+        max_val = max_val.clamp(min=eps)
+        qscale = max_val / max_int
+        qweight = torch.clamp(
+                        torch.round(weight * (1.0 / qscale)), min_int, max_int
+                    ).to(torch.int8)
+        qscale = qscale.squeeze().to(weight_dtype)
+        return qweight, qscale
+    
+    def process_weights_after_loading(self, layer: Module) -> None:
+        device = layer.weight.device
+        qweight, qscale = self.quantize_weight(layer.weight)
+        qweight = qweight.to(device)
+        qscale = qscale.to(device)
+        layer.weight = Parameter(qweight, requires_grad=False)
+        layer.scale = Parameter(qscale, requires_grad=False)
+    
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        weight = layer.weight
+        scale = layer.scale
+        return torch.ops.xla.quantized_matmul(x, weight, scale)

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -94,14 +94,15 @@ def _get_quantization_config(
     """Get the quantization config."""
     if model_config.quantization is not None:
         quant_config = get_quant_config(model_config, load_config)
-        capability = current_platform.get_device_capability()
-        capability = capability[0] * 10 + capability[1]
-        if capability < quant_config.get_min_capability():
-            raise ValueError(
-                f"The quantization method {model_config.quantization} is not "
-                "supported for the current GPU. "
-                f"Minimum capability: {quant_config.get_min_capability()}. "
-                f"Current capability: {capability}.")
+        if not is_tpu():
+            capability = current_platform.get_device_capability()
+            capability = capability[0] * 10 + capability[1]
+            if capability < quant_config.get_min_capability():
+                raise ValueError(
+                    f"The quantization method {model_config.quantization} is not "
+                    "supported for the current GPU. "
+                    f"Minimum capability: {quant_config.get_min_capability()}. "
+                    f"Current capability: {capability}.")
         supported_dtypes = quant_config.get_supported_act_dtypes()
         if model_config.dtype not in supported_dtypes:
             raise ValueError(

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -99,8 +99,8 @@ def _get_quantization_config(
             capability = capability[0] * 10 + capability[1]
             if capability < quant_config.get_min_capability():
                 raise ValueError(
-                    f"The quantization method {model_config.quantization} is not "
-                    "supported for the current GPU. "
+                    f"The quantization method {model_config.quantization} "
+                    "is not supported for the current GPU. "
                     f"Minimum capability: {quant_config.get_min_capability()}. "
                     f"Current capability: {capability}.")
         supported_dtypes = quant_config.get_supported_act_dtypes()


### PR DESCRIPTION
Add Load-time W8A16 quantization for TPU Backend. The workflow is similar to the existing load-time fp8 quantization. Open the PR to help discussion process.

- Added a new quantization type `tpu_int8` for load-time int8 weight only quantization for tpu Backend. (e.g. `LLM(model="google/gemma-2b", quantization="tpu_int8"`)
- Added `TPUInt8LinearMethod` which quantizes `bfloat16` weights to `int8` weights for linear layers, and calls TPU quantized ops in `forward`.