### PR TITLE
[Bugfix] Fixes for Phi3v and Ultravox Multimodal EmbeddingInputs Support

### DIFF
--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -618,11 +618,13 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal):
             if is_list_of(image_data, torch.Tensor):
                 # it's already a list of tensors
                 return image_data
-            if len(image_data.shape) == 2:
-                # 2D tensor
-                return image_data
-            # 3D tensor
-            return list(torch.unbind(image_data, dim=0))
+            if len(image_data.shape) == 3:
+                # 3D tensor
+                return list(torch.unbind(image_data, dim=0))
+            raise ValueError(
+                "We expect batched 2D tensors;"
+                "this can be either a list of 2D tensors or a single 3D tensor."
+            )
 
         assert self.vision_embed_tokens is not None
         image_embeds = self.vision_embed_tokens(image_input["data"],

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -439,7 +439,7 @@ def input_processor_for_phi3v(ctx: InputContext,
     elif isinstance(image_data, torch.Tensor):
         num_images, image_feature_size, hidden_size = image_data.shape
     elif is_list_of(image_data, torch.Tensor):
-        image_feature_size = [item.shape[1] for item in image_data]
+        image_feature_size = [item.shape[0] for item in image_data]
     else:
         raise TypeError(f"Invalid image type: {type(image_data)}")
 
@@ -577,9 +577,6 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal):
         image_sizes = kwargs.pop("image_sizes", None)
         image_embeds = kwargs.pop("image_embeds", None)
 
-        if pixel_values is None:
-            return None
-
         if pixel_values is None and image_embeds is None:
             return None
 
@@ -616,7 +613,7 @@ class Phi3VForCausalLM(nn.Module, SupportsMultiModal):
     ) -> torch.Tensor:
 
         if image_input["type"] == "image_embeds":
-            return image_input["data"]
+            return list(torch.unbind(image_input["data"], dim=0))
 
         assert self.vision_embed_tokens is not None
         image_embeds = self.vision_embed_tokens(image_input["data"],

--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -153,8 +153,7 @@ def input_mapper_for_ultravox(ctx: InputContext, data: object):
         # Remove the batch dimension because we're wrapping it in a list.
         audio_features.append(single_audio_features.squeeze(0))
 
-    return (MultiModalInputs({"audio_embeds": audio_embeds})
-            if is_audio_embeds
+    return (MultiModalInputs({"audio_embeds": audio_embeds}) if is_audio_embeds
             else MultiModalInputs({"audio_features": audio_features}))
 
 
@@ -190,7 +189,7 @@ def input_processor_for_ultravox(ctx: InputContext, llm_inputs: LLMInputs):
                 max(
                     1,
                     math.ceil(feature_extractor_output_length /
-                            (uv_config.stack_factor * 2))),
+                              (uv_config.stack_factor * 2))),
                 get_ultravox_max_audio_tokens(ctx))
             audio_token_counts.append(audio_num_tokens)
 


### PR DESCRIPTION
I found some bugs with Phi3V and Ultravox related to EmbeddingInputs support. For Phi3V, there was an extra if statement and the input processor used the wrong shape dimension for image feature size. For Ultravox, while it had `UltravoxAudioEmbeddingInputs` as an input type, there wasn't actually support for `audio_embeds` in the code itself, so I added it.

FIX bugs found locally (I didn't see any existing issues, but I did run into these bugs locally).