### PR TITLE
[misc][distributed] auto port selection and disable tests

### DIFF
--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -109,6 +109,8 @@ def allgather_worker(rank, WORLD_SIZE, port1, port2):
     pg1.barrier()
 
 
+# TODO: investigate why this test is flaky. It hangs during initialization.
+@pytest.skip("Skip the test because it is flaky.")
 @multi_gpu_test(num_gpus=4)
 @pytest.mark.parametrize(
     "worker", [cpu_worker, gpu_worker, broadcast_worker, allgather_worker])

--- a/tests/distributed/test_utils.py
+++ b/tests/distributed/test_utils.py
@@ -110,7 +110,7 @@ def allgather_worker(rank, WORLD_SIZE, port1, port2):
 
 
 # TODO: investigate why this test is flaky. It hangs during initialization.
-@pytest.skip("Skip the test because it is flaky.")
+@pytest.mark.skip("Skip the test because it is flaky.")
 @multi_gpu_test(num_gpus=4)
 @pytest.mark.parametrize(
     "worker", [cpu_worker, gpu_worker, broadcast_worker, allgather_worker])


### PR DESCRIPTION
observed flakiness in ci, e.g. https://buildkite.com/vllm/fastcheck/builds/7714#01931945-8b3f-4a69-a9fe-4f933c0a44e2 and https://buildkite.com/vllm/ci-aws/builds/11061#01931a04-7249-4e65-881c-94deb12c98c6 . might be caused by port conflict. use auto selection instead.