### PR TITLE
[Core] support LoRA and prompt adapter in content-based hashing for Block Manager v2 prefix caching

### DIFF
--- a/tests/core/utils.py
+++ b/tests/core/utils.py
@@ -46,6 +46,16 @@ def create_dummy_prompt(
     return prompt, seq_group
 
 
+def create_dummy_lora_sequence(request_id: int, token_ids: List[int],
+                               block_size: int, lora_int_id: int) -> Sequence:
+    return Sequence(seq_id=request_id,
+                    inputs=token_inputs(token_ids),
+                    block_size=block_size,
+                    lora_request=LoRARequest(lora_name="dummy",
+                                             lora_path="/dummy",
+                                             lora_int_id=lora_int_id))
+
+
 def create_dummy_sequence(request_id: int, token_ids: List[int],
                           block_size: int) -> Sequence:
     return Sequence(

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -171,7 +171,8 @@ class BlockTable:
 
         self._num_full_slots += len(token_ids)
 
-    def ensure_num_empty_slots(self, num_empty_slots: int,
+    def ensure_num_empty_slots(self,
+                               num_empty_slots: int,
                                contextual_hash: Optional[int] = None) -> None:
         """Ensures that the BlockTable has at least the specified number of
         empty slots available.

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -97,10 +97,11 @@ class BlockTable:
         """
         assert not self._is_allocated
         assert token_ids
-        blocks = self._allocate_blocks_for_token_ids(prev_block=None,
-                                                     token_ids=token_ids,
-                                                     device=device,
-                                                     contextual_hash=contextual_hash)
+        blocks = self._allocate_blocks_for_token_ids(
+            prev_block=None,
+            token_ids=token_ids,
+            device=device,
+            contextual_hash=contextual_hash)
         self.update(blocks)
         self._num_full_slots = len(token_ids)
 
@@ -264,10 +265,9 @@ class BlockTable:
         # ones after the appended ones.
         return sequence_token_ids[self.num_full_slots:]
 
-    def _allocate_blocks_for_token_ids(self, prev_block: Optional[Block],
-                                       token_ids: List[int],
-                                       device: Device,
-                                       contextual_hash: Optional[int]) -> List[Block]:
+    def _allocate_blocks_for_token_ids(
+            self, prev_block: Optional[Block], token_ids: List[int],
+            device: Device, contextual_hash: Optional[int]) -> List[Block]:
         blocks: List[Block] = []
 
         block_token_ids = []
@@ -281,8 +281,10 @@ class BlockTable:
         if block_token_ids:
             blocks.extend(
                 self._allocator.allocate_immutable_blocks(
-                    prev_block, block_token_ids=block_token_ids,
-                    device=device, contextual_hash=contextual_hash))
+                    prev_block,
+                    block_token_ids=block_token_ids,
+                    device=device,
+                    contextual_hash=contextual_hash))
             prev_block = blocks[-1]
 
         if tail_token_ids:
@@ -290,7 +292,9 @@ class BlockTable:
             cur_token_ids = tail_token_ids[0]
 
             block = self._allocator.allocate_mutable_block(
-                prev_block=prev_block, device=device, contextual_hash=contextual_hash)
+                prev_block=prev_block,
+                device=device,
+                contextual_hash=contextual_hash)
             block.append_token_ids(cur_token_ids)
 
             blocks.append(block)

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -81,7 +81,7 @@ class BlockTable:
     def allocate(self,
                  token_ids: List[int],
                  device: Device = Device.GPU,
-                 extra_hash: Optional[int] = 0) -> None:
+                 extra_hash: Optional[int] = None) -> None:
         """Allocates memory blocks for storing the given sequence of token IDs.
 
         This method allocates the required number of blocks to store the given
@@ -115,7 +115,7 @@ class BlockTable:
                          token_ids: List[int],
                          num_lookahead_slots: int = 0,
                          num_computed_slots: Optional[int] = None,
-                         extra_hash: Optional[int] = 0) -> None:
+                         extra_hash: Optional[int] = None) -> None:
         """Appends a sequence of token IDs to the existing blocks in the
         BlockTable.
 
@@ -279,7 +279,7 @@ class BlockTable:
 
     def _allocate_blocks_for_token_ids(
             self, prev_block: Optional[Block], token_ids: List[int],
-            device: Device, extra_hash: Optional[int]) -> List[Block]:
+            device: Device, extra_hash: Optional[int] = None) -> List[Block]:
         blocks: List[Block] = []
 
         block_token_ids = []

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -172,7 +172,7 @@ class BlockTable:
         self._num_full_slots += len(token_ids)
 
     def ensure_num_empty_slots(self, num_empty_slots: int,
-                               contextual_hash: Optional[int]) -> None:
+                               contextual_hash: Optional[int] = None) -> None:
         """Ensures that the BlockTable has at least the specified number of
         empty slots available.
 

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -137,8 +137,9 @@ class BlockTable:
                 Without sliding window, None can be passed.
                 Without chunked prefill, it should be the same as
                 _num_full_slots.
-            contextual_hash (Optional[int]): The hash value of additional factors
-                such as adapters that influence the block, apart from the token_ids.
+            contextual_hash (Optional[int]): The hash value of additional
+                factors such as adapters that influence the block, apart
+                from the token_ids.
         """
         assert self._is_allocated, "no blocks have been allocated"
         assert len(self._blocks) > 0
@@ -170,7 +171,8 @@ class BlockTable:
 
         self._num_full_slots += len(token_ids)
 
-    def ensure_num_empty_slots(self, num_empty_slots: int, contextual_hash: int) -> None:
+    def ensure_num_empty_slots(self, num_empty_slots: int,
+                               contextual_hash: Optional[int]) -> None:
         """Ensures that the BlockTable has at least the specified number of
         empty slots available.
 
@@ -181,8 +183,9 @@ class BlockTable:
 
         Args:
             num_empty_slots (int): The minimum number of empty slots required.
-            contextual_hash (Optional[int]): The hash value of additional factors
-                such as adapters that influence the block, apart from the token_ids.
+            contextual_hash (Optional[int]): The hash value of additional
+                factors such as adapters that influence the block, apart
+                from the token_ids.
         """
         # Currently the block table only supports
         # appending tokens to GPU blocks.
