### PR TITLE
[ci] try to log process using the port to debug the port usage

### DIFF
--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -52,8 +52,9 @@ async def serve_http(app: FastAPI, engine: AsyncEngineClient,
         port = uvicorn_kwargs["port"]
         process = find_process_using_port(port)
         if process is not None:
-            logger.debug("port %s is still in use by process %s", port,
-                         process)
+            logger.debug(
+                "port %s is used by process %s launched with command:\n%s",
+                port, process, " ".join(process.cmdline()))
         logger.info("Gracefully stopping http server")
         return server.shutdown()
 

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -10,6 +10,7 @@ from vllm import envs
 from vllm.engine.async_llm_engine import AsyncEngineDeadError
 from vllm.engine.protocol import AsyncEngineClient
 from vllm.logger import init_logger
+from vllm.utils import find_process_using_port
 
 logger = init_logger(__name__)
 
@@ -48,6 +49,11 @@ async def serve_http(app: FastAPI, engine: AsyncEngineClient,
         await server_task
         return dummy_shutdown()
     except asyncio.CancelledError:
+        port = uvicorn_kwargs["port"]
+        process = find_process_using_port(port)
+        if process is not None:
+            logger.debug("port %s is still in use by process %s", port,
+                         process)
         logger.info("Gracefully stopping http server")
         return server.shutdown()
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -547,6 +547,16 @@ def get_open_port() -> int:
             return s.getsockname()[1]
 
 
+def find_process_using_port(port: int) -> Optional[psutil.Process]:
+    for conn in psutil.net_connections():
+        if conn.laddr.port == port:
+            try:
+                return psutil.Process(conn.pid)
+            except psutil.NoSuchProcess:
+                return None
+    return None
+
+
 def update_environment_variables(envs: Dict[str, str]):
     for k, v in envs.items():
         if k in os.environ and os.environ[k] != v:


### PR DESCRIPTION
found in https://buildkite.com/vllm/ci-aws/builds/7212#01916eca-b3be-4d73-8eed-7987501bd353 and many other ci failures, we are trying to bind a port that is already used. however, we cannot find that process.

adding more information here.

note that it is under debug level, so it should not disturb normal users.