### PR TITLE
[BugFix] Fix multiprocessing shutdown errors

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -390,6 +390,12 @@ class AsyncLLMEngine:
         # Lazy initialized fields
         self._request_tracker: RequestTracker
 
+    def shutdown_background_loop(self) -> None:
+        if self._background_loop_unshielded is not None:
+            self._background_loop_unshielded.cancel()
+            self._background_loop_unshielded = None
+        self.background_loop = None
+
     @classmethod
     def _get_executor_cls(
             cls, engine_config: EngineConfig) -> Type[ExecutorAsyncBase]:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -340,6 +340,8 @@ class LLMEngine:
 
         tokenizer_group = self.get_tokenizer_group()
 
+        # Ensure that the function doesn't contain a reference to self,
+        # to avoid engine GC issues
         def get_tokenizer_for_seq(sequence: Sequence) -> AnyTokenizer:
             return tokenizer_group.get_lora_tokenizer(sequence.lora_request)
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -309,7 +309,8 @@ class LLMEngine:
 
             # Create the scheduler.
             # NOTE: the cache_config here have been updated with the numbers of
-            # GPU and CPU blocks, which are profiled in the distributed executor.
+            # GPU and CPU blocks, which are profiled in the distributed
+            # executor.
             self.scheduler = [
                 Scheduler(scheduler_config, cache_config, lora_config,
                           parallel_config.pipeline_parallel_size)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -260,98 +260,113 @@ class LLMEngine:
             prompt_adapter_config=prompt_adapter_config,
         )
 
-        if not self.model_config.embedding_mode:
-            self._initialize_kv_caches()
+        init_success = False
+        try:
+            if not self.model_config.embedding_mode:
+                self._initialize_kv_caches()
 
-        # If usage stat is enabled, collect relevant info.
-        if is_usage_stats_enabled():
-            from vllm.model_executor.model_loader import (
-                get_architecture_class_name)
-            usage_message.report_usage(
-                get_architecture_class_name(model_config),
-                usage_context,
-                extra_kvs={
-                    # Common configuration
-                    "dtype":
-                    str(model_config.dtype),
-                    "tensor_parallel_size":
-                    parallel_config.tensor_parallel_size,
-                    "block_size":
-                    cache_config.block_size,
-                    "gpu_memory_utilization":
-                    cache_config.gpu_memory_utilization,
+            # If usage stat is enabled, collect relevant info.
+            if is_usage_stats_enabled():
+                from vllm.model_executor.model_loader import (
+                    get_architecture_class_name)
+                usage_message.report_usage(
+                    get_architecture_class_name(model_config),
+                    usage_context,
+                    extra_kvs={
+                        # Common configuration
+                        "dtype":
+                        str(model_config.dtype),
+                        "tensor_parallel_size":
+                        parallel_config.tensor_parallel_size,
+                        "block_size":
+                        cache_config.block_size,
+                        "gpu_memory_utilization":
+                        cache_config.gpu_memory_utilization,
 
-                    # Quantization
-                    "quantization":
-                    model_config.quantization,
-                    "kv_cache_dtype":
-                    str(cache_config.cache_dtype),
+                        # Quantization
+                        "quantization":
+                        model_config.quantization,
+                        "kv_cache_dtype":
+                        str(cache_config.cache_dtype),
 
-                    # Feature flags
-                    "enable_lora":
-                    bool(lora_config),
-                    "enable_prompt_adapter":
-                    bool(prompt_adapter_config),
-                    "enable_prefix_caching":
-                    cache_config.enable_prefix_caching,
-                    "enforce_eager":
-                    model_config.enforce_eager,
-                    "disable_custom_all_reduce":
-                    parallel_config.disable_custom_all_reduce,
-                })
+                        # Feature flags
+                        "enable_lora":
+                        bool(lora_config),
+                        "enable_prompt_adapter":
+                        bool(prompt_adapter_config),
+                        "enable_prefix_caching":
+                        cache_config.enable_prefix_caching,
+                        "enforce_eager":
+                        model_config.enforce_eager,
+                        "disable_custom_all_reduce":
+                        parallel_config.disable_custom_all_reduce,
+                    })
 
-        if self.tokenizer:
-            # Ping the tokenizer to ensure liveness if it runs in a
-            # different process.
-            self.tokenizer.ping()
+            if self.tokenizer:
+                # Ping the tokenizer to ensure liveness if it runs in a
+                # different process.
+                self.tokenizer.ping()
 
