### PR TITLE
Enable Random Prefix Caching in Serving Profiling Tool (benchmark_serving.py)

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -195,16 +195,16 @@ def sample_sonnet_requests(
 
 
 def sample_random_requests(
-        prefix_len: int,
-        input_len: int,
-        output_len: int,
-        num_prompts: int,
-        range_ratio: float,
-        tokenizer: PreTrainedTokenizerBase,
+    prefix_len: int,
+    input_len: int,
+    output_len: int,
+    num_prompts: int,
+    range_ratio: float,
+    tokenizer: PreTrainedTokenizerBase,
 ) -> List[Tuple[str, int, int]]:
-    prefix_token_ids = np.random.randint(
-        0, tokenizer.vocab_size, size=prefix_len
-    ).tolist()
+    prefix_token_ids = np.random.randint(0,
+                                         tokenizer.vocab_size,
+                                         size=prefix_len).tolist()
 
     input_lens = np.random.randint(
         int(input_len * range_ratio),
@@ -219,17 +219,12 @@ def sample_random_requests(
     offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
     input_requests = []
     for i in range(num_prompts):
-        prompt = tokenizer.decode(
-            prefix_token_ids +
-            [(offsets[i] + i + j) % tokenizer.vocab_size for j in range(input_lens[i])]
-        )
+        prompt = tokenizer.decode(prefix_token_ids +
+                                  [(offsets[i] + i + j) % tokenizer.vocab_size
+                                   for j in range(input_lens[i])])
 
         input_requests.append(
-            (
-                prompt,
-                int(prefix_len + input_lens[i]), int(output_lens[i])
-            )
-        )
+            (prompt, int(prefix_len + input_lens[i]), int(output_lens[i])))
 
     return input_requests
 
@@ -582,9 +577,9 @@ def main(args: argparse.Namespace):
 
     elif args.dataset_name == "random":
         input_requests = sample_random_requests(
+            prefix_len=args.random_prefix_len,
             input_len=args.random_input_len,
             output_len=args.random_output_len,
-            prefix_len=args.random_prefix_len,
             num_prompts=args.num_prompts,
             range_ratio=args.random_range_ratio,
             tokenizer=tokenizer,
@@ -786,9 +781,9 @@ if __name__ == "__main__":
         type=int,
         default=0,
         help="Number of fixed prefix tokens before random "
-        " context. Total length of a random request is "
-        "random-prefix-len + random-input-len."
-    )
+        " context. The length range of context in a random "
+        " request is [random-prefix-len, "
+        " random-prefix-len + random-prefix-len * random-range-ratio).")
     parser.add_argument(
         "--request-rate",
         type=float,


### PR DESCRIPTION
Prefix-caching is an important feature but not supported in vllm's serving profiler. This PR extends random data generator in `benchmark_serving.py` to create requests with fixed prefix context. The newly added `--random-prefix-len` specifies the prefix in every random request; the total context length per request is `random_prefix_len` + `random_input_len`.