### PR TITLE
[Model] MLPSpeculator quantization support

### DIFF
--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -7,10 +7,9 @@ import torch.nn as nn
 
 from vllm.distributed import (tensor_model_parallel_all_gather,
                               tensor_model_parallel_gather)
+from vllm.model_executor.layers.linear import LinearBase
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
-from vllm.model_executor.layers.linear import (
-    LinearBase)
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.platforms import current_platform
 
@@ -87,9 +86,10 @@ class LogitsProcessor(nn.Module):
             linear_method = lm_head.quant_method
         elif isinstance(lm_head, VocabParallelEmbedding):
             linear_method = lm_head.linear_method
+        assert linear_method is not None
         logits = linear_method.apply(lm_head,
-                                    hidden_states,
-                                    bias=embedding_bias)
+                                     hidden_states,
+                                     bias=embedding_bias)
         if self.use_gather:
             # None may be returned for rank > 0
             logits = tensor_model_parallel_gather(logits)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -1,6 +1,6 @@
 """A layer that compute logits from hidden_stats."""
 import inspect
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -48,7 +48,7 @@ class LogitsProcessor(nn.Module):
 
     def forward(
         self,
-        lm_head: VocabParallelEmbedding | LinearBase,
+        lm_head: Union[VocabParallelEmbedding, LinearBase],
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
         embedding_bias: Optional[torch.Tensor] = None,
@@ -78,7 +78,7 @@ class LogitsProcessor(nn.Module):
     def _get_logits(
         self,
         hidden_states: torch.Tensor,
-        lm_head: VocabParallelEmbedding | LinearBase,
+        lm_head: Union[VocabParallelEmbedding, LinearBase],
         embedding_bias: Optional[torch.Tensor],
     ) -> Optional[torch.Tensor]:
         # Get the logits for the next tokens.

--- a/vllm/model_executor/models/mlp_speculator.py
+++ b/vllm/model_executor/models/mlp_speculator.py
@@ -1,17 +1,17 @@
 import math
-from typing import Iterable, List, Tuple, Optional
+from typing import Iterable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
 
 from vllm.model_executor import SamplingMetadata
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
-from vllm.model_executor.layers.sampler import Sampler, SamplerOutput
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
+from vllm.model_executor.layers.sampler import Sampler, SamplerOutput
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
-from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.transformers_utils.configs import MLPSpeculatorConfig
 
@@ -68,7 +68,10 @@ class MLPSpeculator(nn.Module):
     https://huggingface.co/ibm-fms and https://huggingface.co/ibm-granite
     """
 
-    def __init__(self, config: MLPSpeculatorConfig, quant_config: Optional[QuantizationConfig] = None, **kwargs) -> None:
+    def __init__(self,
+                 config: MLPSpeculatorConfig,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 **kwargs) -> None:
         super().__init__()
         self.n_predict = config.n_predict
         self.vocab_size = config.vocab_size
@@ -98,7 +101,10 @@ class MLPSpeculator(nn.Module):
             self.proj = nn.ModuleList([proj_first] + [proj_tied] *
                                       (self.max_speculative_tokens - 1))
 
-            head = ReplicatedLinear(self.inner_dim, self.vocab_size, bias=False, quant_config=quant_config)
+            head = ReplicatedLinear(self.inner_dim,
+                                    self.vocab_size,
+                                    bias=False,
+                                    quant_config=quant_config)
             self.head = nn.ModuleList([head] * self.max_speculative_tokens)
 
             ln = MLPSpeculatorLayerNorm(self.inner_dim,


### PR DESCRIPTION
This PR adds the required changes for enabling the quantization of `MLPSpeculator`.

PR #7343 adds a command line option for selecting quantization for speculative model. However, this is ignored by `MLPSpeculator`. This PR replaces ParallelLMHead usage with ReplicatedLinear so that it can be quantized correctly with existing logic.
