### PR TITLE
[Bugfix] Fix `illegal memory access` error with chunked prefill, prefix caching, block manager v2 and xformers enabled together

### DIFF
--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -5,11 +5,20 @@ Run `pytest tests/prefix_caching/test_prefix_caching.py`.
 import pytest
 
 from tests.kernels.utils import override_backend_env_variable
+from vllm import SamplingParams, TokensPrompt
 
 from ..models.utils import check_outputs_equal
 
 MODELS = [
     "facebook/opt-125m",
+]
+
+UNSTABLE_PROMPT_SEQUENCE = [
+    ([0] * 588) + ([1] * 1332) + ([2] * 30) + ([3] * 1),
+    ([0] * 588) + ([1] * 1332) + ([4] * 3) + ([5] * 50),
+    ([0] * 588) + ([1] * 1332) + ([2] * 30) + ([6] * 95),
+    ([0] * 588) + ([1] * 1332) + ([4] * 3) + ([7] * 174),
+    ([0] * 588) + ([8] * 1539),
 ]
 
 
@@ -57,3 +66,22 @@ def test_mixed_requests(
         name_0="hf",
         name_1="vllm",
     )
+
+
+@pytest.mark.parametrize("backend", ["FLASH_ATTN", "FLASHINFER", "XFORMERS"])
+def test_unstable_prompt_sequence(
+    vllm_runner,
+    backend: str,
+    monkeypatch,
+) -> None:
+    override_backend_env_variable(monkeypatch, backend)
+
+    with vllm_runner(
+            enable_chunked_prefill=True,
+            enable_prefix_caching=True,
+            max_model_len=4096,
+            model="Qwen/Qwen2.5-0.5B-Instruct",
+    ) as vllm_model:
+        for prompt in UNSTABLE_PROMPT_SEQUENCE:
+            vllm_model.generate(TokensPrompt(prompt_token_ids=prompt),
+                                SamplingParams(max_tokens=1))

