### PR TITLE
[Bugfix] Use host argument to bind to interface

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -541,7 +541,7 @@ async def run_server(args, **uvicorn_kwargs) -> None:
     # This avoids race conditions with ray.
     # see https://github.com/vllm-project/vllm/issues/8204
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("", args.port))
+    sock.bind((args.host, args.port))
 
     def signal_handler(*_) -> None:
         # Interrupt server on sigterm while initializing

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -77,7 +77,7 @@ class PromptAdapterParserAction(argparse.Action):
 def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
     parser.add_argument("--host",
                         type=nullable_str,
-                        default=None,
+                        default="0.0.0.0",
                         help="host name")
     parser.add_argument("--port", type=int, default=8000, help="port number")
     parser.add_argument(


### PR DESCRIPTION
From what I can gather from the documentation, the `--host` argument is supposed to bind the process to the interface with the IP address provided as the value.

This passes the IP address to the `sock.bind()` call. To be compatible to the existing behavior, I set the default value for `args.host` to `0.0.0.0`. However, I think the default value SHOULD be `127.0.0.1` as missing this setting can result in severe misconfiguration of services.

FIX #9797