### PR TITLE
[CI/Build] Always run the ruff workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,12 +15,17 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "**/*.py"
-      - pyproject.toml
-      - requirements-lint.txt
-      - .github/workflows/matchers/ruff.json
-      - .github/workflows/ruff.yml
+    # This workflow is only relevant when one of the following files changes.
+    # However, we have github configured to expect and require this workflow
+    # to run and pass before github with auto-merge a pull request. Until github
+    # allows more flexible auto-merge policy, we can just run this on every PR.
+    # It doesn't take that long to run, anyway.
+    #paths:
+    #  - "**/*.py"
+    #  - pyproject.toml
+    #  - requirements-lint.txt
+    #  - .github/workflows/matchers/ruff.json
+    #  - .github/workflows/ruff.yml
 
 jobs:
   ruff:


### PR DESCRIPTION
A prior PR, #9928, modified this workflow to only run when relevant
files have changed. However, github is configured to expect and
require this workflow to run and pass before a PR can be auto-merged.
GitHub configuration is not quite flexible enough to say "require this
workflow to pass before merging, but only if we plan to run it."

This change is the simplest: just run it always. The change also
leaves a comment in the workflow explaining why it is this way.

An alternative in the future could be to switch to a different
framework for doing auto-merges. Mergify, which is already in use for
some things, has flexible enough policy configuration to capture more
complex merge criteria. Swithing to it just because of this is not
necessary.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
