### PR TITLE
[Bugfix] Fix async postprocessor in case of preemption

### DIFF
--- a/tests/basic_correctness/test_preemption.py
+++ b/tests/basic_correctness/test_preemption.py
@@ -57,14 +57,12 @@ def test_chunked_prefill_recompute(
     with hf_runner(model, dtype=dtype) as hf_model:
         hf_outputs = hf_model.generate_greedy(example_prompts, max_tokens)
 
-    with vllm_runner(
-            model,
-            dtype=dtype,
-            max_num_batched_tokens=max_num_batched_tokens,
-            enable_chunked_prefill=enable_chunked_prefill,
-            max_num_seqs=max_num_seqs,
-            worker_use_ray=worker_use_ray,
-    ) as vllm_model:
+    with vllm_runner(model,
+                     dtype=dtype,
+                     max_num_batched_tokens=max_num_batched_tokens,
+                     enable_chunked_prefill=enable_chunked_prefill,
+                     max_num_seqs=max_num_seqs,
+                     worker_use_ray=worker_use_ray) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
         assert (vllm_model.model.llm_engine.scheduler[0].artificial_preempt_cnt
                 < ARTIFICIAL_PREEMPTION_MAX_CNT)

--- a/tests/basic_correctness/test_preemption.py
+++ b/tests/basic_correctness/test_preemption.py
@@ -57,12 +57,14 @@ def test_chunked_prefill_recompute(
     with hf_runner(model, dtype=dtype) as hf_model:
         hf_outputs = hf_model.generate_greedy(example_prompts, max_tokens)
 
-    with vllm_runner(model,
-                     dtype=dtype,
-                     max_num_batched_tokens=max_num_batched_tokens,
-                     enable_chunked_prefill=enable_chunked_prefill,
-                     max_num_seqs=max_num_seqs,
-                     worker_use_ray=worker_use_ray) as vllm_model:
+    with vllm_runner(
+            model,
+            dtype=dtype,
+            max_num_batched_tokens=max_num_batched_tokens,
+            enable_chunked_prefill=enable_chunked_prefill,
+            max_num_seqs=max_num_seqs,
+            worker_use_ray=worker_use_ray,
+    ) as vllm_model:
         vllm_outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
         assert (vllm_model.model.llm_engine.scheduler[0].artificial_preempt_cnt
                 < ARTIFICIAL_PREEMPTION_MAX_CNT)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -558,9 +558,9 @@ class Scheduler:
             ) > self.scheduler_config.max_model_len:
                 self._async_stopped.append(seq_group)
                 continue
-            
-            # NOTE(woosuk): Preemption happens only when there is no available slot
-            # to keep all the sequence groups in the RUNNING state.
+
+            # NOTE(woosuk): Preemption happens only when there is no available
+            # slot to keep all the sequence groups in the RUNNING state.
             while not self._can_append_slots(seq_group):
                 budget.subtract_num_batched_tokens(seq_group.request_id,
                                                    num_running_tokens)
@@ -585,6 +585,7 @@ class Scheduler:
                 # we need to ensure it has no pending async postprocessor
                 do_preempt = True
                 if self.use_async_output_proc:
+                    assert self.output_proc_callback is not None
                     self.output_proc_callback(
                         request_id=victim_seq_group.request_id)
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -594,7 +594,7 @@ class Scheduler:
                         request_id=victim_seq_group.request_id)
 
                     # It may be that the async pending "victim_seq_group"
-                    # becomes finished, in which case we simply free it
+                    # becomes finished, in which case we simply free it.
                     if victim_seq_group.is_finished():
                         self._free_finished_seq_group(victim_seq_group)
                         do_preempt = False

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -537,13 +537,6 @@ class Scheduler:
         preempted: List[SequenceGroup] = ret.preempted
         swapped_out: List[SequenceGroup] = ret.swapped_out
 
