### PR TITLE
[CI/Build] Configure matcher for actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -34,4 +34,5 @@ jobs:
 
       - name: "Run actionlint"
         run: |
+          echo "::add-matcher::.github/workflows/matchers/actionlint.json"
           tools/actionlint.sh -color


### PR DESCRIPTION
When introducing the CI workflow that lints github CI config, this
detail was left out. This ensures that github will interpret the job
output properly and highlight errors in the diff viewer when new
errors are introduced. The config was present, just not loaded
properly.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
