### PR TITLE
[Bugfix] Mirror jinja2 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     "setuptools >= 49.4.0",
     "torch == 2.4.0",
     "wheel",
+    "jinja2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
In #7695, `jinja2` was added to `requirements-build.txt` but was not mirrored in `pyproject.toml`, causing build errors in a clean environment such as `cibuildwheel`.

https://github.com/sasha0552/pascal-pkgs-ci/actions/runs/10485853952/job/29042838246