@@ -199,7 +202,9 @@ class BlockTable:
             assert len(self._blocks) > 0
             self._blocks.append(
                 self._allocator.allocate_mutable_block(
-                    prev_block=self._blocks[-1], device=device, contextual_hash=contextual_hash))
+                    prev_block=self._blocks[-1],
+                    device=device,
+                    contextual_hash=contextual_hash))
 
     def fork(self) -> "BlockTable":
         """Creates a new BlockTable instance with a copy of the blocks from the

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -97,11 +97,10 @@ class BlockTable:
         """
         assert not self._is_allocated
         assert token_ids
-        blocks = self._allocate_blocks_for_token_ids(
-            prev_block=None,
-            token_ids=token_ids,
-            device=device,
-            extra_hash=extra_hash)
+        blocks = self._allocate_blocks_for_token_ids(prev_block=None,
+                                                     token_ids=token_ids,
+                                                     device=device,
+                                                     extra_hash=extra_hash)
         self.update(blocks)
         self._num_full_slots = len(token_ids)
 
@@ -278,8 +277,11 @@ class BlockTable:
         return sequence_token_ids[self.num_full_slots:]
 
     def _allocate_blocks_for_token_ids(
-            self, prev_block: Optional[Block], token_ids: List[int],
-            device: Device, extra_hash: Optional[int] = None) -> List[Block]:
+            self,
+            prev_block: Optional[Block],
+            token_ids: List[int],
+            device: Device,
+            extra_hash: Optional[int] = None) -> List[Block]:
         blocks: List[Block] = []
 
         block_token_ids = []
@@ -304,9 +306,7 @@ class BlockTable:
             cur_token_ids = tail_token_ids[0]
 
             block = self._allocator.allocate_mutable_block(
-                prev_block=prev_block,
-                device=device,
-                extra_hash=extra_hash)
+                prev_block=prev_block, device=device, extra_hash=extra_hash)
             block.append_token_ids(cur_token_ids)
 
             blocks.append(block)

--- a/vllm/core/block/common.py
+++ b/vllm/core/block/common.py
@@ -178,7 +178,7 @@ class BlockPool:
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None,
-                                   contextual_hash=0))
+                                   extra_hash=0))
 
     def increase_pool(self):
         """Doubles the internal pool size
@@ -196,14 +196,14 @@ class BlockPool:
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None,
-                                   contextual_hash=0))
+                                   extra_hash=0))
 
     def init_block(self,
                    prev_block: Optional[Block],
                    token_ids: List[int],
                    block_size: int,
                    physical_block_id: Optional[int],
-                   contextual_hash: Optional[int] = 0) -> Block:
+                   extra_hash: Optional[int] = 0) -> Block:
         if len(self._free_ids) == 0:
             self.increase_pool()
             assert len(self._free_ids) > 0
@@ -217,7 +217,7 @@ class BlockPool:
             block_size=block_size,
             allocator=block._allocator,  # type: ignore[attr-defined] 
             block_id=physical_block_id,
-            contextual_hash=contextual_hash)
+            extra_hash=extra_hash)
         block.pool_id = pool_id  # type: ignore[attr-defined]
         return block
 

--- a/vllm/core/block/common.py
+++ b/vllm/core/block/common.py
@@ -177,7 +177,8 @@ class BlockPool:
                                    token_ids=[],
                                    block_size=self._block_size,
                                    allocator=self._allocator,
-                                   block_id=None))
+                                   block_id=None,
+                                   contextual_hash=0))
 
     def increase_pool(self):
         """Doubles the internal pool size
@@ -194,10 +195,11 @@ class BlockPool:
                                    token_ids=[],
                                    block_size=self._block_size,
                                    allocator=self._allocator,
-                                   block_id=None))
+                                   block_id=None,
+                                   contextual_hash=0))
 
     def init_block(self, prev_block: Optional[Block], token_ids: List[int],
-                   block_size: int, physical_block_id: Optional[int]) -> Block:
+                   block_size: int, physical_block_id: Optional[int], contextual_hash: Optional[int] = 0) -> Block:
         if len(self._free_ids) == 0:
             self.increase_pool()
             assert len(self._free_ids) > 0
@@ -210,7 +212,8 @@ class BlockPool:
             token_ids=token_ids,
             block_size=block_size,
             allocator=block._allocator,  # type: ignore[attr-defined] 
-            block_id=physical_block_id)
+            block_id=physical_block_id,
+            contextual_hash=contextual_hash)
         block.pool_id = pool_id  # type: ignore[attr-defined]
         return block
 

--- a/vllm/core/block/common.py
+++ b/vllm/core/block/common.py
@@ -178,7 +178,7 @@ class BlockPool:
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None,
-                                   extra_hash=0))
+                                   extra_hash=None))
 
     def increase_pool(self):
         """Doubles the internal pool size
@@ -196,14 +196,14 @@ class BlockPool:
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None,
-                                   extra_hash=0))
+                                   extra_hash=None))
 
     def init_block(self,
                    prev_block: Optional[Block],
                    token_ids: List[int],
                    block_size: int,
                    physical_block_id: Optional[int],
-                   extra_hash: Optional[int] = 0) -> Block:
+                   extra_hash: Optional[int] = None) -> Block:
         if len(self._free_ids) == 0:
             self.increase_pool()
             assert len(self._free_ids) > 0

--- a/vllm/core/block/common.py
+++ b/vllm/core/block/common.py
@@ -198,8 +198,12 @@ class BlockPool:
                                    block_id=None,
                                    contextual_hash=0))
 
-    def init_block(self, prev_block: Optional[Block], token_ids: List[int],
-                   block_size: int, physical_block_id: Optional[int], contextual_hash: Optional[int] = 0) -> Block:
+    def init_block(self,
+                   prev_block: Optional[Block],
+                   token_ids: List[int],
+                   block_size: int,
+                   physical_block_id: Optional[int],
+                   contextual_hash: Optional[int] = 0) -> Block:
         if len(self._free_ids) == 0:
             self.increase_pool()
             assert len(self._free_ids) > 0

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -124,14 +124,14 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
                                device: Device,
-                               contextual_hash: Optional[int] = 0) -> Block:
+                               extra_hash: Optional[int] = 0) -> Block:
         """Allocates a new mutable block on the specified device.
 
         Args:
             prev_block (Optional[Block]): The previous block to in the sequence.
                 Used for prefix hashing.
             device (Device): The device on which to allocate the new block.
-            contextual_hash (Optional[int]): The hash value of additional
+            extra_hash (Optional[int]): The hash value of additional
                 factors, such as adapters, that influence the block hash
                 in the prefix caching block.
 
