### PR TITLE
[CI/Build] mypy: check vllm/entrypoints

### DIFF
--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -19,7 +19,7 @@ run_mypy vllm/attention
 #run_mypy vllm/core
 run_mypy vllm/distributed
 run_mypy vllm/engine
-#run_mypy vllm/entrypoints
+run_mypy vllm/entrypoints
 run_mypy vllm/executor
 #run_mypy vllm/inputs
 run_mypy vllm/logging

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -514,10 +514,13 @@ class LLM:
         # Handle multi and single conversations
         if is_list_of(messages, list):
             # messages is List[List[...]]
-            list_of_messages = messages
+            list_of_messages = cast(List[List[ChatCompletionMessageParam]],
+                                    messages)
         else:
             # messages is List[...]
-            list_of_messages = [messages]
+            list_of_messages = [
+                cast(List[ChatCompletionMessageParam], messages)
+            ]
 
         prompts: List[Union[TokensPrompt, TextPrompt]] = []
 


### PR DESCRIPTION
Resolve mypy warnings under `vllm/entrypoints` and turn on `mypy`
checks for this directory in `format.sh` and in CI.

part of issue #3680

Signed-off-by: Russell Bryant <rbryant@redhat.com>
