### PR TITLE
[MISC] Disable chunked prefill with fp8 kv-cache

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -761,6 +761,7 @@ class EngineArgs:
                         and not self.enable_lora
                         and not self.enable_prompt_adapter
                         and not self.enable_prefix_caching
+                        and self.kv_cache_dtype != "auto"
                         and not has_seqlen_agnostic_layers):
                     self.enable_chunked_prefill = True
                     logger.warning(


### PR DESCRIPTION
Chunked prefill currently doesn't work with FP8 kv-cache, so this PR prevents it from being enabled automatically with long context.

Related to #4381 

cc @K-mistele