### PR TITLE
[CI][Bugfix] Skip chameleon for transformers 4.46.1

### DIFF
--- a/tests/models/decoder_only/vision_language/test_broadcast.py
+++ b/tests/models/decoder_only/vision_language/test_broadcast.py
@@ -24,7 +24,7 @@ def test_models(hf_runner, vllm_runner, image_assets,
     elif model.startswith("llava-hf/llava-v1.6"):
         from .test_llava_next import models, run_test  # type: ignore[no-redef]
     elif model.startswith("facebook/chameleon"):
-        if transformers.__version__.startswith("4.46.0"):
+        if transformers.__version__.startswith("4.46"):
             pytest.skip("Model broken in HF, "
                         "see huggingface/transformers#34379")
         from .test_chameleon import models, run_test  # type: ignore[no-redef]


### PR DESCRIPTION
Chameleon test only specifically checked for 4.46.0, however the newly released [4.46.1](https://github.com/huggingface/transformers/releases/tag/v4.46.1) did not address this model

Failing CI https://buildkite.com/vllm/ci-aws/builds/10430#0192d917-3982-44f7-8c97-0a3e2472c7b1/159-4366