### PR TITLE
[CI/build] update torch to 2.5.1 in publish.yml to match requirements-build.txt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
           os: ['ubuntu-20.04']
           python-version: ['3.9', '3.10', '3.11', '3.12']
-          pytorch-version: ['2.4.0']  # Must be the most recent version that meets requirements-cuda.txt.
+          pytorch-version: ['2.5.1']  # Must be the most recent version that meets requirements-cuda.txt.
           cuda-version: ['11.8', '12.1']
 
     steps:


### PR DESCRIPTION
Following https://github.com/vllm-project/vllm/pull/9860, torch version in publish.yml should be updated as well