### PR TITLE
[Installation] Gate FastAPI version for Python 3.8

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -7,7 +7,8 @@ py-cpuinfo
 transformers >= 4.43.2  # Required for Chameleon and Llama 3.1 hotfox.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
-fastapi >= 0.114.1
+fastapi < 0.113.0; python_version < '3.9'
+fastapi >= 0.114.1; python_version >= '3.9'
 aiohttp
 openai >= 1.40.0 # Ensure modern openai package (ensure types module present)
 uvicorn[standard]


### PR DESCRIPTION
Upgrading FastAPI and Pydantic fails to solve #8212 for Python 3.8 users. To avoid this, this PR updates the dependencies to use an older version of FastAPI for Python 3.8.

FIX #8450