### PR TITLE
[CI/Build] Add linting for github actions workflows

### DIFF
--- a/.github/workflows/actionlint.dockerfile
+++ b/.github/workflows/actionlint.dockerfile
@@ -1,0 +1,3 @@
+# Since dependabot cannot update workflows using docker,
+# we use this indirection since dependabot can update this file.
+FROM docker.io/rhysd/actionlint:1.7.1@sha256:435ecdb63b1169e80ca3e136290072548c07fc4d76a044cf5541021712f8f344

--- a/.github/workflows/actionlint.dockerfile
+++ b/.github/workflows/actionlint.dockerfile
@@ -1,3 +1,0 @@
-# Since dependabot cannot update workflows using docker,
-# we use this indirection since dependabot can update this file.
-FROM docker.io/rhysd/actionlint:1.7.1@sha256:435ecdb63b1169e80ca3e136290072548c07fc4d76a044cf5541021712f8f344

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,42 @@
+name: Lint GitHub Actions workflows
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*'
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - '.github/workflows/*.ya?ml'
+      - '.github/workflows/actionlint.*'
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: "Download actionlint"
+        run: |
+          docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
+
+      - name: "Check workflow files"
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/actionlint.json"
+          docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: "Download actionlint"
+      - name: "Run actionlint"
         run: |
-          docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
-
-      - name: "Check workflow files"
-        run: |
-          echo "::add-matcher::.github/workflows/matchers/actionlint.json"
-          docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color
+          tools/actionlint.sh -color

