### PR TITLE
[Bugfix] Fix crash in multi-step mode when set skip_tokenizer_init=True

### DIFF
--- a/vllm/engine/output_processor/multi_step.py
+++ b/vllm/engine/output_processor/multi_step.py
@@ -165,19 +165,6 @@ class MultiStepOutputProcessor(SequenceGroupOutputProcessor):
         if remaining_tokens < 0:
             output_token_ids = output_token_ids[:remaining_tokens]
 
-        # Truncate any tokens after EOS. This is required as spec decode
-        # generates a fixed number of tokens without evaluating stopping
-        # conditions within the block. This can cause an eos token to be
-        # unintentionally ignored.
-        if not sampling_params.ignore_eos:
-            eos_token_id = self.get_tokenizer_for_seq(seq).eos_token_id
-            # Avoiding .index calls as exception throwing in the happy path
-            # is expensive.
-            for i in range(len(output_token_ids)):
-                if output_token_ids[i] == eos_token_id:
-                    output_token_ids = output_token_ids[:i + 1]
-                    break
-
         is_prefill_sampled_token = seq.data.get_num_uncomputed_tokens() == 0
         # Incrementally append tokens to the sequence, as if we had only one new
         # token.


### PR DESCRIPTION
The crash throw from the bellow code(line 173) when use skip_tokenizer_init=True:

https://github.com/vllm-project/vllm/blob/c49f0407ba60bfee538892a09561c1fe7484adf8/vllm/engine/output_processor/multi_step.py#L172-L179

But in the next code, the line 198 `self._process_decode_and_stop` will call `stop_checker.maybe_stop_sequence` to check whether `seq` is finished. And in the `maybe_stop_sequence` function, they has the same code logic like above code(line 172). So, I think the truncate logic in line 172 is repeated, the PR remove these codes. Note that this also removes the dependence on tokenizer, solving the crash problem.

https://github.com/vllm-project/vllm/blob/c49f0407ba60bfee538892a09561c1fe7484adf8/vllm/engine/output_processor/multi_step.py#L181-L201