### PR TITLE
[CI/Build] fix: Add the +empty tag to the version only when the VLLM_TARGET_DEVICE envvar was explicitly set to "empty"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,8 @@ def get_vllm_version() -> str:
     version = find_version(get_path("vllm", "version.py"))
 
     if _no_device():
-        version += "+empty"
+        if VLLM_TARGET_DEVICE == envs.VLLM_TARGET_DEVICE:
+            version += "+empty"
     elif _is_cuda():
         cuda_version = str(get_nvcc_cuda_version())
         if cuda_version != MAIN_CUDA_VERSION:

--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,7 @@ def get_vllm_version() -> str:
     version = find_version(get_path("vllm", "version.py"))
 
     if _no_device():
-        if VLLM_TARGET_DEVICE == envs.VLLM_TARGET_DEVICE:
+        if envs.VLLM_TARGET_DEVICE == "empty":
             version += "+empty"
     elif _is_cuda():
         cuda_version = str(get_nvcc_cuda_version())


### PR DESCRIPTION
Following https://github.com/vllm-project/vllm/pull/4773

Currently, pip installing vllm form pypi on mac still doesn't work OOTB. It fails with the following error:
```
Requested vllm from https://files.pythonhosted.org/packages/ec/f0/32ea866485d83d1fcde810059a0643ed4726628c17fdac8981606f58219e/vllm-0.5.5.tar.gz has inconsistent version: expected '0.5.5', but metadata has '0.5.5+empty'
```
and then tries to install an earlier version (which obviously fails since it was before https://github.com/vllm-project/vllm/pull/4773).
The issue can be solved by installing with `pip install vllm --use-deprecated=legacy-resolver`, but IMO it's better to make it work OOTB with default `pip install vllm`.

This PR fixes it by adding "+empty" to the version only if VLLM_TARGET_DEVICE envvar was explicitly set to "empty"