### PR TITLE
[Doc] Fix code formatting in spec_decode.rst

### DIFF
--- a/docs/source/models/spec_decode.rst
+++ b/docs/source/models/spec_decode.rst
@@ -44,10 +44,10 @@ To perform the same with an online mode launch the server:
 .. code-block:: bash
 
     python -m vllm.entrypoints.openai.api_server --host 0.0.0.0 --port 8000 --model facebook/opt-6.7b \
-    --seed 42 -tp 1 --speculative_model facebook/opt-125m --use-v2-block-manager \
-    --num_speculative_tokens 5 --gpu_memory_utilization 0.8
+        --seed 42 -tp 1 --speculative_model facebook/opt-125m --use-v2-block-manager \
+        --num_speculative_tokens 5 --gpu_memory_utilization 0.8
 
- Then use a client:
+Then use a client:
 
 .. code-block:: python
 


### PR DESCRIPTION
Small nit to fix this issue:

![image](https://github.com/user-attachments/assets/acf057ea-854b-4cdb-963c-94dc911e4b71)
