### PR TITLE
[WIP] Caching of tensors for decode (flash-attn)

### DIFF
--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -68,12 +68,20 @@ def compute_slot_mapping(is_profile_run: bool, slot_mapping: List[int],
     # tokens are masked and the slot mapping will be
     # [-1, -1, 2, 3, 4, 5, 6, 7, 0, 1].
     block_table = block_tables[seq_id]
-    slot_mapping.extend([PAD_SLOT_ID] * max(0, start_idx - context_len))
-    for i in range(max(start_idx, context_len), seq_len):
+    if start_idx == 0 and (seq_len - context_len) == 1:
+        # Optimization for common-case of decoding next token
+        i = (seq_len - 1)
         block_number = block_table[i // block_size]
         block_offset = i % block_size
         slot = block_number * block_size + block_offset
         slot_mapping.append(slot)
+    else:
+        slot_mapping.extend([PAD_SLOT_ID] * max(0, start_idx - context_len))
+        for i in range(max(start_idx, context_len), seq_len):
+            block_number = block_table[i // block_size]
+            block_offset = i % block_size
+            slot = block_number * block_size + block_offset
+            slot_mapping.append(slot)
 
 
 TAttentionMetadata = TypeVar("TAttentionMetadata", bound='AttentionMetadata')

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -177,6 +177,33 @@ class LRUCache(Generic[T]):
         self.cache.clear()
 
 
+class TensorCache:
+    """Used to cache pytorch tensors for reuse by successive iterations of 
+    the scheduler/prepare_inputs
+    """
+
+    def __init__(self):
+        self._dummy_tensor: torch.Tensor = torch.empty(0)
+        self._tensors: Dict[str, List] = {}
+
+    def get_dummy_tensor(self):
+        return self._dummy_tensor
+
+    def get_tensor(self, name) -> Optional[List]:
+        if name not in self._tensors:
+            return [None, None]
+
+        return self._tensors[name]
+
+    def cache_tensor(self, name: str, tensor_vals: torch.Tensor,
+                     vals: Any) -> None:
+        self._tensors[name] = [tensor_vals, vals]
+
+    def update_vals(self, name: str, vals: Any) -> None:
+        assert name in self._tensors
+        self._tensors[name][1] = vals
+
+
 def is_hip() -> bool:
     return torch.version.hip is not None
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -549,8 +549,10 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             batch_size = graph_batch_size
 
         # Tokens and positions.
-        input_tokens.extend([0] * cuda_graph_pad_size)
-        input_positions.extend([0] * cuda_graph_pad_size)
+        if cuda_graph_pad_size:
+            input_tokens.extend([0] * cuda_graph_pad_size)
+            input_positions.extend([0] * cuda_graph_pad_size)
+        
         input_tokens_tensor = torch.tensor(input_tokens,
                                            dtype=torch.long,
                                            device=self.runner.device)


### PR DESCRIPTION
This PR introduces TensorCache to cache tensors between successive iterations of the scheduler/prepare_inputs. This is similar to the effect of multi-step scheduler, however, this approach maintains a single-step behavior on expense of performance hit.

TODO: 
1. Generalize caching to more complicated cases than simple +1
2. More benchmarks (Looks like it needs to be combined with e2e overheads reductions to see more speedup. In particular it works better when combined with this PR: https://github.com/vllm-project/vllm/pull/7162)
