### PR TITLE
[MISC] Skip dumping inputs when unpicklable

### DIFF
--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -140,7 +140,7 @@ def dump_input_when_exception(exclude_args: Optional[List[int]] = None,
                     try:
                         pickle.dump(dumped_inputs, filep)
                     except Exception as pickle_err:
-                        logger.error(
+                        logger.warning(
                             "Failed to pickle inputs of failed execution: %s",
                             str(pickle_err))
                         raise type(err)(f"Error in model execution: "

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -137,7 +137,15 @@ def dump_input_when_exception(exclude_args: Optional[List[int]] = None,
                                                       for t in kv_caches
                                                       if is_tensor(t)]
 
-                    pickle.dump(dumped_inputs, filep)
+                    try:
+                        pickle.dump(dumped_inputs, filep)
+                    except Exception as pickle_err:
+                        logger.error(
+                            "Failed to pickle inputs of failed execution: %s",
+                            str(pickle_err))
+                        raise type(err)(f"Error in model execution: "
+                                        f"{str(err)}") from err
+
                     logger.info(
                         "Completed writing input of failed execution to %s.",
                         filename)


### PR DESCRIPTION
FIX #8738

Some model inputs such as FlashInfer kernel wrapper cannot be pickled. While we should have a better way to dump these inputs for reproducible, this quick PR simply does not pickle model inputs in this case to make sure the real error can be exposed in the first place.

cc @robertgshaw2-neuralmagic @simon-mo 