### PR TITLE
[Misc] Add metrics for request queue time, forward time, and execute time

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1891,13 +1891,6 @@ class ObservabilityConfig:
                 "'otlp_traces_endpoint'. Ensure OpenTelemetry packages are "
                 f"installed. Original error:\n{otel_import_error_traceback}")
 
-        if ((self.collect_model_forward_time
-             or self.collect_model_execute_time)
-                and self.otlp_traces_endpoint is None):
-            raise ValueError(
-                "collect_model_forward_time or collect_model_execute_time "
-                "requires --otlp-traces-endpoint to be set.")
-
 
 @dataclass(frozen=True)
 class EngineConfig:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1742,12 +1742,12 @@ class LLMEngine:
                     if seq_group.metrics.time_in_queue is not None:
                         time_in_queue_requests.append(
                             seq_group.metrics.time_in_queue)
-                    if seq_group.metrics.model_execute_time is not None:
-                        model_execute_time_requests.append(
-                            seq_group.metrics.model_execute_time)
                     if seq_group.metrics.model_forward_time is not None:
                         model_forward_time_requests.append(
                             seq_group.metrics.model_forward_time)
+                    if seq_group.metrics.model_execute_time is not None:
+                        model_execute_time_requests.append(
+                            seq_group.metrics.model_execute_time)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1744,7 +1744,7 @@ class LLMEngine:
                             seq_group.metrics.time_in_queue)
                     if seq_group.metrics.model_forward_time is not None:
                         model_forward_time_requests.append(
-                            seq_group.metrics.model_forward_time)
+                            seq_group.metrics.model_forward_time / 1000)
                     if seq_group.metrics.model_execute_time is not None:
                         model_execute_time_requests.append(
                             seq_group.metrics.model_execute_time)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1739,9 +1739,11 @@ class LLMEngine:
                     time_e2e_requests.append(now -
                                              seq_group.metrics.arrival_time)
                     if seq_group.metrics.model_execute_time is not None:
-                        time_execute_requests.append(seq_group.metrics.model_execute_time)
+                        time_execute_requests.append(
+                            seq_group.metrics.model_execute_time)
                     if seq_group.metrics.time_in_queue is not None:
-                        time_in_queue_requests.append(seq_group.metrics.time_in_queue)
+                        time_in_queue_requests.append(
+                            seq_group.metrics.time_in_queue)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1744,10 +1744,10 @@ class LLMEngine:
                             seq_group.metrics.time_in_queue)
                     if seq_group.metrics.model_forward_time is not None:
                         model_forward_time_requests.append(
-                            seq_group.metrics.model_forward_time / 1000)
+                            seq_group.metrics.model_forward_time)
                     if seq_group.metrics.model_execute_time is not None:
                         model_execute_time_requests.append(
-                            seq_group.metrics.model_execute_time)
+                            seq_group.metrics.model_execute_time * 1000)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1737,7 +1737,8 @@ class LLMEngine:
                     # Latency timings
                     time_e2e_requests.append(now -
                                              seq_group.metrics.arrival_time)
-                    time_execute_requests.append(seq_group.metrics.model_execute_time)
+                    if seq_group.metrics.model_execute_time is not None:
+                        time_execute_requests.append(seq_group.metrics.model_execute_time)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1643,8 +1643,9 @@ class LLMEngine:
         # Request stats
         #   Latency
         time_e2e_requests: List[float] = []
-        time_execute_requests: List[float] = []
         time_in_queue_requests: List[float] = []
+        model_forward_time_requests: List[float] = []
+        model_execute_time_requests: List[float] = []
         #   Metadata
         num_prompt_tokens_requests: List[int] = []
         num_generation_tokens_requests: List[int] = []
@@ -1738,12 +1739,15 @@ class LLMEngine:
                     # Latency timings
                     time_e2e_requests.append(now -
                                              seq_group.metrics.arrival_time)
-                    if seq_group.metrics.model_execute_time is not None:
-                        time_execute_requests.append(
-                            seq_group.metrics.model_execute_time)
                     if seq_group.metrics.time_in_queue is not None:
                         time_in_queue_requests.append(
                             seq_group.metrics.time_in_queue)
