### PR TITLE
[Neuron] Adding support for context-lenght, token-gen buckets.

### DIFF
--- a/examples/offline_inference_neuron.py
+++ b/examples/offline_inference_neuron.py
@@ -1,4 +1,11 @@
+import os
+
 from vllm import LLM, SamplingParams
+
+# creates XLA hlo graphs for all the context length buckets.
+os.environ['NEURON_CONTEXT_LENGTH_BUCKETS'] = "128,512,1024,2048"
+# creates XLA hlo graphs for all the token gen buckets.
+os.environ['NEURON_TOKEN_GEN_BUCKETS'] = "128,512,1024,2048"
 
 # Sample prompts.
 prompts = [
@@ -19,8 +26,8 @@ llm = LLM(
     # Currently, this is a known limitation in continuous batching support
     # in transformers-neuronx.
     # TODO(liangfu): Support paged-attention in transformers-neuronx.
-    max_model_len=128,
-    block_size=128,
+    max_model_len=2048,
+    block_size=2048,
     # The device can be automatically detected when AWS Neuron SDK is installed.
     # The device argument can be either unspecified for automated detection,
     # or explicitly assigned.


### PR DESCRIPTION
This change request helps us control the context length and token generation buckets using environment variables. Based on the environment variable, multiple XLA HLO graphs are compiled, and the closest XLA HLO graph is selected for latency optimization on the Neuron device, depending on the sequence length.

Examples of compiled graphs:

```
context-seqlen1024-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.850d4839a10a028665ed  token-seqlen2048-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.32b851f3ad074ddfada2
context-seqlen2048-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.8402b528754a038050eb  token-seqlen512-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.bd3c900d8368718f1762
context-seqlen512-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.e3ef76de78873a8f6b0b
```

https://github.com/vllm-project/vllm/discussions/7747


Results:

With out bucketing : 

```
context-seqlen2048-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.8402b528754a038050eb  token-seqlen2048-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.32b851f3ad074ddfada2
```

With bucketing:

```
context-seqlen1024-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.850d4839a10a028665ed  token-seqlen1024-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.f1278f9277f790920bb9
context-seqlen128-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.3cf09c4e171aee8bef59   token-seqlen128-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.93392ea1ffc8d204047e
context-seqlen2048-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.8402b528754a038050eb  token-seqlen2048-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.32b851f3ad074ddfada2
context-seqlen512-batch1-FullyUnrolled.3428.2.0.79554.0a0+846892a0.e3ef76de78873a8f6b0b   token-seqlen512-batch8-FullyUnrolled.4255.2.0.79554.0a0+846892a0.bd3c900d8368718f1762
```

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


