### PR TITLE
[V1] Prefix caching

### DIFF
--- a/benchmarks/benchmark_prefix_caching.py
+++ b/benchmarks/benchmark_prefix_caching.py
@@ -118,7 +118,7 @@ def main(args):
     random.seed(args.seed)
     if args.dataset_path is not None:
         print(f"Start to sample {args.num_prompts} prompts"
-              "from {args.dataset_path}")
+              f"from {args.dataset_path}")
         filtered_datasets = sample_requests(
             dataset_path=args.dataset_path,
             num_requests=args.num_prompts,
@@ -141,13 +141,6 @@ def main(args):
     prompts = repeat_and_sort_requests(filtered_datasets,
                                        repeat_count=args.repeat_count,
                                        sort=args.sort)
-
-    print("------warm up------")
-    test_prefix(
-        llm=llm,
-        prompts=prompts,
-        sampling_params=sampling_params,
-    )
 
     print("------start generating------")
     test_prefix(

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1,0 +1,169 @@
+"""Compare the with and without prefix caching."""
+from vllm.inputs import DecoderOnlyInputs
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.kv_cache_manager import KVCacheManager, Request
+
+
+def make_request(request_id, prompt_token_ids):
+    return Request(
+        request_id=request_id,
+        inputs=DecoderOnlyInputs(prompt_token_ids=prompt_token_ids),
+        sampling_params=SamplingParams(max_tokens=17),
+        eos_token_id=100,
+        arrival_time=0,
+        lora_request=None,
+    )
+
+
+def test_prefill():
+    manager = KVCacheManager(
+        block_size=16,
+        num_gpu_blocks=10,
+        sliding_window=False,
+        enable_caching=True,
+        num_preallocate_tokens=16,
+    )
+
+    # Complete 3 blocks (48 tokens)
+    common_token_ids = [i for i in range(3) for _ in range(16)]
+
+    # Fully cache miss
+    # Incomplete 1 block (7 tokens)
+    unique_token_ids = [3] * 7
+    req0 = make_request("0", common_token_ids + unique_token_ids)
+    computed_block_ids = manager.get_computed_blocks(req0)
+    assert not computed_block_ids
+    block_ids = manager.allocate_slots(req0, 55, computed_block_ids)
+    assert block_ids == [0, 1, 2, 3, 4]
+
+    # Check full block metadata
+    prev_block_id = None
+    for block_id in (0, 1, 2):
+        assert manager.block_pool[block_id].prev_block_id == prev_block_id
+        assert manager.block_pool[block_id].block_hash is not None
+        assert manager.block_pool[block_id].ref_cnt == 1
+        assert manager.block_pool[block_id].num_hashed_tokens == 16 * (
+            block_id + 1)
+        assert manager.block_pool[block_id].token_ids == [block_id] * 16
+        prev_block_id = block_id
+
+    # Check partial/preallocated block metadata
+    for block_id in (3, 4):
+        assert manager.block_pool[block_id].prev_block_id == block_id - 1
+        assert manager.block_pool[block_id].block_hash is None
+        assert manager.block_pool[block_id].ref_cnt == 1
+        assert manager.block_pool[block_id].num_hashed_tokens == 0
+        if block_id == 3:
+            assert manager.block_pool[block_id].token_ids == [3] * 7
+        else:
+            assert not manager.block_pool[block_id].token_ids
+
+    # Cache hit in the common prefix when the original block is still in use.
+    # Incomplete 1 block (5 tokens)
+    unique_token_ids = [3] * 5
+    req1 = make_request("1", common_token_ids + unique_token_ids)
+    computed_block_ids = manager.get_computed_blocks(req1)
+    assert computed_block_ids == [0, 1, 2]
+    num_new_tokens = 53 - 3 * 16
+    block_ids = manager.allocate_slots(req1, num_new_tokens,
+                                       computed_block_ids)
+    assert block_ids == [5, 6]
+    for block_id in (0, 1, 2):
+        assert manager.block_pool[block_id].ref_cnt == 2
+
+    # At this point, we should have 3 free blocks left.
+    assert manager.num_free_blocks == 3
+
+    manager.free(req0)
+    manager.free(req1)
+
+    # All blocks should be available.
+    assert manager.num_free_blocks == 10
+    # The order should be
+    # [unallocated (7, 8)]
+    # [unique_req0 (4, 3)]
+    # [unique_req1 (6, 5)]
+    # [common (2, 1, 0)]
+    assert [b.block_id for b in manager.free_block_queue
+            ] == [7, 8, 9, 4, 3, 6, 5, 2, 1, 0]
+
+    # Cache hit in the common prefix when the original block is already free.
+    # Incomplete 1 block (6 tokens)
+    unique_token_ids = [3] * 6
+    req2 = make_request("2", common_token_ids + unique_token_ids)
+    computed_block_ids = manager.get_computed_blocks(req2)
+    assert computed_block_ids == [0, 1, 2]
+    num_new_tokens = 53 - 3 * 16
+    block_ids = manager.allocate_slots(req2, num_new_tokens,
+                                       computed_block_ids)
+    assert block_ids == [7, 8]
+
+    # Although we only have 5 free blocks, we have 8 blocks in
+    # the free block queue due to lazy removal.
+    assert manager.num_free_blocks == 5
+    assert len(list(manager.free_block_queue)) == 8
+    assert len([b for b in manager.free_block_queue if b.ref_cnt > 0]) == 3
+
+    manager.free(req2)
+
+    # Cache miss and eviction.
+    req3 = make_request("3", [99] * (16 * 9))
+    computed_block_ids = manager.get_computed_blocks(req3)
+    assert not computed_block_ids
+    block_ids = manager.allocate_slots(req2, 16 * 9, computed_block_ids)
+    # This block ID order also checks the eviction order.
+    assert block_ids == [9, 4, 3, 6, 5, 8, 7, 2, 1, 0]
+    assert manager.num_free_blocks == 0
+    assert not manager.free_block_queue
+
+
+def test_decode():
+    manager = KVCacheManager(
+        block_size=16,
+        num_gpu_blocks=10,
+        sliding_window=False,
+        enable_caching=True,
+        num_preallocate_tokens=16,
+    )
+
+    # Complete 3 blocks (48 tokens)
+    common_token_ids = [i for i in range(3) for _ in range(16)]
+
+    # Fully cache miss
+    # Incomplete 1 block (7 tokens)
+    unique_token_ids = [3] * 7
+    req0 = make_request("0", common_token_ids + unique_token_ids)
+    computed_block_ids = manager.get_computed_blocks(req0)
+    assert not computed_block_ids
+    block_ids = manager.allocate_slots(req0, 55, computed_block_ids)
+    assert block_ids == [0, 1, 2, 3, 4]
+
+    # Append slots without allocating a new block.
+    req0.num_computed_tokens = 55
+    req0.output_token_ids = [8] * 4
+    new_block_ids = manager.append_slots(req0, 4)
+    assert new_block_ids is not None and len(new_block_ids) == 0
+    assert len(manager.block_pool[3].token_ids) == 11
+
+    # Append slots without allocating a new block, but start using the
+    # preallocated block.
+    req0.num_computed_tokens = 59
+    # 6 tokens to fill the previous block, and 10 tokens to fill
+    # the preallocated block.
+    req0.output_token_ids += [7] * (5 + 10)
+    new_block_ids = manager.append_slots(req0, 15)
+    assert new_block_ids is not None and len(new_block_ids) == 0
+    assert len(manager.block_pool[3].token_ids) == 16
+    assert len(manager.block_pool[4].token_ids) == 10
+
+    # Append slots with allocating a new block.
+    req0.num_computed_tokens = 74
+    # 6 tokens to fill the previous block, and 10 tokens to fill
+    # the preallocated block.
+    req0.output_token_ids += [12] * (6 + 11)
+    new_block_ids = manager.append_slots(req0, 17)
+    # Plus one preallocated block.
+    assert new_block_ids is not None and len(new_block_ids) == 2
+    assert len(manager.block_pool[4].token_ids) == 16
+    assert len(manager.block_pool[5].token_ids) == 11
+    assert len(manager.block_pool[6].token_ids) == 0

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -295,6 +295,7 @@ class KVCacheManager:
                         # end of the free_block_list to maintain theeviction
                         # order.
                         self.free_block_queue.remove(self.block_pool[block_id])
+                        self.lazy_remove_block_ids.remove(block_id)
                     self.free_block_queue.append(self.block_pool[block_id])
                     self.num_free_blocks += 1
         else:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -1,3 +1,5 @@
+from collections import deque
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 import numpy as np
@@ -8,6 +10,17 @@ from vllm.v1.request import Request
 
 logger = init_logger(__name__)
 
+@dataclass
+class KVCacheBlock:
+    """KV-cache block metadata."""
+    # Block ID, ranging from 0 to num_gpu_blocks - 1.
+    block_id: int
+    # Previous block ID. Used to include block chain in the block hash.
+    prev_block_id: Optional[int] = None
+    # Token IDs in the block.
+    token_ids: List[int] = field(default_factory=list)
+    # The hash of the block. It is only available when the block is full.
+    block_hash: Optional[int] = None
 
 class KVCacheManager:
 
@@ -36,9 +49,11 @@ class KVCacheManager:
         self.num_preallocate_tokens = num_preallocate_tokens
         self.num_preallocate_blocks = cdiv(num_preallocate_tokens, block_size)
 
-        self.free_block_ids = list(range(num_gpu_blocks))
+        self.block_pool: List[KVCacheBlock] = [KVCacheBlock(idx) for idx in range(num_gpu_blocks)]
+        self.free_block_ids = deque(list(range(num_gpu_blocks)))
+        self.allocated_block_ids = set([])
         self.req_to_block_ids: Dict[str, List[int]] = {}
-        self.ref_cnts = np.zeros(num_gpu_blocks, dtype=np.int32)
+
 
     def get_computed_blocks(self, request: Request) -> List[int]:
         if not self.enable_caching:
@@ -52,6 +67,18 @@ class KVCacheManager:
         request: Request,
         num_tokens: int,
     ) -> Optional[List[int]]:
+        """Append slots to the block table of the request.
+        If the last block of the request is not full, we append slots to it
+        first and then allocate new blocks if needed.
+
+        Args:
+            request: The request to append slots.
+            num_tokens: The number of tokens to append.
+        
+        Returns:
+            A list of new block IDs if new blocks are allocated, or None
+            if new blocks are required but cannot be allocated.
+        """
         num_required_blocks = cdiv(request.num_computed_tokens + num_tokens,
                                    self.block_size)
         req_block_ids = self.req_to_block_ids[request.request_id]
@@ -66,12 +93,14 @@ class KVCacheManager:
             return None
 
         # Allocate new blocks.
+        # TODO: If we need to allocate more than one block, it is also
+        # possible that the block is already computed.
         num_new_blocks = min(num_new_blocks + self.num_preallocate_blocks,
                              num_free_blocks)
         new_block_ids = self._get_new_blocks(num_new_blocks)
         req_block_ids.extend(new_block_ids)
-        self.ref_cnts[new_block_ids] += 1
         return new_block_ids
+
 
     def allocate_slots(
         self,
@@ -79,30 +108,71 @@ class KVCacheManager:
         num_tokens: int,
         computed_block_ids: List[int],
     ) -> Optional[List[int]]:
+        """Allocate slots for a new request.
+
+        Args:
+            request: The request to allocate slots.
+            num_tokens: The number of tokens to allocate. Note that this does
+                not include the tokens that have already been computed.
+            computed_block_ids: The block IDs that have already been computed.
+        
+        Returns:
+            A list of block IDs. If computed block IDs are given, the list
+            is composed of the computed block IDs followed by the new block IDs.
+        """
         num_required_blocks = cdiv(num_tokens, self.block_size)
         num_free_blocks = len(self.free_block_ids)
         if num_required_blocks > num_free_blocks:
             # Cannot allocate new blocks.
             return None
 
+        # Allocate new blocks.
         num_new_blocks = min(num_required_blocks + self.num_preallocate_blocks,
                              num_free_blocks)
         new_block_ids = self._get_new_blocks(num_new_blocks)
+
+        # Increase the reference count of the computed blocks.
+        for block_id in computed_block_ids:
+            self.block_pool[block_id].ref_cnt += 1
+
+        # Concatenate the computed block IDs and the new block IDs.
         block_ids = computed_block_ids + new_block_ids
         self.req_to_block_ids[request.request_id] = block_ids
-        self.ref_cnts[block_ids] += 1
         return new_block_ids
 
-    def free(self, request: Request) -> None:
-        block_ids = self.req_to_block_ids.pop(request.request_id)
-        self.ref_cnts[block_ids] -= 1
-        for block_id in block_ids:
-            ref_cnt = self.ref_cnts[block_id]
-            if ref_cnt == 0:
-                self.free_block_ids.append(block_id)
 
-    def _get_new_blocks(self, num_blocks: int) -> List[int]:
+    def free(self, request: Request) -> None:
+        """Free the blocks allocated for the request."""
+        block_ids = self.req_to_block_ids.pop(request.request_id)
+        for block_id in block_ids:
+            self.block_pool[block_id].ref_cnt -= 1
+            if self.block_pool[block_id].ref_cnt == 0:
+                self.allocated_block_ids.remove(block_id)
+                self.free_block_ids.append(block_id)
+                # TODO: Add to evictor.
+
+
+    def _get_new_blocks(self, num_blocks: int, prev_block_id: Optional[int] = None) -> List[int]:
+        """Get new blocks from the free block pool.
+        Specifically, we move block IDs from free_block_ids to
+        allocated_block_ids, and set their reference count to 1.
+
+        Note that we do not reuse existing blocks in this function.
+        
+        Args:
+            num_blocks: The number of blocks to allocate.
+            prev_block_id: The previous block ID. Used to include block chain
+                in the block hash.
+        
+        Returns:
+            A list of new block IDs.
+        """
         assert num_blocks <= len(self.free_block_ids)
-        new_block_ids = self.free_block_ids[-num_blocks:]
-        self.free_block_ids = self.free_block_ids[:-num_blocks]
+        new_block_ids = self.free_block_ids.popleft(num_blocks)
+        for block_id in new_block_ids:
+            self.block_pool[block_id].prev_block_id = prev_block_id
+            self.block_pool[block_id].ref_cnt = 1
+            prev_block_id = block_id
+
+        self.allocated_block_ids.update(new_block_ids)
         return new_block_ids

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -1,8 +1,7 @@
 from collections import deque
+from functools import lru_cache
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
-
-import numpy as np
+from typing import Any, Dict, List, Optional, Tuple
 
 from vllm.logger import init_logger
 from vllm.utils import cdiv
@@ -17,10 +16,116 @@ class KVCacheBlock:
     block_id: int
     # Previous block ID. Used to include block chain in the block hash.
     prev_block_id: Optional[int] = None
+    # Reference count.
+    ref_cnt: int = 0
     # Token IDs in the block.
     token_ids: List[int] = field(default_factory=list)
     # The hash of the block. It is only available when the block is full.
     block_hash: Optional[int] = None
+    # The number of hashed tokens. More hashed tokens means the block
+    # is closer to the end of a prompt and more likely to be evicted.
+    num_hashed_tokens: int = 0
+
+
+class KVCacheBlockPool:
+    def __init__(self, num_blocks, block_size):
+        self.block_size = block_size
+        self.block_pool: List[KVCacheBlock] = [
+            KVCacheBlock(idx) for idx in range(num_blocks)
+        ]
+
+        # The free block list orderd by block ID in the beginning. However,
+        # when a block is allocated and then freed, it will be added back
+        # with the eviction order:
+        # 1. The least recently used block is at the front
+        # 2. If two blocks have the same last accessed time (allocated by the
+        #    same sequence), the one with more hash tokens (the tail of a block
+        #    chain) is at the front.
+        # We maintain this order by reversing the block order when free
+        # blocks of a request.
+        #
+        # Note that the block in this list is NOT guaranteed to be free
+        # due to prefix caching. If a block in free block list is touched
+        # by a request, we do not remove it immediately from free_block_list
+        # due to O(n) removal cost. Instead, we remove ref_cnt>0 blocks when
+        # allocating new blocks. That's why we need to maintain a separate
+        # num_free_blocks counter.
+        self.free_block_queue = deque(self.block_pool)
+        self.num_free_blocks = num_blocks
+
+        # Mapping of cached block hashes to block ID. A cached block is
+        # a full block with a block hash that can be used for prefix caching.
+        # Full blocks in the free_block_ids and being used by running requests
+        # are considered as cached blocks. When a block is evicted, meaning that
+        # it is not used and being removed from free_block_ids due to out of
+        # blocks, it will be removed from cached blocks.
+        self.cached_block_hash_to_block = {}
+
+    def __getitem__(self, block_id: int) -> KVCacheBlock:
+        return self.block_pool[block_id]
+    
+    def get_free_blocks(self, num: int, token_ids: List[int], prev_block: Optional[KVCacheBlock] = None) -> List[KVCacheBlock]:
+        if num > self.num_free_blocks:
+            raise ValueError(f"Cannot get {num} free blocks from the pool")
+        
+        ret = []
+        if prev_block is None:
+            num_hashed_tokens = 0
+        else:
+            num_hashed_tokens = prev_block.num_hashed_tokens
+
+        idx = 0
+        while idx < num:
+            curr_block = self.free_block_queue.popleft()
+            # The block has been allocated by another request. This happens
+            # when another request touches (cache hit) the block before it
+            # is evicted.
+            if curr_block.ref_cnt > 0:
+                continue
+
+            # Evict blocks from the cache.
+            block_hash = curr_block.block_hash
+            if block_hash is not None and block_hash in self.cached_block_hash_to_block:
+                del self.cached_block_hash_to_block[block_hash]
+
+            curr_block.ref_cnt = 1
+            curr_block.token_ids = token_ids[idx * self.block_size:(idx + 1) * self.block_size]
+            # If the block is full, compute its hash and add to the cache.
+            num_block_tokens = len(curr_block.token_ids)
+            if num_block_tokens == self.block_size:
+                num_hashed_tokens += self.block_size
+                block_hash = hash_block_tokens(prev_block.block_hash, tuple(curr_block.token_ids))
+                curr_block.block_hash = block_hash
+                curr_block.num_hashed_tokens = num_hashed_tokens
+                self.cached_block_hash_to_block[block_hash] = curr_block
+            prev_block = curr_block
+
+            ret.append(curr_block)
+            idx += 1
+
+        self.num_free_blocks -= num
+        return ret
+    
+    def get_cached_block(self, block_hash: int) -> Optional[KVCacheBlock]:
+        if block_hash in self.cached_block_hash_to_block:
+            return self.cached_block_hash_to_block[block_hash]
+        return None
+
+
+    def touch(self, block_id: int):
+        """Touch a block manes to remove it from the free block list
+        so that it will not be evicted. This happens when the block is
+        freed but has not been evicted yet, and then it can be reused
+        by another request.
+        """
+        curr_block = self.block_pool[block_id]
+        # The block has no reference yet, meaning that it is in
+        # the free list, so we reduce the number of free blocks by 1,
+        # but not remove it from the free list now to avoid O(n) cost.
+        if curr_block.ref_cnt == 0:
+            self.num_free_blocks -= 1
+        curr_block.ref_cnt += 1
+
 
 class KVCacheManager:
 
@@ -49,18 +154,42 @@ class KVCacheManager:
         self.num_preallocate_tokens = num_preallocate_tokens
         self.num_preallocate_blocks = cdiv(num_preallocate_tokens, block_size)
 
-        self.block_pool: List[KVCacheBlock] = [KVCacheBlock(idx) for idx in range(num_gpu_blocks)]
-        self.free_block_ids = deque(list(range(num_gpu_blocks)))
-        self.allocated_block_ids = set([])
+        self.block_pool = KVCacheBlockPool(num_gpu_blocks, block_size)
+
+        # Mapping from request ID to block IDs to track the blocks allocated
+        # for each request, so that we can free the blocks when the request
+        # is finished.
         self.req_to_block_ids: Dict[str, List[int]] = {}
 
 
     def get_computed_blocks(self, request: Request) -> List[int]:
+        """Get the computed (cached) blocks for the request.
+        Note that the computed blocks must be full.
+
+        Args:
+            request: The request to get the computed blocks.
+        
+        Returns:
+            A list of block IDs that are computed for the request.
+        """
         if not self.enable_caching:
             # No prefix caching.
             return []
-        # TODO(woosuk): Implement hash-based caching.
-        return []
+        
+        computed_block_ids = []
+        block_hashes = self.hash_prompt_tokens(request.prompt_token_ids)
+
+        for block_hash in block_hashes:
+            # block_hashes is a chain of block hashes. If a block hash is not
+            # in the cached_block_hash_to_id, the following block hashes are
+            # not computed yet for sure.
+            if cached_block := self.block_pool.get_cached_block(block_hash):
+                computed_block_ids.append(cached_block.block_id)
+            else:
+                break
+
+        return computed_block_ids
+
 
     def append_slots(
         self,
@@ -79,25 +208,33 @@ class KVCacheManager:
             A list of new block IDs if new blocks are allocated, or None
             if new blocks are required but cannot be allocated.
         """
+        if request.num_computed_tokens < request.num_prompt_tokens:
+            # (Chunked) Prefill.
+            new_token_ids = request.prompt_token_ids[request.num_computed_tokens:request.num_computed_tokens + num_tokens]
+        else:
+            # Decode.
+            num_computed_output_tokens = request.num_computed_tokens - request.num_prompt_tokens
+            new_token_ids = request.output_token_ids[num_computed_output_tokens:num_computed_output_tokens + num_tokens]
+
         num_required_blocks = cdiv(request.num_computed_tokens + num_tokens,
                                    self.block_size)
         req_block_ids = self.req_to_block_ids[request.request_id]
+        last_block_id = req_block_ids[-1]
         if num_required_blocks <= len(req_block_ids):
-            # No new block is needed.
+            # No new block is needed. Update the token IDs in the last block.
+            self.block_pool[last_block_id].token_ids.extend(new_token_ids)
+            # TODO: Promote the block to the cached block if it is full.
             return []
 
         num_new_blocks = num_required_blocks - len(req_block_ids)
-        num_free_blocks = len(self.free_block_ids)
-        if num_new_blocks > num_free_blocks:
+        if num_new_blocks > self.block_pool.num_free_blocks:
             # Cannot allocate new blocks.
             return None
 
         # Allocate new blocks.
-        # TODO: If we need to allocate more than one block, it is also
-        # possible that the block is already computed.
         num_new_blocks = min(num_new_blocks + self.num_preallocate_blocks,
-                             num_free_blocks)
-        new_block_ids = self._get_new_blocks(num_new_blocks)
+                             self.block_pool.num_free_blocks)
+        new_block_ids = self._get_new_blocks(num_new_blocks, new_token_ids, last_block_id)
         req_block_ids.extend(new_block_ids)
         return new_block_ids
 
@@ -120,20 +257,36 @@ class KVCacheManager:
             A list of block IDs. If computed block IDs are given, the list
             is composed of the computed block IDs followed by the new block IDs.
         """
+        if num_tokens == 0:
+            raise ValueError(
+                f"num_tokens must be greater than 0, got {num_tokens}")
+
         num_required_blocks = cdiv(num_tokens, self.block_size)
-        num_free_blocks = len(self.free_block_ids)
-        if num_required_blocks > num_free_blocks:
+        if num_required_blocks > self.block_pool.num_free_blocks:
             # Cannot allocate new blocks.
             return None
 
-        # Allocate new blocks.
+        # Determine the number of new blocks to allocate considering
+        # preallocated blocks.
         num_new_blocks = min(num_required_blocks + self.num_preallocate_blocks,
-                             num_free_blocks)
-        new_block_ids = self._get_new_blocks(num_new_blocks)
+                             self.block_pool.num_free_blocks)
+        # Get the token IDs for the blocks being allocated for hashing.
+        # Note that we expect this function to be called only once for a
+        # request, so we must have new token IDs in the prompt.
+        new_token_ids = request.prompt_token_ids[request.num_computed_tokens:]
+        if not new_token_ids:
+            raise RuntimeError(
+                "Failed to infer the token IDs for allocation. "
+                f"#prompt_tokens={len(request.prompt_token_ids)} < "
+                f"#computed_tokens={request.num_computed_tokens}")
+        # Get the previous block ID to construct the block chain.
+        prev_block_id = computed_block_ids[-1] if computed_block_ids else None
+        new_blocks = self._get_new_blocks(num_new_blocks, num_new_blocks, prev_block_id)
+        new_block_ids = [blk.block_id for blk in new_blocks]
 
-        # Increase the reference count of the computed blocks.
+        # Touch the computed blocks to make sure they are not evicted.
         for block_id in computed_block_ids:
-            self.block_pool[block_id].ref_cnt += 1
+            self.block_pool.touch(block_id)
 
         # Concatenate the computed block IDs and the new block IDs.
         block_ids = computed_block_ids + new_block_ids
@@ -144,35 +297,72 @@ class KVCacheManager:
     def free(self, request: Request) -> None:
         """Free the blocks allocated for the request."""
         block_ids = self.req_to_block_ids.pop(request.request_id)
-        for block_id in block_ids:
+        # Free blocks in reverse order so that the tail blocks are freed first.
+        for block_id in reversed(block_ids):
             self.block_pool[block_id].ref_cnt -= 1
             if self.block_pool[block_id].ref_cnt == 0:
-                self.allocated_block_ids.remove(block_id)
-                self.free_block_ids.append(block_id)
-                # TODO: Add to evictor.
+                self.block_pool.free_block_queue.append(self.block_pool[block_id])
 
 
-    def _get_new_blocks(self, num_blocks: int, prev_block_id: Optional[int] = None) -> List[int]:
+    def _get_new_blocks(self, num_blocks: int, token_ids: List[int], prev_block_id: Optional[int] = None) -> List[KVCacheBlock]:
         """Get new blocks from the free block pool.
-        Specifically, we move block IDs from free_block_ids to
-        allocated_block_ids, and set their reference count to 1.
-
-        Note that we do not reuse existing blocks in this function.
+        Note that we do not check block cache in this function.
         
         Args:
             num_blocks: The number of blocks to allocate.
+            token_ids: The token IDs in the blocks.
             prev_block_id: The previous block ID. Used to include block chain
                 in the block hash.
         
         Returns:
             A list of new block IDs.
         """
-        assert num_blocks <= len(self.free_block_ids)
-        new_block_ids = self.free_block_ids.popleft(num_blocks)
-        for block_id in new_block_ids:
-            self.block_pool[block_id].prev_block_id = prev_block_id
-            self.block_pool[block_id].ref_cnt = 1
-            prev_block_id = block_id
+        assert num_blocks <= len(self.block_pool.num_free_blocks)
+        prev_block = self.block_pool[prev_block_id] if prev_block_id is not None else None
+        return self.block_pool.get_free_blocks(num_blocks, token_ids, prev_block)
 
-        self.allocated_block_ids.update(new_block_ids)
-        return new_block_ids
+
+    def hash_prompt_tokens(self, token_ids: List[int]) -> List[int]:
+        """Computes hash values of a chain of blocks given a sequence of
+        token IDs. The hash value is used for prefix caching.
+
+        Args:
+            token_ids: A sequence of token ids in the prompt.
+
+        Returns:
+            The list of computed hash values.
+        """
+        ret = []
+        prev_block_hash = None
+        for start in range(0, len(token_ids), self.block_size):
+            end = start + self.block_size
+            block_token_ids = tuple(token_ids[start:end])
+            # Do not hash the block if it is not full.
+            if len(block_token_ids) < self.block_size:
+                break
+            block_hash = hash_block_tokens(prev_block_hash, block_token_ids)
+            ret.append(block_hash)
+            prev_block_hash = block_hash
+        return ret
+
+
+@lru_cache(maxsize=1024)
+def hash_block_tokens(prev_block_hash: Optional[int],
+                        cur_block_token_ids: Tuple[int]) -> int:
+    """Computes a hash value corresponding to the contents of a block and
+    the contents of the preceding block(s). The hash value is used for
+    prefix caching.
+
+    TODO: Support arbitrary metadata so that we could support more
+    features such as LoRA adapter.
+
+    Args:
+        prev_block_hash: The hash of the previous block. None
+            if this is the first block.
+        cur_block_token_ids: A tuple of token ids in the current
+            block. The current block is assumed to be full.
+
+    Returns:
+        The computed hash value for the block.
+    """
+    return hash((prev_block_hash, *cur_block_token_ids))

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -292,7 +292,7 @@ class KVCacheManager:
         block_ids = self.req_to_block_ids.pop(request.request_id)
         if self.enable_caching:
             # Make sure async tasks (remove touched blocks) are finished.
-            self._wait_for_removing_touched_blocks()
+            self.wait_for_removing_touched_blocks()
             assert not self.lazy_remove_block_ids
 
             # Free blocks in reverse order so that the tail blocks are
@@ -325,11 +325,11 @@ class KVCacheManager:
             self.lazy_remove_block_ids.clear()
 
         if self.lazy_remove_block_ids:
-            self._wait_for_removing_touched_blocks()
+            self.wait_for_removing_touched_blocks()
             self._async_touch_task = self._async_executor.submit(
                 _sync_remove_touched_blocks)
 
-    def _wait_for_removing_touched_blocks(self) -> None:
+    def wait_for_removing_touched_blocks(self) -> None:
         """Wait for the asynchronous task to finish if there are
         a task on the fly."""
         if self._async_touch_task is not None:

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -210,6 +210,7 @@ class Scheduler:
         )
 
         self.finished_req_ids = set()
