### PR TITLE
[CI/Build] Improve mypy + python version matrix

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -43,4 +43,4 @@ jobs:
     - name: Mypy
       run: |
         echo "::add-matcher::.github/workflows/matchers/mypy.json"
-        tools/mypy.sh 1
+        tools/mypy.sh 1 ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,12 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.9"
-
 ignore_missing_imports = true
 check_untyped_defs = true
 follow_imports = "silent"
 
 # After fixing type errors resulting from follow_imports: "skip" -> "silent",
-# move the directory here and remove it from format.sh and mypy.yaml
+# move the directory here and remove it from tools/mypy.sh
 files = [
     "vllm/*.py",
     "vllm/adapter_commons",

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CI=${1:-0}
+PYTHON_VERSION=${2:-3.9}
 
 if [ $CI -eq 1 ]; then
     set -e
@@ -9,10 +10,10 @@ fi
 run_mypy() {
     echo "Running mypy on $1"
     if [ $CI -eq 1 ] && [ -z "$1" ]; then
-        mypy "$@"
+        mypy --python-version "${PYTHON_VERSION}" "$@"
         return
     fi
-    mypy --follow-imports skip "$@"
+    mypy --follow-imports skip --python-version "${PYTHON_VERSION}" "$@"
 }
 
 run_mypy # Note that this is less strict than CI


### PR DESCRIPTION

b773dc11 [CI/Build] Improve mypy + python version matrix

commit b773dc1162e5f1246c90b32391de348cabbd89b6
Author: Russell Bryant <rbryant@redhat.com>
Date:   Tue Nov 5 15:08:47 2024 +0000

    [CI/Build] Improve mypy + python version matrix
    
    The `mypy` CI job ran using multiple Python versions, though it was
    always checking for compatibility with Python 3.9 because of the
    config option in `pyproject.toml`.
    
    This change makes it so local usage of `format.sh` will still default
    to checking for compatibility with the lowest Python version (3.9).
    The CI job will now check for compatibility with each python version
    used in the matrix instead of only running `mypy` itself with
    different versions, but always checking 3.9 compatibility.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
