### PR TITLE
[Bugfix] Fix FP8 torch._scaled_mm fallback for torch>2.5 with CUDA<12.4

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -7,8 +7,7 @@ from vllm.platforms import current_platform
 
 # Input scaling factors are no longer optional in _scaled_mm starting
 # from pytorch 2.5. Allocating a dummy tensor to pass as input_scale
-TORCH_DEVICE_IDENTITY = torch.ones(1).cuda() \
-            if current_platform.is_rocm() else None
+TORCH_DEVICE_IDENTITY = torch.ones(1).cuda()
 
 
 def cutlass_fp8_supported() -> bool:
@@ -166,8 +165,7 @@ def apply_fp8_linear(
 
             # Making sure the dummy tensor is on the same device as the weight
             global TORCH_DEVICE_IDENTITY
-            if (TORCH_DEVICE_IDENTITY is not None
-                    and TORCH_DEVICE_IDENTITY.device != weight.device):
+            if TORCH_DEVICE_IDENTITY.device != weight.device:
                 TORCH_DEVICE_IDENTITY = TORCH_DEVICE_IDENTITY.to(weight.device)
 
             # GEMM

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -7,7 +7,7 @@ from vllm.platforms import current_platform
 
 # Input scaling factors are no longer optional in _scaled_mm starting
 # from pytorch 2.5. Allocating a dummy tensor to pass as input_scale
-TORCH_DEVICE_IDENTITY = torch.ones(1).cuda()
+TORCH_DEVICE_IDENTITY = torch.ones(1, dtype=torch.float32)
 
 
 def cutlass_fp8_supported() -> bool:


### PR DESCRIPTION
We need to pass a dummy tensor as input_scale now. There was a special case for ROCm in apply_fp8_linear since they moved to torch 2.5, but we did not update this case to include CUDA now that we have also upgrade pytorch versions.

Issue was found in the vLLM slack:
```
[rank0]:   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py", line 135, in apply_weights
[rank0]:     return apply_fp8_linear(
[rank0]:            ^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/model_executor/layers/quantization/utils/w8a8_utils.py", line 176, in apply_fp8_linear
[rank0]:     output = torch._scaled_mm(qinput,
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: _scaled_mm(): argument 'scale_a' must be Tensor, not NoneType
```

Easy to replicate by setting `cutlass_fp8_supported` to be False and running any FP8-dynamic model like: 
```
vllm serve neuralmagic/Llama-3.2-1B-Instruct-FP8-dynamic
```

With this PR and forcing off cutlass, I have a successful eval:
```
vllm (pretrained=neuralmagic/Llama-3.2-1B-Instruct-FP8-dynamic), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.3146|±  |0.0128|
|     |       |strict-match    |     5|exact_match|↑  |0.3146|±  |0.0128|
```