### PR TITLE
[Misc] log when using default MoE config

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -320,8 +320,9 @@ def get_moe_configs(E: int, N: int,
 
     # If no optimized configuration is available, we will use the default
     # configuration
-    logger.info("Using default MoE config. Config file not found at %s",
-                config_file_path)
+    logger.warning(
+        ("Using default MoE config. Performance might be sub-optimal! "
+         "Config file not found at %s"), config_file_path)
     return None
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -320,6 +320,8 @@ def get_moe_configs(E: int, N: int,
 
     # If no optimized configuration is available, we will use the default
     # configuration
+    logger.info("Using default MoE config. Config file not found at %s",
+                config_file_path)
     return None
 
 


### PR DESCRIPTION
MoE config file names are dependent on TP size, GPU name and dtype. 
This PR prevents silent fails when loading the MoE config file and explicitly prints the searched `config_file_path`