### PR TITLE
[Misc] p90 and p95 for serving benchmark

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -61,14 +61,20 @@ class BenchmarkMetrics:
     mean_ttft_ms: float
     median_ttft_ms: float
     std_ttft_ms: float
+    p90_ttft_ms: float
+    p95_ttft_ms: float
     p99_ttft_ms: float
     mean_tpot_ms: float
     median_tpot_ms: float
     std_tpot_ms: float
+    p90_tpot_ms: float
+    p95_tpot_ms: float
     p99_tpot_ms: float
     mean_itl_ms: float
     median_itl_ms: float
     std_itl_ms: float
+    p90_itl_ms: float
+    p95_itl_ms: float
     p99_itl_ms: float
 
 
@@ -278,14 +284,20 @@ def calculate_metrics(
         1000,  # ttfts is empty if streaming is not supported by backend
         median_ttft_ms=np.median(ttfts or 0) * 1000,
         std_ttft_ms=np.std(ttfts or 0) * 1000,
+        p90_ttft_ms=np.percentile(ttfts or 0, 90) * 1000,
+        p95_ttft_ms=np.percentile(ttfts or 0, 95) * 1000,
         p99_ttft_ms=np.percentile(ttfts or 0, 99) * 1000,
         mean_tpot_ms=np.mean(tpots or 0) * 1000,
         median_tpot_ms=np.median(tpots or 0) * 1000,
         std_tpot_ms=np.std(tpots or 0) * 1000,
+        p90_tpot_ms=np.percentile(tpots or 0, 90) * 1000,
+        p95_tpot_ms=np.percentile(tpots or 0, 95) * 1000,
         p99_tpot_ms=np.percentile(tpots or 0, 99) * 1000,
         mean_itl_ms=np.mean(itls or 0) * 1000,
         median_itl_ms=np.median(itls or 0) * 1000,
         std_itl_ms=np.std(itls or 0) * 1000,
+        p90_itl_ms=np.percentile(itls or 0, 90) * 1000,
+        p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
     )
 
@@ -378,6 +390,8 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("Mean TTFT (ms):", metrics.mean_ttft_ms))
     print("{:<40} {:<10.2f}".format("Median TTFT (ms):",
                                     metrics.median_ttft_ms))
+    print("{:<40} {:<10.2f}".format("P90 TTFT (ms):", metrics.p90_ttft_ms))
+    print("{:<40} {:<10.2f}".format("P95 TTFT (ms):", metrics.p95_ttft_ms))
     print("{:<40} {:<10.2f}".format("P99 TTFT (ms):", metrics.p99_ttft_ms))
     print("{s:{c}^{n}}".format(s='Time per Output Token (excl. 1st token)',
                                n=50,
@@ -385,10 +399,14 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("Mean TPOT (ms):", metrics.mean_tpot_ms))
     print("{:<40} {:<10.2f}".format("Median TPOT (ms):",
                                     metrics.median_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P90 TPOT (ms):", metrics.p90_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P95 TPOT (ms):", metrics.p95_tpot_ms))
     print("{:<40} {:<10.2f}".format("P99 TPOT (ms):", metrics.p99_tpot_ms))
     print("{s:{c}^{n}}".format(s='Inter-token Latency', n=50, c='-'))
     print("{:<40} {:<10.2f}".format("Mean ITL (ms):", metrics.mean_itl_ms))
     print("{:<40} {:<10.2f}".format("Median ITL (ms):", metrics.median_itl_ms))
+    print("{:<40} {:<10.2f}".format("P90 ITL (ms):", metrics.p90_itl_ms))
+    print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
     print("=" * 50)
 


### PR DESCRIPTION
Similar to #3889 , we need more percentiles for serving benchmark.

Here are p99 latencies I get across 3 runs:
```python
# p99 ttft, tpot, itl
532.92, 376.76, 583.86
740.69, 446.66, 622.48
597.21, 446.70, 603.08
```

And here are p95 and p90 ttfts I get:
```python
# p95 ttft, tpot, itl
400.04, 334.96, 456.39
432.17, 402.84, 482.56
435.90, 398.58, 469.09
```

```python
# p90 ttft, tpot, itl
332.99, 302.66, 426.95
318.51, 356.61, 453.11
340.88, 349.29, 429.15
```

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  128.37    
Total input tokens:                      213987    
Total generated tokens:                  199771    
Request throughput (req/s):              7.79      
Input token throughput (tok/s):          1666.99   
Output token throughput (tok/s):         1556.25   
---------------Time to First Token----------------
Mean TTFT (ms):                          157.75    
Median TTFT (ms):                        118.73    
P90 TTFT (ms):                           332.99    
P95 TTFT (ms):                           400.04    
P99 TTFT (ms):                           532.92    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          218.36    
Median TPOT (ms):                        223.08    
P90 TPOT (ms):                           302.66    
P95 TPOT (ms):                           334.96    
P99 TPOT (ms):                           376.76    
---------------Inter-token Latency----------------
Mean ITL (ms):                           193.60    
Median ITL (ms):                         153.55    
P90 ITL (ms):                            426.95    
P95 ITL (ms):                            456.39    
P99 ITL (ms):                            583.86    
==================================================
```

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  133.89    
Total input tokens:                      213987    
Total generated tokens:                  199770    
Request throughput (req/s):              7.47      
Input token throughput (tok/s):          1598.24   
Output token throughput (tok/s):         1492.06   
---------------Time to First Token----------------
Mean TTFT (ms):                          164.40    
Median TTFT (ms):                        120.63    
P90 TTFT (ms):                           318.51    
P95 TTFT (ms):                           432.17    
P99 TTFT (ms):                           740.69    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          239.02    
Median TPOT (ms):                        235.90    
P90 TPOT (ms):                           356.61    
P95 TPOT (ms):                           402.84    
P99 TPOT (ms):                           446.66    
---------------Inter-token Latency----------------
Mean ITL (ms):                           207.69    
Median ITL (ms):                         165.18    
P90 ITL (ms):                            453.11    
P95 ITL (ms):                            482.56    
P99 ITL (ms):                            622.48    
==================================================
```

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  131.26    
Total input tokens:                      213987    
Total generated tokens:                  199775    
Request throughput (req/s):              7.62      
Input token throughput (tok/s):          1630.27   
Output token throughput (tok/s):         1522.00   
---------------Time to First Token----------------
Mean TTFT (ms):                          166.36    
Median TTFT (ms):                        118.69    
P90 TTFT (ms):                           340.88    
P95 TTFT (ms):                           435.90    
P99 TTFT (ms):                           597.21    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          232.90    
Median TPOT (ms):                        228.07    
P90 TPOT (ms):                           349.29    
P95 TPOT (ms):                           398.58    
P99 TPOT (ms):                           446.70    
---------------Inter-token Latency----------------
Mean ITL (ms):                           201.46    
Median ITL (ms):                         159.46    
P90 ITL (ms):                            429.15    
P95 ITL (ms):                            469.09    
P99 ITL (ms):                            603.08    
==================================================
```
---



<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


