### PR TITLE
[Bugfix] Fix QwenModel argument

### DIFF
--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -1068,7 +1068,7 @@ class QWenLMHeadModel(QWenBaseModel, SupportsLoRA):
         config = vllm_config.model_config.hf_config
         # Initialize VL
         if hasattr(config, "visual"):
-            return QWenVL(vllm_config)
+            return QWenVL(vllm_config=vllm_config)
         # Initialize LLM
         else:
-            return QWenLLM(vllm_config)
+            return QWenLLM(vllm_config=vllm_config)


### PR DESCRIPTION
The QWen models fail to run due to incorrect argument.
```
ERROR 11-12 11:41:22 engine.py:366]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/loader.py", line 303, in load_model
ERROR 11-12 11:41:22 engine.py:366]     model = _initialize_model(vllm_config=vllm_config)
ERROR 11-12 11:41:22 engine.py:366]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/loader.py", line 95, in _initialize_model
ERROR 11-12 11:41:22 engine.py:366]     return model_class(vllm_config=vllm_config)
ERROR 11-12 11:41:22 engine.py:366]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/qwen.py", line 1071, in __new__
ERROR 11-12 11:41:22 engine.py:366]     return QWenVL(vllm_config)
ERROR 11-12 11:41:22 engine.py:366] TypeError: QWenBaseModel.__init__() takes 1 positional argument but 2 were given
```

This patch try to fix it.
Please review it.
Thanks.