### PR TITLE
[Bugfix]Start Failed with param --limit-mm-per-prompt image=N for Molmo

### DIFF
--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -244,6 +244,10 @@ class InputRegistry:
         if dummy_data.multi_modal_data is not None:
             for k, v in dummy_data.multi_modal_data.items():
                 num_items = len(v) if isinstance(v, list) else 1
+                #fix for molmo 
+                if k == "image" and model_config.hf_config.model_type == "molmo":
+                    if isinstance(v, dict) and "images" in v:
+                        num_items = len(v["images"])
                 num_expected = mm_counts[k]
                 assert num_items >= num_expected, (
                     f"Expected at least {num_expected} dummy '{k}' instances "


### PR DESCRIPTION
Fix bug  run api_server with  param  --limit-mm-per-prompt  image=N for model_type molmo
![image](https://github.com/user-attachments/assets/6be90c05-3f07-4ff1-a991-94fec98ec397)

in function dummy_data_for_profiling .there is a assertion  num_items >= num_expected
which is always failed because in molmo model, milti-modal image is in a dict of only one item 'images'
you can find it in file molmo.py .  function  dummy_data_for_molmo 
<img width="797" alt="image" src="https://github.com/user-attachments/assets/30ad4384-29e6-49ea-b195-c1da28f05cc9">
this commit make num_items correct and make vllm start correct.