+                    if seq_group.metrics.model_execute_time is not None:
+                        model_execute_time_requests.append(
+                            seq_group.metrics.model_execute_time)
+                    if seq_group.metrics.model_forward_time is not None:
+                        model_forward_time_requests.append(
+                            seq_group.metrics.model_forward_time)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))
@@ -1801,8 +1805,9 @@ class LLMEngine:
             # Request stats
             #   Latency
             time_e2e_requests=time_e2e_requests,
-            time_execute_requests=time_execute_requests,
             time_in_queue_requests=time_in_queue_requests,
+            model_forward_time_requests=model_forward_time_requests,
+            model_execute_time_requests=model_execute_time_requests,
             #   Metadata
             num_prompt_tokens_requests=num_prompt_tokens_requests,
             num_generation_tokens_requests=num_generation_tokens_requests,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1644,6 +1644,7 @@ class LLMEngine:
         #   Latency
         time_e2e_requests: List[float] = []
         time_execute_requests: List[float] = []
+        time_in_queue_requests: List[float] = []
         #   Metadata
         num_prompt_tokens_requests: List[int] = []
         num_generation_tokens_requests: List[int] = []
@@ -1739,6 +1740,8 @@ class LLMEngine:
                                              seq_group.metrics.arrival_time)
                     if seq_group.metrics.model_execute_time is not None:
                         time_execute_requests.append(seq_group.metrics.model_execute_time)
+                    if seq_group.metrics.time_in_queue is not None:
+                        time_in_queue_requests.append(seq_group.metrics.time_in_queue)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))
@@ -1797,6 +1800,7 @@ class LLMEngine:
             #   Latency
             time_e2e_requests=time_e2e_requests,
             time_execute_requests=time_execute_requests,
+            time_in_queue_requests=time_in_queue_requests,
             #   Metadata
             num_prompt_tokens_requests=num_prompt_tokens_requests,
             num_generation_tokens_requests=num_generation_tokens_requests,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1643,6 +1643,7 @@ class LLMEngine:
         # Request stats
         #   Latency
         time_e2e_requests: List[float] = []
+        time_execute_requests: List[float] = []
         #   Metadata
         num_prompt_tokens_requests: List[int] = []
         num_generation_tokens_requests: List[int] = []
@@ -1736,6 +1737,7 @@ class LLMEngine:
                     # Latency timings
                     time_e2e_requests.append(now -
                                              seq_group.metrics.arrival_time)
+                    time_execute_requests.append(seq_group.metrics.model_execute_time)
                     # Metadata
                     num_prompt_tokens_requests.append(
                         len(seq_group.prompt_token_ids))
@@ -1793,6 +1795,7 @@ class LLMEngine:
             # Request stats
             #   Latency
             time_e2e_requests=time_e2e_requests,
+            time_execute_requests=time_execute_requests,
             #   Metadata
             num_prompt_tokens_requests=num_prompt_tokens_requests,
             num_generation_tokens_requests=num_generation_tokens_requests,

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -133,17 +133,28 @@ class Metrics:
             name="vllm:e2e_request_latency_seconds",
             documentation="Histogram of end to end request latency in seconds.",
             labelnames=labelnames,
