### PR TITLE
[Misc] Update benchmark to support image_url file or http

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -251,6 +251,19 @@ def sample_hf_requests(
                     "url": f"data:image/jpeg;base64,{image_base64}"
                 },
             }
+        elif "image" in data and isinstance(data["image"], str):
+            if (data["image"].startswith("http://") or \
+                data["image"].startswith("file://")):
+                image_url = data["image"]
+            else:
+                image_url = f"file://{data['image']}"
+
+            mm_content = {
+                "type": "image_url",
+                "image_url": {
+                    "url": image_url
+                },
+            }
         else:
             mm_content = None
 


### PR DESCRIPTION
For testing ShareGPT4V dataset in `benchmarks/benchmark_serving.py`, the part setting image_url was updated slightly.

Client Usage:
```
python3 benchmarks/benchmark_serving.py --backend openai-chat \
    --base-url http://127.0.0.1:8000/v1 \
    --endpoint /chat/completions \
    --model llava-hf/llava-v1.6-mistral-7b-hf \
    --dataset-path Lin-Chen/ShareGPT4V \
    --dataset-name hf --hf-subset ShareGPT4V \
    --hf-split train \
    --num-prompts=100
```