### PR TITLE
[Bugfix] Specify device when loading LoRA and embedding tensors

### DIFF
--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -248,7 +248,7 @@ class LoRAModel(AdapterModel):
                     f" target modules in {expected_lora_modules}"
                     f" but received {unexpected_modules}."
                     f" Please verify that the loaded LoRA module is correct")
-            tensors = torch.load(lora_bin_file_path)
+            tensors = torch.load(lora_bin_file_path, map_location="device")
         else:
             raise ValueError(f"{lora_dir} doesn't contain tensors")
 
@@ -257,7 +257,8 @@ class LoRAModel(AdapterModel):
             embeddings = safetensors.torch.load_file(
                 new_embeddings_tensor_path)
         elif os.path.isfile(new_embeddings_bin_file_path):
-            embeddings = torch.load(new_embeddings_bin_file_path)
+            embeddings = torch.load(new_embeddings_bin_file_path,
+                                    map_location="device")
 
         rank = config["r"]
         lora_alpha = config["lora_alpha"]

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -248,7 +248,7 @@ class LoRAModel(AdapterModel):
                     f" target modules in {expected_lora_modules}"
                     f" but received {unexpected_modules}."
                     f" Please verify that the loaded LoRA module is correct")
-            tensors = torch.load(lora_bin_file_path, map_location="device")
+            tensors = torch.load(lora_bin_file_path, map_location=device)
         else:
             raise ValueError(f"{lora_dir} doesn't contain tensors")
 
@@ -258,7 +258,7 @@ class LoRAModel(AdapterModel):
                 new_embeddings_tensor_path)
         elif os.path.isfile(new_embeddings_bin_file_path):
             embeddings = torch.load(new_embeddings_bin_file_path,
-                                    map_location="device")
+                                    map_location=device)
 
         rank = config["r"]
         lora_alpha = config["lora_alpha"]


### PR DESCRIPTION
[Bugfix] Assign device when loading LoRA modules from file

Fixes [#3374](https://github.com/vllm-project/vllm/issues/3374). Note — existing PR to address this issue got stale; so bumping with some light updates.

This PR addresses the issue of CUDA device mismatch when loading LoRA modules from files. It fixes the `Attempting to deserialize object on CUDA device X but torch.cuda.device_count() is Y` error by explicitly specifying the device during tensor loading.

Changes:
- Add `map_location=device` when loading LoRA tensors from .bin files
- Add `map_location=device` when loading new embeddings from .bin files
