### PR TITLE
[Bugfix][Model] Fix Python 3.8 compatibility in Pixtral model by updating type annotations

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -454,7 +454,7 @@ class Transformer(nn.Module):
         return x
 
 
-def position_meshgrid(patch_embeds_list: list[torch.Tensor], ) -> torch.Tensor:
+def position_meshgrid(patch_embeds_list: List[torch.Tensor], ) -> torch.Tensor:
     positions = torch.cat([
         torch.stack(
             torch.meshgrid(


### PR DESCRIPTION
This PR updates the `position_meshgrid` function in the Pixtral model to ensure compatibility with Python 3.8. The change replaces the built-in `list` with `List` from the `typing` module in the type annotations. This adjustment resolves issues with type hinting in Python 3.8, where support for generic types in standard collections is not available.