### PR TITLE
[plugin] move custom executor to plugins

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -139,7 +139,7 @@ steps:
   - tests/tokenization
   commands:
   - pip install -e ./plugins/vllm_switch_executor
-  - export VLLM_PLUGINS=""
+  - export VLLM_PLUGINS='' # use single quote to avoid conflict!
   - pytest -v -s engine test_sequence.py test_config.py test_logger.py
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -138,6 +138,8 @@ steps:
   - tests/engine
   - tests/tokenization
   commands:
+  - pip install -e ./plugins/vllm_switch_executor
+  - export VLLM_PLUGINS=""
   - pytest -v -s engine test_sequence.py test_config.py test_logger.py
   # OOM in the CI unless we run this separately
   - pytest -v -s tokenization

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -18,7 +18,9 @@ def test_custom_executor(model, tmpdir):
         os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
 
-        engine_args = EngineArgs(model=model, enforce_eager=True)
+        engine_args = EngineArgs(model=model,
+                                 enforce_eager=True,
+                                 gpu_memory_utilization=0.3)
         engine = LLMEngine.from_engine_args(engine_args)
         sampling_params = SamplingParams(max_tokens=1)
 
@@ -43,7 +45,9 @@ def test_custom_executor_async(model, tmpdir):
         os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
 
-        engine_args = AsyncEngineArgs(model=model, enforce_eager=True)
+        engine_args = AsyncEngineArgs(model=model,
+                                      enforce_eager=True,
+                                      gpu_memory_utilization=0.3)
         engine = AsyncLLMEngine.from_engine_args(engine_args)
         sampling_params = SamplingParams(max_tokens=1)
 

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -1,9 +1,10 @@
+import asyncio
 import os
 
 import pytest
 
-from vllm.engine.arg_utils import EngineArgs
-from vllm.engine.llm_engine import LLMEngine
+from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
+from vllm.engine.llm_engine import AsyncLLMEngine, LLMEngine
 from vllm.sampling_params import SamplingParams
 
 
@@ -16,12 +17,38 @@ def test_custom_executor(model, tmpdir):
         os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
 
-        engine_args = EngineArgs(model=model)
+        engine_args = EngineArgs(model=model, enforce_eager=True)
         engine = LLMEngine.from_engine_args(engine_args)
         sampling_params = SamplingParams(max_tokens=1)
 
         engine.add_request("0", "foo", sampling_params)
         engine.step()
+
+        assert os.path.exists(".marker")
+    finally:
+        os.chdir(cwd)
+        os.environ["VLLM_PLUGINS"] = old_env
+
+
+@pytest.mark.parametrize("model", ["facebook/opt-125m"])
+def test_custom_executor_async(model, tmpdir):
+    cwd = os.path.abspath(".")
+    os.chdir(tmpdir)
+    old_env = os.environ["VLLM_PLUGINS"]
+    try:
+        os.environ["VLLM_PLUGINS"] = "switch_executor"
+        assert not os.path.exists(".marker")
+
+        engine_args = AsyncEngineArgs(model=model, enforce_eager=True)
+        engine = AsyncLLMEngine.from_engine_args(engine_args)
+        sampling_params = SamplingParams(max_tokens=1)
+
+        async def t():
+            stream = await engine.add_request("0", "foo", sampling_params)
+            async for x in stream:
+                ...
+
+        asyncio.run(t())
 
         assert os.path.exists(".marker")
     finally:

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -4,7 +4,8 @@ import os
 import pytest
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
-from vllm.engine.llm_engine import AsyncLLMEngine, LLMEngine
+from vllm.engine.llm_engine import LLMEngine
+from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import SamplingParams
 
 

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -4,8 +4,8 @@ import os
 import pytest
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
-from vllm.engine.llm_engine import LLMEngine
 from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.engine.llm_engine import LLMEngine
 from vllm.sampling_params import SamplingParams
 
 
@@ -13,7 +13,7 @@ from vllm.sampling_params import SamplingParams
 def test_custom_executor(model, tmpdir):
     cwd = os.path.abspath(".")
     os.chdir(tmpdir)
-    old_env = os.environ["VLLM_PLUGINS"]
+    old_env = os.environ.get("VLLM_PLUGINS", None)
     try:
         os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
@@ -28,14 +28,17 @@ def test_custom_executor(model, tmpdir):
         assert os.path.exists(".marker")
     finally:
         os.chdir(cwd)
-        os.environ["VLLM_PLUGINS"] = old_env
+        if old_env is not None:
+            os.environ["VLLM_PLUGINS"] = old_env
+        else:
+            del os.environ["VLLM_PLUGINS"]
 
 
 @pytest.mark.parametrize("model", ["facebook/opt-125m"])
 def test_custom_executor_async(model, tmpdir):
     cwd = os.path.abspath(".")
     os.chdir(tmpdir)
