### PR TITLE
[misc][distributed] add VLLM_SKIP_P2P_CHECK flag

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -29,6 +29,8 @@ def _can_p2p(rank: int, world_size: int) -> bool:
         if i == rank:
             continue
         if envs.VLLM_SKIP_P2P_CHECK:
+            logger.info(
+                "Skipping P2P check and trusting the driver's P2P report.")
             return torch.cuda.can_device_access_peer(rank, i)
         if not gpu_p2p_access_check(rank, i):
             return False

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -28,6 +28,8 @@ def _can_p2p(rank: int, world_size: int) -> bool:
     for i in range(world_size):
         if i == rank:
             continue
+        if envs.VLLM_SKIP_P2P_CHECK:
+            return torch.cuda.can_device_access_peer(rank, i)
         if not gpu_p2p_access_check(rank, i):
             return False
     return True

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_ALLOW_DEPRECATED_BEAM_SEARCH: bool = False
+    VLLM_SKIP_P2P_CHECK: bool = False
 
 
 def get_default_cache_root():
@@ -423,6 +424,13 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda:
     (os.environ.get("VLLM_ALLOW_RUNTIME_LORA_UPDATING", "0").strip().lower() in
      ("1", "true")),
+
+    # By default, vLLM will check the peer-to-peer capability itself,
+    # in case of broken drivers. See https://github.com/vllm-project/vllm/blob/a9b15c606fea67a072416ea0ea115261a2756058/vllm/distributed/device_communicators/custom_all_reduce_utils.py#L101-L108 for details. # noqa
+    # If this env var is set to 1, vLLM will skip the peer-to-peer check,
+    # and trust the driver's peer-to-peer capability report.
+    "VLLM_SKIP_P2P_CHECK":
+    lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "0") == "1",
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
if users can trust their driver, they can opt in to skip the check (which takes ~30 seconds for tp=8)

note that one cluster usually has one driver version, so it is feasible for users to test it in one node, and then decide if they want to trust the driver directly.

steps:

1. run with the flag `export VLLM_SKIP_P2P_CHECK=1`
2. if it works, keep it for all nodes
3. if it does not work (might hang or break), it means the driver is broken. try to talk with the admin to upgrade the driver.
4. if you can do nothing about the driver, remove the env var, and use the default setting to let vllm check the actual p2p capability.