### PR TITLE
[Core] Some performance optimizations

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -910,10 +910,6 @@ class LLMEngine:
         sampling_params = self._build_logits_processors(
             sampling_params, lora_request)
 
-        # Defensive copy of SamplingParams, which are used by the sampler,
-        # this doesn't deep-copy LogitsProcessor objects
-        sampling_params = sampling_params.clone()
-
         sampling_params.update_from_generation_config(
             self.generation_config_fields, seq.eos_token_id)
 
@@ -943,8 +939,6 @@ class LLMEngine:
         priority: int = 0,
     ) -> SequenceGroup:
         """Creates a SequenceGroup with PoolingParams."""
-        # Defensive copy of PoolingParams, which are used by the pooler
-        pooling_params = pooling_params.clone()
         # Create the sequence group.
         seq_group = SequenceGroup(
             request_id=request_id,

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -246,8 +246,13 @@ class MQLLMEngine:
     def handle_new_input(self):
         """Handle new input from the socket"""
         try:
-            while self.input_socket.poll(timeout=0) != 0:
-                frames = self.input_socket.recv_multipart(copy=False)
+            while True:
+                try:
+                    frames = self.input_socket.recv_multipart(
+                        flags=zmq.NOBLOCK, copy=False)
+                except zmq.error.Again:
+                    break
+
                 request = pickle.loads(frames[0].buffer)
 
                 if isinstance(request, RPCProcessRequest):


### PR DESCRIPTION
### 1. Remove two instances of defensive copying

I found that making a defensive copy of SamplingParams seems unnecessary. In my application scenario, removing the defensive copy of SamplingParams worked normally and resulted in performance improvement.

In my scenario, the comparison before and after the removal shows that each request is reduced by approximately 189 us, and The function `_create_sequence_group_with_sampling` only takes 23us.

Before removing it.
![image](https://github.com/user-attachments/assets/caa8222a-6749-44ed-8aa7-4b2acaec2463)

After removing it.
![image](https://github.com/user-attachments/assets/a36b3bc6-5b8b-4d79-8fa5-ab3e98935ad1)

### 2. Utilize the non-blocking and exception to reduce one poll per request.

1. Utilize the non-blocking and exceptions of recv_multipart to reduce one poll operation per request.
2. Each poll operation consumes at least 10us.

![image](https://github.com/user-attachments/assets/d7739909-8c3c-4de0-8155-8343c01200ae)

Doing so can indeed reduce one poll operation per request, and each poll operation takes at least 10us. Although for a single request, 10us is very little and can be ignored, what I pursue is ultimate performance. Accumulating small savings here and there, reducing 10us of delay here and 20us of delay there, will significantly reduce the delay for each request when added up.

Moreover, when executing the  function  `handle_new_input`, the GPU is idle. Reducing the execution time of the  function `handle_new_input`  is equivalent to making full use of the GPU.