### PR TITLE
[ci][test] allow longer wait time for api server

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -56,7 +56,7 @@ VLLM_PATH = Path(__file__).parent.parent
 
 class RemoteOpenAIServer:
     DUMMY_API_KEY = "token-abc123"  # vLLM's OpenAI server does not need API key
-    MAX_START_WAIT_S = 120  # wait for server to start for 120 seconds
+    MAX_START_WAIT_S = 240  # wait for server to start for 240 seconds
 
     def __init__(
         self,


### PR DESCRIPTION
https://buildkite.com/vllm/ci-aws/builds/7058#01915eee-35fa-47e4-8270-45cf9478723f
https://buildkite.com/vllm/ci-aws/builds/7058#01915eee-35fa-47e4-8270-45cf9478723f
https://buildkite.com/vllm/ci-aws/builds/7045#01915e5f-3959-4ef9-8670-e5753194b49c

all failed with:

> Server failed to start in time

let's try to increase the start time tolerance.