### PR TITLE
[CI/Build] fix Dockerfile.cpu on podman

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -24,6 +24,8 @@ RUN echo 'ulimit -c 0' >> ~/.bashrc
 
 RUN pip install https://intel-extension-for-pytorch.s3.amazonaws.com/ipex_dev/cpu/intel_extension_for_pytorch-2.4.0%2Bgitfbaa4bc-cp310-cp310-linux_x86_64.whl
 
+WORKDIR /workspace
+
 ENV PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cpu
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,src=requirements-build.txt,target=requirements-build.txt \


### PR DESCRIPTION
podman does not like RUN --mount with relative paths when `WORKDIR` is not set.

fixes #8502
