### PR TITLE
[V1] Fix non-cudagraph op name

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -411,7 +411,7 @@ class GPUModelRunner:
             set_compilation_config(
                 CompilationConfig(
                     use_cudagraph=True,
-                    non_cudagraph_ops=["vllm.unified_flash_attention"],
+                    non_cudagraph_ops=["vllm.unified_v1_flash_attention"],
                     use_inductor=True,
                 ))
 


### PR DESCRIPTION
Currently, we use a wrong name when registering the op to exclude from CUDA graphs. The bug was introduced by #9888 which changed the attention op name. This PR fixes it.