-            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+            buckets=[
+                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+                40.0, 50.0, 60.0
+            ])
         self.histogram_execute_time_request = self._histogram_cls(
             name="vllm:model_execute_time_seconds",
-            documentation="Histogram of time spent in the model execute function in seconds.",
+            documentation=
+            "Histogram of time spent in the model execute function in seconds.",
             labelnames=labelnames,
-            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+            buckets=[
+                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+                40.0, 50.0, 60.0
+            ])
         self.histogram_time_in_queue_request = self._histogram_cls(
             name="vllm:time_in_queue_requests",
-            documentation="Histogram of time the request spent in the queue in seconds.",
+            documentation=
+            "Histogram of time the request spent in the queue in seconds.",
             labelnames=labelnames,
-            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+            buckets=[
+                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+                40.0, 50.0, 60.0
+            ])
         #   Metadata
         self.histogram_num_prompt_tokens_request = self._histogram_cls(
             name="vllm:request_prompt_tokens",

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -133,12 +133,17 @@ class Metrics:
             name="vllm:e2e_request_latency_seconds",
             documentation="Histogram of end to end request latency in seconds.",
             labelnames=labelnames,
-            buckets=[1.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
         self.histogram_execute_time_request = self._histogram_cls(
             name="vllm:model_execute_time_seconds",
             documentation="Histogram of time spent in the model execute function in seconds.",
             labelnames=labelnames,
-            buckets=[1.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+        self.histogram_time_in_queue_request = self._histogram_cls(
+            name="vllm:time_in_queue_requests",
+            documentation="Histogram of time the request spent in the queue in seconds.",
+            labelnames=labelnames,
+            buckets=[0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
         #   Metadata
         self.histogram_num_prompt_tokens_request = self._histogram_cls(
             name="vllm:request_prompt_tokens",
@@ -493,6 +498,8 @@ class PrometheusStatLogger(StatLoggerBase):
                             stats.time_e2e_requests)
         self._log_histogram(self.metrics.histogram_execute_time_request,
                             stats.time_execute_requests)
+        self._log_histogram(self.metrics.histogram_time_in_queue_request,
+                            stats.time_in_queue_requests)
         # Metadata
         finished_reason_counter = CollectionsCounter(
             stats.finished_reason_requests)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -134,6 +134,11 @@ class Metrics:
             documentation="Histogram of end to end request latency in seconds.",
             labelnames=labelnames,
             buckets=[1.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+        self.histogram_execute_time_request = self._histogram_cls(
+            name="vllm:model_execute_time_seconds",
+            documentation="Histogram of time spent in the model execute function in seconds.",
+            labelnames=labelnames,
+            buckets=[1.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0, 40.0, 50.0, 60.0])
         #   Metadata
         self.histogram_num_prompt_tokens_request = self._histogram_cls(
             name="vllm:request_prompt_tokens",
@@ -486,6 +491,8 @@ class PrometheusStatLogger(StatLoggerBase):
         # Latency
         self._log_histogram(self.metrics.histogram_e2e_time_request,
                             stats.time_e2e_requests)
+        self._log_histogram(self.metrics.histogram_execute_time_request,
+                            stats.time_execute_requests)
         # Metadata
         finished_reason_counter = CollectionsCounter(
             stats.finished_reason_requests)

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -147,23 +147,17 @@ class Metrics:
                 40.0, 50.0, 60.0
             ])
         self.histogram_model_forward_time_request = self._histogram_cls(
-            name="vllm:model_forward_time_seconds",
+            name="vllm:model_forward_time_milliseconds",
             documentation=
-            "Histogram of time spent in the model forward pass in seconds.",
+            "Histogram of time spent in the model forward pass in ms.",
             labelnames=labelnames,
-            buckets=[
-                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
-                40.0, 50.0, 60.0
-            ])
+            buckets=build_1_2_3_5_8_buckets(3000))
         self.histogram_model_execute_time_request = self._histogram_cls(
-            name="vllm:model_execute_time_seconds",
+            name="vllm:model_execute_time_milliseconds",
             documentation=
-            "Histogram of time spent in the model execute function in seconds.",
+            "Histogram of time spent in the model execute function in ms.",
             labelnames=labelnames,
-            buckets=[
-                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
-                40.0, 50.0, 60.0
-            ])
+            buckets=build_1_2_3_5_8_buckets(3000))
         #   Metadata
         self.histogram_num_prompt_tokens_request = self._histogram_cls(
             name="vllm:request_prompt_tokens",
@@ -329,16 +323,12 @@ class RayMetrics(Metrics):
         pass
 
 
-def build_1_2_5_buckets(max_value: int) -> List[int]:
+def build_buckets(mantissa_lst: List[int], max_value: int) -> List[int]:
     """
-    Builds a list of buckets with increasing powers of 10 multiplied by 
-    mantissa values (1, 2, 5) until the value exceeds the specified maximum.
+    Builds a list of buckets with increasing powers of 10 multiplied by
+    mantissa values until the value exceeds the specified maximum.
 
-    Example:
-    >>> build_1_2_5_buckets(100)
-    [1, 2, 5, 10, 20, 50, 100]
     """
-    mantissa_lst = [1, 2, 5]
     exponent = 0
     buckets: List[int] = []
     while True:
@@ -349,6 +339,24 @@ def build_1_2_5_buckets(max_value: int) -> List[int]:
             else:
                 return buckets
         exponent += 1
+
+
+def build_1_2_5_buckets(max_value: int) -> List[int]:
+    """
+    Example:
+    >>> build_1_2_5_buckets(100)
+    [1, 2, 5, 10, 20, 50, 100]
+    """
+    return build_buckets([1, 2, 5], max_value)
+
+
+def build_1_2_3_5_8_buckets(max_value: int) -> List[int]:
+    """
+    Example:
+    >>> build_1_2_3_5_8_buckets(100)
+    [1, 2, 3, 5, 8, 10, 20, 30, 50, 80, 100]
+    """
+    return build_buckets([1, 2, 3, 5, 8], max_value)
 
 
 def local_interval_elapsed(now: float, last_log: float,

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -137,19 +137,28 @@ class Metrics:
                 0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
                 40.0, 50.0, 60.0
             ])
-        self.histogram_execute_time_request = self._histogram_cls(
-            name="vllm:model_execute_time_seconds",
+        self.histogram_time_in_queue_request = self._histogram_cls(
+            name="vllm:time_in_queue_requests",
             documentation=
-            "Histogram of time spent in the model execute function in seconds.",
+            "Histogram of time the request spent in the queue in seconds.",
             labelnames=labelnames,
             buckets=[
                 0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
                 40.0, 50.0, 60.0
             ])
-        self.histogram_time_in_queue_request = self._histogram_cls(
-            name="vllm:time_in_queue_requests",
+        self.histogram_model_forward_time_request = self._histogram_cls(
+            name="vllm:model_forward_time_seconds",
             documentation=
-            "Histogram of time the request spent in the queue in seconds.",
+            "Histogram of time spent in the model forward pass in seconds.",
+            labelnames=labelnames,
+            buckets=[
+                0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
+                40.0, 50.0, 60.0
+            ])
+        self.histogram_model_execute_time_request = self._histogram_cls(
+            name="vllm:model_execute_time_seconds",
+            documentation=
+            "Histogram of time spent in the model execute function in seconds.",
             labelnames=labelnames,
             buckets=[
                 0.3, 0.5, 0.8, 1.0, 1.5, 2.0, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0,
@@ -507,10 +516,12 @@ class PrometheusStatLogger(StatLoggerBase):
         # Latency
         self._log_histogram(self.metrics.histogram_e2e_time_request,
                             stats.time_e2e_requests)
-        self._log_histogram(self.metrics.histogram_execute_time_request,
-                            stats.time_execute_requests)
         self._log_histogram(self.metrics.histogram_time_in_queue_request,
                             stats.time_in_queue_requests)
+        self._log_histogram(self.metrics.histogram_model_forward_time_request,
+                            stats.model_forward_time_requests)
+        self._log_histogram(self.metrics.histogram_model_execute_time_request,
+                            stats.model_execute_time_requests)
         # Metadata
         finished_reason_counter = CollectionsCounter(
             stats.finished_reason_requests)

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -46,8 +46,9 @@ class Stats:
     # Request stats (should have _requests suffix)
     #   Latency
     time_e2e_requests: List[float]
-    time_execute_requests: List[float]
     time_in_queue_requests: List[float]
+    model_forward_time_requests: List[float]
+    model_execute_time_requests: List[float]
     #   Metadata
     num_prompt_tokens_requests: List[int]
     num_generation_tokens_requests: List[int]

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -47,6 +47,7 @@ class Stats:
     #   Latency
     time_e2e_requests: List[float]
     time_execute_requests: List[float]
+    time_in_queue_requests: List[float]
     #   Metadata
     num_prompt_tokens_requests: List[int]
     num_generation_tokens_requests: List[int]

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -46,6 +46,7 @@ class Stats:
     # Request stats (should have _requests suffix)
     #   Latency
     time_e2e_requests: List[float]
+    time_execute_requests: List[float]
     #   Metadata
     num_prompt_tokens_requests: List[int]
     num_generation_tokens_requests: List[int]


### PR DESCRIPTION
1. Add metrics for request queue time, forward time, and execute time, which can be returned through the `/metrics` API.
2. Remove the restriction on `collect_model_forward_time` and `collect_model_execute_time` due to the `--otlp-traces-endpoint` flag, so that metrics can also collect information about `model_forward_time` and `model_execute_time`.


