### PR TITLE
[Model] support input image embedding for minicpmv

### DIFF
--- a/docs/source/models/supported_models.rst
+++ b/docs/source/models/supported_models.rst
@@ -378,7 +378,7 @@ Text Generation
     - ✅︎
   * - :code:`MiniCPMV`
     - MiniCPM-V
-    - Image\ :sup:`+`
+    - Image\ :sup:`E+`
     - :code:`openbmb/MiniCPM-V-2` (see note), :code:`openbmb/MiniCPM-Llama3-V-2_5`, :code:`openbmb/MiniCPM-V-2_6`, etc.
     - ✅︎
     - ✅︎

--- a/docs/source/models/vlm.rst
+++ b/docs/source/models/vlm.rst
@@ -58,7 +58,9 @@ To pass an image to the model, note the following in :class:`vllm.inputs.PromptT
 
     # Inference with image embeddings as input with additional parameters
     # Specifically, we are conducting a trial run of Qwen2VL and MiniCPM-V with the new input format, which utilizes additional parameters.
-    image_embeds = torch.load(...) # torch.Tensor of shape (1, image_feature_size, hidden_size of LM)
+    mm_data = {}
+
+    image_embeds = torch.load(...) # torch.Tensor of shape (num_images, image_feature_size, hidden_size of LM)
     # For Qwen2VL, image_grid_thw is needed to calculate positional encoding.
     mm_data['image'] = {
         "image_embeds": image_embeds,

--- a/docs/source/models/vlm.rst
+++ b/docs/source/models/vlm.rst
@@ -57,12 +57,17 @@ To pass an image to the model, note the following in :class:`vllm.inputs.PromptT
         print(generated_text)
 
     # Inference with image embeddings as input with additional parameters
-    # Specifically, we are conducting a trial run of Qwen2VL with the new input format, as the model utilizes additional parameters for calculating positional encoding.
+    # Specifically, we are conducting a trial run of Qwen2VL and MiniCPM-V with the new input format, which utilizes additional parameters.
     image_embeds = torch.load(...) # torch.Tensor of shape (1, image_feature_size, hidden_size of LM)
