### PR TITLE
[Bugfix] Fix Weight Loading Multiple GPU Test - Large Models

### DIFF
--- a/tests/weight_loading/models-large.txt
+++ b/tests/weight_loading/models-large.txt
@@ -1,6 +1,5 @@
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-quantized, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W4A16-channel-quantized, main
 compressed-tensors, nm-testing/Mixtral-8x7B-Instruct-v0.1-W8A16-quantized, main
-compressed-tensors, mgoin/DeepSeek-Coder-V2-Lite-Instruct-FP8, main
 gptq_marlin, TheBloke/Mixtral-8x7B-v0.1-GPTQ, main
 awq_marlin, casperhansen/deepseek-coder-v2-instruct-awq, main

--- a/tests/weight_loading/models.txt
+++ b/tests/weight_loading/models.txt
@@ -20,6 +20,7 @@ compressed-tensors, nm-testing/Meta-Llama-3-8B-FP8-compressed-tensors-test, main
 compressed-tensors, nm-testing/Phi-3-mini-128k-instruct-FP8, main
 compressed-tensors, neuralmagic/Phi-3-medium-128k-instruct-quantized.w4a16, main
 compressed-tensors, nm-testing/TinyLlama-1.1B-Chat-v1.0-actorder-group, main
+compressed-tensors, mgoin/DeepSeek-Coder-V2-Lite-Instruct-FP8, main
 awq, casperhansen/mixtral-instruct-awq, main
 awq_marlin, casperhansen/mixtral-instruct-awq, main
 fp8, neuralmagic/Meta-Llama-3-8B-Instruct-FP8-KV, main


### PR DESCRIPTION
The weight loading multiple gpu "large" test has been failing on main ([link](https://buildkite.com/vllm/ci-aws/builds/9703#0192729f-c700-4c9e-990e-8157c85d377d)) due to the DeepSeek-Coder-V2-Lite-Instruct model being too small for TP=2 with fp8 marlin. Let's try moving the model to the regular set of models to avoid A100.