### PR TITLE
[Performance][Spec Decode] Optimize ngram lookup performance

### DIFF
--- a/vllm/spec_decode/ngram_worker.py
+++ b/vllm/spec_decode/ngram_worker.py
@@ -67,9 +67,16 @@ class NGramWorker(NonLLMProposerWorkerBase):
                 execute_model_req.seq_group_metadata_list):
             seq_data = next(iter(seq_group_metadata.seq_data.values()))
 
+            seq_len = seq_data.get_len()
+            # When seq_len is less than 3072 (3K), we use CPU to perform
+            # the ngram match. Otherwise, we use the device specified in
+            # the model config (normally GPU). 3072 is a rough threshold
+            # based on profiling on H100, and it can be adjusted based
+            # on the actual performance on different hardware.
+            cur_device = "cpu" if seq_len < 3072 else self.device
             input_ids = torch.as_tensor(seq_data.get_token_ids(),
                                         dtype=torch.long,
-                                        device='cpu')
+                                        device=cur_device)
             input_length = seq_data.get_len()
 
             for ngram_size in range(
@@ -94,8 +101,9 @@ class NGramWorker(NonLLMProposerWorkerBase):
                 first_match = matches.max(dim=-1)
                 if first_match.values.item():
                     proposal_start_idx = first_match.indices.add_(ngram_size)
-                    spec_indices = (proposal_start_idx).repeat(
-                        sample_len) + torch.arange(sample_len)
+                    spec_indices = (
+                        proposal_start_idx).repeat(sample_len) + torch.arange(
+                            sample_len, device=cur_device)
                     spec_indices.clamp_(max=input_ids.shape[-1] - 1)
                     res = input_ids.gather(dim=-1,
                                            index=spec_indices).to(self.device)

--- a/vllm/spec_decode/ngram_worker.py
+++ b/vllm/spec_decode/ngram_worker.py
@@ -90,9 +90,6 @@ class NGramWorker(NonLLMProposerWorkerBase):
                 # first_match includes "values" (bool), indicating whether
                 # the match is found, and "indices", indicating the index
                 # of the first match.
-                # Note that "first_match.values.item()" triggers GPU-CPU
-                # sync so it is a bit inefficient, but we have not found
-                # a better way to do this.
                 first_match = matches.max(dim=-1)
                 if first_match.values.item():
                     proposal_start_idx = first_match.indices.add_(ngram_size)

--- a/vllm/spec_decode/ngram_worker.py
+++ b/vllm/spec_decode/ngram_worker.py
@@ -68,7 +68,8 @@ class NGramWorker(NonLLMProposerWorkerBase):
             seq_data = next(iter(seq_group_metadata.seq_data.values()))
 
             input_ids = torch.as_tensor(seq_data.get_token_ids(),
-                                        dtype=torch.long, device='cpu')
+                                        dtype=torch.long,
+                                        device='cpu')
             input_length = seq_data.get_len()
 
             for ngram_size in range(
@@ -93,11 +94,11 @@ class NGramWorker(NonLLMProposerWorkerBase):
                 first_match = matches.max(dim=-1)
                 if first_match.values.item():
                     proposal_start_idx = first_match.indices.add_(ngram_size)
-                    spec_indices = (
-                        proposal_start_idx).repeat(sample_len) + torch.arange(
-                            sample_len)
+                    spec_indices = (proposal_start_idx).repeat(
+                        sample_len) + torch.arange(sample_len)
                     spec_indices.clamp_(max=input_ids.shape[-1] - 1)
-                    res = input_ids.gather(dim=-1, index=spec_indices).to(self.device)
+                    res = input_ids.gather(dim=-1,
+                                           index=spec_indices).to(self.device)
                     token_id_list.append(res)
                     token_prob_list.append(
                         torch.nn.functional.one_hot(

--- a/vllm/spec_decode/ngram_worker.py
+++ b/vllm/spec_decode/ngram_worker.py
@@ -68,8 +68,7 @@ class NGramWorker(NonLLMProposerWorkerBase):
             seq_data = next(iter(seq_group_metadata.seq_data.values()))
 
             input_ids = torch.as_tensor(seq_data.get_token_ids(),
-                                        dtype=torch.long,
-                                        device=self.device)
+                                        dtype=torch.long, device='cpu')
             input_length = seq_data.get_len()
 
             for ngram_size in range(
@@ -99,9 +98,9 @@ class NGramWorker(NonLLMProposerWorkerBase):
                     proposal_start_idx = first_match.indices.add_(ngram_size)
                     spec_indices = (
                         proposal_start_idx).repeat(sample_len) + torch.arange(
-                            sample_len, device=self.device)
+                            sample_len)
                     spec_indices.clamp_(max=input_ids.shape[-1] - 1)
-                    res = input_ids.gather(dim=-1, index=spec_indices)
+                    res = input_ids.gather(dim=-1, index=spec_indices).to(self.device)
                     token_id_list.append(res)
                     token_prob_list.append(
                         torch.nn.functional.one_hot(


### PR DESCRIPTION
After benchmarking the performance of ngram in vllm, it seems that the proposal time is longer than expected. The main reason is that there are (1) CPU <-> GPU communication when building the ngram lookup table. (2) Building the ngram contains many small kernels (duration < 5 microseconds) as show below:
<img width="783" alt="Screenshot 2024-10-13 at 11 07 44 PM" src="https://github.com/user-attachments/assets/5ef7d0e4-31a0-43ff-9a19-5a3ded9be009">

Zoom in the propose time:
<img width="723" alt="Screenshot 2024-10-13 at 11 09 55 PM" src="https://github.com/user-attachments/assets/95ac97c5-65b3-426e-9556-5fd45a433e5a">

The PR tries to
(1) perform lookup operation on CPU.
(2) trigger CPU <-> GPU communication only when there is a match in lookup.

Some performance numbers on a single H100:
input_len: 550, output_len: 150
I changed the prompt to try different system efficiency (which might include the number of CPU <-> GPU sync).
| System efficiency | propose time before this PR | propose time after this PR | end2end latency before this PR | end2end latency after this PR |
| -- | -- | -- | -- | -- |
| 0.31 | 4.4ms | 2.2ms | 6.4s | 5.6s |
| 0.63 | 3.3ms | 1.5ms | 3.8s | 3.2s |
| 0.80 | 2.6 ms | 1.5ms | 3.0s | 2.6s |


input_len: 2048, output_len: 150
| System efficiency | propose time before this PR | propose time after this PR | end2end latency before this PR | end2end latency after this PR |
| -- | -- | -- | -- | -- |
| 0.30 | 6.00ms | 4.54ms | 9.83s | 9.25s |
| 0.63 | 2.90ms | 2.70ms | 5.84s | 5.45s |