### PR TITLE
[CI/Build] Always run mypy

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -14,11 +14,16 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - '**/*.py'
-      - '.github/workflows/mypy.yaml'
-      - 'tools/mypy.sh'
-      - 'pyproject.toml'
+    # This workflow is only relevant when one of the following files changes.
+    # However, we have github configured to expect and require this workflow
+    # to run and pass before github with auto-merge a pull request. Until github
+    # allows more flexible auto-merge policy, we can just run this on every PR.
+    # It doesn't take that long to run, anyway.
+    #paths:
+    #  - '**/*.py'
+    #  - '.github/workflows/mypy.yaml'
+    #  - 'tools/mypy.sh'
+    #  - 'pyproject.toml'
 
 jobs:
   mypy:


### PR DESCRIPTION
If you would like to configure the repo to block auto-merges if the
mypy workflow fails, you will first need to merge this PR so that the
workflow runs on all PRs, regardless of the files that have changed.
This is because github configuration does not support blocking on
workflows that run conditionally.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
