### PR TITLE
[Bugfix] Fix default weight loading for scalars

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -517,8 +517,8 @@ def default_weight_loader(param: torch.Tensor,
     """Default weight loader."""
     try:
         if param.numel() == 1 and loaded_weight.numel() == 1:
-            # Sometimes scalar values aren't tensors with shapes
-            # so if both param and loaded_weight is a scalar,
+            # Sometimes scalar values aren't considered tensors with shapes
+            # so if both param and loaded_weight are a scalar,
             # "broadcast" instead of copy
             param.data.fill_(loaded_weight.item())
         else:

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -517,7 +517,9 @@ def default_weight_loader(param: torch.Tensor,
     """Default weight loader."""
     try:
         if param.numel() == 1 and loaded_weight.numel() == 1:
-            # If loaded_weight is a scalar or shape [1], broadcast it
+            # Sometimes scalar values aren't tensors with shapes
+            # so if both param and loaded_weight is a scalar,
+            # "broadcast" instead of copy
             param.data.fill_(loaded_weight.item())
         else:
             assert param.size() == loaded_weight.size(), (

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -516,11 +516,15 @@ def default_weight_loader(param: torch.Tensor,
                           loaded_weight: torch.Tensor) -> None:
     """Default weight loader."""
     try:
-        assert param.size() == loaded_weight.size(), (
-            f"Attempted to load weight ({loaded_weight.size()}) "
-            f"into parameter ({param.size()})")
+        if param.numel() == 1 and loaded_weight.numel() == 1:
+            # If loaded_weight is a scalar or shape [1], broadcast it
+            param.data.fill_(loaded_weight.item())
+        else:
+            assert param.size() == loaded_weight.size(), (
+                f"Attempted to load weight ({loaded_weight.size()}) "
+                f"into parameter ({param.size()})")
 
-        param.data.copy_(loaded_weight)
+            param.data.copy_(loaded_weight)
     except Exception:
         # NOTE: This exception is added for the purpose of setting breakpoint to
         # debug weight loading issues.


### PR DESCRIPTION
It is pretty easy to run into issues when loading scalar weights from checkpoints into parameters, since they can have no shape in some cases, resulting in errors like
```
  File "/home/mgoin/code/vllm/vllm/model_executor/model_loader/weight_utils.py", line 525, in default_weight_loader
    assert param.size() == loaded_weight.size(), (
AssertionError: Attempted to load weight (torch.Size([1])) into parameter (torch.Size([]))
```

I think it makes sense to detect and allow "broadcasting" in this special case for ease of use.