### PR TITLE
[CI/Build] install setuptools-scm when building the wheel

### DIFF
--- a/.github/workflows/scripts/build.sh
+++ b/.github/workflows/scripts/build.sh
@@ -8,7 +8,7 @@ PATH=${cuda_home}/bin:$PATH
 LD_LIBRARY_PATH=${cuda_home}/lib64:$LD_LIBRARY_PATH
 
 # Install requirements
-$python_executable -m pip install wheel packaging
+$python_executable -m pip install wheel packaging setuptools-scm>=8.0
 $python_executable -m pip install -r requirements-cuda.txt
 
 # Limit the number of parallel jobs to avoid OOM


### PR DESCRIPTION
`publish.yml` currently fails, see https://github.com/vllm-project/vllm/pull/8771#issuecomment-2376202075 for context