### PR TITLE
[Misc] Show AMD GPU topology in `collect_env.py`

### DIFF
--- a/collect_env.py
+++ b/collect_env.py
@@ -285,9 +285,14 @@ def summarize_vllm_build_flags():
 
 
 def get_gpu_topo(run_lambda):
+    output = None
+
     if get_platform() == 'linux':
-        return run_and_read_all(run_lambda, 'nvidia-smi topo -m')
-    return None
+        output = run_and_read_all(run_lambda, 'nvidia-smi topo -m')
+        if output is None:
+            output = run_and_read_all(run_lambda, 'rocm-smi --showtopo')
+
+    return output
 
 
 # example outputs of CPU infos


### PR DESCRIPTION
This PR updates `collect_env.py` to show the topology of AMD GPUs. I have tested this locally.

Example output: https://github.com/vllm-project/vllm/issues/8630#issuecomment-2362592214

cc @alexeykondrat 

