### PR TITLE
[V1] Do not use inductor for piecewise CUDA graphs

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -404,15 +404,14 @@ class GPUModelRunner:
 
     def load_model(self) -> None:
         if self.use_cuda_graph:
-            # FIXME(woosuk): Currently, the custom ops are not supported
-            # in the piecewise compilation mode. We rely on TorchInductor
-            # to optimize the model.
+            # FIXME(woosuk): Currently, we do not use inductor to avoid the
+            # compilation time.
             os.environ["VLLM_CUSTOM_OPS"] = "none"
             set_compilation_config(
                 CompilationConfig(
                     use_cudagraph=True,
                     non_cudagraph_ops=["vllm.unified_v1_flash_attention"],
-                    use_inductor=True,
+                    use_inductor=False,
                 ))
 
         logger.info("Starting to load model %s...", self.model_config.model)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -404,8 +404,8 @@ class GPUModelRunner:
 
     def load_model(self) -> None:
         if self.use_cuda_graph:
-            # FIXME(woosuk): Currently, we do not use inductor to avoid the
-            # compilation time.
+            # FIXME(woosuk): Currently, we do not use inductor to reduce the
+            # compilation time and any potential issues with the inductor.
             os.environ["VLLM_CUSTOM_OPS"] = "none"
             set_compilation_config(
                 CompilationConfig(


### PR DESCRIPTION
This PR disables the use of TorchInductor, to avoid the compilation time and issue. We can flip the flag again once the compiler becomes more stable.