-    old_env = os.environ["VLLM_PLUGINS"]
+    old_env = os.environ.get("VLLM_PLUGINS", None)
     try:
         os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
@@ -54,4 +57,7 @@ def test_custom_executor_async(model, tmpdir):
         assert os.path.exists(".marker")
     finally:
         os.chdir(cwd)
-        os.environ["VLLM_PLUGINS"] = old_env
+        if old_env is not None:
+            os.environ["VLLM_PLUGINS"] = old_env
+        else:
+            del os.environ["VLLM_PLUGINS"]

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -1,61 +1,22 @@
-import asyncio
 import os
 
 import pytest
 
-from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
-from vllm.engine.async_llm_engine import AsyncLLMEngine
+from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.llm_engine import LLMEngine
-from vllm.executor.gpu_executor import GPUExecutor, GPUExecutorAsync
 from vllm.sampling_params import SamplingParams
-
-
-class Mock:
-    ...
-
-
-class CustomGPUExecutor(GPUExecutor):
-
-    def execute_model(self, *args, **kwargs):
-        # Drop marker to show that this was ran
-        with open(".marker", "w"):
-            ...
-        return super().execute_model(*args, **kwargs)
-
-
-class CustomGPUExecutorAsync(GPUExecutorAsync):
-
-    async def execute_model_async(self, *args, **kwargs):
-        with open(".marker", "w"):
-            ...
-        return await super().execute_model_async(*args, **kwargs)
-
-
-@pytest.mark.parametrize("model", ["facebook/opt-125m"])
-def test_custom_executor_type_checking(model):
-    with pytest.raises(ValueError):
-        engine_args = EngineArgs(model=model,
-                                 distributed_executor_backend=Mock)
-        LLMEngine.from_engine_args(engine_args)
-    with pytest.raises(ValueError):
-        engine_args = AsyncEngineArgs(model=model,
-                                      distributed_executor_backend=Mock)
-        AsyncLLMEngine.from_engine_args(engine_args)
-    with pytest.raises(TypeError):
-        engine_args = AsyncEngineArgs(
-            model=model, distributed_executor_backend=CustomGPUExecutor)
-        AsyncLLMEngine.from_engine_args(engine_args)
 
 
 @pytest.mark.parametrize("model", ["facebook/opt-125m"])
 def test_custom_executor(model, tmpdir):
     cwd = os.path.abspath(".")
     os.chdir(tmpdir)
+    old_env = os.environ["VLLM_PLUGINS"]
     try:
+        os.environ["VLLM_PLUGINS"] = "switch_executor"
         assert not os.path.exists(".marker")
 
-        engine_args = EngineArgs(
-            model=model, distributed_executor_backend=CustomGPUExecutor)
+        engine_args = EngineArgs(model=model)
         engine = LLMEngine.from_engine_args(engine_args)
         sampling_params = SamplingParams(max_tokens=1)
 
@@ -65,27 +26,4 @@ def test_custom_executor(model, tmpdir):
         assert os.path.exists(".marker")
     finally:
         os.chdir(cwd)
-
-
-@pytest.mark.parametrize("model", ["facebook/opt-125m"])
-def test_custom_executor_async(model, tmpdir):
-    cwd = os.path.abspath(".")
-    os.chdir(tmpdir)
-    try:
-        assert not os.path.exists(".marker")
-
-        engine_args = AsyncEngineArgs(
-            model=model, distributed_executor_backend=CustomGPUExecutorAsync)
-        engine = AsyncLLMEngine.from_engine_args(engine_args)
-        sampling_params = SamplingParams(max_tokens=1)
-
-        async def t():
-            stream = await engine.add_request("0", "foo", sampling_params)
-            async for x in stream:
-                ...
-
-        asyncio.run(t())
-
-        assert os.path.exists(".marker")
-    finally:
-        os.chdir(cwd)
+        os.environ["VLLM_PLUGINS"] = old_env

--- a/tests/plugins/vllm_switch_executor/setup.py
+++ b/tests/plugins/vllm_switch_executor/setup.py
@@ -1,0 +1,9 @@
+from setuptools import setup
+
+setup(name='vllm_switch_executor',
+      version='0.1',
+      packages=['vllm_switch_executor'],
+      entry_points={
+          'vllm.general_plugins':
+          ["switch_executor = vllm_switch_executor:switch_executor"]
+      })

--- a/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
+++ b/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
@@ -1,4 +1,4 @@
-from vllm.executor.gpu_executor import GPUExecutor
+from vllm.executor.gpu_executor import GPUExecutor, GPUExecutorAsync
 
 
 class CustomGPUExecutor(GPUExecutor):
@@ -10,6 +10,15 @@ class CustomGPUExecutor(GPUExecutor):
         return super().execute_model(*args, **kwargs)
 
 
