### PR TITLE
[BugFix][Core] Prefix caching: Postpone prefill scheduling for prompts with the same prefix

### DIFF
--- a/vllm/core/block_manager_v1.py
+++ b/vllm/core/block_manager_v1.py
@@ -334,8 +334,9 @@ class BlockSpaceManagerV1(BlockSpaceManager):
                     seq.hash_of_block(logical_idx),
                     seq.num_hashed_tokens_of_block(logical_idx))
                 if not block.computed and block.ref_count > 1:
+                    # the block is being computed
                     self.gpu_allocator.free(block)
-                    for prev_block in block_table:
+                    for prev_block in block_table.list():
                         self.gpu_allocator.free(prev_block)
                     block_table.reset()
                     return block_table
@@ -752,4 +753,3 @@ class BlockSpaceManagerV1(BlockSpaceManager):
         if device == Device.CPU:
             return self.cpu_allocator.get_prefix_cache_hit_rate()
         raise ValueError(f"Invalid device: {device}")
-

--- a/vllm/core/block_manager_v2.py
+++ b/vllm/core/block_manager_v2.py
@@ -244,7 +244,7 @@ class BlockSpaceManagerV2(BlockSpaceManager):
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()
         return new_cows
-    
+
     def exist(self, seq: Sequence) -> bool:
         return seq.seq_id in self.block_tables
 

--- a/vllm/core/block_manager_v2.py
+++ b/vllm/core/block_manager_v2.py
@@ -244,6 +244,9 @@ class BlockSpaceManagerV2(BlockSpaceManager):
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()
         return new_cows
+    
+    def free(self, seq: Sequence) -> bool:
+        return seq.seq_id in self.block_tables
 
     def free(self, seq: Sequence) -> None:
         seq_id = seq.seq_id

--- a/vllm/core/block_manager_v2.py
+++ b/vllm/core/block_manager_v2.py
@@ -244,6 +244,9 @@ class BlockSpaceManagerV2(BlockSpaceManager):
         # Return any new copy-on-writes.
         new_cows = self.block_allocator.clear_copy_on_writes()
         return new_cows
+    
+    def exist(self, seq: Sequence) -> bool:
+        return seq.seq_id in self.block_tables
 
     def free(self, seq: Sequence) -> None:
         seq_id = seq.seq_id

--- a/vllm/core/interfaces.py
+++ b/vllm/core/interfaces.py
@@ -88,6 +88,10 @@ class BlockSpaceManager(ABC):
         pass
 
     @abstractmethod
+    def exist(self, seq: Sequence) -> bool:
+        pass
+
+    @abstractmethod
     def free(self, seq: Sequence) -> None:
         pass
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -342,7 +342,6 @@ class Scheduler:
         self.waiting: Deque[SequenceGroup] = deque()
         # Sequence groups in the RUNNING state.
         # Contain decode requests.
-        self.waiting_dupe: Deque[SequenceGroup] = deque()
         self.running: Deque[SequenceGroup] = deque()
         # Sequence groups in the SWAPPED state.
         # Contain decode requests that are swapped out.
@@ -843,16 +842,41 @@ class Scheduler:
         self.running = running_queue
         return force_preemption_count
     
-    def _do_schedule_prefills(
+    def _schedule_prefills(
         self,
         budget: SchedulingBudget,
         curr_loras: Optional[Set[int]],
-        enable_chunking: bool,
-        ignored_seq_groups: List[SequenceGroup],
-        seq_groups: List[ScheduledSequenceGroup],
-        waiting_queue: Deque[SequenceGroup],
-        leftover_waiting_sequences: Deque[SequenceGroup] = None):
-        
+        enable_chunking: bool = False,
+    ) -> SchedulerPrefillOutputs:
+        """Schedule sequence groups that are in prefill stage.
+
+        Note that the current scheduler treats PREEMPTED_FOR_RECOMPUTE
+        as a new prefill (that starts from beginning -> most recently generated
+        tokens).
+
+        It schedules waiting requests as long as it fits `budget` and
+        curr_loras <= max_lora from the scheduling config. The input arguments
+        `budget` and `curr_loras` are updated based on scheduled seq_groups.
+
+        Args:
+            budget: The scheduling budget. The argument is in-place updated
+                when any requests are scheduled.
+            curr_loras: Currently batched lora request ids. The argument is
+                in-place updated when any requests are scheduled.
+            enable_chunking: If True, seq group can be chunked and only a
+                chunked number of tokens are scheduled  if
+                `budget.num_batched_tokens` has not enough capacity to schedule
+                all tokens.
+
+        Returns:
+            SchedulerPrefillOutputs.
+        """
+        ignored_seq_groups: List[SequenceGroup] = []
+        seq_groups: List[ScheduledSequenceGroup] = []
+
+        waiting_queue = self.waiting
+
+        leftover_waiting_sequences: Deque[SequenceGroup] = deque()
         while self._passed_delay(time.time()) and waiting_queue:
             seq_group = waiting_queue[0]
 
