### PR TITLE
Combine async postprocessor and multi-step - first WIP version

### DIFF
--- a/tests/async_engine/test_async_llm_engine.py
+++ b/tests/async_engine/test_async_llm_engine.py
@@ -126,8 +126,7 @@ def test_asyncio_run():
     )
 
     engine = AsyncLLMEngine.from_engine_args(
-        AsyncEngineArgs(model="facebook/opt-125m",
-                        disable_output_proc_callback=False))
+        AsyncEngineArgs(model="facebook/opt-125m"))
 
     async def run(prompt: str):
         sampling_params = SamplingParams(

--- a/tests/async_engine/test_async_llm_engine.py
+++ b/tests/async_engine/test_async_llm_engine.py
@@ -126,7 +126,8 @@ def test_asyncio_run():
     )
 
     engine = AsyncLLMEngine.from_engine_args(
-        AsyncEngineArgs(model="facebook/opt-125m"))
+        AsyncEngineArgs(model="facebook/opt-125m",
+                        disable_output_proc_callback=False))
 
     async def run(prompt: str):
         sampling_params = SamplingParams(

--- a/tests/core/test_chunked_prefill_scheduler.py
+++ b/tests/core/test_chunked_prefill_scheduler.py
@@ -21,7 +21,7 @@ def append_new_token(seq_group, token_id: int):
 
 
 def schedule_and_update_computed_tokens(scheduler):
-    metas, out = scheduler.schedule()
+    metas, out, _, _ = scheduler.schedule()
     for s, meta in zip(out.scheduled_seq_groups, metas):
         s.seq_group.update_num_computed_tokens(meta.token_chunk_size)
     return metas, out
@@ -180,7 +180,7 @@ def test_maximal_decoding():
     """Verify decoding requests are prioritized."""
     block_size = 4
     max_seqs = 2
-    max_model_len = 2
+    max_model_len = 8
     max_num_batched_tokens = 2
     scheduler_config = SchedulerConfig(max_num_batched_tokens,
                                        max_seqs,

--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -199,7 +199,7 @@ def append_new_token(out, token_id: int):
 
 
 def schedule_and_update_computed_tokens(scheduler):
-    metas, out = scheduler.schedule()
+    metas, out, _, _ = scheduler.schedule()
     for s, meta in zip(out.scheduled_seq_groups, metas):
         s.seq_group.update_num_computed_tokens(meta.token_chunk_size)
     return metas, out

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -49,6 +49,8 @@ def test_compare_tp(TP_SIZE, PP_SIZE, EAGER_MODE, CHUNKED_PREFILL, MODEL_NAME,
         str(TP_SIZE),
         "--distributed-executor-backend",
         DIST_BACKEND,
+        # disable output proc callback to test PP
+        "--disable-output-proc-callback",
     ]
 
     # compare without pipeline parallelism

--- a/tests/distributed/test_pp_cudagraph.py
+++ b/tests/distributed/test_pp_cudagraph.py
@@ -22,6 +22,8 @@ def test_pp_cudagraph(PP_SIZE, MODEL_NAME, ATTN_BACKEND):
         str(PP_SIZE),
         "--distributed-executor-backend",
         "mp",
+        # disable output proc callback to test PP
+        "--disable-output-proc-callback",
     ]
     os.environ["VLLM_ATTENTION_BACKEND"] = ATTN_BACKEND
 

--- a/tests/engine/test_stop_strings.py
+++ b/tests/engine/test_stop_strings.py
@@ -98,6 +98,10 @@ def _test_stopping(llm_engine: LLMEngine,
     output: Optional[CompletionOutput] = None
     output_text = ""
     stop_reason = None
+
+    # Run first (because of async callback)
+    llm_engine.step()
+
     while llm_engine.has_unfinished_requests():
         (request_output, ) = llm_engine.step()
         (output, ) = request_output.outputs

--- a/tests/multi_step/test_correctness.py
+++ b/tests/multi_step/test_correctness.py
@@ -60,7 +60,7 @@ async def test_multi_step(example_prompts, model: str, tp_size: int,
 
     server_args = DEFAULT_SERVER_ARGS + ["--enforce-eager"]
     ms_server_args = DEFAULT_SERVER_ARGS + \
-        ["--num-scheduler-steps", f"{num_scheduler_steps}"]
+        ["--num-scheduler-steps", f"{num_scheduler_steps}"]#, "--disable-output-proc-callback"]
 
     if eager_mode:
         ms_server_args.append("--enforce-eager")
@@ -82,4 +82,11 @@ async def test_multi_step(example_prompts, model: str, tp_size: int,
 
     ref_generations = get_text_generations(ref_completions)
     test_generations = get_text_generations(test_completions)
+
+    print("ref_generations:")
+    for gen in ref_generations:
+        print("ref_gen: {}".format(gen))
+    print("test_generations:")
+    for gen in test_generations:
+        print("test_gen: {}".format(gen))
     assert ref_generations == test_generations

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -137,6 +137,7 @@ class ModelConfig:
         skip_tokenizer_init: bool = False,
         served_model_name: Optional[Union[str, List[str]]] = None,
         limit_mm_per_prompt: Optional[Mapping[str, int]] = None,
+        use_output_proc_callback: Optional[bool] = True,
     ) -> None:
         self.model = model
         self.tokenizer = tokenizer
@@ -167,6 +168,7 @@ class ModelConfig:
                                     code_revision, rope_scaling, rope_theta)
         self.hf_text_config = get_hf_text_config(self.hf_config)
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
+        self.use_output_proc_callback = use_output_proc_callback
 
         # Choose a default enforce_eager value if the user did not specify
         # a value (enforce_eager is None)
@@ -320,6 +322,30 @@ class ModelConfig:
         self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
                                           self.max_model_len)
 
+    def verify_output_proc_callback(self, speculative_config,
+                                    device_config) -> None:
+        if device_config.device_type != "cuda":
+            logger.warning(
+                "Output proc callback can only be enabled with CUDA")
+            self.use_output_proc_callback = False
+            return
+        if self.enforce_eager:
+            logger.warning(
+                "To see benefits of output processor callback, enable CUDA "
+                "graph. Since, enforce-eager is enabled, output processor "
+                "callback cannot be used")
+            self.use_output_proc_callback = not self.enforce_eager
+            return
+        # Async postprocessor is not necessary with embedding mode
+        # since there is no token generation
+        if self.embedding_mode:
+            self.use_output_proc_callback = False
+
+        if speculative_config:
+            self.use_output_proc_callback = False
+
+        # TO DO: assert mp backend
+
     def verify_with_parallel_config(
         self,
         parallel_config: "ParallelConfig",
@@ -351,6 +377,11 @@ class ModelConfig:
             logger.warning("CUDA graph is not supported on BitAndBytes yet, "
                            "fallback to the eager mode.")
             self.enforce_eager = True
+
+        if (pipeline_parallel_size > 1) and (self.use_output_proc_callback):
+            raise NotImplementedError(
+                "Output processor callback is not supported with "
+                "pipeline parallelism currently. Disable the callback.")
 
     def get_hf_config_sliding_window(self) -> Optional[int]:
         """Get the sliding window size, or None if disabled."""
@@ -1754,6 +1785,8 @@ class EngineConfig:
     def __post_init__(self):
         """Verify configs are valid & consistent with each other.
         """
+        self.model_config.verify_output_proc_callback(self.speculative_config,
+                                                      self.device_config)
         self.model_config.verify_with_parallel_config(self.parallel_config)
         self.cache_config.verify_with_parallel_config(self.parallel_config)
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1104,9 +1104,7 @@ class Scheduler:
             common_computed_block_nums = []
 
         # TODO: Combine multi-step and async postprocessor
-        allow_output_proc_callback: bool = (
-            self.use_output_proc_callback
-            and not self.scheduler_config.is_multi_step)
+        allow_output_proc_callback: bool = self.use_output_proc_callback
 
         # Create list of scheduled request ids
         scheduled_ids: List[Tuple[ScheduledSequenceGroup,

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1103,12 +1103,16 @@ class Scheduler:
         if not self.cache_config.enable_prefix_caching:
             common_computed_block_nums = []
 
+        # TODO: Combine multi-step and async postprocessor
+        allow_output_proc_callback: bool = (
+            self.use_output_proc_callback
+            and not self.scheduler_config.is_multi_step)
+
         # Create list of scheduled request ids
         scheduled_ids: List[Tuple[ScheduledSequenceGroup,
                                   SequenceGroupMetadata]] = []
         # Create input data structures.
         seq_group_metadata_list: List[SequenceGroupMetadata] = []
-        allow_output_proc_callback: bool = False
         for i, scheduled_seq_group in enumerate(
                 scheduler_outputs.scheduled_seq_groups):
             seq_group = scheduled_seq_group.seq_group
@@ -1209,10 +1213,9 @@ class Scheduler:
                 )
             seq_group_metadata_list.append(seq_group_metadata)
 
-            if self.use_output_proc_callback:
-                allow_output_proc_callback = (
-                    allow_output_proc_callback
-                    and self._allow_output_proc_callback(seq_group))
+            if allow_output_proc_callback:
+                allow_output_proc_callback = self._allow_output_proc_callback(
+                    seq_group)
 
             scheduled_ids.append((scheduled_seq_group, seq_group_metadata))
         # Now that the batch has been created, we can assume all blocks in the

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -147,6 +147,7 @@ class EngineArgs:
 
     otlp_traces_endpoint: Optional[str] = None
     collect_detailed_traces: Optional[str] = None
+    disable_output_proc_callback: Optional[bool] = False
 
     def __post_init__(self):
         if self.tokenizer is None:
@@ -735,6 +736,12 @@ class EngineArgs:
             "modules. This involves use of possibly costly and or blocking "
             "operations and hence might have a performance impact.")
 
+        parser.add_argument('--disable-output-proc-callback',
+                            action='store_true',
+                            default=False,
+                            help="Use output processing callback to remove "
+                            "python overheads in decoding. If False, "
+                            "will default to older version.")
         return parser
 
     @classmethod
@@ -794,6 +801,7 @@ class EngineArgs:
             skip_tokenizer_init=self.skip_tokenizer_init,
             served_model_name=self.served_model_name,
             limit_mm_per_prompt=self.limit_mm_per_prompt,
+            use_output_proc_callback=not self.disable_output_proc_callback,
         )
         cache_config = CacheConfig(
             block_size=self.block_size,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -736,12 +736,12 @@ class EngineArgs:
             "modules. This involves use of possibly costly and or blocking "
             "operations and hence might have a performance impact.")
 
-        parser.add_argument('--disable-output-proc-callback',
-                            action='store_true',
-                            default=False,
-                            help="Use output processing callback to remove "
-                            "python overheads in decoding. If False, "
-                            "will default to older version.")
+        parser.add_argument(
+            '--disable-output-proc-callback',
+            action='store_true',
+            default=False,
+            help="Disable async output processing. This may result in "
+            "lower performance.")
         return parser
 
     @classmethod

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -380,6 +380,7 @@ class _AsyncLLMEngine(LLMEngine):
 
                 # Log stats.
                 self.do_log_stats(scheduler_outputs, output)
+                
                 # Tracing
                 self.do_tracing(scheduler_outputs)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -365,7 +365,7 @@ class _AsyncLLMEngine(LLMEngine):
 
             # Cache results in engine
             self.output_queue.append(
-                (output, scheduled_ids, scheduler_outputs.ignored_seq_groups))
+                (output, scheduled_ids, scheduler_outputs))
 
             if (len(output) > 0) and allow_output_proc_callback:
                 assert len(
@@ -377,14 +377,14 @@ class _AsyncLLMEngine(LLMEngine):
 
             if not allow_output_proc_callback:
                 self._process_model_outputs(is_async=False)
+
+                # Log stats.
+                self.do_log_stats(scheduler_outputs, output)
+                # Tracing
+                self.do_tracing(scheduler_outputs)
+
         else:
             self.request_outputs = []
-
-        # Log stats.
-        self.do_log_stats(scheduler_outputs, output)
-
-        # Tracing
-        self.do_tracing(scheduler_outputs)
 
         return self.request_outputs
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -896,10 +896,6 @@ class AsyncLLMEngine:
         else:
             request_outputs = await self.engine.step_async(virtual_engine)
 
-        # HACK: no output returned in first step
-        if not request_outputs:
-            return False
-
         # Put the outputs into the corresponding streams.
         finished = True
         for request_output in request_outputs:

--- a/vllm/engine/output_processor/interfaces.py
+++ b/vllm/engine/output_processor/interfaces.py
@@ -25,13 +25,10 @@ class SequenceGroupOutputProcessor(ABC):
 
     @staticmethod
     def create_output_processor(
-        scheduler_config: SchedulerConfig,
-        detokenizer: Detokenizer,
-        scheduler: List[Scheduler],
-        seq_counter: Counter,
-        get_tokenizer_for_seq: Callable[[Sequence], PreTrainedTokenizer],
-        stop_checker: "StopChecker",
-    ):
+            scheduler_config: SchedulerConfig, detokenizer: Detokenizer,
+            scheduler: List[Scheduler], seq_counter: Counter,
+            get_tokenizer_for_seq: Callable[[Sequence], PreTrainedTokenizer],
+            stop_checker: "StopChecker"):
         """Create an output processor.
 
         This returns a single-step output processor if num_lookahead_slots is
@@ -41,13 +38,9 @@ class SequenceGroupOutputProcessor(ABC):
             # Importing here to avoid cycle.
             from vllm.engine.output_processor.single_step import (
                 SingleStepOutputProcessor)
-            return SingleStepOutputProcessor(
-                scheduler_config,
-                detokenizer,
-                scheduler,
-                seq_counter,
-                stop_checker,
-            )
+            return SingleStepOutputProcessor(scheduler_config, detokenizer,
+                                             scheduler, seq_counter,
+                                             stop_checker)
         else:
             # Importing here to avoid cycle.
             from vllm.engine.output_processor.multi_step import (
@@ -62,7 +55,8 @@ class SequenceGroupOutputProcessor(ABC):
 
     @abstractmethod
     def process_outputs(self, sequence_group: SequenceGroup,
-                        outputs: List[SequenceGroupOutput]) -> None:
+                        outputs: List[SequenceGroupOutput],
+                        is_async: bool) -> None:
         """Process new token ids for the sequence group. Handles logic such as
         detokenization, stop checking, and freeing/forking sequences in the
         scheduler.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -605,7 +605,6 @@ class LLM:
             inputs = [inputs]
 
         num_requests = len(inputs)
