### PR TITLE
[Bugfix]disable cuda graph when max_decode_seq_len is close to max_seq_len_to_capture

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -667,7 +667,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                             max_decode_seq_len: int) -> bool:
         return (self.decode_only and not self.runner.model_config.enforce_eager
                 and batch_size <= self.runner.max_batchsize_to_capture
-                and max_decode_seq_len <= self.runner.max_seq_len_to_capture)
+                and max_decode_seq_len + 
+                self.scheduler_config.num_lookahead_slots <= self.runner.max_seq_len_to_capture)
 
     def build(self) -> ModelInputForGPU:
         """Finalize the builder intermediate data and


### PR DESCRIPTION
when enable spec decoding（num_lookahead_slots = 7）and cuda graph. We meet the problem：ValueError: could not broadcast input array from shape (513,) into shape (512,) 
When starting spec decode, in order to ensure sufficient space is allocated, new tokens + num_lookahead_slots slots are allocated by default. Therefore, when the input + output is 8186, 8186 + 7 just triggers the boundary of 8192, requiring an additional block to be allocated, resulting in the block_table length exceeding the input_block_tables[i] range.