### PR TITLE
[BugFix] Fix DeepSeek remote code

### DIFF
--- a/.buildkite/lm-eval-harness/configs/DeepSeek-V2-Lite-Chat.yaml
+++ b/.buildkite/lm-eval-harness/configs/DeepSeek-V2-Lite-Chat.yaml
@@ -9,3 +9,4 @@ tasks:
     value: 0.664
 limit: 1000
 num_fewshot: 5
+trust_remote_code: True

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -23,9 +23,15 @@ TP_SIZE = os.environ.get("LM_EVAL_TP_SIZE", 1)
 
 
 def launch_lm_eval(eval_config):
+    try:
+        trust_remote_code = eval_config['trust_remote_code']
+    except:
+        trust_remote_code = False
+
     model_args = f"pretrained={eval_config['model_name']}," \
                  f"tensor_parallel_size={TP_SIZE}," \
-                 f"add_bos_token=true"
+                 f"add_bos_token=true," \
+                 f"trust_remote_code={trust_remote_code}"
 
     results = lm_eval.simple_evaluate(
         model="vllm",

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -25,7 +25,7 @@ TP_SIZE = os.environ.get("LM_EVAL_TP_SIZE", 1)
 def launch_lm_eval(eval_config):
     try:
         trust_remote_code = eval_config['trust_remote_code']
-    except Exception
+    except Exception:
         trust_remote_code = False
 
     model_args = f"pretrained={eval_config['model_name']}," \

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -25,7 +25,7 @@ TP_SIZE = os.environ.get("LM_EVAL_TP_SIZE", 1)
 def launch_lm_eval(eval_config):
     try:
         trust_remote_code = eval_config['trust_remote_code']
-    except:
+    except Exception
         trust_remote_code = False
 
     model_args = f"pretrained={eval_config['model_name']}," \

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -23,10 +23,7 @@ TP_SIZE = os.environ.get("LM_EVAL_TP_SIZE", 1)
 
 
 def launch_lm_eval(eval_config):
-    try:
-        trust_remote_code = eval_config['trust_remote_code']
-    except Exception:
-        trust_remote_code = False
+    trust_remote_code = eval_config.get('trust_remote_code', False)
 
     model_args = f"pretrained={eval_config['model_name']}," \
                  f"tensor_parallel_size={TP_SIZE}," \


### PR DESCRIPTION
# Summary: 
- LM Eval Tests require the `trust_remote_code` flag to be enabled for DeepkSeek. PR adds an optional flag to the config file.
