### PR TITLE
[Frontend] Utilize the non-blocking and exceptions of `recv_multipart` to reduce one `poll` operation per request.

### DIFF
--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -238,8 +238,13 @@ class MQLLMEngine:
     def handle_new_input(self):
         """Handle new input from the socket"""
         try:
-            while self.input_socket.poll(timeout=0) != 0:
-                frames = self.input_socket.recv_multipart(copy=False)
+            while True:
+                try:
+                    frames = self.input_socket.recv_multipart(
+                        flags=zmq.NOBLOCK, copy=False)
+                except zmq.error.Again:
+                    break
+
                 request = pickle.loads(frames[0].buffer)
 
                 if isinstance(request, RPCProcessRequest):


### PR DESCRIPTION
1. Utilize the non-blocking and exceptions of `recv_multipart` to reduce one `poll` operation per request.
2. Each poll operation consumes at least 10us.

Before optimization.

![优化前](https://github.com/user-attachments/assets/2635f034-e02a-4287-803f-49d234888fdf)

After optimization.

![优化后](https://github.com/user-attachments/assets/34af680a-a267-4225-8207-28d5c2077e6f)
