### PR TITLE
[CI/Build] Adopt Mergify for auto-labeling PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,33 @@
+pull_request_rules:
+- name: label-documentation
+  description: Automatically apply documentation label
+  conditions:
+    - or:
+      - files~=^[^/]+\.md$
+      - files~=^docs/
+  actions:
+    label:
+      add:
+        - documentation
+
+- name: ping author on conflicts and add 'needs-rebase' label
+  conditions:
+      - conflict
+      - -closed
+  actions:
+    label:
+      add:
+        - needs-rebase
+    comment:
+      message: |
+       This pull request has merge conflicts that must be resolved before it can be
+       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+- name: remove 'needs-rebase' label when conflict is resolved
+  conditions:
+      - -conflict
+      - -closed
+  actions:
+    label:
+      remove:
+        - needs-rebase

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,6 +10,21 @@ pull_request_rules:
       add:
         - documentation
 
+- name: label-ci-build
+  description: Automatically apply ci/build label
+  conditions:
+    - files~=^\.github/
+    - files~=\.buildkite/
+    - files~=^cmake/
+    - files=CMakeLists.txt
+    - files~=^Dockerfile
+    - files~=^requirements.*\.txt
+    - files=setup.py
+  actions:
+    label:
+      add:
+        - ci/build
+
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
       - conflict

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,6 +25,15 @@ pull_request_rules:
       add:
         - ci/build
 
+- name: label-frontend
+  description: Automatically apply frontend label
+  conditions:
+    - files~=^vllm/entrypoints/
+  actions:
+    label:
+      add:
+        - frontend
+
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
       - conflict


### PR DESCRIPTION
Import initial configuration for [Mergify](https://docs.mergify.com/).
This configuration does the following:

- Auto-label PRs that change docs (`docs/` directory or any file
  ending in `.md`) with the `documentation` label

- Auto-label PRs that change CI/Build related files with the `ci/build` label.

- Auto-label PRs with the `frontend` label if they change files under
  `vllm/entrypoints`.

- Auto-label PRs with `kernel` if they change files under `csrc`. I know more
  paths are needed here.

- Auto-label PRs that go into conflict with `main` and ping the PR
  author to highlight that a conflict exists. Auto-remove this label
  when conflicts are resolved.

This pattern serves as a starting point. I'm sure there are a lot more
desired labeling additions. Please send me requests and I'll add them!

Closes #9192

Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

cc @simon-mo

tasks that someone with commit access needs to do:

- [x] Add the Mergify github application to the `vllm-project` organization and the
  `vllm` repository. See https://docs.mergify.com/getting-started/

- Create the following labels. The config uses them and I'm not positive if they
  will get automatically created if they don't exist, so might as well just
  create them.
  - [x] `needs-rebase`
  - [x] `ci/build`
  - [x] `frontend`
  - [x] `kernel`

