### PR TITLE
Move verify_marlin_supported to GPTQMarlinLinearMethod

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -51,10 +51,6 @@ class GPTQMarlinConfig(QuantizationConfig):
 
         self.quant_type = self.TYPE_MAP[(weight_bits, is_sym)]
 
-        # Verify supported on platform.
-        verify_marlin_supported(quant_type=self.quant_type,
-                                group_size=self.group_size)
-
     def __repr__(self) -> str:
         return (f"GPTQMarlinConfig(quant_type={self.quant_type}, "
                 f"group_size={self.group_size}, "
@@ -152,6 +148,10 @@ class GPTQMarlinLinearMethod(LinearMethodBase):
 
     def __init__(self, quant_config: GPTQMarlinConfig) -> None:
         self.quant_config = quant_config
+
+        # Verify supported on platform.
+        verify_marlin_supported(quant_type=self.quant_config.quant_type,
+                                group_size=self.quant_config.group_size)
 
     def create_weights(
         self,


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/8149

We fail when constructing the GPTQMarlin config on unsupported platforms, meaning that `GPTQMarlin.get_min_capability()` can't be queried to check for support without failing to allow for GPTQ fallback. This PR moves the check to when we actually need it in the GPTQMarlinLinearMethod construction