### PR TITLE
[Bugfix] fix for deepseek w4a16

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/marlin.py
@@ -38,10 +38,11 @@ class MarlinLinearKernel(MPLinearKernel):
                             "Marlin, supported group sizes are: "\
                             f"{MARLIN_SUPPORTED_GROUP_SIZES}"
 
-        return check_marlin_supports_shape(c.partition_weight_shape[0],
-                                           c.partition_weight_shape[1],
-                                           c.full_weight_shape[1],
-                                           c.group_size)
+        return check_marlin_supports_shape(
+            c.partition_weight_shape[1], # out_features
+            c.partition_weight_shape[0], # in_features
+            c.full_weight_shape[0], # in_features
+            c.group_size)
 
     # note assumes that
     #  `weight_packed` is: {input_dim = 0, output_dim = 1, packed_dim = 0}

--- a/vllm/model_executor/layers/quantization/kernels/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/marlin.py
@@ -39,9 +39,9 @@ class MarlinLinearKernel(MPLinearKernel):
                             f"{MARLIN_SUPPORTED_GROUP_SIZES}"
 
         return check_marlin_supports_shape(
-            c.partition_weight_shape[1], # out_features
-            c.partition_weight_shape[0], # in_features
-            c.full_weight_shape[0], # in_features
+            c.partition_weight_shape[1],  # out_features
+            c.partition_weight_shape[0],  # in_features
+            c.full_weight_shape[0],  # in_features
             c.group_size)
 
     # note assumes that


### PR DESCRIPTION
Bad shape check `check_marlin_supports_shape` is out_features, in_features not in_features, out_features (opposite of torch.Linear and more other functions)