### PR TITLE
[CI/Build] Limit github CI jobs based on files changed

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - '.github/workflows/*.ya?ml'
       - '.github/workflows/actionlint.*'
+      - '.github/workflows/matchers/actionlint.json'
   pull_request:
     branches:
       - "main"
     paths:
       - '.github/workflows/*.ya?ml'
       - '.github/workflows/actionlint.*'
+      - '.github/workflows/matchers/actionlint.json'
 
 env:
   LC_ALL: en_US.UTF-8

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -6,9 +6,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.h'
+      - '**/*.cpp'
+      - '**/*.cu'
+      - '**/*.cuh'
+      - '.github/workflows/clang-format.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - '**/*.h'
+      - '**/*.cpp'
+      - '**/*.cu'
+      - '**/*.cuh'
+      - '.github/workflows/clang-format.yml'
 
 jobs:
   clang-format:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -6,9 +6,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '**/*.py'
+      - '.github/workflows/mypy.yaml'
+      - 'tools/mypy.sh'
   pull_request:
     branches:
       - main
+    paths:
+      - '**/*.py'
+      - '.github/workflows/mypy.yaml'
+      - 'tools/mypy.sh'
 
 jobs:
   mypy:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -10,6 +10,7 @@ on:
       - '**/*.py'
       - '.github/workflows/mypy.yaml'
       - 'tools/mypy.sh'
+      - 'pyproject.toml'
   pull_request:
     branches:
       - main
@@ -17,6 +18,7 @@ on:
       - '**/*.py'
       - '.github/workflows/mypy.yaml'
       - 'tools/mypy.sh'
+      - 'pyproject.toml'
 
 jobs:
   mypy:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,9 +6,21 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - pyproject.toml
+      - requirements-lint.txt
+      - .github/workflows/matchers/ruff.json
+      - .github/workflows/ruff.yml
   pull_request:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - pyproject.toml
+      - requirements-lint.txt
+      - .github/workflows/matchers/ruff.json
+      - .github/workflows/ruff.yml
 
 jobs:
   ruff:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -42,9 +42,6 @@ jobs:
       run: |
         echo "::add-matcher::.github/workflows/matchers/ruff.json"
         ruff check --output-format github .
-    - name: Spelling check with codespell
-      run: |
-        codespell --toml pyproject.toml
     - name: Run isort
       run: |
         isort . --check-only

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - .github/workflows/yapf.yml
   pull_request:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - .github/workflows/yapf.yml
+
 jobs:
   yapf:
     runs-on: ubuntu-latest

--- a/.github/workflows/yapf.yml
+++ b/.github/workflows/yapf.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
     - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I noticed that these github CI jobs run against all PRs, including ones where
the job is not relevant. We can save a bit of time and resources by only running
jobs when relevant files have changed.

This PR would reduce the jobs that run by quite a bit on a PR that only changes
docs, for example.

8f2f6780 [CI/Build] Conditionally run clang-format
b1daf192 [CI/Build] Conditionally run mypy job
692d7cf4 [CI/Build] Conditionally run ruff job
bd611cae [CI/Build] Conditionally run yapf job
b837e466 [CI/Build] Add actionlint error matcher to job paths
18fc4052 [CI/Build] Move codespell to its own job
8dbb5956 [CI/Build] Only run the ruff job with one Python version
3942c38c Run mypy job when pyproject.toml changes
faff4e64 Only run yapf with Python 3.12

commit 8f2f6780417046cc1fa1a72573040e66050be9f9
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:18:49 2024 +0000

    [CI/Build] Conditionally run clang-format
    
    Update the `clang-format` job to only run when relevant files have
    changed: `*.h`, `*.cpp`, `*.cu`, or `*.cuh`. This matches the patterns
    in the `find` command in this job. Also run the workflow when the
    workflow definition itself changes.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b1daf192e8fed8cf90f3a9556c30ff42f36dd97b
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:23:07 2024 +0000

    [CI/Build] Conditionally run mypy job
    
    Only run the `mypy` CI job when the following paths change:
    
    - any Python file, `*.py`
    - the workflow definition
    - `tools/mypy.sh`
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 692d7cf4293c1c31ebcbadc470eec6fb03c56692
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:26:23 2024 +0000

    [CI/Build] Conditionally run ruff job
    
    Only run the `ruff` CI job when relevant paths change:
    
    - the workflow file, or the error matching config
    - pyproject.toml
    - any Python file, `*.py`
    - requirements-lint.txt
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit bd611cae475239ff59eb55940d3ca9d2f5b1ae7b
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:28:19 2024 +0000

    [CI/Build] Conditionally run yapf job
    
    Only run `yapf` job when the following paths change:
    
    - any python file, `*.py`
    - the workflow definition file
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b837e466934d1be1190160d94fe11b45701a5043
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:29:13 2024 +0000

    [CI/Build] Add actionlint error matcher to job paths
    
    Run the actionlint job if the error matching config changes.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 18fc40520a3eaedc7c66f5b1eb845731b71e6d22
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:43:15 2024 +0000

    [CI/Build] Move codespell to its own job
    
    Move `codespell` out of the `ruff` job because `codespell` checks more
    file types than `ruff`. This one needs to run on doc-only changes,
    whiel `ruff` does not.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 8dbb595690531a66d665888273d64ce4fbce24fb
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Nov 1 17:44:34 2024 +0000

    [CI/Build] Only run the ruff job with one Python version
    
    Ruff itself is not a Python tool, so running it in 5 different Python
    environments doesn't provide much value, other than ensuring
    `requirements-lint.txt` can be installed in all of these versions.
    That doesn't seem like enough value to run 5 copies of the job all the
    time.
    
    Coverage using different Python versions makes more sense for jobs
    that are actually running the code.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 3942c38cf48f3166de82f659b3213264ab8c9f4c
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Nov 4 20:57:39 2024 +0000

    Run mypy job when pyproject.toml changes
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit faff4e645d92da2e6fc82d3f096f5578793439b4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Nov 4 20:59:52 2024 +0000

    Only run yapf with Python 3.12
    
    There does not seem to be much benefit of running several versions of
    this.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
