### PR TITLE
[Bugfix] Fix divide by zero when serving Mamba models

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1612,7 +1612,7 @@ class LLMEngine:
         # KV Cache Usage in %
         num_total_gpu = self.cache_config.num_gpu_blocks
         gpu_cache_usage_sys = 0.
-        if num_total_gpu is not None:
+        if num_total_gpu:  # Guard against both None and 0
             num_free_gpu = sum(
                 scheduler.block_manager.get_num_free_gpu_blocks()
                 for scheduler in self.scheduler)
@@ -1620,7 +1620,7 @@ class LLMEngine:
 
         num_total_cpu = self.cache_config.num_cpu_blocks
         cpu_cache_usage_sys = 0.
-        if num_total_cpu is not None and num_total_cpu > 0:
+        if num_total_cpu:  # Guard against both None and 0
             num_free_cpu = sum(
                 scheduler.block_manager.get_num_free_cpu_blocks()
                 for scheduler in self.scheduler)


### PR DESCRIPTION
`num_total_gpu` ends up being 0 for attention-free models, which results in a divide-by-zero in llm_engine.py when running:
```
vllm serve tiiuae/falcon-mamba-7b-instruct
```

We're already guarding against None here so this guards against zero as well.

I also tried setting `num_gpu_blocks` to `None` in `determine_num_available_blocks` but a couple of different spots choked on this.

Closes #7478 (again)