@@ -139,12 +139,12 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             Block: The newly allocated mutable block.
         """
         return self._allocators[device].allocate_mutable_block(
-            prev_block, contextual_hash=contextual_hash)
+            prev_block, extra_hash=extra_hash)
 
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
             block_token_ids: List[List[int]], device: Device,
-            contextual_hash: Optional[int]) -> List[Block]:
+            extra_hash: Optional[int]) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
 
@@ -154,7 +154,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             block_token_ids (List[int]): The list of block token IDs to be 
                 stored in the new blocks.
             device (Device): The device on which to allocate the new block.
-            contextual_hash (Optional[int]): The hash value of additional
+            extra_hash (Optional[int]): The hash value of additional
                 factors, such as adapters, that influence the block hash
                 in the prefix caching block.
 
@@ -163,11 +163,11 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
                 containing the provided block token IDs.
         """
         return self._allocators[device].allocate_immutable_blocks(
-            prev_block, block_token_ids, contextual_hash=contextual_hash)
+            prev_block, block_token_ids, extra_hash=extra_hash)
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int], device: Device,
-                                 contextual_hash: Optional[int]) -> Block:
+                                 extra_hash: Optional[int]) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
 
@@ -177,7 +177,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             token_ids (List[int]): The list of token IDs to be stored in the new
                 block.
             device (Device): The device on which to allocate the new block.
-            contextual_hash (Optional[int]): The hash value of additional
+            extra_hash (Optional[int]): The hash value of additional
                 factors, such as adapters, that influence the block hash
                 in the prefix caching block.
 
@@ -186,7 +186,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
                 token IDs.
         """
         return self._allocators[device].allocate_immutable_block(
-            prev_block, token_ids, contextual_hash=contextual_hash)
+            prev_block, token_ids, extra_hash=extra_hash)
 
     def free(self, block: Block) -> None:
         """Frees the memory occupied by the given block.
@@ -401,7 +401,7 @@ class NullBlock(Block):
         return self._proxy.prev_block
 
     @property
-    def contextual_hash(self):
+    def extra_hash(self):
         return None
 
     @property

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -142,8 +142,10 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             prev_block, extra_hash=extra_hash)
 
     def allocate_immutable_blocks(
-            self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]], device: Device,
+            self,
+            prev_block: Optional[Block],
+            block_token_ids: List[List[int]],
+            device: Device,
             extra_hash: Optional[int] = None) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
@@ -165,8 +167,10 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return self._allocators[device].allocate_immutable_blocks(
             prev_block, block_token_ids, extra_hash=extra_hash)
 
-    def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int], device: Device,
+    def allocate_immutable_block(self,
+                                 prev_block: Optional[Block],
+                                 token_ids: List[int],
+                                 device: Device,
                                  extra_hash: Optional[int] = None) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -122,22 +122,26 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return self._null_block
 
     def allocate_mutable_block(self, prev_block: Optional[Block],
-                               device: Device) -> Block:
+                               device: Device, contextual_hash: Optional[int] = 0) -> Block:
         """Allocates a new mutable block on the specified device.
 
         Args:
             prev_block (Optional[Block]): The previous block to in the sequence.
                 Used for prefix hashing.
             device (Device): The device on which to allocate the new block.
+            contextual_hash (Optional[int]): The hash value of additional
+                factors, such as adapters, that influence the block hash
+                in the prefix caching block.
 
         Returns:
             Block: The newly allocated mutable block.
         """
-        return self._allocators[device].allocate_mutable_block(prev_block)
+        return self._allocators[device].allocate_mutable_block(prev_block, contextual_hash=contextual_hash)
 
     def allocate_immutable_blocks(self, prev_block: Optional[Block],
                                   block_token_ids: List[List[int]],
-                                  device: Device) -> List[Block]:
+                                  device: Optional[Device],
+                                  contextual_hash: Optional[int]) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
 
@@ -147,17 +151,21 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             block_token_ids (List[int]): The list of block token IDs to be 
                 stored in the new blocks.
             device (Device): The device on which to allocate the new block.
+            contextual_hash (Optional[int]): The hash value of additional
+                factors, such as adapters, that influence the block hash
+                in the prefix caching block.
 
         Returns:
             List[Block]: The newly allocated list of immutable blocks 
                 containing the provided block token IDs.
         """
         return self._allocators[device].allocate_immutable_blocks(
-            prev_block, block_token_ids)
+            prev_block, block_token_ids, contextual_hash=contextual_hash)
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 device: Device) -> Block:
+                                 device: Device,
+                                 contextual_hash: Optional[int]) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
 
@@ -167,13 +175,16 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             token_ids (List[int]): The list of token IDs to be stored in the new
                 block.
             device (Device): The device on which to allocate the new block.
+            contextual_hash (Optional[int]): The hash value of additional
+                factors, such as adapters, that influence the block hash
+                in the prefix caching block.
 
         Returns:
             Block: The newly allocated immutable block containing the provided
                 token IDs.
         """
         return self._allocators[device].allocate_immutable_block(
-            prev_block, token_ids)
+            prev_block, token_ids, contextual_hash=contextual_hash)
 
     def free(self, block: Block) -> None:
         """Frees the memory occupied by the given block.

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -121,8 +121,10 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
                 self.allocate_mutable_block(None, Device.GPU))
         return self._null_block
 
-    def allocate_mutable_block(self, prev_block: Optional[Block],
-                               device: Device, contextual_hash: Optional[int] = 0) -> Block:
+    def allocate_mutable_block(self,
+                               prev_block: Optional[Block],
+                               device: Device,
+                               contextual_hash: Optional[int] = 0) -> Block:
         """Allocates a new mutable block on the specified device.
 
         Args:
@@ -136,12 +138,13 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         Returns:
             Block: The newly allocated mutable block.
         """
-        return self._allocators[device].allocate_mutable_block(prev_block, contextual_hash=contextual_hash)
+        return self._allocators[device].allocate_mutable_block(
+            prev_block, contextual_hash=contextual_hash)
 
-    def allocate_immutable_blocks(self, prev_block: Optional[Block],
-                                  block_token_ids: List[List[int]],
-                                  device: Optional[Device],
-                                  contextual_hash: Optional[int]) -> List[Block]:
+    def allocate_immutable_blocks(
+            self, prev_block: Optional[Block],
+            block_token_ids: List[List[int]], device: Device,
+            contextual_hash: Optional[int]) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
 
@@ -163,8 +166,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             prev_block, block_token_ids, contextual_hash=contextual_hash)
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int],
-                                 device: Device,
+                                 token_ids: List[int], device: Device,
                                  contextual_hash: Optional[int]) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
@@ -397,6 +399,10 @@ class NullBlock(Block):
     @property
     def prev_block(self):
         return self._proxy.prev_block
+
+    @property
+    def contextual_hash(self):
+        return None
 
     @property
     def computed(self):

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -124,7 +124,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
                                device: Device,
-                               extra_hash: Optional[int] = 0) -> Block:
+                               extra_hash: Optional[int] = None) -> Block:
         """Allocates a new mutable block on the specified device.
 
         Args:
