### PR TITLE
[Core] Change multiproc method default to `spawn`

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -225,7 +225,6 @@ steps:
   - tests/tensorizer_loader
   commands:
     - apt-get update && apt-get install -y curl libsodium23
-    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s tensorizer_loader
 
 - label: Benchmarks # 9min
@@ -251,7 +250,6 @@ steps:
   - vllm/model_executor/layers/quantization
   commands:
   - pip install lm-eval
-  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - bash ./run-tests.sh -c configs/models-small.txt -t 1
 
 - label: Encoder Decoder tests # 5min
@@ -403,9 +401,6 @@ steps:
   - vllm/lora
   - tests/lora/test_long_context
   commands:
-    # FIXIT: find out which code initialize cuda before running the test
-    # before the fix, we need to use spawn to test it
-    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - pytest -v -s -x lora/test_long_context.py
 
 - label: Weight Loading Multiple GPU Test
@@ -453,5 +448,4 @@ steps:
   - vllm/model_executor/layers/quantization
   commands:
   - pip install lm-eval
-  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
   - bash ./run-tests.sh -c configs/models-large.txt -t 4

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_SPMD_WORKER: bool = False
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_USE_RAY_COMPILED_DAG_NCCL_CHANNEL: bool = True
-    VLLM_WORKER_MULTIPROC_METHOD: str = "fork"
+    VLLM_WORKER_MULTIPROC_METHOD: str = "spawn"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
     VLLM_AUDIO_FETCH_TIMEOUT: int = 5
@@ -335,7 +335,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work
     "VLLM_WORKER_MULTIPROC_METHOD":
-    lambda: os.getenv("VLLM_WORKER_MULTIPROC_METHOD", "fork"),
+    lambda: os.getenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn"),
 
     # Path to the cache for storing downloaded assets
     "VLLM_ASSETS_CACHE":


### PR DESCRIPTION
The default of `fork` is known to be problematic. Python itself is changing the default to `spawn`. The new default is expected to be in place for Python 3.14.

Python references for the change to the default:

* https://github.com/python/cpython/issues/84559
* https://github.com/python/cpython/pull/100618

We also have several places where this option had to be set to `spawn` to make tests work. The AMD code even checks and overrides the value if it's not set to `spawn`.

Simplify things for everyone and just default to `spawn`, but leave the option in place just in case, at least for now.