### PR TITLE
`[Core]` Added streaming support to `LLM` Class

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from typing import ClassVar, List, Optional, Sequence, Union, cast, overload
+from typing import ClassVar, Iterator, List, Optional, Sequence, Union, cast, overload
 
 from tqdm.auto import tqdm
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -192,6 +192,18 @@ class LLM:
             self.llm_engine.tokenizer.tokenizer = get_cached_tokenizer(
                 tokenizer)
 
+    def _run_stream_engine(self) -> Iterator[RequestOutput]:
+        """Executes a streaming engine that yields outputs from unfinished LLM requests.
+
+        Yields:
+            - Iterator[RequestOutput]: An iterator that produces outputs from the LLM
+            engine as they become available.
+        """
+        while self.llm_engine.has_unfinished_requests():
+            step_outputs = self.llm_engine.step()
+            for output in step_outputs:
+                yield output
+
     @overload  # LEGACY: single (prompt + optional token ids)
     def generate(
         self,
@@ -201,6 +213,7 @@ class LLM:
         prompt_token_ids: Optional[List[int]] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -213,6 +226,7 @@ class LLM:
         prompt_token_ids: Optional[List[List[int]]] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -226,6 +240,7 @@ class LLM:
         prompt_token_ids: List[int],
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -239,6 +254,7 @@ class LLM:
         prompt_token_ids: List[List[int]],
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -250,6 +266,7 @@ class LLM:
         prompt_token_ids: Union[List[int], List[List[int]]],
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -263,6 +280,7 @@ class LLM:
                                         Sequence[SamplingParams]]] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
+        stream: bool = False,
     ) -> List[RequestOutput]:
         ...
 
@@ -283,8 +301,9 @@ class LLM:
         lora_request: Optional[Union[List[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
-                                               GuidedDecodingRequest]] = None
-    ) -> List[RequestOutput]:
+                                               GuidedDecodingRequest]] = None,
+        stream: bool = False,
+    ) -> Union[List[RequestOutput], Iterator[RequestOutput]]:
         """Generates the completions for the input prompts.
 
         This class automatically batches the given prompts, considering
@@ -302,6 +321,7 @@ class LLM:
             lora_request: LoRA request to use for generation, if any.
             prompt_adapter_request: Prompt Adapter request to use for
                 generation, if any.
+            stream: Whether to stream the generated outputs.
 
         Returns:
             A list of ``RequestOutput`` objects containing the
@@ -344,8 +364,11 @@ class LLM:
             prompt_adapter_request=prompt_adapter_request,
             guided_options=guided_options_request)
 
-        outputs = self._run_engine(use_tqdm=use_tqdm)
-        return LLMEngine.validate_outputs(outputs, RequestOutput)
+        if stream:
+            return self._run_stream_engine()
+        else:
+            outputs = self._run_engine(use_tqdm=use_tqdm)
+            return LLMEngine.validate_outputs(outputs, RequestOutput)
 
     def chat(
         self,
@@ -656,7 +679,7 @@ class LLM:
                 decoding_config = self.llm_engine.get_decoding_config()
                 guided_options.guided_decoding_backend = (
                     decoding_config.guided_decoding_backend)
-            guided_logits_processor = get_local_guided_decoding_logits_processor(  #noqa
+            guided_logits_processor = get_local_guided_decoding_logits_processor(  # noqa
                 guided_options.guided_decoding_backend, guided_options,
                 self.get_tokenizer())
             if guided_logits_processor:
@@ -691,7 +714,8 @@ class LLM:
                         if isinstance(output, RequestOutput):
                             # Calculate tokens only for RequestOutput
                             total_in_toks += len(output.prompt_token_ids)
-                            in_spd = total_in_toks / pbar.format_dict["elapsed"]
+                            in_spd = total_in_toks / \
+                                pbar.format_dict["elapsed"]
                             total_out_toks += sum(
                                 len(stp.token_ids) for stp in output.outputs)
                             out_spd = (total_out_toks /

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
-from typing import ClassVar, Iterator, List, Optional, Sequence, Union, cast, overload
+from typing import (ClassVar, Iterator, List, Optional, Sequence, Union, cast,
+                    overload)
 
 from tqdm.auto import tqdm
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -193,11 +194,12 @@ class LLM:
                 tokenizer)
 
     def _run_stream_engine(self) -> Iterator[RequestOutput]:
-        """Executes a streaming engine that yields outputs from unfinished LLM requests.
+        """Executes a streaming engine that yields outputs from 
+        unfinished LLM requests.
 
         Yields:
-            - Iterator[RequestOutput]: An iterator that produces outputs from the LLM
-            engine as they become available.
+            - Iterator[RequestOutput]: An iterator that produces 
+            outputs from the LLM engine as they become available.
         """
         while self.llm_engine.has_unfinished_requests():
             step_outputs = self.llm_engine.step()


### PR DESCRIPTION
### Pull Request Summary

This pull request, based on #1052, introduces modifications to the `LLM` class to enable streaming when the `.generate()` method is invoked with the `stream=True` flag.

### Code Example

```python
from vllm import LLM, SamplingParams
prompts = [
    "Hello, my name is"
]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=200)
llm = LLM(model="gpt2")
tokenizer = llm.get_tokenizer()

outputs = llm.generate(prompts, sampling_params, stream=True)

for output in outputs:
    prompt = output.prompt
    last_token_id = output.outputs[0].token_ids[-1]
    last_token = tokenizer.decode(last_token_id)
    print(f"{last_token}", end="", flush=True)

```
### Important Considerations

- **Batch Generation:** When a batch of prompts is provided, tokens are produced sequentially for each batch (e.g., token 1 from batch 1, then token 1 from batch 2, etc.). This necessitates additional parsing logic.

- **Error Handling for Consistency:** To maintain consistent behaviour with `vllm/entrypoints/api_server.py`, where only a single input is supported, an error should be raised in `.generate` if a batch of inputs is provided with `stream=True`.