### PR TITLE
[Performance] Enable chunked prefill and prefix caching together

### DIFF
--- a/benchmarks/benchmark_prefix_caching.py
+++ b/benchmarks/benchmark_prefix_caching.py
@@ -135,7 +135,10 @@ def main(args):
               enforce_eager=True,
               use_v2_block_manager=args.use_v2_block_manager,
               tensor_parallel_size=args.tensor_parallel_size,
-              enable_prefix_caching=args.enable_prefix_caching)
+              enable_prefix_caching=args.enable_prefix_caching,
+              enable_chunked_prefill=True,
+              max_num_batched_tokens=128,
+              max_num_seqs=128)
 
     sampling_params = SamplingParams(temperature=0, max_tokens=args.output_len)
 

--- a/benchmarks/benchmark_prefix_caching.py
+++ b/benchmarks/benchmark_prefix_caching.py
@@ -135,10 +135,7 @@ def main(args):
               enforce_eager=True,
               use_v2_block_manager=args.use_v2_block_manager,
               tensor_parallel_size=args.tensor_parallel_size,
-              enable_prefix_caching=args.enable_prefix_caching,
-              enable_chunked_prefill=True,
-              max_num_batched_tokens=128,
-              max_num_seqs=128)
+              enable_prefix_caching=args.enable_prefix_caching)
 
     sampling_params = SamplingParams(temperature=0, max_tokens=args.output_len)
 

