### PR TITLE
[Doc] Put collect_env issue output in a <detail> block

### DIFF
--- a/.github/ISSUE_TEMPLATE/400-bug report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug report.yml
@@ -20,9 +20,14 @@ body:
       ```
       It is suggested to download and execute the latest script, as vllm might frequently update the diagnosis information needed for accurately and quickly responding to issues.
     value: |
+      <details>
+      <summary>The output of `python collect_env.py`</summary>
+
       ```text
-      The output of `python collect_env.py`
+      Your output of `python collect_env.py` here
       ```
+      
+      </details>
   validations:
     required: true
 - type: textarea


### PR DESCRIPTION
Since the output of collect_env.py is large and at the top of the issue template, place it in a foldable detail block by default.

Example here of the feature: https://gist.github.com/scmx/eca72d44afee0113ceb0349dd54a84a2