### PR TITLE
[BUGFIX]: top_k is expected to be an integer.

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -224,6 +224,9 @@ class SamplingParams:
         if self.top_k < -1 or self.top_k == 0:
             raise ValueError(f"top_k must be -1 (disable), or at least 1, "
                              f"got {self.top_k}.")
+        if not isinstance(self.top_k, int):
+            raise TypeError(
+                f"top_k must be an integer, got {type(self.top_k).__name__}")
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError("min_p must be in [0, 1], got "
                              f"{self.min_p}.")


### PR DESCRIPTION
FIX #7203 

A TypeError is thrown if top_k is not an `int` instance. The other parameters were not as tricky, so they are not modified. I tried to automatically validate all variables with looping through the type hints but I stuck on some edge cases. I can work on this in a spare time.