### PR TITLE
[Bugfix] Fix incorrect llava next feature size calculation

### DIFF
--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -87,17 +87,19 @@ def _get_llava_next_num_unpadded_features(
     current_height = npatches * num_patch_height
     current_width = npatches * num_patch_width
 
-    aspect_ratio = original_width / original_height
+    original_aspect_ratio = original_width / original_height
     current_aspect_ratio = current_width / current_height
 
-    if aspect_ratio > current_aspect_ratio:
-        new_height = (original_height * current_width) // original_width
+    if original_aspect_ratio > current_aspect_ratio:
+        scale_factor = current_width / original_width
+        new_height = int(original_height * scale_factor)
         padding = (current_height - new_height) // 2
-        current_height -= padding * 2
+        current_height -= 2 * padding
     else:
-        new_width = (original_width * current_height) // original_height
+        scale_factor = current_height / original_height
+        new_width = int(original_width * scale_factor)
         padding = (current_width - new_width) // 2
-        current_width -= padding * 2
+        current_width -= 2 * padding
 
     unpadded_features = current_height * current_width
     newline_features = current_height


### PR DESCRIPTION
The old code produces incorrect feature size and leads to 
```
Attempted to assign XXX = XXX multimodal tokens to YYY placeholders
```
An image with size 700x840 can trigger this

FIX #8421