### PR TITLE
[Model] Update MPT model with GLU and rope and add low precision layer norm

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -1,11 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 """Custom normalization layers."""
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Type, Union
 
 import torch
 import torch.nn as nn
 
 from vllm.model_executor.custom_op import CustomOp
+
+
+def _cast_if_autocast_enabled(
+        tensor: Optional[torch.Tensor]) -> Optional[torch.Tensor]:
+    if tensor is not None and torch.is_autocast_enabled():
+        return tensor.to(dtype=torch.get_autocast_dtype(tensor.device.type))
+    return tensor
+
+
+class LPLayerNorm(nn.LayerNorm):
+    """Low Precision LayerNorm."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        module_device = x.device
+        downcast_x = _cast_if_autocast_enabled(x)
+        downcast_weight = _cast_if_autocast_enabled(self.weight)
+        downcast_bias = _cast_if_autocast_enabled(self.bias)
+        with torch.autocast(enabled=False, device_type=module_device.type):
+            return nn.functional.layer_norm(
+                downcast_x,
+                self.normalized_shape,
+                downcast_weight,
+                downcast_bias,
+                self.eps,
+            )
 
 
 @CustomOp.register("rms_norm")
@@ -149,6 +174,24 @@ class RMSNorm(CustomOp):
         return s
 
 
+class LPRMSNorm(RMSNorm):
+    """Low Precision root mean square normalization."""
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        downcast_x = _cast_if_autocast_enabled(x)
+        downcast_residual = _cast_if_autocast_enabled(residual)
+        weight_backup = self.weight.data
+        self.weight.data = _cast_if_autocast_enabled(self.weight.data)
+        with torch.autocast(enabled=False, device_type=x.device.type):
+            ret = super().forward(downcast_x, downcast_residual)
+        self.weight.data = weight_backup
+        return ret
+
+
 @CustomOp.register("gemma_rms_norm")
 class GemmaRMSNorm(CustomOp):
     """RMS normalization for Gemma.
@@ -211,3 +254,11 @@ class GemmaRMSNorm(CustomOp):
                 self.forward_static)
             self._is_compiled = True
         return self.forward_native(x, residual)
+
+
+NORM_CLASS_REGISTRY: Dict[str, Type[torch.nn.Module]] = {
+    "layernorm": torch.nn.LayerNorm,
+    "low_precision_layernorm": LPLayerNorm,
+    "rmsnorm": RMSNorm,
+    "low_precision_rmsnorm": LPRMSNorm,
+}

--- a/vllm/model_executor/models/mpt.py
+++ b/vllm/model_executor/models/mpt.py
@@ -13,6 +13,7 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import (get_pp_group, get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size)
 from vllm.model_executor.layers.activation import get_act_fn
+from vllm.model_executor.layers.layernorm import NORM_CLASS_REGISTRY
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
@@ -78,8 +79,9 @@ class MPTAttention(nn.Module):
             quant_config=quant_config,
         )
         if self.qk_ln:
-            self.q_ln = nn.LayerNorm(self.d_model)
-            self.k_ln = nn.LayerNorm(self.d_model)
+            norm_class = NORM_CLASS_REGISTRY[config.norm_type]
+            self.q_ln = norm_class(self.d_model)
+            self.k_ln = norm_class(self.d_model)
         self.out_proj = RowParallelLinear(
             self.d_model,
             self.d_model,
@@ -182,12 +184,13 @@ class MPTBlock(nn.Module):
     ):
         super().__init__()
         hidden_size = config.d_model
-        self.norm_1 = nn.LayerNorm(hidden_size)
+        norm_class = NORM_CLASS_REGISTRY[config.norm_type]
+        self.norm_1 = norm_class(hidden_size)
         self.attn = MPTAttention(config,
                                  cache_config,
                                  quant_config,
                                  prefix=f"{prefix}.attn")
-        self.norm_2 = nn.LayerNorm(hidden_size)
+        self.norm_2 = norm_class(hidden_size)
         self.ffn = MPTMLP(config, quant_config)
 
     def forward(
@@ -218,7 +221,12 @@ class MPTModel(nn.Module):
         quant_config = vllm_config.quant_config
 
         assert config.embedding_fraction == 1.0
-        assert config.norm_type == "low_precision_layernorm"
+        assert config.norm_type in (
+            "layernorm",
+            "low_precision_layernorm",
+            "rmsnorm",
+            "low_precision_rmsnorm",
+        )
 
         self.wte = VocabParallelEmbedding(
             config.vocab_size,
@@ -229,7 +237,7 @@ class MPTModel(nn.Module):
             lambda prefix: MPTBlock(
                 config, cache_config, quant_config, prefix=prefix),
             prefix=f"{prefix}.blocks")
-        self.norm_f = nn.LayerNorm(config.d_model)
+        self.norm_f = NORM_CLASS_REGISTRY[config.norm_type](config.d_model)
         if config.no_bias:
             for module in self.modules():
                 if hasattr(module, "bias") and isinstance(

--- a/vllm/transformers_utils/configs/mpt.py
+++ b/vllm/transformers_utils/configs/mpt.py
@@ -46,7 +46,7 @@ class MPTConfig(PretrainedConfig):
                  d_model: int = 2048,
                  n_heads: int = 16,
                  n_layers: int = 24,
-                 expansion_ratio: int = 4,
+                 expansion_ratio: float = 4,
                  max_seq_len: int = 2048,
                  vocab_size: int = 50368,
                  resid_pdrop: float = 0.0,


### PR DESCRIPTION
This PR does the following like #4116

* Update the MPT model to match the latest in https://github.com/mosaicml/llm-foundry/tree/main/llmfoundry/models/mpt
* Add low precision layer norm
* Allow MPT model to select layer norm algorithms

differents from #4116 is
* Uses MergedColumnParallelLinear instead of  two separated ColumnParallelLinear
* Uses torch.get_autocast_dtype instead of old APIs (get_autocast_gpu_dtype / get_autocast_cpu_dtype)
* Reduces redundants code.

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


