### PR TITLE
[Bugfix] Update InternVL input mapper to support image embeds

### DIFF
--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -342,6 +342,8 @@ class InternVLInputPipeline:
         elif is_list_of(data, Image.Image):
             # we can't stack here because images may have different num_patches
             data = [image_pixel_values_mapper(img) for img in data]
+        else:
+            return MultiModalInputs({ "image_embeds": data })
         model_config = ctx.model_config
         tokenizer = cached_get_tokenizer(
             model_config.tokenizer,

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -343,7 +343,7 @@ class InternVLInputPipeline:
             # we can't stack here because images may have different num_patches
             data = [image_pixel_values_mapper(img) for img in data]
         else:
-            return MultiModalInputs({ "image_embeds": data })
+            return MultiModalInputs({"image_embeds": data})
         model_config = ctx.model_config
         tokenizer = cached_get_tokenizer(
             model_config.tokenizer,


### PR DESCRIPTION
The InternVL input mapper originally only outputs MultiModalInputs with pixel values. However, the model itself has support for image embedding inputs and this change is needed for image embedding inputs to be recognized by `_parse_and_validate_image_input` (and thus the forward function).

FIX bug found locally.