### PR TITLE
[Bugfix] Fix layer skip logic with bitsandbytes

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -123,7 +123,8 @@ def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
     components = prefix.split('.')
 
     # Check if any of the skip modules exactly matches any component
-    return any(module_name in components for module_name in llm_int8_skip_modules)
+    return any(module_name in components
+               for module_name in llm_int8_skip_modules)
 
 
 class BitsAndBytesLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -119,7 +119,11 @@ class BitsAndBytesConfig(QuantizationConfig):
 
 
 def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
-    return any(module_name in prefix for module_name in llm_int8_skip_modules)
+    # Split the prefix into its dot-separated components
+    components = prefix.split('.')
+
+    # Check if any of the skip modules exactly matches any component
+    return any(module_name in components for module_name in llm_int8_skip_modules)
 
 
 class BitsAndBytesLinearMethod(LinearMethodBase):


### PR DESCRIPTION
Found while debugging why `openbmb/MiniCPM-Llama3-V-2_5-int4` doesn't work in https://github.com/vllm-project/vllm/issues/6932, however this is not the full solution.

The current implementation was doing a substring match, which causes `kv_proj` to match within `qkv_proj`. We want to match exact module names between the "dots" in full module names.

References for `llm_int8_skip_modules`:
* https://huggingface.co/openbmb/MiniCPM-Llama3-V-2_5-int4/blob/028d758be0c431f9cf79c859b7124e12aaed5129/config.json#L39-L43
* https://huggingface.co/Isotr0py/Llama-3.2-11B-Vision-Instruct-bnb-8bit/blob/93905aff4669cc350692a99561f68c535ce0c7d9/config.json#L17-L20