### PR TITLE
[V1] Integrate Piecewise CUDA graphs

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -496,8 +496,11 @@ class PiecewiseBackend:
                 return entry.runnable(*args)
 
             if self.is_first_graph:
-                logger.info("Capturing a cudagraph for shape %s",
-                            runtime_shape)
+                # Since we capture cudagraph for many different shapes and
+                # capturing is fast, we don't need to log it for every shape.
+                # We only log it in the debug mode.
+                logger.debug("Capturing a cudagraph for shape %s",
+                             runtime_shape)
 
             input_addresses = [
                 x.data_ptr() for x in args if isinstance(x, torch.Tensor)

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -157,7 +157,7 @@ class FlashAttentionImpl(AttentionImpl):
 
 
 def unified_flash_attention(
-    out: torch.Tensor,
+    output: torch.Tensor,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -202,7 +202,7 @@ def unified_flash_attention(
         v_scale,
     )
 
-    output = flash_attn_varlen_func(
+    attn_output = flash_attn_varlen_func(
         q=query[:num_actual_tokens],
         k=key_cache,
         v=value_cache,
@@ -217,13 +217,13 @@ def unified_flash_attention(
         block_table=attn_metadata.block_table,
         softcap=logits_soft_cap,
     )
-    output = output.view(num_actual_tokens, -1)
+    attn_output = attn_output.view(num_actual_tokens, -1)
     # TODO(woosuk): Optimize this.
-    out[:num_actual_tokens].copy_(output, non_blocking=True)
+    output[:num_actual_tokens].copy_(attn_output)
 
 
 def unified_flash_attention_fake(
-    out: torch.Tensor,
+    output: torch.Tensor,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -245,6 +245,6 @@ def unified_flash_attention_fake(
 direct_register_custom_op(
     op_name="unified_flash_attention",
     op_func=unified_flash_attention,
-    mutates_args=["kv_cache", "out"],
+    mutates_args=["kv_cache", "output"],
     fake_impl=unified_flash_attention_fake,
 )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -51,6 +51,7 @@ class FlashAttentionMetadata:
     # |-------------------- seq_len ---------------------|
     #                                   |-- query_len ---|
 
+    num_actual_tokens: int  # Number of tokens excluding padding.
     max_query_len: int
     query_start_loc: torch.Tensor
     max_seq_len: int
@@ -134,7 +135,9 @@ class FlashAttentionImpl(AttentionImpl):
         assert k_scale == 1.0 and v_scale == 1.0, (
             "key/v_scale is not supported in FlashAttention.")
 
-        output = torch.ops.vllm.unified_flash_attention(
+        output = torch.empty_like(query)
+        torch.ops.vllm.unified_flash_attention(
+            output,
             query,
             key,
             value,
@@ -154,6 +157,7 @@ class FlashAttentionImpl(AttentionImpl):
 
 
 def unified_flash_attention(
+    out: torch.Tensor,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -168,17 +172,17 @@ def unified_flash_attention(
     window_size: Optional[List[int]] = None,
     alibi_slopes: Optional[torch.Tensor] = None,
     logits_soft_cap: Optional[float] = None,
-) -> torch.Tensor:
+) -> None:
     current_metadata = get_forward_context()
     if current_metadata is None:
         # Profiling run.
-        return torch.empty_like(query)
+        return
 
     assert current_metadata is not None
     assert isinstance(current_metadata, FlashAttentionMetadata)
     attn_metadata: FlashAttentionMetadata = current_metadata
+    num_actual_tokens = attn_metadata.num_actual_tokens
 
-    num_tokens, hidden_size = query.shape
     # Reshape the query, key, and value tensors.
     query = query.view(-1, num_heads, head_size)
     key = key.view(-1, num_kv_heads, head_size)
@@ -188,10 +192,10 @@ def unified_flash_attention(
     key_cache = kv_cache[0]
     value_cache = kv_cache[1]
     torch.ops._C_cache_ops.reshape_and_cache_flash(
-        key,
-        value,
-        kv_cache[0],
-        kv_cache[1],
+        key[:num_actual_tokens],
+        value[:num_actual_tokens],
+        key_cache,
+        value_cache,
         attn_metadata.slot_mapping,
         kv_cache_dtype,
         k_scale,
@@ -199,7 +203,7 @@ def unified_flash_attention(
     )
 
     output = flash_attn_varlen_func(
-        q=query,
+        q=query[:num_actual_tokens],
         k=key_cache,
         v=value_cache,
         cu_seqlens_q=attn_metadata.query_start_loc,
@@ -213,10 +217,13 @@ def unified_flash_attention(
         block_table=attn_metadata.block_table,
         softcap=logits_soft_cap,
     )
-    return output.view(num_tokens, hidden_size)
+    output = output.view(num_actual_tokens, -1)
+    # TODO(woosuk): Optimize this.
+    out[:num_actual_tokens].copy_(output, non_blocking=True)
 
 
 def unified_flash_attention_fake(
+    out: torch.Tensor,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -231,13 +238,13 @@ def unified_flash_attention_fake(
     window_size: Optional[List[int]] = None,
     alibi_slopes: Optional[torch.Tensor] = None,
     logits_soft_cap: Optional[float] = None,
-) -> torch.Tensor:
-    return torch.empty_like(query)
+) -> None:
+    return
 
 
 direct_register_custom_op(
     op_name="unified_flash_attention",
     op_func=unified_flash_attention,
-    mutates_args=["kv_cache"],
+    mutates_args=["kv_cache", "out"],
     fake_impl=unified_flash_attention_fake,
 )

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1,3 +1,4 @@
+import os
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set
@@ -407,7 +408,7 @@ class GPUModelRunner:
             # FIXME(woosuk): Currently, the custom ops are not supported
             # in the piecewise compilation mode. We rely on TorchInductor
             # to optimize the model.
-            envs.VLLM_CUSTOM_OPS = "none"
+            os.environ["VLLM_CUSTOM_OPS"] = "none"
             set_compilation_config(
                 CompilationConfig(
                     use_cudagraph=True,
@@ -451,7 +452,7 @@ class GPUModelRunner:
 
     @torch.inference_mode()
     def capture_model(self) -> None:
-        if self.use_cuda_graph:
+        if not self.use_cuda_graph:
             logger.warning(
                 "Skipping CUDA graph capture. Please set "
                 "VLLM_TORCH_COMPILE_LEVEL=%d to use CUDA graphs.",


### PR DESCRIPTION
This PR integrates the piecewise CUDA graphs into the V1 model runner.

* Set `VLLM_TORCH_COMPILE_LEVEL=3` to enable the feature.
* The compilation + capturing time takes at most ~17 secs.
* Currently, piecewise CUDA graphs are not compatible with custom ops. Therefore, we rely on Torch Inductor to optimize the model.
* Consequently, FP8 or other quantizations are not supported with piecewise CUDA graphs.

## Benchmarks (`benchmark_latency.py`)

| Model              | Version | CUDA Graphs                | Time (s) |
|--------------------|---------|----------------------------|----------|
| OPT-125M (fp16)           | V1      | w/o Piecewise CUDA Graphs | 0.41     |
|                    | V1      | w/ Piecewise CUDA Graphs    | 0.21     |
|                    | V0      | w/o CUDA Graphs           | 0.47     |
|                    | V0      | w/ CUDA Graphs              | 0.21     |
| Llama 3.1 8B (bf16)       | V1      | w/o Piecewise CUDA Graphs | 1.26     |
|          | V1      | w/ Piecewise CUDA Graphs    | 1.04     |
|                    | V0      | w/o CUDA Graphs           | 1.10     |
|                    | V0      | w/ CUDA Graphs              | 0.99     |

