### PR TITLE
[Core] Streamline stream termination in `AsyncLLMEngine`

### DIFF
--- a/tests/async_engine/test_request_tracker.py
+++ b/tests/async_engine/test_request_tracker.py
@@ -47,8 +47,10 @@ async def test_request_tracker():
     assert tracker.new_requests_event.is_set()
     await tracker.wait_for_new_requests()
     new, aborted = tracker.get_new_and_aborted_requests()
-    assert len(aborted) == 1
-    assert "4" in aborted
+    # aborted new requests will cancel each other out -
+    # there's no need for them to propagate into the
+    # engine
+    assert not aborted
     assert not new
     assert stream_4.finished
 


### PR DESCRIPTION
Follow-on from https://github.com/vllm-project/vllm/pull/7111, avoid unnecessarily enqueuing of a final message after an exception and avoid aborting requests in the engine that were never started.
