### PR TITLE
[Bugfix][Core] Fix tekken edge case for mistral tokenizer

### DIFF
--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -65,7 +65,7 @@ EXPECTED_FUNC_CALL = (
     '{"city": "Dallas", "state": "TX", "unit": "fahrenheit"}}]')
 
 
-@pytest.mark.parametrize("model", MODELS[2:])
+@pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("max_tokens", [64])
 @pytest.mark.parametrize("num_logprobs", [5])
@@ -79,13 +79,13 @@ def test_models(
     num_logprobs: int,
 ) -> None:
     # TODO(sang): Sliding window should be tested separately.
+    with hf_runner(model, dtype=dtype) as hf_model:
+        hf_outputs = hf_model.generate_greedy_logprobs_limit(
+            example_prompts, max_tokens, num_logprobs)
+            
     with vllm_runner(model, dtype=dtype,
                      tokenizer_mode="mistral") as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(
-            example_prompts, max_tokens, num_logprobs)
-
-    with hf_runner(model, dtype=dtype) as hf_model:
-        hf_outputs = hf_model.generate_greedy_logprobs_limit(
             example_prompts, max_tokens, num_logprobs)
 
     check_logprobs_close(

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -4,8 +4,7 @@ Run `pytest tests/models/test_mistral.py`.
 """
 import pytest
 
-from vllm import SamplingParams
-from vllm import LLM
+from vllm import LLM, SamplingParams
 
 from ...utils import check_logprobs_close
 

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -135,6 +135,7 @@ def test_mistral_format(
         name_1="mistral",
     )
 
+
 @pytest.mark.parametrize("model", MODELS[1:])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("max_tokens", [64])
@@ -149,13 +150,14 @@ def test_mistral_symbolic_languages(
     prompt: str,
 ) -> None:
     prompt = "hi"
-    msg = {
-        "role": "user",
-        "content": prompt
-    }
-    llm = LLM(model=model, tokenizer_mode="mistral", config_format="mistral", load_format="mistral")
+    msg = {"role": "user", "content": prompt}
+    llm = LLM(model=model,
+              tokenizer_mode="mistral",
+              config_format="mistral",
+              load_format="mistral")
     outputs = llm.chat([msg], sampling_params=SAMPLING_PARAMS)
     assert "�" not in outputs[0].outputs[0].text.strip()
+
 
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("model", MODELS[1:])  # v1 can't do func calling

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -141,16 +141,15 @@ def test_mistral_format(
 @pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("prompt", SYMBOLIC_LANG_PROMPTS)
 def test_mistral_symbolic_languages(
-    vllm_runner,
     model: str,
     dtype: str,
-    max_tokens: int,
-    num_logprobs: int,
     prompt: str,
 ) -> None:
     prompt = "hi"
     msg = {"role": "user", "content": prompt}
     llm = LLM(model=model,
+              dtype=dtype,
+              max_model_len=8192,
               tokenizer_mode="mistral",
               config_format="mistral",
               load_format="mistral")

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -137,8 +137,6 @@ def test_mistral_format(
 
 @pytest.mark.parametrize("model", MODELS[1:])
 @pytest.mark.parametrize("dtype", ["bfloat16"])
-@pytest.mark.parametrize("max_tokens", [64])
-@pytest.mark.parametrize("num_logprobs", [5])
 @pytest.mark.parametrize("prompt", SYMBOLIC_LANG_PROMPTS)
 def test_mistral_symbolic_languages(
     model: str,

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -82,6 +82,7 @@ def test_models(
     with hf_runner(model, dtype=dtype) as hf_model:
         hf_outputs = hf_model.generate_greedy_logprobs_limit(
             example_prompts, max_tokens, num_logprobs)
+
     with vllm_runner(model, dtype=dtype,
                      tokenizer_mode="mistral") as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -82,7 +82,6 @@ def test_models(
     with hf_runner(model, dtype=dtype) as hf_model:
         hf_outputs = hf_model.generate_greedy_logprobs_limit(
             example_prompts, max_tokens, num_logprobs)
-            
     with vllm_runner(model, dtype=dtype,
                      tokenizer_mode="mistral") as vllm_model:
         vllm_outputs = vllm_model.generate_greedy_logprobs(

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -220,7 +220,10 @@ class MistralTokenizer:
 
         tokens = [self.tokenizer.id_to_piece(id) for id in ids]
 
-        if tokens[-1] == "�":
-            tokens[-1] = self.tokenizer.id_to_byte_piece(ids[-1])
+        if any(t.strip() == "�" for t in tokens):
+            # if any stripped decoded token is undefined
+            # because it's invalid unicode then pass bytes
+            # See: https://github.com/vllm-project/vllm/pull/8640
+            tokens = [self.tokenizer.id_to_byte_piece(id) for id in ids]
 
         return tokens

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -175,13 +175,22 @@ class MistralTokenizer:
 
     def convert_tokens_to_string(self, tokens: List[str]) -> str:
         if isinstance(self.tokenizer, Tekkenizer):
-            tokens = [t for t in tokens if t not in self.tokenizer._all_special_tokens]
+            tokens = [
+                t for t in tokens
+                if t not in self.tokenizer._all_special_tokens
+            ]
 
             if any(isinstance(t, bytes) for t in tokens):
                 # we need to encode and decode all tokens again
                 shift = self.tokenizer.num_special_tokens
-                byte_tokens = [t.encode("utf-8") if not isinstance(t, bytes) else t for t in tokens]
-                ids = [self.tokenizer._tekken_token2id_nospecial[t] + shift for t in byte_tokens]
+                byte_tokens = [
+                    t.encode("utf-8") if not isinstance(t, bytes) else t
+                    for t in tokens
+                ]
+                ids = [
+                    self.tokenizer._tekken_token2id_nospecial[t] + shift
+                    for t in byte_tokens
+                ]
                 decoded = self.tokenizer.decode(ids)
             else:
                 decoded = "".join(tokens)


### PR DESCRIPTION
Fix leading non-utf unicode tokens for tekken

FIX #8627

Generally, decoding id by id is dangerous for unicode tokenizers such as tekken (see: https://github.com/openai/tiktoken/issues/202#issuecomment-1749969932)

This PR makes sure that invalid tokens are instead passed as valid unicode code bytes and then later correctly decoded



