### PR TITLE
[Build/CI] Set FETCHCONTENT_BASE_DIR to one location for better caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+/.deps/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,16 @@ if(NVCC_THREADS AND VLLM_GPU_LANG STREQUAL "CUDA")
   list(APPEND VLLM_GPU_FLAGS "--threads=${NVCC_THREADS}")
 endif()
 
+
+#
+# Use FetchContent for C++ dependencies that are compiled as part of vLLM's build process.
+# Configure it to place files in vllm/.deps, in order to play nicely with sccache.
+#
 include(FetchContent)
+get_filename_component(PROJECT_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+file(MAKE_DIRECTORY "${FETCHCONTENT_BASE_DIR}")
+set(FETCHCONTENT_BASE_DIR "${PROJECT_ROOT_DIR}/.deps")
+message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
 
 #
 # Define other extension targets


### PR DESCRIPTION
We use CMake's FetchContent for managing dependencies that are compiled as part of vLLM's build process, e.g. CUTLASS, and vllm-flash-attn. FetchContent will by default place dependencies at `CMAKE_BINARY_DIR/_deps`. See documentation [here](https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_BASE_DIR).

When building vllm with `python setup.py build_ext --inplace`, this is OK, as `CMAKE_BINARY_DIR` will always be `vllm/build/temp.linux-x86_64-cpython-310`

However most people use `pip install -e .`, in which case `CMAKE_BINARY_DIR` will be a path like `/tmp/tmp9cnuhpg3.build-temp`. This path varies, which seems to be causing sccache misses and excessive compilation.

This PR sets `FETCH_CONTENT_BASE_DIR` in `CMakeLists.txt` to `vllm/.deps` to avoid these misses 

