### PR TITLE
[doc] improve debugging code

### DIFF
--- a/docs/source/getting_started/debugging.rst
+++ b/docs/source/getting_started/debugging.rst
@@ -75,6 +75,9 @@ If GPU/CPU communication cannot be established, you can use the following Python
 
     print("PyTorch GLOO is successful!")
 
+    if world_size <= 1:
+        exit()
+
     # Test vLLM NCCL, with cuda graph
     from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 


### PR DESCRIPTION
running the debug code with 1 GPU will lead to:

> AttributeError: 'PyNcclCommunicator' object has no attribute 'device'

as reported in https://github.com/vllm-project/vllm/issues/5484#issuecomment-2467061953 