### PR TITLE
[Bugfix] Update grafana dashboard

### DIFF
--- a/examples/production_monitoring/grafana.json
+++ b/examples/production_monitoring/grafana.json
@@ -1222,7 +1222,11 @@
         "skipUrlSync": false
       },
       {
-        "definition": "label_values(model_name)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(vllm:num_requests_running, model_name)",
         "hide": 0,
         "includeAll": false,
         "label": "model_name",
@@ -1230,7 +1234,7 @@
         "name": "model_name",
         "options": [],
         "query": {
-          "query": "label_values(model_name)",
+          "query": "label_values(vllm:num_requests_running, model_name)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
Use templated datasource in query

FIX #6136
It defines a variable `DS_PROMETHEUS`. It should be used in the variable `model_name` but it does not.

Q: Why the metric `vllm:num_requests_running` is introduced?
A: The label `model_name` is too common that node_exporter will also set this label to metrics. With a specific metric, it can ensure the metrics is vllm-related

Here is a negative example. See `model_name="45N1767"` in `node_power_supply_info`.

```
node_power_supply_info{capacity_level="Normal", env="build", exported_type="Battery", instance="example.com:9100", job="k8s", manufacturer="SANYO", model_name="45N1767", power_supply="BAT0", serial_number="3861", status="Not charging", team="build", technology="Li-ion", type="k8s"}
```



