### PR TITLE
Add more percentiles and latencies

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -70,13 +70,13 @@ class BenchmarkMetrics:
     median_itl_ms: float
     std_itl_ms: float
     percentiles_itl_ms: List[Tuple[float, float]]
-    # ETEL stands for end-to-end latency per request.
+    # E2EL stands for end-to-end latency per request.
     # It is the time taken on the client side from sending
     # a request to receiving a complete response.
-    mean_etel_ms: float
-    median_etel_ms: float
-    std_etel_ms: float
-    percentiles_etel_ms: List[Tuple[float, float]]
+    mean_e2el_ms: float
+    median_e2el_ms: float
+    std_e2el_ms: float
+    percentiles_e2el_ms: List[Tuple[float, float]]
 
 
 def sample_sharegpt_requests(
@@ -251,7 +251,7 @@ def calculate_metrics(
     itls: List[float] = []
     tpots: List[float] = []
     ttfts: List[float] = []
-    etels: List[float] = []
+    e2els: List[float] = []
     for i in range(len(outputs)):
         if outputs[i].success:
             # We use the tokenizer to count the number of output tokens for all
@@ -268,7 +268,7 @@ def calculate_metrics(
                     (outputs[i].latency - outputs[i].ttft) / (output_len - 1))
             itls += outputs[i].itl
             ttfts.append(outputs[i].ttft)
-            etels.append(outputs[i].latency)
+            e2els.append(outputs[i].latency)
             completed += 1
         else:
             actual_output_lens.append(0)
@@ -301,10 +301,10 @@ def calculate_metrics(
         median_itl_ms=np.median(itls or 0) * 1000,
         percentiles_itl_ms=[(p, np.percentile(itls or 0, p) * 1000)
                             for p in selected_percentiles],
-        mean_etel_ms=np.median(etels or 0) * 1000,
-        std_etel_ms=np.std(etels or 0) * 1000,
-        median_etel_ms=np.mean(etels or 0) * 1000,
-        percentiles_etel_ms=[(p, np.percentile(etels or 0, p) * 1000)
+        mean_e2el_ms=np.median(e2els or 0) * 1000,
+        std_e2el_ms=np.std(e2els or 0) * 1000,
+        median_e2el_ms=np.mean(e2els or 0) * 1000,
+        percentiles_e2el_ms=[(p, np.percentile(e2els or 0, p) * 1000)
                              for p in selected_percentiles],
     )
 
@@ -483,7 +483,7 @@ async def benchmark(
     process_one_metric("tpot", "TPOT",
                        "Time per Output Token (excl. 1st token)")
     process_one_metric("itl", "ITL", "Inter-token Latency")
-    process_one_metric("etel", "ETEL", "End-to-end Latency")
+    process_one_metric("e2el", "E2EL", "End-to-end Latency")
 
     print("=" * 50)
 
@@ -810,7 +810,7 @@ if __name__ == "__main__":
         default="ttft,tpot,itl",
         help="Comma-seperated list of selected metrics to report percentils. "
         "This argument specifies the metrics to report percentiles. "
-        "Allowed metric names are \"ttft\", \"tpot\", \"itl\", \"etel\". "
+        "Allowed metric names are \"ttft\", \"tpot\", \"itl\", \"e2el\". "
         "Default value is \"ttft,tpot,itl\".")
     parser.add_argument(
         "--metric-percentiles",

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -61,15 +61,15 @@ class BenchmarkMetrics:
     mean_ttft_ms: float
     median_ttft_ms: float
     std_ttft_ms: float
-    percentiles_ttft_ms: List[Tuple[float,float]]
+    percentiles_ttft_ms: List[Tuple[float, float]]
     mean_tpot_ms: float
     median_tpot_ms: float
     std_tpot_ms: float
-    percentiles_tpot_ms: List[Tuple[float,float]]
+    percentiles_tpot_ms: List[Tuple[float, float]]
     mean_itl_ms: float
     median_itl_ms: float
     std_itl_ms: float
-    percentiles_itl_ms: List[Tuple[float,float]]
+    percentiles_itl_ms: List[Tuple[float, float]]
     # ETEL stands for end-to-end latency per request.
     # It is the time taken on the client side from sending
     # a request to receiving a complete response.
@@ -289,19 +289,23 @@ def calculate_metrics(
         1000,  # ttfts is empty if streaming is not supported by backend
         std_ttft_ms=np.std(ttfts or 0) * 1000,
         median_ttft_ms=np.median(ttfts or 0) * 1000,
-        percentiles_ttft_ms=[(p, np.percentile(ttfts or 0, p) * 1000) for p in selected_percentiles],
+        percentiles_ttft_ms=[(p, np.percentile(ttfts or 0, p) * 1000)
+                             for p in selected_percentiles],
         mean_tpot_ms=np.mean(tpots or 0) * 1000,
         std_tpot_ms=np.std(tpots or 0) * 1000,
         median_tpot_ms=np.median(tpots or 0) * 1000,
-        percentiles_tpot_ms=[(p, np.percentile(tpots or 0, p) * 1000) for p in selected_percentiles],
+        percentiles_tpot_ms=[(p, np.percentile(tpots or 0, p) * 1000)
+                             for p in selected_percentiles],
         mean_itl_ms=np.mean(itls or 0) * 1000,
         std_itl_ms=np.std(itls or 0) * 1000,
         median_itl_ms=np.median(itls or 0) * 1000,
-        percentiles_itl_ms=[(p, np.percentile(itls or 0, p) * 1000) for p in selected_percentiles],
+        percentiles_itl_ms=[(p, np.percentile(itls or 0, p) * 1000)
+                            for p in selected_percentiles],
         mean_etel_ms=np.median(etels or 0) * 1000,
         std_etel_ms=np.std(etels or 0) * 1000,
         median_etel_ms=np.mean(etels or 0) * 1000,
-        percentiles_etel_ms=[(p, np.percentile(etels or 0, p) * 1000) for p in selected_percentiles],
+        percentiles_etel_ms=[(p, np.percentile(etels or 0, p) * 1000)
+                             for p in selected_percentiles],
     )
 
     return metrics, actual_output_lens
@@ -445,8 +449,10 @@ async def benchmark(
 
     if "ttft" in selected_percentile_metrics:
         print("{s:{c}^{n}}".format(s='Time to First Token', n=50, c='-'))
-        print("{:<40} {:<10.2f}".format("Mean TTFT (ms):", metrics.mean_ttft_ms))
-        print("{:<40} {:<10.2f}".format("Median TTFT (ms):", metrics.median_ttft_ms))
+        print("{:<40} {:<10.2f}".format("Mean TTFT (ms):",
+                                        metrics.mean_ttft_ms))
+        print("{:<40} {:<10.2f}".format("Median TTFT (ms):",
+                                        metrics.median_ttft_ms))
         result["mean_ttft_ms"] = metrics.mean_ttft_ms
         result["median_ttft_ms"] = metrics.median_ttft_ms
         result["std_ttft_ms"] = metrics.std_ttft_ms
@@ -457,10 +463,12 @@ async def benchmark(
 
     if "tpot" in selected_percentile_metrics:
         print("{s:{c}^{n}}".format(s='Time per Output Token (excl. 1st token)',
-                                  n=50,
-                                  c='-'))
-        print("{:<40} {:<10.2f}".format("Median TPOT (ms):", metrics.median_tpot_ms))
-        print("{:<40} {:<10.2f}".format("Mean TPOT (ms):", metrics.mean_tpot_ms))
+                                   n=50,
+                                   c='-'))
+        print("{:<40} {:<10.2f}".format("Median TPOT (ms):",
+                                        metrics.median_tpot_ms))
+        print("{:<40} {:<10.2f}".format("Mean TPOT (ms):",
+                                        metrics.mean_tpot_ms))
         result["mean_tpot_ms"] = metrics.mean_tpot_ms
         result["median_tpot_m"] = metrics.median_tpot_ms
         result["std_tpot_ms"] = metrics.std_tpot_ms
@@ -472,7 +480,8 @@ async def benchmark(
     if "itl" in selected_percentile_metrics:
         print("{s:{c}^{n}}".format(s='Inter-token Latency', n=50, c='-'))
         print("{:<40} {:<10.2f}".format("Mean ITL (ms):", metrics.mean_itl_ms))
-        print("{:<40} {:<10.2f}".format("Median ITL (ms):", metrics.median_itl_ms))
+        print("{:<40} {:<10.2f}".format("Median ITL (ms):",
+                                        metrics.median_itl_ms))
         result["mean_itl_ms"] = metrics.mean_itl_ms,
         result["median_itl_ms"] = metrics.median_itl_ms,
         result["std_itl_ms"] = metrics.std_itl_ms,
@@ -483,7 +492,8 @@ async def benchmark(
 
     if "etel" in selected_percentile_metrics:
         print("{s:{c}^{n}}".format(s='End-to-end Latency', n=50, c='-'))
-        print("{:<40} {:<10.2f}".format("Mean ETEL (ms):", metrics.mean_etel_ms))
+        print("{:<40} {:<10.2f}".format("Mean ETEL (ms):",
+                                        metrics.mean_etel_ms))
         print("{:<40} {:<10.2f}".format("Median ETEL (ms):",
                                         metrics.median_etel_ms))
         result["mean_etel_ms"] = metrics.mean_etel_ms,
@@ -595,7 +605,9 @@ def main(args: argparse.Namespace):
             disable_tqdm=args.disable_tqdm,
             profile=args.profile,
             selected_percentile_metrics=args.percentile_metrics.split(","),
-            selected_percentiles=[float(p) for p in args.metric_percentiles.split(",")],
+            selected_percentiles=[
+                float(p) for p in args.metric_percentiles.split(",")
+            ],
         ))
 
     # Save config and results to json
@@ -818,8 +830,7 @@ if __name__ == "__main__":
         help="Comma-seperated list of selected metrics to report percentils. "
         "This argument specifies the metrics to report percentiles. "
         "Allowed metric names are \"ttft\", \"tpot\", \"itl\", \"etel\". "
-        "Default value is \"ttft,tpot,itl\"."
-    )
+        "Default value is \"ttft,tpot,itl\".")
     parser.add_argument(
         "--metric-percentiles",
         type=str,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -61,15 +61,31 @@ class BenchmarkMetrics:
     mean_ttft_ms: float
     median_ttft_ms: float
     std_ttft_ms: float
+    p25_ttft_ms: float
+    p75_ttft_ms: float
+    p95_ttft_ms: float
     p99_ttft_ms: float
     mean_tpot_ms: float
     median_tpot_ms: float
     std_tpot_ms: float
+    p25_tpot_ms: float
+    p75_tpot_ms: float
+    p95_tpot_ms: float
     p99_tpot_ms: float
     mean_itl_ms: float
     median_itl_ms: float
     std_itl_ms: float
+    p25_itl_ms: float
+    p75_itl_ms: float
+    p95_itl_ms: float
     p99_itl_ms: float
+    mean_latency_ms: float
+    median_latency_ms: float
+    std_latency_ms: float
+    p25_latency_ms: float
+    p75_latency_ms: float
+    p95_latency_ms: float
+    p99_latency_ms: float
 
 
 def sample_sharegpt_requests(
@@ -242,6 +258,7 @@ def calculate_metrics(
     itls: List[float] = []
     tpots: List[float] = []
     ttfts: List[float] = []
+    latencies: List[float] = []
     for i in range(len(outputs)):
         if outputs[i].success:
             # We use the tokenizer to count the number of output tokens for all
@@ -258,6 +275,7 @@ def calculate_metrics(
                     (outputs[i].latency - outputs[i].ttft) / (output_len - 1))
             itls += outputs[i].itl
             ttfts.append(outputs[i].ttft)
+            latencies.append(outputs[i].latency)
             completed += 1
         else:
             actual_output_lens.append(0)
@@ -276,17 +294,33 @@ def calculate_metrics(
         output_throughput=sum(actual_output_lens) / dur_s,
         mean_ttft_ms=np.mean(ttfts or 0) *
         1000,  # ttfts is empty if streaming is not supported by backend
-        median_ttft_ms=np.median(ttfts or 0) * 1000,
         std_ttft_ms=np.std(ttfts or 0) * 1000,
+        p25_ttft_ms=np.percentile(ttfts or 0, 25) * 1000,
+        median_ttft_ms=np.median(ttfts or 0) * 1000,
+        p75_ttft_ms=np.percentile(ttfts or 0, 75) * 1000,
+        p95_ttft_ms=np.percentile(ttfts or 0, 95) * 1000,
         p99_ttft_ms=np.percentile(ttfts or 0, 99) * 1000,
         mean_tpot_ms=np.mean(tpots or 0) * 1000,
-        median_tpot_ms=np.median(tpots or 0) * 1000,
         std_tpot_ms=np.std(tpots or 0) * 1000,
+        p25_tpot_ms=np.percentile(tpots or 0, 25) * 1000,
+        median_tpot_ms=np.median(tpots or 0) * 1000,
+        p75_tpot_ms=np.percentile(tpots or 0, 75) * 1000,
+        p95_tpot_ms=np.percentile(tpots or 0, 95) * 1000,
         p99_tpot_ms=np.percentile(tpots or 0, 99) * 1000,
         mean_itl_ms=np.mean(itls or 0) * 1000,
-        median_itl_ms=np.median(itls or 0) * 1000,
         std_itl_ms=np.std(itls or 0) * 1000,
+        p25_itl_ms=np.percentile(itls or 0, 25) * 1000,
+        median_itl_ms=np.median(itls or 0) * 1000,
+        p75_itl_ms=np.percentile(itls or 0, 75) * 1000,
+        p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
+        mean_latency_ms=np.median(latencies or 0) * 1000,
+        std_latency_ms=np.std(latencies or 0) * 1000,
+        p25_latency_ms=np.percentile(latencies or 0, 25) * 1000,
+        median_latency_ms=np.mean(latencies or 0) * 1000,
+        p75_latency_ms=np.percentile(latencies or 0, 75) * 1000,
+        p95_latency_ms=np.percentile(latencies or 0, 95) * 1000,
+        p99_latency_ms=np.percentile(latencies or 0, 99) * 1000,
     )
 
     return metrics, actual_output_lens
@@ -409,20 +443,37 @@ async def benchmark(
                                     metrics.output_throughput))
     print("{s:{c}^{n}}".format(s='Time to First Token', n=50, c='-'))
     print("{:<40} {:<10.2f}".format("Mean TTFT (ms):", metrics.mean_ttft_ms))
-    print("{:<40} {:<10.2f}".format("Median TTFT (ms):",
-                                    metrics.median_ttft_ms))
+    print("{:<40} {:<10.2f}".format("P25 TTFT (ms):", metrics.p25_ttft_ms))
+    print("{:<40} {:<10.2f}".format("P75 TTFT (ms):", metrics.p75_ttft_ms))
+    print("{:<40} {:<10.2f}".format("p50 TTFT (ms):", metrics.median_ttft_ms))
+    print("{:<40} {:<10.2f}".format("P95 TTFT (ms):", metrics.p95_ttft_ms))
     print("{:<40} {:<10.2f}".format("P99 TTFT (ms):", metrics.p99_ttft_ms))
     print("{s:{c}^{n}}".format(s='Time per Output Token (excl. 1st token)',
                                n=50,
                                c='-'))
     print("{:<40} {:<10.2f}".format("Mean TPOT (ms):", metrics.mean_tpot_ms))
-    print("{:<40} {:<10.2f}".format("Median TPOT (ms):",
-                                    metrics.median_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P25 TPOT (ms):", metrics.p25_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P50 TPOT (ms):", metrics.median_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P75 TPOT (ms):", metrics.p75_tpot_ms))
+    print("{:<40} {:<10.2f}".format("P95 TPOT (ms):", metrics.p95_tpot_ms))
     print("{:<40} {:<10.2f}".format("P99 TPOT (ms):", metrics.p99_tpot_ms))
+
     print("{s:{c}^{n}}".format(s='Inter-token Latency', n=50, c='-'))
     print("{:<40} {:<10.2f}".format("Mean ITL (ms):", metrics.mean_itl_ms))
-    print("{:<40} {:<10.2f}".format("Median ITL (ms):", metrics.median_itl_ms))
+    print("{:<40} {:<10.2f}".format("P25 ITL (ms):", metrics.p25_itl_ms))
+    print("{:<40} {:<10.2f}".format("P50 ITL (ms):", metrics.median_itl_ms))
+    print("{:<40} {:<10.2f}".format("P75 ITL (ms):", metrics.p75_itl_ms))
+    print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
+
+    print("{s:{c}^{n}}".format(s='End-to-end Latency', n=50, c='-'))
+    print("{:<40} {:<10.2f}".format("Mean EEL (ms):", metrics.mean_latency_ms))
+    print("{:<40} {:<10.2f}".format("P25 EEL (ms):", metrics.p25_latency_ms))
+    print("{:<40} {:<10.2f}".format("P50 EEL (ms):",
+                                    metrics.median_latency_ms))
+    print("{:<40} {:<10.2f}".format("P75 EEL (ms):", metrics.p75_latency_ms))
+    print("{:<40} {:<10.2f}".format("P95 EEL (ms):", metrics.p95_latency_ms))
+    print("{:<40} {:<10.2f}".format("P99 EEL (ms):", metrics.p99_latency_ms))
     print("=" * 50)
 
     result = {

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -455,6 +455,8 @@ async def benchmark(
         # E.g., "Time to First Token"
         metric_header: str,
     ):
+        # This function print and add statistics of the specified
+        # metric.
         if metric_attribute_name not in selected_percentile_metrics:
             return
         print("{s:{c}^{n}}".format(s=metric_header, n=50, c='-'))
@@ -470,7 +472,8 @@ async def benchmark(
             metrics, f"median_{metric_attribute_name}_ms")
         result[f"std_{metric_attribute_name}_ms"] = getattr(
             metrics, f"std_{metric_attribute_name}_ms")
-        for p, value in getattr(metrics, f"percentiles_{metric_attribute_name}_ms"):
+        for p, value in getattr(metrics,
+                                f"percentiles_{metric_attribute_name}_ms"):
             p_word = str(int(p)) if int(p) == p else str(p)
             print("{:<40} {:<10.2f}".format(f"P{p_word} {metric_name} (ms):",
                                             value))


### PR DESCRIPTION
99-precentile can be far away from median, average, and sometimes even 95-percentile. This PR adds more latency percentiles and end-to-end latency for profiling throughput.


Example usage (see `--percentile-metrics` and `--metric-percentiles`):
```bash
model_name="meta-llama/Meta-Llama-3.1-70B-Instruct"
python3 benchmark_serving.py \
    --backend vllm \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --model $model_name \
    --num-prompts 20 \
    --endpoint /v1/completions \
    --tokenizer $model_name \
    --save-result \
    --percentile-metrics "ttft,tpot,itl,e2el" \
    --metric-percentiles "30,50,70,90" \
    --port 9487 \
    2>&1 | tee benchmark_serving.txt
bench_serving_exit_code=$?
```
produces
```
============ Serving Benchmark Result ============
Successful requests:                     20        
Benchmark duration (s):                  34.57     
Total input tokens:                      3590      
Total generated tokens:                  3927      
Request throughput (req/s):              0.58      
Input token throughput (tok/s):          103.86    
Output token throughput (tok/s):         113.61    
---------------Time to First Token----------------
Mean TTFT (ms):                          280.00    
Median TTFT (ms):                        184.59    
P30 TTFT (ms):                           183.32    
P50 TTFT (ms):                           184.59    
P70 TTFT (ms):                           429.35    
P90 TTFT (ms):                           518.89    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          48.98     
Median TPOT (ms):                        48.70     
P30 TPOT (ms):                           47.43     
P50 TPOT (ms):                           48.70     
P70 TPOT (ms):                           49.40     
P90 TPOT (ms):                           50.74     
---------------Inter-token Latency----------------
Mean ITL (ms):                           47.45     
Median ITL (ms):                         46.75     
P30 ITL (ms):                            46.32     
P50 ITL (ms):                            46.75     
P70 ITL (ms):                            47.46     
P90 ITL (ms):                            48.31     
----------------End-to-end Latency----------------
Mean E2EL (ms):                          5670.77   
Median E2EL (ms):                        9628.67   
P30 E2EL (ms):                           2497.91   
P50 E2EL (ms):                           5670.77   
P70 E2EL (ms):                           13700.87  
P90 E2EL (ms):                           20139.72  
==================================================
```