### PR TITLE
[BugFix]: properly deserialize `tool_calls` iterator before processing by mistral-common when MistralTokenizer is used

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -119,6 +119,42 @@ class OpenAIServingChat(OpenAIServing):
                 return self.create_error_response(
                     "tool_choice = \"required\" is not supported!")
 
+            # NOTE: There is currently a bug in pydantic where attributes
+            # declared as iterables are replaced in in the instances by
+            # pydantic-core ValidatorIterator instance. In particular, this
+            # affects tool_calls defined in ChatCompletionAssistantMessageParam
+            # model:
+            # see:
+            #   - https://github.com/pydantic/pydantic/issues/9467
+            # As a result, tool_calls from assistant messages are never
+            # deserialized in the request object if the tool_calls iterator is
+            # not consumed. This affect messages passed to the MistralTokenizer
+            # since no chat template is applied and therefore the tools_calls
+            # iterator is not directly consumed.
+            # Issue is tracked on Pydantic side, with resolution planned for
+            # v2.11 release. In the meantime, the official workaround is to
+            # consume the iterator so the tool_calls are correctly deserialized
+            # in the OpenAI ChatCompletionAssistantMessageParam object
+            # https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291 # noqa: E501
+            # Official Pydantic Issues:
+            #   - https://github.com/pydantic/pydantic/issues/9541
+            # TODO: remove when pydantic v2.11 is released
+            if isinstance(tokenizer, MistralTokenizer):
+                for i, message in enumerate(request.messages):
+                    if message.get("role") == 'assistant':
+                        tool_calls_validator = message.get(
+                            "tool_calls", ().__iter__())
+                        validated_tool_calls = []
+                        while True:
+                            try:
+                                tool_call = next(
+                                    tool_calls_validator)  # type: ignore
+                                validated_tool_calls.append(tool_call)
+                            except StopIteration:
+                                break
+                        request.messages[i][
+                            "tool_calls"] = validated_tool_calls
+
             if (request.tool_choice == "auto" and
                     not (self.enable_auto_tools and tool_parser is not None)
                     and not isinstance(tokenizer, MistralTokenizer)):


### PR DESCRIPTION
There is currently a [bug in the Pydantic library](https://github.com/pydantic/pydantic/issues/9541) where attributes declared as iterables are eagerly evaluated and therefore replaced in the instances by pydantic-core `ValidatorIterator` instance, when waiting to be consumed.

When the `MistralTokenizer` is used, no chat template is applied, and the request messages are directly sent to be processed by `mistral-common`. As a result, the `tool_calls` field, which is defined as `Iterable` in the Assitant message request object definition (both in the vllm [CustomChatCompletionMessageParam](https://github.com/vllm-project/vllm/blob/eed92f12fc829ff074e7341283cb1677b7e65aa2/vllm/entrypoints/chat_utils.py#L111) or the official OpenAI [ChatCompletionAssistantMessageParam](https://github.com/openai/openai-python/blob/891e1c17b7fecbae34d1915ba90c15ddece807f9/src/openai/types/chat/chat_completion_assistant_message_param.py#L69)) is not consumed and is sent as a pydantic `ValidatorIterator` to `mistral-common` :

```
{'role': 'assistant', 'content': None, 'tool_calls': ValidatorIterator(index=0, schema=Some(DefinitionRef(DefinitionRefValidator { definition: "typed-dict" })))}
```

The `tool_calls` field is then rightfully processed as an empty list by `mistral-common`, meaning that if any `tool_calls` is sent with an assistant message, they are ignored after processing by `mistral-common`:

```
AssistantMessage(role='assistant', content=None, tool_calls=[], prefix=False)
```

This causes the `mistral-common` validation check ([here](https://github.com/mistralai/mistral-common/blob/221cbf4dd93cd945dff1f09fe6470d3ed67eec8d/src/mistral_common/protocol/instruct/validator.py#L146)) to fail as both side are evaluated to false.

```
ERROR 09-29 17:36:44 serving_chat.py:153]   File "/conda/envs/vllm_env/lib/python3.12/site-packages/mistral_common/protocol/instruct/validator.py", line 147, in _validate_assistant_message
ERROR 09-29 17:36:44 serving_chat.py:153]     raise InvalidAssistantMessageException(
ERROR 09-29 17:36:44 serving_chat.py:153] mistral_common.exceptions.InvalidAssistantMessageException: Assistant message must have either content or tool_calls, but not both.
```

The bug is not seen when chat templates are used, since the `tools_calls` iterator is consumed in the template when looping over each `tool_call`.

The bug is known on Pydantic side, and it indeed particularly affects the `tool_calls` field for LLM-based workloads using the OpenAI client (see [this issue](https://github.com/pydantic/pydantic/issues/9467) for exemple).

This PR makes the `tool_calls` received in the request for the assistant messages being consumed (and therefore valided) when the `MistralTokenizer` is used.

FIX https://github.com/vllm-project/vllm/issues/9059

