### PR TITLE
[Bugfix] Ensure multistep lookahead allocation is compatible with cuda graph max capture

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -11,9 +11,7 @@ prompts = [
 sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=8)
 
 # Create an LLM.
-llm = LLM(model="facebook/opt-125m",
-          max_seq_len_to_capture=15,
-          num_scheduler_steps=64)
+llm = LLM(model="facebook/opt-125m")
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.
 outputs = llm.generate(prompts, sampling_params)

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -8,7 +8,7 @@ prompts = [
     "The future of AI is",
 ]
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=8)
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 
 # Create an LLM.
 llm = LLM(model="facebook/opt-125m")

--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -8,10 +8,12 @@ prompts = [
     "The future of AI is",
 ]
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=8)
 
 # Create an LLM.
-llm = LLM(model="facebook/opt-125m")
+llm = LLM(model="facebook/opt-125m",
+          max_seq_len_to_capture=15,
+          num_scheduler_steps=64)
 # Generate texts from the prompts. The output is a list of RequestOutput objects
 # that contain the prompt, generated text, and other information.
 outputs = llm.generate(prompts, sampling_params)

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -471,7 +471,7 @@ class FlashAttentionMetadataBuilder(
                     else:
                         # It may be possible to have more blocks allocated due
                         # to lookahead slots of multi-step, however, they are
-                        # not used anyway, so can be safely ignored
+                        # not used anyway, so can be safely ignored.
                         input_block_tables[
                             i, :max_blocks] = block_table[:max_blocks]
 

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -462,9 +462,19 @@ class FlashAttentionMetadataBuilder(
             # The shape of graph_block_tables is
             # [max batch size, max context len // block size].
             input_block_tables = self.runner.graph_block_tables[:batch_size]
+            max_blocks = input_block_tables.shape[1]
             for i, block_table in enumerate(self.block_tables):
                 if block_table:
-                    input_block_tables[i, :len(block_table)] = block_table
+                    num_blocks = len(block_table)
+                    if num_blocks <= max_blocks:
+                        input_block_tables[i, :num_blocks] = block_table
+                    else:
+                        # It may be possible to have more blocks allocated due
+                        # to lookahead slots of multi-step, however, they are
+                        # not used anyway, so can be safely ignored
+                        input_block_tables[
+                            i, :max_blocks] = block_table[:max_blocks]
+
             block_tables = torch.from_numpy(input_block_tables).to(
                 device=device, non_blocking=True)
         else:


### PR DESCRIPTION
This PR fixes the issue described here: https://github.com/vllm-project/vllm/issues/8068.

The problem is that multistep lookahead block allocation may allocate more blocks than what max capture is using for the cuda graphs. The solution here is to simply ignore these extra additional blocks, since the model won't execute more than the max capture size / max_model_len anyway.
