### PR TITLE
[Bugfix] Catch up with removed parameter 'is_prompt' in cpu/xpu model runner

### DIFF
--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -111,6 +111,11 @@ class CPUModelRunner(ModelRunnerBase[CPUModelInput]):
             self.kv_cache_dtype,
             self.block_size,
         )
+        print("@"*30)
+        print(self.attn_backend)
+        print("@"*30)
+        from vllm.attention.backends.torch_sdpa import TorchSDPABackend
+        self.attn_backend = TorchSDPABackend 
 
         # Multi-modal data support
         self.mm_registry = MULTIMODAL_REGISTRY

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -206,6 +206,7 @@ class CPUModelRunner(ModelRunnerBase[CPUModelInput]):
                                     device=self.device)  # type: ignore
 
         attn_metadata = self.attn_backend.make_metadata(
+            is_prompt=True,
             seq_lens=seq_lens,
             seq_lens_tensor=torch.tensor([]),
             max_decode_seq_len=0,
@@ -286,6 +287,7 @@ class CPUModelRunner(ModelRunnerBase[CPUModelInput]):
         )
 
         attn_metadata = self.attn_backend.make_metadata(
+            is_prompt=False,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seq_lens_tensor=seq_lens_tensor,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -201,7 +201,6 @@ class CPUModelRunner(ModelRunnerBase[CPUModelInput]):
                                     device=self.device)  # type: ignore
 
         attn_metadata = self.attn_backend.make_metadata(
-            is_prompt=True,
             seq_lens=seq_lens,
             seq_lens_tensor=torch.tensor([]),
             max_decode_seq_len=0,
@@ -282,7 +281,6 @@ class CPUModelRunner(ModelRunnerBase[CPUModelInput]):
         )
 
         attn_metadata = self.attn_backend.make_metadata(
-            is_prompt=False,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seq_lens_tensor=seq_lens_tensor,

--- a/vllm/worker/xpu_model_runner.py
+++ b/vllm/worker/xpu_model_runner.py
@@ -225,7 +225,6 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
         seqlen_q = torch.cumsum(seqlen, dim=0).to(device=self.device)
 
         attn_metadata = self.attn_backend.make_metadata(
-            is_prompt=True,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seqlen_q=seqlen_q,
@@ -308,7 +307,6 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
         )
 
         attn_metadata = self.attn_backend.make_metadata(
-            is_prompt=False,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seqlen_q=torch.tensor([]),

--- a/vllm/worker/xpu_model_runner.py
+++ b/vllm/worker/xpu_model_runner.py
@@ -225,6 +225,7 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
         seqlen_q = torch.cumsum(seqlen, dim=0).to(device=self.device)
 
         attn_metadata = self.attn_backend.make_metadata(
+            is_prompt=True,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seqlen_q=seqlen_q,
@@ -307,6 +308,7 @@ class ModelInputForXPUBuilder(ModelRunnerInputBuilderBase[ModelInputForXPU]):
         )
 
         attn_metadata = self.attn_backend.make_metadata(
+            is_prompt=False,
             slot_mapping=slot_mapping,
             seq_lens=seq_lens,
             seqlen_q=torch.tensor([]),


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

FIX #6225

I've encountered the same issue above. There might be refactoring issue from #4681.
There is no longer exists a parameter 'is_prompt' in AttentionMetadata class. Looks like such field's role was moved to each method (to determine the token is for prompt or decoding)
But, in cpu/xpu model runner, they use such parameter as a key-value args. Thus, making an error when serving some model with cpu device.

### How to reproduce

```
VLLM_CPU_KVCACHE_SPACE=16 python benchmarks/benchmark_throughput.py --model mosaicml/mpt-7b --input-len 128 --output-len 512 --trust-remote-code --backend=vllm  --device cpu --dtype bfloat16
```
Built vllm package with editable mode (`pip install -e .`)

- error log
```
INFO 08-23 07:42:03 cpu_executor.py:207] # CPU blocks: 2048
Processed prompts:   0%|                                                                                                                 | 0/1000 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s][rank0]: Traceback (most recent call last):
[rank0]:   File "/vllm/benchmarks/benchmark_throughput.py", line 439, in <module>
[rank0]:     main(args)
[rank0]:   File "/vllm/benchmarks/benchmark_throughput.py", line 227, in main
[rank0]:     elapsed_time = run_vllm(
[rank0]:   File "/vllm/benchmarks/benchmark_throughput.py", line 127, in run_vllm
[rank0]:     llm.generate(prompts, sampling_params, use_tqdm=True)
[rank0]:   File "/vllm/vllm/utils.py", line 1030, in inner
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/vllm/vllm/entrypoints/llm.py", line 345, in generate
[rank0]:     outputs = self._run_engine(use_tqdm=use_tqdm)
[rank0]:   File "/vllm/vllm/entrypoints/llm.py", line 686, in _run_engine
[rank0]:     step_outputs = self.llm_engine.step()
[rank0]:   File "/vllm/vllm/engine/llm_engine.py", line 1319, in step
[rank0]:     output = self.model_executor.execute_model(
[rank0]:   File "/vllm/vllm/executor/cpu_executor.py", line 222, in execute_model
[rank0]:     output = self.driver_method_invoker(self.driver_worker,
[rank0]:   File "/vllm/vllm/executor/cpu_executor.py", line 356, in _driver_method_invoker
[rank0]:     return getattr(driver, method)(*args, **kwargs)
[rank0]:   File "/vllm/vllm/worker/worker_base.py", line 290, in execute_model
[rank0]:     inputs = self.prepare_input(execute_model_req)
[rank0]:   File "/vllm/vllm/worker/worker_base.py", line 278, in prepare_input
[rank0]:     return self._get_driver_input_and_broadcast(execute_model_req)
[rank0]:   File "/vllm/vllm/worker/worker_base.py", line 249, in _get_driver_input_and_broadcast
[rank0]:     self.model_runner.prepare_model_input(
[rank0]:   File "/vllm/vllm/worker/cpu_model_runner.py", line 322, in prepare_model_input
[rank0]:     ) = self._prepare_prompt(seq_group_metadata_list)
[rank0]:   File "/vllm/vllm/worker/cpu_model_runner.py", line 201, in _prepare_prompt
[rank0]:     attn_metadata = self.attn_backend.make_metadata(
[rank0]:   File "/vllm/vllm/attention/backends/abstract.py", line 47, in make_metadata
[rank0]:     return cls.get_metadata_cls()(*args, **kwargs)
[rank0]: TypeError: FlashAttentionMetadata.__init__() got an unexpected keyword argument 'is_prompt'
Processed prompts:   0%|                                                                                                                 | 0/1000 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
```


Root cause: Incorrect Attention Backend Selection on CPU

- Context: When running vllm with device="cpu", the engine correctly sets executor_class to CPUExecutor.
- Root Cause:
   - The get_attn_backend() function incorrectly selects FlashAttentionBackend instead of TorchSDPABackend.
   - This happens because which_attn_to_use() bases its decision on the package configuration (CPU/GPU), ignoring the runtime device parameter.
- Impact:
   - This results in the wrong backend being used in CPU environments, leading to potential errors and performance issues.
   - Additionally, there’s an issue with argument mismatches due to the incorrect backend being selected.
- Proposed Solution:
   - Update which_attn_to_use() to consider the device parameter when selecting the backend.


**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


