### PR TITLE
[Core/Bugfix] Per FlashInfer API changing data_type to kv_data_type for kv_cache

### DIFF
--- a/tests/kernels/test_flashinfer.py
+++ b/tests/kernels/test_flashinfer.py
@@ -447,7 +447,7 @@ def test_flashinfer_decode_with_paged_fp8_kv(
                           head_size,
                           block_size,
                           "NONE",
-                          data_type=dtype,
+                          kv_data_type=dtype,
                           q_data_type=dtype)
     output = wrapper.forward(query,
                              kv_cache_fp8,

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -364,7 +364,7 @@ class FlashInferMetadata(AttentionMetadata):
                     self.paged_kv_indices,
                     self.paged_kv_last_page_len[:self.num_prefills],
                     self.num_qo_heads, self.num_kv_heads, self.head_dim,
-                    self.page_size)
+                    self.page_size, kv_data_type=self.data_type)
         if self.num_decode_tokens > 0:
             assert self.paged_kv_indices is not None
             assert self.paged_kv_indptr is not None
@@ -392,7 +392,7 @@ class FlashInferMetadata(AttentionMetadata):
                 # Disable flashinfer's pos encoding and use vllm's rope.
                 pos_encoding_mode="NONE",
                 # kv-cache data type.
-                data_type=self.data_type,
+                kv_data_type=self.data_type,
                 # query data type.
                 q_data_type=self.q_data_type)
 


### PR DESCRIPTION
[FlashInfer plan API](https://github.com/flashinfer-ai/flashinfer/blob/main/python/flashinfer/prefill.py#L952) renamed data_type to kv_data_type. To sync the change.

cc @yzh119