### PR TITLE
[misc] avoid circular import

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -18,7 +18,6 @@ from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.spec_decode.metrics import SpecDecodeWorkerMetrics
 
 if TYPE_CHECKING:
     from vllm.inputs import SingletonInputs
@@ -1132,6 +1131,8 @@ class PoolerOutput(
     """The output from a pooling operation in the embedding model."""
     outputs: List[EmbeddingSequenceGroupOutput]
 
+    # lazy import to avoid circular import
+    from vllm.spec_decode.metrics import SpecDecodeWorkerMetrics
     spec_decode_worker_metrics: Optional[SpecDecodeWorkerMetrics] = None
 
     def __getitem__(self, idx: int) -> EmbeddingSequenceGroupOutput:


### PR DESCRIPTION
a circular import found:

```text
  File "/data/youkaichao/vllm/tests/compile/piecewise/test_toy_llama.py", line 14, in <module>
    from vllm.compilation.decorators import support_torch_compile
  File "/data/youkaichao/vllm/vllm/compilation/decorators.py", line 10, in <module>
    from vllm.sequence import IntermediateTensors
  File "/data/youkaichao/vllm/vllm/sequence.py", line 21, in <module>
    from vllm.spec_decode.metrics import SpecDecodeWorkerMetrics
  File "/data/youkaichao/vllm/vllm/spec_decode/metrics.py", line 7, in <module>
    from vllm.model_executor.layers.spec_decode_base_sampler import (
  File "/data/youkaichao/vllm/vllm/model_executor/__init__.py", line 3, in <module>
    from vllm.model_executor.sampling_metadata import (SamplingMetadata,
  File "/data/youkaichao/vllm/vllm/model_executor/sampling_metadata.py", line 8, in <module>
    from vllm.sequence import (VLLM_TOKEN_ID_ARRAY_TYPE, SequenceData,
ImportError: cannot import name 'VLLM_TOKEN_ID_ARRAY_TYPE' from partially initialized module 'vllm.sequence' (most likely due to a circular import) (/data/youkaichao/vllm/vllm/sequence.py)
```