### PR TITLE
[Bugfix] Fix Token IDs Reference for MiniCPM-V When Images are Provided With No Placeholders

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -274,8 +274,8 @@ def input_processor_for_minicpmv(ctx: InputContext, llm_inputs: LLMInputs):
             get_slice_image_placeholder(image_size, num_image)
 
     prompt = llm_inputs.get("prompt")
+    token_ids = llm_inputs.get("prompt_token_ids")
     if prompt is None:
-        token_ids = llm_inputs.get("prompt_token_ids")
         prompt = tokenizer.decode(token_ids)
 
     pattern = "(<image>./</image>)"


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/8990

Super small change to move the `llm_inputs.get("prompt_token_ids")` out of the conditional for when the prompt is `None` so that if `len(image_tags) == 0`, it doesn't throw from `token_ids` being undefined.