+class CustomGPUExecutorAsync(GPUExecutorAsync):
+
+    async def execute_model_async(self, *args, **kwargs):
+        with open(".marker", "w"):
+            ...
+        return await super().execute_model_async(*args, **kwargs)
+
+
 def switch_executor():
-    from vllm.plugins import set_executor_cls
+    from vllm.plugins import set_async_executor_cls, set_executor_cls
     set_executor_cls(CustomGPUExecutor)
+    set_async_executor_cls(CustomGPUExecutorAsync)

--- a/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
+++ b/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
@@ -1,0 +1,13 @@
+from vllm.executor.gpu_executor import GPUExecutor
+
+class CustomGPUExecutor(GPUExecutor):
+
+    def execute_model(self, *args, **kwargs):
+        # Drop marker to show that this was ran
+        with open(".marker", "w"):
+            ...
+        return super().execute_model(*args, **kwargs)
+
+def switch_executor():
+    from vllm.plugins import set_executor_cls
+    set_executor_cls(CustomGPUExecutor)

--- a/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
+++ b/tests/plugins/vllm_switch_executor/vllm_switch_executor/__init__.py
@@ -1,5 +1,6 @@
 from vllm.executor.gpu_executor import GPUExecutor
 
+
 class CustomGPUExecutor(GPUExecutor):
 
     def execute_model(self, *args, **kwargs):
@@ -7,6 +8,7 @@ class CustomGPUExecutor(GPUExecutor):
         with open(".marker", "w"):
             ...
         return super().execute_model(*args, **kwargs)
+
 
 def switch_executor():
     from vllm.plugins import set_executor_cls

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -13,7 +13,6 @@ from vllm.config import (CacheConfig, DecodingConfig, DeviceConfig,
                          ModelConfig, ObservabilityConfig, ParallelConfig,
                          PromptAdapterConfig, SchedulerConfig,
                          SpeculativeConfig, TokenizerPoolConfig)
-from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
 from vllm.utils import FlexibleArgumentParser
@@ -70,11 +69,7 @@ class EngineArgs:
     seed: int = 0
     max_model_len: Optional[int] = None
     worker_use_ray: bool = False
-    # Note: Specifying a custom executor backend by passing a class
-    # is intended for expert use only. The API may change without
-    # notice.
-    distributed_executor_backend: Optional[Union[str,
-                                                 Type[ExecutorBase]]] = None
+    distributed_executor_backend: Optional[str] = None
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
     max_parallel_loading_workers: Optional[int] = None

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -660,6 +660,9 @@ class AsyncLLMEngine:
         stat_loggers: Optional[Dict[str, StatLoggerBase]] = None,
     ) -> "AsyncLLMEngine":
         """Creates an async LLM engine from the engine arguments."""
+        from vllm.plugins import load_general_plugins
+        load_general_plugins()
+
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -237,9 +237,6 @@ class LLMEngine:
             cache_config.enable_prefix_caching,
         )
         # TODO(woosuk): Print more configs in debug mode.
-        from vllm.plugins import load_general_plugins
-        load_general_plugins()
-
         self.model_config = model_config
         self.cache_config = cache_config
         self.lora_config = lora_config
@@ -484,6 +481,9 @@ class LLMEngine:
         stat_loggers: Optional[Dict[str, StatLoggerBase]] = None,
     ) -> "LLMEngine":
         """Creates an LLM engine from the engine arguments."""
+        from vllm.plugins import load_general_plugins
+        load_general_plugins()
+
         # Create the engine configs.
         engine_config = engine_args.create_engine_config()
         executor_class = cls._get_executor_cls(engine_config)

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -1,6 +1,8 @@
 import logging
+from typing import Optional, Type
 
 import vllm.envs as envs
+from vllm.executor.executor_base import ExecutorBase
 
 logger = logging.getLogger(__name__)
 
@@ -29,3 +31,28 @@ def load_general_plugins():
             except Exception:
                 logger.exception("Failed to load general plugin: %s",
                                  plugin.name)
+
+
+_executor_cls_to_use: Optional[Type[ExecutorBase]] = None
+
+
+def set_executor_cls(executor_cls: Type[ExecutorBase]):
+    """
+    Set the executor class to use. This is used by plugins to set the executor
+    """
+    global _executor_cls_to_use
+    if _executor_cls_to_use is not None and \
+        _executor_cls_to_use is not executor_cls:
+        logger.warning(
+            "Executor class has already been set to %s by other plugins."
+            "Changing the executor class to %s now.", _executor_cls_to_use,
+            executor_cls)
+    _executor_cls_to_use = executor_cls
+
+
+def get_executor_cls() -> Optional[Type[ExecutorBase]]:
+    """
+    Get the executor class to use. This is used by the main code to get the
+    executor class to use.
+    """
+    return _executor_cls_to_use


### PR DESCRIPTION
move the custom executor introduced in https://github.com/vllm-project/vllm/pull/6557 to plugin system, to reduce the code complexity of the main codebase.