--- a/tests/prefix_caching/test_prefix_caching.py
+++ b/tests/prefix_caching/test_prefix_caching.py
@@ -77,10 +77,10 @@ def test_unstable_prompt_sequence(
     override_backend_env_variable(monkeypatch, backend)
 
     with vllm_runner(
+            "Qwen/Qwen2.5-0.5B-Instruct",
             enable_chunked_prefill=True,
             enable_prefix_caching=True,
             max_model_len=4096,
-            model="Qwen/Qwen2.5-0.5B-Instruct",
     ) as vllm_model:
         for prompt in UNSTABLE_PROMPT_SEQUENCE:
             vllm_model.generate(TokensPrompt(prompt_token_ids=prompt),

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -138,7 +138,6 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             chunked_prefill_enabled: bool):
         is_prompt = inter_data.is_prompt
         block_tables = inter_data.block_tables
-        computed_block_nums = inter_data.computed_block_nums
 
         for (seq_id, token_len, seq_len, curr_seq_len, query_len, context_len,
              curr_sliding_window_block) in zip(
@@ -164,10 +163,14 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             # NOTE: This only works for oooooooxxx style attention.
             block_table = []
             if inter_data.prefix_cache_hit:
-                block_table = computed_block_nums
+                block_table = block_tables[seq_id]
             elif ((chunked_prefill_enabled or not is_prompt)
                   and block_tables is not None):
-                block_table = block_tables[seq_id][-curr_sliding_window_block:]
+                if curr_sliding_window_block == 0:
+                    block_table = block_tables[seq_id]
+                else:
+                    block_table = block_tables[seq_id][
+                        -curr_sliding_window_block:]
             self.block_tables.append(block_table)
 
             # Compute slot mapping.

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -536,7 +536,7 @@ class XFormersMetadataBuilder(AttentionMetadataBuilder[XFormersMetadata]):
                      dtype=query_start_loc.dtype,
                      out=query_start_loc[1:])
 
-        return self._metadata_cls(  # type: ignore
+        return XFormersMetadata(
             num_prefills=self.num_prefills,
             slot_mapping=slot_mapping_tensor,
             num_prefill_tokens=self.num_prefill_tokens,

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -1,6 +1,6 @@
 """Attention layer with xFormers and PagedAttention."""
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type
 
 import torch
 from xformers import ops as xops
@@ -10,12 +10,20 @@ from xformers.ops.fmha.attn_bias import (AttentionBias,
                                          LowerTriangularMaskWithTensorBias)
 
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
-                                              AttentionMetadata, AttentionType)
-from vllm.attention.backends.utils import (CommonAttentionState,
-                                           CommonMetadataBuilder)
+                                              AttentionMetadata,
+                                              AttentionMetadataBuilder,
+                                              AttentionType)
+from vllm.attention.backends.utils import (PAD_SLOT_ID, CommonAttentionState,
+                                           compute_slot_mapping,
+                                           compute_slot_mapping_start_idx,
+                                           is_block_tables_empty)
 from vllm.attention.ops.paged_attn import (PagedAttention,
                                            PagedAttentionMetadata)
 from vllm.logger import init_logger
+from vllm.utils import async_tensor_h2d, make_tensor_with_pad
+
+if TYPE_CHECKING:
+    from vllm.worker.model_runner import ModelInputForGPUBuilder
 
 logger = init_logger(__name__)
 
@@ -384,9 +392,166 @@ def _get_seq_len_block_table_args(
         raise AttributeError(f"Invalid attention type {str(attn_type)}")
 
 
-class XFormersMetadataBuilder(CommonMetadataBuilder[XFormersMetadata]):
+class XFormersMetadataBuilder(AttentionMetadataBuilder[XFormersMetadata]):
 
-    _metadata_cls = XFormersMetadata
+    def __init__(self, input_builder: "ModelInputForGPUBuilder"):
+        self.slot_mapping: List[int] = []
+        self.prefill_seq_lens: List[int] = []
+        self.context_lens: List[int] = []
+        self.block_tables: List[List[int]] = []
+        self.curr_seq_lens: List[int] = []
+        self.num_prefills = 0
+        self.num_prefill_tokens = 0
+        self.num_decode_tokens = 0
+        self.has_prefix_cache_hit = False
+
+        self.input_builder = input_builder
+        self.runner = input_builder.runner
+
+        self.sliding_window = input_builder.sliding_window
+        self.block_size = input_builder.block_size
+
+    def _add_seq_group(
+            self, inter_data: "ModelInputForGPUBuilder.InterDataForSeqGroup",
+            chunked_prefill_enabled: bool, prefix_cache_hit: bool):
+        is_prompt = inter_data.is_prompt
+        block_tables = inter_data.block_tables
+
+        for (seq_id, token_len, seq_len, curr_seq_len, query_len, context_len,
+             curr_sliding_window_block) in zip(
+                 inter_data.seq_ids, [len(t) for t in inter_data.input_tokens],
+                 inter_data.orig_seq_lens, inter_data.seq_lens,
+                 inter_data.query_lens, inter_data.context_lens,
+                 inter_data.curr_sliding_window_blocks):
+            self.context_lens.append(context_len)
+            if is_prompt:
+                self.num_prefills += 1
+                self.num_prefill_tokens += token_len
+                self.prefill_seq_lens.append(seq_len)
+            else:
+                assert query_len == 1, (
+                    "seq_len: {}, context_len: {}, query_len: {}".format(
+                        seq_len, context_len, query_len))
+                self.num_decode_tokens += query_len
+                self.curr_seq_lens.append(curr_seq_len)
+
+            # Compute block table.
+            # TODO(sang): Combine chunked prefill and prefix caching by
+            # only allowing multiple of block_size chunk size.
+            # NOTE: This only works for oooooooxxx style attention.
+            block_table = []
+            if prefix_cache_hit:
+                # NOTE(woosuk): For xformers, the block table should
+                # include the entries for the incoming prefill tokens.
+                block_table = block_tables[seq_id]
+            elif ((chunked_prefill_enabled or not is_prompt)
+                  and block_tables is not None):
+                if curr_sliding_window_block == 0:
+                    block_table = block_tables[seq_id]
+                else:
+                    block_table = block_tables[seq_id][
+                        -curr_sliding_window_block:]
+            self.block_tables.append(block_table)
+
+            # Compute slot mapping.
+            is_profile_run = is_block_tables_empty(block_tables)
+            start_idx = compute_slot_mapping_start_idx(is_prompt, query_len,
+                                                       context_len,
+                                                       self.sliding_window)
+            compute_slot_mapping(is_profile_run, self.slot_mapping, seq_id,
+                                 seq_len, context_len, start_idx,
+                                 self.block_size, inter_data.block_tables)
+
+    def build(self, seq_lens: List[int], query_lens: List[int],
+              cuda_graph_pad_size: int, batch_size: int):
+        """Build attention metadata with on-device tensors.
+
+        Args:
+            seq_lens: The maybe padded sequence lengths of the input sequences.
+            query_lens: The query lengths of the input sequences.
+            cuda_graph_pad_size: The padding size for cuda graph.
+                                 -1 if cuda graph is not used.
+            batch_size: The maybe padded batch size.
+        """
+        prefix_cache_hit = any([
+            inter_data.prefix_cache_hit
+            for inter_data in self.input_builder.inter_data_list
+        ])
+        for inter_data in self.input_builder.inter_data_list:
+            self._add_seq_group(inter_data,
+                                self.input_builder.chunked_prefill_enabled,
+                                prefix_cache_hit)
+
+        device = self.runner.device
+        use_captured_graph = cuda_graph_pad_size != -1
+
+        max_query_len = max(query_lens)
+        max_prefill_seq_len = max(self.prefill_seq_lens, default=0)
+        max_decode_seq_len = max(self.curr_seq_lens, default=0)
+        num_decode_tokens = self.num_decode_tokens
+
+        if use_captured_graph:
+            self.slot_mapping.extend([PAD_SLOT_ID] * cuda_graph_pad_size)
+            self.block_tables.extend([] * cuda_graph_pad_size)
+            num_decode_tokens = batch_size
+
+            # The shape of graph_block_tables is
+            # [max batch size, max context len // block size].
+            input_block_tables = self.runner.graph_block_tables[:batch_size]
+            for i, block_table in enumerate(self.block_tables):
+                if block_table:
+                    input_block_tables[i, :len(block_table)] = block_table
+            block_tables = torch.from_numpy(input_block_tables).to(
+                device, non_blocking=True)
+        else:
+            block_tables = make_tensor_with_pad(
+                self.block_tables,
+                pad=0,
+                dtype=torch.int,
+                device=device,
+            )
+        assert max_query_len > 0, "query_lens: {}".format(query_lens)
+
+        assert device is not None
+        context_lens_tensor = async_tensor_h2d(self.context_lens, torch.int,
+                                               device, self.runner.pin_memory)
+        seq_lens_tensor = async_tensor_h2d(seq_lens, torch.int, device,
+                                           self.runner.pin_memory)
+        query_lens_tensor = async_tensor_h2d(query_lens, torch.long, device,
+                                             self.runner.pin_memory)
+        slot_mapping_tensor = async_tensor_h2d(self.slot_mapping, torch.long,
+                                               device, self.runner.pin_memory)
+        query_start_loc = torch.zeros(query_lens_tensor.shape[0] + 1,
+                                      dtype=torch.int32,
+                                      device=device)
+        seq_start_loc = torch.zeros(seq_lens_tensor.shape[0] + 1,
+                                    dtype=torch.int32,
+                                    device=device)
+        torch.cumsum(seq_lens_tensor,
+                     dim=0,
+                     dtype=seq_start_loc.dtype,
+                     out=seq_start_loc[1:])
+        torch.cumsum(query_lens_tensor,
+                     dim=0,
+                     dtype=query_start_loc.dtype,
+                     out=query_start_loc[1:])
+
+        return self._metadata_cls(  # type: ignore
+            num_prefills=self.num_prefills,
+            slot_mapping=slot_mapping_tensor,
+            num_prefill_tokens=self.num_prefill_tokens,
+            num_decode_tokens=num_decode_tokens,
+            seq_lens=seq_lens,
+            seq_lens_tensor=seq_lens_tensor,
+            max_query_len=max_query_len,
+            max_prefill_seq_len=max_prefill_seq_len,
+            max_decode_seq_len=max_decode_seq_len,
+            query_start_loc=query_start_loc,
+            seq_start_loc=seq_start_loc,
+            context_lens_tensor=context_lens_tensor,
+            block_tables=block_tables,
+            use_cuda_graph=use_captured_graph,
+        )
 
 
 class XFormersImpl(AttentionImpl[XFormersMetadata]):


### PR DESCRIPTION
<details>
<summary>Deleted</summary>

~~This PR (in its current form) is intended to simply reproduce a crash I've locally observed on a P40 with a particular request sequence, on CI (which have a *supported* GPU), so don't merge it.~~

~~Eventually (regardless of reproductibility on other hardware) I hope to find the cause and fix the crash (although this may take a long time as I'm not familiar with these parts of vLLM, so any help is welcome).~~
</details>

For certain sequences of requests ~~(you can find one in `temp.py` to reproduce manually, it works using an OpenAI-compatible API)~~, vLLMs with

1. Chunked prefill
2. Prefix caching
3. Block manager V2
4. XFormers

crashes with `CUDA error: an illegal memory access was encountered` somewhere. (sometimes, e.g., in the prefix caching kernel).

~~I believe this is not a Triton for Pascal (or my hardware in general) problem, as I have found similar issues about crashes with prefix caching on other hardware.~~

<details>
<summary>The crash looks like this...</summary>

```text
(VllmWorkerProcess pid=14578) WARNING 10-17 12:17:31 model_runner_base.py:143] Failed to pickle inputs of failed execution: CUDA error: an illegal memory access was encountered
(VllmWorkerProcess pid=14578) WARNING 10-17 12:17:31 model_runner_base.py:143] Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(VllmWorkerProcess pid=14578) WARNING 10-17 12:17:31 model_runner_base.py:143]
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231] Exception in worker VllmWorkerProcess while processing method execute_model: Error in model execution: Triton Error [CUDA]: an illegal memory access was encountered, Traceback (most recent call last):
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner_base.py", line 116, in _wrapper
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return func(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner.py", line 1665, in execute_model
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     hidden_or_intermediate_states = model_executable(
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                                     ^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self._call_impl(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return forward_call(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/model_executor/models/llama.py", line 556, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     model_output = self.model(input_ids, positions, kv_caches,
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self._call_impl(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return forward_call(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/model_executor/models/llama.py", line 345, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     hidden_states, residual = layer(positions, hidden_states,
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self._call_impl(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return forward_call(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/model_executor/models/llama.py", line 257, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     hidden_states = self.self_attn(positions=positions,
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self._call_impl(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return forward_call(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/model_executor/models/llama.py", line 187, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self._call_impl(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return forward_call(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/attention/layer.py", line 100, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return self.impl.forward(query,
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/attention/backends/xformers.py", line 620, in forward
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     out = PagedAttention.forward_prefix(
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/attention/ops/paged_attn.py", line 211, in forward_prefix
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     context_attention_fwd(
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return func(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/attention/ops/prefix_prefill.py", line 811, in context_attention_fwd
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     _fwd_kernel[grid](
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/triton/runtime/jit.py", line 345, in <lambda>
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/triton/runtime/jit.py", line 691, in run
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     kernel.run(grid_0, grid_1, grid_2, stream, kernel.function, kernel.packed_metadata, launch_metadata,
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/triton/backends/nvidia/driver.py", line 365, in __call__
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     self.launch(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231] RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231] The above exception was the direct cause of the following exception:
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231] Traceback (most recent call last):
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/executor/multiproc_worker_utils.py", line 224, in _run_worker_process
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     output = executor(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]              ^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/worker_base.py", line 327, in execute_model
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     output = self.model_runner.execute_model(
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     return func(*args, **kwargs)
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner_base.py", line 146, in _wrapper
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]     raise type(err)(f"Error in model execution: "
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231] RuntimeError: Error in model execution: Triton Error [CUDA]: an illegal memory access was encountered
(VllmWorkerProcess pid=14578) ERROR 10-17 12:17:31 multiproc_worker_utils.py:231]
```
</details>

<details>
<summary>... or this ...</summary>

```text
ERROR 10-17 12:43:16 engine.py:160] RuntimeError('CUDA error: an illegal memory access was encountered\nCUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.\nFor debugging consider passing CUDA_LAUNCH_BLOCKING=1\nCompile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.\n')
ERROR 10-17 12:43:16 engine.py:160] Traceback (most recent call last):
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 158, in start
ERROR 10-17 12:43:16 engine.py:160]     self.run_engine_loop()
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 221, in run_engine_loop
ERROR 10-17 12:43:16 engine.py:160]     request_outputs = self.engine_step()
ERROR 10-17 12:43:16 engine.py:160]                       ^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 239, in engine_step
ERROR 10-17 12:43:16 engine.py:160]     raise e
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/multiprocessing/engine.py", line 230, in engine_step
ERROR 10-17 12:43:16 engine.py:160]     return self.engine.step()
ERROR 10-17 12:43:16 engine.py:160]            ^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/engine/llm_engine.py", line 1386, in step
ERROR 10-17 12:43:16 engine.py:160]     outputs = self.model_executor.execute_model(
ERROR 10-17 12:43:16 engine.py:160]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/executor/gpu_executor.py", line 134, in execute_model
ERROR 10-17 12:43:16 engine.py:160]     output = self.driver_worker.execute_model(execute_model_req)
ERROR 10-17 12:43:16 engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/worker_base.py", line 303, in execute_model
ERROR 10-17 12:43:16 engine.py:160]     inputs = self.prepare_input(execute_model_req)
ERROR 10-17 12:43:16 engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/worker_base.py", line 291, in prepare_input
ERROR 10-17 12:43:16 engine.py:160]     return self._get_driver_input_and_broadcast(execute_model_req)
ERROR 10-17 12:43:16 engine.py:160]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/worker_base.py", line 253, in _get_driver_input_and_broadcast
ERROR 10-17 12:43:16 engine.py:160]     self.model_runner.prepare_model_input(
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner.py", line 1593, in prepare_model_input
ERROR 10-17 12:43:16 engine.py:160]     model_input = self._prepare_model_input_tensors(
ERROR 10-17 12:43:16 engine.py:160]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner.py", line 1200, in _prepare_model_input_tensors
ERROR 10-17 12:43:16 engine.py:160]     return builder.build()  # type: ignore
ERROR 10-17 12:43:16 engine.py:160]            ^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/worker/model_runner.py", line 871, in build
ERROR 10-17 12:43:16 engine.py:160]     attn_metadata = self.attn_metadata_builder.build(
ERROR 10-17 12:43:16 engine.py:160]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/attention/backends/utils.py", line 227, in build
ERROR 10-17 12:43:16 engine.py:160]     block_tables = make_tensor_with_pad(
ERROR 10-17 12:43:16 engine.py:160]                    ^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160]   File "/home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/vllm/utils.py", line 857, in make_tensor_with_pad
ERROR 10-17 12:43:16 engine.py:160]     tensor = torch.from_numpy(padded_x).to(device)
ERROR 10-17 12:43:16 engine.py:160]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 10-17 12:43:16 engine.py:160] RuntimeError: CUDA error: an illegal memory access was encountered
ERROR 10-17 12:43:16 engine.py:160] CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
ERROR 10-17 12:43:16 engine.py:160] For debugging consider passing CUDA_LAUNCH_BLOCKING=1
ERROR 10-17 12:43:16 engine.py:160] Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
ERROR 10-17 12:43:16 engine.py:160]
ERROR:    Exception in ASGI application
```
</details>

~~... or as in the issues.~~

~~Based on this (and the test I wrote), I can assume that something **in block manager V2** is corrupting the CUDA memory.~~

| block manager | chunked prefill | prefix caching | works |
|---------------|-----------------|----------------|-------|
| v1            | -               | -              | +     |
| v2            | -               | -              | +     |
| v1            | +               | -              | +     |
| v2            | +               | -              | +     |
| v1            | -               | +              | +     |
| v2            | -               | +              | +     |
| v1            | +               | +              | +     |
| v2            | +               | +              | -     |

<details>
<summary>Test output on P40</summary>

```text
tori@torilinux ~ % HF_HOME=/mnt/hf HF_HUB_OFFLINE=1 pytest -s repro_fin.py
================================================================================ test session starts =================================================================================
platform linux -- Python 3.11.8, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/tori
plugins: anyio-4.6.2.post1
collected 8 items

repro_fin.py INFO 10-20 04:09:12 config.py:1670] Downcasting torch.float32 to torch.float16.
WARNING 10-20 04:09:16 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:09:16 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=False, num_scheduler_steps=1, chunked_prefill_enabled=False multi_step_stream_outputs=True, enable_prefix_caching=False, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:09:17 selector.py:224] Cannot use FlashAttention-2 backend for Volta and Turing GPUs.
INFO 10-20 04:09:17 selector.py:115] Using XFormers backend.
INFO 10-20 04:09:17 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:09:18 selector.py:224] Cannot use FlashAttention-2 backend for Volta and Turing GPUs.
INFO 10-20 04:09:18 selector.py:115] Using XFormers backend.
INFO 10-20 04:09:18 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:09:18 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.35s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.35s/it]

INFO 10-20 04:11:33 model_runner.py:1071] Loading model weights took 14.9693 GB
INFO 10-20 04:11:43 gpu_executor.py:122] # GPU blocks: 2042, # CPU blocks: 0
INFO 10-20 04:11:43 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 7.98x
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:08<00:00,  8.54s/it, est. speed input: 228.38 toks/s, output: 0.12 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:09<00:00,  9.18s/it, est. speed input: 214.98 toks/s, output: 0.11 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:09<00:00,  9.42s/it, est. speed input: 217.21 toks/s, output: 0.11 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:10<00:00, 10.09s/it, est. speed input: 207.83 toks/s, output: 0.10 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:10<00:00, 10.18s/it, est. speed input: 208.94 toks/s, output: 0.10 toks/s]
.INFO 10-20 04:12:31 config.py:1670] Downcasting torch.float32 to torch.float16.
WARNING 10-20 04:12:31 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:12:31 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=True, num_scheduler_steps=1, chunked_prefill_enabled=False multi_step_stream_outputs=True, enable_prefix_caching=False, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:12:32 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:12:33 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:12:33 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.66s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.66s/it]

INFO 10-20 04:14:47 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:14:57 gpu_executor.py:122] # GPU blocks: 2105, # CPU blocks: 0
INFO 10-20 04:14:57 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 8.22x
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:25<00:00, 25.69s/it, est. speed input: 75.95 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:26<00:00, 26.14s/it, est. speed input: 75.46 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:29<00:00, 29.42s/it, est. speed input: 69.51 toks/s, output: 0.03 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:28<00:00, 28.05s/it, est. speed input: 74.75 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:30<00:00, 30.72s/it, est. speed input: 69.23 toks/s, output: 0.03 toks/s]
.INFO 10-20 04:17:17 config.py:1670] Downcasting torch.float32 to torch.float16.
INFO 10-20 04:17:17 config.py:1005] Chunked prefill is enabled with max_num_batched_tokens=512.
WARNING 10-20 04:17:17 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:17:17 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=False, num_scheduler_steps=1, chunked_prefill_enabled=True multi_step_stream_outputs=True, enable_prefix_caching=False, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:17:18 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:17:18 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:17:18 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.61s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.62s/it]

INFO 10-20 04:19:33 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:19:36 gpu_executor.py:122] # GPU blocks: 2454, # CPU blocks: 0
INFO 10-20 04:19:36 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 9.59x
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:23<00:00, 23.92s/it, est. speed input: 81.57 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:18<00:00, 18.79s/it, est. speed input: 104.99 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:27<00:00, 27.82s/it, est. speed input: 73.50 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:20<00:00, 20.58s/it, est. speed input: 101.89 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:22<00:00, 22.07s/it, est. speed input: 96.38 toks/s, output: 0.05 toks/s]
.INFO 10-20 04:21:30 config.py:1670] Downcasting torch.float32 to torch.float16.
INFO 10-20 04:21:30 config.py:1005] Chunked prefill is enabled with max_num_batched_tokens=512.
WARNING 10-20 04:21:30 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:21:30 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=True, num_scheduler_steps=1, chunked_prefill_enabled=True multi_step_stream_outputs=True, enable_prefix_caching=False, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:21:31 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:21:31 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:21:31 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.09s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.10s/it]

INFO 10-20 04:23:45 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:23:51 gpu_executor.py:122] # GPU blocks: 2454, # CPU blocks: 0
INFO 10-20 04:23:51 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 9.59x
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:22<00:00, 22.02s/it, est. speed input: 88.62 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:21<00:00, 21.44s/it, est. speed input: 92.01 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:22<00:00, 22.91s/it, est. speed input: 89.25 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:20<00:00, 20.53s/it, est. speed input: 102.14 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:22<00:00, 22.13s/it, est. speed input: 96.11 toks/s, output: 0.05 toks/s]
.INFO 10-20 04:25:40 config.py:1670] Downcasting torch.float32 to torch.float16.
WARNING 10-20 04:25:40 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:25:40 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=False, num_scheduler_steps=1, chunked_prefill_enabled=False multi_step_stream_outputs=True, enable_prefix_caching=True, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:25:41 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:25:41 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:25:41 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:16<00:00, 136.90s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:16<00:00, 136.92s/it]

INFO 10-20 04:27:58 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:28:08 gpu_executor.py:122] # GPU blocks: 2105, # CPU blocks: 0
INFO 10-20 04:28:08 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 8.22x
INFO 10-20 04:28:08 block_manager_v1.py:263] Automatic prefix caching is enabled.
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:24<00:00, 24.40s/it, est. speed input: 79.96 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.74s/it, est. speed input: 1135.02 toks/s, output: 0.58 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.27s/it, est. speed input: 626.31 toks/s, output: 0.31 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:05<00:00,  5.10s/it, est. speed input: 410.85 toks/s, output: 0.20 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:29<00:00, 29.94s/it, est. speed input: 71.05 toks/s, output: 0.03 toks/s]
.INFO 10-20 04:29:13 config.py:1670] Downcasting torch.float32 to torch.float16.
WARNING 10-20 04:29:13 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:29:13 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=True, num_scheduler_steps=1, chunked_prefill_enabled=False multi_step_stream_outputs=True, enable_prefix_caching=True, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:29:14 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:29:14 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:29:14 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:13<00:00, 133.83s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:13<00:00, 133.84s/it]

INFO 10-20 04:31:28 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:31:38 gpu_executor.py:122] # GPU blocks: 2105, # CPU blocks: 0
INFO 10-20 04:31:38 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 8.22x
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:26<00:00, 26.08s/it, est. speed input: 74.81 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.73s/it, est. speed input: 1138.99 toks/s, output: 0.58 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.30s/it, est. speed input: 619.15 toks/s, output: 0.30 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:05<00:00,  5.36s/it, est. speed input: 390.89 toks/s, output: 0.19 toks/s]
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:31<00:00, 31.64s/it, est. speed input: 67.23 toks/s, output: 0.03 toks/s]
.INFO 10-20 04:32:46 config.py:1670] Downcasting torch.float32 to torch.float16.
INFO 10-20 04:32:46 config.py:1005] Chunked prefill is enabled with max_num_batched_tokens=512.
WARNING 10-20 04:32:46 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:32:46 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=False, num_scheduler_steps=1, chunked_prefill_enabled=True multi_step_stream_outputs=True, enable_prefix_caching=True, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:32:47 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:32:47 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:32:47 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.58s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:14<00:00, 134.58s/it]

INFO 10-20 04:35:02 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:35:08 gpu_executor.py:122] # GPU blocks: 2454, # CPU blocks: 0
INFO 10-20 04:35:08 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 9.59x
INFO 10-20 04:35:08 block_manager_v1.py:263] Automatic prefix caching is enabled.
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:21<00:00, 21.49s/it, est. speed input: 90.78 toks/s, output: 0.05 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:03<00:00,  3.32s/it, est. speed input: 593.78 toks/s, output: 0.30 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.90s/it, est. speed input: 417.39 toks/s, output: 0.20 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:05<00:00,  5.31s/it, est. speed input: 394.64 toks/s, output: 0.19 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:20<00:00, 20.02s/it, est. speed input: 106.24 toks/s, output: 0.05 toks/s]
.INFO 10-20 04:36:03 config.py:1670] Downcasting torch.float32 to torch.float16.
INFO 10-20 04:36:03 config.py:1005] Chunked prefill is enabled with max_num_batched_tokens=512.
WARNING 10-20 04:36:03 config.py:380] To see benefits of async output processing, enable CUDA graph. Since, enforce-eager is enabled, async output processor cannot be used
INFO 10-20 04:36:03 llm_engine.py:237] Initializing an LLM engine (v999.999.999) with config: model='mistralai/Ministral-8B-Instruct-2410', speculative_config=None, tokenizer='mistralai/Ministral-8B-Instruct-2410', skip_tokenizer_init=False, tokenizer_mode=mistral, revision=None, override_neuron_config=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=4096, download_dir=None, load_format=LoadFormat.MISTRAL, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='outlines'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=0, served_model_name=mistralai/Ministral-8B-Instruct-2410, use_v2_block_manager=True, num_scheduler_steps=1, chunked_prefill_enabled=True multi_step_stream_outputs=True, enable_prefix_caching=True, use_async_output_proc=False, use_cached_outputs=False, mm_processor_kwargs=None)
INFO 10-20 04:36:04 model_runner.py:1060] Starting to load model mistralai/Ministral-8B-Instruct-2410...
INFO 10-20 04:36:04 weight_utils.py:243] Using model weights format ['consolidated*.safetensors', '*.pt']
INFO 10-20 04:36:04 weight_utils.py:288] No consolidated.safetensors.index.json found in remote.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:15<00:00, 135.10s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [02:15<00:00, 135.11s/it]

INFO 10-20 04:38:19 model_runner.py:1071] Loading model weights took 14.9381 GB
INFO 10-20 04:38:22 gpu_executor.py:122] # GPU blocks: 2454, # CPU blocks: 0
INFO 10-20 04:38:22 gpu_executor.py:126] Maximum concurrency for 4096 tokens per request: 9.59x
Processed prompts: 100%|███████████████████████████████████████████████████████████████████████████| 1/1 [00:22<00:00, 22.35s/it, est. speed input: 87.30 toks/s, output: 0.04 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.72s/it, est. speed input: 725.20 toks/s, output: 0.37 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.82s/it, est. speed input: 424.19 toks/s, output: 0.21 toks/s]
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████| 1/1 [00:05<00:00,  5.47s/it, est. speed input: 383.18 toks/s, output: 0.18 toks/s]
Processed prompts:   0%|                                                                                    | 0/1 [00:04<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]
.

================================================================================== warnings summary ==================================================================================
repro_fin.py::test_vllm[False-False-False-False]
  /home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/xformers/ops/fmha/flash.py:211: FutureWarning: `torch.library.impl_abstract` was renamed to `torch.library.register_fake`. Please use that instead; we will remove `torch.library.impl_abstract` in a future version of PyTorch.
    @torch.library.impl_abstract("xformers_flash::flash_fwd")

repro_fin.py::test_vllm[False-False-False-False]
  /home/tori/.local/share/pipx/venvs/vllm-pascal/lib/python3.11/site-packages/xformers/ops/fmha/flash.py:344: FutureWarning: `torch.library.impl_abstract` was renamed to `torch.library.register_fake`. Please use that instead; we will remove `torch.library.impl_abstract` in a future version of PyTorch.
    @torch.library.impl_abstract("xformers_flash::flash_bwd")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================== 8 passed, 2 warnings in 1797.88s (0:29:57) =====================================================================
HF_HOME=/mnt/hf HF_HUB_OFFLINE=1 pytest -s repro_fin.py  969.67s user 135.33s system 61% cpu 30:03.72 total
```
</details>
