### PR TITLE
[Bugfix] Bind api server port before starting engine

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,6 +179,7 @@ def compare_two_settings(model: str,
         env1: The first set of environment variables to pass to the API server.
         env2: The second set of environment variables to pass to the API server.
     """
+    os.environ["VLLM_PORT"] = "8001"
 
     trust_remote_code = "--trust-remote-code"
     if trust_remote_code in arg1 or trust_remote_code in arg2:
@@ -297,6 +298,8 @@ def compare_two_settings(model: str,
                 "test": "streaming",
                 "texts": texts,
             })
+
+    os.environ.pop("VLLM_PORT")
 
     n = len(results) // 2
     arg1_results = results[:n]
@@ -491,6 +494,7 @@ async def completions_with_server_args(
     Returns:
       OpenAI Completion instance
     '''
+    os.environ["VLLM_PORT"] = "8001"
 
     outputs = None
     with RemoteOpenAIServer(model_name,
@@ -503,6 +507,8 @@ async def completions_with_server_args(
                                                   stream=False,
                                                   max_tokens=5,
                                                   logprobs=num_logprobs)
+    os.environ.pop("VLLM_PORT")
+    
     assert outputs is not None
 
     return outputs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -508,7 +508,7 @@ async def completions_with_server_args(
                                                   max_tokens=5,
                                                   logprobs=num_logprobs)
     os.environ.pop("VLLM_PORT")
-    
+
     assert outputs is not None
 
     return outputs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,7 +76,9 @@ class RemoteOpenAIServer:
                                  "when `auto_port=True`.")
 
             # Don't mutate the input args
-            vllm_serve_args = vllm_serve_args + ["--port", str(0)]
+            vllm_serve_args = vllm_serve_args + [
+                "--port", str(get_open_port())
+            ]
 
         parser = FlexibleArgumentParser(
             description="vLLM's remote OpenAI server.")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -179,7 +179,6 @@ def compare_two_settings(model: str,
         env1: The first set of environment variables to pass to the API server.
         env2: The second set of environment variables to pass to the API server.
     """
-    os.environ["VLLM_PORT"] = "8001"
 
     trust_remote_code = "--trust-remote-code"
     if trust_remote_code in arg1 or trust_remote_code in arg2:
@@ -298,8 +297,6 @@ def compare_two_settings(model: str,
                 "test": "streaming",
                 "texts": texts,
             })
-
-    os.environ.pop("VLLM_PORT")
 
     n = len(results) // 2
     arg1_results = results[:n]
@@ -494,7 +491,6 @@ async def completions_with_server_args(
     Returns:
       OpenAI Completion instance
     '''
-    os.environ["VLLM_PORT"] = "8001"
 
     outputs = None
     with RemoteOpenAIServer(model_name,
@@ -507,8 +503,6 @@ async def completions_with_server_args(
                                                   stream=False,
                                                   max_tokens=5,
                                                   logprobs=num_logprobs)
-    os.environ.pop("VLLM_PORT")
-
     assert outputs is not None
 
     return outputs

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -76,9 +76,7 @@ class RemoteOpenAIServer:
                                  "when `auto_port=True`.")
 
             # Don't mutate the input args
-            vllm_serve_args = vllm_serve_args + [
-                "--port", str(get_open_port())
-            ]
+            vllm_serve_args = vllm_serve_args + ["--port", str(0)]
 
         parser = FlexibleArgumentParser(
             description="vLLM's remote OpenAI server.")

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -5,6 +5,7 @@ import multiprocessing
 import os
 import re
 import signal
+import socket
 import tempfile
 from argparse import Namespace
 from contextlib import asynccontextmanager
@@ -525,6 +526,9 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     logger.info("vLLM API server version %s", VLLM_VERSION)
     logger.info("args: %s", args)
 
+    temp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    temp_socket.bind(("", args.port))
+
     def signal_handler(*_) -> None:
         # Interrupt server on sigterm while initializing
         raise KeyboardInterrupt("terminated")
@@ -540,6 +544,8 @@ async def run_server(args, **uvicorn_kwargs) -> None:
 
         model_config = await async_engine_client.get_model_config()
         init_app_state(async_engine_client, model_config, app.state, args)
+
+        temp_socket.close()
 
         shutdown_task = await serve_http(
             app,


### PR DESCRIPTION
~Potential alternate solution for #8204--I saw that asyncio will use a default port of 0 in the context of create_server() if no port is given in the config. Binding to port 0 with socket.socket.bind() apparently means the OS will pick an available port for you, which I think functions similarly to get_open_port()~

~But instead of choosing the port first and binding it later after the engine starts, choosing as the port is bound may resolve potential conflicts with Ray picking the same port?~

Bind the chosen api server port to a temp socket until engine is started to avoid port conflict.

FIX #8204

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