+        self.kv_cache_manager.async_remove_touched_blocks()
         return scheduler_output
 
     def _make_running_request_data(

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -138,13 +138,11 @@ class Scheduler:
                 # which have output tokens.
                 num_new_tokens = request.num_tokens - num_computed_tokens
                 if num_new_tokens == 0:
-                    # FIXME: The happens when prompt length is divisible by
-                    # the block size and all blocks are cached. We have to
-                    # support query_len=0 in model runner to handle this case.
-                    # Now we force to recompute the last block, which hurts
-                    # performance and introduces duplications.
-                    num_computed_tokens -= self.block_size
-                    num_new_tokens = self.block_size
+                    # The happens when prompt length is divisible by the block
+                    # size and all blocks are cached. Now we force to recompute
+                    # the last token.
+                    num_computed_tokens -= 1
+                    num_new_tokens = 1
                     computed_block_ids.pop()
                 num_new_tokens = min(num_new_tokens, token_budget)
                 assert num_new_tokens > 0


### PR DESCRIPTION
This PR adds prefix caching to V1.

## Data Structure

- Block pool: A pool of kv-cache blocks corresponding to block IDs that will be used in the entire engine lifecycle.
- Free block queue: A queue of free blocks to be allocated. The blocks in this queue may be able to be reused (cache hit) by other requests.
- Cached block map: Mapping from block hash to a list of blocks. The reason to have a list of blocks is we don't do de-duplication (see "Duplication" below for details). When cache hit, we always allocate the first block in the list to aggregate the references.

## Algorithms

### Allocate Slots

When a request is scheduled for the first time, `allocate_slots()` is used to allocate blocks based on the current scheduled prompt tokens. If the prompt is chunked due to chunked prefill, we will only allocate blocks for the scheduled tokens. In addition to the scheduled tokens, we also pre-allocate empty blocks to reduce allocation overheads.

With prefix caching, when we attempt to allocate a full block, we will compute its block hash and query the cached block map. There are 3 possible outcomes:
1. **Cache miss:** Allocate a new block from free block queue: The new allocated block may be evicted from the cache.
2. **Cache hit and the block is in free block queue:** Reuse the block and mark it to be removed from the queue.
3. **Cache hit and the block is not in free block queue (being used by other requests as well):** Reuse the block.

Note 1: When cache hit a block in the free block queue, we put the block in a "lazy remove set" instead of immediately removing the block from the queue. This is because removing an element from a queue takes O(N). Instead, when we are allocating  a new block and the front block in the queue is marked as lazy remove, we pop the block and move to the next one.

Note 2: When cache miss and we allocate a new block, the token IDs will be added to the allocated block to construct its hash. The block will also be added to the cache if it is full.

### Append Slots

When a request is scheduled again, `append_slots()` is used to maybe allocate more blocks. This can be the case of continuous chunked prefill or decode. Here are the steps in the append slots:
1. Check the allocated slots (empty slots in a partial block and preallocated blocks), and add token IDs to these slots.
2. If the allocated blocks are full, add them to the cache.
3. If the allocated slots are insufficient, allocate new blocks.

### Free

When a request is done, all its blocks will decrease the reference count by 1. If a block now has 0 reference, it will be freed (push to the free block queue). Note that since we allocate new blocks by popping the free block queue, the block order in the free block queue is also the eviction order. Since we now use LRU eviction policy, the eviction order is
1. The least accessed block.
2. When a sequence of blocks has the same access time, the one with the longest hashed tokens will be evicted first, because this is the last block in a sequence and is less likely to be shared with other requests.

We maintain the above order by pushing free blocks to the queue in the **reversed** order, so that:
1. The order of free requests implies the access time. An early free block will appear at the front of the queue.
2. When pushing a sequence of blocks to the queue, the last block with more hashed tokens goes first.

### Get Computed Blocks

Before calling `allocate_slots()`, the scheduler calls `get_computed_block_ids()` to know how many blocks hits the cache. This function simply computes the hash of full blocks and queries the cache for existing block IDs. This function won't allocate any block or change the block metadata.

## Duplication

Since V1 has incremental prepare inputs, the block table is append-only. This results in potential duplications as shown below. Suppose we have 2 identical requests (same prompt with greedy sampling) arriving at different time:

TIme 1
```
req1: [0, 1, 2, 3 (partial, 14/16)]
```
Time 2
```
req1: [0, 1, 2, 3 (partial, 15/16)]
req2: [0, 1, 2, 4 (partial, 14/16)] # Partial block cannot be shared so we allocate a new block for req2
```
TIme 3
```
req1: [0, 1, 2, 3 (full)] # Block 3 is now sharable
req2: [0, 1, 2, 4 (partial, 15/16)]
```
TIme 4
```
req1: [0, 1, 2, 3 (full)]
req2: [0, 1, 2, 4 (full)]
```

At time 4, block becomes full and has the same hash and content as block 3. In vLLM V0 block manager, we will free block 4 and assign block 3 to req2 in the next step. However, we cannot do this in V1 because block table is append only. As a result, at this moment the cache will look like:

```
block_0_hash: [block0]
block_1_hash: [block1]
block_2_hash: [block2]
block_3_hash: [block3, block4]
```

- When another request hits block 3 hash, we always allocate block 3.
- Block 4 will be free once req2 is done.

We consider that this is fine with practical use cases, because:
1. Only partial blocks will potentially have duplications. This happens at the last block of a prompt, or the first N blocks of decode.
2. Only the same prompt with greedy sampling will encounter this issue, which is not a practical use case.

cc @WoosukKwon @zhuohan123 