### PR TITLE
[Misc] improve logits processors logging message

### DIFF
--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -73,7 +73,6 @@ def test_serving_chat_should_set_correct_max_tokens():
     with suppress(Exception):
         asyncio.run(serving_chat.create_chat_completion(req))
 
-    # AsyncLLMEngine.generate(inputs, sampling_params, ...)
     assert mock_engine.generate.call_args.args[1].max_tokens == 93
 
     req.max_tokens = 10

--- a/vllm/entrypoints/openai/logits_processors.py
+++ b/vllm/entrypoints/openai/logits_processors.py
@@ -71,7 +71,7 @@ def get_logits_processors(
         # Check if token_id is within the vocab size
         for token_id, bias in clamped_logit_bias.items():
             if token_id < 0 or token_id >= tokenizer.vocab_size:
-                raise ValueError("token_id in logit_bias contains "
+                raise ValueError(f"token_id {token_id} in logit_bias contains "
                                  "out-of-vocab token id")
 
         logits_processors.append(


### PR DESCRIPTION
Just a small improvement to the logits processors logging message so that the offending `token_id` is included in the error message.

Also removes an extraneous commented-out-line in `test_serving_chat.py`. 
