### PR TITLE
[Doc][Neuron] add note to neuron documentation about resolving triton issue

### DIFF
--- a/docs/source/getting_started/neuron-installation.rst
+++ b/docs/source/getting_started/neuron-installation.rst
@@ -27,6 +27,10 @@ Installation steps:
 
 .. _build_from_source_neuron:
 
+.. note::
+
+    The currently supported version of Pytorch for Neuron installs `triton` version `2.1.0`. This is incompatible with vLLM >= 0.5.3. You may see an error `cannot import name 'default_dump_dir...`. To work around this, run a `pip install --upgrade triton==3.0.0` after installing the vLLM wheel.
+
 Build from source
 -----------------
 


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

Neuron currently uses `torch` version `2.1.0`, which has a dependency on an older version of `triton`. This PR adds a note to the documentation for resolving an error using this dependency with newer versions of vLLM. 

FIX #7166 (*link existing issues this PR will resolve*)

