### PR TITLE
[Gemma2] add bitsandbytes support for Gemma2

### DIFF
--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -312,7 +312,15 @@ class Gemma2ForCausalLM(nn.Module, SupportsLoRA):
     # Gemma does not apply LoRA to the embedding layer.
     embedding_modules = {}
     embedding_padding_modules = []
-
+    bitsandbytes_stacked_params_mapping = {
+        # shard_name, weight_name, index
+        "q_proj": ("qkv_proj", 0),
+        "k_proj": ("qkv_proj", 1),
+        "v_proj": ("qkv_proj", 2),
+        "gate_proj": ("gate_up_proj", 0),
+        "up_proj": ("gate_up_proj", 1),
+    }
+    
     def __init__(
         self,
         config: Gemma2Config,

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -46,6 +46,7 @@ logger = init_logger(__name__)
 
 
 class Gemma2MLP(nn.Module):
+
     def __init__(
         self,
         hidden_size: int,
@@ -78,6 +79,7 @@ class Gemma2MLP(nn.Module):
 
 
 class Gemma2Attention(nn.Module):
+
     def __init__(self,
                  layer_idx: int,
                  config: Gemma2Config,
@@ -166,6 +168,7 @@ class Gemma2Attention(nn.Module):
 
 
 class Gemma2DecoderLayer(nn.Module):
+
     def __init__(
         self,
         layer_idx: int,
@@ -235,6 +238,7 @@ class Gemma2DecoderLayer(nn.Module):
 
 
 class Gemma2Model(nn.Module):
+
     def __init__(
         self,
         config: Gemma2Config,

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -46,7 +46,6 @@ logger = init_logger(__name__)
 
 
 class Gemma2MLP(nn.Module):
-
     def __init__(
         self,
         hidden_size: int,
@@ -79,7 +78,6 @@ class Gemma2MLP(nn.Module):
 
 
 class Gemma2Attention(nn.Module):
-
     def __init__(self,
                  layer_idx: int,
                  config: Gemma2Config,
@@ -168,7 +166,6 @@ class Gemma2Attention(nn.Module):
 
 
 class Gemma2DecoderLayer(nn.Module):
-
     def __init__(
         self,
         layer_idx: int,
@@ -238,7 +235,6 @@ class Gemma2DecoderLayer(nn.Module):
 
 
 class Gemma2Model(nn.Module):
-
     def __init__(
         self,
         config: Gemma2Config,
@@ -320,7 +316,7 @@ class Gemma2ForCausalLM(nn.Module, SupportsLoRA):
         "gate_proj": ("gate_up_proj", 0),
         "up_proj": ("gate_up_proj", 1),
     }
-    
+
     def __init__(
         self,
         config: Gemma2Config,


### PR DESCRIPTION
When I attempt to use Gemma2-2b with bitsandbytes quantization, I encounter the error message: `AttributeError: Model Gemma2ForCausalLM does not support BitsAndBytes quantization yet`. Also, similar issues #6068 and #6186 are reported for Gemma2-9b and Gemma2-27b.

The root cause is that the essential mapping `bitsandbytes_stacked_params_mapping` is missing in Gemma2. 

This PR aims to enable support for bitsandbytes quantization in Gemma2 by simply adding the `bitsandbytes_stacked_params_mapping`.

I have tested this PR with the model `unsloth/gemma-2-27b-it-bnb-4bit`, and it works well.

Here's my test scripts:
```
from vllm.entrypoints.llm import LLM, SamplingParams
import torch

prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

llm = LLM(model="unsloth/gemma-2-2b-it-bnb-4bit", 
          dtype=torch.bfloat16, 
          trust_remote_code=True, 
          quantization="bitsandbytes", 
          load_format="bitsandbytes", 
          enforce_eager=True)


outputs = llm.generate(prompts, sampling_params)

# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```
With this PR, I can get the following response:
```
Prompt: 'Hello, my name is', Generated text: " Liam. \n\nI'm an AI assistant, but I don't"
Prompt: 'The president of the United States is', Generated text: ' considered to be the leader of the free world.\n\nThis statement is true,'
Prompt: 'The capital of France is', Generated text: ' **Paris**. 🇫🇷 \n'
Prompt: 'The future of AI is', Generated text: " exciting, and there are so many possibilities! Here's a glimpse of what"
```

From my end, I believe this PR works for all scales of Gemma2 models.

FIX #6068

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


