### PR TITLE
Save speculative decoding states

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1168,6 +1168,7 @@ class LLMEngine:
 
         Returns RequestOutputs that can be returned to the client.
         """
+        logger.info(output)
 
         now = time.time()
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -64,7 +64,8 @@ async def generate(request: Request) -> Response:
             text_outputs = [
                 prompt + output.text for output in request_output.outputs
             ]
-            ret = {"text": text_outputs}
+            speculative_decode_outputs = [output.speculative_decode_outputs for output in request_output.outputs]
+            ret = {"text": text_outputs, "speculative_decode_outputs": speculative_decode_outputs}
             yield (json.dumps(ret) + "\0").encode("utf-8")
 
     if stream:
@@ -81,7 +82,8 @@ async def generate(request: Request) -> Response:
     assert final_output is not None
     prompt = final_output.prompt
     text_outputs = [prompt + output.text for output in final_output.outputs]
-    ret = {"text": text_outputs}
+    speculative_decode_outputs = [output.speculative_decode_outputs for output in request_output.outputs]
+    ret = {"text": text_outputs, "speculative_decode_outputs": speculative_decode_outputs}
     return JSONResponse(ret)
 
 

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -7,6 +7,30 @@ from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
                            SequenceGroup, SequenceStatus)
 
 
+class SpeculativeDecodeOutput:
+    def __init__(
+        self,
+        draft_token_indices: list[int],
+        target_token_indices: list[int],
+        accepted_tokens_count: int,
+    ) -> None:
+        self._draft_token_indices = draft_token_indices
+        self._target_token_indices = target_token_indices
+        self._accepted_tokens_count = accepted_tokens_count
+    
+    @property
+    def draft_token_indices(self) -> list[int]:
+        return self._draft_token_indices
+    
+    @property
+    def target_token_indices(self) -> list[int]:
+        return self._target_token_indices
+    
+    @property
+    def accepted_tokens_count(self) -> list[int]:
+        return self._accepted_tokens_count
+
+
 @dataclass
 class CompletionOutput:
     """The output data of one completion output of a request.
@@ -34,6 +58,7 @@ class CompletionOutput:
     finish_reason: Optional[str] = None
     stop_reason: Union[int, str, None] = None
     lora_request: Optional[LoRARequest] = None
+    speculative_decode_outputs: Optional[list[SpeculativeDecodeOutput]] = None
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -45,6 +70,7 @@ class CompletionOutput:
                 f"cumulative_logprob={self.cumulative_logprob}, "
                 f"logprobs={self.logprobs}, "
                 f"finish_reason={self.finish_reason}, "
+                f"speculative_decode_outputs={self.speculative_decode_outputs}), "
                 f"stop_reason={self.stop_reason})")
 
 

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -5,30 +5,7 @@ from typing import List, Optional, Tuple, Union
 from vllm.lora.request import LoRARequest
 from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
                            SequenceGroup, SequenceStatus)
-
-
-class SpeculativeDecodeOutput:
-    def __init__(
-        self,
-        draft_token_indices: list[int],
-        target_token_indices: list[int],
-        accepted_tokens_count: int,
-    ) -> None:
-        self._draft_token_indices = draft_token_indices
-        self._target_token_indices = target_token_indices
-        self._accepted_tokens_count = accepted_tokens_count
-    
-    @property
-    def draft_token_indices(self) -> list[int]:
-        return self._draft_token_indices
-    
-    @property
-    def target_token_indices(self) -> list[int]:
-        return self._target_token_indices
-    
-    @property
-    def accepted_tokens_count(self) -> list[int]:
-        return self._accepted_tokens_count
+from vllm.speculative_decode_output import SpeculativeDecodeOutput
 
 
 @dataclass

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -15,6 +15,7 @@ from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
+from vllm.speculative_decode_output import SpeculativeDecodeOutput
 
 if TYPE_CHECKING:
     from vllm.inputs import LLMInputs
@@ -99,30 +100,6 @@ class RequestMetrics:
     first_token_time: Optional[float]
     time_in_queue: Optional[float]
     finished_time: Optional[float] = None
-
-
-class SpeculativeDecodeOutput:
-    def __init__(
-        self,
-        draft_token_indices: list[int],
-        target_token_indices: list[int],
-        accepted_tokens_count: int,
-    ) -> None:
-        self._draft_token_indices = draft_token_indices
-        self._target_token_indices = target_token_indices
-        self._accepted_tokens_count = accepted_tokens_count
-    
-    @property
-    def draft_token_indices(self) -> list[int]:
-        return self._draft_token_indices
-    
-    @property
-    def target_token_indices(self) -> list[int]:
-        return self._target_token_indices
-    
-    @property
-    def accepted_tokens_count(self) -> list[int]:
-        return self._accepted_tokens_count
 
 
 class SequenceData:
