### PR TITLE
[Core][Frontend] Add faster-outlines as guided decoding backend

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,6 +19,7 @@ prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.10.6
 outlines >= 0.0.43, < 0.1
+faster-outlines >= 2024.11.10
 typing_extensions >= 4.10
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4
 partial-json-parser # used for parsing partial JSON outputs

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,7 +19,7 @@ prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer == 0.10.6
 outlines >= 0.0.43, < 0.1
-faster-outlines >= 2024.11.10
+faster-outlines >= 2024.11.14
 typing_extensions >= 4.10
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4
 partial-json-parser # used for parsing partial JSON outputs

--- a/tests/model_executor/test_guided_processors.py
+++ b/tests/model_executor/test_guided_processors.py
@@ -34,13 +34,16 @@ def test_guided_logits_processors(sample_regex, sample_json_schema):
     assert tensor.shape == original_tensor.shape
     assert not torch.allclose(tensor, original_tensor)
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["faster-outlines"])
-async def test_guided_logits_processor_black_box_faster_outlines(backend: str, sample_regex, # noqa: E501
-                                                 sample_json_schema):
+async def test_guided_logits_processor_black_box_faster_outlines(
+        backend: str,
+        sample_regex,  # noqa: E501
+        sample_json_schema):
     # faster-outlines processors require special handling,
-    # since they do not begin computation of a fsm index until they have been 
-    # both serialized and deserialized. More on the reason why can be found 
+    # since they do not begin computation of a fsm index until they have been
+    # both serialized and deserialized. More on the reason why can be found
     # in the doc comment for the class:
     # https://github.com/unaidedelf8777/faster-outlines/blob/main/faster_outlines/fsm/vllm_guide.py # noqa: E501
     import pickle

