### PR TITLE
[Performance][Core] Optimize the performance of evictor v1 and v2 by applying a priority queue and lazy deletion

### DIFF
--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -114,7 +114,8 @@ class LRUEvictor(Evictor):
         self.free_table[block_id].last_accessed = last_accessed
 
     def _cleanup_if_necessary(self):
-        if len(self.priority_queue) > LRUEvictor.CLEANUP_THRESHOLD * len(self.free_table):
+        if len(self.priority_queue) > LRUEvictor.CLEANUP_THRESHOLD * len(
+                self.free_table):
             self._cleanup()
 
     def _cleanup(self):

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -3,6 +3,8 @@ import heapq
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
+CLEANUP_THRESHOLD = 50
+
 
 class EvictionPolicy(enum.Enum):
     """Enum for eviction policy used by make_evictor to instantiate the correct
@@ -112,7 +114,7 @@ class LRUEvictor(Evictor):
         self.free_table[block_id].last_accessed = last_accessed
 
     def _cleanup_if_necessary(self):
-        if len(self.priority_queue) > 50 * len(self.free_table):
+        if len(self.priority_queue) > CLEANUP_THRESHOLD * len(self.free_table):
             self._cleanup()
 
     def _cleanup(self):

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -119,14 +119,14 @@ class LRUEvictor(Evictor):
             self._cleanup()
 
     def _cleanup(self):
-        new_priority_queue: List[Tuple[int, int, int, int]] = []
-        for last_accessed, neg_num_hashed_tokens, content_hash, block_id in (
-                self.priority_queue):
-            if (block_id in self.free_table and
-                    self.free_table[block_id].last_accessed == last_accessed):
-                heapq.heappush(new_priority_queue,
-                               (last_accessed, neg_num_hashed_tokens,
-                                content_hash, block_id))
+        new_priority_queue: List[Tuple[float, int, int, int]] = []
+
+        for block_id, block in self.free_table.items():
+            new_priority_queue.append(
+                (block.last_accessed, -block.num_hashed_tokens,
+                 block.content_hash, block_id))
+        heapq.heapify(new_priority_queue)
+
         self.priority_queue = new_priority_queue
 
     def remove(self, block_id: int):

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -3,8 +3,6 @@ import heapq
 from abc import ABC, abstractmethod
 from typing import Dict, List, Tuple
 
-CLEANUP_THRESHOLD = 50
-
 
 class EvictionPolicy(enum.Enum):
     """Enum for eviction policy used by make_evictor to instantiate the correct
@@ -78,6 +76,8 @@ class LRUEvictor(Evictor):
     highest num_hashed_tokens value, then one will be chose arbitrarily
     """
 
+    CLEANUP_THRESHOLD = 50
+
     def __init__(self):
         self.free_table: Dict[int, BlockMetaData] = {}
         self.priority_queue = []
@@ -114,7 +114,7 @@ class LRUEvictor(Evictor):
         self.free_table[block_id].last_accessed = last_accessed
 
     def _cleanup_if_necessary(self):
-        if len(self.priority_queue) > CLEANUP_THRESHOLD * len(self.free_table):
+        if len(self.priority_queue) > LRUEvictor.CLEANUP_THRESHOLD * len(self.free_table):
             self._cleanup()
 
     def _cleanup(self):

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -76,9 +76,9 @@ class LRUEvictor(Evictor):
     highest num_hashed_tokens value, then one will be chose arbitrarily
     """
 
-    # CLEANUP_THRESHOLD determines the maximum allowable size of the priority queue
-    # relative to the free table size. When this threshold is exceeded, a cleanup
-    # operation is triggered to reduce memory usage.
+    # CLEANUP_THRESHOLD determines the maximum allowable size of the priority
+    # queue relative to the free table size. When this threshold is exceeded,
+    # a cleanup operation is triggered to reduce memory usage.
     CLEANUP_THRESHOLD = 50
 
     def __init__(self):
@@ -94,8 +94,9 @@ class LRUEvictor(Evictor):
 
         while self.priority_queue:
             # Lazy deletion algorithm is applied here. We do not remove outdated
-            # entries from the priority queue at the time of updating the last_accessed
-            # timestamp. Instead, outdated entries are filtered out during eviction.
+            # entries from the priority queue at the time of updating the
+            # last_accessed timestamp.
+            # Instead, outdated entries are filtered out during eviction.
             last_accessed, _, block_id, content_hash = heapq.heappop(
                 self.priority_queue)
             if (block_id in self.free_table and

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -91,7 +91,7 @@ class LRUEvictor(Evictor):
 
         while self.priority_queue:
             # Lazy deletion algorithm is applied.
-            last_accessed, _, content_hash, block_id = heapq.heappop(
+            last_accessed, _, block_id, content_hash = heapq.heappop(
                 self.priority_queue)
             if (block_id in self.free_table and
                     self.free_table[block_id].last_accessed == last_accessed):
@@ -107,7 +107,7 @@ class LRUEvictor(Evictor):
                                                   last_accessed)
         heapq.heappush(
             self.priority_queue,
-            (last_accessed, -num_hashed_tokens, content_hash, block_id))
+            (last_accessed, -num_hashed_tokens, block_id, content_hash))
         self._cleanup_if_necessary()
 
     def update(self, block_id: int, last_accessed: float):