-        # Create the scheduler.
-        # NOTE: the cache_config here have been updated with the numbers of
-        # GPU and CPU blocks, which are profiled in the distributed executor.
-        self.scheduler = [
-            Scheduler(scheduler_config, cache_config, lora_config,
-                      parallel_config.pipeline_parallel_size)
-            for _ in range(parallel_config.pipeline_parallel_size)
-        ]
+            # Create the scheduler.
+            # NOTE: the cache_config here have been updated with the numbers of
+            # GPU and CPU blocks, which are profiled in the distributed executor.
+            self.scheduler = [
+                Scheduler(scheduler_config, cache_config, lora_config,
+                          parallel_config.pipeline_parallel_size)
+                for _ in range(parallel_config.pipeline_parallel_size)
+            ]
 
-        # Metric Logging.
-        if self.log_stats:
-            if stat_loggers is not None:
-                self.stat_loggers = stat_loggers
-            else:
-                self.stat_loggers = {
-                    "logging":
-                    LoggingStatLogger(
-                        local_interval=_LOCAL_LOGGING_INTERVAL_SEC),
-                    "prometheus":
-                    PrometheusStatLogger(
-                        local_interval=_LOCAL_LOGGING_INTERVAL_SEC,
-                        labels=dict(model_name=model_config.served_model_name),
-                        max_model_len=self.model_config.max_model_len),
-                }
-                self.stat_loggers["prometheus"].info("cache_config",
-                                                     self.cache_config)
+            # Metric Logging.
+            if self.log_stats:
+                if stat_loggers is not None:
+                    self.stat_loggers = stat_loggers
+                else:
+                    self.stat_loggers = {
+                        "logging":
+                        LoggingStatLogger(
+                            local_interval=_LOCAL_LOGGING_INTERVAL_SEC),
+                        "prometheus":
+                        PrometheusStatLogger(
+                            local_interval=_LOCAL_LOGGING_INTERVAL_SEC,
+                            labels=dict(
+                                model_name=model_config.served_model_name),
+                            max_model_len=self.model_config.max_model_len),
+                    }
+                    self.stat_loggers["prometheus"].info(
+                        "cache_config", self.cache_config)
 
-        self.tracer = None
-        if self.observability_config.otlp_traces_endpoint:
-            self.tracer = init_tracer(
-                "vllm.llm_engine",
-                self.observability_config.otlp_traces_endpoint)
+            self.tracer = None
+            if self.observability_config.otlp_traces_endpoint:
+                self.tracer = init_tracer(
+                    "vllm.llm_engine",
+                    self.observability_config.otlp_traces_endpoint)
 
