### PR TITLE
[Doc] fix third-party model example

### DIFF
--- a/docs/source/models/adding_model.rst
+++ b/docs/source/models/adding_model.rst
@@ -133,7 +133,9 @@ If you are running api server with :code:`vllm serve <args>`, you can wrap the e
     from vllm import ModelRegistry
     from your_code import YourModelForCausalLM
     ModelRegistry.register_model("YourModelForCausalLM", YourModelForCausalLM)
-    import runpy
-    runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
+
+    if __name__ == '__main__':
+        import runpy
+        runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 
 Save the above code in a file and run it with :code:`python your_file.py <args>`.


### PR DESCRIPTION
The docs give some sample code for running with a third-party model.
This example doesn't work with the `spawn` multiprocessing method. In
that case, you get a recursive run of the `runpy.run_module()` call.
Wrapping that call in a `__main__` guard avoids this problem.

Closes #9763

Signed-off-by: Russell Bryant <rbryant@redhat.com>
