### PR TITLE
[Docs] Remove PDF build from Readtehdocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,11 @@
 
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 sphinx:
    configuration: docs/source/conf.py
    fail_on_warning: true
@@ -14,3 +19,4 @@ formats: []
 python:
    install:
    - requirements: docs/requirements-docs.txt
+

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,18 +3,12 @@
 
 version: 2
 
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.8"
-
 sphinx:
    configuration: docs/source/conf.py
    fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+formats: []
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
According to https://github.com/readthedocs/readthedocs.org/pull/10115, this should resolve our build problem by skipping PDF builds. 

This is the cause of our recent problems with latest not updating. 