-    image_grid_thw = torch.load(...) # torch.Tensor of shape (1, 3)
+    # For Qwen2VL, image_grid_thw is needed to calculate positional encoding.
     mm_data['image'] = {
         "image_embeds": image_embeds,
-        "image_grid_thw":  image_grid_thw,
+        "image_grid_thw": torch.load(...) # torch.Tensor of shape (1, 3),
+    }
+    # For MiniCPM-V, image_size_list is needed to calculate details of the sliced image.
+    mm_data['image'] = {
+        "image_embeds": image_embeds,
+        "image_size_list": [image.size] # list of image sizes
     }
     outputs = llm.generate({
         "prompt": prompt,

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -425,7 +425,8 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
             vision_hidden_states = torch.tensor([], device=input_ids.device)
         else:
             if image_inputs["type"] == "image_embeds":
-                vision_hidden_states = image_inputs["data"]
+                vision_hidden_states = (image_inputs["data"].type(
+                    vlm_embedding.dtype).to(vlm_embedding.device))
             else:
                 vision_hidden_states = self.get_vision_hidden_states(
                     image_inputs)

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -758,7 +758,7 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
 
     def get_vision_hidden_states(self,
                                  data: MiniCPMVImageInputs) -> torch.Tensor:
-        pixel_values = data["pixel_values"]
+        pixel_values = data["data"]
 
         return self.get_vision_embedding(pixel_values)
 
@@ -846,7 +846,7 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
 
     def get_vision_hidden_states(self,
                                  data: MiniCPMVImageInputs) -> torch.Tensor:
-        pixel_values = data["pixel_values"]
+        pixel_values = data["data"]
         tgt_sizes = data["tgt_sizes"]
 
         device = self.vpm.embeddings.position_embedding.weight.device

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -24,9 +24,8 @@
 import math
 import re
 from functools import partial
-from typing import (Any, Callable, Iterable, List, Mapping, Optional, Tuple,
-                    TypedDict)
-
+from typing import (Any, Callable, Iterable, List, Literal, Mapping, Optional,
+                    Tuple, TypedDict, Union)
 import torch
 import torch.types
 from PIL import Image
@@ -65,10 +64,12 @@ _KEYS_TO_MODIFY_MAPPING = {
     "llm.lm_head": "lm_head",
 }
 
+RawImageType = Union[Image.Image, torch.Tensor]
 
-class MiniCPMVImageInput(TypedDict):
+
+class MiniCPMVRawImageInput(TypedDict):
     """Input mapper input with auxiliary data for computing image bounds."""
-    image: Image.Image
+    image: RawImageType
 
     # Image bounds token ids in 0-dim scaler tensor.
     im_start_id: torch.Tensor
@@ -78,7 +79,8 @@ class MiniCPMVImageInput(TypedDict):
 
 
 class MiniCPMVImagePixelInputs(TypedDict):
-    pixel_values: List[torch.Tensor]
+    type: Literal["pixel_values"]
+    data: List[torch.Tensor]
     """
     Shape: `(batch_size * num_images, num_channels, height, width)`
 
@@ -100,6 +102,27 @@ class MiniCPMVImagePixelInputs(TypedDict):
     This should be in `(height, width)` format.
     """
 
+
+class MiniCPMVImageEmbeddingInputs(TypedDict):
+    type: Literal["image_embeds"]
+    data: torch.Tensor
+    """
+    Shape: `(batch_size * num_images, image_feature_size, hidden_size)`
+
+    `hidden_size` must match the hidden size of language model backbone.
+    instead of a batched tensor.
+    """
+
+    image_bounds: torch.Tensor
+    """
+    Shape: `(batch_size * num_images, 2)`
+
+    This should be in `(start, stop)` format.
+    """
+
+
+MiniCPMVImageInputs = Union[MiniCPMVImagePixelInputs,
+                            MiniCPMVImageEmbeddingInputs]
 
 DEFAULT_LN = partial(nn.LayerNorm, eps=1e-6)
 
@@ -194,22 +217,22 @@ class Resampler2_5(BaseResampler):
 
 
 def _build_image_input(ctx: InputContext,
-                       image: Image.Image) -> MiniCPMVImageInput:
+                       image: RawImageType) -> MiniCPMVRawImageInput:
     tokenizer = cached_get_tokenizer(
         ctx.model_config.tokenizer,
         trust_remote_code=ctx.model_config.trust_remote_code)
     if hasattr(tokenizer, "slice_start_id"):
-        return MiniCPMVImageInput(
+        return MiniCPMVRawImageInput(
             image=image,
             im_start_id=torch.tensor(tokenizer.im_start_id),
             im_end_id=torch.tensor(tokenizer.im_end_id),
             slice_start_id=torch.tensor(tokenizer.slice_start_id),
             slice_end_id=torch.tensor(tokenizer.slice_end_id))
     else:
-        return MiniCPMVImageInput(image=image,
-                                  im_start_id=torch.tensor(
-                                      tokenizer.im_start_id),
-                                  im_end_id=torch.tensor(tokenizer.im_end_id))
+        return MiniCPMVRawImageInput(
+            image=image,
+            im_start_id=torch.tensor(tokenizer.im_start_id),
+            im_end_id=torch.tensor(tokenizer.im_end_id))
 
 
 def get_version_by_config(config: PretrainedConfig) -> Tuple[int, ...]:
@@ -280,20 +303,25 @@ def input_processor_for_minicpmv(ctx: InputContext, llm_inputs: LLMInputs):
 
     pattern = "(<image>./</image>)"
     images = multi_modal_data["image"]
-    if isinstance(images, Image.Image):
-        images = [images]
     image_tags = re.findall(pattern, prompt)
-
     if len(image_tags) == 0:
         new_token_ids = token_ids
         new_prompt = prompt
     else:
+        if isinstance(images, dict):
+            image_size_list = images.get("image_size_list")
+            images = [images.get("image_embeds")]
+        else:
+            if isinstance(images, Image.Image):
+                images = [images]
+            image_size_list = [image.size for image in images]
+
         text_chunks = prompt.split(pattern)
         new_prompt_chunks: List[str] = []
-        for i in range(len(images)):
+        for i in range(len(image_size_list)):
             new_prompt_chunks += [
                 text_chunks[i],
-                get_placeholder(images[i].size, i)
+                get_placeholder(image_size_list[i], i)
             ]
         new_prompt_chunks.append(text_chunks[-1])
         new_prompt = "".join(new_prompt_chunks)
@@ -323,9 +351,15 @@ def input_mapper_for_minicpmv(ctx: InputContext, data: object):
     if not isinstance(data, list):
         raise ValueError(
             "Image input must be list of MiniCPMVImageInput, got (%s)", data)
-    batch_data = image_processor \
-        .preprocess([img["image"] for img in data], return_tensors="pt") \
-        .data
+
+    if len(data) > 0 and isinstance(data[0]['image'], torch.Tensor):
+        batch_data = {
+            "image_embeds": data[0]['image'],
+        }
+    else:
+        batch_data = image_processor \
+            .preprocess([img["image"] for img in data], return_tensors="pt") \
+            .data
 
     if len(data) > 0:
         batch_data["im_start_id"] = data[0]["im_start_id"]
@@ -380,7 +414,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
     def get_embedding(
         self,
         input_ids: torch.Tensor,
-        image_inputs: Optional[MiniCPMVImagePixelInputs],
+        image_inputs: Optional[MiniCPMVImageInputs],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         vlm_embedding: torch.Tensor = self.llm.embed_tokens(input_ids)
         if hasattr(self.config, "scale_emb"):
@@ -389,7 +423,11 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         if image_inputs is None:  # No image
             vision_hidden_states = torch.tensor([], device=input_ids.device)
         else:
-            vision_hidden_states = self.get_vision_hidden_states(image_inputs)
+            if image_inputs["type"] == "image_embeds":
+                vision_hidden_states = image_inputs["data"]
+            else:
+                vision_hidden_states = self.get_vision_hidden_states(
+                    image_inputs)
 
             # See NOTE in _parse_and_validate_inputs
             image_bounds = image_inputs["image_bounds"]
@@ -440,9 +478,23 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         self,
         input_ids: torch.Tensor,
         **kwargs: object,
-    ) -> Optional[MiniCPMVImagePixelInputs]:
+    ) -> Optional[MiniCPMVImageInputs]:
         pixel_values = kwargs.pop("pixel_values", [])
         tgt_sizes = kwargs.pop("tgt_sizes", [])
+        im_start_id = kwargs.pop("im_start_id", None)
+        im_end_id = kwargs.pop("im_end_id", None)
+        slice_start_id = kwargs.pop("slice_start_id", None)
+        slice_end_id = kwargs.pop("slice_end_id", None)
+        image_embeds = kwargs.pop("image_embeds", None)
+
+        if image_embeds is not None:
+            return MiniCPMVImageEmbeddingInputs(
+                image_bounds=self._get_image_bounds(input_ids, im_start_id,
+                                                    im_end_id, slice_start_id,
+                                                    slice_end_id),
+                data=image_embeds,
+                type="image_embeds",
+            )
 
         if not isinstance(pixel_values, (torch.Tensor, list)):
             raise ValueError("Incorrect type of pixel values. "
@@ -477,10 +529,6 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         if len(pixel_values_flat) == 0:
             return None
 
-        im_start_id = kwargs.pop("im_start_id", None)
-        im_end_id = kwargs.pop("im_end_id", None)
-        slice_start_id = kwargs.pop("slice_start_id", None)
-        slice_end_id = kwargs.pop("slice_end_id", None)
         if im_start_id is None:
             return None
 
@@ -488,8 +536,9 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
             image_bounds=self._get_image_bounds(input_ids, im_start_id,
                                                 im_end_id, slice_start_id,
                                                 slice_end_id),
-            pixel_values=pixel_values_flat,
+            data=pixel_values_flat,
             tgt_sizes=torch.stack(tgt_sizes_flat),
+            type="pixel_values",
         )
 
     def forward(
@@ -610,8 +659,8 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
     ) -> torch.Tensor:
         raise NotImplementedError
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         raise NotImplementedError
 
     def is_default_weight_loading(self, name: str) -> bool:
@@ -705,8 +754,8 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
             res.append(self.resampler(vision_embedding, tgt_size))
         return torch.vstack(res)
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
 
         return self.get_vision_embedding(pixel_values)
@@ -793,8 +842,8 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
         vision_embedding = self.resampler(vision_embedding, tgt_sizes)
         return vision_embedding
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
         tgt_sizes = data["tgt_sizes"]
 
@@ -909,9 +958,9 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
         )
         return vision_embedding
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
-        pixel_values = data["pixel_values"]
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
+        pixel_values = data["data"]
         tgt_sizes = data["tgt_sizes"]
 
         device = self.vpm.embeddings.position_embedding.weight.device

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -24,8 +24,8 @@
 import math
 import re
 from functools import partial
