### PR TITLE
[TPU] Suppress import custom_ops warning

### DIFF
--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -6,13 +6,15 @@ import torch
 
 from vllm._core_ext import ScalarType
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
-try:
-    import vllm._C
-except ImportError as e:
-    logger.warning("Failed to import from vllm._C with %r", e)
+if not current_platform.is_tpu():
+    try:
+        import vllm._C
+    except ImportError as e:
+        logger.warning("Failed to import from vllm._C with %r", e)
 
 with contextlib.suppress(ImportError):
     # ruff: noqa: F401

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 import torch
 
 from vllm.utils import is_tpu
 
 from .interface import Platform, PlatformEnum, UnspecifiedPlatform
 
-current_platform: Optional[Platform]
+current_platform: Platform
 
 if torch.version.cuda is not None:
     from .cuda import CudaPlatform

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -29,7 +29,6 @@ import torch.types
 from typing_extensions import ParamSpec, TypeIs, assert_never
 
 import vllm.envs as envs
-from vllm import _custom_ops as ops
 from vllm.logger import enable_trace_function_call, init_logger
 
 logger = init_logger(__name__)
@@ -368,6 +367,7 @@ def is_xpu() -> bool:
 @lru_cache(maxsize=None)
 def get_max_shared_memory_bytes(gpu: int = 0) -> int:
     """Returns the maximum shared memory per thread block in bytes."""
+    from vllm import _custom_ops as ops
     max_shared_mem = (
         ops.get_max_shared_memory_per_block_device_attribute(gpu))
     # value 0 will cause MAX_SEQ_LEN become negative and test_attention.py


### PR DESCRIPTION
This PR suppresses the unnecessary warning when running vLLM on TPUs:
```
WARNING 08-13 04:48:22 _custom_ops.py:15] Failed to import from vllm._C with ModuleNotFoundError("No module named 'vllm._C'")
```