### PR TITLE
[Misc] Use RoPE cache for MRoPE

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -990,7 +990,7 @@ def get_rope(
                 base, is_neox_style, dtype, short_factor, long_factor,
                 **extra_kwargs)
         elif scaling_type == "mrope":
-            return MRotaryEmbedding(
+            rotary_emb = MRotaryEmbedding(
                 head_size,
                 rotary_dim,
                 max_position,


### PR DESCRIPTION
A small PR to use `_ROPE_DICT` for `MRotaryEmbedding` in Qwen2-VL. This enables sharing the same RoPE between different layers in the model, reducing model's GPU memory usage and initialization time.