### PR TITLE
[CI/Build] Add error matching for ruff output

### DIFF
--- a/.github/workflows/matchers/ruff.json
+++ b/.github/workflows/matchers/ruff.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "ruff",
+        "pattern": [
+          {
+            "regexp": "^(.+?):(\\d+):(\\d+): (\\w+): (.+)$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "code": 4,
+            "message": 5
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -28,7 +28,8 @@ jobs:
         pip install -r requirements-lint.txt
     - name: Analysing the code with ruff
       run: |
-        ruff check .
+        echo "::add-matcher::.github/workflows/matchers/ruff.json"
+        ruff check --output-format github .
     - name: Spelling check with codespell
       run: |
         codespell --toml pyproject.toml


### PR DESCRIPTION
56c1c54d [CI/Build] Tell ruff to generate github formatted errors

commit 56c1c54dc4d6839f9e219bfba10923bfb2c64958
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Oct 18 19:27:31 2024 +0000

    [CI/Build] Tell ruff to generate github formatted errors
    
    `ruff` has built-in support for generating errors in a format that
    GitHub understands so that errors will be shown in the diff viewer.
    This makes it easy to see errors inline with the code and without
    having to open CI logs.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

Sample display of an error:

<img width="651" alt="image" src="https://github.com/user-attachments/assets/e844ac4c-153a-422d-84fb-ed1f177d5c01">

