### PR TITLE
[bugfix] fix weak ref in piecewise cudagraph and tractable test

### DIFF
--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -83,10 +83,12 @@ class LlamaMLP(nn.Module):
         else:
             nn.init.xavier_normal_(self.gate_up_projection.weight.data,
                                    generator=torch.Generator().manual_seed(
-                                       config.random_seed))
+                                       config.random_seed),
+                                   gain=0.001)
             nn.init.xavier_normal_(self.down_projection.weight.data,
                                    generator=torch.Generator().manual_seed(
-                                       config.random_seed))
+                                       config.random_seed),
+                                   gain=0.001)
 
     def forward(self, x):
         # for tractable_init and positive input, this is
@@ -124,10 +126,12 @@ class LlamaAttention(nn.Module):
         else:
             nn.init.xavier_normal_(self.qkv_projection.weight.data,
                                    generator=torch.Generator().manual_seed(
-                                       config.random_seed))
+                                       config.random_seed),
+                                   gain=0.001)
             nn.init.xavier_normal_(self.output_projection.weight.data,
                                    generator=torch.Generator().manual_seed(
-                                       config.random_seed))
+                                       config.random_seed),
+                                   gain=0.001)
 
     def forward(
         self,

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -92,11 +92,13 @@ class LlamaAttention(nn.Module):
         self.qkv_projection = nn.Linear(
             in_features=config.hidden_size,
             out_features=config.hidden_size * 3,
+            bias=False,
         )
 
         self.output_projection = nn.Linear(
             in_features=config.hidden_size,
             out_features=config.hidden_size,
+            bias=False,
         )
 
         nn.init.eye_(self.qkv_projection.weight.data[:config.hidden_size])
@@ -202,13 +204,13 @@ def tractable_computation(input_ids: torch.Tensor,
                                dtype=input_ids.dtype) * init_value
 
     # first layer
-    residual = hidden_states * 4 + positions * 2 + 3
+    residual = hidden_states * 4 + positions.unsqueeze(1) * 2 + 3
     hidden_states = (residual + 1)**2
 
     # following layers
     for _ in range(config.num_layers - 1):
         hidden_states = hidden_states + residual
-        residual = hidden_states * 4 + positions * 2 + 3
+        residual = hidden_states * 4 + positions.unsqueeze(1) * 2 + 3
         hidden_states = (residual + 1)**2
 
     return hidden_states

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -260,7 +260,7 @@ def run_model(llama_config,
     output = output.cpu()
 
     expected_output = tractable_computation(input_ids[:2], positions[:2],
-                                            llama_config.num_layers).cpu()
+                                            llama_config).cpu()
 
     assert torch.allclose(output, expected_output)
 

--- a/tests/compile/piecewise/test_toy_llama.py
+++ b/tests/compile/piecewise/test_toy_llama.py
@@ -303,7 +303,7 @@ def test_toy_llama():
     llama_config = LlamaConfig(hidden_size=128,
                                mlp_size=256,
                                vocab_size=128,
-                               num_layers=2)
+                               num_layers=12)
 
     tractable_config = LlamaConfig(hidden_size=128,
                                    mlp_size=256,

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -356,8 +356,9 @@ class VllmBackend:
             graph, self.compilation_configs.non_cudagraph_ops)
 
         from torch._dynamo.utils import lazy_format_graph_code
-        logger.debug("%s",
-                     lazy_format_graph_code("stiching module", self.split_gm))
+        logger.debug("%s", lazy_format_graph_code("before split", self.graph))
+        logger.debug("%s", lazy_format_graph_code("after split",
+                                                  self.split_gm))
 
         compilation_counter.num_piecewise_graphs_seen += len(
             self.piecewise_graphs)

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -194,6 +194,7 @@ def wrap_inductor(graph,
 @dataclasses.dataclass
 class SplitItem:
     submod_name: str
+    graph_id: int
     is_splitting_graph: bool
     graph: fx.GraphModule
 
@@ -227,9 +228,7 @@ def split_graph(graph: fx.GraphModule,
 
     outputs = []
 
-    # sort the names to make sure the order is deterministic
     names = [name for (name, module) in split_gm.named_modules()]
-    names.sort()
 
     for name in names:
         if "." in name or name == "":
@@ -239,7 +238,11 @@ def split_graph(graph: fx.GraphModule,
         module = getattr(split_gm, name)
 
         graph_id = int(name.replace("submod_", ""))
-        outputs.append(SplitItem(name, graph_id in split_op_graphs, module))
+        outputs.append(
+            SplitItem(name, graph_id, (graph_id in split_op_graphs), module))
+
+    # sort by intetger graph_id, rather than string name
+    outputs.sort(key=lambda x: x.graph_id)
 
     return split_gm, outputs
 


### PR DESCRIPTION
@WoosukKwon finds out the piecewise cudagraph has correctness issue, and this pr fixes it.

the toy llama tests pass because the weights are all zero. now they are also fixed.