@@ -144,7 +144,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
             block_token_ids: List[List[int]], device: Device,
-            extra_hash: Optional[int]) -> List[Block]:
+            extra_hash: Optional[int] = None) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
 
@@ -167,7 +167,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int], device: Device,
-                                 extra_hash: Optional[int]) -> Block:
+                                 extra_hash: Optional[int] = None) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -87,7 +87,7 @@ class Block(ABC):
             allocator: "BlockAllocator",
             block_id: Optional[int] = None,
             computed: bool = False,
-            extra_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = None,
         ) -> "Block":
             pass
 
@@ -210,13 +210,13 @@ class DeviceAwareBlockAllocator(ABC):
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
                                device: Device,
-                               extra_hash: Optional[int] = 0) -> Block:
+                               extra_hash: Optional[int] = None) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int], device: Device,
-                                 extra_hash: Optional[int]) -> Block:
+                                 extra_hash: Optional[int] = None) -> Block:
         pass
 
     @abstractmethod
@@ -225,7 +225,7 @@ class DeviceAwareBlockAllocator(ABC):
         prev_block: Optional[Block],
         block_token_ids: List[List[int]],
         device: Device,
-        extra_hash: Optional[int],
+        extra_hash: Optional[int] = None,
     ) -> List[Block]:
         pass
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -52,7 +52,7 @@ class Block(ABC):
 
     @property
     @abstractmethod
-    def contextual_hash(self):
+    def extra_hash(self):
         return None
 
     @property
@@ -87,7 +87,7 @@ class Block(ABC):
             allocator: "BlockAllocator",
             block_id: Optional[int] = None,
             computed: bool = False,
-            contextual_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = 0,
         ) -> "Block":
             pass
 
@@ -107,20 +107,20 @@ class BlockAllocator(ABC):
 
     @abstractmethod
     def allocate_mutable_block(self, prev_block: Optional[Block],
-                               contextual_hash: Optional[int]) -> Block:
+                               extra_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 contextual_hash: Optional[int]) -> Block:
+                                 extra_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
             block_token_ids: List[List[int]],
-            contextual_hash: Optional[int]) -> List[Block]:
+            extra_hash: Optional[int]) -> List[Block]:
         pass
 
     @abstractmethod
@@ -210,13 +210,13 @@ class DeviceAwareBlockAllocator(ABC):
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
                                device: Device,
-                               contextual_hash: Optional[int] = 0) -> Block:
+                               extra_hash: Optional[int] = 0) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int], device: Device,
-                                 contextual_hash: Optional[int]) -> Block:
+                                 extra_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
@@ -225,7 +225,7 @@ class DeviceAwareBlockAllocator(ABC):
         prev_block: Optional[Block],
         block_token_ids: List[List[int]],
         device: Device,
-        contextual_hash: Optional[int],
+        extra_hash: Optional[int],
     ) -> List[Block]:
         pass
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -117,10 +117,9 @@ class BlockAllocator(ABC):
         pass
 
     @abstractmethod
-    def allocate_immutable_blocks(
-            self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]],
-            extra_hash: Optional[int]) -> List[Block]:
+    def allocate_immutable_blocks(self, prev_block: Optional[Block],
+                                  block_token_ids: List[List[int]],
+                                  extra_hash: Optional[int]) -> List[Block]:
         pass
 
     @abstractmethod
@@ -214,8 +213,10 @@ class DeviceAwareBlockAllocator(ABC):
         pass
 
     @abstractmethod
-    def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int], device: Device,
+    def allocate_immutable_block(self,
+                                 prev_block: Optional[Block],
+                                 token_ids: List[int],
+                                 device: Device,
                                  extra_hash: Optional[int] = None) -> Block:
         pass
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -52,7 +52,7 @@ class Block(ABC):
 
     @property
     @abstractmethod
-    def extra_hash(self):
+    def extra_hash(self) -> Optional[int]:
         return None
 
     @property

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -52,6 +52,11 @@ class Block(ABC):
 
     @property
     @abstractmethod
+    def contextual_hash(self):
+        return None
+
+    @property
+    @abstractmethod
     def computed(self) -> bool:
         raise NotImplementedError
 
@@ -99,18 +104,18 @@ class Block(ABC):
 class BlockAllocator(ABC):
 
     @abstractmethod
-    def allocate_mutable_block(self, prev_block: Optional[Block]) -> Block:
+    def allocate_mutable_block(self, prev_block: Optional[Block], contextual_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int]) -> Block:
+                                 token_ids: List[int], contextual_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]]) -> List[Block]:
+            block_token_ids: List[List[int]], contextual_hash: Optional[int]) -> List[Block]:
         pass
 
     @abstractmethod
@@ -198,13 +203,15 @@ class DeviceAwareBlockAllocator(ABC):
 
     @abstractmethod
     def allocate_mutable_block(self, prev_block: Optional[Block],
-                               device: Device) -> Block:
+                               device: Device,
+                               contextual_hash: Optional[int] = 0) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 device: Device) -> Block:
+                                 device: Device,
+                                 contextual_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
@@ -213,6 +220,7 @@ class DeviceAwareBlockAllocator(ABC):
         prev_block: Optional[Block],
         block_token_ids: List[List[int]],
         device: Device,
+        contextual_hash: Optional[int],
     ) -> List[Block]:
         pass
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -86,6 +86,8 @@ class Block(ABC):
             block_size: int,
             allocator: "BlockAllocator",
             block_id: Optional[int] = None,
+            computed: bool = False,
+            contextual_hash: Optional[int] = 0,
         ) -> "Block":
             pass
 
@@ -104,18 +106,21 @@ class Block(ABC):
 class BlockAllocator(ABC):
 
     @abstractmethod
-    def allocate_mutable_block(self, prev_block: Optional[Block], contextual_hash: Optional[int]) -> Block:
+    def allocate_mutable_block(self, prev_block: Optional[Block],
+                               contextual_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int], contextual_hash: Optional[int]) -> Block:
+                                 token_ids: List[int],
+                                 contextual_hash: Optional[int]) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]], contextual_hash: Optional[int]) -> List[Block]:
+            block_token_ids: List[List[int]],
+            contextual_hash: Optional[int]) -> List[Block]:
         pass
 
     @abstractmethod
