### PR TITLE
[CI/Build] change conflict PR comment from mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -46,7 +46,9 @@ pull_request_rules:
     comment:
       message: |
        This pull request has merge conflicts that must be resolved before it can be
-       merged. @{{author}} please rebase it. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+       merged. Please rebase the PR, @{{author}}.
+
+       https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
 
 - name: remove 'needs-rebase' label when conflict is resolved
   conditions:


### PR DESCRIPTION
On PRs opened by dependabot, this comment is interpreted by dependabot
as a command to rebase the PR. We don't need the bots telling each
other what to do. An example is #9746.

The simplest change is to update the text so it will no longer be
interpreted as a command by dependabot. We do that by putting the
"rebase" word prior to the username mention.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
