### PR TITLE
[BugFix] Typing fixes to RequestOutput.prompt and beam search

### DIFF
--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
-from sequence import Logprob
+from vllm.sequence import Logprob
 
 
 @dataclass

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional
+
+from sequence import Logprob
 
 
 @dataclass
@@ -11,6 +13,7 @@ class BeamSearchSequence:
     """
     # The tokens includes the prompt.
     tokens: List[int]
+    logprobs: List[Dict[int, Logprob]]
     cum_logprob: float = 0.0
     text: Optional[str] = None
 
@@ -28,7 +31,7 @@ class BeamSearchInstance:
 
     def __init__(self, prompt_tokens: List[int]):
         self.beams: List[BeamSearchSequence] = [
-            BeamSearchSequence(tokens=prompt_tokens)
+            BeamSearchSequence(tokens=prompt_tokens, logprobs=[])
         ]
         self.completed: List[BeamSearchSequence] = []
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -433,6 +433,7 @@ class LLM:
                         for token_id, logprob_obj in logprobs.items():
                             new_beam = BeamSearchSequence(
                                 tokens=current_beam.tokens + [token_id],
+                                logprobs=current_beam.logprobs + [logprobs],
                                 cum_logprob=current_beam.cum_logprob +
                                 logprob_obj.logprob)
 

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from typing import Sequence as GenericSequence
 from typing import Union
 
-from vllm.inputs import PromptType
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import RequestOutputKind
 from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
@@ -93,7 +92,7 @@ class RequestOutput:
     def __init__(
         self,
         request_id: str,
-        prompt: Optional[PromptType],
+        prompt: Optional[str],
         prompt_token_ids: Optional[List[int]],
         prompt_logprobs: Optional[PromptLogprobs],
         outputs: List[CompletionOutput],


### PR DESCRIPTION
This reverts a recent typing change that was made in https://github.com/vllm-project/vllm/pull/9267 which was due to another recent incorrect change in the "external" beam search implementation. It would be a breaking change to the type of `RequestOutput.prompt` in the API (and caused some typing breakages to the front-end API code which references this field).

I have made some related changes/fixes to the beam search impl including properly returning logprobs, but it still needs quite a bit more work overall (for subsequent PRs).