### PR TITLE
Support mistral interleaved attn

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -173,10 +173,14 @@ class ModelConfig:
         if self.enforce_eager is None:
             self.enforce_eager = False
 
-        has_interleaved_attention = isinstance(self.hf_text_config.sliding_window, list) or (self.hf_text_config.model_type in ["gemma2"] and self.hf_text_config.sliding_window is not None)
+        has_interleaved_attention = isinstance(
+            self.hf_text_config.sliding_window,
+            list) or (self.hf_text_config.model_type in ["gemma2"]
+                      and self.hf_text_config.sliding_window is not None)
 
         if (not self.disable_sliding_window and has_interleaved_attention):
-            sliding_window_len_min = get_min_sliding_window(self.hf_text_config.sliding_window)
+            sliding_window_len_min = get_min_sliding_window(
+                self.hf_text_config.sliding_window)
 
             print_warning_once(
                 f"{self.hf_text_config.model_type} has interleaved attention, "
@@ -424,7 +428,8 @@ class ModelConfig:
                                "pipeline parallelism currently. Disabling it.")
                 self.use_async_output_proc = False
 
-    def get_hf_config_sliding_window(self) -> Optional[Union[int, List[int]]]:
+    def get_hf_config_sliding_window(
+            self) -> Optional[Union[int, List[Optional[int]]]]:
         """Get the sliding window size, or None if disabled."""
 
         # Some models, like Qwen2 and Qwen1.5, use `use_sliding_window` in
@@ -435,7 +440,7 @@ class ModelConfig:
             return None
         return getattr(self.hf_text_config, "sliding_window", None)
 
-    def get_sliding_window(self) -> Optional[int]:
+    def get_sliding_window(self) -> Optional[Union[int, List[Optional[int]]]]:
         """Get the sliding window size, or None if disabled.
         """
         # If user disables sliding window, return None.
@@ -1719,7 +1724,8 @@ def _get_and_verify_max_len(
         sliding_window_len_min = get_min_sliding_window(sliding_window_len)
         max_len_key = "sliding_window" \
             if sliding_window_len_min < derived_max_model_len else max_len_key
-        derived_max_model_len = min(derived_max_model_len, sliding_window_len_min)
+        derived_max_model_len = min(derived_max_model_len,
+                                    sliding_window_len_min)
 
     # If none of the keys were found in the config, use a default and
     # log a warning.
@@ -1807,7 +1813,8 @@ def _get_and_verify_max_len(
     return int(max_model_len)
 
 
-def get_min_sliding_window(sliding_window: Union[int, List[Optional[int]]]) -> int:
+def get_min_sliding_window(
+        sliding_window: Union[int, List[Optional[int]]]) -> int:
     if isinstance(sliding_window, list):
         return min([s for s in sliding_window if s is not None])
     else:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -429,7 +429,7 @@ class ModelConfig:
                 self.use_async_output_proc = False
 
     def get_hf_config_sliding_window(
-            self) -> Optional[Union[int, List[Optional[int]]]]:
+            self) -> Union[Optional[int], List[Optional[int]]]]:
         """Get the sliding window size, or None if disabled."""
 
         # Some models, like Qwen2 and Qwen1.5, use `use_sliding_window` in
