### PR TITLE
Fix beam search eos

### DIFF
--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -140,7 +140,13 @@ class EngineClient(ABC):
         best_beams = sorted_completed[:beam_width]
 
         for beam in best_beams:
-            beam.text = tokenizer.decode(beam.tokens[tokenized_length:])
+            if (beam.tokens[-1] == tokenizer.eos_token_id and
+                not ignore_eos):
+                # Remove the eos token from the text.
+                tokens = beam.tokens[tokenized_length:-1]
+            else:
+                tokens = beam.tokens[tokenized_length:]
+            beam.text = tokenizer.decode(tokens)
 
         beam_search_output = RequestOutput(
             request_id=request_id,

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -140,8 +140,7 @@ class EngineClient(ABC):
         best_beams = sorted_completed[:beam_width]
 
         for beam in best_beams:
-            if (beam.tokens[-1] == tokenizer.eos_token_id and
-                not ignore_eos):
+            if (beam.tokens[-1] == tokenizer.eos_token_id and not ignore_eos):
                 # Remove the eos token from the text.
                 tokens = beam.tokens[tokenized_length:-1]
             else:

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -141,7 +141,7 @@ class EngineClient(ABC):
 
         for beam in best_beams:
             if (beam.tokens[-1] == tokenizer.eos_token_id and not ignore_eos):
-                # Remove the eos token from the text.
+                # Skip the eos token in the text.
                 tokens = beam.tokens[tokenized_length:-1]
             else:
                 tokens = beam.tokens[tokenized_length:]


### PR DESCRIPTION
SUMMARY:
* `beam_search` via the api is including the eos token in the text
* I do not think we can use `tokenizer.decode(xxx, skip_special_tokens=True)` because this strips out all the special tokens in chat templates