### PR TITLE
[V1] Add all_token_ids attribute to Request

### DIFF
--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -246,7 +246,7 @@ class Scheduler:
                 # NOTE(woosuk): Currently, we assume that each request
                 # generates at most one token at each step.
                 token_id = sampled_token_ids[req_index]
-                request.output_token_ids.append(token_id)
+                request.append_output_token_ids(token_id)
                 sampled.append((request, 1))
                 # TODO: Update the KV cache manager for prefix caching.
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -324,7 +324,7 @@ class LLMEngine:
         )
         for req, num_tokens in sampled:
             inputs.req_ids.append(req.request_id)
-            if len(req.output_token_ids) == num_tokens:
+            if req.num_output_tokens == num_tokens:
                 # The request is first detokenized.
                 inputs.prompt_token_ids.append(req.prompt_token_ids)
             else:

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -1,0 +1,61 @@
+from typing import List, overload, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ConstantList(Generic[T]):
+
+    def __init__(self, x: List[T]) -> None:
+        self._x = x
+
+    def append(self, item):
+        raise Exception("Cannot append to a constant list")
+
+    def extend(self, item):
+        raise Exception("Cannot extend a constant list")
+
+    def insert(self, item):
+        raise Exception("Cannot insert into a constant list")
+
+    def pop(self, item):
+        raise Exception("Cannot pop from a constant list")
+
+    def remove(self, item):
+        raise Exception("Cannot remove from a constant list")
+
+    def clear(self):
+        raise Exception("Cannot clear a constant list")
+
+    def index(self, item):
+        return self._x.index(item)
+
+    @overload
+    def __getitem__(self, item) -> T:
+        ...
+
+    @overload
+    def __getitem__(self, s: slice, /) -> List[T]:
+        ...
+
+    def __getitem__(self, item):
+        return self._x[item]
+
+    @overload
+    def __setitem__(self, item, value):
+        raise Exception("Cannot set item in a constant list")
+
+    @overload
+    def __setitem__(self, s: slice, value, /):
+        raise Exception("Cannot set item in a constant list")
+
+    def __delitem__(self, item):
+        raise Exception("Cannot delete item from a constant list")
+
+    def __iter__(self):
+        return iter(self._x)
+
+    def __contains__(self, item):
+        return item in self._x
+
+    def __len__(self):
+        return len(self._x)

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -1,4 +1,4 @@
-from typing import List, overload, Generic, TypeVar
+from typing import Generic, List, TypeVar, overload
 
 T = TypeVar("T")
 
@@ -42,10 +42,13 @@ class ConstantList(Generic[T]):
 
     @overload
     def __setitem__(self, item, value):
-        raise Exception("Cannot set item in a constant list")
+        ...
 
     @overload
     def __setitem__(self, s: slice, value, /):
+        ...
+
+    def __setitem__(self, item, value):
         raise Exception("Cannot set item in a constant list")
 
     def __delitem__(self, item):


### PR DESCRIPTION
This PR adds the `all_token_ids` to the `Request` class, which is always updated with `output_token_ids`. Having `all_token_ids` can be useful because we can directly on the entire list of token ids (i.e., `prompt_token_ids + output_token_ids`) without the O(n) computation every time.

To make sure that the two lists are updated atomically, the PR introduces ConstantList. The constant list provides an immutable view of the list with O(1) overheads.