### PR TITLE
[Bugfix][Harmless] Fix hardcoded float16 dtype for model_is_embedding

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -66,7 +66,7 @@ def model_is_embedding(model_name: str, trust_remote_code: bool) -> bool:
                        tokenizer_mode="auto",
                        trust_remote_code=trust_remote_code,
                        seed=0,
-                       dtype="float16").embedding_mode
+                       dtype="auto").embedding_mode
 
 
 @asynccontextmanager


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/7561

On main you would see a concerning but harmless message about casting to float16 for models that are bfloat16:
```
vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct
...
WARNING 08-15 21:06:16 config.py:1514] Casting torch.bfloat16 to torch.float16.
INFO 08-15 21:06:16 api_server.py:111] Multiprocessing frontend to use ipc:///tmp/5c13e2e7-a88a-4ffa-bb14-492eaa9851f8 for RPC Path.
INFO 08-15 21:06:16 api_server.py:122] Started engine process with PID 265910
```

This PR removes that by making the `ModelConfig` made in `model_is_embedding` just use `dtype="auto"`:
```
vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct
...
INFO 08-15 21:05:58 api_server.py:111] Multiprocessing frontend to use ipc:///tmp/79226d04-56b8-4839-a94e-8da715e35d1c for RPC Path.
INFO 08-15 21:05:58 api_server.py:122] Started engine process with PID 265174
```


This is just a cosmetic issue since this config isn't actually used for loading the model, just to check if the model is for embedding