### PR TITLE
[BugFix] lazy init _copy_stream to avoid torch init wrong gpu instance

### DIFF
--- a/vllm/worker/multi_step_model_runner.py
+++ b/vllm/worker/multi_step_model_runner.py
@@ -231,10 +231,13 @@ class MultiStepModelRunner(GPUModelRunnerBase[StatefulModelInput]):
 
         self.is_multi_step = self.scheduler_config.is_multi_step
         # used to copy tensors from GPU to CPU asynchronously
-        self._copy_stream = torch.cuda.Stream()
         self.pinned_sampled_token_ids: Optional[torch.Tensor] = None
 
         self.pythonization_cache = PythonizationCache()
+
+    @functools.cached_property
+    def _copy_stream(self):
+        return torch.cuda.Stream()
 
     def make_model_input_from_broadcasted_tensor_dict(
             self, tensor_dict: Dict[str, Any]) -> StatefulModelInput:

--- a/vllm/worker/multi_step_model_runner.py
+++ b/vllm/worker/multi_step_model_runner.py
@@ -230,13 +230,13 @@ class MultiStepModelRunner(GPUModelRunnerBase[StatefulModelInput]):
         self._base_model_runner: GPUModelRunnerBase = base_model_runner
 
         self.is_multi_step = self.scheduler_config.is_multi_step
-        # used to copy tensors from GPU to CPU asynchronously
         self.pinned_sampled_token_ids: Optional[torch.Tensor] = None
 
         self.pythonization_cache = PythonizationCache()
 
     @functools.cached_property
     def _copy_stream(self):
+        # used to copy tensors from GPU to CPU asynchronously
         return torch.cuda.Stream()
 
     def make_model_input_from_broadcasted_tensor_dict(


### PR DESCRIPTION
Because MultiStepModelRunner is initialized before init_device, torch.cuda.Stream() will use the wrong GPU instance in multi GPU environment. lazy init _copy_stream to fix this issue.