### PR TITLE
[Docs] Add README to the build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ COPY csrc csrc
 COPY setup.py setup.py
 COPY cmake cmake
 COPY CMakeLists.txt CMakeLists.txt
+COPY README.md README.md
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-cuda.txt requirements-cuda.txt
 COPY pyproject.toml pyproject.toml


### PR DESCRIPTION
Currently the vLLM PyPi has no description because we don't include the README when building the wheel in the docker

![image](https://github.com/user-attachments/assets/16d9a379-d6ec-4a5d-9803-a511c1d4dbc4)

We don't take notice of this in the CI because we have a sneaky fallback to an empty string in the read_readme function
https://github.com/vllm-project/vllm/blob/7193774b1ff8603ad5bf4598e5efba0d9a39b436/setup.py#L399-L405

This PR copies the README into the docker image so it will be included in the wheel