### PR TITLE
[Bugfix] Flash attention arches not getting set properly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,17 @@ if (NOT VLLM_TARGET_DEVICE STREQUAL "cuda")
   return()
 endif ()
 
+# vLLM flash attention requires VLLM_GPU_ARCHES to contain the set of target  
+# arches in the CMake syntax (75-real, 89-virtual, etc), since we clear the 
+# arches in the CUDA case (and instead set the gencodes on a per file basis) 
+# we need to manually set VLLM_GPU_ARCHES here.
+if(VLLM_GPU_LANG STREQUAL "CUDA")
+  foreach(_ARCH ${CUDA_ARCHS})
+    string(REPLACE "." "" _ARCH "${_ARCH}")
+    list(APPEND VLLM_GPU_ARCHES "${_ARCH}-real")
+  endforeach()
+endif()
+
 #
 # Build vLLM flash attention from source
 #


### PR DESCRIPTION
After https://github.com/vllm-project/vllm/pull/8845/ the flash attention arches were not getting set correctly since in the flash attention sub-repo the CMakeList.txt depends on VLLM_GPU_ARCHES (not something readily obvious). The https://github.com/vllm-project/vllm/pull/8845 PR stopped uses VLLM_GPU_ARCHES for CUDA in favor of setting the gencodes PR file. This is a quick fix (potential for a cleaner fix in a future PR) for restoring the VLLM_GPU_ARCHES to the state flash attention expects before the building flash attention.

(potentially fixes: https://github.com/vllm-project/vllm/issues/9060)