### PR TITLE
[Bugfix][Kernel] Implement acquire/release polyfill for Pascal

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -131,15 +131,26 @@ DINLINE O downcast(array_t<float, O::size> val) {
 }
 
 static DINLINE void st_flag_release(FlagType* flag_addr, FlagType flag) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
   asm volatile("st.release.sys.global.u32 [%1], %0;" ::"r"(flag),
                "l"(flag_addr));
+#else
+  asm volatile("membar.sys; st.volatile.global.u32 [%1], %0;" ::"r"(flag),
+               "l"(flag_addr));
+#endif
 }
 
 static DINLINE FlagType ld_flag_acquire(FlagType* flag_addr) {
   FlagType flag;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
   asm volatile("ld.acquire.sys.global.u32 %0, [%1];"
                : "=r"(flag)
                : "l"(flag_addr));
+#else
+  asm volatile("ld.volatile.sys.global.u32 %0, [%1]; membar.gl;"
+               : "=r"(flag)
+               : "l"(flag_addr));
+#endif
   return flag;
 }
 

--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -147,7 +147,7 @@ static DINLINE FlagType ld_flag_acquire(FlagType* flag_addr) {
                : "=r"(flag)
                : "l"(flag_addr));
 #else
-  asm volatile("ld.volatile.sys.global.u32 %0, [%1]; membar.gl;"
+  asm volatile("ld.volatile.global.u32 %0, [%1]; membar.gl;"
                : "=r"(flag)
                : "l"(flag_addr));
 #endif

--- a/csrc/custom_all_reduce_test.cu
+++ b/csrc/custom_all_reduce_test.cu
@@ -49,7 +49,7 @@ __global__ void dummy_kernel() {
 #else
   for (int i = 0; i < 100; i++) {
     long long int start = clock64();
-    while (clock64() - start < 1000000);  // something like 100ms
+    while (clock64() - start < 150000000);  // approximately 98.4ms on P40
   }
 #endif
 }

--- a/csrc/custom_all_reduce_test.cu
+++ b/csrc/custom_all_reduce_test.cu
@@ -44,7 +44,14 @@
   } while (0)
 
 __global__ void dummy_kernel() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 700
   for (int i = 0; i < 100; i++) __nanosleep(1000000);  // 100ms
+#else
+  for (int i = 0; i < 100; i++) {
+    long long int start = clock64();
+    while (clock64() - start < 1000000);  // something like 100ms
+  }
+#endif
 }
 
 template <typename T>


### PR DESCRIPTION
#8558 introduces the use of acquire/release instructions, which are not supported on architectures below sm_70. This leads to build errors when compiling for older architectures:

```
ptxas /tmp/tmpxft_0000060f_00000000-13_custom_all_reduce.compute_60.ptx, line 338; error   : Feature '.release' requires .target sm_70 or higher
ptxas /tmp/tmpxft_0000060f_00000000-13_custom_all_reduce.compute_60.ptx, line 343; error   : Feature '.acquire' requires .target sm_70 or higher
...
```

(https://github.com/sasha0552/pascal-pkgs-ci/actions/runs/11005971990/job/30578026588)

This PR attempts to fix these build errors by implementing a polyfill of these instructions.

The polyfill was adapted from this code:
https://github.com/NVIDIA/nccl/blob/2ea4ee94bfb04c886c79ccae60ac9961000fdee2/src/device/op128.h#L304-L312
https://github.com/NVIDIA/nccl/blob/2ea4ee94bfb04c886c79ccae60ac9961000fdee2/src/device/op128.h#L324-L330

This PR hasn't been tested yet; I'll mark PR as ready for review when I test it.