-from typing import (Any, Callable, Iterable, List, Mapping, Optional, Tuple,
-                    TypedDict)
+from typing import (Any, Callable, Iterable, List, Literal, Mapping, Optional,
+                    Tuple, TypedDict, Union)
 
 import torch
 import torch.types
@@ -65,10 +65,12 @@ _KEYS_TO_MODIFY_MAPPING = {
     "llm.lm_head": "lm_head",
 }
 
+RawImageType = Union[Image.Image, torch.Tensor]
 
-class MiniCPMVImageInput(TypedDict):
+
+class MiniCPMVRawImageInput(TypedDict):
     """Input mapper input with auxiliary data for computing image bounds."""
-    image: Image.Image
+    image: RawImageType
 
     # Image bounds token ids in 0-dim scaler tensor.
     im_start_id: torch.Tensor
@@ -78,7 +80,8 @@ class MiniCPMVImageInput(TypedDict):
 
 
 class MiniCPMVImagePixelInputs(TypedDict):
-    pixel_values: List[torch.Tensor]
+    type: Literal["pixel_values"]
+    data: List[torch.Tensor]
     """
     Shape: `(batch_size * num_images, num_channels, height, width)`
 
@@ -100,6 +103,27 @@ class MiniCPMVImagePixelInputs(TypedDict):
     This should be in `(height, width)` format.
     """
 