-        # NOTE(woosuk): Preemption happens only when there is no available slot
-        # to keep all the sequence groups in the RUNNING state.
-
-        # Store original running requests for the case of async + preemption
-        # if self.use_async_output_proc:
-        #     orig_running = self.running.copy()
-
         running_queue = self.running
         assert len(self._async_stopped) == 0
         while running_queue:
@@ -552,6 +545,7 @@ class Scheduler:
                 seq_group, SequenceStatus.RUNNING, enable_chunking, budget)
 
             if num_running_tokens == 0:
+                # No budget => Stop
                 break
 
             running_queue.popleft()
@@ -564,19 +558,9 @@ class Scheduler:
             ) > self.scheduler_config.max_model_len:
                 self._async_stopped.append(seq_group)
                 continue
-
-            # With async postprocessor, when preemption kicks in, we need
-            # first to drain the async postprocessor, so that all async
-            # block_table freeing is applied before the preemption freeing
-            # is applied.
-            # if self.use_async_output_proc and not self._can_append_slots(
-            #         seq_group):
-            #     tmp = self.running
-            #     self.running = orig_running
-            #     assert self.output_proc_callback is not None
-            #     self.output_proc_callback()
-            #     self.running = tmp
-
+            
+            # NOTE(woosuk): Preemption happens only when there is no available slot
+            # to keep all the sequence groups in the RUNNING state.
             while not self._can_append_slots(seq_group):
                 budget.subtract_num_batched_tokens(seq_group.request_id,
                                                    num_running_tokens)
@@ -588,35 +572,39 @@ class Scheduler:
                         and seq_group.lora_int_id in curr_loras):
                     curr_loras.remove(seq_group.lora_int_id)
 
+                # Determine victim sequence
                 if running_queue:
-                    # Preempt the lowest-priority sequence groups.
+                    # Preempt the lowest-priority sequence group.
                     victim_seq_group = running_queue.pop()
+                else:
+                    # No other sequence group can be preempted.
+                    # Preempt the current sequence group.
+                    victim_seq_group = seq_group
 
-                    if self.use_async_output_proc:
-                        self.output_proc_callback(sync_request_id=victim_seq_group.request_id)
-                        if victim_seq_group.is_finished():
-                            continue
-                        
+                # With async postprocessor, before preempting a sequence
+                # we need to ensure it has no pending async postprocessor
+                do_preempt = True
+                if self.use_async_output_proc:
+                    self.output_proc_callback(
+                        request_id=victim_seq_group.request_id)
+
+                    # It may be that the async pending "victim_seq_group"
+                    # becomes finished, in which case we simply free its
+                    # memory
+                    if victim_seq_group.is_finished():
+                        self._free_finished_seq_group(victim_seq_group)
+                        do_preempt = False
+
+                # Do preemption
+                if do_preempt:
                     preempted_mode = self._preempt(victim_seq_group,
                                                    blocks_to_swap_out)
                     if preempted_mode == PreemptionMode.RECOMPUTE:
                         preempted.append(victim_seq_group)
                     else:
                         swapped_out.append(victim_seq_group)
-                else:
-                    # No other sequence groups can be preempted.
-                    # Preempt the current sequence group.
-                    if self.use_async_output_proc:
-                        self.output_proc_callback(sync_request_id=victim_seq_group.request_id)
-                        if victim_seq_group.is_finished():
-                            continue
 
-                    preempted_mode = self._preempt(seq_group,
-                                                   blocks_to_swap_out)
-                    if preempted_mode == PreemptionMode.RECOMPUTE:
-                        preempted.append(seq_group)
-                    else:
-                        swapped_out.append(seq_group)
+                if not running_queue:
                     break
             else:
                 self._append_slots(seq_group, blocks_to_copy)
@@ -1275,21 +1263,25 @@ class Scheduler:
             if seq.is_finished():
                 self.free_seq(seq)
 
