### PR TITLE
pass ignore_eos parameter to all benchmark_serving calls

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -431,17 +431,15 @@ async def benchmark(
 
     if profile:
         print("Starting profiler...")
-        profile_input = RequestFuncInput(
-            model=model_id,
-            prompt=test_prompt,
-            api_url=base_url + "/start_profile",
-            prompt_len=test_prompt_len,
-            output_len=test_output_len,
-            logprobs=logprobs,
-            best_of=best_of,
-            multi_modal_content=test_mm_content,
-            ignore_eos=ignore_eos
-        )
+        profile_input = RequestFuncInput(model=model_id,
+                                         prompt=test_prompt,
+                                         api_url=base_url + "/start_profile",
+                                         prompt_len=test_prompt_len,
+                                         output_len=test_output_len,
+                                         logprobs=logprobs,
+                                         best_of=best_of,
+                                         multi_modal_content=test_mm_content,
+                                         ignore_eos=ignore_eos)
         profile_output = await request_func(request_func_input=profile_input)
         if profile_output.success:
             print("Profiler started")
@@ -454,17 +452,15 @@ async def benchmark(
     tasks: List[asyncio.Task] = []
     async for request in get_request(input_requests, request_rate):
         prompt, prompt_len, output_len, mm_content = request
-        request_func_input = RequestFuncInput(
-            model=model_id,
-            prompt=prompt,
-            api_url=api_url,
-            prompt_len=prompt_len,
-            output_len=output_len,
-            logprobs=logprobs,
-            best_of=best_of,
-            multi_modal_content=mm_content,
-            ignore_eos=ignore_eos
-        )
+        request_func_input = RequestFuncInput(model=model_id,
+                                              prompt=prompt,
+                                              api_url=api_url,
+                                              prompt_len=prompt_len,
+                                              output_len=output_len,
+                                              logprobs=logprobs,
+                                              best_of=best_of,
+                                              multi_modal_content=mm_content,
+                                              ignore_eos=ignore_eos)
         tasks.append(
             asyncio.create_task(
                 request_func(request_func_input=request_func_input,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -440,6 +440,7 @@ async def benchmark(
             logprobs=logprobs,
             best_of=best_of,
             multi_modal_content=test_mm_content,
+            ignore_eos=ignore_eos
         )
         profile_output = await request_func(request_func_input=profile_input)
         if profile_output.success:
@@ -462,6 +463,7 @@ async def benchmark(
             logprobs=logprobs,
             best_of=best_of,
             multi_modal_content=mm_content,
+            ignore_eos=ignore_eos
         )
         tasks.append(
             asyncio.create_task(


### PR DESCRIPTION
Currently ignore_eos parameter set by the user isn't passed into the profiler and actual benchmark run sections of benchmark_serving, but only in the first promopt run section. This means the output sequence length of different backends tested with benchmark_serving may be different,  since ignore_eos isn't set to true. With this fix all backends with the same dataset should now generate the same number of output tokens per test and the results can be comparable.


