### PR TITLE
[Core] Fix invalid args to _process_request

### DIFF
--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -606,7 +606,8 @@ class MQLLMEngineClient:
                 and request_id is not None)
 
         return self._process_request(prompt, pooling_params, request_id,
-                                     lora_request, trace_headers, priority)
+                                     lora_request, trace_headers, None,
+                                     priority)
 
     async def _process_request(
         self,


### PR DESCRIPTION
I spotted this while working on expanding coverage with `mypy`. This
call to `_process_request` passed `priority` in the positional
argument location for `prompt_adapter_request`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
