### PR TITLE
[Core]LLMEngine removes `sampling_params = sampling_params.clone()`

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -833,10 +833,6 @@ class LLMEngine:
             raise ValueError(f"Cannot request more than "
                              f"{max_logprobs} logprobs.")
 
-        # Defensive copy of SamplingParams, which are used by the sampler,
-        # this doesn't deep-copy LogitsProcessor objects
-        sampling_params = sampling_params.clone()
-
         sampling_params.update_from_generation_config(
             self.generation_config_fields, seq.eos_token_id)
 


### PR DESCRIPTION
I found that making a defensive copy of SamplingParams seems unnecessary. In my application scenario, removing the defensive copy of SamplingParams worked normally and resulted in performance improvement.

In my scenario, the comparison before and after removal shows a reduction of 176us per request.

Before removing it.
![1](https://github.com/user-attachments/assets/91bfb569-df88-4e74-863d-5671a384f7ae)


After removing it.
![2](https://github.com/user-attachments/assets/6020bf70-0ded-4e10-b007-49d10d2e3d1a)

If my understanding is not thorough, please enlighten me.