### PR TITLE
[MISC] Set label value to timestamp over 0, to keep track of recent history 

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -1,3 +1,4 @@
+import time
 from typing import TYPE_CHECKING
 from typing import Counter as CollectionsCounter
 from typing import Dict, List, Optional, Type, Union, cast
@@ -228,6 +229,10 @@ class _RayGaugeWrapper:
 
     def set(self, value: Union[int, float]):
         return self._gauge.set(value)
+
+    def set_to_current_time(self):
+        # ray metrics doesn't have set_to_current time, https://docs.ray.io/en/latest/_modules/ray/util/metrics.html
+        return self._gauge.set(time.time())
 
 
 class _RayCounterWrapper:

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -441,7 +441,7 @@ class PrometheusStatLogger(StatLoggerBase):
             histogram.labels(**self.labels).observe(datum)
 
     def _log_gauge_string(self, gauge, data: Dict[str, str]) -> None:
-        gauge.labels(**data).set(1)
+        gauge.labels(**data).set_to_current_time()
 
     def _log_prometheus(self, stats: Stats) -> None:
         # System state data


### PR DESCRIPTION
Set label value to timestamp over 0 which is not consumed at all, to keep track of recent history of waiting adapters and active adapters, so metrics polling doesn't have to be aggressive.
We plan to leverage this information for routing decisions in https://github.com/kubernetes-sigs/llm-instance-gateway


