### PR TITLE
[Bugfix] Fix compressed_tensors_moe bad config.strategy

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe.py
@@ -245,7 +245,7 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
         config = self.quant_config.target_scheme_map["Linear"].get("weights")
         self.num_bits = config.num_bits
         self.packed_factor = 32 // config.num_bits
-        self.strategy = config.strategy.value
+        self.strategy = config.strategy
         self.group_size = config.group_size
         assert config.symmetric, (
             "Only symmetric quantization is supported for MoE")


### PR DESCRIPTION
Fix failing weight loader test for MoE models: https://buildkite.com/vllm/ci-aws/builds/10271#0192bcae-a692-4f44-8e4b-fd45214b339e

```
self = <vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors_moe.CompressedTensorsWNA16MoEMethod object at 0x7fb81491aff0>
--
  | quant_config = <vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors.CompressedTensorsConfig object at 0x7fb814a3b950>
  |  
  | def __init__(
  | self,
  | quant_config: "CompressedTensorsConfig"  # type: ignore # noqa E501
  | ):
  | self.quant_config = quant_config
  | # TODO: @dsikka: refactor this to use schemes as other kernels
  | # are supported + check if the layer is being ignored.
  | config = self.quant_config.target_scheme_map["Linear"].get("weights")
  | self.num_bits = config.num_bits
  | self.packed_factor = 32 // config.num_bits
  | >       self.strategy = config.strategy.value
  | E       AttributeError: 'str' object has no attribute 'value'
```