@@ -919,11 +943,13 @@ class Scheduler:
                                                num_new_seqs=num_new_seqs)):
                 break
 
+            waiting_queue.popleft()
+            if not self._allocate_and_set_running(seq_group):
+                leftover_waiting_sequences.appendleft(seq_group)
+                continue
             # Can schedule this request.
             if curr_loras is not None and lora_int_id > 0:
                 curr_loras.add(lora_int_id)
-            waiting_queue.popleft()
-            self._allocate_and_set_running(seq_group)
 
             if enable_chunking and self.scheduler_config.is_multi_step:
                 blocks_to_copy: List[Tuple[int, int]] = []
@@ -948,62 +974,10 @@ class Scheduler:
             budget.add_num_batched_tokens(seq_group.request_id, num_new_tokens)
             budget.add_num_seqs(seq_group.request_id, num_new_seqs)
 
-        if leftover_waiting_sequences:
-            # Queue requests that couldn't be scheduled.
-            waiting_queue.extendleft(leftover_waiting_sequences)
-            if len(seq_groups) > 0:
-                self.prev_prompt = True
-
-    def _schedule_prefills(
-        self,
-        budget: SchedulingBudget,
-        curr_loras: Optional[Set[int]],
-        enable_chunking: bool = False,
-    ) -> SchedulerPrefillOutputs:
-        """Schedule sequence groups that are in prefill stage.
-
-        Note that the current scheduler treats PREEMPTED_FOR_RECOMPUTE
-        as a new prefill (that starts from beginning -> most recently generated
-        tokens).
-
-        It schedules waiting requests as long as it fits `budget` and
-        curr_loras <= max_lora from the scheduling config. The input arguments
-        `budget` and `curr_loras` are updated based on scheduled seq_groups.
-
-        Args:
-            budget: The scheduling budget. The argument is in-place updated
-                when any requests are scheduled.
-            curr_loras: Currently batched lora request ids. The argument is
-                in-place updated when any requests are scheduled.
-            enable_chunking: If True, seq group can be chunked and only a
-                chunked number of tokens are scheduled  if
-                `budget.num_batched_tokens` has not enough capacity to schedule
-                all tokens.
-
-        Returns:
-            SchedulerPrefillOutputs.
-        """
-        ignored_seq_groups: List[SequenceGroup] = []
-        seq_groups: List[ScheduledSequenceGroup] = []
-        leftover_waiting_sequences: Deque[SequenceGroup] = deque()
-
-
-        self._do_schedule_prefills(
-            budget=budget,
-            curr_loras=curr_loras,
-            enable_chunking=enable_chunking,
-            ignored_seq_groups=ignored_seq_groups,
-            seq_groups=seq_groups,
-            waiting_queue=self.waiting_dupe)
-    
-        self._do_schedule_prefills(
-            budget=budget,
-            curr_loras=curr_loras,
-            enable_chunking=enable_chunking,
-            ignored_seq_groups=ignored_seq_groups,
-            seq_groups=seq_groups,
-            waiting_queue=self.waiting,
-            leftover_waiting_sequences=leftover_waiting_sequences)
+        # Queue requests that couldn't be scheduled.
+        waiting_queue.extendleft(leftover_waiting_sequences)
+        if len(seq_groups) > 0:
+            self.prev_prompt = True
 
         return SchedulerPrefillOutputs(
             seq_groups=seq_groups,
@@ -1438,13 +1412,13 @@ class Scheduler:
 
             self._async_stopped.clear()
 
-    def _allocate_and_set_running(self, seq_group: SequenceGroup) -> None:
+    def _allocate_and_set_running(self, seq_group: SequenceGroup) -> bool:
         self.block_manager.allocate(seq_group)
         for seq in seq_group.get_seqs(status=SequenceStatus.WAITING):
             if not self.block_manager.exist(seq):
-                self.waiting_dupe.append(seq_group)
-                return
+                return False
             seq.status = SequenceStatus.RUNNING
+        return True
 
     def _append_slots(self,
                       seq_group: SequenceGroup,


### PR DESCRIPTION
FILL IN THE PR DESCRIPTION HERE

prompts = [
    "Hello, my name is",
    "Hello, my name is",
]

Identical slot_mapping for these two prompts during prefill and will update the same kv cache slots simultaneously.

Propose scheduling the 2nd prompt which has the same prefix with previous prompt in the budget.
BlockSpaceManagerv2 has the same issue, I only change the v1 and would like to have some feedback before 
looking at v2. Ideally, there should be a dedupe logic to filter out other identical prompts or have the same prefix.

FIX: #7414 


**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


