### PR TITLE
[torch.compile] add a flag to disable custom op

### DIFF
--- a/tests/compile/test_full_graph.py
+++ b/tests/compile/test_full_graph.py
@@ -6,7 +6,8 @@ import pytest
 @pytest.mark.parametrize("model", ["meta-llama/Meta-Llama-3-8B"])
 def test_full_graph(model):
     # make sure these models can be captured in full graph mode
-    os.environ["VLLM_TEST_DYNAMO_GRAPH_CAPTURE"] = "1"
+    if "VLLM_TEST_DYNAMO_GRAPH_CAPTURE" not in os.environ:
+        os.environ["VLLM_TEST_DYNAMO_GRAPH_CAPTURE"] = "1"
 
     from vllm import LLM, SamplingParams
     prompts = [

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -202,6 +202,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     (os.environ.get("VLLM_DYNAMO_USE_CUSTOM_DISPATCHER", "True").lower() in
      ("true", "1")),
 
+    # Internal flag to control whether we use custom op,
+    # or use the native pytorch implementation
+    "VLLM_TEST_COMPILE_NO_CUSTOM_OPS":
+    lambda: int(os.environ.get("VLLM_TEST_COMPILE_NO_CUSTOM_OPS", "0")),
+
     # Internal flag to enable Dynamo fullgraph capture
     "VLLM_TEST_DYNAMO_FULLGRAPH_CAPTURE":
     lambda: bool(

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 
+import vllm.envs as envs
 from vllm.platforms import current_platform
 from vllm.utils import is_cpu, is_hip, is_xpu
 
@@ -53,6 +54,10 @@ class CustomOp(nn.Module):
     def dispatch_forward(self):
         # NOTE(woosuk): Here we assume that vLLM was built for only one
         # specific backend. Currently, we do not support dynamic dispatching.
+
+        if envs.VLLM_TEST_COMPILE_NO_CUSTOM_OPS:
+            return self.forward_native
+
         if is_hip():
             return self.forward_hip
         elif is_cpu():


### PR DESCRIPTION
our final goal is to remove these custom op except for the attention op.

many custom ops are just manual fusions. and we expect torch.compile to do a better job.

however, currently torch.compile will cost more memory.

here we put a new flag to test the behavior.

# current

`VLLM_TEST_DYNAMO_GRAPH_CAPTURE=0 pytest -v -s tests/compile/test_full_graph.py` is the current default behavior, don't use torch.compile .

```text
INFO 09-14 10:11:08 gpu_executor.py:122] # GPU blocks: 27911, # CPU blocks: 2048
```

# compile + custom op

`pytest -v -s tests/compile/test_full_graph.py` is to test torch.compile with vllm custom op:

```text
INFO 09-14 10:03:27 gpu_executor.py:122] # GPU blocks: 27887, # CPU blocks: 2048
```

# compile without custom op

`VLLM_TEST_COMPILE_NO_CUSTOM_OPS=1 pytest -v -s tests/compile/test_full_graph.py` is to test torch.compile without vllm custom op:

```text
INFO 09-14 10:05:03 gpu_executor.py:122] # GPU blocks: 27601, # CPU blocks: 2048
```

# summary

with compile, we lost 124 blocks.

without custom ops, we lost 286 blocks.

note: 2048 cpu blocks translate into 4 GB cpu memory. so every block is 2 MB memory.