### PR TITLE
[Kernel] Use mutable_data_ptr or const_data_ptr instead of data_ptr

### DIFF
--- a/csrc/attention/attention_kernels.cu
+++ b/csrc/attention/attention_kernels.cu
@@ -711,16 +711,18 @@ void paged_attention_v1_launcher(
 
   // NOTE: alibi_slopes is optional.
   const float* alibi_slopes_ptr =
-      alibi_slopes
-          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
-          : nullptr;
+      alibi_slopes ? reinterpret_cast<const float*>(
+                         alibi_slopes.value().const_data_ptr())
+                   : nullptr;
 
-  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
-  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
-  CACHE_T* key_cache_ptr = reinterpret_cast<CACHE_T*>(key_cache.data_ptr());
-  CACHE_T* value_cache_ptr = reinterpret_cast<CACHE_T*>(value_cache.data_ptr());
-  int* block_tables_ptr = block_tables.data_ptr<int>();
-  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  T* out_ptr = reinterpret_cast<T*>(out.mutable_data_ptr());
+  auto query_ptr = reinterpret_cast<T const*>(query.const_data_ptr());
+  auto key_cache_ptr =
+      reinterpret_cast<CACHE_T const*>(key_cache.const_data_ptr());
+  auto value_cache_ptr =
+      reinterpret_cast<CACHE_T const*>(value_cache.const_data_ptr());
+  auto block_tables_ptr = block_tables.const_data_ptr<int>();
+  auto seq_lens_ptr = seq_lens.const_data_ptr<int>();
 
   constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
   int padded_max_seq_len =
@@ -870,19 +872,21 @@ void paged_attention_v2_launcher(
 
   // NOTE: alibi_slopes is optional.
   const float* alibi_slopes_ptr =
-      alibi_slopes
-          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
-          : nullptr;
+      alibi_slopes ? reinterpret_cast<const float*>(
+                         alibi_slopes.value().const_data_ptr())
+                   : nullptr;
 
-  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
-  float* exp_sums_ptr = reinterpret_cast<float*>(exp_sums.data_ptr());
-  float* max_logits_ptr = reinterpret_cast<float*>(max_logits.data_ptr());
-  T* tmp_out_ptr = reinterpret_cast<T*>(tmp_out.data_ptr());
-  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
-  CACHE_T* key_cache_ptr = reinterpret_cast<CACHE_T*>(key_cache.data_ptr());
-  CACHE_T* value_cache_ptr = reinterpret_cast<CACHE_T*>(value_cache.data_ptr());
-  int* block_tables_ptr = block_tables.data_ptr<int>();
-  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  auto out_ptr = reinterpret_cast<T*>(out.mutable_data_ptr());
+  auto exp_sums_ptr = reinterpret_cast<float*>(exp_sums.mutable_data_ptr());
+  auto max_logits_ptr = reinterpret_cast<float*>(max_logits.mutable_data_ptr());
+  auto tmp_out_ptr = reinterpret_cast<T*>(tmp_out.mutable_data_ptr());
+  auto query_ptr = reinterpret_cast<T const*>(query.const_data_ptr());
+  auto key_cache_ptr =
+      reinterpret_cast<CACHE_T const*>(key_cache.const_data_ptr());
+  auto value_cache_ptr =
+      reinterpret_cast<CACHE_T const*>(value_cache.const_data_ptr());
+  auto block_tables_ptr = block_tables.const_data_ptr<int>();
+  auto seq_lens_ptr = seq_lens.const_data_ptr<int>();
 
   constexpr int NUM_WARPS = NUM_THREADS / WARP_SIZE;
   int max_num_partitions = DIVIDE_ROUND_UP(max_seq_len, PARTITION_SIZE);

--- a/csrc/cache.h
+++ b/csrc/cache.h
@@ -5,29 +5,30 @@
 #include <map>
 #include <vector>
 
-void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
-                 const torch::Tensor& block_mapping);
+void swap_blocks(torch::Tensor const& src, torch::Tensor& dst,
+                 torch::Tensor const& block_mapping);
 
 // Note: the key_caches and value_caches vectors are constant but
 // not the Tensors they contain. The vectors need to be const refs
 // in order to satisfy pytorch's C++ operator registration code.
 void copy_blocks(std::vector<torch::Tensor> const& key_caches,
                  std::vector<torch::Tensor> const& value_caches,
-                 const torch::Tensor& block_mapping);
+                 torch::Tensor const& block_mapping);
 
-void reshape_and_cache(torch::Tensor& key, torch::Tensor& value,
+void reshape_and_cache(torch::Tensor const& key, torch::Tensor const& value,
                        torch::Tensor& key_cache, torch::Tensor& value_cache,
-                       torch::Tensor& slot_mapping,
-                       const std::string& kv_cache_dtype, const double k_scale,
-                       const double v_scale);
+                       torch::Tensor const& slot_mapping,
+                       std::string const& kv_cache_dtype, const double k_scale,
+                       double const v_scale);
 
-void reshape_and_cache_flash(torch::Tensor& key, torch::Tensor& value,
+void reshape_and_cache_flash(torch::Tensor const& key,
+                             torch::Tensor const& value,
                              torch::Tensor& key_cache,
                              torch::Tensor& value_cache,
-                             torch::Tensor& slot_mapping,
-                             const std::string& kv_cache_dtype,
-                             const double k_scale, const double v_scale);
+                             torch::Tensor const& slot_mapping,
+                             std::string const& kv_cache_dtype,
+                             double const k_scale, double const v_scale);
 
 // Just for unittest
-void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,
-                 const double scale, const std::string& kv_cache_dtype);
+void convert_fp8(torch::Tensor& dst_cache, torch::Tensor const& src_cache,
+                 double const scale, std::string const& kv_cache_dtype);

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -260,16 +260,16 @@ __global__ void reshape_and_cache_flash_kernel(
           slot_mapping.const_data_ptr<int64_t>(), key_stride, value_stride, \
           num_heads, head_size, block_size, x, k_scale, v_scale);
 
