### PR TITLE
[Bugfix] Allow prefill of assistant response when using `mistral_common`

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -166,6 +166,10 @@ class MistralTokenizer:
                             tools: Optional[Dict[str, Any]] = None,
                             **kwargs) -> List[int]:
 
+        last_message = messages[len(messages) - 1]
+        if last_message["role"] == "assistant":
+            last_message["prefix"] = True
+
         request = ChatCompletionRequest(messages=messages,
                                         tools=tools)  # type: ignore[type-var]
         encoded = self.mistral.encode_chat_completion(request)

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -166,7 +166,7 @@ class MistralTokenizer:
                             tools: Optional[Dict[str, Any]] = None,
                             **kwargs) -> List[int]:
 
-        last_message = messages[len(messages) - 1]
+        last_message = messages[-1]
         if last_message["role"] == "assistant":
             last_message["prefix"] = True
 


### PR DESCRIPTION
The `mistral_common` tokenizer supports prefilling of an assistant message, when `prefix=True` is used in the last message (`role="assistant"` only).

However, `continue_final_message=False` makes no sense for the `mistral_common` tokenizer because `ChatCompletionRequest` cannot have a last message with `role="assistant"` without `prefix=True`.

Also, AFAIK, OpenAI uses `continue_final_message=True`-like behavior (continues the last assistant message), so I think this behavior should be replicated in vLLM (potentially replacing `add_generation_prompt`/`continue_final_message` in chat completion endpoint?), but that's beyond the scope of this PR. (I'm only fixing the error that vLLM gives when an application sends a message chain in which the last message is an assistant.)

(Also, warnings about `add_generation_prompt`/`continue_final_message` when using `mistral_common` are annoying and should only be logged once (or don't logged at all), but that too is beyond the scope of this PR).