--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Add label
-                uses: actions/github-script@v5
+                uses: actions/github-script@v6
                 with:
                     script: |
                         github.rest.issues.addLabels({

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/matchers/actionlint.json
+++ b/.github/workflows/matchers/actionlint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Extract branch info
         shell: bash
         run: |
-          echo "release_tag=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "release_tag=${GITHUB_REF#refs/*/}" >> "$GITHUB_ENV"
 
       - name: Create Release
         id: create_release
@@ -88,8 +88,8 @@ jobs:
           bash -x .github/workflows/scripts/build.sh ${{ matrix.python-version }} ${{ matrix.cuda-version }}
           wheel_name=$(ls dist/*whl | xargs -n 1 basename)
           asset_name=${wheel_name//"linux"/"manylinux1"}
-          echo "wheel_name=${wheel_name}" >> $GITHUB_ENV
-          echo "asset_name=${asset_name}" >> $GITHUB_ENV
+          echo "wheel_name=${wheel_name}" >> "$GITHUB_ENV"
+          echo "asset_name=${asset_name}" >> "$GITHUB_ENV"
 
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,7 +86,7 @@ jobs:
           CMAKE_BUILD_TYPE: Release # do not compile with debug symbol to reduce wheel size
         run: |
           bash -x .github/workflows/scripts/build.sh ${{ matrix.python-version }} ${{ matrix.cuda-version }}
-          wheel_name=$(ls dist/*whl | xargs -n 1 basename)
+          wheel_name=$(find dist -name "*whl" -print0 | xargs -0 -n 1 basename)
           asset_name=${wheel_name//"linux"/"manylinux1"}
           echo "wheel_name=${wheel_name}" >> "$GITHUB_ENV"
           echo "asset_name=${asset_name}" >> "$GITHUB_ENV"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ hip_compat.h
 
 # Benchmark dataset
 benchmarks/*.json
+
+# Linting
+actionlint

--- a/format.sh
+++ b/format.sh
@@ -286,6 +286,29 @@ else
 fi
 echo 'vLLM clang-format: Done'
 
+echo 'vLLM actionlint:'
+
+DOCKER=""
+if command -v "docker" &>/dev/null; then
+    DOCKER="docker"
+elif command -v "podman" &>/dev/null; then
+    DOCKER="podman"
+else
+    echo "Docker or Podman are not installed. Please install one if you want to lint GitHub CI configuration."
+fi
+
+actionlint() {
+    if [ -z "$DOCKER" ]; then
+        return
+    fi
+    # Ensure we use the same version of actionlint as CI
+    IMAGE="vllm/actionlint:latest"
+    ${DOCKER} build --tag "${IMAGE}" - < .github/workflows/actionlint.dockerfile
+    ${DOCKER} run --volume="${PWD}:/repo:z" --workdir=/repo "${IMAGE}" -color
+}
+
+actionlint
+echo 'vLLM actionlint: Done'
 
 if ! git diff --quiet &>/dev/null; then
     echo 'Reformatted files. Please review and stage the changes.'

--- a/format.sh
+++ b/format.sh
@@ -263,7 +263,7 @@ clang_format_changed() {
     MERGEBASE="$(git merge-base origin/main HEAD)"
 
     # Get the list of changed files, excluding the specified ones
-    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.h' '*.cpp' '*.cu' '*.cuh' | grep -vFf <(printf "%s\n" "${CLANG_FORMAT_EXCLUDES[@]}"))
+    changed_files=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.h' '*.cpp' '*.cu' '*.cuh' | (grep -vFf <(printf "%s\n" "${CLANG_FORMAT_EXCLUDES[@]}") || echo -e))
     if [ -n "$changed_files" ]; then
         echo "$changed_files" | xargs -P 5 clang-format -i
     fi

--- a/format.sh
+++ b/format.sh
@@ -287,27 +287,7 @@ fi
 echo 'vLLM clang-format: Done'
 
 echo 'vLLM actionlint:'
-
-DOCKER=""
-if command -v "docker" &>/dev/null; then
-    DOCKER="docker"
-elif command -v "podman" &>/dev/null; then
-    DOCKER="podman"
-else
-    echo "Docker or Podman are not installed. Please install one if you want to lint GitHub CI configuration."
-fi
-
-actionlint() {
-    if [ -z "$DOCKER" ]; then
-        return
-    fi
-    # Ensure we use the same version of actionlint as CI
-    IMAGE="vllm/actionlint:latest"
-    ${DOCKER} build --tag "${IMAGE}" - < .github/workflows/actionlint.dockerfile
-    ${DOCKER} run --volume="${PWD}:/repo:z" --workdir=/repo "${IMAGE}" -color
-}
-
-actionlint
+tools/actionlint.sh -color
 echo 'vLLM actionlint: Done'
 
 if ! git diff --quiet &>/dev/null; then

--- a/tools/actionlint.sh
+++ b/tools/actionlint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if command -v actionlint &> /dev/null; then
+    actionlint "$@"
+    exit 0
+elif [ -x ./actionlint ]; then
+    ./actionlint "$@"
+    exit 0
+fi
+
+# download a binary to the current directory - v1.7.3
+bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/aa0a7be8e566b096e64a5df8ff290ec24fa58fbc/scripts/download-actionlint.bash)
+./actionlint "$@"


### PR DESCRIPTION
This PR introduces linting for github actions workflows to help prevent any
accidental introduction of errors in the future. It introduces this linting in
two ways:

1. A way to run the linting locally as part of `format.sh`.

2. Automatically run the linter in CI anytime github actions workflows are
   modified.

71be98bf github: Add an actionlint github workflow
a9785b56 github: Quote variables
2dcdd71d github: Handle filenames with special characters
fc050dd9 github: Update versions of various github actions
0956a417 format.sh: Avoid exit when no files changed
276b4088 format.sh: lint github ci configuration

commit 71be98bfa693baa0711e1343adc7917a8e93892f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Aug 26 13:39:01 2024 -0400

    github: Add an actionlint github workflow
    
    Add a new github actions workflow that will perform linting on github
    actions workflow changes. It will only run if github workflows are
    modified.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit a9785b56661f0d65c22ad6eede1053baf1038223
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Aug 26 13:30:03 2024 -0400

    github: Quote variables
    
    Avoid accidental globbing or argument splitting by quoting the
    `$GITHUB_ENV` variable. In practice, this would probably never be a
    problem since github sets the value, but it follows best shell
    practices and makes the shell linter happy.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 2dcdd71d9fee141f61a4e05e9b49c38a90954dfb
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Aug 26 13:34:03 2024 -0400

    github: Handle filenames with special characters
    
    Resolve the following linter warning:
    
    ```
    .github/workflows/publish.yml:87:9: shellcheck reported issue in this script: SC2011:warning:2:14: Use 'find .. -print0 | xargs -0 ..' or 'find .. -exec .. +' to allow non-alphanumeric filenames [shellcheck]
    ```
    
    I don't expect this was a problem in practice, but it follows best
    practice as indicated by the linter.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit fc050dd964c3c898c6cd49868cd177ac664aeace
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Aug 26 14:27:30 2024 -0400

    github: Update versions of various github actions
    
    These were raised by the action linter.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 0956a41791051ab49483751acf9e7e21b743b5c6
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Aug 27 10:08:31 2024 -0400

    format.sh: Avoid exit when no files changed
    
    This script is set to exit any time a command fails. In the case of
    this line, the script unexpectedly errors out on this check to see if
    any files have changed that are relevant for the `clang-format` tool.
    The `grep` specifically will return non-zero in this case.
    
    The workaround here is to catch the error and run `echo -e` instead,
    which we know will succeed and the end result is what we want (the
    list of changed files will be empty).
    
    This allows the script to continue to completion, even when
    `clang-format` has nothing to do.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 276b4088688f13d311f1807de634e20165c35166
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Aug 27 11:08:50 2024 -0400

    format.sh: lint github ci configuration
    
    Update `format.sh` to run the `actionlint` tool to check for errors in
    GitHub CI configuration. Both this script and the workflow to run this
    tool in CI run it using docker to ensure that the same version is in
    use in both places.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
