### PR TITLE
[VLM] Disallow overflowing `max_model_len` for multimodal models

### DIFF
--- a/tests/models/test_llava.py
+++ b/tests/models/test_llava.py
@@ -179,3 +179,20 @@ def test_models(hf_runner, vllm_runner, image_assets, model, size_factors,
         num_logprobs=num_logprobs,
         tensor_parallel_size=1,
     )
+
+
+@pytest.mark.parametrize("model", models)
+def test_context_length_too_short(vllm_runner, image_assets, model):
+    images = [asset.pil_image for asset in image_assets]
+
+    with pytest.raises(ValueError, match="too long to fit into the model"):
+        vllm_model = vllm_runner(
+            model,
+            max_model_len=128,  # LLaVA has a feature size of 576
+            enforce_eager=True,
+        )
+
+        with vllm_model:
+            vllm_model.generate_greedy([HF_IMAGE_PROMPTS[0]],
+                                       max_tokens=1,
+                                       images=[images[0]])

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1964,6 +1964,6 @@ class LLMEngine:
                     f"The prompt (total length {len(prompt_ids)}) is too long "
                     f"to fit into the model (context length {max_prompt_len}). "
                     "Make sure that `max_model_len` is no smaller than the "
-                    "number of text tokens plus multimodal tokens. For images, "
-                    "the number of multimodal tokens depends on the number of "
-                    "input images, and possibly also their aspect ratios.")
+                    "number of text tokens plus multimodal tokens. For image "
+                    "inputs, the number of image tokens depends on the number "
+                    "of input images, and possibly also their aspect ratios.")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1966,4 +1966,4 @@ class LLMEngine:
                     "Make sure that `max_model_len` is no smaller than the "
                     "number of text tokens plus multimodal tokens. For image "
                     "inputs, the number of image tokens depends on the number "
-                    "of input images, and possibly also their aspect ratios.")
+                    "of images, and possibly their aspect ratios as well.")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1961,10 +1961,9 @@ class LLMEngine:
 
             if len(prompt_ids) > max_prompt_len:
                 raise ValueError(
-                    "The prompt with multimodal tokens (total length "
-                    f"{len(prompt_ids)}) is too long to fit into the model "
-                    f"(context length {max_prompt_len}). Make sure that "
-                    "`max_model_len` is no smaller than the number of "
-                    "multimodal tokens. For images, the number of multimodal "
-                    "tokens depends on the number of images passed to the same "
-                    "prompt, and possibly the aspect ratio of each image.")
+                    f"The prompt (total length {len(prompt_ids)}) is too long "
+                    f"to fit into the model (context length {max_prompt_len}). "
+                    "Make sure that `max_model_len` is no smaller than the "
+                    "number of text tokens plus multimodal tokens. For images, "
+                    "the number of multimodal tokens depends on the number of "
+                    "input images, and possibly also their aspect ratios.")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1948,7 +1948,21 @@ class LLMEngine:
 
     def _validate_model_inputs(self, inputs: Union[LLMInputs,
                                                    EncoderDecoderLLMInputs]):
-        prompt_key = "encoder_prompt_token_ids" \
-            if self.is_encoder_decoder_model() else "prompt_token_ids"
-        if not inputs.get(prompt_key):
+        if self.is_encoder_decoder_model():
+            prompt_ids = inputs.get("encoder_prompt_token_ids")
+        else:
+            prompt_ids = inputs.get("prompt_token_ids")
+
+        if prompt_ids is None or len(prompt_ids) == 0:
             raise ValueError("Prompt cannot be empty")
+
+        if self.model_config.multimodal_config is not None:
+            max_prompt_len = self.model_config.max_model_len
+
+            if len(prompt_ids) > max_prompt_len:
+                raise ValueError(
+                    "The prompt with multimodal tokens (total length "
+                    f"{len(prompt_ids)}) is too long to fit into the model "
+                    f"(context length {max_prompt_len}). Make sure that"
+                    "`max_model_len` is no smaller than the size of the "
+                    "multimodal features.")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1963,6 +1963,8 @@ class LLMEngine:
                 raise ValueError(
                     "The prompt with multimodal tokens (total length "
                     f"{len(prompt_ids)}) is too long to fit into the model "
-                    f"(context length {max_prompt_len}). Make sure that"
-                    "`max_model_len` is no smaller than the size of the "
-                    "multimodal features.")
+                    f"(context length {max_prompt_len}). Make sure that "
+                    "`max_model_len` is no smaller than the number of "
+                    "multimodal tokens. For images, the number of multimodal "
+                    "tokens depends on the number of images passed to the same "
+                    "prompt, and possibly the aspect ratio of each image.")


### PR DESCRIPTION
Currently, the placeholder tokens are silently truncated if they exceed the context length, causing confusing errors when later assigning multimodal features to the placeholder tokens inside the model. (e.g. #6176)

This PR avoids such problems by checking the length of the processed prompt beforehand.