### PR TITLE
[CI] Prune down LM Eval Large test time

### DIFF
--- a/.buildkite/lm-eval-harness/configs/Meta-Llama-3.2-1B-Instruct-INT8-compressed-tensors.yaml
+++ b/.buildkite/lm-eval-harness/configs/Meta-Llama-3.2-1B-Instruct-INT8-compressed-tensors.yaml
@@ -4,8 +4,8 @@ tasks:
 - name: "gsm8k"
   metrics:
   - name: "exact_match,strict-match"
-    value: 0.356
+    value: 0.341
   - name: "exact_match,flexible-extract"
-    value: 0.358
+    value: 0.342
 limit: 1000
 num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-AWQ.yaml
+++ b/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-AWQ.yaml
@@ -1,0 +1,12 @@
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ -b "auto" -l 1000 -f 5 -t 1
+# Loading model weights took 23.0240 GB
+model_name: "ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.474
+  - name: "exact_match,flexible-extract"
+    value: 0.498
+limit: 1000
+num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-AWQ.yaml
+++ b/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-AWQ.yaml
@@ -1,12 +1,12 @@
-# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ -b "auto" -l 1000 -f 5 -t 1
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m casperhansen/mixtral-instruct-awq -b "auto" -l 1000 -f 5 -t 1
 # Loading model weights took 23.0240 GB
-model_name: "ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ"
+model_name: "casperhansen/mixtral-instruct-awq"
 tasks:
 - name: "gsm8k"
   metrics:
   - name: "exact_match,strict-match"
-    value: 0.474
+    value: 0.584
   - name: "exact_match,flexible-extract"
-    value: 0.498
+    value: 0.588
 limit: 1000
 num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-GPTQ.yaml
+++ b/.buildkite/lm-eval-harness/configs/Mixtral-8x7B-Instruct-v0.1-GPTQ.yaml
@@ -1,0 +1,12 @@
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m TheBloke/Mixtral-8x7B-Instruct-v0.1-GPTQ -b "auto" -l 1000 -f 5 -t 1
+# Loading model weights took 22.1429 GB
+model_name: "TheBloke/Mixtral-8x7B-Instruct-v0.1-GPTQ"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.570
+  - name: "exact_match,flexible-extract"
+    value: 0.574
+limit: 1000
+num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/Qwen2-57B-A14-Instruct.yaml
+++ b/.buildkite/lm-eval-harness/configs/Qwen2-57B-A14-Instruct.yaml
@@ -1,4 +1,4 @@
-# bash ./run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen2-57B-A14B-Instruct -b "auto" -l 250 -f 5 -t 4
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen2-57B-A14B-Instruct -b "auto" -l 250 -f 5 -t 4
 model_name: "Qwen/Qwen2-57B-A14B-Instruct"
 tasks:
 - name: "gsm8k"

--- a/.buildkite/lm-eval-harness/configs/Qwen2-57B-A14B-Instruct-GPTQ-Int4.yaml
+++ b/.buildkite/lm-eval-harness/configs/Qwen2-57B-A14B-Instruct-GPTQ-Int4.yaml
@@ -1,0 +1,11 @@
+# bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m Qwen/Qwen1.5-MoE-A2.7B-Chat-GPTQ-Int4 -b "auto" -l 1000 -f 5 -t 2
+model_name: "Qwen/Qwen2-57B-A14B-Instruct-GPTQ-Int4"
+tasks:
+- name: "gsm8k"
+  metrics:
+  - name: "exact_match,strict-match"
+    value: 0.789
+  - name: "exact_match,flexible-extract"
+    value: 0.807
+limit: 1000
+num_fewshot: 5

--- a/.buildkite/lm-eval-harness/configs/models-large.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large.txt
@@ -1,4 +1,5 @@
 Meta-Llama-3-8B-Instruct-FBGEMM-nonuniform.yaml
+Meta-Llama-3-8B-QQQ.yaml
 Mixtral-8x7B-Instruct-v0.1-GPTQ.yaml
 Qwen2-57B-A14B-Instruct-GPTQ-Int4.yaml
 DeepSeek-V2-Lite-Chat.yaml

--- a/.buildkite/lm-eval-harness/configs/models-large.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large.txt
@@ -1,5 +1,5 @@
 Meta-Llama-3-8B-Instruct-FBGEMM-nonuniform.yaml
 Meta-Llama-3-8B-QQQ.yaml
-Mixtral-8x7B-Instruct-v0.1-GPTQ.yaml
+Mixtral-8x7B-Instruct-v0.1-AWQ.yaml
 Qwen2-57B-A14B-Instruct-GPTQ-Int4.yaml
 DeepSeek-V2-Lite-Chat.yaml

