### PR TITLE
[Bugfix] Fix print_warning_once's line info

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -744,7 +744,8 @@ def create_kv_caches_with_random(
 
 @lru_cache
 def print_warning_once(msg: str) -> None:
-    logger.warning(msg)
+    # Set the stacklevel to 2 to print the caller's line info
+    logger.warning(msg, stacklevel=2)
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
Fix an issue where `print_warning_once` prints out useless line info on current main.

`logger.warning`:
```
WARNING 09-25 20:30:25 registry.py:238] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
```
vs
`print_warning_once`:
```
WARNING 09-25 20:39:45 utils.py:747] Expected at least 8192 dummy encoder tokens for profiling, but found 6404 tokens instead.
```