### PR TITLE
[BUG] fix crash on flashinfer backend with cudagraph disabled, when attention group_size not in [1,2,4,8]

### DIFF
--- a/tests/kernels/test_flashinfer.py
+++ b/tests/kernels/test_flashinfer.py
@@ -4,7 +4,7 @@ import flashinfer
 import pytest
 import torch
 
-NUM_HEADS = [(16, 16), (32, 8), (64, 8)]
+NUM_HEADS = [(16, 16), (32, 8), (64, 8), (6, 1)]
 HEAD_SIZES = [128, 256]
 BLOCK_SIZES = [16, 32]
 DTYPES = [torch.float16, torch.bfloat16]
@@ -123,7 +123,10 @@ def test_flashinfer_decode_with_paged_kv(kv_lens: List[int],
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8)
     wrapper = flashinfer.\
-        BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD")
+        BatchDecodeWithPagedKVCacheWrapper(workspace_buffer, "NHD",
+                use_tensor_cores=(
+                    (num_query_heads//num_kv_heads) not in (1, 2, 4, 8))
+                )
     wrapper.begin_forward(kv_indptr,
                           kv_indices,
                           kv_last_page_lens,

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -113,7 +113,7 @@ class FlashInferState(AttentionState):
                 self.runner.parallel_config))
             num_kv_heads = self.runner.model_config.get_num_kv_heads(
                 self.runner.parallel_config)
-            use_tensor_cores = (num_qo_heads // num_kv_heads) not in
+            use_tensor_cores = (num_qo_heads // num_kv_heads) not in \
                 (1, 2, 4, 8)
             self._decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
@@ -172,7 +172,7 @@ class FlashInferState(AttentionState):
             self.runner.parallel_config))
         num_kv_heads = self.runner.model_config.get_num_kv_heads(
             self.runner.parallel_config)
-        use_tensor_cores = (num_qo_heads // num_kv_heads) not in
+        use_tensor_cores = (num_qo_heads // num_kv_heads) not in \
             (1, 2, 4, 8)
         self._graph_decode_wrapper = \
             CUDAGraphBatchDecodeWithPagedKVCacheWrapper(

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -113,7 +113,8 @@ class FlashInferState(AttentionState):
                 self.runner.parallel_config))
             num_kv_heads = self.runner.model_config.get_num_kv_heads(
                 self.runner.parallel_config)
-            use_tensor_cores = num_qo_heads // num_kv_heads >= 4
+            use_tensor_cores = (num_qo_heads // num_kv_heads) not in
+                (1, 2, 4, 8)
             self._decode_wrapper = BatchDecodeWithPagedKVCacheWrapper(
                 self._get_workspace_buffer(),
                 "NHD",
@@ -171,7 +172,8 @@ class FlashInferState(AttentionState):
             self.runner.parallel_config))
         num_kv_heads = self.runner.model_config.get_num_kv_heads(
             self.runner.parallel_config)
-        use_tensor_cores = num_qo_heads // num_kv_heads >= 4
+        use_tensor_cores = (num_qo_heads // num_kv_heads) not in
+            (1, 2, 4, 8)
         self._graph_decode_wrapper = \
             CUDAGraphBatchDecodeWithPagedKVCacheWrapper(
             self._graph_decode_workspace_buffer, _indptr_buffer,


### PR DESCRIPTION
when I use flashinfer backend and disable cuda graph, load a model with attention group_size=6, vllm crashs and shows the following log:
![screenshot-20240814-161315](https://github.com/user-attachments/assets/39224bf6-821b-487e-877c-10ed92df4139)

This error consistently occurs under the following conditions：
1. user use flashinfer attention backend explicitly, (set env VLLM_ATTENTION_BACKEND="FLASHINFER")
2. the model use GQA, and group size not in [1,2,4,8]. (I've reviewed flashinfer's [source](https://github.com/flashinfer-ai/flashinfer/blob/main/python/flashinfer/decode.py#L60C5-L60C58), it only support group_size [1,2,4,8] otherwise user need to use_tensor_cores=True to do decode)
3. cuda graph is disabled, it can happen when user set enforce_eager=True, or the decoding batch_size > _BATCH_SIZES_TO_CAPTURE[-1] (variable in model_runner.py, currently 256)
