### PR TITLE
[CI/Build] Add error matching config for mypy

### DIFF
--- a/.github/workflows/matchers/mypy.json
+++ b/.github/workflows/matchers/mypy.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "mypy",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):\\s(error|warning):\\s(.+)$",
+          "file": 1,
+          "line": 2,
+          "severity": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -32,4 +32,5 @@ jobs:
         pip install types-setuptools
     - name: Mypy
       run: |
+        echo "::add-matcher::.github/workflows/matchers/mypy.json"
         tools/mypy.sh

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -33,4 +33,4 @@ jobs:
     - name: Mypy
       run: |
         echo "::add-matcher::.github/workflows/matchers/mypy.json"
-        tools/mypy.sh
+        tools/mypy.sh 1

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -2,6 +2,10 @@
 
 CI=${1:-0}
 
+if [ $CI -eq 1 ]; then
+    set -e
+fi
+
 run_mypy() {
     echo "Running mypy on $1"
     if [ $CI -eq 1 ] && [ -z "$1" ]; then


### PR DESCRIPTION
32318c71 [CI/Build] Add error matching config for mypy
bf37729c [CI/Build] Make mypy job fail when errors occur

commit 32318c71751662327054d76e5cf2bec3b66738e3
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Oct 18 14:34:06 2024 -0400

    [CI/Build] Add error matching config for mypy
    
    This change makes GitHub parse `mypy` output and show errors in the
    diff viewer for PRs. This makes errors more easily visible inline with
    the code that was changed without having to dig through CI logs.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit bf37729c7e492dabea88348da7afe64c83bd00c8
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Oct 18 19:08:44 2024 +0000

    [CI/Build] Make mypy job fail when errors occur
    
    Fix `tools/mypy.sh` to fail when any command fails when running in CI.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

Sample of an intentional mypy error

<img width="655" alt="image" src="https://github.com/user-attachments/assets/60dfc42a-ad6c-43f2-9224-bf7e83e1d988">
