### PR TITLE
[Bugfix] Use "vision_model" prefix for MllamaVisionModel

### DIFF
--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1051,7 +1051,8 @@ class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal):
         self.image_size = config.vision_config.image_size
 
         self.vision_model = MllamaVisionModel(config.vision_config,
-                                              quant_config)
+                                              quant_config,
+                                              prefix="vision_model")
         self.language_model = MllamaForCausalLM(
             config.text_config,
             cache_config=cache_config,


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/9217 introduced quant_config and prefix names to many vision encoders, but for Mllama the base MllamaVisionModel instantiation was missing the "vision_model" prefix.

This broke a previously runnable FP8 checkpoint because the [`should_ignore_layer`](https://github.com/vllm-project/vllm/blob/fc6c27462614924dca90898ef762d6c56c0874ba/vllm/model_executor/layers/quantization/compressed_tensors/utils.py#L20-L21) function was getting layer names that did not match the ignore strings registered in the quant config

Example:
```
should_ignore_layer(.transformer.layers.31.mlp.fc2)? == False
should_ignore_layer(.global_transformer.layers.0.mlp.fc1)? == False
should_ignore_layer(language_model.model.layers.0.self_attn.qkv_proj)? == False
```
This PR corrects this to:
```
should_ignore_layer(vision_model.transformer.layers.31.mlp.fc2)? == True
should_ignore_layer(vision_model.global_transformer.layers.0.mlp.fc1)? == True
should_ignore_layer(language_model.model.layers.0.self_attn.qkv_proj)? == False
```

Script to test issue:
```python
from vllm import LLM

model_name = "neuralmagic/Llama-3.2-11B-Vision-Instruct-FP8-dynamic"
llm = LLM(model=model_name, max_model_len=4096, max_num_seqs=1, enforce_eager=True)
```

Stacktrace before this PR: (unfortunately it seems CLIPMLP doesn't fold batch and token dims together, so it breaks fp8 quant function)
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/home/mgoin/code/vllm/b.py", line 4, in <module>
[rank0]:     llm = LLM(model=model_name,
[rank0]:   File "/home/mgoin/code/vllm/vllm/utils.py", line 1053, in inner
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/entrypoints/llm.py", line 198, in __init__
[rank0]:     self.llm_engine = LLMEngine.from_engine_args(
[rank0]:   File "/home/mgoin/code/vllm/vllm/engine/llm_engine.py", line 578, in from_engine_args
[rank0]:     engine = cls(
[rank0]:   File "/home/mgoin/code/vllm/vllm/engine/llm_engine.py", line 351, in __init__
[rank0]:     self._initialize_kv_caches()
[rank0]:   File "/home/mgoin/code/vllm/vllm/engine/llm_engine.py", line 488, in _initialize_kv_caches
[rank0]:     self.model_executor.determine_num_available_blocks())
[rank0]:   File "/home/mgoin/code/vllm/vllm/executor/gpu_executor.py", line 114, in determine_num_available_blocks
[rank0]:     return self.driver_worker.determine_num_available_blocks()
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/worker/worker.py", line 223, in determine_num_available_blocks
[rank0]:     self.model_runner.profile_run()
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/worker/enc_dec_model_runner.py", line 359, in profile_run
[rank0]:     self.execute_model(model_input, kv_caches, intermediate_tensors)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/worker/enc_dec_model_runner.py", line 203, in execute_model
[rank0]:     hidden_or_intermediate_states = model_executable(
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 1314, in forward
[rank0]:     cross_attention_states = self.get_cross_attention_states(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 1203, in get_cross_attention_states
[rank0]:     cross_attention_states = self.vision_model(pixel_values,
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 605, in forward
[rank0]:     output = self.transformer(
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 466, in forward
[rank0]:     hidden_states = encoder_layer(
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/mllama.py", line 427, in forward
[rank0]:     hidden_state = self.mlp(hidden_state)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/clip.py", line 286, in forward
[rank0]:     hidden_states, _ = self.fc1(hidden_states)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
[rank0]:     return self._call_impl(*args, **kwargs)
[rank0]:   File "/home/mgoin/venvs/vllm/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
[rank0]:     return forward_call(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/linear.py", line 371, in forward
[rank0]:     output_parallel = self.quant_method.apply(self, input_, bias)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 381, in apply
[rank0]:     return scheme.apply_weights(layer, x, bias=bias)
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py", line 135, in apply_weights
[rank0]:     return apply_fp8_linear(
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/utils/w8a8_utils.py", line 101, in apply_fp8_linear
[rank0]:     qinput, x_scale = ops.scaled_fp8_quant(
[rank0]:   File "/home/mgoin/code/vllm/vllm/_custom_ops.py", line 46, in wrapper
[rank0]:     return fn(*args, **kwargs)
[rank0]:   File "/home/mgoin/code/vllm/vllm/_custom_ops.py", line 669, in scaled_fp8_quant
[rank0]:     assert (input.ndim == 2)
[rank0]: AssertionError
```