### PR TITLE
[Bugfix] Reshape the dimensions of the input image embeddings in Qwen2VL

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -967,6 +967,9 @@ class Qwen2VLForConditionalGeneration(nn.Module, SupportsMultiModal,
                                            image_grid_thw=image_grid_thw)
 
         if image_embeds is not None:
+            image_embeds = self._validate_and_reshape_mm_tensor(
+                image_embeds, "image embeds")
+
             if not isinstance(image_embeds, torch.Tensor):
                 raise ValueError("Incorrect type of image embeddings. "
                                  f"Got type: {type(image_embeds)}")


### PR DESCRIPTION
Reshape the dimensions of the input image embeddings to match those of pixel_values.

Without this adjustment, a dimension mismatch error will occur during batch inference when processing image embeddings.

Related to this previous issue https://github.com/vllm-project/vllm/pull/8856

```python
    image_embeds = ……
    # mm_data['image'] = image_embeds
    mm_data['image'] = {
        "image_embeds": image_embeds,
        "image_grid_thw":  inputs["image_grid_thw"],
    }

    llm_inputs = {
        "prompt": prompt,
        "multi_modal_data": mm_data,
    }

    outputs = llm.generate([llm_inputs]*2, sampling_params=sampling_params)
    generated_text = outputs[0].outputs[0].text
```