+
+class MiniCPMVImageEmbeddingInputs(TypedDict):
+    type: Literal["image_embeds"]
+    data: torch.Tensor
+    """
+    Shape: `(batch_size * num_images, image_feature_size, hidden_size)`
+
+    `hidden_size` must match the hidden size of language model backbone.
+    instead of a batched tensor.
+    """
+
+    image_bounds: torch.Tensor
+    """
+    Shape: `(batch_size * num_images, 2)`
+
+    This should be in `(start, stop)` format.
+    """
+
+
+MiniCPMVImageInputs = Union[MiniCPMVImagePixelInputs,
+                            MiniCPMVImageEmbeddingInputs]
 
 DEFAULT_LN = partial(nn.LayerNorm, eps=1e-6)
 
@@ -194,22 +218,22 @@ class Resampler2_5(BaseResampler):
 
 
 def _build_image_input(ctx: InputContext,
-                       image: Image.Image) -> MiniCPMVImageInput:
+                       image: RawImageType) -> MiniCPMVRawImageInput:
     tokenizer = cached_get_tokenizer(
         ctx.model_config.tokenizer,
         trust_remote_code=ctx.model_config.trust_remote_code)
     if hasattr(tokenizer, "slice_start_id"):
-        return MiniCPMVImageInput(
+        return MiniCPMVRawImageInput(
             image=image,
             im_start_id=torch.tensor(tokenizer.im_start_id),
             im_end_id=torch.tensor(tokenizer.im_end_id),
             slice_start_id=torch.tensor(tokenizer.slice_start_id),
             slice_end_id=torch.tensor(tokenizer.slice_end_id))
     else:
-        return MiniCPMVImageInput(image=image,
-                                  im_start_id=torch.tensor(
-                                      tokenizer.im_start_id),
-                                  im_end_id=torch.tensor(tokenizer.im_end_id))
+        return MiniCPMVRawImageInput(
+            image=image,
+            im_start_id=torch.tensor(tokenizer.im_start_id),
+            im_end_id=torch.tensor(tokenizer.im_end_id))
 
 
 def get_version_by_config(config: PretrainedConfig) -> Tuple[int, ...]:
@@ -280,20 +304,25 @@ def input_processor_for_minicpmv(ctx: InputContext, llm_inputs: LLMInputs):
 
     pattern = "(<image>./</image>)"
     images = multi_modal_data["image"]
-    if isinstance(images, Image.Image):
-        images = [images]
     image_tags = re.findall(pattern, prompt)
-
     if len(image_tags) == 0:
         new_token_ids = token_ids
         new_prompt = prompt
     else:
+        if isinstance(images, dict):
+            image_size_list = images.get("image_size_list")
+            images = [images.get("image_embeds")]
+        else:
+            if isinstance(images, Image.Image):
+                images = [images]
+            image_size_list = [image.size for image in images]
+
         text_chunks = prompt.split(pattern)
         new_prompt_chunks: List[str] = []
-        for i in range(len(images)):
+        for i in range(len(image_size_list)):
             new_prompt_chunks += [
                 text_chunks[i],
-                get_placeholder(images[i].size, i)
+                get_placeholder(image_size_list[i], i)
             ]
         new_prompt_chunks.append(text_chunks[-1])
         new_prompt = "".join(new_prompt_chunks)
@@ -323,9 +352,15 @@ def input_mapper_for_minicpmv(ctx: InputContext, data: object):
     if not isinstance(data, list):
         raise ValueError(
             "Image input must be list of MiniCPMVImageInput, got (%s)", data)
-    batch_data = image_processor \
-        .preprocess([img["image"] for img in data], return_tensors="pt") \
-        .data
+
+    if len(data) > 0 and isinstance(data[0]['image'], torch.Tensor):
+        batch_data = {
+            "image_embeds": data[0]['image'],
+        }
+    else:
+        batch_data = image_processor \
+            .preprocess([img["image"] for img in data], return_tensors="pt") \
+            .data
 
     if len(data) > 0:
         batch_data["im_start_id"] = data[0]["im_start_id"]
@@ -380,7 +415,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
     def get_embedding(
         self,
         input_ids: torch.Tensor,
-        image_inputs: Optional[MiniCPMVImagePixelInputs],
+        image_inputs: Optional[MiniCPMVImageInputs],
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         vlm_embedding: torch.Tensor = self.llm.embed_tokens(input_ids)
         if hasattr(self.config, "scale_emb"):
@@ -389,7 +424,11 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         if image_inputs is None:  # No image
             vision_hidden_states = torch.tensor([], device=input_ids.device)
         else:
-            vision_hidden_states = self.get_vision_hidden_states(image_inputs)
+            if image_inputs["type"] == "image_embeds":
+                vision_hidden_states = image_inputs["data"]
+            else:
+                vision_hidden_states = self.get_vision_hidden_states(
+                    image_inputs)
 
             # See NOTE in _parse_and_validate_inputs
             image_bounds = image_inputs["image_bounds"]
@@ -440,9 +479,23 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         self,
         input_ids: torch.Tensor,
         **kwargs: object,
-    ) -> Optional[MiniCPMVImagePixelInputs]:
+    ) -> Optional[MiniCPMVImageInputs]:
         pixel_values = kwargs.pop("pixel_values", [])
         tgt_sizes = kwargs.pop("tgt_sizes", [])
