### PR TITLE
[Bugfix] bitsandbytes models fail to run pipeline parallel

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -39,6 +39,7 @@ from vllm.model_executor.model_loader.weight_utils import (
     get_gguf_extra_tensor_names, gguf_quant_weights_iterator,
     initialize_dummy_weights, np_cache_weights_iterator, pt_weights_iterator,
     safetensors_weights_iterator)
+from vllm.model_executor.models.utils import is_pp_missing_parameter
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils import is_pin_memory_available
@@ -992,6 +993,9 @@ class BitsAndBytesModelLoader(BaseModelLoader):
         param_dict = dict(model.named_parameters())
         stacked_quant_state_dict: Dict[str, Dict[int, Any]] = {}
         for quant_param_name in quant_state_dict:
+            if is_pp_missing_parameter(quant_param_name, model):
+                continue
+
             non_stacked_param_name = quant_param_name
 
             shard_index = 0

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -39,7 +39,6 @@ from vllm.model_executor.model_loader.weight_utils import (
     get_gguf_extra_tensor_names, gguf_quant_weights_iterator,
     initialize_dummy_weights, np_cache_weights_iterator, pt_weights_iterator,
     safetensors_weights_iterator)
-from vllm.model_executor.models.utils import is_pp_missing_parameter
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils import is_pin_memory_available
@@ -992,6 +991,9 @@ class BitsAndBytesModelLoader(BaseModelLoader):
 
         param_dict = dict(model.named_parameters())
         stacked_quant_state_dict: Dict[str, Dict[int, Any]] = {}
+        # TODO: Change this lazy import to normal import
+        # after the checks are updated to run on a new version
+        from vllm.model_executor.models.utils import is_pp_missing_parameter
         for quant_param_name in quant_state_dict:
             if is_pp_missing_parameter(quant_param_name, model):
                 continue


### PR DESCRIPTION
This PR makes a fix so that bitsandbytes models can run pipeline parallel.

During loading bnb model weights, we need to setup the bnb quant states. However, if the model is loaded in pipeline parallel setting, some layers are `PPMissingLayer` instead of the actual layer, causing the error while setting the quant states. This PR fixes the error by ignoring the setting when the layer is not a proper model layer.

~~I had to move the pipeline parallel classes and functions in `vllm/model_executor/models/utils.py` to a new file so that I can import the layer checking function without creating circular import.~~

~~I still need to retain `is_pp_missing_parameter` as other files import this function from `utils.py`, but this leaves the function unused in the file.~~

Thanks to a recent update, this can be done simply by adding a condition to check the layer type before setting quant state.