### PR TITLE
[Frontend] Support simpler image input format

### DIFF
--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -387,3 +387,29 @@ def test_parse_chat_messages_rejects_too_many_images_across_messages(
                     "text": "What about these two?"
                 }]
             }], phi3v_model_config, phi3v_tokenizer)
+
+
+def test_parse_chat_messages_multiple_images_uncommon_input(
+    phi3v_model_config,
+    phi3v_tokenizer,
+    image_url,
+):
+    conversation, mm_data = parse_chat_messages([{
+        "role":
+        "user",
+        "content": [
+            "What's in these images?", {
+                "image_url": image_url
+            }, {
+                "image_url": image_url
+            }
+        ]
+    }], phi3v_model_config, phi3v_tokenizer)
+
+    assert conversation == [{
+        "role":
+        "user",
+        "content":
+        "<|image_1|>\n<|image_2|>\nWhat's in these images?"
+    }]
+    _assert_mm_data_is_image_input(mm_data, 2)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -80,7 +80,8 @@ class CustomChatCompletionContentSimpleAudioParam(TypedDict, total=False):
 ChatCompletionContentPartParam: TypeAlias = Union[
     OpenAIChatCompletionContentPartParam, ChatCompletionContentPartAudioParam,
     ChatCompletionContentPartRefusalParam,
-    CustomChatCompletionContentPartParam, CustomChatCompletionContentSimpleImageParam,
+    CustomChatCompletionContentPartParam,
+    CustomChatCompletionContentSimpleImageParam,
     CustomChatCompletionContentSimpleAudioParam, str]
 
 
@@ -439,8 +440,8 @@ def _parse_chat_message_content_parts(
         elif _is_simple_audio_part(part):
             mm_parser.parse_audio(part["audio_url"]) # type: ignore
         else:
-            # If part is not string, CustomChatCompletionContentSimpleImageParam
-            # CustomChatCompletionContentSimpleAudioParam, process in the following way.
+            # Process not string, CustomChatCompletionContentSimpleImageParam
+            # CustomChatCompletionContentSimpleAudioParam parts.
             part_type = part["type"] # type: ignore
             if part_type == "text":
                 text = _TextParser(part)["text"]

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -537,7 +537,7 @@ def parse_chat_messages_futures(
 ) -> Tuple[List[ConversationMessage], Awaitable[Optional[MultiModalDataDict]]]:
     conversation: List[ConversationMessage] = []
     mm_tracker = AsyncMultiModalItemTracker(model_config, tokenizer)
-    
+
     for msg in messages:
         sub_messages = _parse_chat_message_content(msg, mm_tracker)
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -420,7 +420,7 @@ MM_PARSER_MAP: Dict[str, Callable[[ChatCompletionContentPartParam], str]] = {
 }
 
 
-def _parse_chat_message_content_mm_parts(
+def _parse_chat_message_content_mm_part(
         part: ChatCompletionContentPartParam) -> Tuple[str, str]:
     """
     Parses a given multi modal content part based on its type.
@@ -482,7 +482,7 @@ def _parse_chat_message_content_parts(
             texts.append(text)
         else:  # Handle structured dictionary parts
             assert isinstance(part, dict)
-            part_type, content = _parse_chat_message_content_mm_parts(part)
+            part_type, content = _parse_chat_message_content_mm_part(part)
 
             if part_type in ["text", "refusal"]:
                 texts.append(content)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -60,6 +60,7 @@ class CustomChatCompletionContentPartParam(TypedDict, total=False):
 
 class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     """A simpler version of the param that only accepts a plain image_url.
+    This is supported by OpenAI API, although it is not documented.
     
     Example:
     {

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -57,6 +57,7 @@ class CustomChatCompletionContentPartParam(TypedDict, total=False):
     type: Required[str]
     """The type of the content part."""
 
+
 class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     """A simpler version of the param that only accepts a plain image_url.
     
@@ -67,6 +68,7 @@ class CustomChatCompletionContentSimpleImageParam(TypedDict, total=False):
     """
     image_url: Required[str]
 
+
 class CustomChatCompletionContentSimpleAudioParam(TypedDict, total=False):
     """A simpler version of the param that only accepts a plain audio_url.
     
@@ -76,6 +78,7 @@ class CustomChatCompletionContentSimpleAudioParam(TypedDict, total=False):
     }
     """
     audio_url: Required[str]
+
 
 ChatCompletionContentPartParam: TypeAlias = Union[
     OpenAIChatCompletionContentPartParam, ChatCompletionContentPartAudioParam,
@@ -407,15 +410,18 @@ _AudioParser = partial(cast, ChatCompletionContentPartAudioParam)
 _RefusalParser = partial(cast, ChatCompletionContentPartRefusalParam)
 MODEL_KEEP_MULTI_MODAL_CONTENT = {'mllama'}
 
+
 def _is_simple_image_part(part: ChatCompletionContentPartParam) -> bool:
-    """Check if the part is CustomChatCompletionContentSimpleImageParam type."""
-    return isinstance(part, dict) and "image_url" in part and isinstance(
-        part["image_url"], str)
+    """Check if the part is CustomChatCompletionContentSimpleImageParam."""
+    image_url = part.get("image_url") if isinstance(part, dict) else None
+    return isinstance(image_url, str)
+
 
 def _is_simple_audio_part(part: ChatCompletionContentPartParam) -> bool:
-    """Check if the part is CustomChatCompletionContentSimpleAudioParam type."""
-    return isinstance(part, dict) and "audio_url" in part and isinstance(
-        part["audio_url"], str)
+    """Check if the part is CustomChatCompletionContentSimpleAudioParam."""
+    audio_url = part.get("audio_url") if isinstance(part, dict) else None
+    return isinstance(audio_url, str)
+
 
 def _parse_chat_message_content_parts(
     role: str,
@@ -435,19 +441,19 @@ def _parse_chat_message_content_parts(
             text = _TextParser(part)
             texts.append(text)
         elif _is_simple_image_part(part):
-            mm_parser.parse_image(part["image_url"]) # type: ignore
+            mm_parser.parse_image(part["image_url"])  # type: ignore
             has_image = True
         elif _is_simple_audio_part(part):
-            mm_parser.parse_audio(part["audio_url"]) # type: ignore
+            mm_parser.parse_audio(part["audio_url"])  # type: ignore
         else:
             # Process not string, CustomChatCompletionContentSimpleImageParam
             # CustomChatCompletionContentSimpleAudioParam parts.
-            part_type = part["type"] # type: ignore
+            part_type = part["type"]  # type: ignore
             if part_type == "text":
                 text = _TextParser(part)["text"]
                 texts.append(text)
             # This is the logic that distinguish it's a text / image / audio.
-            
+
             elif part_type == "image_url":
                 image_url = _ImageParser(part)["image_url"]
 


### PR DESCRIPTION
**Why we make this change:**
Some users use a simpler image input format (example below), which we cannot handle properly now:
```
[
  {
    "role": "user",
    "content": [
      "what's the animals in the image?",
      {
        "image_url": "https://animals.com/dog"
      },
      {
        "image_url": "https://animals.com/cat"
      },
      
    ]
  }
]
```

OpenAI can handle this format well even though they didn't document in the API reference. 

**Changes:**
Modified the input parsing logic to support more content types within the "content" field - string, simpler image_url, simpler audio_url.