### PR TITLE
Begin refactoring executor_base ABC

### DIFF
--- a/vllm/executor/cpu_executor.py
+++ b/vllm/executor/cpu_executor.py
@@ -122,10 +122,11 @@ class CPUExecutor(ExecutorBase):
         distributed_init_method: Optional[str] = None,
     ):
         if distributed_init_method is None:
-          # Multiprocessing-based executor does not support multi-node setting.
-          # Since it only works for single node, we can use the loopback address
-          # 127.0.0.1 for communication.
-          self.distributed_init_method = get_distributed_init_method("127.0.0.1", get_open_port())
+            # Multiprocessing-based executor does not support multi-node
+            # setting. Since it only works for single node, we can use the
+            # loopback address 127.0.0.1 for communication.
+            self.distributed_init_method = get_distributed_init_method(
+                "127.0.0.1", get_open_port())
 
         worker_module_name = "vllm.worker.cpu_worker"
         worker_class_name = "CPUWorker"

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -41,9 +41,9 @@ class ExecutorBase(ABC):
 
     @abstractmethod
     def create_worker(self,
-                       local_rank: int = 0,
-                       rank: int = 0,
-                       distributed_init_method: Optional[str] = None):
+                      local_rank: int = 0,
+                      rank: int = 0,
+                      distributed_init_method: Optional[str] = None):
         """Creates the driver worker for the Executor.
        """
         raise NotImplementedError

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -40,6 +40,15 @@ class ExecutorBase(ABC):
         pass
 
     @abstractmethod
+    def create_worker(self,
+                       local_rank: int = 0,
+                       rank: int = 0,
+                       distributed_init_method: Optional[str] = None):
+        """Creates the driver worker for the Executor.
+       """
+        raise NotImplementedError
+
+    @abstractmethod
     def determine_num_available_blocks(self) -> Tuple[int, int]:
         """Determine the number of available blocks for the GPU KV cache and
         swappable CPU KV cache.

--- a/vllm/executor/gpu_executor.py
+++ b/vllm/executor/gpu_executor.py
@@ -13,9 +13,9 @@ from vllm.worker.worker_base import WorkerBase, WorkerWrapperBase
 logger = init_logger(__name__)
 
 
-def create_worker(worker_module_name: str, worker_class_name: str,
-                  worker_class_fn: Optional[Callable[[], Type[WorkerBase]]],
-                  **kwargs):
+def _create_worker(worker_module_name: str, worker_class_name: str,
+                   worker_class_fn: Optional[Callable[[], Type[WorkerBase]]],
+                   **kwargs):
     wrapper = WorkerWrapperBase(
         worker_module_name=worker_module_name,
         worker_class_name=worker_class_name,
@@ -35,7 +35,7 @@ class GPUExecutor(ExecutorBase):
         assert self.parallel_config.world_size == 1, (
             "GPUExecutor only supports single GPU.")
 
-        self.driver_worker = self._create_worker()
+        self.driver_worker = self.create_worker()
         self.driver_worker.init_device()
         self.driver_worker.load_model()
 
@@ -89,11 +89,11 @@ class GPUExecutor(ExecutorBase):
 
         return worker_kwargs
 
-    def _create_worker(self,
-                       local_rank: int = 0,
-                       rank: int = 0,
-                       distributed_init_method: Optional[str] = None):
-        return create_worker(**self._get_create_worker_kwargs(
+    def create_worker(self,
+                      local_rank: int = 0,
+                      rank: int = 0,
+                      distributed_init_method: Optional[str] = None):
+        return _create_worker(**self._get_create_worker_kwargs(
             local_rank=local_rank,
             rank=rank,
             distributed_init_method=distributed_init_method))

--- a/vllm/executor/multiproc_gpu_executor.py
+++ b/vllm/executor/multiproc_gpu_executor.py
@@ -7,7 +7,6 @@ import torch
 
 from vllm.executor.distributed_gpu_executor import (  # yapf: disable
     DistributedGPUExecutor, DistributedGPUExecutorAsync)
-from vllm.executor.gpu_executor import create_worker
 from vllm.executor.multiproc_worker_utils import (ProcessWorkerWrapper,
                                                   ResultHandler, WorkerMonitor)
 from vllm.logger import init_logger
@@ -86,7 +85,7 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
                 worker = ProcessWorkerWrapper(
                     result_handler,
                     partial(
-                        create_worker,
+                        self.create_worker,
                         **self._get_create_worker_kwargs(
                             rank=rank,
                             local_rank=rank,
@@ -105,7 +104,7 @@ class MultiprocessingGPUExecutor(DistributedGPUExecutor):
         # Set up signal handlers to shutdown the executor cleanly
         # sometimes gc does not work well
 
-        self.driver_worker = self._create_worker(
+        self.driver_worker = self.create_worker(
             distributed_init_method=distributed_init_method)
         self._run_workers("init_device")
         self._run_workers("load_model",

--- a/vllm/executor/neuron_executor.py
+++ b/vllm/executor/neuron_executor.py
@@ -27,18 +27,17 @@ class NeuronExecutor(ExecutorBase):
         self.driver_worker.load_model()
 
     def create_worker(self,
-                       local_rank: int = 0,
-                       rank: int = 0,
-                       distributed_init_method: Optional[str] = None):
+                      local_rank: int = 0,
+                      rank: int = 0,
+                      distributed_init_method: Optional[str] = None):
         from vllm.worker.neuron_worker import NeuronWorker
         if distributed_init_method is None:
             distributed_init_method = get_distributed_init_method(
                 get_ip(), get_open_port())
-        return NeuronWorker(
-            vllm_config=self.vllm_config,
-            local_rank=local_rank,
-            rank=rank,
-            distributed_init_method=distributed_init_method)
+        return NeuronWorker(vllm_config=self.vllm_config,
+                            local_rank=local_rank,
+                            rank=rank,
+                            distributed_init_method=distributed_init_method)
 
     def determine_num_available_blocks(self) -> Tuple[int, int]:
         """Determine the number of available KV blocks by invoking the

