### PR TITLE
[ci] set timeout for test_oot_registration.py

### DIFF
--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -186,7 +186,9 @@ class Worker(LocalOrDistributedWorkerBase):
         # GPU did not change their memory usage during the profiling.
         peak_memory = self.init_gpu_memory - free_gpu_memory
         assert peak_memory > 0, (
-            "Error in memory profiling. This happens when the GPU memory was "
+            "Error in memory profiling. "
+            f"Initial free memory {self.init_gpu_memory}, current free memory"
+            f" {free_gpu_memory}. This happens when the GPU memory was "
             "not properly cleaned up before initializing the vLLM instance.")
 
         cache_block_size = self.get_cache_block_size_bytes()

--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -138,7 +138,9 @@ class XPUWorker(LoraNotSupportedWorkerBase, Worker):
         # GPU did not change their memory usage during the profiling.
         peak_memory = self.init_gpu_memory - free_gpu_memory
         assert peak_memory > 0, (
-            "Error in memory profiling. This happens when the GPU memory was "
+            "Error in memory profiling. "
+            f"Initial free memory {self.init_gpu_memory}, current free memory"
+            f" {free_gpu_memory}. This happens when the GPU memory was "
             "not properly cleaned up before initializing the vLLM instance.")
 
         cache_block_size = self.get_cache_block_size_bytes()


### PR DESCRIPTION
observed multiple errors in the main branch ci, e.g. https://buildkite.com/vllm/ci-aws/builds/6093#019113ce-d6dd-4cb5-8dda-d5d66dd344e9 and https://buildkite.com/vllm/ci-aws/builds/6084#019111f1-a753-42f7-9b32-2fb916f22866 .

They error with:

> AssertionError: Error in memory profiling. This happens when the GPU memory was not properly cleaned up before initializing the vLLM instance.

It turns out to be flaky. One retry works https://buildkite.com/vllm/ci-aws/builds/6084#019113eb-bc79-48e8-8849-57f729e30475 , while another does not.

Still investigating, but we need to add timeout to the test, to avoid hanging for one hour.