### PR TITLE
[misc] soft drop beam search

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -195,6 +195,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: (os.environ.get("VLLM_USE_TRITON_FLASH_ATTN", "True").lower() in
              ("true", "1")),
 
+    # If set, allowing the use of deprecated beam search implementation
+    "VLLM_ALLOW_DEPRECATED_BEAM_SEARCH":
+    lambda: os.environ.get("VLLM_ALLOW_DEPRECATED_BEAM_SEARCH", "0") == "1",
+
     # Internal flag to enable Dynamo graph capture
     "VLLM_TEST_DYNAMO_GRAPH_CAPTURE":
     lambda: int(os.environ.get("VLLM_TEST_DYNAMO_GRAPH_CAPTURE", "0")),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     VLLM_TORCH_PROFILER_DIR: Optional[str] = None
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
+    VLLM_ALLOW_DEPRECATED_BEAM_SEARCH: bool = False
 
 
 def get_default_cache_root():

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -262,7 +262,7 @@ class SamplingParams(
         self._verify_args()
         if self.use_beam_search:
             if not envs.VLLM_ALLOW_DEPRECATED_BEAM_SEARCH:
-                raise RuntimeError(
+                raise ValueError(
                     "Using beam search as a sampling parameter is deprecated, and will be removed in the future release. Please use the `vllm.LLM.use_beam_search` method for dedicated beam search instead, or set the environment variable `VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1` to suppress this error. For more details, see https://github.com/vllm-project/vllm/issues/8306 ."  # noqa
                 )
             self._verify_beam_search()

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -8,6 +8,7 @@ import msgspec
 import torch
 from typing_extensions import Annotated
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -260,6 +261,10 @@ class SamplingParams(
 
         self._verify_args()
         if self.use_beam_search:
+            if not envs.VLLM_ALLOW_DEPRECATED_BEAM_SEARCH:
+                raise RuntimeError(
+                    "Using beam search as a sampling parameter is deprecated, and will be removed in the future release. Please use the `vllm.LLM.use_beam_search` method for dedicated beam search instead, or set the environment variable `VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1` to suppress this error. For more details, see https://github.com/vllm-project/vllm/issues/8306 ."  # noqa
+                )
             self._verify_beam_search()
         else:
             self._verify_non_beam_search()


### PR DESCRIPTION
manually tested, this will not result in DoS. a single beam search request will get "bad request", while the rest requests are processed as normal.

server side:

```bash
$ vllm serve meta-llama/Meta-Llama-3-8B
```

client side:

```python
from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="key123",
)

prompt = "Capital of France is"

try:
    completion = client.completions.create(
        model="meta-llama/Meta-Llama-3-8B",
        prompt=prompt,
        max_tokens=4,
        extra_body={'use_beam_search': True, 'best_of': 3}
    )
except Exception as e:
    print(e)

completion = client.completions.create(
    model="meta-llama/Meta-Llama-3-8B",
    prompt=prompt,
    max_tokens=4,
)

print(completion.choices[0].text)
```

output:

```text
Error code: 400 - {'object': 'error', 'message': 'Using beam search as a sampling parameter is deprecated, and will be removed in the future release. Please use the `vllm.LLM.use_beam_search` method for dedicated beam search instead, or set the environment variable `VLLM_ALLOW_DEPRECATED_BEAM_SEARCH=1` to suppress this error. For more details, see https://github.com/vllm-project/vllm/issues/8306 .', 'type': 'BadRequestError', 'param': None, 'code': 400}
 Paris and its official
```