-        # Create sequence output processor, e.g. for beam search or
-        # speculative decoding.
-        self.output_processor = (
-            SequenceGroupOutputProcessor.create_output_processor(
-                self.scheduler_config,
-                self.detokenizer,
-                self.scheduler,
-                self.seq_counter,
-                self.get_tokenizer_for_seq,
-                stop_checker=StopChecker(
-                    self.scheduler_config.max_model_len,
-                    self.get_tokenizer_for_seq,
-                ),
-            ))
+            tokenizer_group = self.get_tokenizer_group()
+
+            def get_tokenizer_for_seq(sequence: Sequence) -> AnyTokenizer:
+                return tokenizer_group.get_lora_tokenizer(
+                    sequence.lora_request)
+
+            # Create sequence output processor, e.g. for beam search or
+            # speculative decoding.
+            self.output_processor = (
+                SequenceGroupOutputProcessor.create_output_processor(
+                    self.scheduler_config,
+                    self.detokenizer,
+                    self.scheduler,
+                    self.seq_counter,
+                    get_tokenizer_for_seq,
+                    stop_checker=StopChecker(
+                        self.scheduler_config.max_model_len,
+                        get_tokenizer_for_seq,
+                    ),
+                ))
+            init_success = True
+        finally:
+            if not init_success:
+                # Ensure that model_executor is shut down if LLMEngine init
+                # failed
+                self.model_executor.shutdown()
 
     def _initialize_kv_caches(self) -> None:
         """Initialize the KV cache in the worker(s).
@@ -480,10 +495,6 @@ class LLMEngine:
         lora_request: Optional[LoRARequest] = None,
     ) -> AnyTokenizer:
         return self.get_tokenizer_group().get_lora_tokenizer(lora_request)
-
-    def get_tokenizer_for_seq(self, sequence: Sequence) -> AnyTokenizer:
-        return self.get_tokenizer_group().get_lora_tokenizer(
-            sequence.lora_request)
 
     def _init_tokenizer(self, **tokenizer_init_kwargs) -> BaseTokenizerGroup:
         init_kwargs = dict(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -260,114 +260,103 @@ class LLMEngine:
             prompt_adapter_config=prompt_adapter_config,
         )
 
-        init_success = False
-        try:
-            if not self.model_config.embedding_mode:
-                self._initialize_kv_caches()
+        if not self.model_config.embedding_mode:
+            self._initialize_kv_caches()
 
-            # If usage stat is enabled, collect relevant info.
-            if is_usage_stats_enabled():
-                from vllm.model_executor.model_loader import (
-                    get_architecture_class_name)
-                usage_message.report_usage(
-                    get_architecture_class_name(model_config),
-                    usage_context,
-                    extra_kvs={
-                        # Common configuration
-                        "dtype":
-                        str(model_config.dtype),
-                        "tensor_parallel_size":
-                        parallel_config.tensor_parallel_size,
-                        "block_size":
-                        cache_config.block_size,
-                        "gpu_memory_utilization":
-                        cache_config.gpu_memory_utilization,
+        # If usage stat is enabled, collect relevant info.
+        if is_usage_stats_enabled():
+            from vllm.model_executor.model_loader import (
+                get_architecture_class_name)
+            usage_message.report_usage(
+                get_architecture_class_name(model_config),
+                usage_context,
+                extra_kvs={
+                    # Common configuration
+                    "dtype":
+                    str(model_config.dtype),
+                    "tensor_parallel_size":
+                    parallel_config.tensor_parallel_size,
+                    "block_size":
+                    cache_config.block_size,
+                    "gpu_memory_utilization":
+                    cache_config.gpu_memory_utilization,
 
-                        # Quantization
-                        "quantization":
-                        model_config.quantization,
-                        "kv_cache_dtype":
-                        str(cache_config.cache_dtype),
+                    # Quantization
+                    "quantization":
+                    model_config.quantization,
+                    "kv_cache_dtype":
+                    str(cache_config.cache_dtype),
 
-                        # Feature flags
-                        "enable_lora":
-                        bool(lora_config),
-                        "enable_prompt_adapter":
-                        bool(prompt_adapter_config),
-                        "enable_prefix_caching":
-                        cache_config.enable_prefix_caching,
-                        "enforce_eager":
-                        model_config.enforce_eager,
-                        "disable_custom_all_reduce":
-                        parallel_config.disable_custom_all_reduce,
-                    })
+                    # Feature flags
+                    "enable_lora":
+                    bool(lora_config),
+                    "enable_prompt_adapter":
+                    bool(prompt_adapter_config),
+                    "enable_prefix_caching":
+                    cache_config.enable_prefix_caching,
+                    "enforce_eager":
+                    model_config.enforce_eager,
+                    "disable_custom_all_reduce":
+                    parallel_config.disable_custom_all_reduce,
+                })
 
-            if self.tokenizer:
-                # Ping the tokenizer to ensure liveness if it runs in a
-                # different process.
-                self.tokenizer.ping()
+        if self.tokenizer:
+            # Ping the tokenizer to ensure liveness if it runs in a
+            # different process.
+            self.tokenizer.ping()
 
-            # Create the scheduler.
-            # NOTE: the cache_config here have been updated with the numbers of
-            # GPU and CPU blocks, which are profiled in the distributed
-            # executor.
-            self.scheduler = [
-                Scheduler(scheduler_config, cache_config, lora_config,
-                          parallel_config.pipeline_parallel_size)
-                for _ in range(parallel_config.pipeline_parallel_size)
-            ]
+        # Create the scheduler.
+        # NOTE: the cache_config here have been updated with the numbers of
+        # GPU and CPU blocks, which are profiled in the distributed executor.
+        self.scheduler = [
+            Scheduler(scheduler_config, cache_config, lora_config,
+                      parallel_config.pipeline_parallel_size)
+            for _ in range(parallel_config.pipeline_parallel_size)
+        ]
 
-            # Metric Logging.
-            if self.log_stats:
-                if stat_loggers is not None:
-                    self.stat_loggers = stat_loggers
-                else:
-                    self.stat_loggers = {
-                        "logging":
-                        LoggingStatLogger(
-                            local_interval=_LOCAL_LOGGING_INTERVAL_SEC),
-                        "prometheus":
-                        PrometheusStatLogger(
-                            local_interval=_LOCAL_LOGGING_INTERVAL_SEC,
-                            labels=dict(
-                                model_name=model_config.served_model_name),
-                            max_model_len=self.model_config.max_model_len),
-                    }
-                    self.stat_loggers["prometheus"].info(
-                        "cache_config", self.cache_config)
+        # Metric Logging.
+        if self.log_stats:
+            if stat_loggers is not None:
+                self.stat_loggers = stat_loggers
+            else:
+                self.stat_loggers = {
+                    "logging":
+                    LoggingStatLogger(
+                        local_interval=_LOCAL_LOGGING_INTERVAL_SEC),
+                    "prometheus":
+                    PrometheusStatLogger(
+                        local_interval=_LOCAL_LOGGING_INTERVAL_SEC,
+                        labels=dict(model_name=model_config.served_model_name),
+                        max_model_len=self.model_config.max_model_len),
+                }
+                self.stat_loggers["prometheus"].info("cache_config",
+                                                     self.cache_config)
 
-            self.tracer = None
-            if self.observability_config.otlp_traces_endpoint:
-                self.tracer = init_tracer(
-                    "vllm.llm_engine",
-                    self.observability_config.otlp_traces_endpoint)
+        self.tracer = None
+        if self.observability_config.otlp_traces_endpoint:
+            self.tracer = init_tracer(
+                "vllm.llm_engine",
+                self.observability_config.otlp_traces_endpoint)
 
-            tokenizer_group = self.get_tokenizer_group()
+        tokenizer_group = self.get_tokenizer_group()
 
-            def get_tokenizer_for_seq(sequence: Sequence) -> AnyTokenizer:
-                return tokenizer_group.get_lora_tokenizer(
-                    sequence.lora_request)
+        def get_tokenizer_for_seq(sequence: Sequence) -> AnyTokenizer:
+            return tokenizer_group.get_lora_tokenizer(sequence.lora_request)
 
-            # Create sequence output processor, e.g. for beam search or
-            # speculative decoding.
-            self.output_processor = (
-                SequenceGroupOutputProcessor.create_output_processor(
-                    self.scheduler_config,
-                    self.detokenizer,
-                    self.scheduler,
-                    self.seq_counter,
+        # Create sequence output processor, e.g. for beam search or
+        # speculative decoding.
+        self.output_processor = (
+            SequenceGroupOutputProcessor.create_output_processor(
+                self.scheduler_config,
+                self.detokenizer,
+                self.scheduler,
+                self.seq_counter,
+                get_tokenizer_for_seq,
+                stop_checker=StopChecker(
+                    self.scheduler_config.max_model_len,
                     get_tokenizer_for_seq,
-                    stop_checker=StopChecker(
-                        self.scheduler_config.max_model_len,
-                        get_tokenizer_for_seq,
-                    ),
-                ))
-            init_success = True
-        finally:
-            if not init_success:
-                # Ensure that model_executor is shut down if LLMEngine init
-                # failed
-                self.model_executor.shutdown()
+                ),
+            ))
 
     def _initialize_kv_caches(self) -> None:
         """Initialize the KV cache in the worker(s).

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import importlib
 import inspect
 import re
