### PR TITLE
mLlama load error with non-default vocabulary sizes

### DIFF
--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -778,7 +778,10 @@ class MllamaTextModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        self.embed_tokens = VocabParallelEmbedding(config.vocab_size + 8,
+
+        # Adjusting to the nearest padding multiple
+        vocab_size_adjusted = math.ceil(config.vocab_size / 64) * 64
+        self.embed_tokens = VocabParallelEmbedding(vocab_size_adjusted,
                                                    config.hidden_size)
         self.cross_attention_layers = config.cross_attention_layers
 


### PR DESCRIPTION
mllama has an unexplained offset in its tokenizer initialization. I assume it's to deal with an adding issue, but I'm unsure. If you add any special tokens to the model, it is unable to initialize.

Happy to make a more in depth edit, but I wanted to confirm I was on the right path first.


@DarkLight1337 any insight?