### PR TITLE
[Misc] Add jinja2 as an explicit build requirement

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -5,3 +5,4 @@ packaging
 setuptools>=49.4.0
 torch==2.4.0
 wheel
+jinja2


### PR DESCRIPTION
Adding `jinja2` was missed in the final 'review comments' commit of the Machete kernel (https://github.com/vllm-project/vllm/pull/7691, https://github.com/vllm-project/vllm/pull/7174#discussion_r1722351387). `jinja2` is used by `csrc/quantization/machete/generate.py` during the build.

It is not really an issue since torch is a build requirement and [depends on jinja2](https://github.com/pytorch/pytorch/blob/2bd02e0c82c6d76157244655256062bade5070ae/requirements.txt#L16) but still good to explicit here

