### PR TITLE
speedup hash_of_block function

### DIFF
--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -746,7 +746,7 @@ class BlockSpaceManagerV1(BlockSpaceManager):
             return self.cpu_allocator.get_prefix_cache_hit_rate()
         raise ValueError(f"Invalid device: {device}")
 
-    def _get_pre_block_hash(self, seq: Sequence) -> int:
+    def _get_pre_block_hash(self, seq: Sequence) -> Optional[int]:
         if seq.n_blocks > 1:
             block_table = self.block_tables[seq.seq_id]
             return block_table[seq.n_blocks - 2].block_hash

--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -330,7 +330,8 @@ class BlockSpaceManagerV1(BlockSpaceManager):
                 # Set the reference counts of the token blocks.
                 block.ref_count = ref_count
             elif not is_encoder_decoder and self.enable_caching:
-                pre_block_hash = block_table[logical_idx - 1].block_hash if logical_idx > 0 else None
+                pre_block_hash = block_table[logical_idx - 1].block_hash \
+                    if logical_idx > 0 else None
                 block = self.gpu_allocator.allocate(
                     seq.hash_of_block(logical_idx, pre_block_hash),
                     seq.num_hashed_tokens_of_block(logical_idx))

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -283,7 +283,7 @@ class SequenceData(msgspec.Struct,
 
     def get_range_token_ids(
             self, start_pos: int, end_pos: int
-    ) -> Tuple[Tuple[int, ...], Optional[Tuple[int, ...]]]:
+    ) -> Tuple[Optional[Tuple[int, ...]], Optional[Tuple[int, ...]]]:
         """Get range tokens, and make the return value hashable"""
         num_tokens = end_pos - start_pos
         prompt_length = self.get_prompt_len()

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -538,7 +538,7 @@ class Sequence:
 
         return self.data._cached_all_token_ids[-num_new_tokens:]
 
-    def hash_of_block(self, logical_idx: int, pre_block_hash: int) -> int:
+    def hash_of_block(self, logical_idx: int, pre_block_hash: Optional[int] = None) -> int:
         # TODO This can produce incorrect hash when block size > prompt size
         # Compute the number of tokens in the sequence
         # The current hashing function is O(L).

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -291,11 +291,14 @@ class SequenceData(msgspec.Struct,
             if end_pos <= prompt_length:
                 return (self._prompt_token_ids_tuple[start_pos: end_pos], None)
             else:
+                num_output_tokens = num_tokens - prompt_length
                 return (self._prompt_token_ids_tuple,
-                        tuple(self._output_token_ids[:num_tokens - prompt_length]))
+                        tuple(self._output_token_ids[:num_output_tokens]))
         else:
+            output_start_pos = start_pos - prompt_length
+            output_end_pos = end_pos - prompt_length
             return (None,
-                    tuple(self._output_token_ids[start_pos - prompt_length : end_pos - prompt_length]))
+                    tuple(self._output_token_ids[output_start_pos : output_end_pos]))
 
     def get_num_computed_tokens(self) -> int:
         """Return the number of prefill tokens that are already computed."""


### PR DESCRIPTION
The current time complexity of the hash_of_block function is O(n^2). This PR aimed to optimize it to O(n) by including the hash of the predecessor block in the calculation, in addition to the tokens of current block when calculating its hash.