### PR TITLE
[ci] Soft fail Entrypoints, Samplers, LoRA, Decoder-only VLM

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -83,6 +83,7 @@ steps:
 
 - label: Entrypoints Test # 20min
   working_dir: "/vllm-workspace/tests"
+  soft_fail: true
   fast_check: true
   mirror_hardwares: [amd]
   source_file_dependencies:
@@ -174,6 +175,7 @@ steps:
     - pytest -v -s prefix_caching
 
 - label: Samplers Test # 18min
+  soft_fail: true
   source_file_dependencies:
   - vllm/model_executor/layers
   - vllm/sampling_metadata.py
@@ -201,6 +203,7 @@ steps:
 
 - label: LoRA Test %N # 30min each
   mirror_hardwares: [amd]
+  soft_fail: true
   source_file_dependencies:
   - vllm/lora
   - tests/lora
@@ -290,6 +293,7 @@ steps:
     - pytest -v -s models/decoder_only/language
 
 - label: Decoder-only Multi-Modal Models Test # 56min
+  soft_fail: true
   #mirror_hardwares: [amd]
   source_file_dependencies:
   - vllm/


### PR DESCRIPTION
A lot of tests broke due to transformer upgrade to `4.45` following Llama3.2 release. Soft-failing tests until they are fixed so we don't block CI