@@ -202,15 +207,15 @@ class BlockAllocator(ABC):
 class DeviceAwareBlockAllocator(ABC):
 
     @abstractmethod
-    def allocate_mutable_block(self, prev_block: Optional[Block],
+    def allocate_mutable_block(self,
+                               prev_block: Optional[Block],
                                device: Device,
                                contextual_hash: Optional[int] = 0) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int],
-                                 device: Device,
+                                 token_ids: List[int], device: Device,
                                  contextual_hash: Optional[int]) -> Block:
         pass
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -63,7 +63,7 @@ class NaiveBlockAllocator(BlockAllocator):
     def allocate_immutable_block(self,
                                  prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 contextual_hash: Optional[int] = 0,
+                                 extra_hash: Optional[int] = 0,
                                  device: Optional[Device] = None) -> Block:
         """Allocates a new immutable block with the given token IDs, linked to
         the previous block.
@@ -86,7 +86,7 @@ class NaiveBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
-            contextual_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = 0,
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
@@ -108,7 +108,7 @@ class NaiveBlockAllocator(BlockAllocator):
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               contextual_hash: Optional[int] = 0,
+                               extra_hash: Optional[int] = 0,
                                device: Optional[Device] = None) -> Block:
         """Allocates a new mutable block, linked to the previous block.
 
@@ -359,7 +359,7 @@ class NaiveBlock(Block):
                  allocator: BlockAllocator,
                  block_id: Optional[int] = None,
                  _cow_target: Optional[Block] = None,
-                 contextual_hash: Optional[int] = None):
+                 extra_hash: Optional[int] = None):
         self._token_ids: List[int] = []
         self._block_size = block_size
         self._prev_block = prev_block
@@ -446,7 +446,7 @@ class NaiveBlock(Block):
         return self._prev_block
 
     @property
-    def contextual_hash(self):
+    def extra_hash(self):
         return None
 
     @property

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -63,7 +63,7 @@ class NaiveBlockAllocator(BlockAllocator):
     def allocate_immutable_block(self,
                                  prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 extra_hash: Optional[int] = 0,
+                                 extra_hash: Optional[int] = None,
                                  device: Optional[Device] = None) -> Block:
         """Allocates a new immutable block with the given token IDs, linked to
         the previous block.
@@ -86,7 +86,7 @@ class NaiveBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
-            extra_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = None,
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
@@ -108,7 +108,7 @@ class NaiveBlockAllocator(BlockAllocator):
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               extra_hash: Optional[int] = 0,
+                               extra_hash: Optional[int] = None,
                                device: Optional[Device] = None) -> Block:
         """Allocates a new mutable block, linked to the previous block.
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -358,7 +358,8 @@ class NaiveBlock(Block):
                  block_size: int,
                  allocator: BlockAllocator,
                  block_id: Optional[int] = None,
-                 _cow_target: Optional[Block] = None):
+                 _cow_target: Optional[Block] = None,
+                 contextual_hash: Optional[int] = None):
         self._token_ids: List[int] = []
         self._block_size = block_size
         self._prev_block = prev_block

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -63,6 +63,7 @@ class NaiveBlockAllocator(BlockAllocator):
     def allocate_immutable_block(self,
                                  prev_block: Optional[Block],
                                  token_ids: List[int],
+                                 contextual_hash: Optional[int] = 0,
                                  device: Optional[Device] = None) -> Block:
         """Allocates a new immutable block with the given token IDs, linked to
         the previous block.
@@ -85,6 +86,7 @@ class NaiveBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
+            contextual_hash: Optional[int] = 0,
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
@@ -106,7 +108,8 @@ class NaiveBlockAllocator(BlockAllocator):
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               device: Optional[Device] = None) -> Block:
+                               device: Optional[Device] = None,
+                               contextual_hash: Optional[int] = 0) -> Block:
         """Allocates a new mutable block, linked to the previous block.
 
         Args:
@@ -440,6 +443,10 @@ class NaiveBlock(Block):
     @property
     def prev_block(self) -> Optional["Block"]:
         return self._prev_block
+
+    @property
+    def contextual_hash(self):
+        return None
 
     @property
     def content_hash(self) -> Optional[int]:

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -108,8 +108,8 @@ class NaiveBlockAllocator(BlockAllocator):
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               device: Optional[Device] = None,
-                               contextual_hash: Optional[int] = 0) -> Block:
+                               contextual_hash: Optional[int] = 0,
+                               device: Optional[Device] = None) -> Block:
         """Allocates a new mutable block, linked to the previous block.
 
         Args:

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -830,7 +830,7 @@ class PrefixCachingBlock(Block):
         return self._prev_block
 
     @property
-    def extra_hash(self):
+    def extra_hash(self) -> Optional[int]:
         return self._extra_hash
 
     @property

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -870,7 +870,7 @@ class PrefixCachingBlock(Block):
     @staticmethod
     def hash_block_tokens(is_first_block: bool, prev_block_hash: Optional[int],
                           cur_block_token_ids: List[int],
-                          extra_hash: Optional[int]) -> int:
+                          extra_hash: Optional[int] = None) -> int:
         """Computes a hash value corresponding to the contents of a block and
         the contents of the preceding block(s). The hash value is used for
         prefix caching.

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -126,7 +126,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
         allocator: BlockAllocator,
         block_id: Optional[int] = None,
         computed: bool = False,
-        extra_hash: Optional[int] = 0,
+        extra_hash: Optional[int] = None,
     ) -> Block:
         # Bind block to self.
         allocator = self
@@ -144,7 +144,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
     def allocate_immutable_block(self,
                                  prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 extra_hash: Optional[int] = 0,
+                                 extra_hash: Optional[int] = None,
                                  device: Optional[Device] = None) -> Block:
         """Allocates an immutable block with the given token IDs, reusing cached
         blocks if possible.
@@ -186,7 +186,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
-            extra_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = None,
             device: Optional[Device] = None) -> List[Block]:
         blocks = []
         for token_ids in block_token_ids:
@@ -200,7 +200,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               extra_hash: Optional[int] = 0,
+                               extra_hash: Optional[int] = None,
                                device: Optional[Device] = None) -> Block:
         """Allocates a mutable block. If there are no free blocks, this will
         evict unused cached blocks.
