### PR TITLE
[Misc][Installation] Improve source installation script and related documentation

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -84,6 +84,8 @@ Latest code can contain bugs and may not be stable. Please use it with caution.
 Build from source
 ==================
 
+.. _python-only-build:
+
 Python-only build (without compilation)
 ----------------------------------------
 
@@ -114,6 +116,23 @@ The script will:
 
 Now, you can edit the Python code in the current directory, and the changes will be reflected when you run vLLM.
 
+Once you have finished editing or want to install another vLLM wheel, you should exit the development environment using `the same script <https://github.com/vllm-project/vllm/blob/main/python_only_dev.py>`_ with the ``--quit-dev``(or ``-q`` for short) flag:
+
+.. code-block:: console
+
+    $ python python_only_dev.py --quit-dev
+
+The script with ``--quit-dev`` flag will:
+
+* Remove the symbolic link from the current directory to the vLLM package.
+* Restore the original vLLM package from the backup.
+
+If you update the vLLM wheel and want to rebuild from the source and make further edits, you will need to start `all above <#python-only-build>`_ over again.
+
+.. note::
+
+    There is a possibility that your source code may have a different commit ID compared to the latest vLLM wheel, which could potentially lead to unknown errors.
+    It is recommended to use the same commit ID for the source code as the vLLM wheel you have installed. Please refer to `the above section <#install-the-latest-code>`_ for instructions on how to install a specified wheel.
 
 Full build (with compilation)
 ---------------------------------

--- a/python_only_dev.py
+++ b/python_only_dev.py
@@ -1,17 +1,18 @@
 # enable python only development
 # copy compiled files to the current directory directly
 
+import argparse
 import os
 import shutil
 import subprocess
 import sys
 import warnings
-import argparse
 
-parser = argparse.ArgumentParser(description="Development mode for python-only code")
+parser = argparse.ArgumentParser(
+    description="Development mode for python-only code")
 parser.add_argument('-q',
-                    '--quit-dev', 
-                    action='store_true', 
+                    '--quit-dev',
+                    action='store_true',
                     help='Set the flag to quit development mode')
 args = parser.parse_args()
 
@@ -52,9 +53,10 @@ try:
     from setuptools_scm import get_version
     get_version(write_to="vllm/_version.py")
 except ImportError:
-    warnings.warn("To avoid warnings related to vllm._version, "
-                  "you should install setuptools-scm by pip install setuptools-scm",
-                  stacklevel=2)
+    warnings.warn(
+        "To avoid warnings related to vllm._version, "
+        "you should install setuptools-scm by pip install setuptools-scm",
+        stacklevel=2)
 
 if not args.quit_dev:
     for file in files_to_copy:
@@ -76,11 +78,15 @@ else:
     vllm_symlink_path = os.path.join(package_path, "vllm")
     vllm_backup_path = os.path.join(package_path, "vllm_pre_built")
     current_vllm_path = os.path.join(cwd, "vllm")
-    
+
     print(f"Unlinking {current_vllm_path} to {vllm_symlink_path}")
-    assert os.path.islink(vllm_symlink_path), f"not in dev mode: {vllm_symlink_path} is not a symbolic link"
-    assert current_vllm_path == os.readlink(vllm_symlink_path), "current directory is not the source code of package"
+    assert os.path.islink(
+        vllm_symlink_path
+    ), f"not in dev mode: {vllm_symlink_path} is not a symbolic link"
+    assert current_vllm_path == os.readlink(
+        vllm_symlink_path
+    ), "current directory is not the source code of package"
     os.unlink(vllm_symlink_path)
 
-    print(f"Recovering backup package from {vllm_backup_path} to {vllm_symlink_path}")
+    print(f"Recovering backup from {vllm_backup_path} to {vllm_symlink_path}")
     os.rename(vllm_backup_path, vllm_symlink_path)

