### PR TITLE
[Core] Optimize evictor-v2 performance

### DIFF
--- a/vllm/core/evictor_v2.py
+++ b/vllm/core/evictor_v2.py
@@ -91,8 +91,9 @@ class LRUEvictor(Evictor):
         # at the start of OrderedDict. Loop through all these blocks to
         # find the one with maximum number of hashed tokens.
         for _id, block in self.free_table.items():
-            if evicted_block.last_accessed > block.last_accessed or (
-                    evicted_block.last_accessed == block.last_accessed and
+            if evicted_block.last_accessed < block.last_accessed:
+                break
+            if (evicted_block.last_accessed == block.last_accessed and
                     evicted_block.num_hashed_tokens < block.num_hashed_tokens):
                 evicted_block = block
                 evicted_block_id = _id
@@ -109,6 +110,7 @@ class LRUEvictor(Evictor):
 
     def update(self, block_id: int, last_accessed: float):
         self.free_table[block_id].last_accessed = last_accessed
+        self.free_table.move_to_end(block_id)
 
     def remove(self, block_id: int):
         if block_id not in self.free_table:


### PR DESCRIPTION
Using the AutoPrefixCache, the block_manager_v2 performs worse than v1.
- llama-3.1-8b, H800
- Test 3510 cases from mmlu dataset

```
llm = LLM(
        model=path,
        tensor_parallel_size=1,
        trust_remote_code=True,
        gpu_memory_utilization=0.8,
        max_num_seqs=512,
        enable_prefix_caching=True,
        use_v2_block_manager=XXXX,
    )
​
sampling_params = SamplingParams(temperature=1.0, max_tokens=1)
​
mmlu_dataset = [...] # 3510 cases from mmlu
​
outputs = llm.generate(
        sampling_params=sampling_params,
        prompt_token_ids=mmlu_dataset,
    )

```

![image](https://github.com/user-attachments/assets/a2f49d32-029e-42bc-8b43-37200d0adbce)



The self.free_table in evictor_v2::LRUEvictor is OrderedDict class that remembers the order in which keys were first inserted. The larger timestamps will be at the end.  

The reason V2 slower than V1 , is that V2 will go through all the free_table, in evict. 

V2 has the 'update',  It breaks the order. So we can move the block to the end when update. That can keep the lowest timestamp at the start. 







