### PR TITLE
[Kernel] changing fused moe kernel chunk size default to 32k

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -352,7 +352,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
             os.path.join(get_default_cache_root(), "vllm", "xla_cache"),
         )),
     "VLLM_FUSED_MOE_CHUNK_SIZE":
-    lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "65536")),
+    lambda: int(os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", "32768")),
 
     # If set, vllm will skip the deprecation warnings.
     "VLLM_NO_DEPRECATION_WARNING":


### PR DESCRIPTION
This PR changes the default value of VLLM_FUSED_MOE_CHUNK_SIZE from 64k to 32k, which lowers memory consumption during the forward pass.
We've measured the effects on kernel latency and found them to be minimal (see table below).
These numbers are for A100 80GB, we also tested on an H100 and found similar results.

```
|   intermediate_size |   32k chunk |   64k chunk | slowdown (%)   |
|--------------------:|------------:|------------:|:---------------|
|                1536 |     140.117 |     139.287 | 0.6%           |
|                3072 |     271.47  |     270.644 | 0.3%           |
|                6144 |     617.339 |     615.37  | 0.3%           |
|               12288 |    1442     |    1438.64  | 0.2%           |
```

For clarity, here is how we called the kernel to measure perf (we warmed up the kernel + averaged multiple iterations ofc).

```
fused_moe(a,  # shape = [256K, 4K]
          w1, # shape = [16, 2 * intermediate_size, 4K]
          w2, # shape = [16, intermediate_size, 4K]
          router_logits, # shape = [256K, 16]
          topk, # = 2
          inplace = True,
          renormalize = False)
```