+// clang-format off
 void reshape_and_cache(
-    torch::Tensor& key,    // [num_tokens, num_heads, head_size]
-    torch::Tensor& value,  // [num_tokens, num_heads, head_size]
-    torch::Tensor&
-        key_cache,  // [num_blocks, num_heads, head_size/x, block_size, x]
-    torch::Tensor&
-        value_cache,  // [num_blocks, num_heads, head_size, block_size]
-    torch::Tensor& slot_mapping,  // [num_tokens]
-    const std::string& kv_cache_dtype, const double k_scale,
-    const double v_scale) {
+    torch::Tensor const& key,    // [num_tokens, num_heads, head_size]
+    torch::Tensor const& value,  // [num_tokens, num_heads, head_size]
+    torch::Tensor& key_cache,    // [num_blocks, num_heads, head_size/x, block_size, x]
+    torch::Tensor& value_cache,  // [num_blocks, num_heads, head_size, block_size]
+    torch::Tensor const& slot_mapping,  // [num_tokens]
+    std::string const& kv_cache_dtype, double const k_scale,
+    double const v_scale) {
+// clang-format on 
   int num_tokens = key.size(0);
   int num_heads = key.size(1);
   int head_size = key.size(2);
@@ -301,15 +301,16 @@ void reshape_and_cache(
           slot_mapping.const_data_ptr<int64_t>(), block_stride, key_stride, \
           value_stride, num_heads, head_size, block_size, k_scale, v_scale);
 
+// clang-format off
 void reshape_and_cache_flash(
-    torch::Tensor& key,        // [num_tokens, num_heads, head_size]
-    torch::Tensor& value,      // [num_tokens, num_heads, head_size]
-    torch::Tensor& key_cache,  // [num_blocks, block_size, num_heads, head_size]
-    torch::Tensor&
-        value_cache,  // [num_blocks, block_size, num_heads, head_size]
-    torch::Tensor& slot_mapping,  // [num_tokens]
-    const std::string& kv_cache_dtype, const double k_scale,
-    const double v_scale) {
+    torch::Tensor const& key,    // [num_tokens, num_heads, head_size]
+    torch::Tensor const& value,  // [num_tokens, num_heads, head_size]
+    torch::Tensor& key_cache,    // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor& value_cache,  // [num_blocks, block_size, num_heads, head_size]
+    torch::Tensor const& slot_mapping,  // [num_tokens]
+    std::string const& kv_cache_dtype, double const k_scale,
+    double const v_scale) {
+  // clang-format on
   int num_tokens = key.size(0);
   int num_heads = key.size(1);
   int head_size = key.size(2);
@@ -353,8 +354,8 @@ __global__ void convert_fp8_kernel(const Tin* __restrict__ src_cache,
       block_stride);
 
 // Only for testing.
-void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,
-                 const double scale, const std::string& kv_cache_dtype) {
+void convert_fp8(torch::Tensor& dst_cache, torch::Tensor const& src_cache,
+                 double const scale, std::string const& kv_cache_dtype) {
   torch::Device src_device = src_cache.device();
   torch::Device dst_device = dst_cache.device();
   TORCH_CHECK(src_device.is_cuda(), "src must be on a GPU")

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -21,7 +21,7 @@
 typedef __hip_bfloat16 __nv_bfloat16;
 #endif
 
-void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
+void swap_blocks(torch::Tensor const& src, torch::Tensor& dst,
                  const torch::Tensor& block_mapping) {
   torch::Device src_device = src.device();
   torch::Device dst_device = dst.device();
@@ -43,8 +43,8 @@ void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
   // synchronization.
   TORCH_CHECK(block_mapping.device().is_cpu(), "block_mapping must be on CPU");
 
-  char* src_ptr = static_cast<char*>(src.data_ptr());
-  char* dst_ptr = static_cast<char*>(dst.data_ptr());
+  auto src_ptr = static_cast<char const*>(src.const_data_ptr());
+  auto dst_ptr = static_cast<char*>(dst.mutable_data_ptr());
 
   const int64_t block_size_in_bytes = src.element_size() * src[0].numel();
   const at::cuda::OptionalCUDAGuard device_guard(
@@ -115,9 +115,9 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
   int64_t value_cache_ptrs[num_layers];
   for (int layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
     key_cache_ptrs[layer_idx] =
-        reinterpret_cast<int64_t>(key_caches[layer_idx].data_ptr());
+        reinterpret_cast<int64_t>(key_caches[layer_idx].const_data_ptr());
     value_cache_ptrs[layer_idx] =
-        reinterpret_cast<int64_t>(value_caches[layer_idx].data_ptr());
+        reinterpret_cast<int64_t>(value_caches[layer_idx].const_data_ptr());
   }
 
   // block_mapping is a 2D tensor with shape (num_pairs, 2).
@@ -141,9 +141,9 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
   VLLM_DISPATCH_FLOATING_AND_BYTE_TYPES(
       key_caches[0].scalar_type(), "copy_blocks_kernel", ([&] {
         vllm::copy_blocks_kernel<scalar_t><<<grid, block, 0, stream>>>(
-            key_cache_ptrs_tensor.data_ptr<int64_t>(),
-            value_cache_ptrs_tensor.data_ptr<int64_t>(),
-            block_mapping.data_ptr<int64_t>(), numel_per_block);
+            key_cache_ptrs_tensor.mutable_data_ptr<int64_t>(),
+            value_cache_ptrs_tensor.mutable_data_ptr<int64_t>(),
+            block_mapping.const_data_ptr<int64_t>(), numel_per_block);
       }));
 }
 
@@ -250,14 +250,14 @@ __global__ void reshape_and_cache_flash_kernel(
 // KV_T is the stored data type of kv-cache.
 // CACHE_T is the data type of key and value tensors.
 // KV_DTYPE is the real data type of kv-cache.
-#define CALL_RESHAPE_AND_CACHE(KV_T, CACHE_T, KV_DTYPE)               \
-  vllm::reshape_and_cache_kernel<KV_T, CACHE_T, KV_DTYPE>             \
-      <<<grid, block, 0, stream>>>(                                   \
-          reinterpret_cast<KV_T*>(key.data_ptr()),                    \
-          reinterpret_cast<KV_T*>(value.data_ptr()),                  \
-          reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),           \
-          reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),         \
-          slot_mapping.data_ptr<int64_t>(), key_stride, value_stride, \
+#define CALL_RESHAPE_AND_CACHE(KV_T, CACHE_T, KV_DTYPE)                     \
+  vllm::reshape_and_cache_kernel<KV_T, CACHE_T, KV_DTYPE>                   \
+      <<<grid, block, 0, stream>>>(                                         \
+          reinterpret_cast<KV_T const*>(key.const_data_ptr()),              \
+          reinterpret_cast<KV_T const*>(value.const_data_ptr()),            \
+          reinterpret_cast<CACHE_T*>(key_cache.mutable_data_ptr()),         \
+          reinterpret_cast<CACHE_T*>(value_cache.mutable_data_ptr()),       \
+          slot_mapping.const_data_ptr<int64_t>(), key_stride, value_stride, \
           num_heads, head_size, block_size, x, k_scale, v_scale);
 
 void reshape_and_cache(
@@ -291,14 +291,14 @@ void reshape_and_cache(
 // KV_T is the stored data type of kv-cache.
 // CACHE_T is the data type of key and value tensors.
 // KV_DTYPE is the real data type of kv-cache.
-#define CALL_RESHAPE_AND_CACHE_FLASH(KV_T, CACHE_T, KV_DTYPE)         \
-  vllm::reshape_and_cache_flash_kernel<KV_T, CACHE_T, KV_DTYPE>       \
-      <<<grid, block, 0, stream>>>(                                   \
-          reinterpret_cast<KV_T*>(key.data_ptr()),                    \
-          reinterpret_cast<KV_T*>(value.data_ptr()),                  \
-          reinterpret_cast<CACHE_T*>(key_cache.data_ptr()),           \
-          reinterpret_cast<CACHE_T*>(value_cache.data_ptr()),         \
-          slot_mapping.data_ptr<int64_t>(), block_stride, key_stride, \
+#define CALL_RESHAPE_AND_CACHE_FLASH(KV_T, CACHE_T, KV_DTYPE)               \
+  vllm::reshape_and_cache_flash_kernel<KV_T, CACHE_T, KV_DTYPE>             \
+      <<<grid, block, 0, stream>>>(                                         \
+          reinterpret_cast<KV_T const*>(key.const_data_ptr()),              \
+          reinterpret_cast<KV_T const*>(value.const_data_ptr()),            \
+          reinterpret_cast<CACHE_T*>(key_cache.mutable_data_ptr()),         \
+          reinterpret_cast<CACHE_T*>(value_cache.mutable_data_ptr()),       \
+          slot_mapping.const_data_ptr<int64_t>(), block_stride, key_stride, \
           value_stride, num_heads, head_size, block_size, k_scale, v_scale);
 
 void reshape_and_cache_flash(
@@ -348,8 +348,9 @@ __global__ void convert_fp8_kernel(const Tin* __restrict__ src_cache,
 
 #define CALL_CONVERT_FP8(Tout, Tin, KV_DTYPE)                                \
   vllm::convert_fp8_kernel<Tout, Tin, KV_DTYPE><<<grid, block, 0, stream>>>( \
-      reinterpret_cast<Tin*>(src_cache.data_ptr()),                          \
-      reinterpret_cast<Tout*>(dst_cache.data_ptr()), scale, block_stride);
+      reinterpret_cast<Tin const*>(src_cache.const_data_ptr()),              \
+      reinterpret_cast<Tout*>(dst_cache.mutable_data_ptr()), scale,          \
+      block_stride);
 
 // Only for testing.
 void convert_fp8(torch::Tensor& dst_cache, torch::Tensor& src_cache,

--- a/csrc/cpu/activation.cpp
+++ b/csrc/cpu/activation.cpp
@@ -3,7 +3,8 @@
 namespace {
 template <typename scalar_t, vec_op::FP32Vec8 (*func)(const vec_op::FP32Vec8&),
           bool is_gated>
-void activation_kernel(int num_tokens, int d, scalar_t* __restrict__ input,
+void activation_kernel(int num_tokens, int d,
+                       scalar_t const* __restrict__ input,
                        scalar_t* __restrict__ output) {
   using scalar_vec_t = vec_op::vec_t<scalar_t>;
   constexpr int VEC_ELEM_NUM = scalar_vec_t::get_elem_num();

--- a/csrc/cpu/activation.cpp
+++ b/csrc/cpu/activation.cpp
@@ -84,20 +84,21 @@ FORCE_INLINE vec_op::FP32Vec8 gelu_tanh_act(const vec_op::FP32Vec8& x) {
 }
 };  // namespace
 
-void silu_and_mul(torch::Tensor& out, torch::Tensor& input) {
+void silu_and_mul(torch::Tensor& out, torch::Tensor const& input) {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1) / 2;
 
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "silu_and_mul_impl", [&] {
     CPU_KERNEL_GUARD_IN(silu_and_mul_impl)
     activation_kernel<scalar_t, silu_act, true>(
-        num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+        num_tokens, d, input.const_data_ptr<scalar_t>(),
+        out.mutable_data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(silu_and_mul_impl)
   });
 }
 
-void gelu_and_mul(torch::Tensor& out,    // [..., d]
-                  torch::Tensor& input)  // [..., 2 * d]
+void gelu_and_mul(torch::Tensor& out,          // [..., d]
+                  torch::Tensor const& input)  // [..., 2 * d]
 {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1) / 2;
@@ -105,13 +106,14 @@ void gelu_and_mul(torch::Tensor& out,    // [..., d]
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_and_mul_impl", [&] {
     CPU_KERNEL_GUARD_IN(gelu_and_mul_impl)
     activation_kernel<scalar_t, gelu_act, true>(
-        num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+        num_tokens, d, input.const_data_ptr<scalar_t>(),
+        out.mutable_data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(gelu_and_mul_impl)
   });
 }
 
-void gelu_tanh_and_mul(torch::Tensor& out,    // [..., d]
-                       torch::Tensor& input)  // [..., 2 * d]
+void gelu_tanh_and_mul(torch::Tensor& out,          // [..., d]
+                       torch::Tensor const& input)  // [..., 2 * d]
 {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1) / 2;
@@ -120,44 +122,47 @@ void gelu_tanh_and_mul(torch::Tensor& out,    // [..., d]
       input.scalar_type(), "gelu_tanh_and_mul_impl", [&] {
         CPU_KERNEL_GUARD_IN(gelu_tanh_and_mul_impl)
         activation_kernel<scalar_t, gelu_tanh_act, true>(
-            num_tokens, d, input.data_ptr<scalar_t>(),
-            out.data_ptr<scalar_t>());
+            num_tokens, d, input.const_data_ptr<scalar_t>(),
+            out.mutable_data_ptr<scalar_t>());
         CPU_KERNEL_GUARD_OUT(gelu_tanh_and_mul_impl)
       });
 }
 
-void gelu_new(torch::Tensor& out, torch::Tensor& input) {
+void gelu_new(torch::Tensor& out, torch::Tensor const& input) {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1);
 
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_new_impl", [&] {
     CPU_KERNEL_GUARD_IN(gelu_new_impl)
     activation_kernel<scalar_t, gelu_new_act, false>(
-        num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+        num_tokens, d, input.const_data_ptr<scalar_t>(),
+        out.mutable_data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(gelu_new_impl)
   });
 }
 
-void gelu_fast(torch::Tensor& out, torch::Tensor& input) {
+void gelu_fast(torch::Tensor& out, torch::Tensor const& input) {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1);
 
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_fast_impl", [&] {
     CPU_KERNEL_GUARD_IN(gelu_fast_impl)
     activation_kernel<scalar_t, gelu_fast_act, false>(
-        num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+        num_tokens, d, input.const_data_ptr<scalar_t>(),
+        out.mutable_data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(gelu_fast_impl)
   });
 }
 
-void gelu_quick(torch::Tensor& out, torch::Tensor& input) {
+void gelu_quick(torch::Tensor& out, torch::Tensor const& input) {
   int num_tokens = input.numel() / input.size(-1);
   int d = input.size(-1);
 
   VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "gelu_quick_impl", [&] {
     CPU_KERNEL_GUARD_IN(gelu_quick_impl)
     activation_kernel<scalar_t, gelu_quick_act, false>(
-        num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
+        num_tokens, d, input.const_data_ptr<scalar_t>(),
+        out.mutable_data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(gelu_quick_impl)
   });
 }

--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -363,16 +363,17 @@ void paged_attention_v1_impl_launcher(
 
   // NOTE: alibi_slopes is optional.
   const float* alibi_slopes_ptr =
-      alibi_slopes
-          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
-          : nullptr;
+      alibi_slopes ? reinterpret_cast<const float*>(
+                         alibi_slopes.value().const_data_ptr())
+                   : nullptr;
 
-  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
-  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
-  T* key_cache_ptr = reinterpret_cast<T*>(key_cache.data_ptr());
-  T* value_cache_ptr = reinterpret_cast<T*>(value_cache.data_ptr());
-  int* block_tables_ptr = block_tables.data_ptr<int>();
-  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  auto out_ptr = reinterpret_cast<T*>(out.mutable_data_ptr());
+  auto query_ptr = reinterpret_cast<T const*>(query.const_data_ptr());
+  auto key_cache_ptr = reinterpret_cast<T const*>(key_cache.const_data_ptr());
+  auto value_cache_ptr =
+      reinterpret_cast<T const*>(value_cache.const_data_ptr());
+  auto block_tables_ptr = block_tables.const_data_ptr<int>();
+  auto seq_lens_ptr = seq_lens.const_data_ptr<int>();
 
   switch (head_size) {
     case 64:
@@ -677,19 +678,20 @@ void paged_attention_v2_impl_launcher(
 
   // NOTE: alibi_slopes is optional.
   const float* alibi_slopes_ptr =
-      alibi_slopes
-          ? reinterpret_cast<const float*>(alibi_slopes.value().data_ptr())
-          : nullptr;
+      alibi_slopes ? reinterpret_cast<const float*>(
+                         alibi_slopes.value().const_data_ptr())
+                   : nullptr;
 
-  T* out_ptr = reinterpret_cast<T*>(out.data_ptr());
-  float* exp_sums_ptr = reinterpret_cast<float*>(exp_sums.data_ptr());
-  float* max_logits_ptr = reinterpret_cast<float*>(max_logits.data_ptr());
-  T* tmp_out_ptr = reinterpret_cast<T*>(tmp_out.data_ptr());
-  T* query_ptr = reinterpret_cast<T*>(query.data_ptr());
-  T* key_cache_ptr = reinterpret_cast<T*>(key_cache.data_ptr());
-  T* value_cache_ptr = reinterpret_cast<T*>(value_cache.data_ptr());
-  int* block_tables_ptr = block_tables.data_ptr<int>();
-  int* seq_lens_ptr = seq_lens.data_ptr<int>();
+  auto out_ptr = reinterpret_cast<T*>(out.mutable_data_ptr());
+  auto exp_sums_ptr = reinterpret_cast<float*>(exp_sums.mutable_data_ptr());
+  auto max_logits_ptr = reinterpret_cast<float*>(max_logits.mutable_data_ptr());
+  auto tmp_out_ptr = reinterpret_cast<T*>(tmp_out.mutable_data_ptr());
+  auto query_ptr = reinterpret_cast<T const*>(query.const_data_ptr());
+  auto key_cache_ptr = reinterpret_cast<T const*>(key_cache.const_data_ptr());
+  auto value_cache_ptr =
+      reinterpret_cast<T const*>(value_cache.const_data_ptr());
+  auto block_tables_ptr = block_tables.const_data_ptr<int>();
+  auto seq_lens_ptr = seq_lens.const_data_ptr<int>();
 
   switch (head_size) {
     case 64:

--- a/csrc/cpu/cache.cpp
+++ b/csrc/cpu/cache.cpp
@@ -88,7 +88,7 @@ void reshape_and_cache_cpu_impl(
 // in order to satisfy pytorch's C++ operator registration code.
 void copy_blocks(std::vector<torch::Tensor> const& key_caches,
                  std::vector<torch::Tensor> const& value_caches,
-                 const torch::Tensor& block_mapping) {
+                 torch::Tensor const& block_mapping) {
   unsigned num_layers = key_caches.size();
   TORCH_CHECK(num_layers == value_caches.size());
   if (num_layers == 0) {
@@ -134,7 +134,7 @@ void reshape_and_cache(torch::Tensor const& key, torch::Tensor const& value,
       });
 }
 
-void swap_blocks(torch::Tensor& src, torch::Tensor& dst,
-                 const torch::Tensor& block_mapping) {
+void swap_blocks(torch::Tensor const& src, torch::Tensor& dst,
+                 torch::Tensor const& block_mapping) {
   TORCH_CHECK(false, "swap_blocks is unsupported on CPU.")
 }

--- a/csrc/cpu/cache.cpp
+++ b/csrc/cpu/cache.cpp
@@ -19,13 +19,13 @@ void copy_blocks_cpu_impl(std::vector<torch::Tensor> const& key_caches,
           element_num_per_block * mapping_pairs[pair][0].item<int64_t>();
       int64_t target_offset =
           element_num_per_block * mapping_pairs[pair][1].item<int64_t>();
-      scalar_t* key_cache_ptr = key_caches[layer].const_data_ptr<scalar_t>();
+      scalar_t* key_cache_ptr = key_caches[layer].mutable_data_ptr<scalar_t>();
       scalar_t* source_ptr = key_cache_ptr + source_offset;
       scalar_t* target_ptr = key_cache_ptr + target_offset;
       std::memcpy(target_ptr, source_ptr, block_bytes);
 
       scalar_t* value_cache_ptr =
-          value_caches[layer].const_data_ptr<scalar_t>();
+          value_caches[layer].mutable_data_ptr<scalar_t>();
       source_ptr = value_cache_ptr + source_offset;
       target_ptr = value_cache_ptr + target_offset;
       std::memcpy(target_ptr, source_ptr, block_bytes);

--- a/csrc/custom_all_reduce.cu
+++ b/csrc/custom_all_reduce.cu
@@ -50,14 +50,14 @@ fptr_t init_custom_ar(torch::Tensor& meta, torch::Tensor& rank_data,
  * 5. A[None].expand(2, -1, -1, -1): Not OK
  * 6. A[:, 1:, 1:]: Not OK
  */
-bool _is_weak_contiguous(torch::Tensor& t) {
+bool _is_weak_contiguous(torch::Tensor const& t) {
   return t.is_contiguous() ||
          (t.storage().nbytes() - t.storage_offset() * t.element_size() ==
           t.numel() * t.element_size());
 }
 
-bool should_custom_ar(torch::Tensor& inp, int64_t max_size, int64_t world_size,
-                      bool full_nvlink) {
+bool should_custom_ar(torch::Tensor const& inp, int64_t max_size,
+                      int64_t world_size, bool full_nvlink) {
   auto inp_size = inp.numel() * inp.element_size();
   // custom allreduce requires input byte size to be multiples of 16
   if (inp_size % 16 != 0) return false;
@@ -99,7 +99,7 @@ void _all_reduce(fptr_t _fa, torch::Tensor const& inp, torch::Tensor& out,
   }
 }
 
-void all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out) {
+void all_reduce_reg(fptr_t _fa, torch::Tensor const& inp, torch::Tensor& out) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(inp));
   auto stream = c10::cuda::getCurrentCUDAStream().stream();
   TORCH_CHECK_EQ(inp.scalar_type(), out.scalar_type());

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -258,12 +258,12 @@ class CustomAllreduce {
 
   // below are device pointers
   RankSignals sg_;
-  std::unordered_map<void*, RankData*> buffers_;
+  std::unordered_map<void const*, RankData*> buffers_;
   Signal* self_sg_;
 
   // stores the registered device pointers from all ranks
   RankData *d_rank_data_base_, *d_rank_data_end_;
-  std::vector<void*> graph_unreg_buffers_;
+  std::vector<void const*> graph_unreg_buffers_;
   // a map from IPC handles to opened IPC pointers
   std::map<IPC_KEY, char*> ipc_handles_;
 
@@ -342,7 +342,7 @@ class CustomAllreduce {
   }
 
   void register_buffer(const std::vector<std::string>& handles,
-                       const std::vector<int64_t>& offsets, void* self) {
+                       const std::vector<int64_t>& offsets, void const* self) {
     check_rank_data_capacity();
     RankData data;
     for (int i = 0; i < world_size_; i++) {
@@ -402,7 +402,7 @@ class CustomAllreduce {
    * will cause contention on NVLink bus.
    */
   template <typename T>
-  void allreduce(cudaStream_t stream, T* input, T* output, int size,
+  void allreduce(cudaStream_t stream, T const* input, T* output, int size,
                  int threads = 512, int block_limit = 36) {
     auto d = packed_t<T>::P::size;
     if (size % d != 0)

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -4,4 +4,4 @@
 
 void topk_softmax(torch::Tensor& topk_weights, torch::Tensor& topk_indices,
                   torch::Tensor& token_expert_indices,
-                  torch::Tensor& gating_output);
+                  torch::Tensor const& gating_output);

--- a/csrc/moe/topk_softmax_kernels.cu
+++ b/csrc/moe/topk_softmax_kernels.cu
@@ -480,7 +480,7 @@ void topk_softmax(
     torch::Tensor& topk_weights,                // [num_tokens, topk]
     torch::Tensor& topk_indices,                // [num_tokens, topk]
     torch::Tensor& token_expert_indices,        // [num_tokens, topk]
-    torch::Tensor& gating_output)               // [num_tokens, num_experts]
+    torch::Tensor const& gating_output)               // [num_tokens, num_experts]
 {
     const int num_experts = gating_output.size(-1);
     const int num_tokens = gating_output.numel() / num_experts;
@@ -494,11 +494,11 @@ void topk_softmax(
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
     torch::Tensor softmax_workspace = torch::empty({workspace_size}, gating_output.options());
     vllm::moe::topkGatingSoftmaxKernelLauncher(
-        gating_output.data_ptr<float>(),
-        topk_weights.data_ptr<float>(),
-        topk_indices.data_ptr<int>(),
-        token_expert_indices.data_ptr<int>(),
-        softmax_workspace.data_ptr<float>(),
+        gating_output.const_data_ptr<float>(),
+        topk_weights.mutable_data_ptr<float>(),
+        topk_indices.mutable_data_ptr<int>(),
+        token_expert_indices.mutable_data_ptr<int>(),
+        softmax_workspace.mutable_data_ptr<float>(),
         num_tokens,
         num_experts,
         topk,

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -26,38 +26,41 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
-void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
-              double epsilon);
+void rms_norm(torch::Tensor& out, torch::Tensor const& input,
+              torch::Tensor const& weight, double epsilon);
 
 void fused_add_rms_norm(torch::Tensor& input, torch::Tensor& residual,
-                        torch::Tensor& weight, double epsilon);
+                        torch::Tensor const& weight, double epsilon);
 
-void rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
+void rotary_embedding(torch::Tensor const& positions, torch::Tensor& query,
                       torch::Tensor& key, int64_t head_size,
-                      torch::Tensor& cos_sin_cache, bool is_neox);
+                      torch::Tensor const& cos_sin_cache, bool is_neox);
 
-void batched_rotary_embedding(torch::Tensor& positions, torch::Tensor& query,
-                              torch::Tensor& key, int64_t head_size,
-                              torch::Tensor& cos_sin_cache, bool is_neox,
+void batched_rotary_embedding(torch::Tensor const& positions,
+                              torch::Tensor& query, torch::Tensor& key,
+                              int64_t head_size,
+                              torch::Tensor const& cos_sin_cache, bool is_neox,
                               int64_t rot_dim,
-                              torch::Tensor& cos_sin_cache_offsets);
+                              torch::Tensor const& cos_sin_cache_offsets);
 
-void silu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void silu_and_mul(torch::Tensor& out, torch::Tensor const& input);
 
-void gelu_and_mul(torch::Tensor& out, torch::Tensor& input);
+void gelu_and_mul(torch::Tensor& out, torch::Tensor const& input);
 
-void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor& input);
+void gelu_tanh_and_mul(torch::Tensor& out, torch::Tensor const& input);
 
-void gelu_new(torch::Tensor& out, torch::Tensor& input);
+void gelu_new(torch::Tensor& out, torch::Tensor const& input);
 
-void gelu_fast(torch::Tensor& out, torch::Tensor& input);
+void gelu_fast(torch::Tensor& out, torch::Tensor const& input);
 
-void gelu_quick(torch::Tensor& out, torch::Tensor& input);
+void gelu_quick(torch::Tensor& out, torch::Tensor const& input);
 
 void advance_step(int64_t num_seqs, int64_t num_queries, int64_t block_size,
-                  torch::Tensor& input_tokens, torch::Tensor& sampled_token_ids,
+                  torch::Tensor& input_tokens,
+                  torch::Tensor const& sampled_token_ids,
                   torch::Tensor& input_positions, torch::Tensor& seq_lens,
-                  torch::Tensor& slot_mapping, torch::Tensor& block_tables);
+                  torch::Tensor& slot_mapping,
+                  torch::Tensor const& block_tables);
 
 #ifndef USE_ROCM
 torch::Tensor aqlm_gemm(const torch::Tensor& input, const torch::Tensor& codes,
@@ -70,56 +73,58 @@ torch::Tensor aqlm_dequant(const torch::Tensor& codes,
                            const torch::Tensor& codebooks,
                            const torch::Tensor& codebook_partition_sizes);
 
-torch::Tensor awq_gemm(torch::Tensor _in_feats, torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors, torch::Tensor _zeros,
-                       int64_t split_k_iters);
+torch::Tensor awq_gemm(torch::Tensor const& _in_feats,
+                       torch::Tensor const& _kernel,
+                       torch::Tensor const& _scaling_factors,
+                       torch::Tensor const& _zeros, int64_t split_k_iters);
 
-torch::Tensor awq_dequantize(torch::Tensor _kernel,
-                             torch::Tensor _scaling_factors,
-                             torch::Tensor _zeros, int64_t split_k_iters,
+torch::Tensor awq_dequantize(torch::Tensor const& _kernel,
+                             torch::Tensor const& _scaling_factors,
+                             torch::Tensor const& _zeros, int64_t split_k_iters,
                              int64_t thx, int64_t thy);
 
-torch::Tensor marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                          torch::Tensor& b_scales, torch::Tensor& workspace,
-                          int64_t size_m, int64_t size_n, int64_t size_k);
+torch::Tensor marlin_gemm(torch::Tensor const& a,
+                          torch::Tensor const& b_q_weight,
+                          torch::Tensor const& b_scales,
+                          torch::Tensor& workspace, int64_t size_m,
+                          int64_t size_n, int64_t size_k);
 
-torch::Tensor gptq_marlin_24_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                                  torch::Tensor& b_meta,
-                                  torch::Tensor& b_scales,
-                                  torch::Tensor& workspace,
-                                  vllm::ScalarTypeTorchPtr const& b_q_type,
-                                  int64_t size_m, int64_t size_n,
-                                  int64_t size_k);
+torch::Tensor gptq_marlin_24_gemm(
+    torch::Tensor const& a, torch::Tensor const& b_q_weight,
+    torch::Tensor const& b_meta, torch::Tensor const& b_scales,
+    torch::Tensor& workspace, vllm::ScalarTypeTorchPtr const& b_q_type,
+    int64_t size_m, int64_t size_n, int64_t size_k);
 
-torch::Tensor gptq_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                               torch::Tensor& b_scales, torch::Tensor& b_zeros,
-                               torch::Tensor& g_idx, torch::Tensor& perm,
-                               torch::Tensor& workspace,
-                               vllm::ScalarTypeTorchPtr const& b_q_type,
-                               int64_t size_m, int64_t size_n, int64_t size_k,
-                               bool is_k_full, bool has_zp,
-                               bool use_fp32_reduce);
+torch::Tensor gptq_marlin_gemm(
+    torch::Tensor const& a, torch::Tensor const& b_q_weight,
+    torch::Tensor const& b_scales, torch::Tensor const& b_zeros,
+    torch::Tensor const& g_idx, torch::Tensor const& perm,
+    torch::Tensor& workspace, vllm::ScalarTypeTorchPtr const& b_q_type,
+    int64_t size_m, int64_t size_n, int64_t size_k, bool is_k_full, bool has_zp,
+    bool use_fp32_reduce);
 
-torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
-                                 int64_t size_k, int64_t size_n,
-                                 int64_t num_bits);
+torch::Tensor gptq_marlin_repack(torch::Tensor const& b_q_weight,
+                                 torch::Tensor const& perm, int64_t size_k,
+                                 int64_t size_n, int64_t num_bits);
 
-torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
+torch::Tensor awq_marlin_repack(torch::Tensor const& b_q_weight, int64_t size_k,
                                 int64_t size_n, int64_t num_bits);
 
-torch::Tensor ggml_dequantize(torch::Tensor W, int8_t type, int64_t m,
+torch::Tensor ggml_dequantize(torch::Tensor const& W, int8_t type, int64_t m,
                               int64_t n);
 
-torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W, torch::Tensor X, int8_t type,
+torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor const& W,
+                                  torch::Tensor const& X, int8_t type,
                                   int64_t row);
 
-torch::Tensor ggml_mul_mat_a8(torch::Tensor W, torch::Tensor X, int8_t type,
-                              int64_t row);
+torch::Tensor ggml_mul_mat_a8(torch::Tensor const& W, torch::Tensor const& X,
+                              int8_t type, int64_t row);
 
-torch::Tensor fp8_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                              torch::Tensor& b_scales, torch::Tensor& workspace,
-                              int64_t num_bits, int64_t size_m, int64_t size_n,
-                              int64_t size_k);
+torch::Tensor fp8_marlin_gemm(torch::Tensor const& a,
+                              torch::Tensor const& b_q_weight,
+                              torch::Tensor const& b_scales,
+                              torch::Tensor& workspace, int64_t num_bits,
+                              int64_t size_m, int64_t size_n, int64_t size_k);
 
 bool cutlass_scaled_mm_supports_fp8(int64_t cuda_device_capability);
 
@@ -151,13 +156,14 @@ void static_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
 void dynamic_scaled_int8_quant(torch::Tensor& out, torch::Tensor const& input,
                                torch::Tensor& scales);
 
-void squeezellm_gemm(torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
-                     torch::Tensor lookup_table);
+void squeezellm_gemm(torch::Tensor const& vec, torch::Tensor const& mat,
+                     torch::Tensor& mul, torch::Tensor const& lookup_table);
 
-torch::Tensor gptq_gemm(torch::Tensor a, torch::Tensor b_q_weight,
-                        torch::Tensor b_gptq_qzeros,
-                        torch::Tensor b_gptq_scales, torch::Tensor b_g_idx,
-                        bool use_exllama, int64_t bit);
+torch::Tensor gptq_gemm(torch::Tensor const& a, torch::Tensor const& b_q_weight,
+                        torch::Tensor const& b_gptq_qzeros,
+                        torch::Tensor const& b_gptq_scales,
+                        torch::Tensor const& b_g_idx, bool use_exllama,
+                        int64_t bit);
 
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit);
 
@@ -171,29 +177,29 @@ void dynamic_per_token_scaled_fp8_quant(
     torch::Tensor& out, torch::Tensor const& input, torch::Tensor& scale,
     c10::optional<torch::Tensor> const& scale_ub);
 
-void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
-                          int64_t block_size, torch::Tensor sorted_token_ids,
-                          torch::Tensor experts_ids,
-                          torch::Tensor num_tokens_post_pad);
+void moe_align_block_size(torch::Tensor const& topk_ids, int64_t num_experts,
+                          int64_t block_size, torch::Tensor& sorted_token_ids,
+                          torch::Tensor& experts_ids,
+                          torch::Tensor& num_tokens_post_pad);
 
 #ifndef USE_ROCM
 using fptr_t = int64_t;
 fptr_t init_custom_ar(torch::Tensor& meta, torch::Tensor& rank_data,
-                      const std::vector<std::string>& handles,
-                      const std::vector<int64_t>& offsets, int64_t rank,
+                      std::vector<std::string> const& handles,
+                      std::vector<int64_t> const& offsets, int64_t rank,
                       bool full_nvlink);
-bool should_custom_ar(torch::Tensor& inp, int64_t max_size, int64_t world_size,
-                      bool full_nvlink);
-void all_reduce_reg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& out);
-void all_reduce_unreg(fptr_t _fa, torch::Tensor& inp, torch::Tensor& reg_buffer,
-                      torch::Tensor& out);
+bool should_custom_ar(torch::Tensor const& inp, int64_t max_size,
+                      int64_t world_size, bool full_nvlink);
+void all_reduce_reg(fptr_t _fa, torch::Tensor const& inp, torch::Tensor& out);
+void all_reduce_unreg(fptr_t _fa, torch::Tensor const& inp,
+                      torch::Tensor& reg_buffer, torch::Tensor& out);
 void dispose(fptr_t _fa);
 int64_t meta_size();
-void register_buffer(fptr_t _fa, torch::Tensor& t,
-                     const std::vector<std::string>& handles,
-                     const std::vector<int64_t>& offsets);
+void register_buffer(fptr_t _fa, torch::Tensor const& t,
+                     std::vector<std::string> const& handles,
+                     std::vector<int64_t> const& offsets);
 std::tuple<torch::Tensor, std::vector<int64_t>> get_graph_buffer_ipc_meta(
     fptr_t _fa);
-void register_graph_buffers(fptr_t _fa, const std::vector<std::string>& handles,
-                            const std::vector<std::vector<int64_t>>& offsets);
+void register_graph_buffers(fptr_t _fa, std::vector<std::string> const& handles,
+                            std::vector<std::vector<int64_t>> const& offsets);
 #endif

--- a/csrc/quantization/aqlm/gemm_kernels.cu
+++ b/csrc/quantization/aqlm/gemm_kernels.cu
@@ -416,9 +416,9 @@ void code1x16_matvec(
   int prob_m = C.size(0);
   int prob_k = B.size(0);
 
-  code1x16_matvec_cuda(A.data_ptr(), B.data_ptr(), C.data_ptr(),
-                       codebook.data_ptr(), prob_m, prob_k, codebook_a_sizes,
-                       codebook_stride(codebook));
+  code1x16_matvec_cuda(A.const_data_ptr(), B.const_data_ptr(),
+                       C.mutable_data_ptr(), codebook.const_data_ptr(), prob_m,
+                       prob_k, codebook_a_sizes, codebook_stride(codebook));
 }
 
 torch::Tensor code1x16_matmat(const torch::Tensor& input,
@@ -459,9 +459,9 @@ void code2x8_matvec(const torch::Tensor& A, const torch::Tensor& B,
   const at::cuda::OptionalCUDAGuard device_guard(device_of(A));
   int prob_m = C.size(0);
   int prob_k = B.size(0);
-  code2x8_matvec_cuda(A.data_ptr(), B.data_ptr(), C.data_ptr(),
-                      codebook.data_ptr(), prob_m, prob_k, codebook_a_sizes,
-                      2 * codebook_stride(codebook));
+  code2x8_matvec_cuda(A.const_data_ptr(), B.const_data_ptr(),
+                      C.mutable_data_ptr(), codebook.const_data_ptr(), prob_m,
+                      prob_k, codebook_a_sizes, 2 * codebook_stride(codebook));
 }
 
 torch::Tensor code2x8_matmat(const torch::Tensor& input,
@@ -565,10 +565,10 @@ torch::Tensor aqlm_dequant(const torch::Tensor& codes,
                                   .device(codebooks.device()));
 
   if (nbooks == 1 && entries == (1 << 16)) {
-    vllm::aqlm::code1x16_dequant_cuda(codes.data_ptr(), weights.data_ptr(),
-                                      codebooks.data_ptr(), out_features,
-                                      in_features, cumulative_sizes,
-                                      vllm::aqlm::codebook_stride(codebooks));
+    vllm::aqlm::code1x16_dequant_cuda(
+        codes.const_data_ptr(), weights.mutable_data_ptr(),
+        codebooks.const_data_ptr(), out_features, in_features, cumulative_sizes,
+        vllm::aqlm::codebook_stride(codebooks));
 
     // if you wanted to flip to scaling the weights, (though it's 30%-ish slower
     // and not consistent with gemv implementation.) weights *=
@@ -578,10 +578,10 @@ torch::Tensor aqlm_dequant(const torch::Tensor& codes,
   }
 
   if (nbooks == 2 && entries == (1 << 8)) {
-    vllm::aqlm::code2x8_dequant_cuda(codes.data_ptr(), weights.data_ptr(),
-                                     codebooks.data_ptr(), out_features,
-                                     in_features, cumulative_sizes,
-                                     vllm::aqlm::codebook_stride(codebooks));
+    vllm::aqlm::code2x8_dequant_cuda(
+        codes.const_data_ptr(), weights.mutable_data_ptr(),
+        codebooks.const_data_ptr(), out_features, in_features, cumulative_sizes,
+        vllm::aqlm::codebook_stride(codebooks));
 
     // if you wanted to flip to scaling the weights, (though it's 30%-ish slower
     // and not consistent with gemv implementation) weights *=

--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -413,9 +413,9 @@ __global__ void __launch_bounds__(64)
 }  // namespace awq
 }  // namespace vllm
 
-torch::Tensor awq_dequantize(torch::Tensor const _kernel,
-                             torch::Tensor const _scaling_factors,
-                             torch::Tensor const _zeros, int64_t split_k_iters,
+torch::Tensor awq_dequantize(torch::Tensor const& _kernel,
+                             torch::Tensor const& _scaling_factors,
+                             torch::Tensor const& _zeros, int64_t split_k_iters,
                              int64_t thx, int64_t thy) {
   int in_c = _kernel.size(0);
   int qout_c = _kernel.size(1);
@@ -470,9 +470,10 @@ torch::Tensor awq_dequantize(torch::Tensor const _kernel,
 // zeros: IC // G, OC // 8 [int32] -> cast to IC // G, OC [uint4b]
 // assume that batch_size < 16 for now
 
-torch::Tensor awq_gemm(torch::Tensor _in_feats, torch::Tensor _kernel,
-                       torch::Tensor _scaling_factors, torch::Tensor _zeros,
-                       int64_t split_k_iters) {
+torch::Tensor awq_gemm(torch::Tensor const& _in_feats,
+                       torch::Tensor const& _kernel,
+                       torch::Tensor const& _scaling_factors,
+                       torch::Tensor const& _zeros, int64_t split_k_iters) {
   int num_in_feats = _in_feats.size(0);
   int num_in_channels = _in_feats.size(1);
   const at::cuda::OptionalCUDAGuard device_guard(device_of(_in_feats));

--- a/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
+++ b/csrc/quantization/compressed_tensors/int8_quant_kernels.cu
@@ -87,9 +87,10 @@ void static_scaled_int8_quant(torch::Tensor& out,          // [..., hidden_size]
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "static_scaled_int8_quant_kernel", [&] {
         vllm::static_scaled_int8_quant_kernel<scalar_t, float>
-            <<<grid, block, 0, stream>>>(input.data_ptr<scalar_t>(),
-                                         out.data_ptr<int8_t>(),
-                                         scale.data_ptr<float>(), hidden_size);
+            <<<grid, block, 0, stream>>>(input.const_data_ptr<scalar_t>(),
+                                         out.mutable_data_ptr<int8_t>(),
+                                         scale.const_data_ptr<float>(),
+                                         hidden_size);
       });
 }
 
@@ -108,8 +109,9 @@ void dynamic_scaled_int8_quant(
   VLLM_DISPATCH_FLOATING_TYPES(
       input.scalar_type(), "dynamic_scaled_int8_quant_kernel", [&] {
         vllm::dynamic_scaled_int8_quant_kernel<scalar_t, float>
-            <<<grid, block, 0, stream>>>(input.data_ptr<scalar_t>(),
-                                         out.data_ptr<int8_t>(),
-                                         scales.data_ptr<float>(), hidden_size);
+            <<<grid, block, 0, stream>>>(input.const_data_ptr<scalar_t>(),
+                                         out.mutable_data_ptr<int8_t>(),
+                                         scales.mutable_data_ptr<float>(),
+                                         hidden_size);
       });
 }

--- a/csrc/quantization/fp8/fp8_marlin.cu
+++ b/csrc/quantization/fp8/fp8_marlin.cu
@@ -1209,10 +1209,11 @@ void marlin_mm_f16i4(const void* A, const void* B, void* C, const void* s,
 
 }  // namespace fp8_marlin
 
-torch::Tensor fp8_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                              torch::Tensor& b_scales, torch::Tensor& workspace,
-                              int64_t num_bits, int64_t size_m, int64_t size_n,
-                              int64_t size_k) {
+torch::Tensor fp8_marlin_gemm(torch::Tensor const& a,
+                              torch::Tensor const& b_q_weight,
+                              torch::Tensor const& b_scales,
+                              torch::Tensor& workspace, int64_t num_bits,
+                              int64_t size_m, int64_t size_n, int64_t size_k) {
   // Verify num_bits
   TORCH_CHECK(num_bits == 8, "num_bits must be 8. Got = ", num_bits);
   int pack_factor = 32 / num_bits;

--- a/csrc/quantization/fp8/fp8_marlin.cu
+++ b/csrc/quantization/fp8/fp8_marlin.cu
@@ -66,10 +66,11 @@ __global__ void Marlin(
 
 }  // namespace fp8_marlin
 
-torch::Tensor fp8_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                              torch::Tensor& b_scales, torch::Tensor& workspace,
-                              int64_t num_bits, int64_t size_m, int64_t size_n,
-                              int64_t size_k) {
+torch::Tensor fp8_marlin_gemm(torch::Tensor const& a,
+                              torch::Tensor const& b_q_weight,
+                              torch::Tensor const& b_scales,
+                              torch::Tensor& workspace, int64_t num_bits,
+                              int64_t size_m, int64_t size_n, int64_t size_k) {
   TORCH_CHECK_NOT_IMPLEMENTED(false,
                               "marlin_gemm(..) requires CUDA_ARCH >= 8.0");
   return torch::empty({1, 1});

--- a/csrc/quantization/gguf/gguf_kernel.cu
+++ b/csrc/quantization/gguf/gguf_kernel.cu
@@ -67,7 +67,8 @@ torch::Tensor ggml_dequantize(torch::Tensor W,  // quant weight
   at::Tensor DW = torch::empty({m, n}, options);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   const to_fp16_cuda_t to_fp16_cuda = ggml_get_to_fp16_cuda(type);
-  to_fp16_cuda((void*)W.data_ptr(), (half*)DW.data_ptr(), m * n, stream);
+  to_fp16_cuda((void*)W.const_data_ptr(), (half*)DW.mutable_data_ptr(), m * n,
+               stream);
   return DW;
 }
 
@@ -83,88 +84,98 @@ torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W,  // quant weight
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   options = torch::TensorOptions().dtype(torch::kInt32).device(W.device());
   at::Tensor quant_X = torch::empty({1, padded / 32 * 9}, options);
-  quantize_row_q8_1_cuda((half*)X.data_ptr(), (void*)quant_X.data_ptr(), col, 1,
-                         stream);
+  quantize_row_q8_1_cuda((half*)X.const_data_ptr(),
+                         (void*)quant_X.mutable_data_ptr(), col, 1, stream);
   switch (type) {
     case 2:
-      mul_mat_vec_q4_0_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q4_0_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 3:
-      mul_mat_vec_q4_1_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q4_1_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 6:
-      mul_mat_vec_q5_0_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q5_0_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 7:
-      mul_mat_vec_q5_1_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q5_1_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 8:
-      mul_mat_vec_q8_0_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q8_0_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 10:
-      mul_mat_vec_q2_K_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q2_K_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 11:
-      mul_mat_vec_q3_K_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q3_K_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 12:
-      mul_mat_vec_q4_K_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q4_K_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 13:
-      mul_mat_vec_q5_K_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q5_K_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 14:
-      mul_mat_vec_q6_K_q8_1_cuda((void*)W.data_ptr(), (void*)quant_X.data_ptr(),
-                                 (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_q6_K_q8_1_cuda((void*)W.const_data_ptr(),
+                                 (void*)quant_X.const_data_ptr(),
+                                 (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 16:
-      mul_mat_vec_iq2_xxs_q8_1_cuda((void*)W.data_ptr(),
-                                    (void*)quant_X.data_ptr(),
-                                    (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq2_xxs_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 17:
-      mul_mat_vec_iq2_xs_q8_1_cuda((void*)W.data_ptr(),
-                                   (void*)quant_X.data_ptr(),
-                                   (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq2_xs_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 18:
-      mul_mat_vec_iq3_xxs_q8_1_cuda((void*)W.data_ptr(),
-                                    (void*)quant_X.data_ptr(),
-                                    (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq3_xxs_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 19:
-      mul_mat_vec_iq1_s_q8_1_cuda((void*)W.data_ptr(),
-                                  (void*)quant_X.data_ptr(),
-                                  (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq1_s_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 20:
-      mul_mat_vec_iq4_nl_q8_1_cuda((void*)W.data_ptr(),
-                                   (void*)quant_X.data_ptr(),
-                                   (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq4_nl_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 21:
-      mul_mat_vec_iq3_s_q8_1_cuda((void*)W.data_ptr(),
-                                  (void*)quant_X.data_ptr(),
-                                  (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq3_s_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 22:
-      mul_mat_vec_iq2_s_q8_1_cuda((void*)W.data_ptr(),
-                                  (void*)quant_X.data_ptr(),
-                                  (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq2_s_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
     case 23:
-      mul_mat_vec_iq4_xs_q8_1_cuda((void*)W.data_ptr(),
-                                   (void*)quant_X.data_ptr(),
-                                   (half*)Y.data_ptr(), col, row, stream);
+      mul_mat_vec_iq4_xs_q8_1_cuda(
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, stream);
       break;
   }
   return Y;
@@ -183,59 +194,59 @@ torch::Tensor ggml_mul_mat_a8(torch::Tensor W,  // quant weight
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   options = torch::TensorOptions().dtype(torch::kInt32).device(W.device());
   at::Tensor quant_X = torch::empty({batch, padded / 32 * 9}, options);
-  quantize_row_q8_1_cuda((half*)X.data_ptr(), (void*)quant_X.data_ptr(), col,
-                         batch, stream);
+  quantize_row_q8_1_cuda((half*)X.const_data_ptr(),
+                         (void*)quant_X.mutable_data_ptr(), col, batch, stream);
 
   switch (type) {
     case 2:
       ggml_mul_mat_q4_0_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 3:
       ggml_mul_mat_q4_1_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 6:
       ggml_mul_mat_q5_0_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 7:
       ggml_mul_mat_q5_1_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 8:
       ggml_mul_mat_q8_0_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 10:
       ggml_mul_mat_q2_K_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 11:
       ggml_mul_mat_q3_K_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 12:
       ggml_mul_mat_q4_K_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 13:
       ggml_mul_mat_q5_K_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
     case 14:
       ggml_mul_mat_q6_K_q8_1_cuda(
-          (void*)W.data_ptr(), (void*)quant_X.data_ptr(), (half*)Y.data_ptr(),
-          col, row, batch, padded, row, stream);
+          (void*)W.const_data_ptr(), (void*)quant_X.const_data_ptr(),
+          (half*)Y.mutable_data_ptr(), col, row, batch, padded, row, stream);
       break;
   }
   return Y;

--- a/csrc/quantization/gguf/gguf_kernel.cu
+++ b/csrc/quantization/gguf/gguf_kernel.cu
@@ -59,7 +59,7 @@ static void quantize_row_q8_1_cuda(const half* x, void* vy, const int kx,
   quantize_q8_1<<<num_blocks, block_size, 0, stream>>>(x, vy, kx, kx_padded);
 }
 
-torch::Tensor ggml_dequantize(torch::Tensor W,  // quant weight
+torch::Tensor ggml_dequantize(torch::Tensor const& W,  // quant weight
                               int8_t type, int64_t m, int64_t n) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(W));
   auto options =
@@ -67,13 +67,13 @@ torch::Tensor ggml_dequantize(torch::Tensor W,  // quant weight
   at::Tensor DW = torch::empty({m, n}, options);
   cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
   const to_fp16_cuda_t to_fp16_cuda = ggml_get_to_fp16_cuda(type);
-  to_fp16_cuda((void*)W.const_data_ptr(), (half*)DW.mutable_data_ptr(), m * n,
-               stream);
+  to_fp16_cuda((void const*)W.const_data_ptr(), (half*)DW.mutable_data_ptr(),
+               m * n, stream);
   return DW;
 }
 
-torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W,  // quant weight
-                                  torch::Tensor X,  // input
+torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor const& W,  // quant weight
+                                  torch::Tensor const& X,  // input
                                   int8_t type, int64_t row) {
   int col = X.sizes()[1];
   const int padded = (col + 512 - 1) / 512 * 512;
@@ -181,8 +181,8 @@ torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W,  // quant weight
   return Y;
 }
 
-torch::Tensor ggml_mul_mat_a8(torch::Tensor W,  // quant weight
-                              torch::Tensor X,  // input
+torch::Tensor ggml_mul_mat_a8(torch::Tensor const& W,  // quant weight
+                              torch::Tensor const& X,  // input
                               int8_t type, int64_t row) {
   int col = X.sizes()[1];
   int padded = (col + 512 - 1) / 512 * 512;

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -1820,10 +1820,10 @@ void shuffle_exllama_weight(uint32_t* q_weight, int const* q_perm, int height,
 }  // namespace gptq
 }  // namespace vllm
 
-torch::Tensor gptq_gemm(torch::Tensor const a, torch::Tensor const b_q_weight,
-                        torch::Tensor const b_gptq_qzeros,
-                        torch::Tensor const b_gptq_scales,
-                        torch::Tensor const b_g_idx, bool use_exllama,
+torch::Tensor gptq_gemm(torch::Tensor const& a, torch::Tensor const& b_q_weight,
+                        torch::Tensor const& b_gptq_qzeros,
+                        torch::Tensor const& b_gptq_scales,
+                        torch::Tensor const& b_g_idx, bool use_exllama,
                         int64_t bit) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(a));
   auto options = torch::TensorOptions().dtype(a.dtype()).device(a.device());

--- a/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
@@ -11,9 +11,8 @@ __global__ void awq_marlin_repack_kernel(
 
 }  // namespace marlin
 
-torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
-                                int64_t size_k, int64_t size_n,
-                                int64_t num_bits) {
+torch::Tensor awq_marlin_repack(torch::Tensor const& b_q_weight, int64_t size_k,
+                                int64_t size_n, int64_t num_bits) {
   TORCH_CHECK_NOT_IMPLEMENTED(
       false, "marlin_repack_from_gptq(..) requires CUDA_ARCH >= 8.0");
   return torch::empty({1, 1});

--- a/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
@@ -205,7 +205,7 @@ __global__ void awq_marlin_repack_kernel(
               b_q_weight_ptr, out_ptr, size_k, size_n);                       \
     }
 
-torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
+torch::Tensor awq_marlin_repack(torch::Tensor const& b_q_weight, int64_t size_k,
                                 int64_t size_n, int64_t num_bits) {
   // Verify compatibility with marlin tile of 16x64
   TORCH_CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,

--- a/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/awq_marlin_repack.cu
@@ -241,8 +241,8 @@ torch::Tensor awq_marlin_repack(torch::Tensor& b_q_weight, int64_t size_k,
 
   // Get ptrs
   uint32_t const* b_q_weight_ptr =
-      reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr());
-  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out.data_ptr());
+      reinterpret_cast<uint32_t const*>(b_q_weight.const_data_ptr());
+  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out.mutable_data_ptr());
 
   // Get dev info
   int dev = b_q_weight.get_device();

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -74,13 +74,13 @@ __global__ void Marlin(
 
 }  // namespace marlin
 
-torch::Tensor gptq_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                               torch::Tensor& b_scales, torch::Tensor& b_zeros,
-                               torch::Tensor& g_idx, torch::Tensor& perm,
-                               torch::Tensor& workspace,
-                               vllm::ScalarTypeTorchPtr const& b_q_type,
-                               int64_t size_m, int64_t size_n, int64_t size_k,
-                               bool is_k_full, bool has_zp) {
+torch::Tensor gptq_marlin_gemm(
+    torch::Tensor const& a, torch::Tensor const& b_q_weight,
+    torch::Tensor const& b_scales, torch::Tensor const& b_zeros,
+    torch::Tensor const& g_idx, torch::Tensor const& perm,
+    torch::Tensor& workspace, vllm::ScalarTypeTorchPtr const const& b_q_type,
+    int64_t size_m, int64_t size_n, int64_t size_k, bool is_k_full,
+    bool has_zp) {
   TORCH_CHECK_NOT_IMPLEMENTED(false,
                               "marlin_gemm(..) requires CUDA_ARCH >= 8.0");
   return torch::empty({1, 1});
@@ -2126,14 +2126,13 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp,
 
 }  // namespace marlin
 
-torch::Tensor gptq_marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                               torch::Tensor& b_scales, torch::Tensor& b_zeros,
-                               torch::Tensor& g_idx, torch::Tensor& perm,
-                               torch::Tensor& workspace,
-                               vllm::ScalarTypeTorchPtr const& b_q_type,
-                               int64_t size_m, int64_t size_n, int64_t size_k,
-                               bool is_k_full, bool has_zp,
-                               bool use_fp32_reduce) {
+torch::Tensor gptq_marlin_gemm(
+    torch::Tensor const& a, torch::Tensor const& b_q_weight,
+    torch::Tensor const& b_scales, torch::Tensor const& b_zeros,
+    torch::Tensor const& g_idx, torch::Tensor const& perm,
+    torch::Tensor& workspace, vllm::ScalarTypeTorchPtr const& b_q_type,
+    int64_t size_m, int64_t size_n, int64_t size_k, bool is_k_full, bool has_zp,
+    bool use_fp32_reduce) {
   if (has_zp) {
     TORCH_CHECK(*b_q_type == vllm::kU4 || *b_q_type == vllm::kU8,
                 "b_q_type must be u4 or u8 when has_zp = True. Got = ",

--- a/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
@@ -312,9 +312,10 @@ torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
 
   // Get ptrs
   uint32_t const* b_q_weight_ptr =
-      reinterpret_cast<uint32_t const*>(b_q_weight.data_ptr());
-  uint32_t const* perm_ptr = reinterpret_cast<uint32_t const*>(perm.data_ptr());
-  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out.data_ptr());
+      reinterpret_cast<uint32_t const*>(b_q_weight.const_data_ptr());
+  uint32_t const* perm_ptr =
+      reinterpret_cast<uint32_t const*>(perm.const_data_ptr());
+  uint32_t* out_ptr = reinterpret_cast<uint32_t*>(out.mutable_data_ptr());
 
   // Get dev info
   int dev = b_q_weight.get_device();

--- a/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
@@ -268,9 +268,9 @@ __global__ void gptq_marlin_repack_kernel(
               b_q_weight_ptr, perm_ptr, out_ptr, size_k, size_n);             \
     }
 
-torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
-                                 int64_t size_k, int64_t size_n,
-                                 int64_t num_bits) {
+torch::Tensor gptq_marlin_repack(torch::Tensor const& b_q_weight,
+                                 torch::Tensor const& perm, int64_t size_k,
+                                 int64_t size_n, int64_t num_bits) {
   // Verify compatibility with marlin tile of 16x64
   TORCH_CHECK(size_k % marlin::tile_k_size == 0, "size_k = ", size_k,
               " is not divisible by tile_k_size = ", marlin::tile_k_size);

--- a/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin_repack.cu
@@ -12,9 +12,9 @@ __global__ void gptq_marlin_repack_kernel(
 
 }  // namespace marlin
 
-torch::Tensor gptq_marlin_repack(torch::Tensor& b_q_weight, torch::Tensor& perm,
-                                 int64_t size_k, int64_t size_n,
-                                 int64_t num_bits) {
+torch::Tensor gptq_marlin_repack(torch::Tensor const& b_q_weight,
+                                 torch::Tensor const& perm, int64_t size_k,
+                                 int64_t size_n, int64_t num_bits) {
   TORCH_CHECK_NOT_IMPLEMENTED(
       false, "marlin_repack_from_gptq(..) requires CUDA_ARCH >= 8.0");
   return torch::empty({1, 1});

--- a/csrc/quantization/marlin/dense/marlin_cuda_kernel.cu
+++ b/csrc/quantization/marlin/dense/marlin_cuda_kernel.cu
@@ -973,9 +973,11 @@ void marlin_cuda(void const* A, void const* B, void* C, void const* s,
 
 }  // namespace marlin_dense
 
-torch::Tensor marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                          torch::Tensor& b_scales, torch::Tensor& workspace,
-                          int64_t size_m, int64_t size_n, int64_t size_k) {
+torch::Tensor marlin_gemm(torch::Tensor const& a,
+                          torch::Tensor const& b_q_weight,
+                          torch::Tensor const& b_scales,
+                          torch::Tensor& workspace, int64_t size_m,
+                          int64_t size_n, int64_t size_k) {
   // Verify M
   TORCH_CHECK(size_m == a.size(0),
               "Shape mismatch: a.size(0) = " + str(a.size(0)) +

--- a/csrc/quantization/marlin/dense/marlin_cuda_kernel.cu
+++ b/csrc/quantization/marlin/dense/marlin_cuda_kernel.cu
@@ -868,10 +868,11 @@ thread_config_t determine_thread_config(int prob_m, int prob_n, int prob_k) {
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)
 
-void marlin_cuda(const void* A, const void* B, void* C, void* s, int prob_m,
-                 int prob_n, int prob_k, void* workspace, int groupsize = -1,
-                 int dev = 0, cudaStream_t stream = 0, int thread_k = -1,
-                 int thread_n = -1, int sms = -1, int max_par = 16) {
+void marlin_cuda(void const* A, void const* B, void* C, void const* s,
+                 int prob_m, int prob_n, int prob_k, void* workspace,
+                 int groupsize = -1, int dev = 0, cudaStream_t stream = 0,
+                 int thread_k = -1, int thread_n = -1, int sms = -1,
+                 int max_par = 16) {
   int tot_m = prob_m;
   int tot_m_blocks = ceildiv(tot_m, 16);
   int pad = 16 * tot_m_blocks - tot_m;
@@ -1058,9 +1059,10 @@ torch::Tensor marlin_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
                   " is below min_workspace_size = " + str(min_workspace_size));
 
   int dev = a.get_device();
-  marlin_dense::marlin_cuda(a.data_ptr(), b_q_weight.data_ptr(), c.data_ptr(),
-                            b_scales.data_ptr(), size_m, size_n, size_k,
-                            workspace.data_ptr(), groupsize, dev,
+  marlin_dense::marlin_cuda(a.const_data_ptr(), b_q_weight.const_data_ptr(),
+                            c.mutable_data_ptr(), b_scales.const_data_ptr(),
+                            size_m, size_n, size_k,
+                            workspace.mutable_data_ptr(), groupsize, dev,
                             at::cuda::getCurrentCUDAStream(dev), thread_k,
                             thread_n, sms, marlin_dense::max_par);
 

--- a/csrc/quantization/marlin/qqq/marlin_qqq_gemm_kernel.cu
+++ b/csrc/quantization/marlin/qqq/marlin_qqq_gemm_kernel.cu
@@ -1019,9 +1019,9 @@ thread_config_t determine_thread_config(int prob_m, int prob_n, int prob_k) {
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, -1, NUM_THREADS) \
   __CALL_IF(4, N_BLOCKS, K_BLOCKS, 8, NUM_THREADS)
 
-void marlin_qqq_cuda(const void* A, const void* B, void* C, void* D,
-                     void* s_tok, void* s_ch, void* s_group, int prob_m,
-                     int prob_n, int prob_k, void* workspace,
+void marlin_qqq_cuda(void const* A, void const* B, void* C, void* D,
+                     void const* s_tok, void const* s_ch, void const* s_group,
+                     int prob_m, int prob_n, int prob_k, void* workspace,
                      int groupsize = -1, int dev = 0, cudaStream_t stream = 0,
                      int thread_k = -1, int thread_n = -1, int sms = -1,
                      int max_par = 16) {
@@ -1234,9 +1234,10 @@ torch::Tensor marlin_qqq_gemm(torch::Tensor const& a,
 
   int dev = a.get_device();
   marlin_qqq_cuda(
-      a.data_ptr(), b_q_weight.data_ptr(), c.data_ptr(), d.data_ptr(),
-      s_tok.data_ptr(), s_ch.data_ptr(), s_group.data_ptr(), size_m, size_n,
-      size_k, workspace.data_ptr(), groupsize, dev,
+      a.const_data_ptr(), b_q_weight.const_data_ptr(), c.mutable_data_ptr(),
+      d.mutable_data_ptr(), s_tok.const_data_ptr(), s_ch.const_data_ptr(),
+      s_group.const_data_ptr(), size_m, size_n, size_k,
+      workspace.mutable_data_ptr(), groupsize, dev,
       at::cuda::getCurrentCUDAStream(dev), thread_k, thread_n, sms, max_par);
 
   return d;

--- a/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
+++ b/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
@@ -885,7 +885,7 @@ __global__ void Marlin_24(
   }
 
 void marlin_cuda_2_4(const void* A, const void* B, const void* meta, void* C,
-                     void* s, int prob_m, int prob_n, int prob_k,
+                     void const* s, int prob_m, int prob_n, int prob_k,
                      void* workspace, int num_bits, int groupsize = -1,
                      int dev = 0, cudaStream_t stream = 0, int thread_k = -1,
                      int thread_m = -1, int sms = -1, int max_par = 16) {
@@ -1127,9 +1127,9 @@ torch::Tensor gptq_marlin_24_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
 
   int dev = a.get_device();
   marlin_24::marlin_cuda_2_4(
-      a.data_ptr(), b_q_weight.data_ptr(), b_meta.data_ptr(), c.data_ptr(),
-      b_scales.data_ptr(), size_n, size_m, size_k, workspace.data_ptr(),
-      b_q_type->size_bits(), groupsize, dev,
+      a.const_data_ptr(), b_q_weight.const_data_ptr(), b_meta.const_data_ptr(),
+      c.mutable_data_ptr(), b_scales.const_data_ptr(), size_n, size_m, size_k,
+      workspace.mutable_data_ptr(), b_q_type->size_bits(), groupsize, dev,
       at::cuda::getCurrentCUDAStream(dev), thread_k, thread_m, sms, max_par);
 
   return c;

--- a/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
+++ b/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
@@ -1024,13 +1024,11 @@ void marlin_cuda_2_4(const void* A, const void* B, const void* meta, void* C,
 
 }  // namespace marlin_24
 
-torch::Tensor gptq_marlin_24_gemm(torch::Tensor& a, torch::Tensor& b_q_weight,
-                                  torch::Tensor& b_meta,
-                                  torch::Tensor& b_scales,
-                                  torch::Tensor& workspace,
-                                  vllm::ScalarTypeTorchPtr const& b_q_type,
-                                  int64_t size_m, int64_t size_n,
-                                  int64_t size_k) {
+torch::Tensor gptq_marlin_24_gemm(
+    torch::Tensor const& a, torch::Tensor const& b_q_weight,
+    torch::Tensor const& b_meta, torch::Tensor const& b_scales,
+    torch::Tensor& workspace, vllm::ScalarTypeTorchPtr const& b_q_type,
+    int64_t size_m, int64_t size_n, int64_t size_k) {
   // Verify num_bits
   TORCH_CHECK(*b_q_type == vllm::kU4B8 || *b_q_type == vllm::kU8B128,
               "num_bits must be uint4b8 or uint8b128. Got = ", b_q_type->str());

--- a/csrc/quantization/squeezellm/quant_cuda_kernel.cu
+++ b/csrc/quantization/squeezellm/quant_cuda_kernel.cu
@@ -181,8 +181,8 @@ __global__ void NUQ4MatMulKernel(
 }  // namespace vllm
 
 // 4-bit matvec kernel (LUT-based)
-void squeezellm_gemm(torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
-                     torch::Tensor lookup_table) {
+void squeezellm_gemm(torch::Tensor const& vec, torch::Tensor const& mat,
+                     torch::Tensor& mul, torch::Tensor const& lookup_table) {
   int height = mat.size(0);
   int width = mat.size(1);
 
@@ -193,22 +193,19 @@ void squeezellm_gemm(torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
               (width + BLOCKWIDTH - 1) / BLOCKWIDTH);
   dim3 threads(BLOCKWIDTH);
 
+#ifndef USE_ROCM
+  using MUL_TYPE = half2;
+#else
+  using MUL_TYPE = float2;
+#endif
+
   const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   vllm::squeezellm::NUQ4MatMulKernel<<<blocks, threads, 0, stream>>>(
-#ifndef USE_ROCM
-      (half2*)vec.data_ptr<at::Half>(),
-#else
-      (__half2*)vec.data_ptr<at::Half>(),
-#endif
-      mat.data_ptr<int>(),
-#ifndef USE_ROCM
-      (half2*)mul.data_ptr<at::Half>(),
-      (__half*)lookup_table.data_ptr<at::Half>(),
-#else
-      (float2*)mul.data_ptr<float>(),
-      (__half*)lookup_table.data_ptr<at::Half>(),
-#endif
+      reinterpret_cast<__half2 const*>(vec.const_data_ptr<at::Half>()),
+      mat.const_data_ptr<int>(),
+      reinterpret_cast<MUL_TYPE*>(mul.mutable_data_ptr()),
+      reinterpret_cast<__half const*>(lookup_table.const_data_ptr<at::Half>()),
       height, width, batch, vec_height);
 }
 


### PR DESCRIPTION
This PR removes every usage of `tensor.data_ptr` in the `csrc` directory and instead uses `mutable_data_ptr` and `const_data_ptr`. 

This change makes our code to be explicit about whether it modifies a tensor or not. Unfortunately, this will not prevent us from modifying tensors that are passed as const-reference, as a `Tensor const&` is treated as a const reference to a mutable buffer, as `mutable_data_ptr`[ is marked const](https://github.com/pytorch/pytorch/blob/51e13745be7052c02913db79b268e637c32546dd/aten/src/ATen/core/TensorBase.h#L585-L587).

See https://github.com/pytorch/pytorch/issues/97856, which is aimed at this issue and at least aims to make `data_ptr` return a const pointer.

Being more rigorous about constness uncovered a few issues where we were being lazy about converting from const to non-const pointers, so I also fixed several cases like that. I also marked tensors as const in several functions declared in `ops.h`, and changed several interfaces to pass tensors by reference (`const` where possible) instead of by value.  