@@ -1816,9 +1816,9 @@ def _get_and_verify_max_len(
 def get_min_sliding_window(
         sliding_window: Union[int, List[Optional[int]]]) -> int:
     if isinstance(sliding_window, list):
-        return min([s for s in sliding_window if s is not None])
-    else:
-        return sliding_window
+        return min(s for s in sliding_window if s is not None)
+    
+    return sliding_window
 
 
 def get_served_model_name(model: str,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -173,10 +173,8 @@ class ModelConfig:
         if self.enforce_eager is None:
             self.enforce_eager = False
 
-        has_interleaved_attention = isinstance(
-            self.hf_text_config.sliding_window,
-            list) or (self.hf_text_config.model_type in ["gemma2"]
-                      and self.hf_text_config.sliding_window is not None)
+        sliding_window = getattr(self.hf_text_config, "sliding_window", None)
+        has_interleaved_attention = (sliding_window is not None) and (isinstance(sliding_window, list) or (self.hf_text_config.model_type in ["gemma2"]))
 
         if (not self.disable_sliding_window and has_interleaved_attention):
             sliding_window_len_min = get_min_sliding_window(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -174,7 +174,9 @@ class ModelConfig:
             self.enforce_eager = False
 
         sliding_window = getattr(self.hf_text_config, "sliding_window", None)
-        has_interleaved_attention = (sliding_window is not None) and (isinstance(sliding_window, list) or (self.hf_text_config.model_type in ["gemma2"]))
+        has_interleaved_attention = (sliding_window is not None) and (
+            isinstance(sliding_window, list) or
+            (self.hf_text_config.model_type in ["gemma2"]))
 
         if (not self.disable_sliding_window and has_interleaved_attention):
             sliding_window_len_min = get_min_sliding_window(
@@ -427,7 +429,7 @@ class ModelConfig:
                 self.use_async_output_proc = False
 
     def get_hf_config_sliding_window(
-            self) -> Union[Optional[int], List[Optional[int]]]]:
+            self) -> Union[Optional[int], List[Optional[int]]]:
         """Get the sliding window size, or None if disabled."""
 
         # Some models, like Qwen2 and Qwen1.5, use `use_sliding_window` in
@@ -1815,7 +1817,7 @@ def get_min_sliding_window(
         sliding_window: Union[int, List[Optional[int]]]) -> int:
     if isinstance(sliding_window, list):
         return min(s for s in sliding_window if s is not None)
-    
+
     return sliding_window
 
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -173,14 +173,16 @@ class ModelConfig:
         if self.enforce_eager is None:
             self.enforce_eager = False
 
-        if (not self.disable_sliding_window
-                and self.hf_text_config.model_type == "gemma2"
-                and self.hf_text_config.sliding_window is not None):
+        has_interleaved_attention = isinstance(self.hf_text_config.sliding_window, list) or (self.hf_text_config.model_type in ["gemma2"] and self.hf_text_config.sliding_window is not None)
+
+        if (not self.disable_sliding_window and has_interleaved_attention):
+            sliding_window_len_min = get_min_sliding_window(self.hf_text_config.sliding_window)
+
             print_warning_once(
-                "Gemma 2 uses sliding window attention for every odd layer, "
+                f"{self.hf_text_config.model_type} has interleaved attention, "
                 "which is currently not supported by vLLM. Disabling sliding "
                 "window and capping the max length to the sliding window size "
-                f"({self.hf_text_config.sliding_window}).")
+                f"({sliding_window_len_min}).")
             self.disable_sliding_window = True
 
         self.max_model_len = _get_and_verify_max_len(
@@ -422,7 +424,7 @@ class ModelConfig:
                                "pipeline parallelism currently. Disabling it.")
                 self.use_async_output_proc = False
 
-    def get_hf_config_sliding_window(self) -> Optional[int]:
+    def get_hf_config_sliding_window(self) -> Optional[Union[int, List[int]]]:
         """Get the sliding window size, or None if disabled."""
 
         # Some models, like Qwen2 and Qwen1.5, use `use_sliding_window` in
@@ -1680,7 +1682,7 @@ def _get_and_verify_max_len(
     hf_config: PretrainedConfig,
     max_model_len: Optional[int],
     disable_sliding_window: bool,
-    sliding_window_len: Optional[int],
+    sliding_window_len: Optional[Union[int, List[Optional[int]]]],
     spec_target_max_model_len: Optional[int] = None,
 ) -> int:
     """Get and verify the model's maximum length."""
@@ -1713,9 +1715,11 @@ def _get_and_verify_max_len(
     # If sliding window is manually disabled, max_length should be less
     # than the sliding window length in the model config.
     if disable_sliding_window and sliding_window_len is not None:
+
+        sliding_window_len_min = get_min_sliding_window(sliding_window_len)
         max_len_key = "sliding_window" \
-            if sliding_window_len < derived_max_model_len else max_len_key
-        derived_max_model_len = min(derived_max_model_len, sliding_window_len)
+            if sliding_window_len_min < derived_max_model_len else max_len_key
+        derived_max_model_len = min(derived_max_model_len, sliding_window_len_min)
 
     # If none of the keys were found in the config, use a default and
     # log a warning.
@@ -1801,6 +1805,13 @@ def _get_and_verify_max_len(
                     f"{msg} To allow overriding this maximum, set "
                     "the env var VLLM_ALLOW_LONG_MAX_MODEL_LEN=1")
     return int(max_model_len)
+
+
+def get_min_sliding_window(sliding_window: Union[int, List[Optional[int]]]) -> int:
+    if isinstance(sliding_window, list):
+        return min([s for s in sliding_window if s is not None])
+    else:
+        return sliding_window
 
 
 def get_served_model_name(model: str,


### PR DESCRIPTION
Allow mistral models with interleaved attention patterns to be run-able in vLLM. For now we'll have to cap the max model length to the minimum of the allowed attention pattern until we figure out how to cleanly support interleaved attention pattern (similar to Gemma)