### PR TITLE
[CI/Build][LoRA] Temporarily fix long context failure issue

### DIFF
--- a/tests/lora/test_long_context.py
+++ b/tests/lora/test_long_context.py
@@ -115,6 +115,7 @@ def lora_llm(long_context_infos):
                    long_lora_scaling_factors=tuple(scaling_factors),
                    max_num_batched_tokens=4096 * 8,
                    tensor_parallel_size=4,
+                   disable_async_output_proc=True,
                    distributed_executor_backend="mp")
     yield llm
     del llm

--- a/tests/lora/test_long_context.py
+++ b/tests/lora/test_long_context.py
@@ -108,15 +108,17 @@ def lora_llm(long_context_infos):
         for info in long_context_infos.values()
     ]
 
-    llm = vllm.LLM("meta-llama/Llama-2-13b-chat-hf",
-                   enable_lora=True,
-                   max_num_seqs=16,
-                   max_loras=2,
-                   long_lora_scaling_factors=tuple(scaling_factors),
-                   max_num_batched_tokens=4096 * 8,
-                   tensor_parallel_size=4,
-                   disable_async_output_proc=True,
-                   distributed_executor_backend="mp")
+    llm = vllm.LLM(
+        "meta-llama/Llama-2-13b-chat-hf",
+        enable_lora=True,
+        max_num_seqs=16,
+        max_loras=2,
+        long_lora_scaling_factors=tuple(scaling_factors),
+        max_num_batched_tokens=4096 * 8,
+        tensor_parallel_size=4,
+        # FIXME enable async output processor
+        disable_async_output_proc=True,
+        distributed_executor_backend="mp")
     yield llm
     del llm
 

--- a/tests/lora/test_long_context.py
+++ b/tests/lora/test_long_context.py
@@ -28,9 +28,15 @@ sampling_params = SamplingParams(
 def _create_lora_request(lora_id, long_context_infos):
     context_len = long_context_infos[lora_id]["context_length"]
     scaling_factor = context_len_to_scaling_factor[context_len]
-    return LoRARequest(context_len, lora_id,
-                       long_context_infos[lora_id]["lora"], None,
-                       4096 * scaling_factor)
+    return LoRARequest(
+        # There are 2 LoRAs for 16K, we need to add lora_id to indicate
+        # they are different LoRAs.
+        context_len + str(lora_id),
+        lora_id,
+        long_context_infos[lora_id]["lora"],
+        None,
+        4096 * scaling_factor,
+    )
 
 
 def evaluate_json_response(model_response, golden_response):


### PR DESCRIPTION
#7049  added the parameter `disable_async_output_proc` with a default value of False, which led to `test_long_context` raising an `IndexError: list index out of range error`, see:  https://buildkite.com/vllm/ci-aws/builds/7645#01919198-199d-488c-9834-8c48ae675338/193-420.  Since then, this test has consistently shown this error, which has hidden errors introduced by other PRs. For example, when setting `disable_async_output_proc=True`, inference works without errors but generates incorrect results due to the cudagraph issue from #8645 (which has been fixed by #9549). 

This PR is a temporary solution to make this  test pass correctly, so that issues like #8645 can be exposed earlier in CI.

ping @DarkLight1337 , also cc  @megha95  @alexm-neuralmagic 