### PR TITLE
[CI/Build] Fix machete generated kernel files ordering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         && export CMAKE_BUILD_TYPE=Release \
         && sccache --show-stats \
         && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38 \
-        && sccache --show-stats; \
+        && SCCACHE_LOG=debug sccache --show-stats; \
     fi
 
 ENV CCACHE_DIR=/root/.cache/ccache

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,6 @@ ENV NVCC_THREADS=$nvcc_threads
 ARG USE_SCCACHE
 ARG SCCACHE_BUCKET_NAME=vllm-build-sccache
 ARG SCCACHE_REGION_NAME=us-west-2
-ARG SCCACHE_S3_NO_CREDENTIALS=0
 # if USE_SCCACHE is set, use sccache to speed up compilation
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
@@ -103,7 +102,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         && rm -rf sccache.tar.gz sccache-v0.8.1-x86_64-unknown-linux-musl \
         && export SCCACHE_BUCKET=${SCCACHE_BUCKET_NAME} \
         && export SCCACHE_REGION=${SCCACHE_REGION_NAME} \
-        && export SCCACHE_S3_NO_CREDENTIALS=${SCCACHE_S3_NO_CREDENTIALS} \
         && export SCCACHE_IDLE_TIMEOUT=0 \
         && export CMAKE_BUILD_TYPE=Release \
         && sccache --show-stats \

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ ENV NVCC_THREADS=$nvcc_threads
 ARG USE_SCCACHE
 ARG SCCACHE_BUCKET_NAME=vllm-build-sccache
 ARG SCCACHE_REGION_NAME=us-west-2
+ARG SCCACHE_S3_NO_CREDENTIALS=0
 # if USE_SCCACHE is set, use sccache to speed up compilation
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
@@ -102,11 +103,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         && rm -rf sccache.tar.gz sccache-v0.8.1-x86_64-unknown-linux-musl \
         && export SCCACHE_BUCKET=${SCCACHE_BUCKET_NAME} \
         && export SCCACHE_REGION=${SCCACHE_REGION_NAME} \
+        && export SCCACHE_S3_NO_CREDENTIALS=${SCCACHE_S3_NO_CREDENTIALS} \
         && export SCCACHE_IDLE_TIMEOUT=0 \
         && export CMAKE_BUILD_TYPE=Release \
         && sccache --show-stats \
         && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38 \
-        && SCCACHE_LOG=debug sccache --show-stats; \
+        && sccache --show-stats; \
     fi
 
 ENV CCACHE_DIR=/root/.cache/ccache

--- a/csrc/quantization/machete/generate.py
+++ b/csrc/quantization/machete/generate.py
@@ -457,8 +457,11 @@ def generate():
             )),
     ]
 
+    # Do not use schedules = list(set(...)) because we need to make sure
+    # the output list is deterministic; otherwise the generated kernel file
+    # will be non-deterministic and causes ccache miss.
     schedules = []
-    for constraints, schedule_config in default_heuristic:
+    for _, schedule_config in default_heuristic:
         if schedule_config not in schedules:
             schedules.append(schedule_config)
 

--- a/csrc/quantization/machete/generate.py
+++ b/csrc/quantization/machete/generate.py
@@ -457,7 +457,10 @@ def generate():
             )),
     ]
 
-    schedules = list(set([x[1] for x in default_heuristic]))
+    schedules = []
+    for constraints, schedule_config in default_heuristic:
+        if schedule_config not in schedules:
+            schedules.append(schedule_config)
 
     impl_configs = []
 


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/7701/files#diff-4f01f81e1eabfb248161ca5a69f9d98fe79208335b27b44b6122f1c26427809dR460 leads to `schedules` being created in a random order due to `set` being used to deduplicate schedule configs, thus leading to sccache miss on CI. This fixes the issue by adding schedule configs in the original deterministic order. 