### PR TITLE
[Bugfix] Eagle: change config name for fc bias

### DIFF
--- a/vllm/model_executor/models/eagle.py
+++ b/vllm/model_executor/models/eagle.py
@@ -44,7 +44,7 @@ class EAGLE(nn.Module):
         self.model = model_cls(self.config.model, *args, **kwargs)
         self.fc = nn.Linear(config.model.hidden_size * 2,
                             config.model.hidden_size,
-                            bias=getattr(self.config, "bias", False))
+                            bias=getattr(self.config, "eagle_fc_bias", False))
 
         self.orig_vocab_size = config.vocab_size
         self.truncated_vocab_size = config.truncated_vocab_size


### PR DESCRIPTION
- Changes were made to load fc bias from config as part of this PR - https://github.com/vllm-project/vllm/pull/8790
- `bias` param in config is also used to decide if attention has a bias or not in [LlamaDecoderLayer](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/llama.py#L215)
- Due to the same param name, model is not loaded properly for cases which do not have bias in attention in decoder layer but have a bias in eagle fc layer.
- Have changed the param to `eagle_fc_bias` to avoid conflict.