### PR TITLE
[CI/Build] Ignore .gitignored files for shellcheck

### DIFF
--- a/tools/shellcheck.sh
+++ b/tools/shellcheck.sh
@@ -18,4 +18,4 @@ if ! [ -x "$(command -v shellcheck)" ]; then
 fi
 
 # TODO - fix warnings in .buildkite/run-amd-test.sh
-find . -name "*.sh" -not -path "./.deps/*" -not -path "./.buildkite/run-amd-test.sh" -exec shellcheck {} +
+find . -name "*.sh" -not -path "./.buildkite/run-amd-test.sh" -exec sh -c 'git check-ignore -q $1 || shellcheck $1' _ {} \;


### PR DESCRIPTION
Do not run shellcheck on files that are ignored by Git. This makes it easier so we don't have to maintain a separate ignore list for shellcheck, and helps reduce headaches if developers have stuff in their `vllm` folder that is ignored by git (virtual environments, workspaces, other files...).

