### PR TITLE
Fix cache management in "Close inactive issues and PRs" actions workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      actions: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0


### PR DESCRIPTION
- Error: [Error delete _state: [403] Resource not accessible by integration](https://github.com/vllm-project/vllm/actions/runs/11536713880/job/32113279528#step:2:18375)
- Consequence: Stale workflow cannot update its cache, so it always starts from the first cache
- Solution: https://github.com/actions/stale/issues/1133#issuecomment-2079373371