### PR TITLE
[Misc] Enable multi-step output streaming by default

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -145,7 +145,7 @@ class EngineArgs:
     max_cpu_loras: Optional[int] = None
     device: str = 'auto'
     num_scheduler_steps: int = 1
-    multi_step_stream_outputs: bool = False
+    multi_step_stream_outputs: bool = True
     ray_workers_use_nsight: bool = False
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = 0
@@ -600,13 +600,17 @@ class EngineArgs:
 
         parser.add_argument(
             '--multi-step-stream-outputs',
-            action='store_true',
-            help='If True, then multi-step will stream outputs for every step')
+            action=StoreBoolean,
+            default=EngineArgs.multi_step_stream_outputs,
+            nargs="?",
+            const="True",
+            help='If False, then multi-step will stream outputs at the end '
+            'of all steps')
         parser.add_argument(
             '--scheduler-delay-factor',
             type=float,
             default=EngineArgs.scheduler_delay_factor,
-            help='Apply a delay (of delay factor multiplied by previous'
+            help='Apply a delay (of delay factor multiplied by previous '
             'prompt latency) before scheduling next prompt.')
         parser.add_argument(
             '--enable-chunked-prefill',
@@ -629,7 +633,7 @@ class EngineArgs:
             type=nullable_str,
             choices=[*QUANTIZATION_METHODS, None],
             default=EngineArgs.speculative_model_quantization,
-            help='Method used to quantize the weights of speculative model.'
+            help='Method used to quantize the weights of speculative model. '
             'If None, we first check the `quantization_config` '
             'attribute in the model config file. If that is '
             'None, we assume the model weights are not '


### PR DESCRIPTION
I think we should consider enabling it by default for the so we have good ITL metrics with multi-step. There is a small performance penalty of ~7% in the PR that implemented this https://github.com/vllm-project/vllm/pull/8335, but we still have the flag in place to disable if needed, using `--multi-step-stream-outputs=False`.

Reposting performance metrics from linked PR implementing the feature:
Performance results for Llama 3.1 8B on H100 GPU with ShareGPT show that streaming introduces only 6% penalty for TPOT and improves ITL by 7.8X.

**Multi-step + async + no streaming**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  23.56     
Total input tokens:                      215196    
Total generated tokens:                  197521    
Request throughput (req/s):              42.44     
Output token throughput (tok/s):         8382.12   
Total Token throughput (tok/s):          17514.31  
---------------Time to First Token----------------
Mean TTFT (ms):                          7615.81   
Median TTFT (ms):                        7257.60   
P99 TTFT (ms):                           16401.42  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          26.01     
Median TPOT (ms):                        22.20     
P99 TPOT (ms):                           126.35    
---------------Inter-token Latency----------------
Mean ITL (ms):                           166.52    
Median ITL (ms):                         169.27    
P99 ITL (ms):                            505.28    
==================================================
```
**Multi-step + async + with streaming**
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  23.81     
Total input tokens:                      215196    
Total generated tokens:                  197520    
Request throughput (req/s):              41.99     
Output token throughput (tok/s):         8294.15   
Total Token throughput (tok/s):          17330.55  
---------------Time to First Token----------------
Mean TTFT (ms):                          7500.72   
Median TTFT (ms):                        7002.99   
P99 TTFT (ms):                           15986.18  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          27.78     
Median TPOT (ms):                        22.95     
P99 TPOT (ms):                           145.44    
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.30     
Median ITL (ms):                         14.17     
P99 ITL (ms):                            193.40    
==================================================

```