### PR TITLE
[Frontend] Avoid creating guided decoding LogitsProcessor unnecessarily

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -49,14 +49,17 @@ class GuidedDecodingParams:
 
     @staticmethod
     def from_optional(
-        json: Optional[Union[Dict, BaseModel, str]],
+        json: Optional[Union[Dict, BaseModel, str]] = None,
         regex: Optional[str] = None,
         choice: Optional[List[str]] = None,
         grammar: Optional[str] = None,
         json_object: Optional[bool] = None,
         backend: Optional[str] = None,
         whitespace_pattern: Optional[str] = None,
-    ) -> "GuidedDecodingParams":
+    ) -> Optional["GuidedDecodingParams"]:
+        if all(arg is None
+               for arg in (json, regex, choice, grammar, json_object)):
+            return None
         # Extract json schemas from pydantic models
         if isinstance(json, (BaseModel, type(BaseModel))):
             json = json.model_json_schema()


### PR DESCRIPTION
We were inadvertently creating a `LogitsProcessor` for outlines for all requests even if no guided decoding parameters were specified.