### PR TITLE
[Frontend] Fix multiple values for keyword argument error (#10075)

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -443,29 +443,28 @@ class OpenAIServing:
             tokenizer,
         )
 
+        _chat_template_kwargs: Dict[str, Any] = dict(
+            chat_template=chat_template,
+            add_generation_prompt=add_generation_prompt,
+            continue_final_message=continue_final_message,
+            tools=tool_dicts,
+            documents=documents,
+        )
+        _chat_template_kwargs.update(chat_template_kwargs or {})
+
         request_prompt: Union[str, List[int]]
         is_mistral_tokenizer = isinstance(tokenizer, MistralTokenizer)
         if is_mistral_tokenizer:
             request_prompt = apply_mistral_chat_template(
                 tokenizer,
                 messages=messages,
-                chat_template=chat_template,
-                add_generation_prompt=add_generation_prompt,
-                continue_final_message=continue_final_message,
-                tools=tool_dicts,
-                documents=documents,
-                **(chat_template_kwargs or {}),
+                **_chat_template_kwargs,
             )
         else:
             request_prompt = apply_hf_chat_template(
                 tokenizer,
                 conversation=conversation,
-                chat_template=chat_template,
-                add_generation_prompt=add_generation_prompt,
-                continue_final_message=continue_final_message,
-                tools=tool_dicts,
-                documents=documents,
-                **(chat_template_kwargs or {}),
+                **_chat_template_kwargs,
             )
 
         mm_data = await mm_data_future


### PR DESCRIPTION
Fix #10075 like:

```
curl -X POST "http://39.105.21.95:12481/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d '{
           "model": "meta-llama/Meta-Llama-3-8B-Instruct",
           "messages": [
             {
               "role": "user",
               "content": "tell me a common saying"
             },
             {
               "role": "assistant",
               "content": "Here is a common saying about apple. An apple a day, keeps"
             }
           ],
           "add_generation_prompt": false, "chat_template_kwargs":{"continue_final_message": true}
         }'

Internal Server Error%  
```

Error message on server
```
TypeError: vllm.entrypoints.chat_utils.apply_hf_chat_template() got multiple values for keyword argument 'continue_final_message'
````