--- a/tests/basic_correctness/test_chunked_prefill.py
+++ b/tests/basic_correctness/test_chunked_prefill.py
@@ -155,7 +155,7 @@ def test_models_with_fp8_kv_cache(
 
 @pytest.mark.parametrize("max_tokens", [16])
 @pytest.mark.parametrize("enforce_eager", [False])
-@pytest.mark.parametrize("chunk_size", [30, 32, 64])
+@pytest.mark.parametrize("chunk_size", [30, 32])
 @pytest.mark.parametrize("use_v2_block_manager", [False, True])
 # NOTE: Increasing this in this suite will fail CI because we currently cannot
 # reset distributed env properly. Use a value > 1 just when you test.

--- a/tests/basic_correctness/test_chunked_prefill.py
+++ b/tests/basic_correctness/test_chunked_prefill.py
@@ -6,6 +6,7 @@ prefill requests are chunked.
 
 Run `pytest tests/models/test_chunked_prefill.py`.
 """
+from contextlib import nullcontext
 
 import pytest
 
@@ -154,6 +155,8 @@ def test_models_with_fp8_kv_cache(
 
 @pytest.mark.parametrize("max_tokens", [16])
 @pytest.mark.parametrize("enforce_eager", [False])
+@pytest.mark.parametrize("chunk_size", [30, 32, 64])
+@pytest.mark.parametrize("use_v2_block_manager", [False, True])
 # NOTE: Increasing this in this suite will fail CI because we currently cannot
 # reset distributed env properly. Use a value > 1 just when you test.
 @pytest.mark.parametrize("tensor_parallel_size", [1])
@@ -161,6 +164,8 @@ def test_with_prefix_caching(
     vllm_runner,
     max_tokens: int,
     enforce_eager: bool,
+    chunk_size: int,
+    use_v2_block_manager: bool,
     tensor_parallel_size: int,
 ) -> None:
     """
@@ -168,54 +173,46 @@ def test_with_prefix_caching(
     with chunked prefill enabled.
     """
     model = "meta-llama/Llama-2-7b-chat-hf"
-    # The common prompt has 41 tokens with Llama-2 tokenizer.
-    common_prompt = "<s>[INST] You are a helpful assistant. Please answer and elaborate the question user ask below. Your response should be profession and concise. Do not make any facts by yourself."  # noqa: E501
+    # The common prompt has 142 tokens with Llama-2 tokenizer.
+    common_prompt = "You are a helpful AI assistant " * 20
     unique_prompts = [
-        "Why birds can fly?",  # Warmup
-        "Why birds can fly?",  # Fully cached
-        "What is the capital of France?",  # Partial cached
+        "Question",  # Warmup
+        "Question",  # Fully cached
+        "Another question",  # Partial cached
     ]
-    full_prompts = [f"{common_prompt}\n{p} [/INST]" for p in unique_prompts]
+    full_prompts = [f"{common_prompt}\n{p}" for p in unique_prompts]
 
-    # Test an invalid (non-divisible to the block size 16) chunk size.
-    max_num_batched_tokens = max_num_seqs = 14
-    with vllm_runner(
-            model,
-            dtype="half",
-            max_num_batched_tokens=14,
-            enable_chunked_prefill=True,
-            enable_prefix_caching=True,
-            tensor_parallel_size=tensor_parallel_size,
-            enforce_eager=enforce_eager,
-            max_num_seqs=max_num_seqs,
-    ) as vllm_model, pytest.raises(ValueError):
-        vllm_model.generate_greedy(full_prompts[:1], max_tokens)
-
-    # Set the chunked prefill to have more than 2 blocks for
-    # the common prompt.
-    max_num_batched_tokens = max_num_seqs = 16
-
+    max_num_batched_tokens = max_num_seqs = chunk_size
     outputs = {}  # type: ignore
-    for enable_prefix_caching in (False, True):
+    check_result = True
+    for enable in (True, False):
         with vllm_runner(
                 model,
                 dtype="half",
                 max_num_batched_tokens=max_num_batched_tokens,
                 enable_chunked_prefill=True,
-                enable_prefix_caching=enable_prefix_caching,
+                enable_prefix_caching=enable,
                 tensor_parallel_size=tensor_parallel_size,
+                use_v2_block_manager=use_v2_block_manager,
                 enforce_eager=enforce_eager,
                 max_num_seqs=max_num_seqs,
         ) as vllm_model:
-            outputs[enable_prefix_caching] = []
+            # It should fail when prefix caching is enable and chunk
+            # size is not a multiple of block size (16).
+            should_fail = chunk_size % 16 != 0 and enable
+            check_result &= not should_fail
+            outputs[enable] = []
             # Send the request one-by-one to ensure the cache is populated.
-            for prompt in full_prompts:
-                outputs[enable_prefix_caching] += vllm_model.generate_greedy(
-                    [prompt], max_tokens)
+            with pytest.raises(ValueError) if should_fail else nullcontext():
+                for prompt in full_prompts:
+                    outputs[enable] += vllm_model.generate_greedy([prompt],
+                                                                  max_tokens)
 
-    check_outputs_equal(
-        outputs_0_lst=outputs[False],
-        outputs_1_lst=outputs[True],
-        name_0="w/o prefix caching",
-        name_1="with prefix caching",
-    )
+    # Check results only if we did not expect a failure.
+    if check_result:
+        check_outputs_equal(
+            outputs_0_lst=outputs[False],
+            outputs_1_lst=outputs[True],
+            name_0="w/o prefix caching",
+            name_1="with prefix caching",
+        )

--- a/tests/basic_correctness/test_chunked_prefill.py
+++ b/tests/basic_correctness/test_chunked_prefill.py
@@ -164,8 +164,8 @@ def test_with_prefix_caching(
     tensor_parallel_size: int,
 ) -> None:
     """
-    Checks exact match decode between huggingface model and vllm runner with
-    chunked prefill.
+    Checks exact match decode with and without prefix caching
+    with chunked prefill enabled.
     """
     model = "meta-llama/Llama-2-7b-chat-hf"
     # The common prompt has 41 tokens with Llama-2 tokenizer.

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -684,10 +684,6 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         if seq.seq_id not in self.block_tables:
             return
 
-        # max_full_block = seq.get_len() // self.block_size - 1
-        # computed_full_blocks = seq.get_len() // self.block_size
-        # print(f"{seq.data.get_prompt_len()=}")
-
         # When chunked prefill is enabled, the computed full blocks
         # should be calculated based on the number of computed tokens.
         max_computed_tokens = (seq.data.get_num_computed_tokens() +

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -680,14 +680,24 @@ class BlockSpaceManagerV1(BlockSpaceManager):
             for block in block_table:
                 block.last_accessed = access_time
 
-    def compute_full_blocks_in_seq(self, seq: Sequence):
+    def compute_full_blocks_in_seq(self, seq: Sequence, token_chunk_size: int):
         if seq.seq_id not in self.block_tables:
             return
-        max_full_block = seq.get_len() // self.block_size - 1
+
+        # max_full_block = seq.get_len() // self.block_size - 1
+        # computed_full_blocks = seq.get_len() // self.block_size
+        # print(f"{seq.data.get_prompt_len()=}")
+
+        # When chunked prefill is enabled, the computed full blocks
+        # should be calculated based on the number of computed tokens.
+        max_computed_tokens = (seq.data.get_num_computed_tokens() +
+                               token_chunk_size)
+        computed_full_blocks = max_computed_tokens // self.block_size
+
         block_table = self.block_tables[seq.seq_id]
-        if max_full_block == -1:
+        if computed_full_blocks == 0:
             return
-        for i in reversed(range(max_full_block)):
+        for i in reversed(range(computed_full_blocks - 1)):
             if block_table[i].computed:
                 break
             block_table[i].computed = True
@@ -717,10 +727,11 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         ids_list = [self.get_all_computed_blocks(seq) for seq in seqs]
         return commonprefix([ids for ids in ids_list if ids != []])
 
-    def mark_blocks_as_computed(self, seq_group: SequenceGroup):
+    def mark_blocks_as_computed(self, seq_group: SequenceGroup,
+                                token_chunk_size: int):
         if self.enable_caching:
             for seq in seq_group.get_seqs():
-                self.compute_full_blocks_in_seq(seq)
+                self.compute_full_blocks_in_seq(seq, token_chunk_size)
 
     def get_prefix_cache_hit_rate(self, device: Device) -> float:
         if device == Device.GPU:

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -693,7 +693,7 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         block_table = self.block_tables[seq.seq_id]
         if computed_full_blocks == 0:
             return
-        for i in reversed(range(computed_full_blocks - 1)):
+        for i in reversed(range(computed_full_blocks)):
             if block_table[i].computed:
                 break
             block_table[i].computed = True

--- a/vllm/core/block_manager_v2.py
+++ b/vllm/core/block_manager_v2.py
@@ -286,7 +286,8 @@ class BlockSpaceManagerV2(BlockSpaceManager):
             self._last_access_blocks_tracker.update_last_access(
                 seq.seq_id, now)
 
-    def mark_blocks_as_computed(self, seq_group: SequenceGroup):
+    def mark_blocks_as_computed(self, seq_group: SequenceGroup,
+                                token_chunk_size: int):
         # If prefix caching is enabled, mark immutable blocks as computed
         # right after they have been scheduled (for prefill). This assumes
         # the scheduler is synchronous so blocks are actually computed when

--- a/vllm/core/embedding_model_block_manager.py
+++ b/vllm/core/embedding_model_block_manager.py
@@ -80,7 +80,8 @@ class EmbeddingModelBlockSpaceManager(BlockSpaceManager):
                                       seq_group: SequenceGroup) -> List[int]:
         return None  # type: ignore
 
-    def mark_blocks_as_computed(self, seq_group: SequenceGroup):
+    def mark_blocks_as_computed(self, seq_group: SequenceGroup,
+                                token_chunk_size: int):
         pass
 
     def get_prefix_cache_hit_rate(self, device: Device) -> float:

--- a/vllm/core/interfaces.py
+++ b/vllm/core/interfaces.py
@@ -115,7 +115,8 @@ class BlockSpaceManager(ABC):
         pass
 
     @abstractmethod
-    def mark_blocks_as_computed(self, seq_group: SequenceGroup):
+    def mark_blocks_as_computed(self, seq_group: SequenceGroup,
+                                token_chunk_size: int):
         pass
 
     @abstractmethod

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1145,7 +1145,8 @@ class Scheduler:
         # will crash the vLLM instance / will not retry.
         for scheduled_seq_group in scheduler_outputs.scheduled_seq_groups:
             self.block_manager.mark_blocks_as_computed(
-                scheduled_seq_group.seq_group)
+                scheduled_seq_group.seq_group,
+                scheduled_seq_group.token_chunk_size)
 
         scheduler_time = time.perf_counter() - scheduler_start_time
         # Add this to scheduler time to all the sequences that are currently

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1358,12 +1358,14 @@ class Scheduler:
                 # the number of new tokens that is dividable by the block size
                 # to avoid partial block matching.
                 block_size = self.cache_config.block_size
-                if budget.token_budget % block_size != 0:
+                reminder = budget.token_budget % block_size
+                if reminder != 0:
                     raise ValueError("When enabling chunked prefill and "
                                      "prefix caching, max_num_batched_tokens "
                                      "(chunk size) must be dividable by "
-                                     "block size, but got "
-                                     f"{budget.token_budget % block_size = }")
+                                     "block size, but got chunk_size "
+                                     f"({budget.token_budget}) % block_size "
+                                     f"({block_size}) = {reminder}")
                 if remaining_token_budget < num_new_tokens:
                     num_new_tokens = (remaining_token_budget //
                                       block_size) * block_size

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1356,8 +1356,14 @@ class Scheduler:
                 # When prefix caching is enabled, we always allocate
                 # the number of new tokens that is dividable by the block size
                 # to avoid partial block matching.
+                block_size = self.cache_config.block_size
+                if budget.token_budget % block_size != 0:
+                    raise ValueError("When enabling chunked prefill and "
+                                     "prefix caching, max_num_batched_tokens "
+                                     "(chunk size) must be dividable by "
+                                     "block size, but got "
+                                     f"{budget.token_budget % block_size = }")
                 if remaining_token_budget < num_new_tokens:
-                    block_size = self.cache_config.block_size
                     num_new_tokens = (remaining_token_budget //
                                       block_size) * block_size
             else:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -499,23 +499,50 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                             and self.sliding_window is None
                             and inter_data.is_prompt)
         inter_data.prefix_cache_hit = prefix_cache_hit
-        if self.chunked_prefill_enabled and prefix_cache_hit:
-            raise RuntimeError(
-                "chunked prefill cannot be used with prefix caching now.")
 
-        # If prefix cache is hit, advance context length to bypass
-        # hit blocks. Accordingly, input tokens, position and query length
-        # have to be updated.
-        if prefix_cache_hit:
-            assert computed_block_nums is not None
-            context_len = len(computed_block_nums) * self.block_size
+        if not prefix_cache_hit:
+            return
+
+        assert computed_block_nums is not None
+        # The cache hit prompt tokens in this sequence. Note that
+        # this may be larger than the sequence length if chunked
+        # prefill is enabled.
+        prefix_cache_len = len(computed_block_nums) * self.block_size
+        # The number of so far computed prompt tokens in this sequence.
+        context_len = inter_data.context_lens[seq_idx]
+        # The total number of prompt tokens in this sequence.
+        # When chunked prefill is enabled, this is the token number of
+        # computed chunks + current chunk.
+        seq_len = inter_data.seq_lens[seq_idx]
+        if prefix_cache_len <= context_len:
+            # We already passed the cache hit region,
+            # so do normal computation.
+            pass
+        elif context_len < prefix_cache_len < seq_len:
+            # Partial hit. Compute the missing part.
+            uncomputed_start = prefix_cache_len - context_len
             inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
-                seq_idx][context_len:]
+                seq_idx][uncomputed_start:]
             inter_data.input_positions[seq_idx] = inter_data.input_positions[
-                seq_idx][context_len:]
+                seq_idx][uncomputed_start:]
+            context_len = prefix_cache_len
+
             inter_data.context_lens[seq_idx] = context_len
             inter_data.query_lens[
                 seq_idx] = inter_data.seq_lens[seq_idx] - context_len
+        elif seq_len <= prefix_cache_len:
+            # Full hit. Only compute the last block to avoid
+            # erroneous behavior. FIXME: Ideally we should directly
+            # mark all tokens as computed in the scheduler and do not
+            # schedule this sequence, so this case should not happen.
+            block_size = self.block_size
+            inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
+                seq_idx][-block_size:]
+            inter_data.input_positions[seq_idx] = inter_data.input_positions[
+                seq_idx][-block_size:]
+            inter_data.query_lens[seq_idx] = block_size
+            inter_data.context_lens[seq_idx] = inter_data.seq_lens[
+                seq_idx] - inter_data.query_lens[seq_idx]
 
     def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
                                     seq_idx: int,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -531,18 +531,16 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             inter_data.query_lens[
                 seq_idx] = inter_data.seq_lens[seq_idx] - context_len
         elif seq_len <= prefix_cache_len:
-            # Full hit. Only compute the last block to avoid
+            # Full hit. Only compute the last token to avoid
             # erroneous behavior. FIXME: Ideally we should directly
             # mark all tokens as computed in the scheduler and do not
             # schedule this sequence, so this case should not happen.
-            block_size = self.block_size
             inter_data.input_tokens[seq_idx] = inter_data.input_tokens[
-                seq_idx][-block_size:]
+                seq_idx][-1:]
             inter_data.input_positions[seq_idx] = inter_data.input_positions[
-                seq_idx][-block_size:]
-            inter_data.query_lens[seq_idx] = block_size
-            inter_data.context_lens[seq_idx] = inter_data.seq_lens[
-                seq_idx] - inter_data.query_lens[seq_idx]
+                seq_idx][-1:]
+            inter_data.query_lens[seq_idx] = 1
+            inter_data.context_lens[seq_idx] = inter_data.seq_lens[seq_idx] - 1
 
     def _compute_for_sliding_window(self, inter_data: InterDataForSeqGroup,
                                     seq_idx: int,


### PR DESCRIPTION
Reference PRs: #6144, #6819
Make @sighingnow and @Juelianqvq as co-authors of this PR.

This PR supports prefix caching and chunked prefill to be enabled together. Different from the reference PRs, this PR simplifies the logic of dealing with partial blocks (thanks to @rkooo567 for the suggestion). Here is the execution flow:

1. In scheduler, when determining the new tokens to be scheduled and both chunked prefill and prefix caching are enabled. 
    1. If all uncomputed tokens can be scheduled (i.e., the last chunk of the prompt), then schedule them all.
    2. Otherwise, we always schedule the number of tokens that is divisible by the block size. For example, if the remaining budget is 133 tokens and the block size is 16, we will only schedule `(133//16)*16=112` tokens. Although this approach wastes some token budget, it makes the following process straightforward.
2. In prepare input, if all scheduled tokens are cached, we only compute the last block. Note that:
    1. We cannot skip all blocks at this moment because model runner doesn't support this case. Currently when block manager determines prefix cache blocks, it will also skip the last block due to the same reason (e.g., https://github.com/vllm-project/vllm/blob/main/vllm/core/block/prefix_caching_block.py#L556). This can be improved in the future if we move prefix caching to scheduler so that this case won't happen anymore.
    2. Since we guarantee the scheduled tokens are divisible by block size, we don't need to consider partial blocks in prepare input.

A test case for functional correctness is also added.

Throughput benchmarking results:
- Model: neuralmagic/Meta-Llama-3-8B-Instruct-FP8
- GPU: 1xL4
- Number of requests: 600
- Average prompt length: 637 (shared prefix ~180, cache hit rate ~20%)
- Max output length: 200
- Block manager v1
- Chunked prefill size 2048

Branch | ChunkedPrefill | PrefixCaching| Elapsed Time (s) | Throughput (tok/s)
--|--|--|--|--
main | x | v | 154.37 | 3631.2
main | v | x | 173.84 | 3215.1
PR | x | v | 155.88 | 3596.2 
PR | v | x | 174.18 | 3298.8 
PR | v | v | 142.81 | 3929.7

cc @rkooo567 