+        im_start_id = kwargs.pop("im_start_id", None)
+        im_end_id = kwargs.pop("im_end_id", None)
+        slice_start_id = kwargs.pop("slice_start_id", None)
+        slice_end_id = kwargs.pop("slice_end_id", None)
+        image_embeds = kwargs.pop("image_embeds", None)
+
+        if image_embeds is not None:
+            return MiniCPMVImageEmbeddingInputs(
+                image_bounds=self._get_image_bounds(input_ids, im_start_id,
+                                                    im_end_id, slice_start_id,
+                                                    slice_end_id),
+                data=image_embeds,
+                type="image_embeds",
+            )
 
         if not isinstance(pixel_values, (torch.Tensor, list)):
             raise ValueError("Incorrect type of pixel values. "
@@ -477,10 +530,6 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         if len(pixel_values_flat) == 0:
             return None
 
-        im_start_id = kwargs.pop("im_start_id", None)
-        im_end_id = kwargs.pop("im_end_id", None)
-        slice_start_id = kwargs.pop("slice_start_id", None)
-        slice_end_id = kwargs.pop("slice_end_id", None)
         if im_start_id is None:
             return None
 
@@ -488,8 +537,9 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
             image_bounds=self._get_image_bounds(input_ids, im_start_id,
                                                 im_end_id, slice_start_id,
                                                 slice_end_id),
-            pixel_values=pixel_values_flat,
+            data=pixel_values_flat,
             tgt_sizes=torch.stack(tgt_sizes_flat),
+            type="pixel_values",
         )
 
     def forward(
@@ -610,8 +660,8 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
     ) -> torch.Tensor:
         raise NotImplementedError
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         raise NotImplementedError
 
     def is_default_weight_loading(self, name: str) -> bool:
