### PR TITLE
[CI/Build] Update Dockerfile install+deploy image to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 #################### DEV IMAGE ####################
 #################### vLLM installation IMAGE ####################
 # image with vLLM installed
-FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu20.04 AS vllm-base
+FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu22.04 AS vllm-base
 ARG CUDA_VERSION=12.4.1
 ARG PYTHON_VERSION=3.12
 WORKDIR /vllm-workspace


### PR DESCRIPTION
We need to build the vLLM wheel using ubuntu 20.04 in order to make a widely usable wheel (ref: https://github.com/vllm-project/vllm/pull/6517), but the final deployment image where we install the wheel can use a newer version with LTS. Several users have been reporting that it would be helpful for a variety of reasons (security, package versions, etc) to upgrade the official vLLM docker image to a more modern OS version. 

This idea has been mentioned a few times to separate the OS from build and install+deploy (ref: https://github.com/vllm-project/vllm/pull/6820#issuecomment-2252030438)