### PR TITLE
[Bugfix] Fix edge cases for MistralTokenizer

### DIFF
--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -89,9 +89,8 @@ def test_decode_streaming(tokenizer, truth, with_prompt, skip_special_tokens):
         generated_input_ids = truth_tokens[len(truth) // 2:]
         all_input_ids = prompt_input_ids + generated_input_ids
         starting_index = len(prompt_input_ids)
-        prompt = (tokenizer.decode(prompt_input_ids) if isinstance(
-            tokenizer, MistralTokenizer) else tokenizer.decode(
-                prompt_input_ids, skip_special_tokens=skip_special_tokens))
+        prompt = tokenizer.decode(prompt_input_ids,
+                                  skip_special_tokens=skip_special_tokens)
         generated = truth[len(prompt):]
     else:
         generated = truth
@@ -236,12 +235,8 @@ def test_decode_prompt_logprobs(complete_sequence_token_ids: List[int],
     # decoded_prompt_logprobs doesn't contain the first token.
     token_ids = complete_sequence_token_ids
     tokenizer = detokenizer.get_tokenizer_for_seq(seq)
-    text_full = (tokenizer.decode(token_ids) if isinstance(
-        tokenizer, MistralTokenizer) else tokenizer.decode(
-            token_ids, skip_special_tokens=True))
-    text_first = (tokenizer.decode(token_ids[0]) if isinstance(
-        tokenizer, MistralTokenizer) else tokenizer.decode(
-            token_ids[0], skip_special_tokens=True))
+    text_full = tokenizer.decode(token_ids, skip_special_tokens=True)
+    text_first = tokenizer.decode(token_ids[0], skip_special_tokens=True)
     text = text_full[len(text_first):]
 
     # Text for logprobs for the chosen token should be the same as the

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -13,6 +13,7 @@ TRUTH = [
     "Hello here, this is a simple test",
     "vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs. It is designed to be used in production environments, where inference and serving",  # noqa
     "我很感谢你的热情",
+    # see https://github.com/vllm-project/vllm/pull/9625
     "THIS IS AN URGENCY",
 ]
 TOKENIZERS = [
@@ -57,6 +58,14 @@ def tokenizer(tokenizer_name):
     return (MistralTokenizer.from_pretrained(tokenizer_name)
             if "mistral" in tokenizer_name else
             AutoTokenizer.from_pretrained(tokenizer_name))
+
+
+# see https://github.com/vllm-project/vllm/pull/9625
+@pytest.mark.parametrize("tokenizer_name", ["mistralai/Pixtral-12B-2409"])
+def test_mistral_edge_case(tokenizer):
+    assert (_run_incremental_decode(tokenizer, [1492, 1176, 115679],
+                                    skip_special_tokens=True,
+                                    starting_index=0) == " ð")
 
 
 @pytest.fixture

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -254,9 +254,10 @@ class MistralTokenizer:
 
         tokens = [self.tokenizer.id_to_piece(id) for id in ids]
 
-        if any(t.strip() == "�" for t in tokens):
-            # if any stripped decoded token is undefined
-            # because it's invalid unicode then pass bytes
+        if any("�" in t for t in tokens):
+            # if a decoded token contains the replacement character, then the
+            # token has an incomplete UTF-8 character so we must use a byte
+            # string to avoid losing information
             # See: https://github.com/vllm-project/vllm/pull/8640
             tokens = [self.tokenizer.id_to_byte_piece(id) for id in ids]
 

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -244,7 +244,13 @@ class MistralTokenizer:
 
         return decoded
 
-    def decode(self, ids: Union[List[int], int]) -> str:
+    def decode(self,
+               ids: Union[List[int], int],
+               skip_special_tokens: bool = True) -> str:
+        assert (
+            skip_special_tokens
+        ), "Skipping special tokens is not supported for Mistral tokenizers."
+
         if isinstance(ids, int):
             ids = [ids]
         return self.tokenizer.decode(ids)

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -90,7 +90,7 @@ class MistralTokenizer:
             for idx, token in enumerate(self._vocab)
         }
         self.tokenizer = tokenizer_
-        self._max_token_id = max(self._vocab.values())
+        self._max_token_id = self.vocab_size - 1
 
     @classmethod
     def from_pretrained(cls,

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -82,6 +82,10 @@ class MistralTokenizer:
             raise TypeError(f"Unsupported tokenizer: {type(tokenizer_)}")
 
         self._vocab = tokenizer_.vocab()
+        # Convert to a Dict[str, int] to match protocol, but this is a lossy
+        # conversion. There may be multiple token ids that decode to the same
+        # string due to partial UTF-8 byte sequences being converted to �
+        self.vocab_dict = {token: idx for idx, token in enumerate(self._vocab)}
         self.tokenizer = tokenizer_
         self._max_token_id = max(self._vocab.values())
 
@@ -180,10 +184,7 @@ class MistralTokenizer:
         return Encoding(input_ids=input_ids)
 
     def get_vocab(self) -> Dict[str, int]:
-        # Convert to a Dict[str, int] to match protocol, but this is a lossy
-        # conversion. There may be multiple token ids that decode to the same
-        # string due to partial UTF-8 byte sequences being converted to �
-        return {token: idx for idx, token in enumerate(self._vocab)}
+        return self.vocab_dict
 
     def get_added_vocab(self) -> Dict[str, int]:
         # Mistral tokenizers have no added vocabulary

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -72,18 +72,12 @@ class MistralTokenizer:
             # Make sure special tokens will not raise
             tokenizer_.special_token_policy = SpecialTokenPolicy.IGNORE
 
-            self._vocab = {
-                token: idx
-                for idx, token in enumerate(tokenizer_.vocab())
-            }
         elif isinstance(tokenizer_, SentencePieceTokenizer):
-            self._vocab = {
-                token: idx
-                for idx, token in enumerate(tokenizer_.vocab())
-            }
+            pass
         else:
             raise TypeError(f"Unsupported tokenizer: {type(tokenizer_)}")
 
+        self._vocab = tokenizer_.vocab()
         self.tokenizer = tokenizer_
         self._max_token_id = max(self._vocab.values())
 
@@ -182,7 +176,10 @@ class MistralTokenizer:
         return Encoding(input_ids=input_ids)
 
     def get_vocab(self) -> Dict[str, int]:
-        return self._vocab
+        # Convert to a Dict[str, int] to match protocol, but this is a lossy
+        # conversion. There may be multiple token ids that decode to the same
+        # string due to partial UTF-8 byte sequences being converted to �
+        return {token: idx for idx, token in enumerate(self._vocab)}
 
     def get_added_vocab(self) -> Dict[str, int]:
         # Mistral tokenizers have no added vocabulary


### PR DESCRIPTION
We have encountered a couple of bugs when using `--tokenizer-mode mistral` with `mistralai/Pixtral-12B-2409` (i.e. the V3-Tekken tokenizer) that cause the engine to crash with an error when certain tokens are generated. The exception is a `KeyError` when converting from strings to token ids, after converting from ids to string. Both bugs found occur becaue the code expects that each token id maps to a unique string and vice-versa, but the MistralTokenizer is byte-based and there are collisions between id and string due to the replacement character, �, replacing bytes of a partial UTF-8 codepoint. 

1.

One case we've seen is due to an empty string:
```
  File "/home/vllm/my-vllm/lib64/python3.12/site-packages/vllm/transformers_utils/tokenizers/mistral.py", line 223, in convert_tokens_to_string
    self.tokenizer._tekken_token2id_nospecial[t] + shift
  KeyError: b''
```

Which can be triggered with:
```
curl http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
      "model": "mistralai/Pixtral-12B-2409",
      "prompt": "Repeat the phrase 'URGENCY🌶️'\nURGENCY🌶️\nURGENCY🌶️\n",
      "temperature": 0
  }'
```

The empty string is mapped from a token when the token id exceeds the `len()` of the tokenizer [REF](https://github.com/vllm-project/vllm/blob/6567e13724110fac2042d06a9e4c01fd822e8909/vllm/transformers_utils/detokenizer_utils.py#L122-L123). With the Mistral Tokenizer, there is a mismatch in the length of the vLLM `MistralTokenizer` and the underlying Tekkenizer tokenizer:
```python
>>> len(tokenizer)
130044
```
vs
```python
>>> len(tokenizer.tokenizer.vocab())
131072
```

`len(tokenizer)` is computed as `len(tokenizer._vocab)` where _vocab is constructed as a `Dict[str, int]`, i.e. text to id. The underlying Tekkenizer’s `vocab()` is a `List[str]`. The construction of the Dict is collapsing entries where the text matches. This occurs when the text contains the `�` character replacing an incomplete codepoint:
```python
>>> [(t, count) for t, count in collections.Counter(tokenizer.tokenizer.vocab()).items() if count > 1]
[('�', 606), (' �', 269), ('�다', 7), ('��', 101), ('ー�', 2), ('�்', 2), ('�i', 3), ('�്�', 4), (' 어�', 5), ('"�', 3), ('�ი', 3), ('�n', 2), ('�을', 3), ('�်�', 3), ('�ျ', 4), ('�ြ', 5), ('�ှ', 3), ('�్య', 3), ('�名', 2), ('�은', 4), ('�이', 3), ('�ွ', 3), (' 느�', 2), (' 바�', 2), ('�ng', 2), ('�니다', 2), ('�ို့', 2), ('�ံ', 2), ('�ան', 2), (' 나�', 3), (' 기�', 2)]
```

For the repro case above, it happens that the token id for `CY` is 130282 which is greater than 130044 and hence maps to an empty string. The '🌶️' is necessary in the repro to put bytes in the set of tokens being incrementally detokenized to go down the code path that maps from token strings back to ids [here](https://github.com/vllm-project/vllm/blob/6567e13724110fac2042d06a9e4c01fd822e8909/vllm/transformers_utils/tokenizers/mistral.py#L215-L226)

2.

The other crash we have seen is for a KeyError containing bytes:
```
  File "/home/vllm/my-vllm/lib64/python3.12/site-packages/vllm/transformers_utils/tokenizers/mistral.py", line 223, in convert_tokens_to_string
    self.tokenizer._tekken_token2id_nospecial[t] + shift
  KeyError: "Error in model execution: b'\\xe1\\x80\\x84\\xe1\\x80\\xba\\xef\\xbf\\xbd'"
```

Which can be triggered with:
```
curl http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
      "model": "mistralai/Pixtral-12B-2409",
      "prompt": "ပုံပြင်လေးပြောပြပါ်\n",
      "temperature": 0
  }'
```
(The input is "Tell me a story\n" in Burmese.)

The cause of this one is when a token id is generated that has the replacement character as well as a valid codepoint. The stringified version of such a token will be like `င်�`. If these token strings go down the code path and are converted to bytes, the replacement character is replaced with its bytes and the full byte string, `b'\xe1\x80\x84\xe1\x80\xba\xef\xbf\xbd'` no longer maps to a token in the tokenizer. Tokens that stringify to a single `�` are already handled with the fix in https://github.com/vllm-project/vllm/pull/8640.

FIX #9557

**BEFORE SUBMITTING, PLEASE READ THE CHECKLIST BELOW AND FILL IN THE DESCRIPTION ABOVE**

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


