### PR TITLE
[Bugfix]: Fix the logic for deciding if tool parsing is used

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -608,7 +608,7 @@ class OpenAIServingChat(OpenAIServing):
             # if auto tools are not enabled, and a named tool choice using
             #   outlines is not being used
             if not (self.enable_auto_tools
-                    or not self.tool_parser) and not isinstance(
+                    and not self.tool_parser) and not isinstance(
                         request.tool_choice,
                         ChatCompletionNamedToolChoiceParam):
                 message = ChatMessage(role=role, content=output.text)

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -607,8 +607,8 @@ class OpenAIServingChat(OpenAIServing):
 
             # if auto tools are not enabled, and a named tool choice using
             #   outlines is not being used
-            if not (self.enable_auto_tools
-                    and not self.tool_parser) and not isinstance(
+            if (not self.enable_auto_tools
+                    or not self.tool_parser) and not isinstance(
                         request.tool_choice,
                         ChatCompletionNamedToolChoiceParam):
                 message = ChatMessage(role=role, content=output.text)


### PR DESCRIPTION
The great work done in https://github.com/vllm-project/vllm/pull/5649 has a small bug with regards to deciding if tool parsing is enabled or not. This PR fixes said bug

I'm pretty sure the logic in `main` is a bug since I compared the logic used in https://github.com/vllm-project/vllm/blob/cea95dfb941878b3370a7c40ca7ab2d549524445/vllm/entrypoints/openai/serving_chat.py#L165 to the one I fixed in https://github.com/vllm-project/vllm/blob/cea95dfb941878b3370a7c40ca7ab2d549524445/vllm/entrypoints/openai/serving_chat.py#L610
Both are checking the same thing - whether or not tool parsing is used. Yet, they have different truth values for the same truth values of `self.enable_auto_tools` and `self.tool_parser`. What I did is to align the logic in line 610 to the one in line 165. It also makes sense given the comment in line 608