### PR TITLE
[Bugfix] Fix logit soft cap in flash-attn backend

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -563,6 +563,7 @@ class FlashAttentionImpl(AttentionImpl):
                 softmax_scale=self.scale,
                 causal=True,
                 alibi_slopes=self.alibi_slopes,
+                softcap=self.logits_soft_cap,
             ).squeeze(1)
 
         # Reshape the output tensor.


### PR DESCRIPTION
Fixes #7419

After this PR, the GSM8K result looks correct:

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.868|±  |0.0215|
|     |       |strict-match    |     5|exact_match|↑  |0.860|±  |0.0220|
```