--- a/vllm/executor/openvino_executor.py
+++ b/vllm/executor/openvino_executor.py
@@ -40,9 +40,9 @@ class OpenVINOExecutor(ExecutorBase):
         self.driver_worker.load_model()
 
     def create_worker(self,
-                       local_rank: int = 0,
-                       rank: int = 0,
-                       distributed_init_method: Optional[str] = None):
+                      local_rank: int = 0,
+                      rank: int = 0,
+                      distributed_init_method: Optional[str] = None):
         from vllm.worker.openvino_worker import OpenVINOWorker
 
         assert (

--- a/vllm/executor/tpu_executor.py
+++ b/vllm/executor/tpu_executor.py
@@ -29,7 +29,7 @@ class TPUExecutor(ExecutorBase):
             self.model_config.dtype = torch.bfloat16
 
         # Instantiate the worker and load the model to the device.
-        self.driver_worker = self._create_worker()
+        self.driver_worker = self.create_worker()
         self.driver_worker.init_device()
         self.driver_worker.load_model()
 
@@ -51,7 +51,7 @@ class TPUExecutor(ExecutorBase):
             is_driver_worker=rank == 0,
         )
 
-    def _create_worker(
+    def create_worker(
         self,
         local_rank: int = 0,
         rank: int = 0,


### PR DESCRIPTION
This was started in support of mypy'ing the remaining libs that need it. It's been extremely difficult to add mypy to anything that touches the executor, because the various diffrent kinds of backends are structured differently, but everything is generally referred to via the abstract base type and then methods are called blindly because we "know" which kind of executor we're dealing with, even if the code doesn't. In addition, the various executor implementations often implement similar functionality decomposed differently - so the same bit of functionality often exists in different places or is referenced differently in different backends.

This is the beginning of a reactor that aims to create more abstract method declarations in executor_base, to allow executor code to be statically type checked, as well as to hopefully let things be structured in a more consistent manner that is easy to understand. This does occasionally mean that a particular backend will have a kind of dummy implementation that doesn't do much, as with the ray_tpu_executor here. 

This PR just starts with the _create_worker method, which I've changed to init the driver worker, but not init the device or load the model across all various backend implementations.
