### PR TITLE
[Frontend] Improve Startup Failure UX

### DIFF
--- a/tests/entrypoints/openai/test_mp_api_server.py
+++ b/tests/entrypoints/openai/test_mp_api_server.py
@@ -1,4 +1,5 @@
 import pytest
+import time
 
 from vllm.entrypoints.openai.api_server import build_async_engine_client
 from vllm.entrypoints.openai.cli_args import make_arg_parser
@@ -6,21 +7,26 @@ from vllm.utils import FlexibleArgumentParser
 
 
 @pytest.mark.asyncio
-async def test_mp_crash_detection():
+async def test_mp_crash_detection(capfd):
 
-    with pytest.raises(RuntimeError) as excinfo:
-        parser = FlexibleArgumentParser(
-            description="vLLM's remote OpenAI server.")
-        parser = make_arg_parser(parser)
-        args = parser.parse_args([])
-        # use an invalid tensor_parallel_size to trigger the
-        # error in the server
-        args.tensor_parallel_size = 65536
+    parser = FlexibleArgumentParser(
+        description="vLLM's remote OpenAI server.")
+    parser = make_arg_parser(parser)
+    args = parser.parse_args([])
+    # use an invalid tensor_parallel_size to trigger the
+    # error in the server
+    args.tensor_parallel_size = 65536
 
-        async with build_async_engine_client(args):
-            pass
-    assert "The server process died before responding to the readiness probe"\
-          in str(excinfo.value)
+    start = time.perf_counter()
+    async with build_async_engine_client(args):
+        pass
+    end = time.perf_counter()
+
+    assert end - start < 60, (
+        "Expected vLLM to gracefully shutdown in <60s "
+        "if there is an error in the startup."
+    )
+
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_mp_api_server.py
+++ b/tests/entrypoints/openai/test_mp_api_server.py
@@ -8,7 +8,7 @@ from vllm.utils import FlexibleArgumentParser
 
 
 @pytest.mark.asyncio
-async def test_mp_crash_detection(capfd):
+async def test_mp_crash_detection():
 
     parser = FlexibleArgumentParser(description="vLLM's remote OpenAI server.")
     parser = make_arg_parser(parser)

--- a/tests/entrypoints/openai/test_mp_api_server.py
+++ b/tests/entrypoints/openai/test_mp_api_server.py
@@ -1,5 +1,6 @@
-import pytest
 import time
+
+import pytest
 
 from vllm.entrypoints.openai.api_server import build_async_engine_client
 from vllm.entrypoints.openai.cli_args import make_arg_parser
@@ -9,8 +10,7 @@ from vllm.utils import FlexibleArgumentParser
 @pytest.mark.asyncio
 async def test_mp_crash_detection(capfd):
 
-    parser = FlexibleArgumentParser(
-        description="vLLM's remote OpenAI server.")
+    parser = FlexibleArgumentParser(description="vLLM's remote OpenAI server.")
     parser = make_arg_parser(parser)
     args = parser.parse_args([])
     # use an invalid tensor_parallel_size to trigger the
@@ -22,11 +22,8 @@ async def test_mp_crash_detection(capfd):
         pass
     end = time.perf_counter()
 
-    assert end - start < 60, (
-        "Expected vLLM to gracefully shutdown in <60s "
-        "if there is an error in the startup."
-    )
-
+    assert end - start < 60, ("Expected vLLM to gracefully shutdown in <60s "
+                              "if there is an error in the startup.")
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -57,7 +57,8 @@ openai_serving_embedding: OpenAIServingEmbedding
 openai_serving_tokenization: OpenAIServingTokenization
 prometheus_multiproc_dir: tempfile.TemporaryDirectory
 
-logger = init_logger(__name__)
+# Cannot use __name__ (https://github.com/vllm-project/vllm/pull/4765)
+logger = init_logger('vllm.entrypoints.openai.api_server')
 
 _running_tasks: Set[asyncio.Task] = set()
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -92,6 +92,14 @@ async def lifespan(app: FastAPI):
 @asynccontextmanager
 async def build_async_engine_client(
     args) -> AsyncIterator[Optional[AsyncEngineClient]]:
