### PR TITLE
[TPU] Avoid initializing TPU runtime in is_tpu

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -8,8 +8,10 @@ current_platform: Platform
 
 is_tpu = False
 try:
-    import torch_xla.core.xla_model as xm
-    xm.xla_device(devkind="TPU")
+    # While it's technically possible to install libtpu on a non-TPU machine,
+    # this is a very uncommon scenario. Therefore, we assume that libtpu is
+    # installed if and only if the machine has TPUs.
+    import libtpu  # noqa: F401
     is_tpu = True
 except Exception:
     pass


### PR DESCRIPTION
#7659 broke the TPU backend with TP > 1 because `xm.xla_device(devkind="TPU")` tries to initialize the TPU runtime for TPU 0 before the worker processes are assigned the rank and set their devices. This leads to a deadlock.

This PR fixes it by just using `libtpu` as a proxy for checking whether the machine has TPUs.