### PR TITLE
[ci][distributed] shorten wait time if server hangs

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,7 +50,7 @@ VLLM_PATH = Path(__file__).parent.parent
 
 class RemoteOpenAIServer:
     DUMMY_API_KEY = "token-abc123"  # vLLM's OpenAI server does not need API key
-    MAX_SERVER_START_WAIT_S = 600  # wait for server to start for 60 seconds
+    MAX_SERVER_START_WAIT_S = 120  # wait for server to start for 120 seconds
 
     def __init__(
         self,


### PR DESCRIPTION
https://buildkite.com/vllm/ci-aws/builds/6110#019115da-1e5b-4f18-ba1a-8f0ed3b8fc7d takes 1.5 h, because all tests fail, and each test is waiting for the server in 10 minutes.