### PR TITLE
[Core] Use uvloop with zmq-decoupled front-end

### DIFF
--- a/vllm/entrypoints/openai/rpc/server.py
+++ b/vllm/entrypoints/openai/rpc/server.py
@@ -3,6 +3,7 @@ import signal
 from typing import Any, Coroutine
 
 import cloudpickle
+import uvloop
 import zmq
 import zmq.asyncio
 from typing_extensions import Never
@@ -217,4 +218,4 @@ async def run_server(server: AsyncEngineRPCServer):
 def run_rpc_server(async_engine_args: AsyncEngineArgs,
                    usage_context: UsageContext, rpc_path: str):
     server = AsyncEngineRPCServer(async_engine_args, usage_context, rpc_path)
-    asyncio.run(run_server(server))
+    uvloop.run(run_server(server))


### PR DESCRIPTION
It's faster than the native python asyncio event loop implementation. uvicorn already uses this but we need to enable it explicitly when starting the zmq RPC server based engine.