### PR TITLE
[Core][VLM] Add support for prefix caching for multi-modal models

### DIFF
--- a/tests/core/block/test_token_ids.py
+++ b/tests/core/block/test_token_ids.py
@@ -1,0 +1,162 @@
+import pytest
+
+from vllm.core.block.token_ids import TokenIds, TokenRangeAnnotation
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Must be contained within the token IDs.
+        [TokenRangeAnnotation(0, 0, -1, 2)],
+        [TokenRangeAnnotation(0, 0, 0, 5)],
+        [TokenRangeAnnotation(0, 0, 4, 5)],
+
+        # Must not overlap.
+        [
+            TokenRangeAnnotation(000, 0, 0, 1),
+            TokenRangeAnnotation(111, 0, 0, 1)
+        ],
+        [
+            TokenRangeAnnotation(000, 0, 0, 2),
+            TokenRangeAnnotation(111, 0, 1, 3)
+        ],
+        [
+            TokenRangeAnnotation(000, 0, 2, 3),
+            TokenRangeAnnotation(111, 0, 0, 4)
+        ],
+
+        # Must be sorted.
+        [
+            TokenRangeAnnotation(000, 0, 2, 3),
+            TokenRangeAnnotation(111, 0, 0, 1)
+        ],
+        [
+            TokenRangeAnnotation(000, 0, 0, 1),
+            TokenRangeAnnotation(111, 0, 3, 4),
+            TokenRangeAnnotation(222, 0, 2, 3)
+        ],
+    ])
+def test_invalid_annotations_should_raise(value):
+    with pytest.raises(ValueError):
+        TokenIds(range(4), value)
+
+
+@pytest.mark.parametrize("value", [
+    TokenIds(()),
+    TokenIds((1, 2, 3)),
+    TokenIds((1, 2, 3), [TokenRangeAnnotation(0, 0, 0, 1)])
+])
+def test_token_ids_add_unit(value):
+    assert value + TokenIds() == value
+    assert TokenIds() + value == value
+
+
+def test_token_ids_add_without_annotations():
+    a = TokenIds((1, 2, 3))
+    b = TokenIds((4, 5, 6))
+    assert a + b == TokenIds((1, 2, 3, 4, 5, 6))
+
+
+def test_token_ids_add_with_annotations():
+    a = TokenIds((1, 2, 3))
+    b = TokenIds((4, 5, 6), [TokenRangeAnnotation(0, 0, 0, 1)])
+
+    assert a + b == TokenIds((1, 2, 3, 4, 5, 6),
+                             [TokenRangeAnnotation(0, 0, 3, 4)])
+    assert b + a == TokenIds((4, 5, 6, 1, 2, 3),
+                             [TokenRangeAnnotation(0, 0, 0, 1)])
+
+
+def test_token_ids_add_can_coalesce():
+    a = TokenIds((1, 2, 3), [TokenRangeAnnotation(111, 0, 1, 3)])
+    b = TokenIds((4, 5, 6), [TokenRangeAnnotation(111, 2, 0, 1)])
+
+    assert a + b == TokenIds((1, 2, 3, 4, 5, 6),
+                             [TokenRangeAnnotation(111, 0, 1, 4)])
+
+
+def test_token_ids_add_cannot_coalesce_different_offsets():
+    a = TokenIds((1, 2, 3), [TokenRangeAnnotation(111, 0, 1, 3)])
+    b = TokenIds((4, 5, 6), [TokenRangeAnnotation(111, 4, 0, 1)])
+
+    assert a + b == TokenIds((1, 2, 3, 4, 5, 6), [
+        TokenRangeAnnotation(111, 0, 1, 3),
+        TokenRangeAnnotation(111, 4, 3, 4)
+    ])
+
+
+def test_token_ids_add_cannot_coalesce_different_hash():
+    a = TokenIds((1, 2, 3), [TokenRangeAnnotation(111, 0, 1, 3)])
+    b = TokenIds((4, 5, 6), [TokenRangeAnnotation(222, 2, 0, 1)])
+
+    assert a + b == TokenIds((1, 2, 3, 4, 5, 6), [
+        TokenRangeAnnotation(111, 0, 1, 3),
+        TokenRangeAnnotation(222, 2, 3, 4)
+    ])
+
+
+def test_annotation_clipping():
+    r = TokenRangeAnnotation(111, 0, 2, 5)
+    # Overlapping windows
+    assert r.clipped_to_slice(0, 1) is None
+    assert r.clipped_to_slice(0, 2) is None
+    assert r.clipped_to_slice(0, 3) == TokenRangeAnnotation(111, 0, 2, 3)
+    assert r.clipped_to_slice(0, 4) == TokenRangeAnnotation(111, 0, 2, 4)
+    assert r.clipped_to_slice(1, 5) == TokenRangeAnnotation(111, 0, 1, 4)
+    assert r.clipped_to_slice(2, 6) == TokenRangeAnnotation(111, 0, 0, 3)
+    assert r.clipped_to_slice(3, 7) == TokenRangeAnnotation(111, 1, 0, 2)
+    assert r.clipped_to_slice(4, 8) == TokenRangeAnnotation(111, 2, 0, 1)
+    assert r.clipped_to_slice(5, 9) is None
+
+    # Interior windows
+    assert r.clipped_to_slice(2, 3) == TokenRangeAnnotation(111, 0, 0, 1)
+    assert r.clipped_to_slice(2, 4) == TokenRangeAnnotation(111, 0, 0, 2)
+    assert r.clipped_to_slice(2, 5) == TokenRangeAnnotation(111, 0, 0, 3)
+    assert r.clipped_to_slice(3, 4) == TokenRangeAnnotation(111, 1, 0, 1)
+    assert r.clipped_to_slice(3, 5) == TokenRangeAnnotation(111, 1, 0, 2)
+    assert r.clipped_to_slice(4, 5) == TokenRangeAnnotation(111, 2, 0, 1)
+    assert r.clipped_to_slice(3, 3) is None
+
+
+def test_token_id_chunks():
+    token_ids = TokenIds(range(8), [
+        TokenRangeAnnotation(111, 0, 2, 5),
+        TokenRangeAnnotation(222, 0, 6, 7),
+        TokenRangeAnnotation(333, 0, 7, 8)
+    ])
+    single_chunks = [
+        TokenIds([0]),
+        TokenIds([1]),
+        TokenIds([2], [TokenRangeAnnotation(111, 0, 0, 1)]),
+        TokenIds([3], [TokenRangeAnnotation(111, 1, 0, 1)]),
+        TokenIds([4], [TokenRangeAnnotation(111, 2, 0, 1)]),
+        TokenIds([5]),
+        TokenIds([6], [TokenRangeAnnotation(222, 0, 0, 1)]),
+        TokenIds([7], [TokenRangeAnnotation(333, 0, 0, 1)]),
+    ]
+
+    # Without overriding initial chunk size
+    for chunk_size in range(1, len(single_chunks) + 1):
+        chunks = list(token_ids.to_chunks(chunk_size))
+        expected_chunks = [
+            sum(single_chunks[i:i + chunk_size], start=TokenIds())
+            for i in range(0, len(single_chunks), chunk_size)
+        ]
+        assert chunks == expected_chunks
+
+    # With overriding first chunk size
+    for first_chunk_size in range(1, len(single_chunks) + 1):
+        first_chunk = sum(single_chunks[0:first_chunk_size], start=TokenIds())
+        for chunk_size in range(1, len(single_chunks) + 1):
+            chunks = list(
+                token_ids.to_chunks(chunk_size,
+                                    first_chunk_size=first_chunk_size))
+            expected_chunks = [first_chunk] + [
+                sum(single_chunks[i:i + chunk_size], start=TokenIds()) for i in
+                range(first_chunk_size, len(single_chunks), chunk_size)
+            ]
+            assert chunks == expected_chunks
+
+    # Slicing should be equivalent
+    for i in range(len(single_chunks)):
+        assert token_ids[i:] == sum(single_chunks[i:], start=TokenIds())

