### PR TITLE
[MISC] Dump model runner inputs when crashing

### DIFF
--- a/.github/ISSUE_TEMPLATE/400-bug report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug report.yml
@@ -32,6 +32,15 @@ body:
     required: true
 - type: textarea
   attributes:
+    label: Model Input Dumps
+    description: |
+      If you are facing crashing due to illegal memory access or other issues with model execution, vLLM may dump the problematic input of the model. In this case, you will see the message `Error in model execution (input dumped to /tmp/err_xxx.pkl)`. If you see this message, please zip the file (because GitHub doesn't support .pkl file format) and upload it here. This will help us to reproduce the issue and facilitate the debugging process.
+    placeholder: |
+      Upload the dumped input file.
+  validations:
+    required: false
+- type: textarea
+  attributes:
     label: 🐛 Describe the bug
     description: |
       Please provide a clear and concise description of what the bug is.

--- a/tests/basic_correctness/test_basic_correctness.py
+++ b/tests/basic_correctness/test_basic_correctness.py
@@ -72,10 +72,9 @@ def test_models(
 
 def test_model_with_failure(vllm_runner) -> None:
     try:
-        exception_secret = "artificial stop"
         with patch("vllm.model_executor.models.opt.OPTForCausalLM.forward",
-                   side_effect=ValueError(exception_secret)):
-            with pytest.raises(Exception, match=exception_secret) as exc_info:
+                   side_effect=ValueError()):
+            with pytest.raises(ValueError) as exc_info:
                 vllm_runner("facebook/opt-125m",
                             dtype="half",
                             enforce_eager=False,

--- a/tests/basic_correctness/test_basic_correctness.py
+++ b/tests/basic_correctness/test_basic_correctness.py
@@ -3,12 +3,16 @@
 Run `pytest tests/basic_correctness/test_basic_correctness.py`.
 """
 import os
+import pickle
+import re
 import weakref
+from unittest.mock import patch
 
 import pytest
 
 from vllm import LLM
 from vllm.utils import is_hip
+from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
 
 from ..models.utils import check_outputs_equal
 
@@ -64,3 +68,30 @@ def test_models(
         name_0="hf",
         name_1="vllm",
     )
+
+
+def test_model_with_failure(vllm_runner) -> None:
+    try:
+        exception_secret = "artificial stop"
+        with patch("vllm.model_executor.models.opt.OPTForCausalLM.forward",
+                   side_effect=ValueError(exception_secret)):
+            with pytest.raises(Exception, match=exception_secret) as exc_info:
+                vllm_runner("facebook/opt-125m",
+                            dtype="half",
+                            enforce_eager=False,
+                            gpu_memory_utilization=0.7)
+            matches = re.search(r"input dumped to (.+).pkl",
+                                str(exc_info.value))
+            assert matches is not None
+            filename = f"{matches.group(1)}.pkl"
+
+        with open(filename, "rb") as filep:
+            inputs = pickle.load(filep)
+
+        if any(key not in inputs for key in ("arg_1", "arg_2", "arg_3")):
+            raise AssertionError("Missing keys in dumped inputs. Dumped keys: "
+                                 f"{list(inputs.keys())}")
+        assert isinstance(inputs["arg_1"],
+                          ModelInputForGPUWithSamplingMetadata)
+    finally:
+        os.remove(filename)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -52,7 +52,7 @@ from vllm.worker.model_runner_base import (
     _add_attn_metadata_broadcastable_dict,
     _add_sampling_metadata_broadcastable_dict,
     _init_attn_metadata_from_tensor_dict,
-    _init_sampling_metadata_from_tensor_dict)
+    _init_sampling_metadata_from_tensor_dict, dump_input_when_exception)
 
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
@@ -1396,6 +1396,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                                    virtual_engine=virtual_engine)
 
     @torch.inference_mode()
+    @dump_input_when_exception(exclude_args=[0], exclude_kwargs=["self"])
     def execute_model(
         self,
         model_input: ModelInputForGPUWithSamplingMetadata,

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -112,7 +112,7 @@ def dump_input_when_exception(exclude_args: Optional[List[int]] = None,
                 return func(*args, **kwargs)
             except Exception as err:
                 timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-                filename = f"err_{func.__name__}_input_{timestamp}.pkl"
+                filename = f"/tmp/err_{func.__name__}_input_{timestamp}.pkl"
                 with open(filename, "wb") as filep:
                     dumped_inputs = {
                         k: v
@@ -123,9 +123,9 @@ def dump_input_when_exception(exclude_args: Optional[List[int]] = None,
                         if i not in (exclude_args or []):
                             dumped_inputs[f"arg_{i}"] = arg
                     pickle.dump(dumped_inputs, filep)
-                raise Exception(
+                raise type(err)(
                     f"Error in model execution (input dumped to {filename}): "
-                    f"{str(err)}.\n") from None
+                    f"{str(err)}") from err
 
         return _wrapper
 

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -1,5 +1,8 @@
 import dataclasses
+import pickle
 from abc import ABC, abstractmethod
+from datetime import datetime
+from functools import wraps
 from typing import (TYPE_CHECKING, Any, Dict, Generic, List, Optional, Type,
                     TypeVar)
 
@@ -96,6 +99,37 @@ def _init_frozen_model_input_from_tensor_dict(
     frozen_model_input = frozen_model_input_cls(**valid_tensor_kwargs)
     tensor_dict["frozen_model_input"] = frozen_model_input
     return tensor_dict
+
+
+def dump_input_when_exception(exclude_args: Optional[List[int]] = None,
+                              exclude_kwargs: Optional[List[str]] = None):
+
+    def _inner(func):
+
+        @wraps(func)
+        def _wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as err:
+                timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+                filename = f"err_{func.__name__}_input_{timestamp}.pkl"
+                with open(filename, "wb") as filep:
+                    dumped_inputs = {
+                        k: v
+                        for k, v in kwargs.items()
+                        if k not in (exclude_kwargs or [])
+                    }
+                    for i, arg in enumerate(args):
+                        if i not in (exclude_args or []):
+                            dumped_inputs[f"arg_{i}"] = arg
+                    pickle.dump(dumped_inputs, filep)
+                raise Exception(
+                    f"Error in model execution (input dumped to {filename}): "
+                    f"{str(err)}.\n") from None
+
+        return _wrapper
+
+    return _inner
 
 
 class BroadcastableModelInput(ABC):


### PR DESCRIPTION
To better reproduce the model runner crashing due to illegal memory access and possibly other errors, this PR introduces a utility that dumps model runner inputs when crashing. Since the model runner inputs may be long, I dumped them using pickle for now. Any suggestions or better ideas are welcome.

cc @robertgshaw2-neuralmagic @simon-mo @DarkLight1337 