### PR TITLE
To compare the matmul performance of bfloat16 and fp8.

### DIFF
--- a/tests/kernels/test_cutlass.py
+++ b/tests/kernels/test_cutlass.py
@@ -125,7 +125,7 @@ def compare_cutlass_fp8_torch_mm_helper(
     cutlass_mm_time = time3 - time2
 
     if display:
-        print(f"{torch_mm_time=:.10f}", f"{scale_time=:.10f}",
+        print(f"{use_bias=}, {torch_mm_time=:.10f}", f"{scale_time=:.10f}",
               f"{cutlass_mm_time=:.10f}")
 
     assert baseline.shape == out.shape


### PR DESCRIPTION
After quantizing the AutoModelForSequenceClassification model using AutoFP8 and serving it with vllm, I've observed a significant performance drop-off. So, I've created a PR to test bfloat16 and fp8 performance. @mgoin , could you give me some advice? As you can see from the charts, the scale + cutlass time is almost same with torch.mm time.
```
m=4096 n=4096 k=4096
pytest test_cutlass.py -k test_compare_cutlass_fp8_torch_mm -s
use_bias=False, torch_mm_time=0.0014884472 scale_time=0.0000164509 cutlass_mm_time=0.0008094311
use_bias=False, torch_mm_time=0.0014874935 scale_time=0.0000212193 cutlass_mm_time=0.0008101463
use_bias=False, torch_mm_time=0.0014891624 scale_time=0.0000171661 cutlass_mm_time=0.0008101463
use_bias=False, torch_mm_time=0.0014884472 scale_time=0.0000157356 cutlass_mm_time=0.0008111000
use_bias=True, torch_mm_time=0.0015590191 scale_time=0.0000166893 cutlass_mm_time=0.0013942719
use_bias=True, torch_mm_time=0.0015594959 scale_time=0.0000171661 cutlass_mm_time=0.0013976097
use_bias=True, torch_mm_time=0.0015587807 scale_time=0.0000176430 cutlass_mm_time=0.0013940334
use_bias=True, torch_mm_time=0.0015587807 scale_time=0.0000171661 cutlass_mm_time=0.0013928413
```
Weird thing is when use_bias=True, cutlass_mm_time increases significantly.

the GPU I used is L20.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


