### PR TITLE
[Model][Pixtral] Optimizations for input_processor_for_pixtral_hf

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -701,12 +701,12 @@ def input_processor_for_pixtral_hf(
     new_prompt = inputs.get("prompt")
     new_token_ids = inputs["prompt_token_ids"]
 
+    image_token = processor.image_token
+    image_break_token = processor.image_break_token
+    image_end_token = processor.image_end_token
+
     # Update new_prompt if present
     if new_prompt:
-        image_token = processor.image_token
-        image_break_token = processor.image_break_token
-        image_end_token = processor.image_end_token
-
         parts = new_prompt.split(image_token)
         assert len(parts) - 1 == len(image_data)
         new_parts = [parts[0]]  # Start with the part before any image tokens
@@ -729,9 +729,10 @@ def input_processor_for_pixtral_hf(
         new_prompt = "".join(new_parts)
 
     # Update new_token_ids
-    image_token_id = 10
-    image_break_id = 12
-    image_end_id = 13
+    convert_tokens_to_ids = processor.tokenizer.convert_tokens_to_ids
+    image_token_id = convert_tokens_to_ids(image_token)
+    image_break_id = convert_tokens_to_ids(image_break_token)
+    image_end_id = convert_tokens_to_ids(image_end_token)
     placeholder_token_id = -999
     # Find all image token indices at once
     placeholder_indices = [


### PR DESCRIPTION
This PR improves the performance of the Pixtral input processor function a bit. 

For `new_prompt` we split the prompt only once, process images and prompt parts together, and generate new tokens for each image more directly.

For `new_token_ids` we now find all image tokens at once, process images and tokens together more efficiently, and replace tokens from end to start to avoid index issues. 