### PR TITLE
[Bugfix] Fix GPTQ and GPTQ Marlin CPU Offloading

### DIFF
--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -29,7 +29,8 @@ def test_cpu_offload_gptq():
     compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", [],
                          ["--cpu-offload-gb", "1"])
     # Test GPTQ
-    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", ["--quantization", "gptq"],
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4",
+                         ["--quantization", "gptq"],
                          ["--quantization", "gptq", "--cpu-offload-gb", "1"])
 
 
@@ -40,7 +41,8 @@ def test_cpu_offload_awq():
     compare_two_settings("Qwen/Qwen2-1.5B-Instruct-AWQ", [],
                          ["--cpu-offload-gb", "1"])
     # Test AWQ
-    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-AWQ", ["--quantization", "awq"],
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-AWQ",
+                         ["--quantization", "awq"],
                          ["--quantization", "awq", "--cpu-offload-gb", "1"])
 
 

--- a/tests/basic_correctness/test_cpu_offload.py
+++ b/tests/basic_correctness/test_cpu_offload.py
@@ -22,11 +22,26 @@ def test_cpu_offload_fp8():
                          ["--cpu-offload-gb", "2"])
 
 
-@pytest.mark.skipif(not is_quant_method_supported("awq"),
-                    reason="awq is not supported on this GPU type.")
+@pytest.mark.skipif(not is_quant_method_supported("gptq_marlin"),
+                    reason="gptq_marlin is not supported on this GPU type.")
+def test_cpu_offload_gptq():
+    # Test GPTQ Marlin
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", [],
+                         ["--cpu-offload-gb", "1"])
+    # Test GPTQ
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4", ["--quantization", "gptq"],
+                         ["--quantization", "gptq", "--cpu-offload-gb", "1"])
+
+
+@pytest.mark.skipif(not is_quant_method_supported("awq_marlin"),
+                    reason="awq_marlin is not supported on this GPU type.")
 def test_cpu_offload_awq():
-    compare_two_settings("casperhansen/llama-3-8b-instruct-awq", [],
-                         ["--cpu-offload-gb", "2"])
+    # Test AWQ Marlin
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-AWQ", [],
+                         ["--cpu-offload-gb", "1"])
+    # Test AWQ
+    compare_two_settings("Qwen/Qwen2-1.5B-Instruct-AWQ", ["--quantization", "awq"],
+                         ["--quantization", "awq", "--cpu-offload-gb", "1"])
 
 
 @pytest.mark.skipif(not is_quant_method_supported("gptq_marlin"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -266,8 +266,9 @@ def compare_two_settings(model: str,
     arg1_results = results[:n]
     arg2_results = results[n:]
     for arg1_result, arg2_result in zip(arg1_results, arg2_results):
-        assert arg1_result == arg2_result, \
-            f"Results for {model=} are not the same with {arg1=} and {arg2=}"
+        assert arg1_result == arg2_result, (
+            f"Results for {model=} are not the same with {arg1=} and {arg2=}. "
+            f"{arg1_result=} != {arg2_result=}")
 
 
 def init_test_distributed_environment(

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -251,7 +251,6 @@ class GPTQMarlinLinearMethod(LinearMethodBase):
                 scales_and_zp_size,
                 output_size_per_partition // self.quant_config.pack_factor,
                 dtype=torch.int32,
-                device="meta",
             ),
             requires_grad=False,
         )


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/7204

GPTQ Marlin was failing with cpu offloading enabled during the initial model creation because `qzeros` was specifically made as a `"meta"` device parameter. There was no need for this so the simplest method was just to remove it. Another possible fix would be to make cpu offload not touch meta device tensors, but it seems meta isn't used anywhere else at the moment.

Upon further testing, GPTQ would produce gibberish with cpu offloading because it shuffled the weights on first forward pass. This was fixed by moving that final preprocessing to `process_weights_after_loading`