### PR TITLE
[V1] Enable Inductor when using piecewise CUDA graphs

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -404,14 +404,16 @@ class GPUModelRunner:
 
     def load_model(self) -> None:
         if self.use_cuda_graph:
-            # FIXME(woosuk): Currently, we do not use inductor to reduce the
-            # compilation time and any potential issues with the inductor.
-            os.environ["VLLM_CUSTOM_OPS"] = "all"
+            # NOTE(woosuk): Currently, we use inductor because the piecewise
+            # CUDA graphs do not work properly with the custom CUDA kernels.
+            # FIXME(woosuk): Disable inductor to reduce the compilation time
+            # and avoid any potential issues with the inductor.
+            os.environ["VLLM_CUSTOM_OPS"] = "none"
             set_compilation_config(
                 CompilationConfig(
                     use_cudagraph=True,
                     non_cudagraph_ops=["vllm.unified_v1_flash_attention"],
-                    use_inductor=False,
+                    use_inductor=True,
                 ))
 
         logger.info("Starting to load model %s...", self.model_config.model)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -414,6 +414,7 @@ class GPUModelRunner:
                     use_cudagraph=True,
                     non_cudagraph_ops=["vllm.unified_v1_flash_attention"],
                     use_inductor=True,
+                    enable_fusion=False,
                 ))
 
         logger.info("Starting to load model %s...", self.model_config.model)


### PR DESCRIPTION
Unfortunately, after the PR #10228   piecewise CUDA graph generates gibberish outputs. For some reason, we have to turn on the inductors and disable the custom CUDA kernels when using piecewise CUDA graphs.

Note that the following error message appears when using the CUDA graphs in V1 (although it functionally works):
```
[rank0]:W1112 00:26:33.338000 39792 site-packages/torch/_inductor/codecache.py:604] [0/0] Can't pickle
[rank0]:W1112 00:26:33.338000 39792 site-packages/torch/_inductor/codecache.py:604] [0/0] Traceback (most recent call last):
[rank0]:W1112 00:26:33.338000 39792 site-packages/torch/_inductor/codecache.py:604] [0/0]   File "/woosuk/miniconda3/envs/vllm/lib/python3.10/site-packages/torch/_inductor/codecache.py", line 600, in dumps
```