@@ -705,7 +705,7 @@ class PrefixCachingBlock(Block):
         allocator: BlockAllocator,
         block_id: Optional[int] = None,
         computed: bool = False,
-        extra_hash: Optional[int] = 0,
+        extra_hash: Optional[int] = None,
     ):
         assert isinstance(allocator, PrefixCachingBlockAllocator), (
             "Currently this class is only tested with "

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -126,7 +126,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
         allocator: BlockAllocator,
         block_id: Optional[int] = None,
         computed: bool = False,
-        contextual_hash: Optional[int] = 0,
+        extra_hash: Optional[int] = 0,
     ) -> Block:
         # Bind block to self.
         allocator = self
@@ -138,13 +138,13 @@ class PrefixCachingBlockAllocator(BlockAllocator):
             block_id=block_id,
             allocator=allocator,
             computed=computed,
-            contextual_hash=contextual_hash,
+            extra_hash=extra_hash,
         )
 
     def allocate_immutable_block(self,
                                  prev_block: Optional[Block],
                                  token_ids: List[int],
-                                 contextual_hash: Optional[int] = 0,
+                                 extra_hash: Optional[int] = 0,
                                  device: Optional[Device] = None) -> Block:
         """Allocates an immutable block with the given token IDs, reusing cached
         blocks if possible.
@@ -164,7 +164,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                                             token_ids=token_ids,
                                             block_size=self._block_size,
                                             physical_block_id=None,
-                                            contextual_hash=contextual_hash)
+                                            extra_hash=extra_hash)
         assert block.content_hash is not None
 
         cached_block_id = self._cached_blocks.get(block.content_hash, None)
@@ -178,7 +178,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
 
         # No cached block => Allocate a new block
         block = self.allocate_mutable_block(prev_block,
-                                            contextual_hash=contextual_hash)
+                                            extra_hash=extra_hash)
         block.append_token_ids(token_ids)
         return block
 
@@ -186,7 +186,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
-            contextual_hash: Optional[int] = 0,
+            extra_hash: Optional[int] = 0,
             device: Optional[Device] = None) -> List[Block]:
         blocks = []
         for token_ids in block_token_ids:
@@ -194,13 +194,13 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                 prev_block=prev_block,
                 token_ids=token_ids,
                 device=device,
-                contextual_hash=contextual_hash)
+                extra_hash=extra_hash)
             blocks.append(prev_block)
         return blocks
 
     def allocate_mutable_block(self,
                                prev_block: Optional[Block],
-                               contextual_hash: Optional[int] = 0,
+                               extra_hash: Optional[int] = 0,
                                device: Optional[Device] = None) -> Block:
         """Allocates a mutable block. If there are no free blocks, this will
         evict unused cached blocks.
@@ -220,7 +220,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                                             token_ids=[],
                                             block_size=self._block_size,
                                             physical_block_id=block_id,
-                                            contextual_hash=contextual_hash)
+                                            extra_hash=extra_hash)
         assert not block.computed
         assert block.content_hash is None
         return block
@@ -393,7 +393,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                 token_ids=block.token_ids,
                 block_size=self._block_size,
                 physical_block_id=block_id,
-                contextual_hash=block.contextual_hash)
+                extra_hash=block.extra_hash)
 
             forked_blocks.append(forked_block)
             prev_block = forked_blocks[-1]
@@ -621,11 +621,11 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                 tmp_block = self.allocate_immutable_block(
                     prev_block=block.prev_block,
                     token_ids=block.token_ids,
-                    contextual_hash=block.contextual_hash)
+                    extra_hash=block.extra_hash)
             else:
                 tmp_block = self.allocate_mutable_block(
                     prev_block=block.prev_block,
-                    contextual_hash=block.contextual_hash)
+                    extra_hash=block.extra_hash)
                 tmp_block.append_token_ids(block.token_ids)
 
             block_id = tmp_block.block_id
@@ -693,7 +693,7 @@ class PrefixCachingBlock(Block):
             caching block allocator associated with this block.
         block_id (Optional[int], optional): The physical block index
             of this block. Defaults to None.
-        contextual_hash (Optional[int]): The hash value of additional factors 
+        extra_hash (Optional[int]): The hash value of additional factors
             such as adapters that influence the block, apart from the token_ids.
     """
 
@@ -705,7 +705,7 @@ class PrefixCachingBlock(Block):
         allocator: BlockAllocator,
         block_id: Optional[int] = None,
         computed: bool = False,
-        contextual_hash: Optional[int] = 0,
+        extra_hash: Optional[int] = 0,
     ):
         assert isinstance(allocator, PrefixCachingBlockAllocator), (
             "Currently this class is only tested with "
@@ -719,7 +719,7 @@ class PrefixCachingBlock(Block):
         self._allocator = allocator
         self._last_accessed: float = _DEFAULT_LAST_ACCESSED_TIME
         self._computed = computed
-        self._contextual_hash = contextual_hash
+        self._extra_hash = extra_hash
 
         # On the first time, we create the block object, and next we only
         # reinitialize it
@@ -830,8 +830,8 @@ class PrefixCachingBlock(Block):
         return self._prev_block
 
     @property
-    def contextual_hash(self):
-        return self._contextual_hash
+    def extra_hash(self):
+        return self._extra_hash
 
     @property
     def content_hash(self) -> Optional[int]:
@@ -864,13 +864,13 @@ class PrefixCachingBlock(Block):
             is_first_block,
             prev_block_hash,
             cur_block_token_ids=self.token_ids,
-            contextual_hash=self._contextual_hash)
+            extra_hash=self._extra_hash)
         return self._cached_content_hash
 
     @staticmethod
     def hash_block_tokens(is_first_block: bool, prev_block_hash: Optional[int],
                           cur_block_token_ids: List[int],
-                          contextual_hash: Optional[int]) -> int:
+                          extra_hash: Optional[int]) -> int:
         """Computes a hash value corresponding to the contents of a block and
         the contents of the preceding block(s). The hash value is used for
         prefix caching.
@@ -882,7 +882,7 @@ class PrefixCachingBlock(Block):
             if this is the first block.
         - cur_block_token_ids (List[int]): A list of token ids in the current
             block. The current block is assumed to be full.
-        - contextual_hash (Optional[int]): The hash value of additional factors 
+        - extra_hash (Optional[int]): The hash value of additional factors
             such as adapters that influence the block, apart from the token_ids.
 
         Returns:
