### PR TITLE
[Bugfix] Correct update of sampling parameters with default generation configuration

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -307,6 +307,11 @@ class LLMEngine:
         self.generation_config_fields = _load_generation_config_dict(
             model_config)
 
+        logger.info(
+            "Stored default generation configuration %s",
+            self.generation_config_fields,
+        )
+
         self.input_preprocessor = InputPreprocessor(model_config,
                                                     self.tokenizer)
 
@@ -765,6 +770,8 @@ class LLMEngine:
         encoder_seq: Optional[Sequence] = None,
     ) -> SequenceGroup:
         """Creates a SequenceGroup with SamplingParams."""
+        logger.info("Received sampling parameters %s", sampling_params)
+
         max_logprobs = self.get_model_config().max_logprobs
         if (sampling_params.logprobs
                 and sampling_params.logprobs > max_logprobs) or (
@@ -777,8 +784,15 @@ class LLMEngine:
         # this doesn't deep-copy LogitsProcessor objects
         sampling_params = sampling_params.clone()
 
+        logger.info(
+            "Start to update sampling parameters %s with default "
+            "generation configuration %s", sampling_params,
+            self.generation_config_fields)
+
         sampling_params.update_from_generation_config(
             self.generation_config_fields, seq.eos_token_id)
+
+        logger.info("Updated sampling parameters %s", sampling_params)
 
         # Create the sequence group.
         seq_group = SequenceGroup(


### PR DESCRIPTION
Engine updates request sampling parameters in unexpected way

Engine tries to [load default generation configuration from default generation configuration file](https://github.com/vllm-project/vllm/blob/260d40b5ea48df9421325388abcc8d907a560fc5/vllm/engine/llm_engine.py#L307-L308) and if it can find the file it saves the default generation configuration into the state of engine

When request arrives to the engine the [sampling parameters will be updated with default generation configuration](https://github.com/vllm-project/vllm/blob/260d40b5ea48df9421325388abcc8d907a560fc5/vllm/engine/llm_engine.py#L780-L781) loaded from the default generation configuration file 

The [actual update of sampling parameters with default generation configuration](https://github.com/vllm-project/vllm/blob/260d40b5ea48df9421325388abcc8d907a560fc5/vllm/sampling_params.py#L367-L370) works is not as it is expected to. In fact it updates only subset of parameters

The expected behavior to resole sampling parameters would look like this. First the engine looks for sampling parameters that are sent by user in the request. If user did not specify some parameter in the request the engine will look for this parameter default value in default generation configuration. If parameter is not specified in the default generation configuration then engine will use default value that are specified as default value in the sampling parameters object

I have added logs in order to trace the fact that engine updates sampling parameters in unexpected way and got these results for some model and the model name is not important here. The important part is that default generation configuration file exists in the model

First the engine tries to load default generation configuration file and successfully loads it

```bash
INFO 09-20 08:37:14 llm_engine.py:310] Stored default generation configuration {'do_sample': True, 'use_cache': False, 'top_k': 1, 'pad_token_id': 0, 'bos_token_id': 1, 'eos_token_id': 2, 'transformers_version': '4.44.2'}
```

Then when I send request

```bash
curl http://localhost:8000/v1/completions \
    -H "Content-Type: application/json" \
    -X POST \
    -d '{
        "model": "/mnt/model",
        "prompt": "San Francisco is a",
        "max_tokens": 32,
        "temperature": 0
    }'
```

The server receives the request

```bash
INFO 09-20 08:38:12 llm_engine.py:773] Received sampling parameters SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None)
```

Then server will try to update parameters

```bash
INFO 09-20 08:38:12 llm_engine.py:787] Start to update sampling parameters SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None) with default generation configuration {'do_sample': True, 'use_cache': False, 'top_k': 1, 'pad_token_id': 0, 'bos_token_id': 1, 'eos_token_id': 2, 'transformers_version': '4.44.2'}
```

The updated sampling parameters looks unexpected way

```bash
INFO 09-20 08:38:12 llm_engine.py:795] Updated sampling parameters SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.0, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None)
```

For instance the updated sampling parameters top_k parameter holds value -1 while user did not pass the parameter since it assumes that value 1 from the generation configuration will be used but gets unexpected generation results since wrong value was used
