### PR TITLE
Update link to KServe deployment guide

### DIFF
--- a/docs/source/serving/deploying_with_kserve.rst
+++ b/docs/source/serving/deploying_with_kserve.rst
@@ -5,4 +5,4 @@ Deploying with KServe
 
 vLLM can be deployed with `KServe <https://github.com/kserve/kserve>`_ on Kubernetes for highly scalable distributed model serving.
 
-Please see `this guide <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/vllm/>`_ for more details on using vLLM with KServe.
+Please see `this guide <https://kserve.github.io/website/latest/modelserving/v1beta1/llm/huggingface/>`_ for more details on using vLLM with KServe.


### PR DESCRIPTION
This would be the new overview guide for deploying vLLM via KServe's Hugging Face Runtime (vLLM engine is the default).