### PR TITLE
[CPU] Missing ray for CPU backend

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -2,5 +2,6 @@
 -r requirements-common.txt
 
 # Dependencies for x86_64 CPUs
+ray >= 2.9
 torch == 2.4.0+cpu; platform_machine != "ppc64le"
 torchvision; platform_machine != "ppc64le"   # required for the image processor of phi3v, this must be updated alongside torch


### PR DESCRIPTION
This patch fixes the follow bug for CPU backend.
```
INFO 11-05 08:54:08 importing.py:15] Triton not installed or not compatible; certain GPU-related functions will not be available.
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/openai/api_server.py", line 30, in <module>
    from vllm.engine.multiprocessing.engine import run_mp_engine
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/multiprocessing/engine.py", line 8, in <module>
    from ray.exceptions import RayTaskError
ModuleNotFoundError: No module named 'ray'
```

Please review it.
Thanks.