### PR TITLE
[Core][Model][Frontend] Model architecture plugins

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -121,6 +121,8 @@ class EngineArgs:
     otlp_traces_endpoint: Optional[str] = None
     collect_detailed_traces: Optional[str] = None
 
+    model_architecture_override: Optional[str] = None
+
     def __post_init__(self):
         if self.tokenizer is None:
             self.tokenizer = self.model
@@ -674,6 +676,14 @@ class EngineArgs:
             "modules. This involves use of possibly costly and or blocking "
             "operations and hence might have a performance impact.")
 
+        parser.add_argument(
+            '--model-architecture-override',
+            type=str,
+            default=None,
+            help=
+            'Override the model architecture to use - useful for using plugins.'
+        )
+
         return parser
 
     @classmethod
@@ -735,6 +745,11 @@ class EngineArgs:
             skip_tokenizer_init=self.skip_tokenizer_init,
             served_model_name=self.served_model_name,
             multimodal_config=multimodal_config)
+        if self.model_architecture_override:
+            model_config.hf_config.architectures = [
+                self.model_architecture_override
+            ]
+
         cache_config = CacheConfig(
             block_size=self.block_size,
             gpu_memory_utilization=self.gpu_memory_utilization,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -42,6 +42,7 @@ from vllm.entrypoints.openai.serving_embedding import OpenAIServingEmbedding
 from vllm.entrypoints.openai.serving_tokenization import (
     OpenAIServingTokenization)
 from vllm.logger import init_logger
+from vllm.plugins.model_plugin import load_model_plugins
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import FlexibleArgumentParser, get_open_zmq_ipc_path
 from vllm.version import __version__ as VLLM_VERSION
@@ -352,6 +353,7 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     logger.info("vLLM API server version %s", VLLM_VERSION)
     logger.info("args: %s", args)
 
+    load_model_plugins()
     async with build_async_engine_client(args) as async_engine_client:
         app = await init_app(async_engine_client, args)
 

--- a/vllm/plugins/model_plugin.py
+++ b/vllm/plugins/model_plugin.py
@@ -1,0 +1,67 @@
+from typing import Optional, Iterable, Tuple, List, Type
+
+from transformers import PretrainedConfig
+from importlib.metadata import entry_points
+
+from vllm import ModelRegistry
+from dataclasses import dataclass
+import torch
+
+from vllm.attention import AttentionMetadata
+from vllm.config import CacheConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from abc import ABC, abstractmethod
+
+from vllm.sequence import IntermediateTensors
+
+
+logger = init_logger(__name__)
+
+
+class ModelArchitectureBase(torch.nn.Module, ABC):
+    def __init__(
+            self,
+            config: PretrainedConfig,
+            cache_config: Optional[CacheConfig] = None,
+            quant_config: Optional[QuantizationConfig] = None,
+    ):
+        self.config = config
+        self.cache_config = cache_config
+        self.quant_config = quant_config
+
+    @abstractmethod
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        pass
+
+    @abstractmethod
+    def forward(
+            self,
+            input_ids: torch.Tensor,
+            positions: torch.Tensor,
+            kv_caches: List[torch.Tensor],
+            attn_metadata: AttentionMetadata,
+            intermediate_tensors: Optional[IntermediateTensors] = None,
+    ) -> torch.Tensor:
+        pass
+
+
+@dataclass
+class ModelPlugin:
+    architecture_name: str
+    implementation_cls: Type[ModelArchitectureBase]
+
+
+def load_model_plugins():
+    for entry_point in entry_points().select(group="vllm.model_architectures"):
+        logger.debug(f"Loading model architecture plugin {entry_point.name}")
+        model_architecture_plugin = entry_point.load()
+        if not isinstance(model_architecture_plugin, ModelPlugin):
+            raise ValueError(
+                f"Model architecture plugin must be an instance of ModelPlugin, got {model_architecture_plugin}"
+            )
+
+        ModelRegistry.register_model(
+            model_architecture_plugin.architecture_name,
+            model_architecture_plugin.implementation_cls,
+        )


### PR DESCRIPTION
Solves #7124 (also relevant for #7131).

This pull request implements support for external model architecture plugins.
As discussed in #7131, vLLM should support both "general purpose" plugins which allow arbitrary modifications, but in addition it should allow simple plugin interfaces for parts in the vLLM architecture which might change a lot.

Using this pull request we can simply create a separate package implementing a model architecture, and install it in the same environment as vLLM.
If the model architecture plugin overrides an existing architecture you can use the `--model-architecture-override` option to specify the name of the new architecture to use.

#### Code for a mock `OPT` architecture implementation
```python
from vllm import ModelRegistry
from vllm.plugins.model_plugin import ModelArchitectureBase, ModelPlugin
from vllm.model_executor.models.opt import OPTForCausalLM


class MyOpt(OPTForCausalLM):
    def __init__(self, config, cache_config, quant_config):
        super().__init__(config, cache_config, quant_config)
    def forward(self, input_ids, positions, kv_caches, attn_metadata, intermediate_tensors=None):
        res = OPTForCausalLM.forward(self, input_ids, positions, kv_caches, attn_metadata, intermediate_tensors)
        res[0] = 1000
        return res


MODEL_PLUGIN = ModelPlugin(architecture_name='MyOpt', implementation_cls=MyOpt)
```

#### `Setup.py` file
```python
from setuptools import setup

setup(name='test_plugin',
      version='0.1',
      description='Example model architecture plugin for vLLM',
      install_requires=[
      ],
      entry_points={
            'vllm.model_architectures': ['test_plugin=test_plugin.main:MODEL_PLUGIN'],
      }
      )
```



#### Todo list

- [x] Implement basic logic
- [ ] Add test
- [ ] Add documentation

