### PR TITLE
[MISC] Add lora requests to metrics

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1620,11 +1620,13 @@ class LLMEngine:
             running_request.lora_request.lora_name
             for scheduler in self.scheduler
             for running_request in scheduler.running
+            if running_request.lora_request
             ]))
         waiting_adapters = dict(collectionsCounter([
             waiting_request.lora_request.lora_name
             for scheduler in self.scheduler
             for waiting_request in scheduler.waiting
+            if waiting_request.lora_request
             ]))
         max_lora_stat = "0"
         if self.lora_config:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1618,13 +1618,13 @@ class LLMEngine:
         finished_reason_requests: List[str] = []
         
         # Lora requests
-        running_adapters = dict(collectionsCounter([
+        running_lora_adapters = dict(collectionsCounter([
             running_request.lora_request.lora_name
             for scheduler in self.scheduler
             for running_request in scheduler.running
             if running_request.lora_request
             ]))
-        waiting_adapters = dict(collectionsCounter([
+        waiting_lora_adapters = dict(collectionsCounter([
             waiting_request.lora_request.lora_name
             for scheduler in self.scheduler
             for waiting_request in scheduler.waiting
@@ -1756,8 +1756,8 @@ class LLMEngine:
             n_requests=n_requests,
             finished_reason_requests=finished_reason_requests,
             max_lora=str(max_lora_stat),
-            waiting_adapters=list(waiting_adapters.keys()),
-            running_adapters=list(running_adapters.keys())
+            waiting_lora_adapters=list(waiting_lora_adapters.keys()),
+            running_lora_adapters=list(running_lora_adapters.keys())
         )
 
     def add_lora(self, lora_request: LoRARequest) -> bool:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1616,6 +1616,8 @@ class LLMEngine:
         num_generation_tokens_requests: List[int] = []
         n_requests: List[int] = []
         finished_reason_requests: List[str] = []
+        
+        # Lora requests
         running_adapters = dict(collectionsCounter([
             running_request.lora_request.lora_name
             for scheduler in self.scheduler
@@ -1631,7 +1633,6 @@ class LLMEngine:
         max_lora_stat = "0"
         if self.lora_config:
             max_lora_stat = str(self.lora_config.max_loras)
-        logger.info("Running Adapters %s, Waiting Adapters %s, max-lora %s", waiting_adapters, running_adapters, max_lora_stat)
         
         # NOTE: This loop assumes prefill seq_groups are before
         # decode seq_groups in scheduled_seq_groups.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1,4 +1,5 @@
 import time
+from collections import Counter as collectionsCounter
 from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -7,7 +8,7 @@ from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Deque, Dict,
                     Iterable, List, Mapping, NamedTuple, Optional)
 from typing import Sequence as GenericSequence
 from typing import Set, Type, Union, cast, overload
-from collections import Counter as collectionsCounter
+
 import torch
 from typing_extensions import TypeVar
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1617,24 +1617,26 @@ class LLMEngine:
         num_generation_tokens_requests: List[int] = []
         n_requests: List[int] = []
         finished_reason_requests: List[str] = []
-        
+
         # Lora requests
-        running_lora_adapters = dict(collectionsCounter([
-            running_request.lora_request.lora_name
-            for scheduler in self.scheduler
-            for running_request in scheduler.running
-            if running_request.lora_request
+        running_lora_adapters = dict(
+            collectionsCounter([
+                running_request.lora_request.lora_name
+                for scheduler in self.scheduler
+                for running_request in scheduler.running
+                if running_request.lora_request
             ]))
-        waiting_lora_adapters = dict(collectionsCounter([
-            waiting_request.lora_request.lora_name
-            for scheduler in self.scheduler
-            for waiting_request in scheduler.waiting
-            if waiting_request.lora_request
+        waiting_lora_adapters = dict(
+            collectionsCounter([
+                waiting_request.lora_request.lora_name
+                for scheduler in self.scheduler
+                for waiting_request in scheduler.waiting
+                if waiting_request.lora_request
             ]))
         max_lora_stat = "0"
         if self.lora_config:
             max_lora_stat = str(self.lora_config.max_loras)
-        
+
         # NOTE: This loop assumes prefill seq_groups are before
         # decode seq_groups in scheduled_seq_groups.
         if scheduler_outputs is not None:
@@ -1758,8 +1760,7 @@ class LLMEngine:
             finished_reason_requests=finished_reason_requests,
             max_lora=str(max_lora_stat),
             waiting_lora_adapters=list(waiting_lora_adapters.keys()),
-            running_lora_adapters=list(running_lora_adapters.keys())
-        )
+            running_lora_adapters=list(running_lora_adapters.keys()))
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_executor.add_lora(lora_request)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -34,6 +34,7 @@ class Metrics:
     See https://prometheus.github.io/client_python/multiprocess/ for more
     details on limitations.
     """
+
     labelname_finish_reason = "finished_reason"
     labelname_waiting_lora_adapters = "waiting_lora_adapters"
     labelname_running_lora_adapters = "running_lora_adapters"
@@ -60,12 +61,13 @@ class Metrics:
             multiprocess_mode="sum")
         self.gauge_lora_info = self._gauge_cls(
             name="vllm:lora_requests_info",
-            documentation="Running stats on lora requests waiting and under process.",
+            documentation="Running stats on lora requests.",
             labelnames=[
                 self.labelname_running_lora_adapters,
-                self.labelname_max_lora, 
-                self.labelname_waiting_lora_adapters],
-            multiprocess_mode="livemostrecent"
+                self.labelname_max_lora,
+                self.labelname_waiting_lora_adapters,
+            ],
+            multiprocess_mode="livemostrecent",
         )
         self.gauge_scheduler_swapped = self._gauge_cls(
             name="vllm:num_requests_swapped",
@@ -437,8 +439,8 @@ class PrometheusStatLogger(StatLoggerBase):
         # Convenience function for logging list to histogram.
         for datum in data:
             histogram.labels(**self.labels).observe(datum)
-            
-    def _log_gauge_string(self, gauge, data:Dict[str,str]) -> None:
+
+    def _log_gauge_string(self, gauge, data: Dict[str, str]) -> None:
         gauge.labels(**data).set(1)
 
     def _log_prometheus(self, stats: Stats) -> None:
@@ -458,10 +460,14 @@ class PrometheusStatLogger(StatLoggerBase):
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
         lora_info = {
-            self.metrics.labelname_running_lora_adapters: ','.join(stats.running_lora_adapters),
-            self.metrics.labelname_waiting_lora_adapters: ','.join(stats.waiting_lora_adapters),
+            self.metrics.labelname_running_lora_adapters: ",".join(
+                stats.running_lora_adapters
+            ),
+            self.metrics.labelname_waiting_lora_adapters: ",".join(
+                stats.waiting_lora_adapters
+            ),
             self.metrics.labelname_max_lora: stats.max_lora,
-            }
+        }
         self._log_gauge_string(self.metrics.gauge_lora_info, lora_info)
         # Iteration level data
         self._log_counter(self.metrics.counter_num_preemption,

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -460,13 +460,12 @@ class PrometheusStatLogger(StatLoggerBase):
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
         lora_info = {
-            self.metrics.labelname_running_lora_adapters: ",".join(
-                stats.running_lora_adapters
-            ),
-            self.metrics.labelname_waiting_lora_adapters: ",".join(
-                stats.waiting_lora_adapters
-            ),
-            self.metrics.labelname_max_lora: stats.max_lora,
+            self.metrics.labelname_running_lora_adapters:
+            ",".join(stats.running_lora_adapters),
+            self.metrics.labelname_waiting_lora_adapters:
+            ",".join(stats.waiting_lora_adapters),
+            self.metrics.labelname_max_lora:
+            stats.max_lora,
         }
         self._log_gauge_string(self.metrics.gauge_lora_info, lora_info)
         # Iteration level data

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -35,8 +35,8 @@ class Metrics:
     details on limitations.
     """
     labelname_finish_reason = "finished_reason"
-    labelname_waiting_adapters = "waiting_adapters"
-    labelname_running_adapters = "running_adapters"
+    labelname_waiting_lora_adapters = "waiting_lora_adapters"
+    labelname_running_lora_adapters = "running_lora_adapters"
     labelname_max_lora = "max_lora"
     _gauge_cls = prometheus_client.Gauge
     _counter_cls = prometheus_client.Counter
@@ -62,9 +62,9 @@ class Metrics:
             name="vllm:lora_requests_info",
             documentation="Running stats on lora requests waiting and under process.",
             labelnames=[
-                self.labelname_running_adapters,
+                self.labelname_running_lora_adapters,
                 self.labelname_max_lora, 
-                self.labelname_waiting_adapters],
+                self.labelname_waiting_lora_adapters],
             multiprocess_mode="livemostrecent"
         )
         self.gauge_scheduler_swapped = self._gauge_cls(
@@ -458,8 +458,8 @@ class PrometheusStatLogger(StatLoggerBase):
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
         lora_info = {
-            self.metrics.labelname_running_adapters: ','.join(stats.running_adapters),
-            self.metrics.labelname_waiting_adapters: ','.join(stats.waiting_adapters),
+            self.metrics.labelname_running_lora_adapters: ','.join(stats.running_lora_adapters),
+            self.metrics.labelname_waiting_lora_adapters: ','.join(stats.waiting_lora_adapters),
             self.metrics.labelname_max_lora: stats.max_lora,
             }
         self._log_gauge_string(self.metrics.gauge_lora_info, lora_info)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Optional, Type, Union, cast
 
 import numpy as np
 import prometheus_client
-import time
 
 from vllm.engine.metrics_types import (StatLoggerBase, Stats,
                                        SupportsMetricsInfo)
@@ -42,7 +41,6 @@ class Metrics:
     _gauge_cls = prometheus_client.Gauge
     _counter_cls = prometheus_client.Counter
     _histogram_cls = prometheus_client.Histogram
-    _info_cls = prometheus_client.Info
 
     def __init__(self, labelnames: List[str], max_model_len: int):
         # Unregister any existing vLLM collectors (for CI/CD)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -459,6 +459,7 @@ class PrometheusStatLogger(StatLoggerBase):
                         stats.cpu_prefix_cache_hit_rate)
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
+        # Including max-lora in metric, in future this property of lora config maybe extended to be dynamic.
         lora_info = {
             self.metrics.labelname_running_lora_adapters:
             ",".join(stats.running_lora_adapters),

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -459,7 +459,8 @@ class PrometheusStatLogger(StatLoggerBase):
                         stats.cpu_prefix_cache_hit_rate)
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
-        # Including max-lora in metric, in future this property of lora config maybe extended to be dynamic.
+        # Including max-lora in metric, in future this property of lora
+        # config maybe extended to be dynamic.
         lora_info = {
             self.metrics.labelname_running_lora_adapters:
             ",".join(stats.running_lora_adapters),

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Type, Union, cast
 
 import numpy as np
 import prometheus_client
+import time
 
 from vllm.engine.metrics_types import (StatLoggerBase, Stats,
                                        SupportsMetricsInfo)
@@ -35,9 +36,13 @@ class Metrics:
     details on limitations.
     """
     labelname_finish_reason = "finished_reason"
+    labelname_waiting_adapters = "waiting_adapters"
+    labelname_running_adapters = "running_adapters"
+    labelname_max_lora = "max_lora"
     _gauge_cls = prometheus_client.Gauge
     _counter_cls = prometheus_client.Counter
     _histogram_cls = prometheus_client.Histogram
+    _info_cls = prometheus_client.Info
 
     def __init__(self, labelnames: List[str], max_model_len: int):
         # Unregister any existing vLLM collectors (for CI/CD)
@@ -55,6 +60,15 @@ class Metrics:
             documentation="Number of requests waiting to be processed.",
             labelnames=labelnames,
             multiprocess_mode="sum")
+        self.gauge_lora_info = self._gauge_cls(
+            name="vllm:lora_requests_info",
+            documentation="Running stats on lora requests waiting and under process.",
+            labelnames=[
+                self.labelname_running_adapters,
+                self.labelname_max_lora, 
+                self.labelname_waiting_adapters],
+            multiprocess_mode="livemostrecent"
+        )
         self.gauge_scheduler_swapped = self._gauge_cls(
             name="vllm:num_requests_swapped",
             documentation="Number of requests swapped to CPU.",
@@ -425,6 +439,9 @@ class PrometheusStatLogger(StatLoggerBase):
         # Convenience function for logging list to histogram.
         for datum in data:
             histogram.labels(**self.labels).observe(datum)
+            
+    def _log_gauge_string(self, gauge, data:Dict[str,str]) -> None:
+        gauge.labels(**data).set(1)
 
     def _log_prometheus(self, stats: Stats) -> None:
         # System state data
@@ -442,7 +459,12 @@ class PrometheusStatLogger(StatLoggerBase):
                         stats.cpu_prefix_cache_hit_rate)
         self._log_gauge(self.metrics.gauge_gpu_prefix_cache_hit_rate,
                         stats.gpu_prefix_cache_hit_rate)
-
+        lora_info = {
+            self.metrics.labelname_running_adapters: ','.join(stats.running_adapters),
+            self.metrics.labelname_waiting_adapters: ','.join(stats.waiting_adapters),
+            self.metrics.labelname_max_lora: stats.max_lora,
+            }
+        self._log_gauge_string(self.metrics.gauge_lora_info, lora_info)
         # Iteration level data
         self._log_counter(self.metrics.counter_num_preemption,
                           stats.num_preemption_iter)

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -51,6 +51,9 @@ class Stats:
     num_generation_tokens_requests: List[int]
     n_requests: List[int]
     finished_reason_requests: List[str]
+    waiting_adapters: List[str]
+    running_adapters: List[str]
+    max_lora: str
 
     spec_decode_metrics: Optional["SpecDecodeWorkerMetrics"] = None
 

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -51,8 +51,8 @@ class Stats:
     num_generation_tokens_requests: List[int]
     n_requests: List[int]
     finished_reason_requests: List[str]
-    waiting_adapters: List[str]
-    running_adapters: List[str]
+    waiting_lora_adapters: List[str]
+    running_lora_adapters: List[str]
     max_lora: str
 
     spec_decode_metrics: Optional["SpecDecodeWorkerMetrics"] = None


### PR DESCRIPTION
This PR adds lora requests to log metrics. The metrics will be logged only when the lora is enabled. Here is an example:
```
# HELP vllm:lora_requests_info Running stats on lora requests waiting and under process.
# TYPE vllm:lora_requests_info gauge
vllm:lora_requests_info{max_lora="1",running_adapters="",waiting_adapters=""} 1.0
```
We plan to leverage this information for routing decisions in https://github.com/kubernetes-sigs/llm-instance-gateway