### PR TITLE
[Core] Use os.sched_yield in ShmRingBuffer instead of time.sleep

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -1,3 +1,4 @@
+import os
 import pickle
 import time
 from contextlib import contextmanager
@@ -17,12 +18,6 @@ from vllm.logger import init_logger
 from vllm.utils import get_ip, get_open_port, is_valid_ipv6_address
 
 VLLM_RINGBUFFER_WARNING_INTERVAL = envs.VLLM_RINGBUFFER_WARNING_INTERVAL
-
-# time to wait if the queue is full or empty
-# if we sleep for too short, it will consume too much CPU
-# if we sleep for too long, it will slow down the writer/reader
-# 0.1 us is a good balance
-RINGBUFFER_SLEEP_INTERVAL = 1e-7
 
 logger = init_logger(__name__)
 
@@ -333,8 +328,8 @@ class MessageQueue:
                     # if this block is not ready to write,
                     # we need to wait until it is read by all readers
 
-                    # wait for a while
-                    time.sleep(RINGBUFFER_SLEEP_INTERVAL)
+                    # Release the processor to other threads
+                    os.sched_yield()
 
                     # if we wait for a long time, we should warn the user
                     if (time.monotonic() - start_time >
@@ -387,8 +382,8 @@ class MessageQueue:
                     # if this block is not ready,
                     # we need to wait until it is written
 
-                    # wait for a while
-                    time.sleep(RINGBUFFER_SLEEP_INTERVAL)
+                    # Release the processor to other threads
+                    os.sched_yield()
 
                     # if we wait for a long time, we should warn the user
                     if (time.monotonic() - start_time >


### PR DESCRIPTION
While profiling #9856, I found that the calls to time.sleep in `shm_broadcast.py` were never taking under 50 microseconds, even if `RINGBUFFER_SLEEP_INTERVAL` is set to 0.

This PR switches to use `os.sched_yield()` instead. 

Using [this gist](https://gist.github.com/tlrmchlsmth/4e366ada4290a1649cef40965115a81f) for benchmarking code, `os.sched_yield()` gives us close to what we wanted, at least on my system.

```
Benchmarking sleep(1.000000e-07) for 10000 iterations...

Results:
Requested sleep duration: 1.000000e-07s
Mean actual duration:     5.247413e-05s
Std dev:                  2.300718e-06s
Min duration:             8.199364e-06s
Max duration:             6.059092e-05s
```

```
Benchmarking os.sched_yield() for 10000 iterations...

Results:
Requested sleep duration: 1.000000e-07s
Mean actual duration:     3.195110e-07s
Std dev:                  1.182954e-07s
Min duration:             2.998859e-07s
Max duration:             1.141988e-05s
```
