### PR TITLE
[CI] Move slow entrypoints tests out of fastcheck

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -104,7 +104,7 @@ steps:
   - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_generate_multiple_loras.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_guided_generate.py # it needs a clean process
-  - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/test_oot_registration.py
+  - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/test_oot_registration.py --ignore=entrypoints/openai/test_accuracy.py --ignore=entrypoints/openai/test_run_batch.py
   - pytest -v -s entrypoints/openai/test_oot_registration.py # it needs a clean process
   - pytest -v -s entrypoints/test_chat_utils.py
   - pytest -v -s entrypoints/offline_mode # Needs to avoid interference with other tests
@@ -142,6 +142,16 @@ steps:
 
 ##### fast check tests  #####
 #####  1 GPU test  #####
+
+- label: Entrypoints Test Slow # 40min
+  working_dir: "/vllm-workspace/tests"
+  mirror_hardwares: [amd]
+  source_file_dependencies:
+  - vllm/
+  commands:
+  - pip install -e ./plugins/vllm_add_dummy_model
+  - pytest -v -s entrypoints/openai/test_accuracy.py
+  - pytest -v -s entrypoints/openai/test_run_batch.py
 
 - label: Regression Test # 5min
   mirror_hardwares: [amd]


### PR DESCRIPTION
Moves `entrypoints/openai/test_accuracy.py` and `entrypoints/openai/test_run_batch.py` out of fastcheck since they take up the majority of entrypoint time