@@ -890,7 +890,7 @@ class PrefixCachingBlock(Block):
         """
         assert (prev_block_hash is None) == is_first_block
         return hash((is_first_block, prev_block_hash, *cur_block_token_ids,
-                     contextual_hash))
+                     extra_hash))
 
 
 class ComputedBlocksTracker:
@@ -962,8 +962,8 @@ class ComputedBlocksTracker:
                                         self._block_size]
 
             # NOTE: If there are any factors affecting the block besides
-            # token_ids, they should be added as input to contextual_hash.
-            contextual_hash = seq.contextual_hash_of_block()
+            # token_ids, they should be added as input to extra_hash.
+            extra_hash = seq.extra_hash()
 
             # This has to be kept in sync with the allocator's hash
             # calculation.
@@ -971,7 +971,7 @@ class ComputedBlocksTracker:
                 is_first_block=prev_block_hash is None,
                 prev_block_hash=prev_block_hash,
                 cur_block_token_ids=block_token_ids,
-                contextual_hash=contextual_hash,
+                extra_hash=extra_hash,
             )
             block_hashes_recorded.append(block_hash)
             prev_block_hash = block_hash

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -960,12 +960,18 @@ class ComputedBlocksTracker:
             assert len(token_ids) >= (i + 1) * self._block_size
             block_token_ids = token_ids[i * self._block_size:(i + 1) *
                                         self._block_size]
+
+            # NOTE: If there are any factors affecting the block besides
+            # token_ids, they should be added as input to contextual_hash.
+            contextual_hash = seq.hash_of_block_v2()
+
             # This has to be kept in sync with the allocator's hash
             # calculation.
             block_hash = PrefixCachingBlock.hash_block_tokens(
                 is_first_block=prev_block_hash is None,
                 prev_block_hash=prev_block_hash,
                 cur_block_token_ids=block_token_ids,
+                contextual_hash=contextual_hash,
             )
             block_hashes_recorded.append(block_hash)
             prev_block_hash = block_hash

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -963,7 +963,7 @@ class ComputedBlocksTracker:
 
             # NOTE: If there are any factors affecting the block besides
             # token_ids, they should be added as input to contextual_hash.
-            contextual_hash = seq.hash_of_block_v2()
+            contextual_hash = seq.contextual_hash_of_block()
 
             # This has to be kept in sync with the allocator's hash
             # calculation.

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -177,8 +177,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
         self._block_pool.free_block(block)
 
         # No cached block => Allocate a new block
-        block = self.allocate_mutable_block(prev_block,
-                                            extra_hash=extra_hash)
+        block = self.allocate_mutable_block(prev_block, extra_hash=extra_hash)
         block.append_token_ids(token_ids)
         return block
 
@@ -190,11 +189,10 @@ class PrefixCachingBlockAllocator(BlockAllocator):
             device: Optional[Device] = None) -> List[Block]:
         blocks = []
         for token_ids in block_token_ids:
-            prev_block = self.allocate_immutable_block(
-                prev_block=prev_block,
-                token_ids=token_ids,
-                device=device,
-                extra_hash=extra_hash)
+            prev_block = self.allocate_immutable_block(prev_block=prev_block,
+                                                       token_ids=token_ids,
+                                                       device=device,
+                                                       extra_hash=extra_hash)
             blocks.append(prev_block)
         return blocks
 
@@ -624,8 +622,7 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                     extra_hash=block.extra_hash)
             else:
                 tmp_block = self.allocate_mutable_block(
-                    prev_block=block.prev_block,
-                    extra_hash=block.extra_hash)
+                    prev_block=block.prev_block, extra_hash=block.extra_hash)
                 tmp_block.append_token_ids(block.token_ids)
 
             block_id = tmp_block.block_id
@@ -868,7 +865,8 @@ class PrefixCachingBlock(Block):
         return self._cached_content_hash
 
     @staticmethod
-    def hash_block_tokens(is_first_block: bool, prev_block_hash: Optional[int],
+    def hash_block_tokens(is_first_block: bool,
+                          prev_block_hash: Optional[int],
                           cur_block_token_ids: List[int],
                           extra_hash: Optional[int] = None) -> int:
         """Computes a hash value corresponding to the contents of a block and

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -152,12 +152,12 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         )
         if seq.get_token_ids():
             # NOTE: If there are any factors affecting the block besides
-            # token_ids, they should be added as input to contextual_hash.
-            contextual_hash = seq.contextual_hash_of_block()
+            # token_ids, they should be added as input to extra_hash.
+            extra_hash = seq.extra_hash()
 
             # Add blocks to the block table only if the sequence is non empty.
             block_table.allocate(token_ids=seq.get_token_ids(),
-                                 contextual_hash=contextual_hash)
+                                 extra_hash=extra_hash)
 
         return block_table
 
@@ -243,7 +243,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             token_ids=block_table.get_unseen_token_ids(seq.get_token_ids()),
             num_lookahead_slots=num_lookahead_slots,
             num_computed_slots=seq.data.get_num_computed_tokens(),
-            contextual_hash=seq.contextual_hash_of_block(),
+            extra_hash=seq.extra_hash(),
         )
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -153,7 +153,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         if seq.get_token_ids():
             # NOTE: If there are any factors affecting the block besides
             # token_ids, they should be added as input to contextual_hash.
-            contextual_hash = seq.hash_of_block_v2()
+            contextual_hash = seq.contextual_hash_of_block()
 
             # Add blocks to the block table only if the sequence is non empty.
             block_table.allocate(token_ids=seq.get_token_ids(),
@@ -243,7 +243,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             token_ids=block_table.get_unseen_token_ids(seq.get_token_ids()),
             num_lookahead_slots=num_lookahead_slots,
             num_computed_slots=seq.data.get_num_computed_tokens(),
-            contextual_hash=seq.hash_of_block_v2(),
+            contextual_hash=seq.contextual_hash_of_block(),
         )
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -151,8 +151,8 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             max_block_sliding_window=self.max_block_sliding_window,
         )
         if seq.get_token_ids():
-            # NOTE: If there are any factors affecting the block besides token_ids,
-            # they should be added as input arguments to contextual_hash.
+            # NOTE: If there are any factors affecting the block besides
+            # token_ids, they should be added as input to contextual_hash.
             contextual_hash = seq.hash_of_block_v2()
 
             # Add blocks to the block table only if the sequence is non empty.

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -153,7 +153,8 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         if seq.get_token_ids():
             contextual_hash = hash((seq.prompt_adapter_id, seq.lora_int_id))
             # Add blocks to the block table only if the sequence is non empty.
