### PR TITLE
[BugFix][SpecDecode] Allow Vllm to run with spec dec where the draft model is Sharded over more gpus

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1371,11 +1371,6 @@ class SpeculativeConfig:
             else:
                 speculative_draft_tensor_parallel_size = \
                     target_parallel_config.tensor_parallel_size
-        elif speculative_draft_tensor_parallel_size != 1:
-            # TODO(wooyeon): allow tp values larger than 1
-            raise ValueError(
-                f"{speculative_draft_tensor_parallel_size=} cannot be "
-                f"other value than 1")
 
         draft_parallel_config = ParallelConfig(
             pipeline_parallel_size=target_parallel_config.


### PR DESCRIPTION
By enabling sharding of the draft model, this change makes it possible to handle significantly larger models without being constrained by a single GPU’s memory and compute limitations.

Implemented the ability to shard the draft model across multiple GPUs, enabling better load distribution and memory usage. Ensured that existing functionality remains intact when the draft model is run on a single GPU for users with limited hardware resources.

The implementation was tested on multi-GPU setups with varying model sizes to ensure stability and performance.

FIX: #8980 [Speculative Decoding]: Shard draft model over multiple GPUs #8980


