### PR TITLE
[Misc] Change dummy profiling and BOS fallback warns to log once

### DIFF
--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -8,6 +8,7 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.transformers_utils.tokenizer_group import BaseTokenizerGroup
+from vllm.utils import print_warning_once
 
 from .data import (EncoderDecoderLLMInputs, LLMInputs, PromptInputs,
                    SingletonPromptInputs)
@@ -71,20 +72,21 @@ class InputPreprocessor:
         '''
 
         if not self.is_encoder_decoder_model():
-            logger.warning("Using None for decoder start token id because "
-                           "this is not an encoder/decoder model.")
+            print_warning_once("Using None for decoder start token id because "
+                               "this is not an encoder/decoder model.")
             return None
 
         if (self.model_config is None or self.model_config.hf_config is None):
-            logger.warning("Using None for decoder start token id because "
-                           "model config is not available.")
+            print_warning_once("Using None for decoder start token id because "
+                               "model config is not available.")
             return None
 
         dec_start_token_id = getattr(self.model_config.hf_config,
                                      'decoder_start_token_id', None)
         if dec_start_token_id is None:
-            logger.warning("Falling back on <BOS> for decoder start token id "
-                           "because decoder start token id is not available.")
+            print_warning_once("Falling back on <BOS> for decoder start token "
+                               "id because decoder start token id is not "
+                               "available.")
             dec_start_token_id = self.get_bos_token_id()
 
         return dec_start_token_id

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -9,7 +9,7 @@ from transformers import PretrainedConfig
 from typing_extensions import TypeVar
 
 from vllm.logger import init_logger
-from vllm.utils import get_allowed_kwarg_only_overrides
+from vllm.utils import get_allowed_kwarg_only_overrides, print_warning_once
 
 from .data import LLMInputs
 
@@ -235,9 +235,9 @@ class InputRegistry:
         num_tokens = seq_data.prompt_token_ids
         if len(num_tokens) < seq_len:
             if is_encoder_data:
-                logger.warning(
-                    "Expected at least %d dummy encoder tokens for profiling, "
-                    "but found %d tokens instead.", seq_len, len(num_tokens))
+                print_warning_once(
+                    f"Expected at least {seq_len} dummy encoder tokens for "
+                    f"profiling, but found {len(num_tokens)} tokens instead.")
             else:
                 raise AssertionError(
                     f"Expected at least {seq_len} dummy tokens for profiling, "


### PR DESCRIPTION
Found while running the mllama example: `python examples/offline_inference_vision_language.py -m mllama`

Before:
```
INFO 09-25 20:30:25 model_runner.py:1025] Loading model weights took 19.9073 GB
INFO 09-25 20:30:25 enc_dec_model_runner.py:297] Starting profile run for multi-modal models.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
INFO 09-25 20:30:33 gpu_executor.py:122] # GPU blocks: 9938, # CPU blocks: 1638
WARNING 09-25 20:30:35 preprocess.py:86] Falling back on <BOS> for decoder start token id because decoder start token id is not available.
WARNING 09-25 20:30:35 preprocess.py:86] Falling back on <BOS> for decoder start token id because decoder start token id is not available.
WARNING 09-25 20:30:35 preprocess.py:86] Falling back on <BOS> for decoder start token id because decoder start token id is not available.
WARNING 09-25 20:30:35 preprocess.py:86] Falling back on <BOS> for decoder start token id because decoder start token id is not available.
```

After:
```
INFO 09-25 20:39:45 model_runner.py:1025] Loading model weights took 19.9073 GB
INFO 09-25 20:39:45 enc_dec_model_runner.py:297] Starting profile run for multi-modal models.
WARNING 09-25 20:39:45 utils.py:747] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
INFO 09-25 20:39:54 gpu_executor.py:122] # GPU blocks: 9938, # CPU blocks: 1638
WARNING 09-25 20:39:56 utils.py:747] Falling back on <BOS> for decoder start token id because decoder start token id is not available.
```