### PR TITLE
[Misc] Allow for unsigned zero NAN representation in ScalarType

### DIFF
--- a/csrc/core/scalar_type.hpp
+++ b/csrc/core/scalar_type.hpp
@@ -284,7 +284,10 @@ class ScalarType {
   }
 
   std::string str() const {
-    /* naming generally follows: https://github.com/jax-ml/ml_dtypes
+    /* naming generally follows:
+     *   https://github.com/jax-ml/ml_dtypes#specifications-of-implemented-floating-point-formats
+     *   https://onnx.ai/onnx/technical/float8.html
+     *   https://github.com/openxla/xla/blob/38c9f654dc308c1247374199a272ac636a5fb79e/xla/xla_data.proto#L85-L100
      * for floating point types (leading f) the scheme is:
      *  `float<size_bits>_e<exponent_bits>m<mantissa_bits>[flags]`
      *  flags:
@@ -292,7 +295,9 @@ class ScalarType {
      *  - b#: indicates a non-standard exponent bias of #
      *  - f: means finite values only (no infinities)
      *  - n: means nans are supported (non-standard encoding)
-     *  - uz: means NAN is represented using `-0.0`
+     *  - uz: means NAN is represented using `-0.0`, (freeing up all 1s for an
+     *        actual value), uz also implies the exponent_bias is increased by
+     *        1, this is the convention used by the references above
      * for integer types the scheme is:
      *  `[u]int<size_bits>[b<bias>]`
      *  - if bias is not present it means its zero

--- a/tests/test_scalartype.py
+++ b/tests/test_scalartype.py
@@ -14,6 +14,7 @@ from vllm.scalar_type import scalar_types
     (torch.uint8, scalar_types.uint8),
     (torch.float8_e5m2, scalar_types.float8_e5m2),
     (torch.float8_e4m3fn, scalar_types.float8_e4m3fn),
+    (torch.float8_e4m3fnuz, scalar_types.float8_e4m3fnuz),
     (torch.bfloat16, scalar_types.float16_e8m7),
     (torch.float16, scalar_types.float16_e5m10),
 ),

--- a/vllm/_core_ext.py
+++ b/vllm/_core_ext.py
@@ -218,6 +218,9 @@ elif core_C_available:
         def bias_getter(self) -> int:
             return self.ScalarType.bias
 
+        def exponent_bias_getter(self) -> int:
+            return self.ScalarType.exponent_bias
+
         def exponent_getter(self) -> int:
             return self.ScalarType.exponent
 

--- a/vllm/scalar_type.py
+++ b/vllm/scalar_type.py
@@ -1,13 +1,18 @@
 from ._core_ext import NanRepr, ScalarType
 
-# naming generally follows: https://github.com/jax-ml/ml_dtypes
+# naming generally follows:
+#   https://github.com/jax-ml/ml_dtypes#specifications-of-implemented-floating-point-formats
+#   https://onnx.ai/onnx/technical/float8.html
+#   https://github.com/openxla/xla/blob/38c9f654dc308c1247374199a272ac636a5fb79e/xla/xla_data.proto#L85-L100
 # for floating point types (leading f) the scheme is:
 #  `float<size_bits>_e<exponent_bits>m<mantissa_bits>[flags]`
 #  flags:
 #  - no-flags: means it follows IEEE 754 conventions
 #  - f: means finite values only (no infinities)
 #  - n: means nans are supported (non-standard encoding)
-#  - uz: means NAN is represented using `-0.0`
+#  - uz: means NAN is represented using `-0.0`, (freeing up all 1s for an actual
+#        value), uz also implies the exponent_bias is increased by 1, this is
+#        the convention used by the references above
 # for integer types the scheme is:
 #  `[u]int<size_bits>[b<bias>]`
 #  - if bias is not present it means its zero

--- a/vllm/scalar_type.py
+++ b/vllm/scalar_type.py
@@ -7,6 +7,7 @@ from ._core_ext import NanRepr, ScalarType
 #  - no-flags: means it follows IEEE 754 conventions
 #  - f: means finite values only (no infinities)
 #  - n: means nans are supported (non-standard encoding)
+#  - uz: means NAN is represented using `-0.0`
 # for integer types the scheme is:
 #  `[u]int<size_bits>[b<bias>]`
 #  - if bias is not present it means its zero
@@ -19,6 +20,8 @@ class scalar_types:
     uint8 = ScalarType.uint(8, None)
     float8_e4m3fn = ScalarType.float_(4, 3, True,
                                       NanRepr.EXTD_RANGE_MAX_MIN.value)
+    float8_e4m3fnuz = ScalarType.float_(4, 3, True,
+                                        NanRepr.EXTD_RANGE_NEG_ZERO.value)
     float8_e5m2 = ScalarType.float_IEEE754(5, 2)
     float16_e8m7 = ScalarType.float_IEEE754(8, 7)
     float16_e5m10 = ScalarType.float_IEEE754(5, 10)


### PR DESCRIPTION
Add support for `float8_e4m3fnuz` to ScalarType, (+some initial structure for non-standard exponent biases)