### PR TITLE
[misc] Optimize speculative decoding

### DIFF
--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -168,7 +168,8 @@ class MultiStepWorker(Worker, ProposerWorkerBase):
     @staticmethod
     def _filter_model_output(
             expanded_batch_outputs: List[SamplerOutput],
-            output_indices_to_retain: List[int]) -> List[SamplerOutput]:
+            output_indices_to_retain: List[int],
+            device: torch.device) -> List[SamplerOutput]:
         """
         Filters the model output to include only the specified sequence
         outputs. This method contracts the expanded batch output from the
@@ -185,26 +186,33 @@ class MultiStepWorker(Worker, ProposerWorkerBase):
             List[SamplerOutput]: A list containing the filtered model 
             outputs for the specified indices.
         """
-        return [
-            SamplerOutput(
-                outputs=[
-                    expanded_batch_output.outputs[i]
-                    for i in output_indices_to_retain
-                ] if len(expanded_batch_output.outputs) > 0 else [],
-                sampled_token_probs=(
-                    expanded_batch_output.
-                    sampled_token_probs[output_indices_to_retain]
-                    if expanded_batch_output.sampled_token_probs is not None
-                    else None),
-                logprobs=(
-                    expanded_batch_output.logprobs[output_indices_to_retain]
-                    if expanded_batch_output.logprobs is not None else None),
-                sampled_token_ids=(expanded_batch_output.
-                                   sampled_token_ids[output_indices_to_retain]
-                                   if expanded_batch_output.sampled_token_ids
-                                   is not None else None))
-            for expanded_batch_output in expanded_batch_outputs
-        ]
+        def _filter_optional_tensor(tensor: torch.Tensor, indices: torch.Tensor) -> torch.Tensor:
+            return tensor.index_select(0, indices) if tensor is not None else None
+
+        if not expanded_batch_outputs:
+            return []
+
+        output_indices_to_retain_tensor = torch.tensor(output_indices_to_retain, device=device)
+
+        filtered_outputs = []
+        for expanded_batch_output in expanded_batch_outputs:
+            outputs = (
+                [expanded_batch_output.outputs[i] for i in output_indices_to_retain]
+                if expanded_batch_output.outputs else []
+            )
+
+            sampled_token_probs = _filter_optional_tensor(expanded_batch_output.sampled_token_probs, output_indices_to_retain_tensor)
+            logprobs = _filter_optional_tensor(expanded_batch_output.logprobs, output_indices_to_retain_tensor)
+            sampled_token_ids = _filter_optional_tensor(expanded_batch_output.sampled_token_ids, output_indices_to_retain_tensor)
+
+            filtered_outputs.append(SamplerOutput(
+                outputs=outputs,
+                sampled_token_probs=sampled_token_probs,
+                logprobs=logprobs,
+                sampled_token_ids=sampled_token_ids
+            ))
+
+        return filtered_outputs
 
     def get_spec_proposals(
         self,

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -100,7 +100,7 @@ class MultiStepWorker(Worker, ProposerWorkerBase):
                 model_outputs.append(model_output)
 
         filtered_model_outputs = self._filter_model_output(
-            model_outputs, indices_of_seq_with_bonus_tokens)
+            model_outputs, indices_of_seq_with_bonus_tokens, self.device)
         return filtered_model_outputs, True
 
     @staticmethod

--- a/vllm/spec_decode/top1_proposer.py
+++ b/vllm/spec_decode/top1_proposer.py
@@ -226,47 +226,31 @@ class Top1Proposer(SpeculativeProposer):
         if maybe_sampler_output is None:
             # If no speculative tokens, the sampler output will be None.
             # In this case we return empty proposals.
-            proposal_tokens = torch.tensor(-1,
-                                           dtype=torch.long,
-                                           device=self._device).expand(
-                                               batch_size, proposal_len)
-            proposal_probs = torch.tensor(0,
-                                          dtype=torch.float32,
-                                          device=self._device).expand(
-                                              batch_size, proposal_len,
-                                              self._vocab_size)
-            proposal_lens_tensor = torch.tensor(0,
-                                                dtype=torch.long,
-                                                device=self._device).expand(
-                                                    len(proposal_lens))
+            proposal_tokens = torch.full((batch_size, proposal_len), -1,
+                                         dtype=torch.long, device=self._device)
+            proposal_probs = torch.zeros((batch_size, proposal_len, self._vocab_size),
+                                         dtype=torch.float32, device=self._device)
+            proposal_lens_tensor = torch.zeros(len(proposal_lens),
+                                               dtype=torch.long, device=self._device)
             return proposal_tokens, proposal_probs, proposal_lens_tensor
 
         sampler_output = maybe_sampler_output
