### PR TITLE
[BugFix] Use args.trust_remote_code

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -61,11 +61,11 @@ logger = init_logger('vllm.entrypoints.openai.api_server')
 _running_tasks: Set[asyncio.Task] = set()
 
 
-def model_is_embedding(model_name: str) -> bool:
+def model_is_embedding(model_name: str, trust_remote_code: bool) -> bool:
     return ModelConfig(model=model_name,
                        tokenizer=model_name,
                        tokenizer_mode="auto",
-                       trust_remote_code=False,
+                       trust_remote_code=trust_remote_code,
                        seed=0,
                        dtype="float16").embedding_mode
 
@@ -98,7 +98,7 @@ async def build_async_engine_client(args) -> AsyncIterator[AsyncEngineClient]:
 
     # If manually triggered or embedding model, use AsyncLLMEngine in process.
     # TODO: support embedding model via RPC.
-    if (model_is_embedding(args.model)
+    if (model_is_embedding(args.model, args.trust_remote_code)
             or args.disable_frontend_multiprocessing):
         async_engine_client = AsyncLLMEngine.from_engine_args(
             engine_args, usage_context=UsageContext.OPENAI_API_SERVER)


### PR DESCRIPTION
openai/api_server.py does not use args.trust_remote_code

This broke due to this change - https://github.com/vllm-project/vllm/pull/6883