### PR TITLE
[Doc] fix doc string typo in block_manager `swap_out` function

### DIFF
--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -393,7 +393,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         with num_lookahead_slots.
 
         Args:
-            seq_group (SequenceGroup): The sequence group to swap in.
+            seq_group (SequenceGroup): The sequence group to swap out.
             num_lookahead_slots (int): Number of lookahead slots used in 
                 speculative decoding, default to 0.
 

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -409,7 +409,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         swapping out the given sequence_group with num_lookahead_slots.
 
         Args:
-            sequence_group (SequenceGroup): The sequence group to swap in.
+            sequence_group (SequenceGroup): The sequence group to swap out.
 
         Returns:
             List[Tuple[int, int]]: The mapping of swapping block from 

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -459,7 +459,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         on to the 'device'.
 
         Args:
-            sequence_group (SequenceGroup): The sequence group to swap in.
+            sequence_group (SequenceGroup): The sequence group to swap in/out.
             device (Device): device to swap the 'seq_group' on.
             status (SequenceStatus): The status of sequence which is needed
                 for action. RUNNING for swap out and SWAPPED for swap in


### PR DESCRIPTION
fix doc string typo in block_manager's `can_swap_out` and `swap_out` function, should be `swap out`