@@ -705,8 +755,8 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
             res.append(self.resampler(vision_embedding, tgt_size))
         return torch.vstack(res)
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
 
         return self.get_vision_embedding(pixel_values)
@@ -793,8 +843,8 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
         vision_embedding = self.resampler(vision_embedding, tgt_sizes)
         return vision_embedding
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
         tgt_sizes = data["tgt_sizes"]
 
@@ -909,9 +959,9 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
         )
         return vision_embedding
 
-    def get_vision_hidden_states(
-            self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
-        pixel_values = data["pixel_values"]
+    def get_vision_hidden_states(self,
+                                 data: MiniCPMVImageInputs) -> torch.Tensor:
+        pixel_values = data["data"]
         tgt_sizes = data["tgt_sizes"]
 
         device = self.vpm.embeddings.position_embedding.weight.device


### PR DESCRIPTION
Follow-up to https://github.com/vllm-project/vllm/pull/6613.

Achieving consistency in multi-image input formats across different multimodal models is challenging. To address this, I adopted a dictionary-based approach to append additional parameters.

I have tested both multi-image and batch inference locally, and the full script is provided below for quick validation.

@DarkLight1337 @HwwwwwwwH Can you help me check ?
```python
from transformers import AutoTokenizer

from vllm import LLM, SamplingParams
from PIL import Image
import torch
import requests
import random

random.seed(0)

model_id = "openbmb/MiniCPM-V-2_6"
image_url = "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
image = Image.open(requests.get(image_url, stream=True).raw).convert("RGB")

question = "what is in this image?"

tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
llm = LLM(
    model=model_id,
    trust_remote_code=True,
    max_model_len=2048,
    gpu_memory_utilization=0.9,
    max_num_seqs=5,
    dtype="auto",
)

messages = [{"role": "user", "content": f"(<image>./</image>)\n{question}"}]
prompt = tokenizer.apply_chat_template(
    messages, tokenize=False, add_generation_prompt=True
)
stop_tokens = ["<|im_end|>", "<|endoftext|>"]
stop_token_ids = [tokenizer.convert_tokens_to_ids(i) for i in stop_tokens]
sampling_params = SamplingParams(
    stop_token_ids=stop_token_ids,
    max_tokens=1000,
    temperature=0,
    best_of=1,
)

mm_data = {}
image_embeds = torch.randn(9, 64, 3584, dtype=torch.bfloat16)

mm_data["image"] = {
    "image_embeds": image_embeds,
    "image_size_list": [image.size],  # list of image sizes
}

# mm_data['image'] = image
llm_inputs = {"prompt": prompt, "multi_modal_data": mm_data}

outputs = llm.generate(
    [llm_inputs],
    sampling_params=sampling_params,
)

# The output is meaningless because the input image_embeds are randomly generated.
print(outputs[0].outputs[0].text)

````


**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


