### PR TITLE
[Frontend] Disallow passing `model` as both argument and option

### DIFF
--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -114,5 +114,5 @@ def test_traces(trace_service):
         SpanAttributes.LLM_LATENCY_TIME_TO_FIRST_TOKEN) == ttft
     e2e_time = metrics.finished_time - metrics.arrival_time
     assert attributes.get(SpanAttributes.LLM_LATENCY_E2E) == e2e_time
-    assert attributes.get(SpanAttributes.LLM_LATENCY_TIME_IN_SCHEDULER
-                          ) == metrics.scheduler_time
+    assert attributes.get(
+        SpanAttributes.LLM_LATENCY_TIME_IN_SCHEDULER) == metrics.scheduler_time

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -32,7 +32,7 @@ def nullable_str(val: str):
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
-    model: str
+    model: str = 'facebook/opt-125m'
     served_model_name: Optional[Union[List[str]]] = None
     tokenizer: Optional[str] = None
     skip_tokenizer_init: bool = False
@@ -133,7 +133,7 @@ class EngineArgs:
         parser.add_argument(
             '--model',
             type=str,
-            default='facebook/opt-125m',
+            default=EngineArgs.model,
             help='Name or path of the huggingface model to use.')
         parser.add_argument(
             '--tokenizer',

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -9,6 +9,7 @@ from typing import List, Optional
 from openai import OpenAI
 from openai.types.chat import ChatCompletionMessageParam
 
+from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.openai.api_server import run_server
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils import FlexibleArgumentParser
@@ -25,7 +26,7 @@ def register_signal_handlers():
 
 def serve(args: argparse.Namespace) -> None:
     # The default value of `--model`
-    if args.model != "facebook/opt-125m":
+    if args.model != EngineArgs.model:
         raise ValueError(
             "With `vllm serve`, you should provide the model as a "
             "positional argument instead of via the `--model` option.")

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -25,6 +25,11 @@ def register_signal_handlers():
 
 def serve(args: argparse.Namespace) -> None:
     # EngineArgs expects the model name to be passed as --model.
+    if args.model is not None:
+        raise ValueError(
+            "In `vllm serve`, you should provide the model as a "
+            "positional argument instead of via the `--model` option.")
+
     args.model = args.model_tag
 
     asyncio.run(run_server(args))

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -24,12 +24,12 @@ def register_signal_handlers():
 
 
 def serve(args: argparse.Namespace) -> None:
-    # EngineArgs expects the model name to be passed as --model.
     if args.model is not None:
         raise ValueError(
             "In `vllm serve`, you should provide the model as a "
             "positional argument instead of via the `--model` option.")
 
+    # EngineArgs expects the model name to be passed as --model.
     args.model = args.model_tag
 
     asyncio.run(run_server(args))

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -24,7 +24,8 @@ def register_signal_handlers():
 
 
 def serve(args: argparse.Namespace) -> None:
-    if args.model is not None:
+    # The default value of `--model`
+    if args.model != "facebook/opt-125m":
         raise ValueError(
             "In `vllm serve`, you should provide the model as a "
             "positional argument instead of via the `--model` option.")

--- a/vllm/scripts.py
+++ b/vllm/scripts.py
@@ -27,7 +27,7 @@ def serve(args: argparse.Namespace) -> None:
     # The default value of `--model`
     if args.model != "facebook/opt-125m":
         raise ValueError(
-            "In `vllm serve`, you should provide the model as a "
+            "With `vllm serve`, you should provide the model as a "
             "positional argument instead of via the `--model` option.")
 
     # EngineArgs expects the model name to be passed as --model.


### PR DESCRIPTION
Currently, it's possible to run `vllm serve <model_tag> --model <model>`, in which case `model` is ignored. To avoid this confusing behavior, this PR prohibits using the `--model` option in `vllm serve`.

FIX #7345