### PR TITLE
[Bugfix][CI/Build] Fix docker build where CUDA archs < 7.0 are being detected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,26 +144,31 @@ else()
 endif()
 
 
-#
-# For cuda we want to be able to control which architectures we compile for on 
-# a per-file basis in order to cut down on compile time. So here we extract
-# the set of architectures we want to compile for and remove the from the 
-# CMAKE_CUDA_FLAGS so that they are not applied globally.
-#
 if(VLLM_GPU_LANG STREQUAL "CUDA")
+  #
+  # For cuda we want to be able to control which architectures we compile for on 
+  # a per-file basis in order to cut down on compile time. So here we extract
+  # the set of architectures we want to compile for and remove the from the 
+  # CMAKE_CUDA_FLAGS so that they are not applied globally.
+  #
   clear_cuda_arches(CUDA_ARCH_FLAGS)
   extract_unique_cuda_archs_ascending(CUDA_ARCHS "${CUDA_ARCH_FLAGS}")
   message(STATUS "CUDA target architectures: ${CUDA_ARCHS}")
+  # Filter the target architectures by the supported supported archs
+  # since for some files we will build for all CUDA_ARCHS.
+  cuda_archs_loose_intersection(CUDA_ARCHS 
+    "${CUDA_SUPPORTED_ARCHS}" "${CUDA_ARCHS}")
+  message(STATUS "CUDA supported target architectures: ${CUDA_ARCHS}")
+else()
+  #
+  # For other GPU targets override the GPU architectures detected by cmake/torch
+  # and filter them by the supported versions for the current language.
+  # The final set of arches is stored in `VLLM_GPU_ARCHES`.
+  #
+  override_gpu_arches(VLLM_GPU_ARCHES
+    ${VLLM_GPU_LANG}
+    "${${VLLM_GPU_LANG}_SUPPORTED_ARCHS}")
 endif()
-
-#
-# Override the GPU architectures detected by cmake/torch and filter them by
-# the supported versions for the current language.
-# The final set of arches is stored in `VLLM_GPU_ARCHES`.
-#
-override_gpu_arches(VLLM_GPU_ARCHES
-  ${VLLM_GPU_LANG}
-  "${${VLLM_GPU_LANG}_SUPPORTED_ARCHS}")
 
 #
 # Query torch for additional GPU compilation flags for the given


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/9226

In this dockerfile the archs being detected by torch is `5.0;8.0;8.6;8.9;9.0;9.0a` we should ensure we prune off `5.0` for the kernels where we build for all target archs. This PR does that by pre-filtering the `CUDA_ARCHS` (target archs) by the `CUDA_SUPPORTED_ARCHS`:
```
  cuda_archs_loose_intersection(CUDA_ARCHS 
    "${CUDA_SUPPORTED_ARCHS}" "${CUDA_ARCHS}")
```
(PR also includes some logging improvements / comments)

Verified using:
```
FROM pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel AS build

ARG GITHASH="e232f585359d50e880bcc4aa8c4161ab17919567"

RUN apt update && apt install gcc g++ git -y && apt clean && rm -rf /var/lib/apt/lists/*

ENV PATH=/workspace-lib:/workspace-lib/bin:$PATH
ENV PYTHONUSERBASE=/workspace-lib

RUN pip install git+https://github.com/neuralmagic/vllm.git@$GITHASH --no-cache-dir --user -v

FROM pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime AS vllm-openai

WORKDIR /vllm-workspace

COPY --from=build /workspace-lib /workspace-lib

ENV PATH=/workspace-lib:/workspace-lib/bin:$PATH
ENV PYTHONUSERBASE=/workspace-lib
ENV PYTHONPATH=/workspace-lib:/vllm-workspace

ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
```