### PR TITLE
[CI/Build] Remove unnecessary `fork_new_process`

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -587,7 +587,7 @@ def large_gpu_test(*, min_gb: int):
     )
 
     def wrapper(f: Callable[_P, None]) -> Callable[_P, None]:
-        return test_skipif(fork_new_process_for_each_test(f))
+        return test_skipif(f)
 
     return wrapper
 


### PR DESCRIPTION
In #8925, I accidentally copied over `fork_new_process_for_each_test` to the `large_gpu_test` when it's actually unnecessary (since `current_platform.get_device_total_memory` is supposed to be stateless).