### PR TITLE
[Misc]Fix Idefics3Model argument

### DIFF
--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -425,7 +425,6 @@ class Idefics3Model(nn.Module):
         self.config = config
         self.padding_idx = self.config.text_config.pad_token_id
         self.vocab_size = self.config.text_config.vocab_size
-
         self.vision_model = Idefics3VisionTransformer(config.vision_config,
                                                       quant_config)
         self.connector = Idefics3Connector(config)

--- a/vllm/model_executor/models/idefics3.py
+++ b/vllm/model_executor/models/idefics3.py
@@ -420,7 +420,6 @@ class Idefics3Model(nn.Module):
         super().__init__()
 
         config = vllm_config.model_config.hf_config
-        cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
 
         self.config = config
@@ -430,8 +429,10 @@ class Idefics3Model(nn.Module):
         self.vision_model = Idefics3VisionTransformer(config.vision_config,
                                                       quant_config)
         self.connector = Idefics3Connector(config)
-        self.text_model = LlamaModel(config.text_config, cache_config,
-                                     quant_config)
+        self.text_model = LlamaModel(
+            vllm_config=vllm_config.with_hf_config(config.text_config),
+            prefix=maybe_prefix(prefix, "text_model"),
+        )
 
         self.image_seq_len = int(
             ((config.vision_config.image_size //


### PR DESCRIPTION
The Idefics3 tests are currently skipped in the vllm CI due to the `transformers` version, which led to ignoring the argument modifications for this model. Similar issues might exist in other models as well, so further checks may be needed.