-        proposal_tokens, proposal_probs, *_ = sampler_output_to_torch(
-            sampler_output, sampler_transposed)
+        proposal_tokens, proposal_probs, *_ = sampler_output_to_torch(sampler_output, sampler_transposed)
 
-        # Now, reformat the output GPU tensors such that each sequence has
-        # a proposal. the proposal can be empty, e.g. [-1, -1, -1]
-
-        entire_proposal_tokens = proposal_tokens.new_full(
-            size=(batch_size, *proposal_tokens.shape[1:]),
-            fill_value=-1,
-        )
-        entire_proposal_tokens[nonzero_proposal_len_indices] = proposal_tokens
-        entire_proposal_probs = proposal_probs.new_zeros(
-            batch_size,
-            *proposal_probs.shape[1:],
-        )
-        entire_proposal_probs[nonzero_proposal_len_indices] = proposal_probs
-
-        proposal_tokens, proposal_probs = (
-            entire_proposal_tokens,
-            entire_proposal_probs,
-        )
+        # Initialize tensors with appropriate sizes
+        entire_proposal_tokens = torch.full_like(proposal_tokens, -1, dtype=torch.long, device=self._device)
+        entire_proposal_probs = torch.zeros_like(proposal_probs, dtype=torch.float32, device=self._device)
+        
+        # Convert nonzero_proposal_len_indices to a tensor for efficient indexing
+        nonzero_indices_tensor = torch.tensor(nonzero_proposal_len_indices, device=self._device)
+        
+        # Use advanced indexing to avoid multiple tensor assignments
+        entire_proposal_tokens.index_copy_(0, nonzero_indices_tensor, proposal_tokens)
+        entire_proposal_probs.index_copy_(0, nonzero_indices_tensor, proposal_probs)
 
         proposal_lens_tensor = torch.zeros(batch_size,
                                            dtype=torch.long,
                                            device=self._device)
-        proposal_lens_tensor[nonzero_proposal_len_indices] = proposal_len
+        proposal_lens_tensor.index_fill_(0, nonzero_indices_tensor, proposal_len)
 
-        return proposal_tokens, proposal_probs, proposal_lens_tensor
+        return entire_proposal_tokens, entire_proposal_probs, proposal_lens_tensor


### PR DESCRIPTION
This PR introduces optimizations to the speculative decoding process by reducing memory copy overhead, resulting in improved performance.

After profiling, I found that cuda memcpy occurred abnormally, so I improved the code. (Refer to the profiling image below)
I experimented with one a100 gpu, and the code I used for the experiment is as follows.

I improved the `_filter_model_output` function and `_merge_outputs` function, and confirmed that the test code below improved by about 3%.

| Applied Function | E2E Latency |
| --- | --- |
| baseline | 0.462s |
| `_filter_model_output` | 0.457s |
| `_merge_outputs` | 0.459s |
| `_filter_model_output` + `_merge_outputs` | 0.449s |

<details>
<summary>Test code using the OPT model</summary>

```python
import time
import nvtx
from typing import List
from vllm import LLM, SamplingParams

def time_generation(llm: LLM, prompts: List[str],
                    sampling_params: SamplingParams):
    llm.generate(prompts, sampling_params)
    llm.generate(prompts, sampling_params)
    times = []
    with nvtx.annotate("generate", color="blue"):
        for _ in range(10):
            start = time.time()
            outputs = llm.generate(prompts, sampling_params)
            end = time.time()
            times.append(end-start)
    print(sum(times) / len(times))

    for output in outputs:
        generated_text = output.outputs[0].text
        print(f"text: {generated_text!r}")


if __name__ == "__main__":
    sampling_params = SamplingParams(temperature=0.0, max_tokens=100)

    prompts = [
        "The president of the United States is",
    ]

    llm = LLM(
        model="facebook/opt-6.7b",
        tensor_parallel_size=1,
        speculative_model="facebook/opt-125m",
        num_speculative_tokens=5,
        use_v2_block_manager=True,
    )

    time_generation(llm, prompts, sampling_params)
```
</details>


**Profiling results**
- Before code improvement
        <img width="2135" alt="2024-08-27_00-08-21" src="https://github.com/user-attachments/assets/b66f43f3-b0ca-4779-af2f-f80f6912ae94">

- After code improvement
        <img width="2095" alt="2024-08-27_00-08-28" src="https://github.com/user-attachments/assets/ea494f45-b399-49df-a943-1b935dac1f58">
