### PR TITLE
[CI/Build] mergify: fix rules for ci/build label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -13,13 +13,14 @@ pull_request_rules:
 - name: label-ci-build
   description: Automatically apply ci/build label
   conditions:
-    - files~=^\.github/
-    - files~=\.buildkite/
-    - files~=^cmake/
-    - files=CMakeLists.txt
-    - files~=^Dockerfile
-    - files~=^requirements.*\.txt
-    - files=setup.py
+    - or:
+      - files~=^\.github/
+      - files~=\.buildkite/
+      - files~=^cmake/
+      - files=CMakeLists.txt
+      - files~=^Dockerfile
+      - files~=^requirements.*\.txt
+      - files=setup.py
   actions:
     label:
       add:


### PR DESCRIPTION
This label would only be applied if a PR matched ALL patterns instead
of at least one of this. This fixes it so the label is applied if any
of the patterns match.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