-        print(f'{num_requests=}')
         if isinstance(params, list) and len(params) != num_requests:
             raise ValueError("The lengths of prompts and params "
                              "must be the same.")

--- a/vllm/executor/distributed_gpu_executor.py
+++ b/vllm/executor/distributed_gpu_executor.py
@@ -64,8 +64,9 @@ class DistributedGPUExecutor(GPUExecutor):
                           num_cpu_blocks=num_cpu_blocks)
 
     def execute_model(
-            self,
-            execute_model_req: ExecuteModelRequest) -> List[SamplerOutput]:
+        self,
+        execute_model_req: ExecuteModelRequest,
+    ) -> List[SamplerOutput]:
         if self.parallel_worker_tasks is None:
             self.parallel_worker_tasks = self._run_workers(
                 "start_worker_execution_loop",
@@ -188,7 +189,7 @@ class DistributedGPUExecutorAsync(DistributedGPUExecutor, ExecutorAsyncBase):
     @abstractmethod
     async def _driver_execute_model_async(
         self,
-        execute_model_req: Optional[ExecuteModelRequest] = None
+        execute_model_req: Optional[ExecuteModelRequest] = None,
     ) -> List[SamplerOutput]:
         """Execute the model asynchronously in the driver worker.
 

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -20,19 +20,14 @@ class ExecutorBase(ABC):
 
     uses_ray: bool  # whether the executor uses Ray for orchestration.
 
-    def __init__(
-        self,
-        model_config: ModelConfig,
-        cache_config: CacheConfig,
-        parallel_config: ParallelConfig,
-        scheduler_config: SchedulerConfig,
-        device_config: DeviceConfig,
-        load_config: LoadConfig,
-        lora_config: Optional[LoRAConfig],
-        speculative_config: Optional[SpeculativeConfig],
-        prompt_adapter_config: Optional[PromptAdapterConfig],
-        observability_config: Optional[ObservabilityConfig],
-    ) -> None:
+    def __init__(self, model_config: ModelConfig, cache_config: CacheConfig,
+                 parallel_config: ParallelConfig,
+                 scheduler_config: SchedulerConfig,
+                 device_config: DeviceConfig, load_config: LoadConfig,
+                 lora_config: Optional[LoRAConfig],
+                 speculative_config: Optional[SpeculativeConfig],
+                 prompt_adapter_config: Optional[PromptAdapterConfig],
+                 observability_config: Optional[ObservabilityConfig]) -> None:
         self.model_config = model_config
         self.cache_config = cache_config
         self.lora_config = lora_config

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -168,5 +168,5 @@ class GPUExecutorAsync(GPUExecutor, ExecutorAsyncBase):
         execute_model_req: ExecuteModelRequest,
     ) -> List[Union[SamplerOutput, PoolerOutput]]:
         output = await make_async(self.driver_worker.execute_model
-                                  )(execute_model_req=execute_model_req, )
+                                  )(execute_model_req=execute_model_req)
         return output

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -218,7 +218,7 @@ class MultiprocessingGPUExecutorAsync(MultiprocessingGPUExecutor,
 
     async def _driver_execute_model_async(
         self,
-        execute_model_req: Optional[ExecuteModelRequest] = None
+        execute_model_req: Optional[ExecuteModelRequest] = None,
     ) -> List[SamplerOutput]:
         if not self.tp_driver_workers:
             return await self.driver_exec_model(execute_model_req)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -5,8 +5,8 @@ from abc import ABC, abstractmethod
 from array import array
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set,
-                    Tuple, Union, cast)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Mapping,
+                    Optional, Set, Tuple, Union, cast)
 
 import msgspec
 import torch
@@ -474,14 +474,15 @@ class Sequence:
         """Reset the sequence states for recomputation."""
         self.data.reset_state_for_recompute()
 
-    def append_token_id(
-        self,
-        token_id: int,
-        logprobs: Dict[int, Logprob],
-    ) -> None:
+    def append_token_id(self,
+                        token_id: int,
+                        logprobs: Dict[int, Logprob],
+                        update_seq_data: bool = True) -> None:
         assert token_id in logprobs
         self.output_logprobs.append(logprobs)
-        self.data.append_token_id(token_id, logprobs[token_id].logprob)
+        # Only do this when output proc callback is not used
+        if update_seq_data:
+            self.data.append_token_id(token_id, logprobs[token_id].logprob)
 
     def get_len(self) -> int:
         return self.data.get_len()
@@ -1242,6 +1243,8 @@ class ExecuteModelRequest(
     finished_requests_ids: List[str] = msgspec.field(default_factory=list)
     # The last sampled token ids for multi step decoding.
     last_sampled_token_ids: Optional[torch.Tensor] = None
+    # Async postprocessor
+    callback_fn: Optional[Callable] = None
 
     @property
     def is_first_multi_step(self) -> bool:
@@ -1287,4 +1290,5 @@ class ExecuteModelRequest(
             num_steps=self.num_steps,
             finished_requests_ids=self.finished_requests_ids,
             last_sampled_token_ids=self.last_sampled_token_ids.clone()
-            if self.last_sampled_token_ids is not None else None)
+            if self.last_sampled_token_ids is not None else None,
+            callback_fn=self.callback_fn)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1245,6 +1245,7 @@ class ExecuteModelRequest(
     last_sampled_token_ids: Optional[torch.Tensor] = None
     # Async postprocessor
     callback_fn: Optional[Callable] = None
+    use_async_and_multi_step: bool = False
 
     @property
     def is_first_multi_step(self) -> bool:
@@ -1291,4 +1292,5 @@ class ExecuteModelRequest(
             finished_requests_ids=self.finished_requests_ids,
             last_sampled_token_ids=self.last_sampled_token_ids.clone()
             if self.last_sampled_token_ids is not None else None,
-            callback_fn=self.callback_fn)
+            callback_fn=self.callback_fn,
+            use_async_and_multi_step=self.use_async_and_multi_step)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -5,8 +5,8 @@ import time
 import warnings
 import weakref
 from dataclasses import dataclass
-from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Type,
-                    TypeVar, Union)
+from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set,
+                    Tuple, Type, TypeVar, Union)
 
 import numpy as np
 import torch
@@ -100,6 +100,7 @@ class ModelInputForGPU(ModelRunnerInputBase):
     request_ids_to_seq_ids: Optional[Dict[str, List[int]]] = None
     finished_requests_ids: Optional[List[str]] = None
     virtual_engine: int = 0
+    callback_fn: Optional[Callable] = None
 
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         tensor_dict = {
@@ -1419,7 +1420,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
         virtual_engine: int = 0,
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[List[str]] = None,
     ) -> ModelInputForGPUWithSamplingMetadata:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.
@@ -1571,6 +1572,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
 
         if not self.is_driver_worker:
             return []
+
+        if (model_input.callback_fn is not None):
+            model_input.callback_fn(is_async=True)
 
         # Sample the next token.
         output: SamplerOutput = self.model.sample(

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -196,6 +196,7 @@ class ModelRunnerBase(ABC, Generic[T]):
         kv_caches: Optional[List[torch.Tensor]],
         intermediate_tensors: Optional[IntermediateTensors],
         num_steps: int = 1,
+        callback_fn = None
     ) -> Optional[List[SamplerOutput]]:
         """
         Execute the model on the given input.

--- a/vllm/worker/multi_step_worker.py
+++ b/vllm/worker/multi_step_worker.py
@@ -1,3 +1,4 @@
+import dataclasses
 from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
@@ -59,6 +60,13 @@ class MultiStepWorker(Worker):
                     execute_model_req.seq_group_metadata_list,
                     execute_model_req.virtual_engine,
                     execute_model_req.finished_requests_ids))
