### PR TITLE
[Bugfix] example template should not add parallel_tool_prompt if tools is none

### DIFF
--- a/examples/tool_chat_template_mistral_parallel.jinja
+++ b/examples/tool_chat_template_mistral_parallel.jinja
@@ -6,8 +6,7 @@
 {%- endif %}
 {%- if not tools is defined %}
     {%- set tools = none %}
-{%- endif %}
-{%- if tools is defined %}
+{%- elif tools is not none %}
     {%- set parallel_tool_prompt = "You are a helpful assistant that can call tools. If you call one or more tools, format them in a single JSON array or objects, where each object is a tool call, not as separate objects outside of an array or multiple arrays. Use the format [{\"name\": tool call name, \"arguments\": tool call arguments}, additional tool calls] if you call more than one tool. If you call tools, do not attempt to interpret them or otherwise provide a response until you receive a tool call result that you can interpret for the user." %}
     {%- if system_message is defined %}
         {%- set system_message = parallel_tool_prompt + "\n\n" + system_message %}


### PR DESCRIPTION
The `tool_chat_template_mistral_parallel.jinja` template currently modifes the system prompt for parallel tool calling even if `tools` are not included with the request. This can cause the model to hallucinate tool calls when it is not expected.

For example, running vLLM with:
```
vllm serve mistralai/Mistral-7B-Instruct-v0.3 --enable-auto-tool-choice --tool-call-parser mistral --chat-template examples/tool_chat_template_mistral_parallel.jinja
 ```
 and sending a simple chat request
```
{
    "model": "mistralai/Mistral-7B-Instruct-v0.3",
    "messages": [
        {
            "role": "user",
            "content": "What is 1 + 1?"
        }
    ],
    "max_tokens": 300
}
```

The model generates a tool calling response
```
{
  "id": "chat-5e359eb4a1564b3693928bb05c2325c6",
  "object": "chat.completion",
  "created": 1727805219,
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": " [{\"name\": \"calculator\", \"arguments\": [\"1\", \"+\", \"1\"]}]",
        "tool_calls": []
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 122,
    "total_tokens": 144,
    "completion_tokens": 22
  },
  "prompt_logprobs": null
}
```

From the logs, it is clear that the `parallel_tool_prompt` is being injected into the request even though no tools are requested:

> INFO 10-01 17:53:39 logger.py:36] Received request chat-5e359eb4a1564b3693928bb05c2325c6: prompt: '\<s>[INST] You are a helpful assistant that can call tools. If you call one or more tools, format them in a single JSON array or objects, where each object is a tool call, not as separate objects outside of an array or multiple arrays. Use the format [{"name": tool call name, "arguments": tool call arguments}, additional tool calls] if you call more than one tool. If you call tools, do not attempt to interpret them or otherwise provide a response until you receive a tool call result that you can interpret for the user.\n\nWhat is 1 + 1?[/INST]', params: SamplingParams(n=1, best_of=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.7, top_p=1.0, top_k=-1, min_p=0.0, seed=None, use_beam_search=False, length_penalty=1.0, early_stopping=False, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=300, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None), prompt_token_ids: [1, 3, 1763, 1228, 1032, 11633, 14660, 1137, 1309, 1802, 7808, 29491, 1815, 1136, 1802, 1392, 1210, 1448, 7808, 29493, 5800, 1474, 1065, 1032, 3460, 10060, 3061, 1210, 7465, 29493, 1738, 2198, 2696, 1117, 1032, 4689, 1802, 29493, 1227, 1158, 8449, 7465, 4304, 1070, 1164, 3061, 1210, 5934, 26300, 29491, 6706, 1040, 5800, 1501, 7567, 1629, 2032, 4689, 1802, 1909, 29493, 1113, 17452, 2032, 4689, 1802, 7382, 1649, 5638, 4689, 7238, 29561, 1281, 1136, 1802, 1448, 1589, 1392, 4689, 29491, 1815, 1136, 1802, 7808, 29493, 1279, 1227, 5004, 1066, 7958, 1474, 1210, 6628, 3852, 1032, 3667, 2764, 1136, 6324, 1032, 4689, 1802, 1972, 1137, 1136, 1309, 7958, 1122, 1040, 2956, 29491, 781, 781, 3963, 1117, 29473, 29508, 1416, 29473, 29508, 29572, 4], lora_request: None, prompt_adapter_request: None.
INFO 10-01 17:53:39 engine.py:288] Added request chat-5e359eb4a1564b3693928bb05c2325c6.


With the modification to the template in this PR, the tool calling prompt is no longer injected and the response does not have the tool call JSON:
```
{
  "id": "chat-01c043f1b0c0461aa896dd95c98f44fc",
  "object": "chat.completion",
  "created": 1727804868,
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": " The sum of 1 and 1 is 2.",
        "tool_calls": []
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": null
    }
  ],
  "usage": {
    "prompt_tokens": 83,
    "total_tokens": 96,
    "completion_tokens": 13
  },
  "prompt_logprobs": null
}
```

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