@@ -270,6 +247,9 @@ class SequenceData:
     @property
     def last_accepted_tokens_count(self) -> int:
         return self._speculative_decode_outputs[-1].accepted_tokens_count
+    
+    def append_speculative_decode_output(self, speculative_decode_output: SpeculativeDecodeOutput) -> None:
+        self._speculative_decode_outputs.append(speculative_decode_output)
 
     def __repr__(self) -> str:
         return (f"SequenceData("

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -101,6 +101,30 @@ class RequestMetrics:
     finished_time: Optional[float] = None
 
 
+class SpeculativeDecodeOutput:
+    def __init__(
+        self,
+        draft_token_indices: list[int],
+        target_token_indices: list[int],
+        accepted_tokens_count: int,
+    ) -> None:
+        self._draft_token_indices = draft_token_indices
+        self._target_token_indices = target_token_indices
+        self._accepted_tokens_count = accepted_tokens_count
+    
+    @property
+    def draft_token_indices(self) -> list[int]:
+        return self._draft_token_indices
+    
+    @property
+    def target_token_indices(self) -> list[int]:
+        return self._target_token_indices
+    
+    @property
+    def accepted_tokens_count(self) -> list[int]:
+        return self._accepted_tokens_count
+
+
 class SequenceData:
     """Data associated with a sequence.
 
@@ -119,12 +143,13 @@ class SequenceData:
         self,
         prompt_token_ids: List[int],
         output_token_ids: Optional[List[int]] = None,
+        speculative_decode_outputs: Optional[list[SpeculativeDecodeOutput]] = None
     ) -> None:
         self._prompt_token_ids = array('l', prompt_token_ids)
         self._prompt_token_ids_tuple: Tuple[int, ...] = tuple(prompt_token_ids)
         self._output_token_ids = array(
             'l', output_token_ids if output_token_ids is not None else [])
-
+        self._speculative_decode_outputs = speculative_decode_outputs
         self.cumulative_logprob = 0.0
         # The number of tokens that are computed (that run against the model).
         self._num_computed_tokens = 0
@@ -233,6 +258,18 @@ class SequenceData:
     @property
     def stage(self) -> SequenceStage:
         return self._stage
+
+    @property
+    def last_draft_token_indices(self) -> list[int]:
+        return self._speculative_decode_outputs[-1].draft_token_indices
+    
+    @property
+    def last_target_token_indices(self) -> list[int]:
+        return self._speculative_decode_outputs[-1].target_token_indices
+    
+    @property
+    def last_accepted_tokens_count(self) -> int:
+        return self._speculative_decode_outputs[-1].accepted_tokens_count
 
     def __repr__(self) -> str:
         return (f"SequenceData("

--- a/vllm/speculative_decode_output.py
+++ b/vllm/speculative_decode_output.py
@@ -1,0 +1,25 @@
+class SpeculativeDecodeOutput:
+    def __init__(
+        self,
+        draft_token_indices: list[int],
+        target_token_indices: list[int],
+        accepted_tokens_count: int,
+    ) -> None:
+        self._draft_token_indices = draft_token_indices
+        self._target_token_indices = target_token_indices
+        self._accepted_tokens_count = accepted_tokens_count
+
+        assert len(draft_token_indices) == len(target_token_indices)
+        assert accepted_tokens_count >= 0
+    
+    @property
+    def draft_token_indices(self) -> list[int]:
+        return self._draft_token_indices
+    
+    @property
+    def target_token_indices(self) -> list[int]:
+        return self._target_token_indices
+    
+    @property
+    def accepted_tokens_count(self) -> list[int]:
+        return self._accepted_tokens_count


### PR DESCRIPTION
#### Description

Allow users to optionally receive speculative decoding artifacts such as history of draft token indices. This would be beneficial for a few reasons. It allows users to explore internal states of speculative decoding algorithms which is helpful if you debug your speculative decode algorithm or model. Specifically for our case we need this feature for subsequent merge request where we present speculative dynamic parallel decode algorithm that makes use of previous draft states in order to predict new draft. The last but not least it allows to use internal history of draft model states to generate dataset that is used to train custom speculative models

We propose to create additional data structure that will hold information about draft sequence, target sequence which is next token for each token in draft predicted by target model and the number of accepted tokens

Each engine step will save this data structure inside sequence meta information such that lated we can retrieve it or use from speculative decoder worker in order to use information about previous draft sequence to predict next draft sequence 

History of data structures that represent speculative decode iteration will be stored in sequence data

https://github.com/vllm-project/vllm/blob/86ab567bae0698425095e28cce67e9a31a261b72/vllm/sequence.py#L114