### PR TITLE
[Bugfix] Fix Machete unittests failing with `NotImplementedError`

### DIFF
--- a/csrc/quantization/machete/machete_pytorch.cu
+++ b/csrc/quantization/machete/machete_pytorch.cu
@@ -89,6 +89,10 @@ torch::Tensor prepack_B(torch::Tensor const& B,
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("machete_prepack_B", &prepack_B);
   m.impl("machete_gemm", &gemm);
+}
+
+// use CatchAll since supported_schedules has no tensor arguments
+TORCH_LIBRARY_IMPL(TORCH_EXTENSION_NAME, CatchAll, m) {
   m.impl("machete_supported_schedules", &supported_schedules);
 }
 


### PR DESCRIPTION
After https://github.com/vllm-project/vllm/pull/8845 
```
pytest tests/kernels/test_machete_gemm.py::test_machete_all_schedules
```
started failing due to `machete_supported_schedules` being registered for CUDA despite having no tensor args (so the dispatcher doesn't know how to dispatch it), fixed this by moving its dispatch key back to `CatchAll`