### PR TITLE
[Frontend] Enable Online Multi-image Support for MLlama

### DIFF
--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -6,9 +6,9 @@ from PIL import Image
 
 from vllm.assets.image import ImageAsset
 from vllm.config import ModelConfig
-from vllm.entrypoints.llm import apply_hf_chat_template
 from vllm.entrypoints.chat_utils import (parse_chat_messages,
                                          parse_chat_messages_futures)
+from vllm.entrypoints.llm import apply_hf_chat_template
 from vllm.multimodal import MultiModalDataDict
 from vllm.multimodal.utils import encode_image_base64
 from vllm.transformers_utils.tokenizer_group import TokenizerGroup
@@ -515,27 +515,38 @@ def test_mllama_interleaved_images(
         }]
     }]
 
+
 def test_mllama_parse_matches_hf(
     mllama_model_config,
     mllama_tokenizer,
     image_url,
 ):
-    """Checks end to end correctness of hf allignment for mllama parsing."""
+    """Checks end to end correctness of hf alignment for mllama parsing."""
+
     def get_conversation(is_hf: bool):
         img_part = {"type": "image_url", "image_url": {"url": image_url}}
         if is_hf:
             img_part = {'type': 'image'}
-        return [
+        return [{
+            'role':
+            'user',
+            'content': [
                 {
-                    'role': 'user', 'content': [
-                        {'type': 'text', 'text': 'The content of the first image is:'},
-                        img_part,
-                        {'type': 'text', 'text': 'The content of the second image is:'},
-                        img_part,
-                        {'type': 'text', 'text': 'What animal is in the first image?'},
-                    ]
-                }
+                    'type': 'text',
+                    'text': 'The content of the first image is:'
+                },
+                img_part,
+                {
+                    'type': 'text',
+                    'text': 'The content of the second image is:'
+                },
+                img_part,
+                {
+                    'type': 'text',
+                    'text': 'What animal is in the first image?'
+                },
             ]
+        }]
 
     tokenizer = mllama_tokenizer.tokenizer
     # Build and parse a conversation with {"type": "image"} using the tokenizer

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -483,7 +483,7 @@ def _parse_chat_message_content_parts(
     parts: Iterable[ChatCompletionContentPartParam],
     mm_tracker: BaseMultiModalItemTracker,
 ) -> List[ConversationMessage]:
-    content = []
+    content: List[Union[str, Dict[str, str]]] = []
 
     mm_parser = mm_tracker.create_parser()
     keep_multimodal_content = \

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -523,29 +523,29 @@ def _parse_chat_message_content_part(
     if isinstance(part, str):  # Handle plain text parts
         text = _TextParser(part)
         return text
-    else:  # Handle structured dictionary parts
-        part_type, content = _parse_chat_message_content_mm_part(part)
 
-        # if part_type is text/refusal/image_url/audio_url but
-        # content is empty, log a warning and skip
-        if part_type in VALID_MESSAGE_CONTENT_MM_PART_TYPES and not content:
-            logger.warning("Skipping multimodal part "
-                           "with empty / unparsable content.")
-            return None
+    # Handle structured dictionary parts
+    part_type, content = _parse_chat_message_content_mm_part(part)
 
-        if part_type in ("text", "refusal"):
-            if wrap_dicts:
-                return {'type': 'text', 'text': content}
-            return content
-        elif part_type == "image_url":
-            mm_parser.parse_image(content)
-            if wrap_dicts:
-                return {'type': 'image'}
-        elif part_type == "audio_url":
-            mm_parser.parse_audio(content)
-        else:
-            raise NotImplementedError(f"Unknown part type: {part_type}")
-    return None
+    # if part_type is text/refusal/image_url/audio_url but
+    # content is empty, log a warning and skip
+    if part_type in VALID_MESSAGE_CONTENT_MM_PART_TYPES and not content:
+        logger.warning("Skipping multimodal part "
+                       "with empty / unparsable content.")
+        return None
+
+    if part_type in ("text", "refusal"):
+        return {'type': 'text', 'text': content} if wrap_dicts else content
+
+    if part_type == "image_url":
+        mm_parser.parse_image(content)
+        return {'type': 'image'} if wrap_dicts else None
+
+    if part_type == "audio_url":
+        mm_parser.parse_audio(content)
+        return {'type': 'audio'} if wrap_dicts else None
+
+    raise NotImplementedError(f"Unknown part type: {part_type}")
 
 
 # No need to validate using Pydantic again

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -530,8 +530,8 @@ def _parse_chat_message_content_part(
     # if part_type is text/refusal/image_url/audio_url but
     # content is empty, log a warning and skip
     if part_type in VALID_MESSAGE_CONTENT_MM_PART_TYPES and not content:
-        logger.warning("Skipping multimodal part "
-                       "with empty / unparsable content.")
+        logger.warning("Skipping multimodal part (type: '%s')"
+                       "with empty / unparsable content.", part_type)
         return None
 
     if part_type in ("text", "refusal"):

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -530,8 +530,9 @@ def _parse_chat_message_content_part(
     # if part_type is text/refusal/image_url/audio_url but
     # content is empty, log a warning and skip
     if part_type in VALID_MESSAGE_CONTENT_MM_PART_TYPES and not content:
-        logger.warning("Skipping multimodal part (type: '%s')"
-                       "with empty / unparsable content.", part_type)
+        logger.warning(
+            "Skipping multimodal part (type: '%s')"
+            "with empty / unparsable content.", part_type)
         return None
 
     if part_type in ("text", "refusal"):


### PR DESCRIPTION
Currently, there is some special handling for mllama in the chat utils that result in only one image placeholder being used when multiple images are added. Now that https://github.com/vllm-project/vllm/pull/9095 added multi-image / interleaved data support, I think this can be removed to handle image placeholders normally for mllama in the frontend.

Example usage:
```
python -m vllm.entrypoints.openai.api_server \
    --device cuda \
    --model meta-llama/Llama-3.2-11B-Vision-Instruct \
    --api-key token-abc123 \
    --tokenizer meta-llama/Llama-3.2-11B-Vision-Instruct \
    --limit-mm-per-prompt image=2 \
    --max-model-len 32000 \
    --dtype=half  \
    --enforce-eager \
    --max-num-seqs 2
```

```bash
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="token-abc123")

completion = client.chat.completions.create(
  model="meta-llama/Llama-3.2-11B-Vision-Instruct",
  messages = [{
        "role": "user", "content": [
          {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg"}},
          {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/7/77/002_The_lion_king_Snyggve_in_the_Serengeti_National_Park_Photo_by_Giles_Laurent.jpg"}},
          {"type": "text", "text": "Can you compare these images?"},
        ]
  }]
)

print(completion.choices[0].message)
```

In the logs, it seems like we do get both placeholders:
> `INFO 10-15 18:01:33 logger.py:37] Received request chat-ca50cc85dea6435790ff6ff07624dade: prompt: '<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\nCutting Knowledge Date: December 2023\nToday Date: 15 Oct 2024\n\n<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n<|image|>\n<|image|>\nCan you compare these images?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.7, top_p=1.0, top_k=-1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=31955, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None), guided_decoding=GuidedDecodingParams(json=None, regex=None, choice=None, grammar=None, json_object=None, backend=None, whitespace_pattern=None), prompt_token_ids: [128000, 128006, 9125, 128007, 271, 38766, 1303, 33025, 2696, 25, 6790, 220, 2366, 18, 198, 15724, 2696, 25, 220, 868, 5020, 220, 2366, 19, 271, 128009, 128006, 882, 128007, 271, 128256, 198, 128256, 198, 6854, 499, 9616, 1521, 5448, 30, 128009, 128006, 78191, 128007, 271], lora_request: None, prompt_adapter_request: None.`
and a reasonable response:
```
ChatCompletionMessage(content='The image of a lion is larger than the image of a duck.', refusal=None, role='assistant', function_call=None, tool_calls=[])
```

This does pass what's expected to the tokenizer when it's applying its chat template, although the format of the prompt is a bit different. It seems to match the [example tool chat template for llama 3.2](https://github.com/vllm-project/vllm/blob/main/examples/tool_chat_template_llama3.2_json.jinja) though

```python
from transformers import AutoTokenizer
model_id = "meta-llama/Llama-3.2-11B-Vision-Instruct"
tokenizer = AutoTokenizer.from_pretrained(model_id)
conversation=[{'role': 'user', 'content': '<|image|>\nCan you compare these images?'}]

out = tokenizer.apply_chat_template(
    conversation=conversation,
    add_generation_prompt=True,
    tokenize=False,
)
print(f"----Output with image placeholder----\n{out}")

conversation=[{'role': 'user', 'content': [{'type': 'image'}, {'type': 'text', 'text': 'Can you compare these images?'}]}]
out = tokenizer.apply_chat_template(
    conversation=conversation,
    add_generation_prompt=True,
    tokenize=False,
)
print(f"----Output with image type----\n{out}")
```
Result:
```
----Output with image placeholder----
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

Cutting Knowledge Date: December 2023
Today Date: 15 Oct 2024

<|eot_id|><|start_header_id|>user<|end_header_id|>

<|image|>
Can you compare these images?<|eot_id|><|start_header_id|>assistant<|end_header_id|>


----Output with image type----
<|begin_of_text|><|start_header_id|>user<|end_header_id|>

<|image|>Can you compare these images?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
```



**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