--- a/python_only_dev.py
+++ b/python_only_dev.py
@@ -55,7 +55,7 @@ try:
 except ImportError:
     warnings.warn(
         "To avoid warnings related to vllm._version, "
-        "you should install setuptools-scm by pip install setuptools-scm",
+        "you should install setuptools-scm by `pip install setuptools-scm`",
         stacklevel=2)
 
 if not args.quit_dev:

--- a/python_only_dev.py
+++ b/python_only_dev.py
@@ -5,6 +5,15 @@ import os
 import shutil
 import subprocess
 import sys
+import warnings
+import argparse
+
+parser = argparse.ArgumentParser(description="Development mode for python-only code")
+parser.add_argument('-q',
+                    '--quit-dev', 
+                    action='store_true', 
+                    help='Set the flag to quit development mode')
+args = parser.parse_args()
 
 # cannot directly `import vllm` , because it will try to
 # import from the current directory
@@ -37,18 +46,41 @@ files_to_copy = [
     # "vllm/_version.py", # not available in nightly wheels yet
 ]
 
-for file in files_to_copy:
-    src = os.path.join(package_path, file)
-    dst = file
-    print(f"Copying {src} to {dst}")
-    shutil.copyfile(src, dst)
+# Try to create _version.py to avoid version related warning
+# Refer to https://github.com/vllm-project/vllm/pull/8771
+try:
+    from setuptools_scm import get_version
+    get_version(write_to="vllm/_version.py")
+except ImportError:
+    warnings.warn("To avoid warnings related to vllm._version, "
+                  "you should install setuptools-scm by pip install setuptools-scm",
+                  stacklevel=2)
 
-pre_built_vllm_path = os.path.join(package_path, "vllm")
-tmp_path = os.path.join(package_path, "vllm_pre_built")
-current_vllm_path = os.path.join(cwd, "vllm")
+if not args.quit_dev:
+    for file in files_to_copy:
+        src = os.path.join(package_path, file)
+        dst = file
+        print(f"Copying {src} to {dst}")
+        shutil.copyfile(src, dst)
 
-print(f"Renaming {pre_built_vllm_path} to {tmp_path}")
-os.rename(pre_built_vllm_path, tmp_path)
+    pre_built_vllm_path = os.path.join(package_path, "vllm")
+    tmp_path = os.path.join(package_path, "vllm_pre_built")
+    current_vllm_path = os.path.join(cwd, "vllm")
 
-print(f"linking {current_vllm_path} to {pre_built_vllm_path}")
-os.symlink(current_vllm_path, pre_built_vllm_path)
+    print(f"Renaming {pre_built_vllm_path} to {tmp_path} for backup")
+    os.rename(pre_built_vllm_path, tmp_path)
+
+    print(f"Linking {current_vllm_path} to {pre_built_vllm_path}")
+    os.symlink(current_vllm_path, pre_built_vllm_path)
+else:
+    vllm_symlink_path = os.path.join(package_path, "vllm")
+    vllm_backup_path = os.path.join(package_path, "vllm_pre_built")
+    current_vllm_path = os.path.join(cwd, "vllm")
+    
+    print(f"Unlinking {current_vllm_path} to {vllm_symlink_path}")
+    assert os.path.islink(vllm_symlink_path), f"not in dev mode: {vllm_symlink_path} is not a symbolic link"
+    assert current_vllm_path == os.readlink(vllm_symlink_path), "current directory is not the source code of package"
+    os.unlink(vllm_symlink_path)
+
+    print(f"Recovering backup package from {vllm_backup_path} to {vllm_symlink_path}")
+    os.rename(vllm_backup_path, vllm_symlink_path)


### PR DESCRIPTION
This PR is to improve the `python_only_dev.py` script introduced in https://github.com/vllm-project/vllm/pull/8818:
1. Add `_version.py` file to avoid related warnings.
2. Add a flag `--quit-dev` to:
      - unlink package and source code 
      - restore the original vLLM package from the backup.
    
      This is useful when updating the wheel.
3. Update related documentation

cc @youkaichao 

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


