### PR TITLE
[Bugfix] Don't disable existing loggers

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -43,6 +43,7 @@ DEFAULT_LOGGING_CONFIG = {
         },
     },
     "version": 1,
+    "disable_existing_loggers": False
 }
 
 


### PR DESCRIPTION
One-liner that stops existing loggers from being disabled. By default, logging.dictConfig disables existing named loggers.

This bug only occurs when Ray is not installed (e.g. for AWS Neuron). This is because Ray adds this field to their logging configuration [here](https://github.com/ray-project/ray/blob/cd9dae2d80964f49e73919f06a4cc2079125707b/python/ray/_private/log.py#L115).

FIX #5803

## Code Example ##
```
import logging

logger = logging.getLogger("logger")

print(f"logger disabled: {logger.disabled}")
# Output: logger disabled: False

import vllm

print(f"logger disabled: {logger.disabled}")
# Before PR, if Ray is not installed:
# Output: logger disabled: True
# After PR:
# Output: logger disabled: False
```