### PR TITLE
Increase operation per run limit for "Close inactive issues and PRs" workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
+          # Increasing this value ensures that changes to this workflow
+          # propagate to all issues and PRs in days rather than months
+          operations-per-run: 1024
+
           exempt-draft-pr: true
           exempt-issue-labels: 'keep-open'
           exempt-pr-labels: 'keep-open'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           # Increasing this value ensures that changes to this workflow
           # propagate to all issues and PRs in days rather than months
-          operations-per-run: 1024
+          operations-per-run: 1000
 
           exempt-draft-pr: true
           exempt-issue-labels: 'keep-open'


### PR DESCRIPTION
Increases `operations-per-run` from `30` to `1000`.

This ensures that changes to this workflow propagate to all issues and PRs in days rather than months.

In the most recent run (https://github.com/vllm-project/vllm/actions/runs/11491223727/job/31983238963#step:2:19447) you can see that there are ~5k operations left. So increasing the limit to 1000 leaves 4000 for other tasks. The usage will only get close to 1000 when the workflow file is changed (or new, as it is now).