### PR TITLE
[CI/Build] Add text-only test for Qwen models 

### DIFF
--- a/.buildkite/run-cpu-test.sh
+++ b/.buildkite/run-cpu-test.sh
@@ -22,7 +22,7 @@ docker exec cpu-test-avx2 bash -c "python3 examples/offline_inference.py"
 
 # Run basic model test
 docker exec cpu-test bash -c "
-  pip install pytest
+  pip install pytest matplotlib einops transformers_stream_generator
   pytest -v -s tests/models -m \"not vlm\" --ignore=tests/models/test_embedding.py --ignore=tests/models/test_oot_registration.py --ignore=tests/models/test_registry.py --ignore=tests/models/test_jamba.py --ignore=tests/models/test_danube3_4b.py" # Mamba and Danube3-4B on CPU is not supported
 
 # online inference

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,7 +11,7 @@ pytest-shard
 
 # testing utils
 awscli
-einops # required for MPT
+einops # required for MPT and qwen-vl
 httpx
 peft
 requests
@@ -19,6 +19,8 @@ ray
 sentence-transformers # required for embedding
 compressed-tensors==0.4.0 # required for compressed-tensors
 timm # required for internvl test
+transformers_stream_generator # required for qwen-vl test
+matplotlib # required for qwen-vl test
 
 # TODO: Add this after fully implementing llava(mantis)
 # git+https://github.com/TIGER-AI-Lab/Mantis.git # required for llava(mantis) test

--- a/tests/models/test_qwen.py
+++ b/tests/models/test_qwen.py
@@ -1,0 +1,48 @@
+from typing import Type
+
+import pytest
+
+from ..conftest import HfRunner, VllmRunner
+from .utils import check_logprobs_close
+
+models = ["qwen/qwen-vl"]
+
+
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("num_logprobs", [5])
+@pytest.mark.parametrize("model", models)
+def test_text_only_qwen_model(
+    hf_runner: Type[HfRunner],
+    vllm_runner: Type[VllmRunner],
+    example_prompts,
+    model: str,
+    *,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+):
+    # This test checks language inputs only, since the visual component
+    # for qwen-vl is still unsupported in VLLM. In the near-future, the
+    # implementation and this test will be extended to consider
+    # visual inputs as well.
+    with hf_runner(model, dtype=dtype, is_vision_model=False) as hf_model:
+        hf_outputs = hf_model.generate_greedy_logprobs_limit(
+            example_prompts,
+            max_tokens,
+            num_logprobs=num_logprobs,
+        )
+
+    with vllm_runner(model, dtype=dtype) as vllm_model:
+        vllm_outputs = vllm_model.generate_greedy_logprobs(
+            example_prompts,
+            max_tokens,
+            num_logprobs=num_logprobs,
+        )
+
+    check_logprobs_close(
+        outputs_0_lst=hf_outputs,
+        outputs_1_lst=vllm_outputs,
+        name_0="hf",
+        name_1="vllm",
+    )


### PR DESCRIPTION
Hello! I noticed that there aren't any model tests for `QwenModel` yet, and was wondering if there was a reason for this, or if it would make sense to add one similar to the other tests running on the example test prompts.

I am working on extending `QwenModel`, which currently skips loading the visual component of models like `Qwen/Qwen-VL` in VLLM so that it can handle text-only inputs, to accept visual inputs. I thought it would be a good idea to potentially add a test for text-only inputs, which could potentially be updated to include visual inputs once that is at a point that it's ready for a look.

It's also probably worth noting that there are some small differences in the produced output for a few of the example prompts, although the produced sequences start the same and are quite close, so maybe it's not an issue. For example:
```
tests/models/test_qwen.py::test_text_only_qwen_model[qwen/qwen-vl-5-32-half]
  /u/brooks/vllm/tests/models/test_qwen.py:44: UserWarning: Test6:
  Matched tokens:       [71703, 25, 576, 98783, 28556, 18824, 374, 6509, 825, 315, 279, 1429]
  hf:   'Assistant: The Mona Lisa painting is considered one of the most famous and iconic works of art in the world. It is a portrait of a woman, believed to'{11245: -0.747456431388855, 26277: -0.747456431388855, 5089: -4.1224565505981445, 65252: -4.6224565505981445, 35948: -5.2474565505981445}
  vllm: 'Assistant: The Mona Lisa painting is considered one of the most iconic and famous works of art in the world. It is a portrait of a woman, believed to'{26277: Logprob(logprob=-0.735495388507843, rank=1, decoded_token=' iconic'), 11245: Logprob(logprob=-0.766745388507843, rank=2, decoded_token=' famous'), 5089: Logprob(logprob=-4.079245567321777, rank=3, decoded_token=' significant'), 65252: Logprob(logprob=-4.516745567321777, rank=4, decoded_token=' recognizable'), 35948: Logprob(logprob=-5.235495567321777, rank=5, decoded_token=' renowned')}
    check_logprobs_close(
```

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