+    def _free_finished_seq_group(self, seq_group: SequenceGroup) -> None:
+        if seq_group.is_finished():
+            # Free cross-attention block table, if it exists
+            self._free_seq_group_cross_attn_blocks(seq_group)
+
+            # Add the finished requests to the finished requests list.
+            # This list will be used to update the Mamba cache in the
+            # next step.
+            self._finished_requests_ids.append(seq_group.request_id)
+
+        # Free finished seqs
+        self._free_finished_seqs(seq_group)
+
     def free_finished_seq_groups(self) -> None:
         remaining: Deque[SequenceGroup] = deque()
         for seq_group in self.running:
-            if seq_group.is_finished():
-                # Free cross-attention block table, if it exists
-                self._free_seq_group_cross_attn_blocks(seq_group)
-                # Add the finished requests to the finished requests list.
-                # This list will be used to update the Mamba cache in the
-                # next step.
-                self._finished_requests_ids.append(seq_group.request_id)
-            else:
+            self._free_finished_seq_group(seq_group)
+            if not seq_group.is_finished():
                 remaining.append(seq_group)
-
-            # Free finished seqs
-            self._free_finished_seqs(seq_group)
 
         self.running = remaining
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1316,7 +1316,12 @@ class LLMEngine:
                     assert i not in skip  # Cannot be called twice
                     indices.append(i)
                     break
-            assert indices
+
+            # If the request_id was not found, then it means that
+            # this is a new request that has no pending async
+            # postprocessor
+            if len(indices) == 0:
+                return
         else:
             indices = range(len(seq_group_metadata_list))  # type: ignore
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1296,7 +1296,7 @@ class LLMEngine:
                     break
             assert indices
         else:
-            indices = range(len(seq_group_metadata_list))
+            indices = range(len(seq_group_metadata_list))  # type: ignore
 
         finished_before: List[int] = []
         finished_now: List[int] = []

--- a/vllm/worker/multi_step_model_runner.py
+++ b/vllm/worker/multi_step_model_runner.py
@@ -274,12 +274,13 @@ class MultiStepModelRunner(GPUModelRunnerBase[StatefulModelInput]):
                                              self.pinned_sampled_token_ids)
                 if model_output.pythonized:
                     ctx = output_proc_callback.keywords["ctx"]
-                    is_async = False
-                    is_last_step = False
-                    ctx.output_queue.append(
-                        ([model_output.sampler_output
-                          ], ctx.seq_group_metadata_list,
-                         ctx.scheduler_outputs, is_async, is_last_step))
+                    ctx.append_output(
+                        outputs=[model_output.sampler_output],
+                        seq_group_metadata_list=ctx.seq_group_metadata_list,
+                        scheduler_outputs=ctx.scheduler_outputs,
+                        is_async=False,
+                        is_last_step=False)
+
                     output_proc_callback()
                 else:
                     cont = False
@@ -319,12 +320,13 @@ class MultiStepModelRunner(GPUModelRunnerBase[StatefulModelInput]):
                     if not is_last_step:
                         ctx = output_proc_callback.keywords[  # type: ignore
                             "ctx"]  # type: ignore
-                        is_async = False
-                        is_last_step = False
-                        ctx.output_queue.append(
-                            ([output.sampler_output
-                              ], ctx.seq_group_metadata_list,
-                             ctx.scheduler_outputs, is_async, is_last_step))
+                        ctx.append_output(
+                            outputs=[output.sampler_output],
+                            seq_group_metadata_list=ctx.
+                            seq_group_metadata_list,
+                            scheduler_outputs=ctx.scheduler_outputs,
+                            is_async=False,
+                            is_last_step=False)
                     else:
                         outputs.append(output.sampler_output)
             else:


### PR DESCRIPTION
This PR fixes the bug reported here https://github.com/vllm-project/vllm/issues/8219. 

When preemption kicks in, the previous code was running the async postprocessor for all sequences and then retrying the scheduling. However, this introduced a race condition with sequences that were already scheduled due to the possibility of them being already finished (via the async run). In this PR, all of this code is removed and changed to running the async postprocessor **only** for the sequence that is actually preempted. This removes the issue and also maintains good performance.