### PR TITLE
[BugFix] Enforce Mistral ToolCall id constraint when using the Mistral tool call parser

### DIFF
--- a/tests/tool_use/test_parallel_tool_calls.py
+++ b/tests/tool_use/test_parallel_tool_calls.py
@@ -45,7 +45,7 @@ async def test_parallel_tool_calls(client: openai.AsyncOpenAI,
         assert tool_call.type == "function"
         assert tool_call.function is not None
         assert isinstance(tool_call.id, str)
-        assert len(tool_call.id) > 16
+        assert len(tool_call.id) >= 9
 
         # make sure the weather tool was called correctly
         assert tool_call.function.name == WEATHER_TOOL["function"]["name"]
@@ -108,7 +108,7 @@ async def test_parallel_tool_calls(client: openai.AsyncOpenAI,
             if tool_call.id:
                 tool_call_id_count += 1
                 assert (isinstance(tool_call.id, str)
-                        and (len(tool_call.id) > 16))
+                        and (len(tool_call.id) >= 9))
 
             # if parts of the function start being streamed
             if tool_call.function:

--- a/tests/tool_use/test_tool_calls.py
+++ b/tests/tool_use/test_tool_calls.py
@@ -33,7 +33,7 @@ async def test_tool_call_and_choice(client: openai.AsyncOpenAI):
     assert tool_calls[0].type == 'function'
     assert tool_calls[0].function is not None
     assert isinstance(tool_calls[0].id, str)
-    assert len(tool_calls[0].id) > 16
+    assert len(tool_calls[0].id) >= 9
 
     # make sure the weather tool was called (classic example) with arguments
     assert tool_calls[0].function.name == WEATHER_TOOL["function"]["name"]
@@ -106,7 +106,7 @@ async def test_tool_call_and_choice(client: openai.AsyncOpenAI):
 
     assert finish_reason_count == 1
     assert role_name == 'assistant'
-    assert isinstance(tool_call_id, str) and (len(tool_call_id) > 16)
+    assert isinstance(tool_call_id, str) and (len(tool_call_id) >= 9)
 
     # validate the name and arguments
     assert function_name == WEATHER_TOOL["function"]["name"]


### PR DESCRIPTION
This PR introduces a dedicated `MistralToolCall` object (directly inheriting from `ToolCall`) to enforce the random alphanumeric string of size 9 to be used for tool calls parsed with Mistral tool call parser.

FIX #9019




