### PR TITLE
[Bugfix] Fix edge-case crash when using chat with the Mistral Tekken Tokenizer

### DIFF
--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -10,13 +10,14 @@ from ...utils import check_logprobs_close
 
 MODELS = [
     "mistralai/Mistral-7B-Instruct-v0.1",
-    "mistralai/Mistral-7B-Instruct-v0.3",
-    # Mistral-Nemo is to big for CI, but passes locally
-    # "mistralai/Mistral-Nemo-Instruct-2407"
 ]
 
 MISTRAL_FORMAT_MODELS = [
     "mistralai/Mistral-7B-Instruct-v0.3",
+    # uses the v3-Tekken tokenizer
+    "mistralai/Ministral-8B-Instruct-2410",
+    # Mistral-Nemo is to big for CI, but passes locally
+    # "mistralai/Mistral-Nemo-Instruct-2407"
 ]
 
 SAMPLING_PARAMS = SamplingParams(max_tokens=512, temperature=0.0, logprobs=5)

--- a/tests/models/decoder_only/language/test_mistral.py
+++ b/tests/models/decoder_only/language/test_mistral.py
@@ -23,6 +23,8 @@ SAMPLING_PARAMS = SamplingParams(max_tokens=512, temperature=0.0, logprobs=5)
 SYMBOLIC_LANG_PROMPTS = [
     "勇敢な船乗りについての詩を書く",  # japanese
     "寫一首關於勇敢的水手的詩",  # chinese
+    "ပုံပြင်လေးပြောပြပါ်:\n",  # burmese
+    "Repeat the phrase 'URGENCY🌶️':\nURGENCY🌶️\nURGENCY🌶️\n",  # see https://github.com/vllm-project/vllm/pull/9625
 ]
 
 # for function calling

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -254,7 +254,7 @@ class MistralTokenizer:
                skip_special_tokens: bool = True) -> str:
         assert (
             skip_special_tokens
-        ), "Skipping special tokens is not supported for Mistral tokenizers."
+        ), "skip_special_tokens=False is not supported for Mistral tokenizers."
 
         if isinstance(ids, int):
             ids = [ids]
@@ -268,11 +268,15 @@ class MistralTokenizer:
         # TODO(Patrick) - potentially allow special tokens to not be skipped
         assert (
             skip_special_tokens
-        ), "Skipping special tokens is not supported for Mistral tokenizers."
+        ), "skip_special_tokens=False is not supported for Mistral tokenizers."
 
         assert isinstance(self.tokenizer,
                           (Tekkenizer, SentencePieceTokenizer)), type(
                               self.tokenizer)
+
+        if isinstance(self.tokenizer, Tekkenizer):
+            # skip special tokens
+            ids = [i for i in ids if i > self.tokenizer.num_special_tokens]
 
         tokens = [self.tokenizer.id_to_piece(id) for id in ids]
 


### PR DESCRIPTION
When running the server with:
```
vllm serve mistralai/Ministral-8B-Instruct-2410 --tokenizer-mode=mistral
```
it is possible to crash the engine/server with a simple request:
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
      "model": "mistralai/Ministral-8B-Instruct-2410",
      "messages": [
        {
          "role": "user",
          "content": "寫一首關於勇敢的水手的詩"
        }
      ]
  }'
```
The stack trace includes:
```
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/engine/output_processor/single_step.py", line 122, in _process_sequence_group_outputs
ERROR 11-05 20:58:45 engine.py:147]     new_char_count = self.detokenizer.decode_sequence_inplace(
ERROR 11-05 20:58:45 engine.py:147]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/transformers_utils/detokenizer.py", line 117, in decode_sequence_inplace
ERROR 11-05 20:58:45 engine.py:147]     seq.read_offset) = convert_prompt_ids_to_tokens(
ERROR 11-05 20:58:45 engine.py:147]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/transformers_utils/detokenizer_utils.py", line 64, in convert_prompt_ids_to_tokens
ERROR 11-05 20:58:45 engine.py:147]     new_tokens = tokenizer.convert_ids_to_tokens(
ERROR 11-05 20:58:45 engine.py:147]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/transformers_utils/tokenizers/mistral.py", line 288, in convert_ids_to_tokens
ERROR 11-05 20:58:45 engine.py:147]     tokens = [self.tokenizer.id_to_byte_piece(id) for id in ids]
ERROR 11-05 20:58:45 engine.py:147]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/mistral_common/tokens/tokenizers/tekken.py", line 280, in id_to_byte_piece
ERROR 11-05 20:58:45 engine.py:147]     return self._model.decode_single_token_bytes(token_id - self.num_special_tokens)
ERROR 11-05 20:58:45 engine.py:147]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147]   File "/workspace/my-vllm/lib64/python3.12/site-packages/tiktoken/core.py", line 272, in decode_single_token_bytes
ERROR 11-05 20:58:45 engine.py:147]     return self._core_bpe.decode_single_token_bytes(token)
ERROR 11-05 20:58:45 engine.py:147]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 11-05 20:58:45 engine.py:147] OverflowError: out of range integral type conversion attempted
```

I traced the cuase to being the id for a special token passed in to `id_to_byte_piece`. The chat template ends with the `[/INST]` special token and generating a token for a symbolic language like chinese is likely to send the code down the [path where it must convert token ids to bytes](https://github.com/vllm-project/vllm/blob/235366fe2eb3144321978e181af94487f0215595/vllm/transformers_utils/tokenizers/mistral.py#L279) for the first generated token. The end of the prompt is included in the "prefix" part of the incremental detokenization, thus triggering the error.

The solution proposed in this PR is to explicitly remove special token ids from the list of tokens passed in to `convert_ids_to_tokens` (it requires `skip_special_tokens=True` anyways).


---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


