### PR TITLE
[Bugfix][CI/Build] Fix CUDA 11.8 Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # For the cutlass_scaled_mm kernels we want to build the c2x (CUTLASS 2.x)
   # kernels for the remaining archs that are not already built for 3x.
   cuda_archs_loose_intersection(SCALED_MM_2X_ARCHS 
-    "7.5;8.0;8.6;8.9;9.0;9.0a" "${CUDA_ARCHS}")
+    "7.5;8.0;8.6;8.9;9.0" "${CUDA_ARCHS}")
   # subtract out the archs that are already built for 3x
   list(REMOVE_ITEM SCALED_MM_2X_ARCHS ${SCALED_MM_3X_ARCHS})
   if (SCALED_MM_2X_ARCHS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,10 +286,6 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     list(APPEND VLLM_GPU_FLAGS "-DENABLE_SCALED_MM_C3X=1")
     message(STATUS "Building scaled_mm_c3x for archs: ${SCALED_MM_3X_ARCHS}")
   else()
-    # clear SCALED_MM_3X_ARCHS so the scaled_mm_c2x kernels know we didn't 
-    # build any 3x kernels
-    set(SCALED_MM_3X_ARCHS)
-
     if (NOT ${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.0 AND SCALED_MM_3X_ARCHS)
       message(STATUS "Not building scaled_mm_c3x as CUDA Compiler version is "
                      "not >= 12.0, we recommend upgrading to CUDA 12.0 or "
@@ -299,6 +295,10 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
       message(STATUS "Not building scaled_mm_c3x as no compatible archs found "
                      "in CUDA target architectures")
     endif()
+
+    # clear SCALED_MM_3X_ARCHS so the scaled_mm_c2x kernels know we didn't 
+    # build any 3x kernels
+    set(SCALED_MM_3X_ARCHS)
   endif()
 
   #


### PR DESCRIPTION
Dont build 9.0a for scaled_mm_c2x since it's outside of cuda 12.0 guard and won't help perf that much that anyways. 

The issue here was that for CUDA 11.8 if we were building for 9.0 we wouldn't build scaled_mm_c3x so we would instead try to build scaled_mm_c2x for all versions, i.e. "7.5;8.0;8.6;8.9;9.0;9.0a", this is incorrect though since 9.0a isn't supported by 11.8. We can just drop 9.0a for scaled_mm_c2x since scaled_mm_c2x won't take advantage of the 9.0a features anyways.

(and fix c3x error message false reporting that there were no compatible arches when on 11.8)