@@ -70,6 +71,8 @@ async def lifespan(app: fastapi.FastAPI):
         task.add_done_callback(_running_tasks.remove)
 
     yield
+
+    engine.shutdown_background_loop()
 
 
 router = APIRouter()
@@ -337,6 +340,9 @@ async def run_server(args, llm_engine=None, **uvicorn_kwargs) -> None:
                     "openai_serving_embedding", "openai_serving_tokenization",
                     "engine_args", "engine"):
             globals().pop(var, None)
+
+    # This is required for the LLMEngine destructor to run
+    gc.collect()
 
 
 if __name__ == "__main__":

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -1,8 +1,5 @@
 import asyncio
 import os
-import signal
-import threading
-import weakref
 from functools import partial
 from typing import Any, List, Optional
 
@@ -120,20 +117,6 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
             self.worker_monitor = WorkerMonitor(self.workers, result_handler)
             result_handler.start()
             self.worker_monitor.start()
-
-        # Set up signal handlers to shutdown the executor cleanly
-        # sometimes gc does not work well
-
-        # Use weakref to avoid holding a reference to self
-        ref = weakref.ref(self)
-
-        def shutdown(signum, frame):
-            if executor := ref():
-                executor.shutdown()
-
-        if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGINT, shutdown)
-            signal.signal(signal.SIGTERM, shutdown)
 
         self.driver_worker = self._create_worker(
             distributed_init_method=distributed_init_method)

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -115,7 +115,6 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
                     self.non_driver_workers.append(worker)
 
             self.worker_monitor = WorkerMonitor(self.workers, result_handler)
-            result_handler.start()
             self.worker_monitor.start()
 
         self.driver_worker = self._create_worker(


### PR DESCRIPTION
1. Don't use daemon threads in the multiproc worker machinery
2. Ensure that the LLMEngine is garbage collected properly, so that the executor and its non-daemon threads are shut down and don't cause the process to hang
3. Keep worker processes as daemons but add a check for `sys.is_finalizing()` to avoid logging any error messages in case they are killed non-cleanly prior to the main process (though this should no longer happen with changes 1 and 2)

There are still two warnings that appear consistently but I think that these are benign and we can investigate as a follow-on to this:
```
[rank0]:[W CudaIPCTypes.cpp:16] Producer process has been terminated before all shared CUDA tensors released. See Note [Sharing CUDA tensors]
/usr/lib64/python3.11/multiprocessing/resource_tracker.py:254: UserWarning: resource_tracker: There appear to be 1 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```


