### PR TITLE
[torch.compile] fix functionalization

### DIFF
--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -16,7 +16,7 @@ def test_full_graph(model):
         "The future of AI is",
     ]
     sampling_params = SamplingParams(temperature=0)
-    llm = LLM(model="meta-llama/Meta-Llama-3-8B", enforce_eager=True)
+    llm = LLM(model=model, enforce_eager=True)
 
     outputs = llm.generate(prompts, sampling_params)
 

--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -19,4 +19,11 @@ def test_full_graph(model):
     llm = LLM(model="meta-llama/Meta-Llama-3-8B",
               enforce_eager=True,
               load_format="dummy")
-    llm.generate(prompts, sampling_params)
+
+    outputs = llm.generate(prompts, sampling_params)
+
+    # Print the outputs.
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -16,9 +16,7 @@ def test_full_graph(model):
         "The future of AI is",
     ]
     sampling_params = SamplingParams(temperature=0)
-    llm = LLM(model="meta-llama/Meta-Llama-3-8B",
-              enforce_eager=True,
-              load_format="dummy")
+    llm = LLM(model="meta-llama/Meta-Llama-3-8B", enforce_eager=True)
 
     outputs = llm.generate(prompts, sampling_params)
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1,0 +1,156 @@
+import operator
+
+import torch
+import torch.fx as fx
+
+
+def fix_functionalization(graph: fx.Graph):
+    """
+    Rewrite the graph module to replace the pattern involving
+    torch._higher_order_ops.auto_functionalize.auto_functionalized
+    with a direct call to the inplace custom op.
+
+    # TODO: check if PyTorch nightly has fixed this issue
+    """
+
+    # debug code, if we want to see the graph before the transformation
+    # with open("before.py", "w") as f:
+    #     print(graph.python_code(root_module="self", verbose=True).src, file=f)
+
+    nodes_to_remove = []
+
+    for node in graph.nodes:
+        # Identify the auto_functionalized node
+        if node.op == 'call_function' and node.target == torch._higher_order_ops.auto_functionalize.auto_functionalized:  # noqa
+            if node.args[0] == torch.ops._C.rotary_embedding.default:
+                # manual replace for rotary_embedding
+
+                # Now, collect the arguments
+                kwargs = node.kwargs
+
+                query = kwargs['query']
+                mm_node = query.args[0].args[0]
+
+                # Create a new call to torch.ops._C.rotary_embedding.default
+                with graph.inserting_before(node):
+                    # just insert the call to the custom op
+                    # NOTE: don't run dead code elimination,
+                    # otherwise this op will be removed
+                    graph.call_function(torch.ops._C.rotary_embedding.default,
+                                        kwargs=kwargs)
+
+                # Remove the auto_functionalized node
+                # Since the node may have outputs, we need to handle its users
+                # Replace uses of the outputs (getitem nodes) with mm_node
+                for user in list(node.users):
+                    if user.op == 'call_function' and user.target == operator.getitem:  # noqa
+                        # Remove the getitem node
+                        for getitem_user in list(user.users):
+                            if (getitem_user.op == 'call_function'
+                                    and getitem_user.target
+                                    == torch.ops.aten.slice_scatter.default):
+                                # Replace the uses of slice_scatter node
+                                # with mm_node
+                                getitem_user.replace_all_uses_with(mm_node)
+                                nodes_to_remove.append(getitem_user)
+                        nodes_to_remove.append(user)
+                nodes_to_remove.append(node)
+
+            elif node.args[0] == torch.ops._C.fused_add_rms_norm.default:
+                # manual replace for fused_add_rms_norm
+                # this is the most effective optimization for llama
+                # failing to do this will result in many unnecessary copies
+
+                kwargs = node.kwargs
+
+                input = kwargs['input']
+                residual = kwargs['residual']
+
+                # Create a new call to torch.ops._C.rotary_embedding.default
+                with graph.inserting_before(node):
+                    # just insert the call to the custom op
+                    # NOTE: don't run dead code elimination,
+                    # otherwise this op will be removed
+                    graph.call_function(
+                        torch.ops._C.fused_add_rms_norm.default, kwargs=kwargs)
+
+                for user in list(node.users):
+                    if user.op == 'call_function' and user.target == operator.getitem:  # noqa
+                        # Remove the getitem node
+                        if user.args[1] == 1:
+                            replace_node = input
+                        elif user.args[1] == 2:
+                            replace_node = residual
+                        user.replace_all_uses_with(replace_node)
+                        nodes_to_remove.append(user)
+                nodes_to_remove.append(node)
+
+            elif node.args[0] == torch.ops._C.rms_norm.default:
+                # manual replace for rms_norm
+
+                kwargs = node.kwargs
+
+                input = kwargs['input']
+                out = kwargs['out']
+                weight = kwargs['weight']
+                epsilon = kwargs['epsilon']
+                # Create a new call to torch.ops._C.rotary_embedding.default
+                # cannot use kwargs, because we have an `out`, see https://github.com/pytorch/pytorch/blob/a00faf440888ffb724bad413f329a49e2b6388e7/torch/_inductor/lowering.py#L351 # noqa
+                with graph.inserting_before(node):
+                    # just insert the call to the custom op
+                    # NOTE: don't run dead code elimination,
+                    # otherwise this op will be removed
+                    graph.call_function(
+                        torch.ops._C.rms_norm.default,
+                        args=(out, input, weight, epsilon),
+                    )
+
+                replace_node = out
+
+                for user in list(node.users):
+                    if user.op == 'call_function' and user.target == operator.getitem:  # noqa
+                        user.replace_all_uses_with(replace_node)
+                        nodes_to_remove.append(user)
+                nodes_to_remove.append(node)
+
+            elif node.args[0] == torch.ops._C.silu_and_mul.default:
+                # manual replace for silu_and_mul
+
+                kwargs = node.kwargs
+
+                input = kwargs['input']
+                out = kwargs['out']
+
+                # Create a new call to torch.ops._C.rotary_embedding.default
+                # cannot use kwargs, because we have an `out`, see https://github.com/pytorch/pytorch/blob/a00faf440888ffb724bad413f329a49e2b6388e7/torch/_inductor/lowering.py#L351 # noqa
+                with graph.inserting_before(node):
+                    # just insert the call to the custom op
+                    # NOTE: don't run dead code elimination,
+                    # otherwise this op will be removed
+                    graph.call_function(
+                        torch.ops._C.silu_and_mul.default,
+                        args=(out, input),
+                    )
+                replace_node = out
+
+                for user in list(node.users):
+                    if user.op == 'call_function' and user.target == operator.getitem:  # noqa
+                        user.replace_all_uses_with(replace_node)
+                        nodes_to_remove.append(user)
+                nodes_to_remove.append(node)
+
+    # Remove the nodes all at once
+    for node in nodes_to_remove:
+        graph.erase_node(node)
+
+    # debug code, if we want to see the graph after the transformation
+    # with open("after.py", "w") as f:
+    #     print(graph.python_code(root_module="self", verbose=True).src, file=f)
+
+
+def vllm_backend(graph, example_inputs):
+    from torch._inductor import config
+    current_config = config.shallow_copy_dict()
+    from torch._inductor.compile_fx import compile_fx
+    current_config['post_grad_custom_post_pass'] = fix_functionalization
+    return compile_fx(graph, example_inputs, config_patches=current_config)

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1064,8 +1064,9 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                     "This may lead to less accurate results!")
 
         if envs.VLLM_TEST_DYNAMO_GRAPH_CAPTURE and supports_dynamo():
