### PR TITLE
[Bugfix] Config.__init__() got an unexpected keyword argument 'engine' api_server args

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -121,7 +121,7 @@ async def run_server(args: Namespace,
 
     shutdown_task = await serve_http(
         app,
-        engine=engine,
+        limit_concurrency=engine.limit_concurrency,
         host=args.host,
         port=args.port,
         log_level=args.log_level,

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -121,7 +121,6 @@ async def run_server(args: Namespace,
 
     shutdown_task = await serve_http(
         app,
-        limit_concurrency=engine.limit_concurrency,
         host=args.host,
         port=args.port,
         log_level=args.log_level,


### PR DESCRIPTION
File "vllm/vllm/entrypoints/api_server.py", line 122, in run_server
[rank0]:     shutdown_task = await serve_http(
[rank0]:   File "vllm/vllm/entrypoints/launcher.py", line 29, in serve_http
[rank0]:     config = uvicorn.Config(app, **uvicorn_kwargs)
[rank0]: TypeError: Config.__init__() got an unexpected keyword argument 'engine'
