### PR TITLE
[Frontend] Publish  Prometheus metrics in run_batch API

### DIFF
--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -1,13 +1,13 @@
-from http import HTTPStatus
-
-import openai
-from prometheus_client.parser import text_string_to_metric_families
-import pytest
-import requests
 import subprocess
 import sys
 import tempfile
 import time
+from http import HTTPStatus
+
+import openai
+import pytest
+import requests
+from prometheus_client.parser import text_string_to_metric_families
 from transformers import AutoTokenizer
 
 from ...utils import RemoteOpenAIServer
@@ -184,35 +184,33 @@ async def test_metrics_exist(client: openai.AsyncOpenAI):
 
 
 def test_metrics_exist_run_batch():
-    input_batch = """{"custom_id": "request-0", "method": "POST", "url": "/v1/embeddings", "body": {"model": "intfloat/e5-mistral-7b-instruct", "input": "You are a helpful assistant."}}"""
+    input_batch = """{"custom_id": "request-0", "method": "POST", "url": "/v1/embeddings", "body": {"model": "intfloat/e5-mistral-7b-instruct", "input": "You are a helpful assistant."}}"""  # noqa: E501
 
     base_url = "0.0.0.0"
     port = "8001"
     server_url = f"http://{base_url}:{port}"
 
-    with tempfile.NamedTemporaryFile("w") as input_file, tempfile.NamedTemporaryFile(
-        "r"
-    ) as output_file:
+    with tempfile.NamedTemporaryFile(
+            "w") as input_file, tempfile.NamedTemporaryFile(
+                "r") as output_file:
         input_file.write(input_batch)
         input_file.flush()
-        proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "vllm.entrypoints.openai.run_batch",
-                "-i",
-                input_file.name,
-                "-o",
-                output_file.name,
-                "--model",
-                "intfloat/e5-mistral-7b-instruct",
-                "--enable-metrics",
-                "--url",
-                base_url,
-                "--port",
-                port,
-            ],
-        )
+        proc = subprocess.Popen([
+            sys.executable,
+            "-m",
+            "vllm.entrypoints.openai.run_batch",
+            "-i",
+            input_file.name,
+            "-o",
+            output_file.name,
+            "--model",
+            "intfloat/e5-mistral-7b-instruct",
+            "--enable-metrics",
+            "--url",
+            base_url,
+            "--port",
+            port,
+        ], )
 
         def is_server_up(url):
             try:

--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -1,9 +1,13 @@
 from http import HTTPStatus
 
 import openai
+from prometheus_client.parser import text_string_to_metric_families
 import pytest
 import requests
-from prometheus_client.parser import text_string_to_metric_families
+import subprocess
+import sys
+import tempfile
+import time
 from transformers import AutoTokenizer
 
 from ...utils import RemoteOpenAIServer
@@ -177,3 +181,50 @@ async def test_metrics_exist(client: openai.AsyncOpenAI):
 
     for metric in EXPECTED_METRICS:
         assert metric in response.text
+
+
+def test_metrics_exist_run_batch():
+    input_batch = """{"custom_id": "request-0", "method": "POST", "url": "/v1/embeddings", "body": {"model": "intfloat/e5-mistral-7b-instruct", "input": "You are a helpful assistant."}}"""
+
+    base_url = "0.0.0.0"
+    port = "8001"
+    server_url = f"http://{base_url}:{port}"
+
+    with tempfile.NamedTemporaryFile("w") as input_file, tempfile.NamedTemporaryFile(
+        "r"
+    ) as output_file:
+        input_file.write(input_batch)
+        input_file.flush()
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "vllm.entrypoints.openai.run_batch",
+                "-i",
+                input_file.name,
+                "-o",
+                output_file.name,
+                "--model",
+                "intfloat/e5-mistral-7b-instruct",
+                "--enable-metrics",
+                "--url",
+                base_url,
+                "--port",
+                port,
+            ],
+        )
+
+        def is_server_up(url):
+            try:
+                response = requests.get(url)
+                return response.status_code == 200
+            except requests.ConnectionError:
+                return False
+
+        while not is_server_up(server_url):
+            time.sleep(1)
+
+        response = requests.get(server_url + "/metrics")
+        assert response.status_code == HTTPStatus.OK
+
+        proc.wait()

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -60,7 +60,21 @@ def parse_args():
                         'ID numbers being printed in log.'
                         '\n\nDefault: Unlimited')
 
-    parser.add_argument("--port", type=int, default=8000, help="port number")
+    parser.add_argument(
+        "--enable-metrics", action="store_true", help="Enable Prometheus metrics"
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        default="0.0.0.0",
+        help="URL to the Prometheus metrics server",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port number for the Prometheus metrics server",
+    )
 
     return parser.parse_args()
 
@@ -192,6 +206,10 @@ if __name__ == "__main__":
 
     # Start the Prometheus metrics server. LLMEngine uses the Prometheus client
     # to publish metrics at the /metrics endpoint.
-    start_http_server(args.port)
+    if args.enable_metrics:
+        logger.info("Prometheus metrics enabled")
+        start_http_server(port=args.port, addr=args.url)
+    else:
+        logger.info("Prometheus metrics disabled")
 
     asyncio.run(main(args))

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -60,9 +60,9 @@ def parse_args():
                         'ID numbers being printed in log.'
                         '\n\nDefault: Unlimited')
 
-    parser.add_argument(
-        "--enable-metrics", action="store_true", help="Enable Prometheus metrics"
-    )
+    parser.add_argument("--enable-metrics",
+                        action="store_true",
+                        help="Enable Prometheus metrics")
     parser.add_argument(
         "--url",
         type=str,

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -67,13 +67,15 @@ def parse_args():
         "--url",
         type=str,
         default="0.0.0.0",
-        help="URL to the Prometheus metrics server",
+        help="URL to the Prometheus metrics server "
+        "(only needed if enable-metrics is set).",
     )
     parser.add_argument(
         "--port",
         type=int,
         default=8000,
-        help="Port number for the Prometheus metrics server",
+        help="Port number for the Prometheus metrics server "
+        "(only needed if enable-metrics is set).",
     )
 
     return parser.parse_args()

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -3,6 +3,7 @@ from io import StringIO
 from typing import Awaitable, Callable, List
 
 import aiohttp
+from prometheus_client import start_http_server
 
 from vllm.engine.arg_utils import AsyncEngineArgs, nullable_str
 from vllm.engine.async_llm_engine import AsyncLLMEngine
@@ -58,6 +59,8 @@ def parse_args():
                         help='Max number of prompt characters or prompt '
                         'ID numbers being printed in log.'
                         '\n\nDefault: Unlimited')
+
+    parser.add_argument("--port", type=int, default=8000, help="port number")
 
     return parser.parse_args()
 
@@ -186,5 +189,9 @@ if __name__ == "__main__":
 
     logger.info("vLLM API server version %s", VLLM_VERSION)
     logger.info("args: %s", args)
+
+    # Start the Prometheus metrics server. LLMEngine uses the Prometheus client
+    # to publish metrics at the /metrics endpoint.
+    start_http_server(args.port)
 
     asyncio.run(main(args))


### PR DESCRIPTION
The run_batch API currently doesn't publish Prometheus metrics because run_batch is not part of api_server that creates a Prometheus client in the server. This PR runs an http server using prometheus_client so that the metrics that get published by LLMEngine at the endpoint /metrics can be served.

