### PR TITLE
[Bugfix]: top_k is expected to be an integer.

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -224,6 +224,8 @@ class SamplingParams:
         if self.top_k < -1 or self.top_k == 0:
             raise ValueError(f"top_k must be -1 (disable), or at least 1, "
                              f"got {self.top_k}.")
+        if not isinstance(self.top_k, int):
+            raise TypeError(f"top_k must be an integer, got {type(self.top_k).__name__}")
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError("min_p must be in [0, 1], got "
                              f"{self.min_p}.")


### PR DESCRIPTION
FIX #7203

If top_k is not an instance of type `int`, a TypeError is thrown. Other parameters are not as tricky as top_k, therefore they are not modified. I tried to automatically validate all variables by traversing the type hints but I stuck on some edge cases. I can integrate this approach in a spare time.