--- a/.buildkite/lm-eval-harness/configs/models-large.txt
+++ b/.buildkite/lm-eval-harness/configs/models-large.txt
@@ -1,5 +1,4 @@
-Meta-Llama-3-70B-Instruct-FBGEMM-nonuniform.yaml
-Meta-Llama-3-70B-Instruct.yaml
-Mixtral-8x7B-Instruct-v0.1.yaml
-Qwen2-57B-A14-Instruct.yaml
+Meta-Llama-3-8B-Instruct-FBGEMM-nonuniform.yaml
+Mixtral-8x7B-Instruct-v0.1-GPTQ.yaml
+Qwen2-57B-A14B-Instruct-GPTQ-Int4.yaml
 DeepSeek-V2-Lite-Chat.yaml

--- a/.buildkite/lm-eval-harness/configs/models-small.txt
+++ b/.buildkite/lm-eval-harness/configs/models-small.txt
@@ -1,4 +1,3 @@
-Meta-Llama-3-8B-Instruct.yaml
 Meta-Llama-3-8B-Instruct-FP8-compressed-tensors.yaml
 Meta-Llama-3.2-1B-Instruct-INT8-compressed-tensors.yaml
 Meta-Llama-3-8B-Instruct-INT8-compressed-tensors-asym.yaml
@@ -7,4 +6,3 @@ Meta-Llama-3-8B-Instruct-Channelwise-compressed-tensors.yaml
 Minitron-4B-Base-FP8.yaml
 Qwen2-1.5B-Instruct-INT8-compressed-tensors.yaml
 Qwen2-1.5B-Instruct-FP8W8.yaml
-Meta-Llama-3-8B-QQQ.yaml

--- a/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
+++ b/.buildkite/lm-eval-harness/test_lm_eval_correctness.py
@@ -20,6 +20,7 @@ TEST_DATA_FILE = os.environ.get(
     ".buildkite/lm-eval-harness/configs/Meta-Llama-3-8B-Instruct.yaml")
 
 TP_SIZE = os.environ.get("LM_EVAL_TP_SIZE", 1)
+MAX_MODEL_LEN = 4096
 
 
 def launch_lm_eval(eval_config):
@@ -28,7 +29,8 @@ def launch_lm_eval(eval_config):
     model_args = f"pretrained={eval_config['model_name']}," \
                  f"tensor_parallel_size={TP_SIZE}," \
                  f"add_bos_token=true," \
-                 f"trust_remote_code={trust_remote_code}"
+                 f"trust_remote_code={trust_remote_code}," \
+                 f"max_model_len={MAX_MODEL_LEN}"
 
     results = lm_eval.simple_evaluate(
         model="vllm",

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -485,19 +485,17 @@ steps:
   - vllm/
   - tests/weight_loading
   commands:
-    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt
+    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt 
 
-- label: Weight Loading Multiple GPU Test - Large Models # optional
-  working_dir: "/vllm-workspace/tests"
+- label: LM Eval Large Models # optional
+  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
   num_gpus: 2
-  gpu: a100
-  optional: true
   source_file_dependencies:
-  - vllm/
-  - tests/weight_loading
+  - csrc/
+  - vllm/model_executor/layers/quantization
   commands:
-    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large.txt 
-
+  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
+  - bash ./run-tests.sh -c configs/models-large.txt -t 2
 
 ##### multi gpus test #####
 ##### A100 test #####
@@ -514,13 +512,13 @@ steps:
   - TARGET_TEST_SUITE=A100 pytest basic_correctness/ -v -s -m distributed_2_gpus
   - pytest -v -s -x lora/test_mixtral.py
 
-- label: LM Eval Large Models # optional
+- label: Weight Loading Multiple GPU Test - Large Models # optional
+  working_dir: "/vllm-workspace/tests"
+  num_gpus: 2
   gpu: a100
-  num_gpus: 4
-  working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
+  optional: true
   source_file_dependencies:
-  - csrc/
-  - vllm/model_executor/layers/quantization
+  - vllm/
+  - tests/weight_loading
   commands:
-  - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - bash ./run-tests.sh -c configs/models-large.txt -t 4
+    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models-large.txt

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -485,7 +485,7 @@ steps:
   - vllm/
   - tests/weight_loading
   commands:
-    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt 
+    - bash weight_loading/run_model_weight_loading_test.sh -c weight_loading/models.txt
 
 - label: LM Eval Large Models # optional
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"


### PR DESCRIPTION
Remove some non-quantized models that are addressed by quantized versions, make the large MoE models quantized, and reduce size of multi-gpu test runner