@@ -124,7 +124,7 @@ class LRUEvictor(Evictor):
         for block_id, block in self.free_table.items():
             new_priority_queue.append(
                 (block.last_accessed, -block.num_hashed_tokens,
-                 block.content_hash, block_id))
+                 block_id, block.content_hash))
         heapq.heapify(new_priority_queue)
 
         self.priority_queue = new_priority_queue

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -123,8 +123,8 @@ class LRUEvictor(Evictor):
 
         for block_id, block in self.free_table.items():
             new_priority_queue.append(
-                (block.last_accessed, -block.num_hashed_tokens,
-                 block_id, block.content_hash))
+                (block.last_accessed, -block.num_hashed_tokens, block_id,
+                 block.content_hash))
         heapq.heapify(new_priority_queue)
 
         self.priority_queue = new_priority_queue

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -76,6 +76,9 @@ class LRUEvictor(Evictor):
     highest num_hashed_tokens value, then one will be chose arbitrarily
     """
 
+    # CLEANUP_THRESHOLD determines the maximum allowable size of the priority queue
+    # relative to the free table size. When this threshold is exceeded, a cleanup
+    # operation is triggered to reduce memory usage.
     CLEANUP_THRESHOLD = 50
 
     def __init__(self):
@@ -90,7 +93,9 @@ class LRUEvictor(Evictor):
             raise ValueError("No usable cache memory left")
 
         while self.priority_queue:
-            # Lazy deletion algorithm is applied.
+            # Lazy deletion algorithm is applied here. We do not remove outdated
+            # entries from the priority queue at the time of updating the last_accessed
+            # timestamp. Instead, outdated entries are filtered out during eviction.
             last_accessed, _, block_id, content_hash = heapq.heappop(
                 self.priority_queue)
             if (block_id in self.free_table and

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -95,8 +95,9 @@ class LRUEvictor(Evictor):
         while self.priority_queue:
             # We do not remove outdated entries from the priority queue at the
             # time of updating the last_accessed timestamp. Instead, outdated
-            # entries are filtered out here during eviction. Outdated entries would
-            # either not in the free table, or have older last accessed time.
+            # entries are filtered out here during eviction. Outdated entries
+            # would either not in the free table, or have older last accessed
+            # time.
             last_accessed, _, block_id, content_hash = heapq.heappop(
                 self.priority_queue)
             if (block_id in self.free_table and

--- a/vllm/core/evictor.py
+++ b/vllm/core/evictor.py
@@ -93,10 +93,10 @@ class LRUEvictor(Evictor):
             raise ValueError("No usable cache memory left")
 
         while self.priority_queue:
-            # Lazy deletion algorithm is applied here. We do not remove outdated
-            # entries from the priority queue at the time of updating the
-            # last_accessed timestamp.
-            # Instead, outdated entries are filtered out during eviction.
+            # We do not remove outdated entries from the priority queue at the
+            # time of updating the last_accessed timestamp. Instead, outdated
+            # entries are filtered out here during eviction. Outdated entries would
+            # either not in the free table, or have older last accessed time.
             last_accessed, _, block_id, content_hash = heapq.heappop(
                 self.priority_queue)
             if (block_id in self.free_table and


### PR DESCRIPTION
FIX #6923

## Summary
- I discovered that the eviction logic with the `OrderedDict` `free_table` in Evictor V1 and V2 slows down overall performance (especially `TTFT`) when using prefix caching mode.
- In some scenarios, utilizing prefix caching mode makes the system slower compared to when prefix caching is not used.
- The evict function is frequently called when allocating a new block, as no block is evicted until the block space is full in prefix caching mode.
- The eviction logic was slow because free_table is declared as an OrderedDict, which is a linked list, and it tries to find a block with `content hash` (Evictor V1) or `block ID` (Evictor V2) in this free_table.
- Utilizing a priority queue and lazy deletion helps find the block faster.

## Result Verification
- As shown in the following output, the block ID and content hash had the same value between the as-is and to-be states (which is expected).
- With this change, I could make the duration of the evict function much faster.

```
===============================
evicted_block_id compare:  12010   12010
content_hash_compare:  -7334740008364413937   -7334740008364413937
as-is evict duration:  7.0807114243507385 ms
to-be evict duration:  0.012848526239395142 ms
===============================
evicted_block_id compare:  12038   12038
content_hash_compare:  -7008894356950570757   -7008894356950570757
as-is evict duration:  7.1028973907232285 ms
to-be evict duration:  0.008581206202507019 ms
===============================
```

## Performance
- I checked the TTFT performance using llmperf and the Llama3-8B model with an A100 GPU.
- I benchmarked with 1536 input token length (512 same prefix + 1024 random input) and 512 output token length.
- By applying this commit, I can make the system faster while utilizing prefix caching.
- The speed-up metric is calculated based on the performance without prefix caching mode.

### as-is
Model | Num Clients | Block Manager | Prefix Caching | TTFT (mean) | Speed Up
-- | -- | -- | -- | -- | --
Llama3-8B | 16 | v2 | X | 841 ms |  
Llama3-8B | 32 | v2 | X | 1441 ms |  
Llama3-8B | 64 | v2 | X | 2619 ms |  
Llama3-8B | 128 | v2 | X | 4729 ms |  
Llama3-8B | 16 | v2 | O | 1962 ms | 0.43 (slowed down)
Llama3-8B | 32 | v2 | O | 8382 ms | 0.17 (slowed down)
Llama3-8B | 64 | v2 | O | 12665 ms | 0.21 (slowed down)
Llama3-8B | 128 | v2 | O | 22439 ms | 0.21 (slowed down)

### to-be
Model | Num Clients | Block Manager | Prefix Caching | TTFT (mean) | Speed Up
-- | -- | -- | -- | -- | --
Llama3-8B | 16 | v2 | O | 541 ms | 1.55
Llama3-8B | 32 | v2 | O | 901 ms | 1.60
Llama3-8B | 64 | v2 | O | 1563 ms | 1.68
Llama3-8B | 128 | v2 | O | 2947 ms | 1.60