### PR TITLE
Print request metrics to stdout

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1797,13 +1797,6 @@ class ObservabilityConfig:
                 "'otlp_traces_endpoint'. Ensure OpenTelemetry packages are "
                 f"installed. Original error:\n{otel_import_error_traceback}")
 
-        if ((self.collect_model_forward_time
-             or self.collect_model_execute_time)
-                and self.otlp_traces_endpoint is None):
-            raise ValueError(
-                "collect_model_forward_time or collect_model_execute_time "
-                "requires --otlp-traces-endpoint to be set.")
-
 
 @dataclass(frozen=True)
 class EngineConfig:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -171,6 +171,7 @@ class RequestTracker:
 
         if verbose and finished:
             logger.info("Finished request %s.", request_id)
+            logger.info("Metrics: %s", request_output.metrics)
 
     def process_exception(self,
                           request_id: str,


### PR DESCRIPTION
Print basic metrics to stdout to avoid the need of open-telemetry for profiling.
