### PR TITLE
Add conditional prompt inclusion in generated output based on `is_ret…

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -50,7 +50,7 @@ async def generate(request: Request) -> Response:
     request_dict = await request.json()
     prompt = request_dict.pop("prompt")
     stream = request_dict.pop("stream", False)
-    is_return_prompt = request_dict.pop("is_return_prompt", False)  # Add this parameter
+    is_return_prompt = request_dict.pop("is_return_prompt", False)
     sampling_params = SamplingParams(**request_dict)
     request_id = random_uuid()
 
@@ -65,7 +65,7 @@ async def generate(request: Request) -> Response:
             prompt = request_output.prompt
             assert prompt is not None
             text_outputs = [
-                (prompt + output.text) if is_return_prompt else output.text  # Conditional prompt inclusion
+                (prompt + output.text) if is_return_prompt else output.text
                 for output in request_output.outputs
             ]
             ret = {"text": text_outputs}

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -86,7 +86,7 @@ async def generate(request: Request) -> Response:
     prompt = final_output.prompt
     assert prompt is not None
     text_outputs = [
-        (prompt + output.text) if is_return_prompt else output.text  # Conditional prompt inclusion
+        (prompt + output.text) if is_return_prompt else output.text
         for output in final_output.outputs
     ]
     ret = {"text": text_outputs}


### PR DESCRIPTION
**Feature:** Conditional Prompt Inclusion in generate Function

**Motivation:** The current implementation of the generate function always includes the prompt in its response. This can be inefficient, especially in streaming scenarios where the prompt is repeatedly included with each token update. The new feature aims to improve efficiency by allowing the prompt to be included conditionally based on a new parameter.

**Changes Made:**

- Introduced a new `is_return_prompt` parameter in the request.
- Modified the list comprehension to conditionally include the prompt in the generated output based on the value of `is_return_prompt`.
If `is_return_prompt` is `True`, the prompt is concatenated with the output text.
If `is_return_prompt` is `False`, only the output text is returned.
- Applied this change to both streaming and non-streaming cases to ensure consistency.

**Related Issues:** #8359

**Additional Context:** Including the prompt in every streaming iteration can be redundant and inefficient. This update provides users with the flexibility to exclude the prompt from the response, improving the overall efficiency of the generate function.

FILL IN THE PR DESCRIPTION HERE

FIX #8359 

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


