### PR TITLE
[Core] zmq: bind only to 127.0.0.1 for local-only usage

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -196,7 +196,9 @@ class MessageQueue:
             # see http://api.zeromq.org/3-3:zmq-setsockopt for more details
             self.local_socket.setsockopt(XPUB_VERBOSE, True)
             local_subscribe_port = get_open_port()
-            self.local_socket.bind(f"tcp://*:{local_subscribe_port}")
+            socket_addr = f"tcp://127.0.0.1:{local_subscribe_port}"
+            logger.debug("Binding to %s", socket_addr)
+            self.local_socket.bind(socket_addr)
 
             self.current_idx = 0
 
@@ -212,7 +214,8 @@ class MessageQueue:
             self.remote_socket = context.socket(XPUB)
             self.remote_socket.setsockopt(XPUB_VERBOSE, True)
             remote_subscribe_port = get_open_port()
-            self.remote_socket.bind(f"tcp://*:{remote_subscribe_port}")
+            socket_addr = f"tcp://*:{remote_subscribe_port}"
+            self.remote_socket.bind(socket_addr)
 
         else:
             remote_subscribe_port = None
@@ -255,8 +258,9 @@ class MessageQueue:
 
             self.local_socket = context.socket(SUB)
             self.local_socket.setsockopt_string(SUBSCRIBE, "")
-            self.local_socket.connect(
-                f"tcp://{handle.connect_ip}:{handle.local_subscribe_port}")
+            socket_addr = f"tcp://127.0.0.1:{handle.local_subscribe_port}"
+            logger.debug("Connecting to %s", socket_addr)
+            self.local_socket.connect(socket_addr)
 
             self.remote_socket = None
         else:
@@ -270,8 +274,9 @@ class MessageQueue:
 
             self.remote_socket = context.socket(SUB)
             self.remote_socket.setsockopt_string(SUBSCRIBE, "")
-            self.remote_socket.connect(
-                f"tcp://{handle.connect_ip}:{handle.remote_subscribe_port}")
+            socket_addr = f"tcp://{handle.connect_ip}:{handle.remote_subscribe_port}"
+            logger.debug("Connecting to %s", socket_addr)
+            self.remote_socket.connect(socket_addr)
 
         return self
 


### PR DESCRIPTION
When running with `--tensor-parallel-size` greater than `1`, I noticed that the zmq socket opened for broadcasting to workers was listening on all interfaces. This change makes both the listening-side and (XPUB) and the receiving side (SUB) use `127.0.0.1` instead of `*` when we know the usage is local-only.

I also added debug logging to show which port numbers are in use by zmq.

By listening on all interfaces, an external party could connect and subscribe to data from the `XPUB` socket if firewall settings allow it. The data received is not particularly useful (it's tensor metadata), but it's still unexpected and undesirable behavior to allow connections from a wider set of potential sources than necessary.

It is already possible to control which IP address is used for the remote case by setting the `VLLM_HOST_IP` environment variable.

