### PR TITLE
[Core] Add padding-aware scheduling for 2D prefills

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1089,7 +1089,7 @@ class SchedulerConfig:
                  multi_step_stream_outputs: bool = False,
                  send_delta_data: bool = False,
                  policy: str = "fcfs",
-                 use_padding_aware_scheduling : bool = False,
+                 use_padding_aware_scheduling: bool = False,
                  max_num_prefill_seqs: Optional[int] = None,
                  padding_method: Optional[str] = None) -> None:
         if max_num_batched_tokens is None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1089,7 +1089,7 @@ class SchedulerConfig:
                  multi_step_stream_outputs: bool = False,
                  send_delta_data: bool = False,
                  policy: str = "fcfs",
-                 use_padding_aware_scheduling=False,
+                 use_padding_aware_scheduling : bool = False,
                  max_num_prefill_seqs: Optional[int] = None,
                  padding_method: Optional[str] = None) -> None:
         if max_num_batched_tokens is None:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -14,6 +14,7 @@ from vllm.config import (CacheConfig, ConfigFormat, DecodingConfig,
                          PromptAdapterConfig, SchedulerConfig,
                          SpeculativeConfig, TaskOption, TokenizerPoolConfig,
                          VllmConfig)
+from vllm.core.scheduler import PaddingMethods
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
@@ -123,6 +124,9 @@ class EngineArgs:
     gpu_memory_utilization: float = 0.90
     max_num_batched_tokens: Optional[int] = None
     max_num_seqs: int = 256
+    use_padding_aware_scheduling: bool = False
+    max_num_prefill_seqs: Optional[int] = None
+    scheduler_padding_method: Optional[str] = None
     max_logprobs: int = 20  # Default value for OpenAI Chat Completions API
     disable_log_stats: bool = False
     revision: Optional[str] = None
@@ -478,6 +482,32 @@ class EngineArgs:
                             type=int,
                             default=EngineArgs.max_num_seqs,
                             help='Maximum number of sequences per iteration.')
+        parser.add_argument(
+            '--use-padding-aware-scheduling',
+            default=EngineArgs.use_padding_aware_scheduling,
+            action='store_true',
+            help=('Use padding-aware scheduling. If True, the scheduler '
+                  'will consider padded tokens in prefill. '
+                  'By default this is set to False. '))
+        parser.add_argument(
+            '--max-num-prefill-seqs',
+            type=int,
+            default=EngineArgs.max_num_prefill_seqs,
+            help=('Maximum number of prefill sequences per '
+                  'iteration. Can be used only with padding-aware '
+                  'scheduling. Must be <= max_num_seqs. '
+                  'Defaults to max_num_seqs if padding-aware '
+                  'scheduling is enabled, is None otherwise.'))
+        parser.add_argument(
+            '--scheduler-padding-fn',
+            type=int,
+            default=EngineArgs.scheduler_padding_method,
+            help=("Padding function for determining effective "
+                  "token budget in padding-aware scheduling. ",
+                  "Requires enabling padding-aware scheduling. "
+                  "Defaults to auto if padding-aware scheduling is "
+                  "enabled, is None otherwise."),
+            choices=PaddingMethods.valid_choices())
         parser.add_argument(
             '--max-logprobs',
             type=int,
@@ -1136,7 +1166,10 @@ class EngineArgs:
             multi_step_stream_outputs=self.multi_step_stream_outputs,
             send_delta_data=(envs.VLLM_USE_RAY_SPMD_WORKER
                              and parallel_config.use_ray),
-            policy=self.scheduling_policy)
+            policy=self.scheduling_policy,
+            use_padding_aware_scheduling=self.use_padding_aware_scheduling,
+            max_num_prefill_seqs=self.max_num_prefill_seqs,
+            padding_method=self.scheduler_padding_method)
         lora_config = LoRAConfig(
             max_lora_rank=self.max_lora_rank,
             max_loras=self.max_loras,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -499,7 +499,7 @@ class EngineArgs:
                   'Defaults to max_num_seqs if padding-aware '
                   'scheduling is enabled, is None otherwise.'))
         parser.add_argument(
-            '--scheduler-padding-fn',
+            '--scheduler-padding-method',
             type=int,
             default=EngineArgs.scheduler_padding_method,
             help=("Padding function for determining effective "


### PR DESCRIPTION
This PR adds two new, user-toggleable flags that are meant to reduce wasted compute on padding and reduce the risk of out-of-memory errors in 2D (`batch_size` x `seq_len`) prefill scenarios used on certain platforms (e.g. HPU, but the functionality is generic), as flat scheduling budget cannot alone accurately reflect the size of 2D memory allocation. 

Consider following example: if we have token budget of 1024 tokens, and have 63 sequences with single token, and one sequence with 961 tokens, In flat scheduling budget, we'd be able to fit all 64 sequences, as they fit in the token budget, but if we are to create `batch_size` x `seq_len` array, we're now looking at 64 x 961 array = 61504 tokens, 60480 of which will be overcomputed, provided the device doesn't run out of memory. The goal here is to have a mechanism limiting the effective number of tokens in 2D scenarios. Once padding is considered in token budget of 1024, we will execute this scenario efficiently in two waves of [63,1] and [1,961] tokens with no padding.

`use_padding_aware_scheduling` - vLLM scheduler will now calculate token cost considering padded prefill shape. Padding is computed using optionally provided `padding_method` (if not provided, appropriate method will be autodetected). Generic implementation takes the product of longest sequence length in batch and batch size. Vendor-specific implementations might include special rules (e.g. padding to powers of two, padding to some arbitrary bucket sizes).

`max_num_prefill_seqs` - padding-aware scheduler will perform an additional check for prefill batch size and will effectively limit prefill batch size at maximum of max_num_prefill_seqs. If unset, max prefill batch size will be max_num_seqs. This is particularly useful for further reduction in memory usage and padding in compute-bound scenarios, where it makes no sense to further increase batch size (and padding), since time and memory needed scales linearly from that point onward.

Both use cases are covered by unit tests.

All added features are disabled by default. Any scenarios using 1D prefill attention should not be impacted whatsoever.