### PR TITLE
[Bugfix][Model] Fix Mllama SDPA illegal memory access for batched multi-image

### DIFF
--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -795,17 +795,19 @@ class MllamaTextCrossAttention(nn.Module):
         kv_len = k.shape[0]
         q = q.transpose(0, 1).view(self.num_local_key_value_heads,
                                    self.num_key_value_groups, q_len,
-                                   self.head_dim)
+                                   self.head_dim).contiguous()
         k = k.transpose(0,
                         1)[:,
                            None, :, :].expand(self.num_local_key_value_heads,
                                               self.num_key_value_groups,
-                                              kv_len, self.head_dim)
+                                              kv_len,
+                                              self.head_dim).contiguous()
         v = v.transpose(0,
                         1)[:,
                            None, :, :].expand(self.num_local_key_value_heads,
                                               self.num_key_value_groups,
-                                              kv_len, self.head_dim)
+                                              kv_len,
+                                              self.head_dim).contiguous()
         attention_mask = attention_mask.view(1, 1, q_len, kv_len)
         output = F.scaled_dot_product_attention(q,
                                                 k,


### PR DESCRIPTION
Mllama could trigger a CUDA error for illegal memory access within the cross-attention SDPA during inference or even profile run when running batch multi-image requests.

When inspecting the inputs to the SDPA, I noticed that the Q/K/V states were not contiguous in all cases (`attention_mask` is contiguous). Once forcing all of them to be contiguous, I found this issue went away.
https://github.com/vllm-project/vllm/blob/fd0e2cfdb2e0fa6ee2822a73141441de51114f2a/vllm/model_executor/models/mllama.py#L810-L814

Script used for testing:
```python
from vllm import LLM, SamplingParams
from vllm.assets.image import ImageAsset

sampling_params = SamplingParams(temperature=0.0, max_tokens=100)

model_name = "meta-llama/Llama-3.2-11B-Vision-Instruct"
llm = LLM(model=model_name,
          max_model_len=4096,
          max_num_seqs=16,
          enforce_eager=True,
          limit_mm_per_prompt={"image": 4},
)

image1 = ImageAsset("cherry_blossom").pil_image.convert("RGB")
image2 = ImageAsset("stop_sign").pil_image.convert("RGB")
input1 = {
    "prompt": "<|image|><|begin_of_text|>Describe the image.",
    "multi_modal_data": {"image": image1},
}
input2 = {
    "prompt": "<|image|><|image|><|image|><|image|><|begin_of_text|>How many duplicated images are there?",
    "multi_modal_data": {"image": [image1, image2, image1, image1]},
}
input3 = {
    "prompt": "<|image|><|image|><|begin_of_text|>Are the images the same?",
    "multi_modal_data": {"image": [image1, image1]},
}
outputs = llm.generate([input1, input2, input3], sampling_params=sampling_params)

for i, output in enumerate(outputs):
    print(f"\nOutput #{i}:", output.outputs[0].text)
```

Error when running with `CUDA_LAUNCH_BLOCKING=1`:
```
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 870, in forward
[rank0]:     hidden_states = self.cross_attn(
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 755, in forward
[rank0]:     output = self.attention_with_mask(q, k, v, kv_cache,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 811, in attention_with_mask
[rank0]:     output = F.scaled_dot_product_attention(q,
[rank0]: RuntimeError: CUDA error: an illegal memory access was encountered
[rank0]: Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

Output when running with this PR:
```
Output #0: The image depicts a serene scene of a white tower, likely a skyscraper or monument, set against a backdrop of vibrant pink cherry blossoms and a clear blue sky. The purpose of the image is to showcase the beauty of nature and architecture in harmony.

* A white tower:
        + The tower is tall and slender, with a distinctive shape that tapers towards the top.
        + It has a series of windows and a pointed roof, giving it a futuristic appearance.
        + The tower is

Output #1:  There are 2 duplicated images in the image. One is the image of the tower and the other is the image of the cherry blossoms. The image of the tower is duplicated in the background, and the image of the cherry blossoms is duplicated in the foreground. The duplicated images are not identical, as the tower is in the background and the cherry blossoms are in the foreground. The duplicated images are not symmetrical, as the tower is on the left side of the image and the cherry

Output #2:  The first image shows a white tower with a round top, surrounded by pink flowers. The second image shows a white tower with a round top, surrounded by pink flowers. The images are similar, but not identical. The first image has a more vibrant color scheme, while the second image has a more muted tone. The first image also has a more prominent shadow on the left side of the tower, while the second image has a more even lighting. Overall, the two images are similar, but with
```