### PR TITLE
[CI/Build] Update PyTorch to the 2.5.1 bugfix release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "packaging",
     "setuptools>=61",
     "setuptools-scm>=8.0",
-    "torch == 2.5.0",
+    "torch == 2.5.1",
     "wheel",
     "jinja2",
 ]

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -4,6 +4,6 @@ ninja
 packaging
 setuptools>=61
 setuptools-scm>=8
-torch==2.5.0
+torch==2.5.1
 wheel
 jinja2

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -4,7 +4,7 @@
 # Dependencies for NVIDIA GPUs
 ray >= 2.9
 nvidia-ml-py >= 12.560.30 # for pynvml package
-torch == 2.5.0
+torch == 2.5.1
 # These must be updated alongside torch
-torchvision == 0.20   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
-xformers == 0.0.28.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.5.0
+torchvision == 0.20.1   # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
+xformers == 0.0.28.post3; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.5.0

--- a/requirements-openvino.txt
+++ b/requirements-openvino.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r requirements-common.txt
 
-torch == 2.5.0 #  should be aligned with "common" vLLM torch version
+torch == 2.5.1 #  should be aligned with "common" vLLM torch version
 openvino >= 2024.4.0 # since 2024.4.0 both CPU and GPU support Paged Attention
 
 optimum @ git+https://github.com/huggingface/optimum.git@main # latest optimum is used to support latest transformers version

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -18,7 +18,7 @@ ray[adag]==2.35
 sentence-transformers # required for embedding
 soundfile # required for audio test
 timm # required for internvl test
-torch==2.5.0
+torch==2.5.1
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
 datamodel_code_generator # required for minicpm3 test

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -492,7 +492,7 @@ timm==1.0.11
     # via -r requirements-test.in
 tokenizers==0.20.1
     # via transformers
-torch==2.5.0
+torch==2.5.1
     # via
     #   -r requirements-test.in
     #   accelerate
@@ -503,7 +503,7 @@ torch==2.5.0
     #   tensorizer
     #   timm
     #   torchvision
-torchvision==0.20.0
+torchvision==0.20.1
     # via timm
 tqdm==4.66.6
     # via


### PR DESCRIPTION
While building in a conda environment on Ubuntu 24.04 CUDA 12.4, I bumped into an error, and upon googling saw some comments recommending to try with torch 2.5.1, which seems to be a bugfix release of torch with relatively few changes.
https://github.com/pytorch/pytorch/releases/tag/v2.5.1

(I'm not sure if torch 2.5.1 solved my particular issue since I changed multiple things including python version, so changing torch might not be fixing any issues.)

xformers and torchvision also had to be incremented by 1 patch release to remain compatible with torch 2.5.1. In particular, xformers 0.0.28.post3 came out only 2 hours ago, so this is hot off the press.

I'd encourage people to test this, especially on other build configurations.
