### PR TITLE
Updating LM Format Enforcer version to v0.10.6

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -17,7 +17,7 @@ pillow  # Required for image processing
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
-lm-format-enforcer == 0.10.3
+lm-format-enforcer == 0.10.6
 outlines >= 0.0.43, < 0.1 # Requires torch >= 2.1.0
 typing_extensions
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4


### PR DESCRIPTION
Fixes a pickling issue causing exceptions in the new OpenAI compatible server.
See this comment by @robertgshaw2-neuralmagic :
https://github.com/noamgat/lm-format-enforcer/issues/124#issuecomment-2261817411

v0.10.6 fixes it.

