### PR TITLE
[Frontend] Expose revision arg in OpenAI server

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -130,8 +130,9 @@ async def build_async_engine_client_from_engine_args(
 
     # If manually triggered or embedding model, use AsyncLLMEngine in process.
     # TODO: support embedding model via RPC.
-    if (model_is_embedding(engine_args.model, engine_args.revision, 
-                           engine_args.trust_remote_code, engine_args.quantization)
+    if (model_is_embedding(engine_args.model, engine_args.revision,
+                           engine_args.trust_remote_code,
+                           engine_args.quantization)
             or disable_frontend_multiprocessing):
         engine_client = AsyncLLMEngine.from_engine_args(
             engine_args, usage_context=UsageContext.OPENAI_API_SERVER)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -68,9 +68,10 @@ logger = init_logger('vllm.entrypoints.openai.api_server')
 _running_tasks: Set[asyncio.Task] = set()
 
 
-def model_is_embedding(model_name: str, trust_remote_code: bool,
+def model_is_embedding(model_name: str, revision: str, trust_remote_code: bool,
                        quantization: Optional[str]) -> bool:
     return ModelConfig(model=model_name,
+                       revision=revision,
                        tokenizer=model_name,
                        tokenizer_mode="auto",
                        trust_remote_code=trust_remote_code,
@@ -129,8 +130,8 @@ async def build_async_engine_client_from_engine_args(
 
     # If manually triggered or embedding model, use AsyncLLMEngine in process.
     # TODO: support embedding model via RPC.
-    if (model_is_embedding(engine_args.model, engine_args.trust_remote_code,
-                           engine_args.quantization)
+    if (model_is_embedding(engine_args.model, engine_args.revision, 
+                           engine_args.trust_remote_code, engine_args.quantization)
             or disable_frontend_multiprocessing):
         engine_client = AsyncLLMEngine.from_engine_args(
             engine_args, usage_context=UsageContext.OPENAI_API_SERVER)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -68,8 +68,9 @@ logger = init_logger('vllm.entrypoints.openai.api_server')
 _running_tasks: Set[asyncio.Task] = set()
 
 
-def model_is_embedding(model_name: str, revision: str, trust_remote_code: bool,
-                       quantization: Optional[str]) -> bool:
+def model_is_embedding(model_name: str, trust_remote_code: bool,
+                       quantization: Optional[str],
+                       revision: Optional[str]) -> bool:
     return ModelConfig(model=model_name,
                        revision=revision,
                        tokenizer=model_name,
@@ -130,9 +131,8 @@ async def build_async_engine_client_from_engine_args(
 
     # If manually triggered or embedding model, use AsyncLLMEngine in process.
     # TODO: support embedding model via RPC.
-    if (model_is_embedding(engine_args.model, engine_args.revision,
-                           engine_args.trust_remote_code,
-                           engine_args.quantization)
+    if (model_is_embedding(engine_args.model, engine_args.trust_remote_code,
+                           engine_args.quantization, engine_args.revision)
             or disable_frontend_multiprocessing):
         engine_client = AsyncLLMEngine.from_engine_args(
             engine_args, usage_context=UsageContext.OPENAI_API_SERVER)


### PR DESCRIPTION
This PR exposes the revision arg in the OpenAPI server so that one can run inference at a desired model revision via:

```shell
vllm serve {MODEL_ID} --revision {REVISION}
```

In particular, it resolves the following error that arises when passing `--revision` to `vllm serve` for model repos that _do not_ have a `config.json` file on the `main` branch (a common pattern among HF Hub users who use branches for versioning experiments):

```
Traceback (most recent call last):
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/utils/_errors.py", line 304, in hf_raise_for_status
    response.raise_for_status()
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://huggingface.co/HuggingFaceH4/gemma-2-2b-gkd/resolve/main/config.json

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/transformers/utils/hub.py", line 402, in cached_file
    resolved_file = hf_hub_download(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/utils/_deprecation.py", line 101, in inner_f
    return f(*args, **kwargs)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1240, in hf_hub_download
    return _hf_hub_download_to_cache_dir(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1303, in _hf_hub_download_to_cache_dir
    (url_to_download, etag, commit_hash, expected_size, head_call_error) = _get_metadata_or_catch_error(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1752, in _get_metadata_or_catch_error
    metadata = get_hf_file_metadata(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 1674, in get_hf_file_metadata
    r = _request_wrapper(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 376, in _request_wrapper
    response = _request_wrapper(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/file_download.py", line 400, in _request_wrapper
    hf_raise_for_status(response)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/huggingface_hub/utils/_errors.py", line 315, in hf_raise_for_status
    raise EntryNotFoundError(message, response) from e
huggingface_hub.utils._errors.EntryNotFoundError: 404 Client Error. (Request ID: Root=1-66e7e09a-17e4310c5f1032c2189efc96;f483305a-4822-4bd4-a502-3a867fafecc9)

Entry Not Found for url: https://huggingface.co/HuggingFaceH4/gemma-2-2b-gkd/resolve/main/config.json.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/fsx/lewis/miniconda3/envs/mixeval/bin/vllm", line 8, in <module>
    sys.exit(main())
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/scripts.py", line 165, in main
    args.dispatch_function(args)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/scripts.py", line 37, in serve
    asyncio.run(run_server(args))
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/entrypoints/openai/api_server.py", line 462, in run_server
    async with build_async_engine_client(args) as async_engine_client:
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/entrypoints/openai/api_server.py", line 108, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/contextlib.py", line 199, in __aenter__
    return await anext(self.gen)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/entrypoints/openai/api_server.py", line 130, in build_async_engine_client_from_engine_args
    if (model_is_embedding(engine_args.model, engine_args.trust_remote_code,
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/entrypoints/openai/api_server.py", line 71, in model_is_embedding
    return ModelConfig(model=model_name,
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/config.py", line 176, in __init__
    self.hf_config = get_config(self.model, trust_remote_code, revision,
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/vllm/transformers_utils/config.py", line 66, in get_config
    config = AutoConfig.from_pretrained(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 976, in from_pretrained
    config_dict, unused_kwargs = PretrainedConfig.get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/transformers/configuration_utils.py", line 632, in get_config_dict
    config_dict, kwargs = cls._get_config_dict(pretrained_model_name_or_path, **kwargs)
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/transformers/configuration_utils.py", line 689, in _get_config_dict
    resolved_config_file = cached_file(
  File "/fsx/lewis/miniconda3/envs/mixeval/lib/python3.10/site-packages/transformers/utils/hub.py", line 456, in cached_file
    raise EnvironmentError(
OSError: HuggingFaceH4/gemma-2-2b-gkd does not appear to have a file named config.json. Checkout 'https://huggingface.co/HuggingFaceH4/gemma-2-2b-gkd/tree/main' for available files.
```

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


