### PR TITLE
[CI/Build] Give PR cleanup job PR write access

### DIFF
--- a/.github/workflows/cleanup_pr_body.yml
+++ b/.github/workflows/cleanup_pr_body.yml
@@ -1,8 +1,11 @@
 name: Cleanup PR Body
 
 on:
-  pull_request:
-    types: [opened, edited, synchronize]
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: write
 
 jobs:
   update-description:


### PR DESCRIPTION
When I ran this job on my own fork, it had the necessary permissions
to edit my own PR. Here, we need to explicitly grant the workflow PR
write access.

Since we are giving the GITHUB_TOKEN some level of elevated access, it
is safer to use `pull_request_event` instead of `pull_request`. The
difference is that `pull_request_event` runs in the context of `main`
instead of the PR. In other words, a PR will not run this workflow
using changes from the PR itself. This prevents a malicious PR from
editing this workflow, or a script that it executes, to do something
malicious with the github token.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
