### PR TITLE
[Bugfix] Fix broken OpenAI tensorizer test

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -481,8 +481,8 @@ class TensorizerLoader(BaseModelLoader):
         return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
-        self.tensorizer_config.verify_with_model_config(model_config)
-        self._get_weights_iterator()
+        with self.tensorizer_config.open_stream():
+            pass
 
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -481,6 +481,8 @@ class TensorizerLoader(BaseModelLoader):
         return model.eval()
 
     def download_model(self, model_config: ModelConfig) -> None:
+        self.tensorizer_config.verify_with_model_config(model_config)
+
         with self.tensorizer_config.open_stream():
             pass
 

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -186,6 +186,11 @@ class BaseModelLoader(ABC):
         self.load_config = load_config
 
     @abstractmethod
+    def download_model(self, model_config: ModelConfig) -> None:
+        """Download a model so that it can be immediately loaded."""
+        raise NotImplementedError
+
+    @abstractmethod
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
                    lora_config: Optional[LoRAConfig],
@@ -193,7 +198,7 @@ class BaseModelLoader(ABC):
                    scheduler_config: SchedulerConfig,
                    cache_config: CacheConfig) -> nn.Module:
         """Load a model with the given configurations."""
-        ...
+        raise NotImplementedError
 
 
 class DefaultModelLoader(BaseModelLoader):
@@ -335,6 +340,11 @@ class DefaultModelLoader(BaseModelLoader):
             weights_iterator = _xla_weights_iterator(weights_iterator)
         return weights_iterator
 
+    def download_model(self, model_config: ModelConfig) -> None:
+        self._prepare_weights(model_config.model,
+                              model_config.revision,
+                              fall_back_to_pt=True)
+
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
                    lora_config: Optional[LoRAConfig],
@@ -376,6 +386,9 @@ class DummyModelLoader(BaseModelLoader):
         if load_config.model_loader_extra_config:
             raise ValueError(f"Model loader extra config is not supported for "
                              f"load format {load_config.load_format}")
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        pass  # Nothing to download
 
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
@@ -466,6 +479,10 @@ class TensorizerLoader(BaseModelLoader):
 
                 model = load_with_tensorizer(tensorizer_config, **extra_kwargs)
         return model.eval()
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        self.tensorizer_config.verify_with_model_config(model_config)
+        self._get_weights_iterator()
 
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
@@ -567,6 +584,9 @@ class ShardedStateLoader(BaseModelLoader):
                 revision,
                 ignore_patterns=self.load_config.ignore_patterns,
             )
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        self._prepare_weights(model_config.model, model_config.revision)
 
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
@@ -995,6 +1015,9 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                     set_weight_attrs(
                         param, {"matmul_state": [None] * len(quant_states)})
 
+    def download_model(self, model_config: ModelConfig) -> None:
+        self._prepare_weights(model_config.model, model_config.revision)
+
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,
                    lora_config: Optional[LoRAConfig],
@@ -1069,6 +1092,9 @@ class GGUFModelLoader(BaseModelLoader):
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
         return gguf_quant_weights_iterator(model_name_or_path,
                                            gguf_to_hf_name_map)
+
+    def download_model(self, model_config: ModelConfig) -> None:
+        self._prepare_weights(model_config.model)
 
     def load_model(self, *, model_config: ModelConfig,
                    device_config: DeviceConfig,

--- a/vllm/model_executor/model_loader/tensorizer.py
+++ b/vllm/model_executor/model_loader/tensorizer.py
@@ -99,6 +99,13 @@ class TensorizerConfig:
                 "Loading a model using Tensorizer with quantization on vLLM"
                 " is unstable and may lead to errors.")
 
+    def open_stream(self, tensorizer_args: Optional["TensorizerArgs"] = None):
+        if tensorizer_args is None:
+            tensorizer_args = self._construct_tensorizer_args()
+
+        return open_stream(self.tensorizer_uri,
+                           **tensorizer_args.stream_params)
+
 
 def load_with_tensorizer(tensorizer_config: TensorizerConfig,
                          **extra_kwargs) -> nn.Module:


### PR DESCRIPTION
The current `RemoteOpenAIServer` assumes default model loader which isn't true in tensorizer tests. This PR adds an explicit `download_model` method to each model loader so that `RemoteOpenAIServer` can download the model in advance regardless of which model loader is used.

FIX #8249
cc @alexeykondrat 