### PR TITLE
[Misc] Remove user-facing error for removed VLM args

### DIFF
--- a/docs/source/models/vlm.rst
+++ b/docs/source/models/vlm.rst
@@ -23,10 +23,6 @@ The :class:`~vllm.LLM` class can be instantiated in much the same way as languag
 
     llm = LLM(model="llava-hf/llava-1.5-7b-hf")
 
-.. note::
-    We have removed all vision language related CLI args in the ``0.5.1`` release. **This is a breaking change**, so please update your code to follow
-    the above snippet. Specifically, ``image_feature_size`` can no longer be specified as we now calculate that internally for each model.
-
 To pass an image to the model, note the following in :class:`vllm.inputs.PromptType`:
 
 * ``prompt``: The prompt should follow the format that is documented on HuggingFace.

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -180,15 +180,7 @@ class LLM:
 
         if "disable_log_stats" not in kwargs:
             kwargs["disable_log_stats"] = True
-        removed_vision_keys = (
-            "image_token_id",
-            "image_feature_size",
-            "image_input_shape",
-            "image_input_type",
-        )
-        if any(k in kwargs for k in removed_vision_keys):
-            raise TypeError(
-                "There is no need to pass vision-related arguments anymore.")
+
         engine_args = EngineArgs(
             model=model,
             tokenizer=tokenizer,


### PR DESCRIPTION
Considering that more than one minor version has passed already, this PR removes the special error handling for the VLM CLI args that have been removed in v0.5.1.