### PR TITLE
[Doc] Fix typo error in vllm/entrypoints/openai/cli_args.py

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -190,7 +190,7 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         default=False,
         help=
         "Enable auto tool choice for supported models. Use --tool-call-parser"
-        "to specify which parser to use")
+        " to specify which parser to use")
 
     valid_tool_parsers = ToolParserManager.tool_parsers.keys()
     parser.add_argument(


### PR DESCRIPTION
The vllm/entrypoints/openai/cli_args.py file has a typo for the help mesage of the "--enable-auto-tool-choice" argument.

I have fixed it.