### PR TITLE
[ci/Build] Skip Chameleon for transformers 4.46.0 on broadcast test #9675

### DIFF
--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -1,4 +1,5 @@
 import pytest
+import transformers
 
 from ....utils import multi_gpu_test
 
@@ -10,10 +11,6 @@ from ....utils import multi_gpu_test
     "llava-hf/llava-v1.6-mistral-7b-hf",
     "facebook/chameleon-7b",
 ])
-@pytest.mark.skipif(
-    transformers.__version__.startswith("4.46.0") and model == "facebook/chameleon-7b",
-    reason="Model broken in HF, see huggingface/transformers#34379",
-)
 def test_models(hf_runner, vllm_runner, image_assets,
                 distributed_executor_backend, model) -> None:
 
@@ -27,6 +24,10 @@ def test_models(hf_runner, vllm_runner, image_assets,
     elif model.startswith("llava-hf/llava-v1.6"):
         from .test_llava_next import models, run_test  # type: ignore[no-redef]
     elif model.startswith("facebook/chameleon"):
+        if transformers.__version__.startswith("4.46.0"):
+            print("Skip since model is broken in HF - "
+              "See huggingface/transformers#34379")
+            return
         from .test_chameleon import models, run_test  # type: ignore[no-redef]
     else:
         raise NotImplementedError(f"Unsupported model: {model}")

--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -26,7 +26,7 @@ def test_models(hf_runner, vllm_runner, image_assets,
     elif model.startswith("facebook/chameleon"):
         if transformers.__version__.startswith("4.46.0"):
             print("Skip since model is broken in HF - "
-            "See huggingface/transformers#34379")
+                  "See huggingface/transformers#34379")
             return
         from .test_chameleon import models, run_test  # type: ignore[no-redef]
     else:

--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -25,9 +25,8 @@ def test_models(hf_runner, vllm_runner, image_assets,
         from .test_llava_next import models, run_test  # type: ignore[no-redef]
     elif model.startswith("facebook/chameleon"):
         if transformers.__version__.startswith("4.46.0"):
-            print("Skip since model is broken in HF - "
-                  "See huggingface/transformers#34379")
-            return
+            pytest.skip("Model broken in HF, "
+                        "see huggingface/transformers#34379")
         from .test_chameleon import models, run_test  # type: ignore[no-redef]
     else:
         raise NotImplementedError(f"Unsupported model: {model}")

--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -26,7 +26,7 @@ def test_models(hf_runner, vllm_runner, image_assets,
     elif model.startswith("facebook/chameleon"):
         if transformers.__version__.startswith("4.46.0"):
             print("Skip since model is broken in HF - "
-              "See huggingface/transformers#34379")
+            "See huggingface/transformers#34379")
             return
         from .test_chameleon import models, run_test  # type: ignore[no-redef]
     else:

--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -10,6 +10,10 @@ from ....utils import multi_gpu_test
     "llava-hf/llava-v1.6-mistral-7b-hf",
     "facebook/chameleon-7b",
 ])
+@pytest.mark.skipif(
+    transformers.__version__.startswith("4.46.0") and model == "facebook/chameleon-7b",
+    reason="Model broken in HF, see huggingface/transformers#34379",
+)
 def test_models(hf_runner, vllm_runner, image_assets,
                 distributed_executor_backend, model) -> None:
 


### PR DESCRIPTION
This temporarily skips Chameleon test in `test_broadcast` since the model is not working with transformers v4.46.0