+
+            if execute_model_req.callback_fn:
+                model_input.frozen_model_input = dataclasses.replace(  # type: ignore
+                    model_input.frozen_model_input,
+                    callback_fn=execute_model_req.callback_fn,
+                    use_async_and_multi_step=execute_model_req.
+                    use_async_and_multi_step)
         else:
             # on subsequent steps we reuse the worker input and model input
             multi_step_state = self.multi_step_states[virtual_engine]


### PR DESCRIPTION
This PR combines async postprocessor with the multi-step execution. The key idea to run sampler pythonization + process_model_outputs of the previous step concurrently with the GPU forward pass (which avoid running a postprocessor at the end of the multi-step for all generated steps at once and being blocked). The code here is WIP and depends on https://github.com/vllm-project/vllm/pull/7049 first landing.

Here are some first results for Llama3.1 8B on H100 with RPS==10, 8 multi-step, 1024 prompt and 512 decode. The TPOT improves by 31% from 27.71ms to 21.05ms. 

**8-multi-step execution** 
```
python benchmark_serving.py --backend vllm --host localhost --port 8888 --endpoint /v1/completions --model meta-llama/Meta-Llama-3.1-8B-Instruct  --num-prompts 200 --dataset-name sonnet --dataset-path sonnet.txt --sonnet-input-len 1024 --sonnet-prefix-len 512 --sonnet-output-len 512 --request-rate 10

============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  30.65     
Total input tokens:                      191053    
Total generated tokens:                  102400    
Request throughput (req/s):              6.53      
Input token throughput (tok/s):          6233.42   
Output token throughput (tok/s):         3340.97   
---------------Time to First Token----------------
Mean TTFT (ms):                          155.89    
Median TTFT (ms):                        144.32    
P99 TTFT (ms):                           419.22    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.71     
Median TPOT (ms):                        29.04     
P99 TPOT (ms):                           32.20     
---------------Inter-token Latency----------------
Mean ITL (ms):                           220.88    
Median ITL (ms):                         216.06    
P99 ITL (ms):                            429.27    
==================================================

```
**8-multi-step execution + async postprocessing**

```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  27.44     
Total input tokens:                      191053    
Total generated tokens:                  102400    
Request throughput (req/s):              7.29      
Input token throughput (tok/s):          6963.68   
Output token throughput (tok/s):         3732.37   
---------------Time to First Token----------------
Mean TTFT (ms):                          120.86    
Median TTFT (ms):                        113.91    
P99 TTFT (ms):                           239.73    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          21.05     
Median TPOT (ms):                        21.91     
P99 TPOT (ms):                           25.17     
---------------Inter-token Latency----------------
Mean ITL (ms):                           167.91    
Median ITL (ms):                         156.76    
P99 ITL (ms):                            366.86    
==================================================
```
