### PR TITLE
[CI/Build] Remove failing Minitron from LM Eval Small Test

### DIFF
--- a/.buildkite/lm-eval-harness/configs/models-small.txt
+++ b/.buildkite/lm-eval-harness/configs/models-small.txt
@@ -4,7 +4,6 @@ Meta-Llama-3-8B-Instruct-FP8-compressed-tensors.yaml
 Meta-Llama-3-8B-Instruct-INT8-compressed-tensors.yaml
 Meta-Llama-3-8B-Instruct-nonuniform-compressed-tensors.yaml
 Meta-Llama-3-8B-Instruct-Channelwise-compressed-tensors.yaml
-Minitron-4B-Base.yaml
 Qwen2-1.5B-Instruct-INT8-compressed-tensors.yaml
 Qwen2-1.5B-Instruct-FP8W8.yaml
 Meta-Llama-3-8B-QQQ.yaml


### PR DESCRIPTION
The Minitron lm eval config has been failing in CI during the "LM Eval Small Models" workflow. This PR removes the model from testing while we look for a long-term fix.

```bash
========================================================================================================================== FAILURES ==========================================================================================================================
__________________________________________________________________________________________________________________ test_lm_eval_correctness __________________________________________________________________________________________________________________

    def test_lm_eval_correctness():
        eval_config = yaml.safe_load(
            Path(TEST_DATA_FILE).read_text(encoding="utf-8"))
    
        # Launch eval requests.
>       results = launch_lm_eval(eval_config)

test_lm_eval_correctness.py:49: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_lm_eval_correctness.py:33: in launch_lm_eval
    results = lm_eval.simple_evaluate(
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/lm_eval/utils.py:395: in _wrapper
    return fn(*args, **kwargs)
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/lm_eval/evaluator.py:277: in simple_evaluate
    results = evaluate(
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/lm_eval/utils.py:395: in _wrapper
    return fn(*args, **kwargs)
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/lm_eval/evaluator.py:449: in evaluate
    resps = getattr(lm, reqtype)(cloned_reqs)
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/lm_eval/models/vllm_causallms.py:372: in generate_until
    eos = self.tokenizer.decode(self.eot_token_id)
/home/mgoin/venvs/vllm/lib/python3.10/site-packages/transformers/tokenization_utils_base.py:4034: in decode
    return self._decode(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = CachedPreTrainedTokenizerFast(name_or_path='nvidia/Minitron-4B-Base', vocab_size=256000, model_max_length=100000000000...alse),
        256000: AddedToken("<|pad|>", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
token_ids = None, skip_special_tokens = False, clean_up_tokenization_spaces = None, kwargs = {}

    def _decode(
        self,
        token_ids: Union[int, List[int]],
        skip_special_tokens: bool = False,
        clean_up_tokenization_spaces: bool = None,
        **kwargs,
    ) -> str:
        self._decode_use_source_tokenizer = kwargs.pop("use_source_tokenizer", False)
    
        if isinstance(token_ids, int):
            token_ids = [token_ids]
>       text = self._tokenizer.decode(token_ids, skip_special_tokens=skip_special_tokens)
E       TypeError: argument 'ids': 'NoneType' object cannot be converted to 'Sequence'

/home/mgoin/venvs/vllm/lib/python3.10/site-packages/transformers/tokenization_utils_fast.py:651: TypeError
```