+    """
+    Create AsyncEngineClient, either:
+        - in-process using the AsyncLLMEngine Directly
+        - multiprocess using AsyncLLMEngine RPC
+
+    Returns the Client or None if the creation failed.
+    """
+
     # Context manager to handle async_engine_client lifecycle
     # Ensures everything is shutdown and cleaned up on error/exit
     global engine_args

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -91,7 +91,7 @@ async def lifespan(app: FastAPI):
 
 @asynccontextmanager
 async def build_async_engine_client(
-    args) -> AsyncIterator[Optional[AsyncEngineClient]]:
+        args) -> AsyncIterator[Optional[AsyncEngineClient]]:
     """
     Create AsyncEngineClient, either:
         - in-process using the AsyncLLMEngine Directly
@@ -158,7 +158,7 @@ async def build_async_engine_client(
                 try:
                     await async_engine_client.setup()
                     break
-                except TimeoutError as e:
+                except TimeoutError:
                     if not rpc_server_process.is_alive():
                         logger.error(
                             "RPCServer process died before responding "
@@ -412,6 +412,7 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     logger.info("args: %s", args)
 
     async with build_async_engine_client(args) as async_engine_client:
+        # If None, creation of the client failed and we exit.
         if async_engine_client is None:
             return
 

--- a/vllm/entrypoints/openai/rpc/client.py
+++ b/vllm/entrypoints/openai/rpc/client.py
@@ -109,7 +109,7 @@ class AsyncEngineRPCClient:
 
             # Await acknowledgement from RPCServer.
             if timeout is not None and await socket.poll(timeout=timeout) == 0:
-                raise TimeoutError(f"server didn't reply within {timeout} ms")
+                raise TimeoutError(f"Server didn't reply within {timeout} ms")
 
             response = cloudpickle.loads(await socket.recv())
 


### PR DESCRIPTION
SUMMARY:
- currently, when the RPCServer fails during initialization, we throw a RuntimeError and a TimeoutError on the RPCClient and crash, alerting the user that we died during startup
- this is confusing, because the useful source of the error is far up in the stack trace
- this PR instead logs an `ERROR`, and exits gracefully, such that the true error is at the top of the stack trace

After the change, the logs look like this on error:

```bash
(venv) (base) rshaw@beaker:~/vllm$ vllm serve $MODEL --tensor-parallel-size 3
INFO 08-21 03:42:15 api_server.py:411] vLLM API server version 0.5.4
INFO 08-21 03:42:15 api_server.py:412] args: Namespace(model_tag='meta-llama/Meta-Llama-3-8B-Instruct', host=None, port=8000, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, model='meta-llama/Meta-Llama-3-8B-Instruct', tokenizer=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, download_dir=None, load_format='auto', dtype='auto', kv_cache_dtype='auto', quantization_param_path=None, max_model_len=None, guided_decoding_backend='outlines', distributed_executor_backend=None, worker_use_ray=False, pipeline_parallel_size=1, tensor_parallel_size=3, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=16, enable_prefix_caching=False, disable_sliding_window=False, use_v2_block_manager=False, num_lookahead_slots=0, seed=0, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_num_batched_tokens=None, max_num_seqs=256, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, enforce_eager=False, max_context_len_to_capture=None, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, limit_mm_per_prompt=None, enable_lora=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, scheduler_delay_factor=0.0, enable_chunked_prefill=None, speculative_model=None, speculative_model_quantization=None, num_speculative_tokens=None, speculative_draft_tensor_parallel_size=None, speculative_max_model_len=None, speculative_disable_by_batch_size=None, ngram_prompt_lookup_max=None, ngram_prompt_lookup_min=None, spec_decoding_acceptance_method='rejection_sampler', typical_acceptance_sampler_posterior_threshold=None, typical_acceptance_sampler_posterior_alpha=None, disable_logprobs_during_spec_decoding=None, model_loader_extra_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=None, qlora_adapter_name_or_path=None, otlp_traces_endpoint=None, collect_detailed_traces=None, engine_use_ray=False, disable_log_requests=False, max_log_len=None, dispatch_function=<function serve at 0x7f5ad4e219e0>)
INFO 08-21 03:42:16 api_server.py:140] Multiprocessing frontend to use ipc:///tmp/763f7a10-3a2f-4e9f-90f2-3f6aa1d701db for RPC Path.
INFO 08-21 03:42:16 api_server.py:151] Started engine process with PID 2402603
INFO 08-21 03:42:19 config.py:807] Defaulting to use ray for distributed inference
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/server.py", line 222, in run_rpc_server
    server = AsyncEngineRPCServer(async_engine_args, usage_context, rpc_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/server.py", line 26, in __init__
    self.engine = AsyncLLMEngine.from_engine_args(async_engine_args,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/engine/async_llm_engine.py", line 726, in from_engine_args
    engine_config = engine_args.create_engine_config()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/engine/arg_utils.py", line 976, in create_engine_config
    return EngineConfig(
           ^^^^^^^^^^^^^
  File "<string>", line 14, in __init__
  File "/home/rshaw/vllm/vllm/config.py", line 1759, in __post_init__
    self.model_config.verify_with_parallel_config(self.parallel_config)
  File "/home/rshaw/vllm/vllm/config.py", line 331, in verify_with_parallel_config
    raise ValueError(
ValueError: Total number of attention heads (32) must be divisible by tensor parallel size (3).
ERROR 08-21 03:42:20 api_server.py:163] RPCServer process died before responding to readiness probe
```

before the change, the logs look like this:

```bash
(venv) (base) rshaw@beaker:~/vllm$ vllm serve $MODEL --tensor-parallel-size 3
INFO 08-21 03:42:51 api_server.py:400] vLLM API server version 0.5.4
INFO 08-21 03:42:51 api_server.py:401] args: Namespace(model_tag='meta-llama/Meta-Llama-3-8B-Instruct', host=None, port=8000, uvicorn_log_level='info', allow_credentials=False, allowed_origins=['*'], allowed_methods=['*'], allowed_headers=['*'], api_key=None, lora_modules=None, prompt_adapters=None, chat_template=None, response_role='assistant', ssl_keyfile=None, ssl_certfile=None, ssl_ca_certs=None, ssl_cert_reqs=0, root_path=None, middleware=[], return_tokens_as_token_ids=False, disable_frontend_multiprocessing=False, model='meta-llama/Meta-Llama-3-8B-Instruct', tokenizer=None, skip_tokenizer_init=False, revision=None, code_revision=None, tokenizer_revision=None, tokenizer_mode='auto', trust_remote_code=False, download_dir=None, load_format='auto', dtype='auto', kv_cache_dtype='auto', quantization_param_path=None, max_model_len=None, guided_decoding_backend='outlines', distributed_executor_backend=None, worker_use_ray=False, pipeline_parallel_size=1, tensor_parallel_size=3, max_parallel_loading_workers=None, ray_workers_use_nsight=False, block_size=16, enable_prefix_caching=False, disable_sliding_window=False, use_v2_block_manager=False, num_lookahead_slots=0, seed=0, swap_space=4, cpu_offload_gb=0, gpu_memory_utilization=0.9, num_gpu_blocks_override=None, max_num_batched_tokens=None, max_num_seqs=256, max_logprobs=20, disable_log_stats=False, quantization=None, rope_scaling=None, rope_theta=None, enforce_eager=False, max_context_len_to_capture=None, max_seq_len_to_capture=8192, disable_custom_all_reduce=False, tokenizer_pool_size=0, tokenizer_pool_type='ray', tokenizer_pool_extra_config=None, limit_mm_per_prompt=None, enable_lora=False, max_loras=1, max_lora_rank=16, lora_extra_vocab_size=256, lora_dtype='auto', long_lora_scaling_factors=None, max_cpu_loras=None, fully_sharded_loras=False, enable_prompt_adapter=False, max_prompt_adapters=1, max_prompt_adapter_token=0, device='auto', num_scheduler_steps=1, scheduler_delay_factor=0.0, enable_chunked_prefill=None, speculative_model=None, speculative_model_quantization=None, num_speculative_tokens=None, speculative_draft_tensor_parallel_size=None, speculative_max_model_len=None, speculative_disable_by_batch_size=None, ngram_prompt_lookup_max=None, ngram_prompt_lookup_min=None, spec_decoding_acceptance_method='rejection_sampler', typical_acceptance_sampler_posterior_threshold=None, typical_acceptance_sampler_posterior_alpha=None, disable_logprobs_during_spec_decoding=None, model_loader_extra_config=None, ignore_patterns=[], preemption_mode=None, served_model_name=None, qlora_adapter_name_or_path=None, otlp_traces_endpoint=None, collect_detailed_traces=None, engine_use_ray=False, disable_log_requests=False, max_log_len=None, dispatch_function=<function serve at 0x7d9fe5260b80>)
INFO 08-21 03:42:51 api_server.py:131] Multiprocessing frontend to use ipc:///tmp/3ac3bbb2-51b7-4c67-b120-4bb2a8642d2d for RPC Path.
INFO 08-21 03:42:51 api_server.py:142] Started engine process with PID 2403196
INFO 08-21 03:42:54 config.py:807] Defaulting to use ray for distributed inference
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/server.py", line 222, in run_rpc_server
    server = AsyncEngineRPCServer(async_engine_args, usage_context, rpc_path)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/server.py", line 26, in __init__
    self.engine = AsyncLLMEngine.from_engine_args(async_engine_args,
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/engine/async_llm_engine.py", line 726, in from_engine_args
    engine_config = engine_args.create_engine_config()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/engine/arg_utils.py", line 976, in create_engine_config
    return EngineConfig(
           ^^^^^^^^^^^^^
  File "<string>", line 14, in __init__
  File "/home/rshaw/vllm/vllm/config.py", line 1759, in __post_init__
    self.model_config.verify_with_parallel_config(self.parallel_config)
  File "/home/rshaw/vllm/vllm/config.py", line 331, in verify_with_parallel_config
    raise ValueError(
ValueError: Total number of attention heads (32) must be divisible by tensor parallel size (3).
Traceback (most recent call last):
  File "/home/rshaw/vllm/vllm/entrypoints/openai/api_server.py", line 150, in build_async_engine_client
    await async_engine_client.setup()
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/client.py", line 35, in setup
    await self.wait_for_server()
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/client.py", line 136, in wait_for_server
    await self._send_one_way_rpc_request(
  File "/home/rshaw/vllm/vllm/entrypoints/openai/rpc/client.py", line 112, in _send_one_way_rpc_request
    raise TimeoutError(f"server didn't reply within {timeout} ms")
TimeoutError: server didn't reply within 1000 ms

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/rshaw/vllm/venv/bin/vllm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/rshaw/vllm/vllm/scripts.py", line 156, in main
    args.dispatch_function(args)
  File "/home/rshaw/vllm/vllm/scripts.py", line 37, in serve
    asyncio.run(run_server(args))
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/entrypoints/openai/api_server.py", line 403, in run_server
    async with build_async_engine_client(args) as async_engine_client:
  File "/home/rshaw/.pyenv/versions/3.11.9/lib/python3.11/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/rshaw/vllm/vllm/entrypoints/openai/api_server.py", line 154, in build_async_engine_client
    raise RuntimeError(
RuntimeError: The server process died before responding to the readiness probe
```

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