-            block_table.allocate(token_ids=seq.get_token_ids(), contextual_hash=contextual_hash)
+            block_table.allocate(token_ids=seq.get_token_ids(),
+                                 contextual_hash=contextual_hash)
 
         return block_table
 

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -151,8 +151,9 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             max_block_sliding_window=self.max_block_sliding_window,
         )
         if seq.get_token_ids():
+            contextual_hash = hash((seq.prompt_adapter_id, seq.lora_int_id))
             # Add blocks to the block table only if the sequence is non empty.
-            block_table.allocate(seq.get_token_ids())
+            block_table.allocate(token_ids=seq.get_token_ids(), contextual_hash=contextual_hash)
 
         return block_table
 

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -151,7 +151,10 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             max_block_sliding_window=self.max_block_sliding_window,
         )
         if seq.get_token_ids():
-            contextual_hash = hash((seq.prompt_adapter_id, seq.lora_int_id))
+            # NOTE: If there are any factors affecting the block besides token_ids,
+            # they should be added as input arguments to contextual_hash.
+            contextual_hash = seq.hash_of_block_v2()
+
             # Add blocks to the block table only if the sequence is non empty.
             block_table.allocate(token_ids=seq.get_token_ids(),
                                  contextual_hash=contextual_hash)
@@ -240,6 +243,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             token_ids=block_table.get_unseen_token_ids(seq.get_token_ids()),
             num_lookahead_slots=num_lookahead_slots,
             num_computed_slots=seq.data.get_num_computed_tokens(),
+            contextual_hash=seq.hash_of_block_v2(),
         )
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -527,6 +527,15 @@ class Sequence:
         hashed_tokens = self.data.get_prefix_token_ids(num_tokens)
         return hash((hashed_tokens, self.lora_int_id))
 
+    def hash_of_block_v2(self) -> int:
+    # This function is introduced for BlockSpaceManagerV2 and is used with prefix caching mode.
+    # The final block hash is determined by applying token_ids in PrefixCachingBlock
+    # under BlockSpaceManagerV2.
+
+    # NOTE: If there are additional factors influencing the block aside from token_ids,
+    # include them as input parameters to the hash.
+        return hash((self.prompt_adapter_id, self.lora_int_id))
+
     def num_hashed_tokens_of_block(self, logical_idx: int):
         return logical_idx * self.block_size + self.block_size
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -528,12 +528,12 @@ class Sequence:
         return hash((hashed_tokens, self.lora_int_id))
 
     def hash_of_block_v2(self) -> int:
-    # This function is introduced for BlockSpaceManagerV2 and is used with prefix caching mode.
-    # The final block hash is determined by applying token_ids in PrefixCachingBlock
-    # under BlockSpaceManagerV2.
+        # This function is introduced for BlockSpaceManagerV2 and is used with
+        # prefix caching mode. The final block hash is determined by applying
+        # token_ids in PrefixCachingBlock under BlockSpaceManagerV2.
 
-    # NOTE: If there are additional factors influencing the block aside from token_ids,
-    # include them as input parameters to the hash.
+        # NOTE: If there are additional factors influencing the block aside from
+        # token_ids, include them as input parameters to the hash.
         return hash((self.prompt_adapter_id, self.lora_int_id))
 
     def num_hashed_tokens_of_block(self, logical_idx: int):

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -527,10 +527,10 @@ class Sequence:
         hashed_tokens = self.data.get_prefix_token_ids(num_tokens)
         return hash((hashed_tokens, self.lora_int_id))
 
-    def hash_of_block_v2(self) -> int:
-        # This function is introduced for BlockSpaceManagerV2 and is used with
-        # prefix caching mode. The final block hash is determined by applying
-        # token_ids in PrefixCachingBlock under BlockSpaceManagerV2.
+    def contextual_hash_of_block(self) -> int:
+        # This function computes a contextual hash for a block, specifically
+        # designed for prefix caching mode. The final block hash is determined
+        # by applying token_ids in PrefixCachingBlock.
 
         # NOTE: If there are additional factors influencing the block aside from
         # token_ids, include them as input parameters to the hash.

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -527,10 +527,10 @@ class Sequence:
         hashed_tokens = self.data.get_prefix_token_ids(num_tokens)
         return hash((hashed_tokens, self.lora_int_id))
 
-    def contextual_hash_of_block(self) -> int:
-        # This function computes a contextual hash for a block, specifically
-        # designed for prefix caching mode. The final block hash is determined
-        # by applying token_ids in PrefixCachingBlock.
+    def extra_hash(self) -> int:
+        # This function computes an extra hash for a sequence, specifically
+        # designed for prefix caching mode. The final sequence hash is determined
+        # by applying token_ids from the sequence's blocks.
 
         # NOTE: If there are additional factors influencing the block aside from
         # token_ids, include them as input parameters to the hash.

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -527,10 +527,14 @@ class Sequence:
         hashed_tokens = self.data.get_prefix_token_ids(num_tokens)
         return hash((hashed_tokens, self.lora_int_id))
 
-    def extra_hash(self) -> int:
-        # This function computes an extra hash for a sequence, specifically
-        # designed for prefix caching mode. The final sequence hash is determined
-        # by applying token_ids from the sequence's blocks.
+    def extra_hash(self) -> Optional[int]:
+        """
+        This function computes an extra hash for a sequence, specifically
+        designed for prefix caching mode. The final sequence hash is determined
+        by applying token_ids from the sequence's blocks.
+        """
+        if self.prompt_adapter_id == 0 and self.lora_int_id == 0:
+            return None
 
         # NOTE: If there are additional factors influencing the block aside from
         # token_ids, include them as input parameters to the hash.


### PR DESCRIPTION
## Summary
Block Manager v2, unlike v1, did not support LoRA and prompt adapter for the block hash in prefix caching mode.
I added logic to inject the LoRA ID and prompt adapter ID into the block hash function to support LoRA and prompt adapter while using `prefix caching mode` with `block manager v2`.

## Detail
Block Manager v1 uses the following hash_of_block function to generate a content hash in prefix caching mode:
https://github.com/vllm-project/vllm/blob/baa5467547a758af35f442af6edfbc0fb73c83ce/vllm/sequence.py#L460-L468

However, Block Manager v2 only uses token IDs, as shown here:
https://github.com/vllm-project/vllm/blob/baa5467547a758af35f442af6edfbc0fb73c83ce/vllm/core/block/prefix_caching_block.py#L855