--- a/tests/engine/output_processor/test_multi_step.py
+++ b/tests/engine/output_processor/test_multi_step.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from transformers import PreTrainedTokenizer
 
+from vllm.core.block.token_ids import TokenIds
 from vllm.core.scheduler import Scheduler
 from vllm.engine.output_processor.multi_step import MultiStepOutputProcessor
 from vllm.engine.output_processor.stop_checker import StopChecker
@@ -49,7 +50,7 @@ def test_appends_token_ids(num_new_tokens: int, seq_output_len: int):
     seq = seq_group.get_seqs()[0]
     seq.status = SequenceStatus.RUNNING
 
-    new_token_ids = list(range(num_new_tokens))
+    new_token_ids = TokenIds(range(num_new_tokens))
 
     outputs = [
         CompletionSequenceGroupOutput(
@@ -101,7 +102,7 @@ def test_respects_max_tokens(num_new_tokens: int, seq_prompt_len: int,
     seq = seq_group.get_seqs()[0]
     seq.status = SequenceStatus.RUNNING
 
-    new_token_ids = list(range(num_new_tokens))
+    new_token_ids = TokenIds(range(num_new_tokens))
 
     outputs = [
         CompletionSequenceGroupOutput(
@@ -165,10 +166,11 @@ def test_respects_eos_token_id(num_new_tokens: int, seq_prompt_len: int,
     seq = seq_group.get_seqs()[0]
     seq.status = SequenceStatus.RUNNING
 
-    new_token_ids = list(range(num_new_tokens))
+    new_token_ids = TokenIds(range(num_new_tokens))
     assert eos_token_id not in new_token_ids
     eos_index = random.randint(0, len(new_token_ids) - 1)
-    new_token_ids[eos_index] = eos_token_id
+    new_token_ids = (new_token_ids[:eos_index] + TokenIds(
+        (eos_token_id, )) + new_token_ids[eos_index + 1:])
 
     outputs = [
         CompletionSequenceGroupOutput(
@@ -234,10 +236,11 @@ def test_ignores_eos_token_id(num_new_tokens: int, seq_prompt_len: int,
     seq = seq_group.get_seqs()[0]
     seq.status = SequenceStatus.RUNNING
 
-    new_token_ids = list(range(num_new_tokens))
+    new_token_ids = TokenIds(range(num_new_tokens))
     assert eos_token_id not in new_token_ids
     eos_index = random.randint(0, len(new_token_ids) - 1)
-    new_token_ids[eos_index] = eos_token_id
+    new_token_ids = (new_token_ids[:eos_index] + TokenIds(
+        (eos_token_id, )) + new_token_ids[eos_index + 1:])
 
     outputs = [
         CompletionSequenceGroupOutput(

--- a/tests/prefix_caching/test_multi_modal_prefix_caching.py
+++ b/tests/prefix_caching/test_multi_modal_prefix_caching.py
@@ -1,0 +1,84 @@
+"""Compare the with and without prefix caching.
+
+Run `pytest tests/prefix_caching/test_multi_modal_prefix_caching.py`.
+"""
+from typing import Tuple
+
+import pytest
+from transformers import AutoTokenizer
+
+from ..models.utils import check_logprobs_close
+
+MODEL_NAME = "fixie-ai/ultravox-v0_3"
+AUDIO_PLACEHOLDER = "<|reserved_special_token_0|>"
+
+
+@pytest.fixture
+def prompt():
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+
+    return tokenizer.apply_chat_template(
+        [{
+            "role": "system",
+            "content": "You are a helpful assistant."
+        }, {
+            'role': 'user',
+            'content': f"{AUDIO_PLACEHOLDER}\n\nDescribe the audio above."
+        }],
+        tokenize=False,
+        add_generation_prompt=True)
+
+
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("audio_asset_names",
+                         [("winning_call", "mary_had_lamb")])
+@pytest.mark.parametrize("num_logprobs", [5])
+@pytest.mark.parametrize("max_tokens", [30])
+def test_multi_modal_prefix_caching(
+    vllm_runner,
+    prompt: str,
+    audio_asset_names: Tuple[str, str],
+    dtype: str,
+    num_logprobs: int,
+    max_tokens: int,
+) -> None:
+    """
+    Test the case when some sequences have the prefix cache hit
+    and the others don't.
+    """
+    from vllm.assets.audio import AudioAsset
+
+    audios = [
+        AudioAsset(asset).audio_and_sample_rate for asset in audio_asset_names
+    ]
+    prompts = [prompt for _ in audios]
+
+    with vllm_runner(
+            MODEL_NAME,
+            dtype=dtype,
+            enable_prefix_caching=True,
+    ) as vllm_model:
+        # Run against the first prompt so the cache is populated
+        _ = vllm_model.generate_greedy(prompts[:1],
+                                       max_tokens,
+                                       audios=audios[:1])
+
+        # Run all the prompts
+        with_prefix_caching = vllm_model.generate_greedy_logprobs(
+            prompts, max_tokens, num_logprobs, audios=audios)
+
+    with vllm_runner(
+            MODEL_NAME,
+            dtype=dtype,
+            enable_prefix_caching=False,
+    ) as vllm_model:
+        # Run all the prompts
+        without_prefix_caching = vllm_model.generate_greedy_logprobs(
+            prompts, max_tokens, num_logprobs, audios=audios)
+
+    check_logprobs_close(
+        outputs_0_lst=with_prefix_caching,
+        outputs_1_lst=without_prefix_caching,
+        name_0="prefix_caching=True",
+        name_1="prefix_caching=False",
+    )

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -240,6 +240,8 @@ class ModelConfig:
 
         self.is_attention_free = self._init_attention_free()
         self.has_inner_state = self._init_has_inner_state()
+        self.supports_chunked_prefill = self._init_supports_chunked_prefill()
+        self.suports_prefix_caching = self._init_supports_prefix_caching()
 
         if current_platform.is_neuron():
             self.override_neuron_config = override_neuron_config
@@ -310,6 +312,14 @@ class ModelConfig:
     def _init_has_inner_state(self) -> bool:
         architectures = getattr(self.hf_config, "architectures", [])
         return ModelRegistry.model_has_inner_state(architectures)
+
+    def _init_supports_chunked_prefill(self) -> bool:
+        architectures = getattr(self.hf_config, "architectures", [])
+        return ModelRegistry.model_supports_chunked_prefill(architectures)
+
+    def _init_supports_prefix_caching(self) -> bool:
+        architectures = getattr(self.hf_config, "architectures", [])
+        return ModelRegistry.model_supports_prefix_caching(architectures)
 
     def _verify_tokenizer_mode(self) -> None:
         tokenizer_mode = self.tokenizer_mode.lower()

--- a/vllm/core/block/common.py
+++ b/vllm/core/block/common.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Deque, Dict, Iterable, List, Optional, Protocol, Tuple
 
 from vllm.core.block.interfaces import Block, BlockAllocator
+from vllm.core.block.token_ids import TokenIds
 
 BlockId = int
 RefCount = int
@@ -174,7 +175,7 @@ class BlockPool:
         for i in range(self._pool_size):
             self._pool.append(
                 self._create_block(prev_block=None,
-                                   token_ids=[],
+                                   token_ids=TokenIds(),
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None))
@@ -191,12 +192,12 @@ class BlockPool:
         for i in range(cur_pool_size, new_pool_size):
             self._pool.append(
                 self._create_block(prev_block=None,
-                                   token_ids=[],
+                                   token_ids=TokenIds(),
                                    block_size=self._block_size,
                                    allocator=self._allocator,
                                    block_id=None))
 
-    def init_block(self, prev_block: Optional[Block], token_ids: List[int],
+    def init_block(self, prev_block: Optional[Block], token_ids: TokenIds,
                    block_size: int, physical_block_id: Optional[int]) -> Block:
         if len(self._free_ids) == 0:
             self.increase_pool()
@@ -248,7 +249,7 @@ class BlockList:
         for block in self._blocks:
             self._add_block_id(block.block_id)
 
-    def append_token_ids(self, block_index: int, token_ids: List[int]) -> None:
+    def append_token_ids(self, block_index: int, token_ids: TokenIds) -> None:
         block = self._blocks[block_index]
         prev_block_id = block.block_id
 

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -4,6 +4,7 @@ from vllm.core.block.interfaces import (Block, BlockAllocator, BlockId,
                                         DeviceAwareBlockAllocator)
 from vllm.core.block.naive_block import NaiveBlock, NaiveBlockAllocator
 from vllm.core.block.prefix_caching_block import PrefixCachingBlockAllocator
+from vllm.core.block.token_ids import TokenIds
 from vllm.platforms import current_platform
 from vllm.utils import Device
 
@@ -136,7 +137,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return self._allocators[device].allocate_mutable_block(prev_block)
 
     def allocate_immutable_blocks(self, prev_block: Optional[Block],
-                                  block_token_ids: List[List[int]],
+                                  block_token_ids: List[TokenIds],
                                   device: Device) -> List[Block]:
         """Allocates a new group of immutable blocks with the provided block 
         token IDs on the specified device.
@@ -144,7 +145,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         Args:
             prev_block (Optional[Block]): The previous block in the sequence.
                 Used for prefix hashing.
-            block_token_ids (List[int]): The list of block token IDs to be 
+            block_token_ids (TokenIds): The block token IDs to be 
                 stored in the new blocks.
             device (Device): The device on which to allocate the new block.
 
@@ -156,16 +157,15 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             prev_block, block_token_ids)
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int],
-                                 device: Device) -> Block:
+                                 token_ids: TokenIds, device: Device) -> Block:
         """Allocates a new immutable block with the provided token IDs on the
         specified device.
 
         Args:
             prev_block (Optional[Block]): The previous block in the sequence.
                 Used for prefix hashing.
-            token_ids (List[int]): The list of token IDs to be stored in the new
-                block.
+            token_ids (TokenIds): The token IDs to be stored in the
+                new block.
             device (Device): The device on which to allocate the new block.
 
         Returns:
@@ -356,7 +356,7 @@ class NullBlock(Block):
         super().__init__()
         self._proxy = proxy
 
-    def append_token_ids(self, token_ids: List[BlockId]):
+    def append_token_ids(self, token_ids: TokenIds):
         raise ValueError("null block should not be modified")
 
     @property
@@ -368,7 +368,7 @@ class NullBlock(Block):
         raise ValueError("null block should not be modified")
 
     @property
-    def token_ids(self) -> List[BlockId]:
+    def token_ids(self) -> TokenIds:
         return self._proxy.token_ids
 
     @property

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, FrozenSet, List, Optional, Protocol, Tuple
 
+from vllm.core.block.token_ids import TokenIds
 from vllm.utils import Device
 
 BlockId = int
@@ -9,7 +10,7 @@ BlockId = int
 class Block(ABC):
 
     @abstractmethod
-    def append_token_ids(self, token_ids: List[int]) -> None:
+    def append_token_ids(self, token_ids: TokenIds) -> None:
         pass
 
     @property
@@ -25,7 +26,7 @@ class Block(ABC):
 
     @property
     @abstractmethod
-    def token_ids(self) -> List[int]:
+    def token_ids(self) -> TokenIds:
         pass
 
     @property
@@ -77,7 +78,7 @@ class Block(ABC):
         def __call__(
             self,
             prev_block: Optional["Block"],
-            token_ids: List[int],
+            token_ids: TokenIds,
             block_size: int,
             allocator: "BlockAllocator",
             block_id: Optional[int] = None,
@@ -104,13 +105,13 @@ class BlockAllocator(ABC):
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int]) -> Block:
+                                 token_ids: TokenIds) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]]) -> List[Block]:
+            block_token_ids: List[TokenIds]) -> List[Block]:
         pass
 
     @abstractmethod
@@ -202,13 +203,12 @@ class DeviceAwareBlockAllocator(ABC):
 
     @abstractmethod
     def allocate_immutable_block(self, prev_block: Optional[Block],
-                                 token_ids: List[int],
-                                 device: Device) -> Block:
+                                 token_ids: TokenIds, device: Device) -> Block:
         pass
 
     @abstractmethod
     def allocate_immutable_blocks(self, prev_block: Optional[Block],
-                                  block_token_ids: List[List[int]],
+                                  block_token_ids: List[TokenIds],
                                   device: Device) -> List[Block]:
         pass
 

--- a/vllm/core/block/token_ids.py
+++ b/vllm/core/block/token_ids.py
@@ -1,0 +1,257 @@
+from typing import Iterable, List, NamedTuple, Optional, Tuple, overload
+
+
+class TokenRangeAnnotation(NamedTuple):
+    """
+    Annotates a range of placeholder tokens to capture content that will
+    replace them.
+    """
+
+    content_hash: int
+    content_offset: int
+    token_start_index: int
+    token_end_index: int
+
+    @property
+    def token_count(self) -> int:
+        return self.token_end_index - self.token_start_index
+
+    @staticmethod
+    def are_adjacent(left: "TokenRangeAnnotation",
+                     right: "TokenRangeAnnotation") -> bool:
+        """
+        Indicates whether two annotations represent adjacent ranges in the
+        hashed content.
+        """
+
+        return (left.content_hash == right.content_hash and
+                left.content_offset + left.token_count == right.content_offset)
+
+    def clipped_to_slice(self, tokens_start: int,
+                         tokens_end: int) -> Optional["TokenRangeAnnotation"]:
+        """
+        Computes a new TokenRangeAnnotation that corresponds to the same
+        content in a slice of the original token IDs.
+
+        For example, consider the following token IDs/annotations:
+
+        AAAA BBBB What do these images have in common?
+        
+        A = TokenRangeAnnotation(0xA, 0, 0, 4)
+        B = TokenRangeAnnotation(0xB, 0, 5, 9)
+
+        tokens = AAAA BBBB What do these images have in common?
+                [AAAA]
+
+        A.clipped_to_slice(0, 4) = TokenRangeAnnotation(0xA, 0, 0, 4)
+        B.clipped_to_slice(0, 4) = None
+
+        tokens = AAAA BBBB What do these images have in common?
+                  [AA BB]
+
+        A.clipped_to_slice(2, 7) = TokenRangeAnnotation(0xA, 2, 0, 2)
+        B.clipped_to_slice(2, 7) = TokenRangeAnnotation(0xB, 0, 3, 5)
+
+        tokens = AAAA BBBB What do these images have in common?
+                     [BBBB What]
+
+        A.clipped_to_slice(5, 14) = None
+        B.clipped_to_slice(5, 14) = TokenRangeAnnotation(0xB, 0, 0, 4)
+        """
+
+        unclamped_annotation_start = self.token_start_index - tokens_start
+        unclamped_annotation_end = self.token_end_index - tokens_start
+
+        annotation_start = max(0, unclamped_annotation_start)
+        annotation_end = min(tokens_end - tokens_start,
+                             unclamped_annotation_end)
+
+        if annotation_start >= annotation_end:
+            # There is no overlap.
+            return None
+
+        return TokenRangeAnnotation(content_hash=self.content_hash,
+                                    content_offset=self.content_offset +
+                                    annotation_start -
+                                    unclamped_annotation_start,
+                                    token_start_index=annotation_start,
+                                    token_end_index=annotation_end)
+
+
+class TokenIds:
+    token_ids: Tuple[int, ...]
+    annotations: Tuple[TokenRangeAnnotation, ...]
+
+    def __init__(self,
+                 token_ids: Iterable[int] = (),
+                 annotations: Iterable[TokenRangeAnnotation] = ()):
+        self.token_ids = tuple(token_ids)
+        self.annotations = tuple(annotations)
+
+        # Ensure that the token annotations are monotonic.
+        current_token_index = 0
+        for annotation in self.annotations:
+            if (annotation.token_start_index < current_token_index or
+                    annotation.token_end_index < annotation.token_start_index):
+                raise ValueError("TokenRangeAnnotations must be sorted and "
+                                 "non-overlapping.")
+
+            current_token_index = annotation.token_end_index
+
+        if current_token_index > len(self.token_ids):
+            raise ValueError("TokenRangeAnnotations must be entirely "
+                             "contained within the token IDs.")
+
+    def to_chunks(self,
+                  chunk_size: int,
+                  *,
+                  first_chunk_size: Optional[int] = None):
+        """
+        Yields successive chunks over the TokenIds, taking care to filter
+        or split TokenRangeAnnotations accordingly.
+        """
+
+        current_annotation_index = 0
+        current_chunk_start = 0
+        current_chunk_end = (chunk_size
+                             if first_chunk_size is None else first_chunk_size)
+
+        while current_chunk_start < len(self.token_ids):
+            current_chunk_annotations: List[TokenRangeAnnotation] = []
+            while current_annotation_index < len(self.annotations):
+                existing_annotation = self.annotations[
+                    current_annotation_index]
+                if existing_annotation.token_start_index >= current_chunk_end:
+                    # This annotation starts after the current chunk.
+                    break
+
+                # Create a new annotation.
+                new_annotation = existing_annotation.clipped_to_slice(
+                    tokens_start=current_chunk_start,
+                    tokens_end=current_chunk_end)
+                assert new_annotation is not None, (
+                    "The existing annotation should overlap with the new one.")
+                current_chunk_annotations.append(new_annotation)
+                if (current_chunk_start + new_annotation.token_end_index ==
+                        existing_annotation.token_end_index):
+                    # We've used up this annotation.
+                    current_annotation_index += 1
+                else:
+                    break
+
+            yield TokenIds(
+                self.token_ids[current_chunk_start:current_chunk_end],
+                current_chunk_annotations)
+
+            current_chunk_start = current_chunk_end
+            current_chunk_end = current_chunk_start + chunk_size
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TokenIds):
+            return (self.token_ids == other.token_ids
+                    and self.annotations == other.annotations)
+
+        return NotImplemented
+
+    def __add__(self, other: "TokenIds") -> "TokenIds":
+        """
+        Combines two ``TokenIds``, possibly merging ``TokenRangeAnnotion``s.
+
+        ``TokenRangeAnnotation``s at the boundary will be coalesced into a
+        single annotation if they have the same content hash and they cover
+        adjacent portions of the hashed content.
+        """
+
+        if not self.token_ids:
+            return other
+        elif not other.token_ids:
+            return self
+
+        # Merge the token annotations if necessary
+        if not other.annotations:
+            combined_annotations: Iterable[
+                TokenRangeAnnotation] = self.annotations
+        else:
+            combined_annotations = list(self.annotations)
+            for annotation in other.annotations:
+                if combined_annotations:
+                    # Check if we can coalesce this annotation with the last.
+                    last_annotation = combined_annotations[-1]
+                    if (TokenRangeAnnotation.are_adjacent(
+                            last_annotation, annotation)
+                            and last_annotation.token_end_index == len(
+                                self.token_ids)
+                            and annotation.token_start_index == 0):
+                        combined_annotations[-1] = TokenRangeAnnotation(
+                            content_hash=last_annotation.content_hash,
+                            content_offset=last_annotation.content_offset,
+                            token_start_index=last_annotation.
+                            token_start_index,
+                            token_end_index=last_annotation.token_end_index +
+                            annotation.token_count)
+                        continue
+
+                combined_annotations.append(
+                    TokenRangeAnnotation(
+                        content_hash=annotation.content_hash,
+                        content_offset=annotation.content_offset,
+                        token_start_index=len(self.token_ids) +
+                        annotation.token_start_index,
+                        token_end_index=len(self.token_ids) +
+                        annotation.token_end_index))
+
+        return TokenIds(token_ids=self.token_ids + other.token_ids,
+                        annotations=combined_annotations)
+
+    def __len__(self) -> int:
+        return len(self.token_ids)
+
+    @overload
+    def __getitem__(self, key: int) -> int:
+        ...
+
+    @overload
+    def __getitem__(self, key: slice) -> "TokenIds":
+        ...
+
+    def __getitem__(self, key):
+        """
+        Gets a single token at an index or a slice of ``TokenIds``.
+        """
+        if isinstance(key, int):
+            return self.token_ids[key]
+
+        if isinstance(key, slice):
+            if key.step:
+                raise IndexError("Step is not supported.")
+
+            # Resolve negative indices.
+            start = key.start or 0
+            start += len(self) if start < 0 else 0
+
+            stop = key.stop if key.stop is not None else len(self)
+            stop += len(self) if stop < 0 else 0
+
+            # Fast path for the common case where the new slice doesn't
+            # include any annotations (e.g. slicing a decoded token).
+            if (not self.annotations
+                    or start >= self.annotations[-1].token_end_index
+                    or stop <= self.annotations[0].token_start_index):
+                return TokenIds(self.token_ids[start:stop])
+
+            # Clamp the indices.
+            start = max(0, min(len(self), start))
+            stop = max(start, min(len(self), stop))
+
+            chunks_iter = iter(
+                self.to_chunks(chunk_size=stop - start,
+                               first_chunk_size=start))
+
+            # Drop the first chunk and return the second chunk.
+            try:
+                next(chunks_iter)
+                return next(chunks_iter)
+            except StopIteration:
+                return TokenIds()
+
+        raise TypeError(f"Unsupported key type: {type(key)}")

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -115,7 +115,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
 
         seq = seq_group.get_seqs(status=SequenceStatus.WAITING)[0]
         num_required_blocks = BlockTable.get_num_required_blocks(
-            seq.get_token_ids(),
+            seq.get_len(),
             block_size=self.block_size,
             num_lookahead_slots=num_lookahead_slots,
         )
@@ -124,7 +124,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             encoder_seq = seq_group.get_encoder_seq()
             assert encoder_seq is not None
             num_required_blocks += BlockTable.get_num_required_blocks(
-                encoder_seq.get_token_ids(),
+                encoder_seq.get_len(),
                 block_size=self.block_size,
             )
 
@@ -150,7 +150,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             block_allocator=self.block_allocator,
             max_block_sliding_window=self.max_block_sliding_window,
         )
-        if seq.get_token_ids():
+        if seq.get_len():
             # Add blocks to the block table only if the sequence is non empty.
             block_table.allocate(seq.get_token_ids())
 
@@ -219,8 +219,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
 
             num_touched_blocks += (
                 block_table.get_num_blocks_touched_by_append_slots(
-                    token_ids=block_table.get_unseen_token_ids(
-                        seq.get_token_ids()),
+                    num_token_ids=block_table.get_unseen_token_id_count(seq),
                     num_lookahead_slots=num_lookahead_slots,
                 ))
 
@@ -237,7 +236,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         block_table = self.block_tables[seq.seq_id]
 
         block_table.append_token_ids(
-            token_ids=block_table.get_unseen_token_ids(seq.get_token_ids()),
+            token_ids=block_table.get_unseen_token_ids(seq),
             num_lookahead_slots=num_lookahead_slots,
             num_computed_slots=seq.data.get_num_computed_tokens(),
         )
@@ -483,7 +482,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
                 # to be touched for the swap.
                 num_blocks_touched += \
                     block_table.get_num_blocks_touched_by_append_slots(
-                        block_table.get_unseen_token_ids(seq.get_token_ids()),
+                        block_table.get_unseen_token_id_count(seq),
                         num_lookahead_slots=num_lookahead_slots)
                 blocks.extend(block_table.blocks)
         # Compute the number of full blocks to touch and add it to the

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -998,11 +998,10 @@ class EngineArgs:
         device_config = DeviceConfig(device=self.device)
         model_config = self.create_model_config()
 
-        if model_config.is_multimodal_model:
-            if self.enable_prefix_caching:
-                logger.warning(
-                    "--enable-prefix-caching is currently not "
-                    "supported for multimodal models and has been disabled.")
+        if (not model_config.suports_prefix_caching
+                and self.enable_prefix_caching):
+            logger.warning("--enable-prefix-caching is currently not "
+                           "supported by this model and has been disabled.")
             self.enable_prefix_caching = False
 
         maybe_register_config_serialize_by_value(self.trust_remote_code)
@@ -1040,10 +1039,7 @@ class EngineArgs:
             # If not explicitly set, enable chunked prefill by default for
             # long context (> 32K) models. This is to avoid OOM errors in the
             # initial memory profiling phase.
-
-            # Chunked prefill is currently disabled for multimodal models by
-            # default.
-            if use_long_context and not model_config.is_multimodal_model:
+            if use_long_context and model_config.supports_chunked_prefill:
                 is_gpu = device_config.device_type == "cuda"
                 use_sliding_window = (model_config.get_sliding_window()
                                       is not None)

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -27,6 +27,16 @@ class SupportsMultiModal(Protocol):
         MRO of your model class.
     """
 
+    supports_chunked_prefill: ClassVar[bool] = False
+    """
+    A flag that indicates this model supports chunked prefill.
+    """
+
+    supports_prefix_caching: ClassVar[bool] = False
+    """
+    A flag that indicates this model supports prefix caching.
+    """
+
     def __init__(self, *, multimodal_config: "MultiModalConfig") -> None:
         ...
 
@@ -36,6 +46,8 @@ class SupportsMultiModal(Protocol):
 @runtime_checkable
 class _SupportsMultiModalType(Protocol):
     supports_multimodal: Literal[True]
+    supports_chunked_prefill: bool
+    supports_prefix_caching: bool
 
     def __call__(self, *, multimodal_config: "MultiModalConfig") -> None:
         ...

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -187,6 +187,8 @@ class _ModelInfo:
     supports_pp: bool
     has_inner_state: bool
     is_attention_free: bool
+    supports_chunked_prefill: bool
+    supports_prefix_caching: bool
 
     @staticmethod
     def from_model_cls(model: Type[nn.Module]) -> "_ModelInfo":
@@ -197,6 +199,10 @@ class _ModelInfo:
             supports_pp=supports_pp(model),
             has_inner_state=has_inner_state(model),
             is_attention_free=is_attention_free(model),
+            supports_chunked_prefill=model.supports_chunked_prefill
+            if supports_multimodal(model) else True,
+            supports_prefix_caching=model.supports_prefix_caching
+            if supports_multimodal(model) else True,
         )
 
 
@@ -424,6 +430,14 @@ class _ModelRegistry:
     def is_attention_free_model(self, architectures: Union[str,
                                                            List[str]]) -> bool:
         return self.inspect_model_cls(architectures).is_attention_free
+
+    def model_supports_chunked_prefill(
+            self, architectures: Union[str, List[str]]) -> bool:
+        return self.inspect_model_cls(architectures).supports_chunked_prefill
+
+    def model_supports_prefix_caching(
+            self, architectures: Union[str, List[str]]) -> bool:
+        return self.inspect_model_cls(architectures).supports_prefix_caching
 
 
 ModelRegistry = _ModelRegistry({

--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -339,6 +339,8 @@ class ModifiedWhisperEncoder(WhisperEncoder):
 @INPUT_REGISTRY.register_dummy_data(dummy_data_for_ultravox)
 @INPUT_REGISTRY.register_input_processor(input_processor_for_ultravox)
 class UltravoxModel(nn.Module, SupportsMultiModal, SupportsPP):
+    supports_chunked_prefill = True
+    supports_prefix_caching = True
 
     def __init__(self,
                  config: UltravoxConfig,

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -1,3 +1,7 @@
+from typing import Tuple, Union, cast
+
+import numpy as np
+
 from vllm.inputs.registry import InputContext
 from vllm.multimodal.base import MultiModalInputs, MultiModalPlugin
 
@@ -7,6 +11,10 @@ class AudioPlugin(MultiModalPlugin):
 
     def get_data_key(self) -> str:
         return "audio"
+
+    def hash_content(self, data: object) -> int:
+        (audio, sr) = cast(Tuple[np.ndarray, Union[float, int]], data)
+        return hash((audio.data.tobytes(), sr))
 
     def _default_input_mapper(self, ctx: InputContext, data: object,
                               **mm_processor_kwargs) -> MultiModalInputs:

--- a/vllm/multimodal/base.py
+++ b/vllm/multimodal/base.py
@@ -236,6 +236,14 @@ class MultiModalPlugin(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def hash_content(self, data: object) -> int:
+        """
+        Calculates a content-based hash of the multi-modal item that can be
+        used to represent the content for prefix caching.
+        """
+        raise NotImplementedError
+
     def register_input_mapper(
         self,
         mapper: Optional[MultiModalInputMapper] = None,

--- a/vllm/multimodal/image.py
+++ b/vllm/multimodal/image.py
@@ -26,6 +26,9 @@ class ImagePlugin(MultiModalPlugin):
     def get_data_key(self) -> str:
         return "image"
 
+    def hash_content(self, data: object) -> int:
+        raise NotImplementedError("Image hashing is not yet implemented")
+
     def _get_hf_image_processor(
         self,
         model_config: "ModelConfig",

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -243,3 +243,6 @@ class MultiModalRegistry:
             This should be called after :meth:`init_mm_limits_per_prompt`.
         """
         return self._limits_by_model[model_config]
+
+    def hash_mm_item_content(self, data_type_key: str, item: object) -> int:
+        return self._get_plugin(data_type_key).hash_content(item)

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -38,6 +38,9 @@ class VideoPlugin(ImagePlugin):
     def get_data_key(self) -> str:
         return "video"
 
+    def hash_content(self, data: object) -> int:
+        raise NotImplementedError("Video hashing is not yet implemented")
+
     def _get_hf_video_processor(
         self,
         model_config: "ModelConfig",

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -40,7 +40,7 @@ class Detokenizer:
         # We can pick any sequence for the prompt.
         seq = seq_group.get_seqs()[0]
         # Only prompt, without the generated token.
-        all_token_ids = seq.get_token_ids()
+        all_token_ids = list(seq.get_token_ids().token_ids)
         prompt_token_ids = all_token_ids[:-1]
         tokenizer = self.get_tokenizer_for_seq(seq)
         prefix_offset = 0
@@ -105,7 +105,7 @@ class Detokenizer:
         Returns:
             The number of characters added to the output text.
         """
-        all_input_ids = seq.get_token_ids()
+        all_input_ids = list(seq.get_token_ids().token_ids)
         token_id_generated_this_iteration = all_input_ids[-1]
         tokenizer = self.get_tokenizer_for_seq(seq)
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -557,12 +557,6 @@ def update_environment_variables(envs: Dict[str, str]):
         os.environ[k] = v
 
 
-def chunk_list(lst: List[T], chunk_size: int):
-    """Yield successive chunk_size chunks from lst."""
-    for i in range(0, len(lst), chunk_size):
-        yield lst[i:i + chunk_size]
-
-
 def cdiv(a: int, b: int) -> int:
     """Ceiling division."""
     return -(a // -b)


### PR DESCRIPTION
This adds support for prefix caching with multi-modal models -- in particular it enables it for Ultravox which uses the precise placeholders added in #8346.

With this change, `SelfAttnBlockSpaceManager` et al. now pass a `TokenIds` type around instead of `List[int]` to represent token ids. This new type can also contain `TokenRangeAnnotation`s which capture the contents that will ultimately replace the placeholder tokens. The `Sequence` calculates these by hashing multi-modal content that supports it (currently only implemented for audio).

FIX #9790