+            from vllm.compilation.backends import vllm_backend
             from vllm.plugins import get_torch_compile_backend
-            backend = get_torch_compile_backend() or "eager"
+            backend = get_torch_compile_backend() or vllm_backend
             self.model = torch.compile(
                 self.model,
                 fullgraph=envs.VLLM_TEST_DYNAMO_FULLGRAPH_CAPTURE,


### PR DESCRIPTION
manually fix the functionalization pass of torch.compile

without compile, after profiling the model, we have:

```text
INFO 09-13 19:19:09 gpu_executor.py:122] # GPU blocks: 27975, # CPU blocks: 2048
```

after turning on torch compile, with this pr, we have:

```text
INFO 09-13 19:20:44 gpu_executor.py:122] # GPU blocks: 27887, # CPU blocks: 2048
```

We lose about 88 GPU blocks, corresponding to `0.17GB` memory. While it still costs 0.17GB memory, this is acceptable now.

Without this pr, if we naively turn on inductor, we have:

```text
INFO 09-13 16:35:35 gpu_executor.py:122] # GPU blocks: 17753, # CPU blocks: 2048
```

It costs about 20 GB memory.

the pattern for reference:

```python
# ============== start reference ==============


def pattern_rotary_embedding(mm, positions, cos_sin_cache):
    """This is the graph for rotary embedding, after post-grad 
    functionalization. We need to remove the `auto_functionalized`
    and `slice_scatter`, to avoid unnecessary copy.
    """
    # File: vllm/vllm/model_executor/models/llama.py:179 in forward, code: q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1) # noqa
    split_with_sizes = torch.ops.aten.split_with_sizes.default(
        mm, [4096, 1024, 1024], -1)
    getitem_2 = split_with_sizes[0]
    getitem_3 = split_with_sizes[1]
    split_with_sizes = None

    # File: vllm/vllm/_custom_ops.py:139 in rotary_embedding, code: torch.ops._C.rotary_embedding(positions, query, key, head_size, cos_sin_cache, is_neox=True) # noqa
    auto_functionalized_1 = torch._higher_order_ops.auto_functionalize.auto_functionalized( # noqa
        torch.ops._C.rotary_embedding.default,
        positions=positions,
        query=getitem_2,
        key=getitem_3,
        head_size=128,
        cos_sin_cache=cos_sin_cache,
        is_neox=True)
    getitem_2 = getitem_3 = None
    getitem_6 = auto_functionalized_1[1]
    getitem_7 = auto_functionalized_1[2]
    auto_functionalized_1 = None
    slice_scatter = torch.ops.aten.slice_scatter.default(
        mm, getitem_6, 1, 0, 4096)
    mm = getitem_6 = None
    slice_scatter_1 = torch.ops.aten.slice_scatter.default(
        slice_scatter, getitem_7, 1, 4096, 5120)
    slice_scatter = getitem_7 = None
    return slice_scatter_1


def replace_rotary_embedding(mm, positions, cos_sin_cache):
    """
    This is the ideal graph for rotary embedding, after post-grad functionalization.
    We want to replace the above pattern with a direct call to `torch.ops._C.rotary_embedding.default`.
    """
    split_with_sizes = torch.ops.aten.split_with_sizes.default(
        mm, [4096, 1024, 1024], -1)
    getitem_2 = split_with_sizes[0]
    getitem_3 = split_with_sizes[1]
    split_with_sizes = None

    torch.ops._C.rotary_embedding.default(positions=positions,
                                          query=getitem_2,
                                          key=getitem_3,
                                          head_size=128,
                                          cos_sin_cache=cos_sin_cache,
                                          is_neox=True)
    getitem_2 = getitem_3 = None
    return mm


def pattern_fused_add_rms_norm(input, residual, weight):
    """
    This is the graph for fused_add_rms_norm, after post-grad functionalization.
    We need to remove the `auto_functionalized`, because PyTorch will not be able to
    functionalize the fused operation well (it will create unnecessary copies).
    """
    # File: vllm/vllm/_custom_ops.py:161 in fused_add_rms_norm, code: torch.ops._C.fused_add_rms_norm(input, residual, weight, epsilon)
    auto_functionalized_3 = torch._higher_order_ops.auto_functionalize.auto_functionalized(
        torch.ops._C.fused_add_rms_norm.default,
        input=mm_1,
        residual=embedding,
        weight=arg4_1,
        epsilon=1e-05)
    mm_1 = embedding = arg4_1 = None
    getitem_26 = auto_functionalized_3[1]
    getitem_27 = auto_functionalized_3[2]
    auto_functionalized_3 = None
    return getitem_26, getitem_27


def replace_fused_add_rms_norm(input, residual, weight):
    """
    This is the ideal graph for fused_add_rms_norm, after post-grad functionalization.
    """
    torch.ops._C.fused_add_rms_norm.default(input=input,
                                            residual=residual,
                                            weight=weight,
                                            epsilon=1e-05)
    return input, residual


# ============== end reference ==============

```