### PR TITLE
[ci][distributed] disable ray dag tests

### DIFF
--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -47,9 +47,9 @@ def test_models(
         pytest.skip(f"Skip test for {test_suite}")
 
     if model == "meta-llama/Llama-2-7b-hf" and distributed_executor_backend == "ray" and attention_backend == "" and test_suite == "L4":  # noqa
-        # test ray adag
-        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "1"
-        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "1"
+        # test ray adag (temporarily disabled)
+        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "0"
+        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "0"
 
     if attention_backend:
         os.environ["VLLM_ATTENTION_BACKEND"] = attention_backend

--- a/tests/distributed/test_basic_distributed_correctness.py
+++ b/tests/distributed/test_basic_distributed_correctness.py
@@ -47,9 +47,9 @@ def test_models(
         pytest.skip(f"Skip test for {test_suite}")
 
     if model == "meta-llama/Llama-2-7b-hf" and distributed_executor_backend == "ray" and attention_backend == "" and test_suite == "L4":  # noqa
-        # test ray adag (temporarily disabled)
-        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "0"
-        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "0"
+        # test ray adag
+        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "1"
+        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "1"
 
     if attention_backend:
         os.environ["VLLM_ATTENTION_BACKEND"] = attention_backend

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -14,35 +14,28 @@ from ..utils import compare_two_settings, fork_new_process_for_each_test
 VLLM_MULTI_NODE = os.getenv("VLLM_MULTI_NODE", "0") == "1"
 
 
-@pytest.mark.parametrize(
-    ("TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, "
-     "MODEL_NAME, DIST_BACKEND, USE_RAY_ADAG, USE_RAY_ADAG_NCCL"), [
-         (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", False, False),
-         (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", False, False),
-         (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "ray", False, False),
-         (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", False, False),
-         (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", False, False),
-         (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", True, False),
-         (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, False),
-         (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, False),
-         (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", True, False),
-         (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, False),
-         (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", True, True),
-         (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, True),
-         (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, True),
-         (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray", True, True),
-         (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray", True, True),
-         (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "mp", False, False),
-         (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "mp", False, False),
-         (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "mp", False, False),
-         (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "mp", False, False),
-         (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "mp", False, False),
-     ])
+@pytest.mark.parametrize(("TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, "
+                          "MODEL_NAME, DIST_BACKEND"),
+                         [
+                             (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray"),
+                             (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray"),
+                             (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "ray"),
+                             (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "ray"),
+                             (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "ray"),
+                             (2, 2, 0, 1, "meta-llama/Meta-Llama-3-8B", "mp"),
+                             (2, 2, 1, 0, "meta-llama/Meta-Llama-3-8B", "mp"),
+                             (1, 3, 0, 0, "meta-llama/Meta-Llama-3-8B", "mp"),
+                             (1, 4, 0, 1, "meta-llama/Meta-Llama-3-8B", "mp"),
+                             (1, 4, 1, 0, "meta-llama/Meta-Llama-3-8B", "mp"),
+                         ])
 def test_compare_tp(TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, MODEL_NAME,
-                    DIST_BACKEND, USE_RAY_ADAG, USE_RAY_ADAG_NCCL):
+                    DIST_BACKEND):
     if VLLM_MULTI_NODE and DIST_BACKEND == "mp":
         pytest.skip("Skipping multi-node pipeline parallel test for "
                     "multiprocessing distributed backend")
+
+    USE_RAY_ADAG_NCCL = 0
+    USE_RAY_ADAG = 0
 
     pp_args = [
         # use half precision for speed and memory savings in CI environment


### PR DESCRIPTION
as observed in https://buildkite.com/vllm/ci-aws/builds/6110#019115da-1e57-4e81-8169-872f9b2d100b and https://buildkite.com/vllm/ci-aws/builds/6110#019115da-1e5b-4f18-ba1a-8f0ed3b8fc7d , test starts to error, after executing one ray adag test.

it is possible that https://github.com/vllm-project/vllm/pull/6883 does not work with adag.

will leave for @ruisearch42 and @rkooo567 to investigate.

temporarily disabling ray adag related tests now.
