### PR TITLE
[BugFix] Spec Decode error:No available block found in 60 Second.

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -931,7 +931,7 @@ def initialize_model_parallel(
     _TP = init_model_parallel_group(group_ranks,
                                     get_world_group().local_rank,
                                     backend,
-                                    use_message_queue_broadcaster=True)
+                                    use_message_queue_broadcaster=False)
 
     # Build the pipeline model-parallel groups.
     num_pipeline_model_parallel_groups: int = (world_size //


### PR DESCRIPTION
# What Does This PR Do?
FIX #7454  #6818  #6614

I am using vllm and Qwen2-72B-Instruct model to do performance test of speculative decode-ngram algorithm. When I set:
speculative_model="[ngram]",
num_speculative_tokens=5,
ngram_prompt_lookup_max=3,
ngram_prompt_lookup_min=1, 
max_tokens=10240, 
max_num_seqs=8,
max_model_len = 20480,
max_num_batched_tokens = 32768,
num_scheduler_steps=1, 
a known bug will appear in the process of running vllm. As the issues I mentioned above, my error is the same as theirs.

I traced the code and found that the original error was generated in https://github.com/vllm-project/vllm/blob/da1a844e61366b473cef6b3f7437ea5dc41876a1/vllm/distributed/device_communicators/shm_broadcast.py#L387,

The calling relationship is as follows ：https://github.com/vllm-project/vllm/blob/da1a844e61366b473cef6b3f7437ea5dc41876a1/vllm/distributed/device_communicators/shm_broadcast.py#L438,

https://github.com/vllm-project/vllm/blob/da1a844e61366b473cef6b3f7437ea5dc41876a1/vllm/distributed/parallel_state.py#L181

https://github.com/vllm-project/vllm/blob/main/vllm/distributed/parallel_state.py#L934

So the trigger of this bug is that use_message_queue_broadcaster=True is set, set it to False, it can run normally. This bug needs further location and confirmation by the vllm team.
