### PR TITLE
[Bugfix] Handle PackageNotFoundError when checking for xpu version

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -341,8 +341,11 @@ def is_tpu() -> bool:
 
 @lru_cache(maxsize=None)
 def is_xpu() -> bool:
-    from importlib.metadata import version
-    is_xpu_flag = "xpu" in version("vllm")
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        is_xpu_flag = "xpu" in version("vllm")
+    except PackageNotFoundError:
+        return False
     # vllm is not build with xpu
     if not is_xpu_flag:
         return False


### PR DESCRIPTION
When vLLM is installed as another package (not `vllm`, but `vllm-pascal` in my case), this check causes the whole process to crash. This PR fixes this behavior.

<details>
<summary>Exception</summary>

```text
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 563, in from_name
    return next(cls.discover(name=name))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/rpc/server.py", line 218, in run_rpc_server
    server = AsyncEngineRPCServer(async_engine_args, usage_context, rpc_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/rpc/server.py", line 25, in __init__
    self.engine = AsyncLLMEngine.from_engine_args(async_engine_args,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/async_llm_engine.py", line 592, in from_engine_args
    engine_config = engine_args.create_engine_config()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/arg_utils.py", line 714, in create_engine_config
    device_config = DeviceConfig(device=self.device)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/config.py", line 922, in __init__
    elif is_xpu():
         ^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/utils.py", line 345, in is_xpu
    is_xpu_flag = "xpu" in version("vllm")
                           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 1008, in version
    return distribution(distribution_name).version
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 981, in distribution
    return Distribution.from_name(distribution_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/metadata/__init__.py", line 565, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: No package metadata was found for vllm
Traceback (most recent call last):
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 127, in build_async_engine_client
    await async_engine_client.setup()
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/rpc/client.py", line 35, in setup
    await self.wait_for_server()
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/rpc/client.py", line 136, in wait_for_server
    await self._send_one_way_rpc_request(
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/rpc/client.py", line 112, in _send_one_way_rpc_request
    raise TimeoutError(f"server didn't reply within {timeout} ms")
TimeoutError: server didn't reply within 1000 ms

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/vllm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/scripts.py", line 149, in main
    args.dispatch_function(args)
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/scripts.py", line 30, in serve
    asyncio.run(run_server(args))
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 355, in run_server
    async with build_async_engine_client(args) as async_engine_client:
  File "/usr/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/ml/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 131, in build_async_engine_client
    raise RuntimeError(
RuntimeError: The server process died before responding to the readiness probe
```
</details>