### PR TITLE
[Bugfix] Fix bug in detokenizer.py

### DIFF
--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Dict, List, Optional, Tuple
 
 from vllm.sequence import Logprob, SamplingParams, Sequence, SequenceGroup
@@ -5,7 +6,6 @@ from vllm.sequence import Logprob, SamplingParams, Sequence, SequenceGroup
 from .tokenizer import AnyTokenizer
 from .tokenizer_group import BaseTokenizerGroup
 
-from copy import deepcopy
 # Used eg. for marking rejected tokens in spec decoding.
 INVALID_TOKEN_ID = -1
 
@@ -91,7 +91,7 @@ class Detokenizer:
             prefix_offset = next_iter_prefix_offset
             read_offset = next_iter_read_offset
             if prev_tokens is None:
-                prev_tokens = deepcopy(next_iter_tokens)
+                prev_tokens = copy.deepcopy(next_iter_tokens)
             else:
                 prev_tokens.extend(next_iter_tokens)
 

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -5,6 +5,7 @@ from vllm.sequence import Logprob, SamplingParams, Sequence, SequenceGroup
 from .tokenizer import AnyTokenizer
 from .tokenizer_group import BaseTokenizerGroup
 
+from copy import deepcopy
 # Used eg. for marking rejected tokens in spec decoding.
 INVALID_TOKEN_ID = -1
 
@@ -90,7 +91,7 @@ class Detokenizer:
             prefix_offset = next_iter_prefix_offset
             read_offset = next_iter_read_offset
             if prev_tokens is None:
-                prev_tokens = next_iter_tokens
+                prev_tokens = deepcopy(next_iter_tokens)
             else:
                 prev_tokens.extend(next_iter_tokens)
 


### PR DESCRIPTION
Fix the bug where the length of `prev_tokens` and `next_iter_tokens` in `detokenizer.py` would grow exponentially in some cases.

The original code assign the reference of `next_iter_tokens` to `prev_tokens` directly, making them point to a same object. When `prev_tokens` is extended by `next_iter_tokens`, both of their length will be doubled, which makes the length grows exponentially.

ps: I didn't find any issue that directly point out this bug.