### PR TITLE
[CI/Build] Add bot to close stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           days-before-issue-stale: 90
           days-before-issue-close: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,54 +1,37 @@
-name: 'Close stale issues and PRs'
+name: 'Close inactive issues and PRs'
 
 on:
   schedule:
     # Daily at 1:30 AM UTC
     - cron: '30 1 * * *'
 
-env:
-  LC_ALL: en_US.UTF-8
-
-defaults:
-  run:
-    shell: bash
-
-permissions:
-  contents: read
-
 jobs:
-  stale:
+  close-issues-and-pull-requests:
     permissions:
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: "Stale Action"
         uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
-          # Apply the `stale` label to an issue with no activity for 90 days.
           days-before-issue-stale: 90
-          # Close the issue if no activity occurs within 30 days after being
-          # marked as stale.
           days-before-issue-close: 30
           stale-issue-label: 'stale'
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not
-            had activity within 90 days. It will be automatically closed if no
+            had any activity within 90 days. It will be automatically closed if no
             further activity occurs within 30 days. Leave a comment if
             you feel this issue should remain open. Thank you!
           close-issue-message: >
             This issue has been automatically closed due to inactivity. Please
             feel free to reopen if you feel it is still relevant. Thank you!
 
-          # Apply the `stale` label to a pull request with no activity for 90 days.
           days-before-pr-stale: 90
-          # Close the pull request if no activity occurs within 30 days after
-          # being marked as stale.
           days-before-pr-close: 30
           stale-pr-label: 'stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
-            has not had activity within 90 days. It will be automatically
+            has not had any activity within 90 days. It will be automatically
             closed if no further activity occurs within 30 days. Leave a comment
             if you feel this pull request should remain open. Thank you!
           close-pr-message: >

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,57 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+    # Daily at 1:30 AM UTC
+    - cron: '30 1 * * *'
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Stale Action"
+        uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+        with:
+          # Apply the `stale` label to an issue with no activity for 90 days.
+          days-before-issue-stale: 90
+          # Close the issue if no activity occurs within 30 days after being
+          # marked as stale.
+          days-before-issue-close: 30
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had activity within 90 days. It will be automatically closed if no
+            further activity occurs within 30 days. Leave a comment if
+            you feel this issue should remain open. Thank you!
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity. Please
+            feel free to reopen if you feel it is still relevant. Thank you!
+
+          # Apply the `stale` label to a pull request with no activity for 90 days.
+          days-before-pr-stale: 90
+          # Close the pull request if no activity occurs within 30 days after
+          # being marked as stale.
+          days-before-pr-close: 30
+          stale-pr-label: 'stale'
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had activity within 90 days. It will be automatically
+            closed if no further activity occurs within 30 days. Leave a comment
+            if you feel this pull request should remain open. Thank you!
+          close-pr-message: >
+            This pull request has been automatically closed due to inactivity.
+            Please feel free to reopen if you intend to continue working on it.
+            Thank you!

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
+          exempt-draft-pr: true
+          exempt-issue-labels: 'keep-open'
+          exempt-pr-labels: 'keep-open'
+
           days-before-issue-stale: 90
           days-before-issue-close: 30
           stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,9 @@ jobs:
           exempt-issue-labels: 'keep-open'
           exempt-pr-labels: 'keep-open'
 
+          labels-to-add-when-unstale: 'unstale'
+          labels-to-remove-when-stale: 'unstale'
+
           days-before-issue-stale: 90
           days-before-issue-close: 30
           stale-issue-label: 'stale'


### PR DESCRIPTION
This PR adds configuration to run the `actions/stale` github
action that closes stale issues and PRs.

Further discussion is on the issue.

Closes #9435

Signed-off-by: Russell Bryant <rbryant@redhat.com>