--- a/tests/model_executor/test_guided_processors.py
+++ b/tests/model_executor/test_guided_processors.py
@@ -36,13 +36,13 @@ def test_guided_logits_processors(sample_regex, sample_json_schema):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("backend", ["faster-outlines"])
-async def test_guided_logits_processor_black_box_faster_outlines(backend: str, sample_regex,
+async def test_guided_logits_processor_black_box_faster_outlines(backend: str, sample_regex, # noqa: E501
                                                  sample_json_schema):
     # faster-outlines processors require special handling,
     # since they do not begin computation of a fsm index until they have been 
     # both serialized and deserialized. More on the reason why can be found 
     # in the doc comment for the class:
-    # https://github.com/unaidedelf8777/faster-outlines/blob/main/faster_outlines/fsm/vllm_guide.py
+    # https://github.com/unaidedelf8777/faster-outlines/blob/main/faster_outlines/fsm/vllm_guide.py # noqa: E501
     import pickle
     tokenizer = AutoTokenizer.from_pretrained('HuggingFaceH4/zephyr-7b-beta')
     token_ids = tokenizer.encode(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2008,7 +2008,9 @@ class DecodingConfig:
     guided_decoding_backend: str = 'outlines'
 
     def __post_init__(self):
-        valid_guided_backends = ['outlines', 'lm-format-enforcer']
+        valid_guided_backends = [
+            'outlines', 'lm-format-enforcer', 'faster-outlines'
+        ]
         backend = self.guided_decoding_backend
         if backend not in valid_guided_backends:
             raise ValueError(f"Invalid guided_decoding_backend '{backend},"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -358,7 +358,7 @@ class EngineArgs:
             '--guided-decoding-backend',
             type=str,
             default='outlines',
-            choices=['outlines', 'lm-format-enforcer'],
+            choices=['outlines', 'lm-format-enforcer', 'faster-outlines'],
             help='Which engine will be used for guided decoding'
             ' (JSON schema / regex etc) by default. Currently support '
             'https://github.com/outlines-dev/outlines and '

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -19,6 +19,11 @@ async def get_guided_decoding_logits_processor(
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
+    if guided_params.backend == 'faster-outlines':
+        from vllm.model_executor.guided_decoding.faster_outlines_decoding import (  # noqa
+            get_local_faster_outlines_guided_decoding_logits_processor)
+        return get_local_faster_outlines_guided_decoding_logits_processor(
+            guided_params, tokenizer)
 
     raise ValueError(
         f"Unknown guided decoding backend '{guided_params.backend}'. "
@@ -39,6 +44,11 @@ def get_local_guided_decoding_logits_processor(
         from vllm.model_executor.guided_decoding.lm_format_enforcer_decoding import (  # noqa
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
+            guided_params, tokenizer)
+    if guided_params.backend == 'faster-outlines':
+        from vllm.model_executor.guided_decoding.faster_outlines_decoding import (  # noqa
+            get_local_faster_outlines_guided_decoding_logits_processor)
+        return get_local_faster_outlines_guided_decoding_logits_processor(
             guided_params, tokenizer)
 
     raise ValueError(

--- a/vllm/model_executor/guided_decoding/faster_outlines_decoding.py
+++ b/vllm/model_executor/guided_decoding/faster_outlines_decoding.py
@@ -1,38 +1,33 @@
 import math
-import torch
-from re import escape as regex_escape
 from json import dumps as json_dumps
+from re import escape as regex_escape
 from typing import Dict, List, Union
 
-from faster_outlines.fsm import (
-    LazyVLLMRegexGuide, 
-    Write,
-    Generate,
-    TokenVocabulary
-)
-from transformers import PreTrainedTokenizerBase
-from vllm.sampling_params import GuidedDecodingParams
+import torch
+from faster_outlines.fsm import (Generate, LazyVLLMRegexGuide, TokenVocabulary,
+                                 Write)
 from outlines.fsm.json_schema import build_regex_from_schema
+from transformers import PreTrainedTokenizerBase
+
+from vllm.sampling_params import GuidedDecodingParams
 
 TOKENIZER_CACHE: Dict[str, TokenVocabulary] = {}
+
 
 class BaseLogitsProcessor:
 
     def __init__(self, guide):
         self._guide = guide
         self.state = 0
-    
+
     def __call__(self, input_ids: List[int],
                  scores: torch.Tensor) -> torch.Tensor:
         """Use the FSM to bias the logits before sampling the next token."""
         if len(input_ids) > 0:
-            self.state = self._guide.get_next_state(
-                state=self.state,
-                token_id=input_ids[-1]
-            )
+            self.state = self._guide.get_next_state(state=self.state,
+                                                    token_id=input_ids[-1])
 
-        instruction = self._guide.get_next_instruction(
-            state=self.state)
+        instruction = self._guide.get_next_instruction(state=self.state)
         if type(instruction) == Generate:  # noqa: E721
             allowed_tokens = instruction.tokens
         elif type(instruction) == Write:  # noqa: E721
@@ -53,8 +48,7 @@ class BaseLogitsProcessor:
 class RegexLogitsProcessor(BaseLogitsProcessor):
 
     @classmethod
-    def _get_guide(cls, regex_string: str,
-                   tokenizer: PreTrainedTokenizerBase):
+    def _get_guide(cls, regex_string: str, tokenizer: PreTrainedTokenizerBase):
         vocab = _adapt_tokenizer(tokenizer)
         return LazyVLLMRegexGuide(regex_string, vocab)
 
@@ -72,6 +66,7 @@ class RegexLogitsProcessor(BaseLogitsProcessor):
         super().__init__(
             RegexLogitsProcessor._get_guide(regex_string, tokenizer))
 
+
 def _adapt_tokenizer(tokenizer: PreTrainedTokenizerBase):
     """
     Adapt VLLM's tokenizer into a TokenVocabulary, readable by Rust.
@@ -80,30 +75,27 @@ def _adapt_tokenizer(tokenizer: PreTrainedTokenizerBase):
 
         return TOKENIZER_CACHE[tokenizer.name_or_path]
 
-    token_vocab = TokenVocabulary(
-        tokenizer.get_vocab(),
-        tokenizer.eos_token_id,
-        set(tokenizer.all_special_tokens)
-    )
+    token_vocab = TokenVocabulary(tokenizer.get_vocab(),
+                                  tokenizer.eos_token_id,
+                                  set(tokenizer.all_special_tokens))
 
     TOKENIZER_CACHE[tokenizer.name_or_path] = token_vocab
 
     return token_vocab
 
+
 def get_local_faster_outlines_guided_decoding_logits_processor(
-    guided_params: GuidedDecodingParams, 
-    tokenizer: PreTrainedTokenizerBase
+        guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizerBase
 ) -> Union[RegexLogitsProcessor, None]:
     regex = _get_regex(guided_params)
 
     if not regex:
         return None
-    
+
     return RegexLogitsProcessor(regex, tokenizer)
 
-def _get_regex(
-    guided_params: GuidedDecodingParams
-) -> Union[str, None]:
+
+def _get_regex(guided_params: GuidedDecodingParams) -> Union[str, None]:
     if guided_params.json:
         if isinstance(guided_params.json, dict):
             # turn dict into hashable string

--- a/vllm/model_executor/guided_decoding/faster_outlines_decoding.py
+++ b/vllm/model_executor/guided_decoding/faster_outlines_decoding.py
@@ -1,0 +1,123 @@
+import math
+import torch
+from re import escape as regex_escape
+from json import dumps as json_dumps
+from typing import Dict, List, Union
+
+from faster_outlines.fsm import (
+    LazyVLLMRegexGuide, 
+    Write,
+    Generate,
+    TokenVocabulary
+)
+from transformers import PreTrainedTokenizerBase
+from vllm.sampling_params import GuidedDecodingParams
+from outlines.fsm.json_schema import build_regex_from_schema
+
+TOKENIZER_CACHE: Dict[str, TokenVocabulary] = {}
+
+class BaseLogitsProcessor:
+
+    def __init__(self, guide):
+        self._guide = guide
+        self.state = 0
+    
+    def __call__(self, input_ids: List[int],
+                 scores: torch.Tensor) -> torch.Tensor:
+        """Use the FSM to bias the logits before sampling the next token."""
+        if len(input_ids) > 0:
+            self.state = self._guide.get_next_state(
+                state=self.state,
+                token_id=input_ids[-1]
+            )
+
+        instruction = self._guide.get_next_instruction(
+            state=self.state)
+        if type(instruction) == Generate:  # noqa: E721
+            allowed_tokens = instruction.tokens
+        elif type(instruction) == Write:  # noqa: E721
+            # TODO: support fast forward tokens
+            allowed_tokens = [instruction.tokens[0]]
+        else:
+            raise TypeError(
+                f"Unsupported instruction type {type(instruction)}")
+
+        mask = torch.full((scores.shape[-1], ),
+                          -math.inf,
+                          device=scores.device)
+        mask[allowed_tokens] = 0
+        scores.add_(mask)
+        return scores
+
+
+class RegexLogitsProcessor(BaseLogitsProcessor):
+
+    @classmethod
+    def _get_guide(cls, regex_string: str,
+                   tokenizer: PreTrainedTokenizerBase):
+        vocab = _adapt_tokenizer(tokenizer)
+        return LazyVLLMRegexGuide(regex_string, vocab)
+
+    def __init__(self, regex_string: str, tokenizer: PreTrainedTokenizerBase):
+        """Compile the FSM that drives the regex-structured generation.
+
+        Parameters
+        ----------
+        regex_string
+            A string that represents a regular expression
+        tokenizer
+            The model's tokenizer
+
+        """
+        super().__init__(
+            RegexLogitsProcessor._get_guide(regex_string, tokenizer))
+
+def _adapt_tokenizer(tokenizer: PreTrainedTokenizerBase):
+    """
+    Adapt VLLM's tokenizer into a TokenVocabulary, readable by Rust.
+    """
+    if TOKENIZER_CACHE.get(tokenizer.name_or_path) is not None:
+
+        return TOKENIZER_CACHE[tokenizer.name_or_path]
+
+    token_vocab = TokenVocabulary(
+        tokenizer.get_vocab(),
+        tokenizer.eos_token_id,
+        set(tokenizer.all_special_tokens)
+    )
+
+    TOKENIZER_CACHE[tokenizer.name_or_path] = token_vocab
+
+    return token_vocab
+
+def get_local_faster_outlines_guided_decoding_logits_processor(
+    guided_params: GuidedDecodingParams, 
+    tokenizer: PreTrainedTokenizerBase
+) -> Union[RegexLogitsProcessor, None]:
+    regex = _get_regex(guided_params)
+
+    if not regex:
+        return None
+    
+    return RegexLogitsProcessor(regex, tokenizer)
+
+def _get_regex(
+    guided_params: GuidedDecodingParams
+) -> Union[str, None]:
+    if guided_params.json:
+        if isinstance(guided_params.json, dict):
+            # turn dict into hashable string
+            json = build_regex_from_schema(json_dumps(guided_params.json))
+        else:
+            json = build_regex_from_schema(guided_params.json)
+        return json
+    elif guided_params.regex:
+        return guided_params.regex
+    elif guided_params.choice:
+        # choice just uses regex
+        choices = [
+            regex_escape(str(choice)) for choice in guided_params.choice
+        ]
+        choices_regex = "(" + "|".join(choices) + ")"
+        return choices_regex
+    return None


### PR DESCRIPTION
Adds support for [faster-outlines](https://github.com/unaidedelf8777/faster-outlines) as a guided decoding backend.

Hello all,

The last few months I have been [porting the algorithms of the outlines library to Rust](https://github.com/unaidedelf8777/faster-outlines), and making them significantly faster ( Note: I started this port long before the outlines team actually did it themselves ). The implementation is specifically tailored to high throughput inference setups, which cannot know the JSON schema/regex's ahead of time. 

One of the specific optimizations which I made in order to reduce TTFT is to make the index compilation parallel with the computation for model inference. Without getting into the nitty gritty of it, it follows a model where we allocate a shared memory block, then launch a thread to compute the tokenizer based FSM index, reporting back the results of each FSM state immediately once it is finished and notifying state status via Atomics. 

This parallel computation reduces the TTFT for nearly all requests to only slightly longer than it takes to compile the FSM based on the regex. 

In terms of VLLM implementation specifics, it parses the regex pattern, translate it to an FSM, and reduce that FSM inside of the server process. Then this FSM is serialized and sent over via pickle to the inference process, where the FSM is used to instantiate a `LazyFSMIndex` object, which is the core of the lazy / parallel computation of the index. On instantiation the `LazyFSMIndex` object launches the index compilation thread using the aforementioned method for sharing state, and then the objects initialization function returns immediately. This whole instantiation process takes less than a millisecond (of course, it could take more than that since it is launching threads, and thus is at the mercy of the OS). From this point on, the object acts as a normal `outlines` guide, implementing an identical guide API, and abstracting any state awaiting / special implementation logic away to Rust. In terms of state awaiting, it usually does not incur overhead, as states are normally computed by the time they are needed by the inference thread, and awaiting only consistently happens in the cases of state machines with 200+ states. The awaiting mechanism is also very fast, using atomics and `FUTEX` sys calls to wake all waiters when a state is ready.

In terms of caching, The implementation delegates this to Rust as well for performance. The cache stores FSM's based on the hashes of both the input regex pattern and the tokenizer to avoid issues. On the event of a cache hit, the object bypasses all state awaiting mechanisms and assumes that all states are computed in order to decrease the overhead of the object to as little as possible. 

The library has been thoroughly tested, and has a small tests in the Rust code, and a main smoke test for all functionality in the codebase, which has a list of regex patterns which need to be compiled and a tokenizer, and then randomly walks the allowed token id's of the FSM in order to try and break it. If at the end of the mock generation loop in the test the decoded token IDs do not match the regex pattern, it fails. For each regex pattern this test is performed 50 times to be absolutely sure of results, and the overall test fails if less than 100% match rate occurs.

Below is a comparison between faster-outlines's state machine compilation time and the time of `outlines-core` (the outlines team's Rust port)
![index compilation time comparison](https://raw.githubusercontent.com/unaidedelf8777/faster-outlines/refs/heads/main/assets/benchmark.png)

The benchmark code used to generate this graph can be [found in the repository](https://github.com/unaidedelf8777/faster-outlines-hidden/blob/main/bench/test_fsm_comp_time.py)
In this test the index object is forced to wait for the compilation of the index to finish before the timer stops and time is saved. 
For all tested regex's, faster-outlines registers at roughly 90% faster for all, with a peek speed up of 94%.
Below are benchmarks showing the TTFT improvements over outlines, and overall request time reduction for unseen regex patterns. All benchmarks performed with default inference settings and dtype, on an L40S.

The `Total` field in the graphs below represents the total time roundtrip for the request. 

**For llama-3.2-1b-Instruct**
![Llama 1b comparison](https://raw.githubusercontent.com/unaidedelf8777/faster-outlines/refs/heads/main/assets/vllm_bench_L1B_L40S.png)

**For llama-3-8b-Instruct**
![Llama 8b comparison](https://raw.githubusercontent.com/unaidedelf8777/faster-outlines/refs/heads/main/assets/vllm_bench_L38B_L40S.png)

The benchmark code used to make these two graphs is located in the repository as well at [this file](https://github.com/unaidedelf8777/faster-outlines/blob/main/bench/vllm_bench.py)

In terms of the integration as a `guided_decoding_backend`, the implementation is a single file, and is quite similar to the one implemented for outlines, just with unnecessary code stripped away and some changes to reduce overhead. 
