### PR TITLE
[Bugfix] Use LoadFormat values as choices for `vllm serve --load-format`

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -9,8 +9,8 @@ import torch
 
 import vllm.envs as envs
 from vllm.config import (CacheConfig, DecodingConfig, DeviceConfig,
-                         EngineConfig, LoadConfig, LoRAConfig, ModelConfig,
-                         ObservabilityConfig, ParallelConfig,
+                         EngineConfig, LoadConfig, LoadFormat, LoRAConfig,
+                         ModelConfig, ObservabilityConfig, ParallelConfig,
                          PromptAdapterConfig, SchedulerConfig,
                          SpeculativeConfig, TokenizerPoolConfig)
 from vllm.executor.executor_base import ExecutorBase
@@ -214,10 +214,7 @@ class EngineArgs:
             '--load-format',
             type=str,
             default=EngineArgs.load_format,
-            choices=[
-                'auto', 'pt', 'safetensors', 'npcache', 'dummy', 'tensorizer',
-                'bitsandbytes'
-            ],
+            choices=[f.value for f in LoadFormat],
             help='The format of the model weights to load.\n\n'
             '* "auto" will try to load the weights in the safetensors format '
             'and fall back to the pytorch bin format if safetensors format '


### PR DESCRIPTION
The choices for the `--load-format` argument haven't been kept in sync with new load formats being added. This PR changes the choices of the arg to directly reference the LoadFormat enum.

For instance, before this PR you could not load sharded_state models with `vllm serve`
```bash
> huggingface-cli download neuralmagic/Meta-Llama-3-8B-Instruct-FP8 --local-dir Meta-Llama-3-8B-Instruct-FP8
> python examples/save_sharded_state.py --model Meta-Llama-3-8B-Instruct-FP8 --tensor-parallel-size 2 --output Meta-Llama-3-8B-Instruct-FP8-SHARDED
> vllm serve Meta-Llama-3-8B-Instruct-FP8-SHARDED --tensor-parallel-size 2 --load-format sharded_state
usage: vllm serve <model_tag> [options]
vllm serve: error: argument --load-format: invalid choice: 'sharded_state' (choose from 'auto', 'pt', 'safetensors', 'npcache', 'dummy', 'tensorizer', 'bitsandbytes')
```

This did not accurately list the enum values we have available 
```python
class LoadFormat(str, enum.Enum):
    AUTO = "auto"
    PT = "pt"
    SAFETENSORS = "safetensors"
    NPCACHE = "npcache"
    DUMMY = "dummy"
    TENSORIZER = "tensorizer"
    SHARDED_STATE = "sharded_state"
    GGUF = "gguf"
    BITSANDBYTES = "bitsandbytes"
```