### PR TITLE
[Model] Add Support for Multimodal Granite Models

### DIFF
--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -468,11 +468,8 @@ class CLIPVisionTransformer(nn.Module):
 
         # Handle post-norm (if applicable) and stacks feature layers if needed
         encoder_outputs = resolve_visual_encoder_outputs(
-            encoder_outputs,
-            feature_sample_layers,
-            self.post_layernorm,
-            len(self.encoder.layers),
-        )
+            encoder_outputs, feature_sample_layers, self.post_layernorm,
+            self.config.num_hidden_layers)
 
         return encoder_outputs
 

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -396,11 +396,8 @@ class CLIPEncoder(nn.Module):
     def forward(self, inputs_embeds: torch.Tensor):
         hidden_states_pool = []
         hidden_states = inputs_embeds
-        # Initialize the hidden states to pool with the inputs if needed
-        if 0 in self.feature_sample_layers:
-            hidden_states_pool.append(hidden_states)
 
-        for layer_idx, encoder_layer in enumerate(self.layers, start=1):
+        for layer_idx, encoder_layer in enumerate(self.layers):
             hidden_states = encoder_layer(hidden_states)
             if layer_idx in self.feature_sample_layers:
                 hidden_states_pool.append(hidden_states)
@@ -471,7 +468,7 @@ class CLIPVisionTransformer(nn.Module):
             # Apply normalization if the last layer is one of the feature sample
             # layers; otherwise don't, since it's not stacked into the output
             if self.post_layernorm is not None and len(
-                    self.encoder.layers) in self.feature_sample_layers:
+                    self.encoder.layers) - 1 in self.feature_sample_layers:
                 hs_pool[-1] = self.post_layernorm(encoder_outputs)
             encoder_outputs = torch.cat(hs_pool, dim=-1)
 

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -368,11 +368,13 @@ class CLIPEncoder(nn.Module):
         config: CLIPConfig
     """
 
-    def __init__(self,
-                 config: CLIPVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 num_hidden_layers_override: Optional[int] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: CLIPVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        num_hidden_layers_override: Optional[int] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         self.config = config
@@ -381,7 +383,6 @@ class CLIPEncoder(nn.Module):
             num_hidden_layers = config.num_hidden_layers
         else:
             num_hidden_layers = num_hidden_layers_override
-
         self.layers = nn.ModuleList([
             CLIPEncoderLayer(config=config,
                              quant_config=quant_config,
@@ -408,13 +409,15 @@ class CLIPEncoder(nn.Module):
 
 class CLIPVisionTransformer(nn.Module):
 
-    def __init__(self,
-                 config: CLIPVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 *,
-                 num_hidden_layers_override: Optional[int] = None,
-                 require_post_norm: Optional[bool] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: CLIPVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        *,
+        num_hidden_layers_override: Optional[int] = None,
+        require_post_norm: Optional[bool] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         self.config = config
@@ -479,13 +482,15 @@ class CLIPVisionModel(nn.Module):
     config_class = CLIPVisionConfig
     main_input_name = "pixel_values"
 
-    def __init__(self,
-                 config: CLIPVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 *,
-                 num_hidden_layers_override: Optional[int] = None,
-                 require_post_norm: Optional[bool] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: CLIPVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        *,
+        num_hidden_layers_override: Optional[int] = None,
+        require_post_norm: Optional[bool] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         self.vision_model = CLIPVisionTransformer(
             config=config,
@@ -495,11 +500,11 @@ class CLIPVisionModel(nn.Module):
             prefix=f"{prefix}.vision_model")
 
     def forward(
-            self,
-            pixel_values: torch.Tensor,
-            feature_sample_layers: Optional[list[int]] = None) -> torch.Tensor:
-        return self.vision_model(pixel_values,
-                                 feature_sample_layers=feature_sample_layers)
+        self,
+        pixel_values: torch.Tensor,
+        feature_sample_layers: Optional[list[int]] = None,
+    ) -> torch.Tensor:
+        return self.vision_model(pixel_values, feature_sample_layers)
 
     @property
     def device(self):

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -433,7 +433,8 @@ class CLIPVisionTransformer(nn.Module):
             config=config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
-            prefix=f"{prefix}.encoder")
+            prefix=f"{prefix}.encoder",
+        )
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -207,6 +207,40 @@ class LlavaLikeConfig(Protocol):
     vision_feature_layer: int
 
 
+def _get_num_hidden_layers(hf_config: LlavaLikeConfig) -> int:
+    """Determine the number of hidden layers to initialize up to in the
+    visual encoder.
+    
+    Args:
+        hf_config: Model config with vision feature layer(s).
+    """
+    feature_layers = hf_config.vision_feature_layer
+    num_hidden_layers = hf_config.vision_config.num_hidden_layers
+    # If we have one feature layer, initialize up to that layer
+    if isinstance(feature_layers, int):
+        return _get_layer_index(feature_layers, num_hidden_layers)
+    # If we have multiple feature layers, initialize up to the deepest one
+    elif isinstance(feature_layers, (list, tuple)):
+        return max(
+            _get_layer_index(idx, num_hidden_layers) for idx in feature_layers)
+    raise TypeError(f"vision_layer_feature type: {type(feature_layers)}"
+                    " is not supported")
+
+
+def _get_layer_index(feature_layer_index: int, num_hidden_layers: int) -> int:
+    """Given an signed vision feature layer, get the number of hidden layers
+    needed to leverage it.
+
+    Args:
+        feature_layer_index: Index of a required layer in the visual encoder.
+        num_hidden_layers: The total number of hidden layers in the visual
+            encoder.
+    """
+    if feature_layer_index < 0:
+        num_hidden_layers = num_hidden_layers + feature_layer_index + 1
+    return feature_layer_index + 1
+
+
 def init_vision_tower_for_llava(
     hf_config: LlavaLikeConfig,
     quant_config: Optional[QuantizationConfig],
@@ -218,22 +252,15 @@ def init_vision_tower_for_llava(
 
     vision_feature_layer = hf_config.vision_feature_layer
 
-    # Initialize the vision tower only up to the required feature layer
+    # Initialize the vision tower only up to the deepest required feature layer
+    num_hidden_layers = _get_num_hidden_layers(hf_config)
+
     if isinstance(vision_feature_layer, int):
-        if vision_feature_layer < 0:
-            num_hidden_layers = hf_config.vision_config.num_hidden_layers \
-                + vision_feature_layer + 1
-        else:
-            num_hidden_layers = vision_feature_layer + 1
         feature_sample_layers = None
     elif isinstance(vision_feature_layer, (list, tuple)):
-        # If we have multiple feature layers, take the hidden layer count as is
-        # and convert the feature sample layers to unsigned ints for use in the
-        # encoder implementations
-        num_hidden_layers = hf_config.vision_config.num_hidden_layers
         feature_sample_layers = [
             layer_idx if layer_idx >= 0 else
-            hf_config.vision_config.num_hidden_layers + layer_idx - 1
+            hf_config.vision_config.num_hidden_layers + layer_idx
             for layer_idx in vision_feature_layer
         ]
     else:

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -237,7 +237,7 @@ def _get_layer_index(feature_layer_index: int, num_hidden_layers: int) -> int:
             encoder.
     """
     if feature_layer_index < 0:
-        num_hidden_layers = num_hidden_layers + feature_layer_index + 1
+        return num_hidden_layers + feature_layer_index + 1
     return feature_layer_index + 1
 
 
@@ -250,23 +250,8 @@ def init_vision_tower_for_llava(
 ):
     vision_config = hf_config.vision_config
 
-    vision_feature_layer = hf_config.vision_feature_layer
-
     # Initialize the vision tower only up to the deepest required feature layer
     num_hidden_layers = _get_num_hidden_layers(hf_config)
-
-    if isinstance(vision_feature_layer, int):
-        feature_sample_layers = None
-    elif isinstance(vision_feature_layer, (list, tuple)):
-        feature_sample_layers = [
-            layer_idx if layer_idx >= 0 else
-            hf_config.vision_config.num_hidden_layers + layer_idx
-            for layer_idx in vision_feature_layer
-        ]
-    else:
-        raise TypeError(
-            f"vision_layer_feature type: {type(vision_feature_layer)}"
-            " is not supported")
 
     if isinstance(vision_config, CLIPVisionConfig):
         return CLIPVisionModel(
@@ -275,7 +260,6 @@ def init_vision_tower_for_llava(
             num_hidden_layers_override=num_hidden_layers,
             require_post_norm=require_post_norm,
             prefix=prefix,
-            feature_sample_layers=feature_sample_layers,
         )
     elif isinstance(vision_config, SiglipVisionConfig):
         return SiglipVisionModel(
@@ -284,7 +268,6 @@ def init_vision_tower_for_llava(
             num_hidden_layers_override=num_hidden_layers,
             require_post_norm=require_post_norm,
             prefix=prefix,
-            feature_sample_layers=feature_sample_layers,
         )
     elif isinstance(vision_config, PixtralVisionConfig):
         return PixtralHFVisionModel(
@@ -293,7 +276,6 @@ def init_vision_tower_for_llava(
             num_hidden_layers_override=num_hidden_layers,
             require_post_norm=require_post_norm,
             prefix=prefix,
-            feature_sample_layers=feature_sample_layers,
         )
 
     msg = f"Unsupported vision config: {type(vision_config)}"

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -204,7 +204,7 @@ def input_processor_for_llava(ctx: InputContext, inputs: DecoderOnlyInputs):
 
 class LlavaLikeConfig(Protocol):
     vision_config: PretrainedConfig
-    vision_feature_layer: Union[int, List]
+    vision_feature_layer: Union[int, List[int]]
 
 
 def _get_num_hidden_layers(hf_config: LlavaLikeConfig) -> int:

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -204,7 +204,7 @@ def input_processor_for_llava(ctx: InputContext, inputs: DecoderOnlyInputs):
 
 class LlavaLikeConfig(Protocol):
     vision_config: PretrainedConfig
-    vision_feature_layer: int
+    vision_feature_layer: Union[int, List]
 
 
 def _get_num_hidden_layers(hf_config: LlavaLikeConfig) -> int:

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -232,9 +232,8 @@ def init_vision_tower_for_llava(
         # encoder implementations
         num_hidden_layers = hf_config.vision_config.num_hidden_layers
         feature_sample_layers = [
-            layer_idx
-            if layer_idx >= 0
-            else hf_config.vision_config.num_hidden_layers + layer_idx - 1
+            layer_idx if layer_idx >= 0 else
+            hf_config.vision_config.num_hidden_layers + layer_idx - 1
             for layer_idx in vision_feature_layer
         ]
     else:

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -292,10 +292,12 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal,
         # Determine the layer up to which we will initialize the vision tower
         if isinstance(vision_feature_layer, int):
             vision_hidden_size = config.vision_config.hidden_size
+            self.feature_sample_layers = None
         # Used for multimodal granite models to control encoder outputs
         elif isinstance(vision_feature_layer, (list, tuple)):
             vision_hidden_size = config.vision_config.hidden_size * len(
                 vision_feature_layer)
+            self.feature_sample_layers = vision_feature_layer
         else:
             raise TypeError(
                 f"vision_layer_feature type: {type(vision_feature_layer)}"
@@ -432,7 +434,8 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal,
 
         # NOTE: we skip the step to select the vision feature layer since
         # this is already done inside the vision tower
-        image_features = vision_tower(pixel_values)
+        image_features = vision_tower(
+            pixel_values, feature_sample_layers=self.feature_sample_layers)
 
         return self._select_image_features(
             image_features,

--- a/vllm/model_executor/models/llava_next.py
+++ b/vllm/model_executor/models/llava_next.py
@@ -288,6 +288,19 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal,
         pooler_config = vllm_config.model_config.pooler_config
         multimodal_config = vllm_config.model_config.multimodal_config
 
+        vision_feature_layer = config.vision_feature_layer
+        # Determine the layer up to which we will initialize the vision tower
+        if isinstance(vision_feature_layer, int):
+            vision_hidden_size = config.vision_config.hidden_size
+        # Used for multimodal granite models to control encoder outputs
+        elif isinstance(vision_feature_layer, (list, tuple)):
+            vision_hidden_size = config.vision_config.hidden_size * len(
+                vision_feature_layer)
+        else:
+            raise TypeError(
+                f"vision_layer_feature type: {type(vision_feature_layer)}"
+                " is not supported")
+
         self.config = config
         self.multimodal_config = multimodal_config
 
@@ -300,7 +313,7 @@ class LlavaNextForConditionalGeneration(nn.Module, SupportsMultiModal,
         self.image_newline = nn.Parameter(
             torch.empty(config.text_config.hidden_size))
         self.multi_modal_projector = LlavaMultiModalProjector(
-            vision_hidden_size=config.vision_config.hidden_size,
+            vision_hidden_size=vision_hidden_size,
             text_hidden_size=config.text_config.hidden_size,
             projector_hidden_act=config.projector_hidden_act)
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -1085,15 +1085,10 @@ class PixtralHFVisionModel(nn.Module):
             patch_embeds,
             attention_mask,
             position_embedding,
-            return_all_hidden_states=return_all_hidden_states,
-        )
+            return_all_hidden_states=return_all_hidden_states)
 
-        out = resolve_visual_encoder_outputs(
-            out,
-            feature_sample_layers,
-            None,
-            len(self.transformer.layers),
-        )
+        out = resolve_visual_encoder_outputs(out, feature_sample_layers, None,
+                                             self.config.num_hidden_layers)
 
         return out
 

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -977,14 +977,11 @@ class PixtralHFTransformer(nn.Module):
         position_embeddings: torch.Tensor,
     ) -> torch.Tensor:
         hidden_states_pool = []
-        # Initialize the hidden states to pool with the inputs if needed
-        if 0 in self.feature_sample_layers:
-            hidden_states_pool.append(x)
 
         # Process the encoder layers, and save hidden states that are
-        # feature_sample_layers; post-norm will by applied later if it's
-        # enabled for the last block.
-        for layer_idx, layer in enumerate(self.layers, start=1):
+        # feature_sample_layers. Pixtral does not have post-norm, so we
+        # do not worry about it here.
+        for layer_idx, layer in enumerate(self.layers):
             x = layer(x, attention_mask, position_embeddings)
             if layer_idx in self.feature_sample_layers:
                 hidden_states_pool.append(x)

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -25,7 +25,8 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal.utils import (cached_get_tokenizer,
                                    consecutive_placeholder_ranges,
-                                   repeat_and_pad_placeholder_tokens)
+                                   repeat_and_pad_placeholder_tokens,
+                                   resolve_visual_encoder_outputs)
 from vllm.sequence import SequenceData
 
 from .utils import get_vit_attn_backend
@@ -428,15 +429,10 @@ class SiglipEncoder(nn.Module):
                  config: SiglipVisionConfig,
                  quant_config: Optional[QuantizationConfig] = None,
                  num_hidden_layers_override: Optional[int] = None,
-                 prefix: str = "",
-                 feature_sample_layers: Optional[list] = None) -> None:
+                 prefix: str = "") -> None:
         super().__init__()
 
         self.config = config
-
-        # Feature sample layers need to be indices from 0 ->  # encoder layers
-        self.feature_sample_layers = (
-            feature_sample_layers if feature_sample_layers is not None else [])
 
         if num_hidden_layers_override is None:
             num_hidden_layers = config.num_hidden_layers
@@ -453,19 +449,20 @@ class SiglipEncoder(nn.Module):
     def forward(
         self,
         inputs_embeds: torch.Tensor,
-    ) -> torch.Tensor:
+        return_all_hidden_states: bool,
+    ) -> Union[torch.Tensor, list[torch.Tensor]]:
         hidden_states_pool = []
         hidden_states = inputs_embeds
 
-        # Process the encoder layers, and save hidden states that are
-        # feature_sample_layers; post-norm will by applied later if it's
-        # enabled for the last block.
-        for layer_idx, encoder_layer in enumerate(self.layers):
+        for encoder_layer in self.layers:
             hidden_states, _ = encoder_layer(hidden_states)
-            if layer_idx in self.feature_sample_layers:
+            if return_all_hidden_states:
                 hidden_states_pool.append(hidden_states)
-
-        return hidden_states, hidden_states_pool
+        # If we have multiple feature sample layers, we return all hidden
+        # states in order and grab the ones we need by index.
+        if return_all_hidden_states:
+            return hidden_states_pool
+        return hidden_states
 
 
 class SiglipMultiheadAttentionPoolingHead(nn.Module):
@@ -510,23 +507,19 @@ class SiglipVisionTransformer(nn.Module):
                  *,
                  num_hidden_layers_override: Optional[int] = None,
                  require_post_norm: Optional[bool] = None,
-                 prefix: str = "",
-                 feature_sample_layers: Optional[list] = None) -> None:
+                 prefix: str = "") -> None:
         super().__init__()
 
         self.config = config
         embed_dim = config.hidden_size
 
         self.embeddings = SiglipVisionEmbeddings(config)
-        self.feature_sample_layers = (
-            feature_sample_layers if feature_sample_layers is not None else [])
 
         self.encoder = SiglipEncoder(
             config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
-            prefix=f"{prefix}.encoder",
-            feature_sample_layers=self.feature_sample_layers)
+            prefix=f"{prefix}.encoder")
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:
@@ -558,24 +551,30 @@ class SiglipVisionTransformer(nn.Module):
         self,
         pixel_values: torch.Tensor,
         interpolate_pos_encoding: bool = True,
+        feature_sample_layers: Optional[list[int]] = None,
     ) -> torch.Tensor:
+
         hidden_states = self.embeddings(
             pixel_values,
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
-        encoder_outputs, hs_pool = self.encoder(inputs_embeds=hidden_states)
+        return_all_hidden_states = feature_sample_layers is not None
 
-        if self.feature_sample_layers and self.post_layernorm is not None:
-            encoder_outputs = self.post_layernorm(encoder_outputs)
+        # Produces either the last layer output or all of the hidden states,
+        # depending on if we have feature_sample_layers or not
+        encoder_outputs = self.encoder(
+            inputs_embeds=hidden_states,
+            return_all_hidden_states=return_all_hidden_states,
+        )
 
-        elif self.feature_sample_layers:
-            # Apply normalization if the last layer is one of the feature sample
-            # layers; otherwise don't, since it's not stacked into the output
-            if self.post_layernorm is not None and len(
-                    self.encoder.layers) - 1 in self.feature_sample_layers:
-                hs_pool[-1] = self.post_layernorm(encoder_outputs)
-            encoder_outputs = torch.cat(hs_pool, dim=-1)
+        # Handle post-norm (if applicable) and stacks feature layers if needed
+        encoder_outputs = resolve_visual_encoder_outputs(
+            encoder_outputs,
+            feature_sample_layers,
+            self.post_layernorm,
+            len(self.encoder.layers),
+        )
 
         # TODO: add this back when pooled_output is used in inference.
         # if self.use_head:
@@ -594,8 +593,7 @@ class SiglipVisionModel(nn.Module):
                  *,
                  num_hidden_layers_override: Optional[int] = None,
                  require_post_norm: Optional[bool] = None,
-                 prefix: str = "",
-                 feature_sample_layers: Optional[list] = None) -> None:
+                 prefix: str = "") -> None:
         super().__init__()
 
         self.vision_model = SiglipVisionTransformer(
@@ -603,8 +601,7 @@ class SiglipVisionModel(nn.Module):
             quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
             require_post_norm=require_post_norm,
-            prefix=f"{prefix}.vision_model",
-            feature_sample_layers=feature_sample_layers)
+            prefix=f"{prefix}.vision_model")
 
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding
@@ -613,10 +610,12 @@ class SiglipVisionModel(nn.Module):
         self,
         pixel_values: torch.Tensor,
         interpolate_pos_encoding: bool = False,
+        feature_sample_layers: Optional[list[int]] = None,
     ) -> torch.Tensor:
         return self.vision_model(
             pixel_values=pixel_values,
             interpolate_pos_encoding=interpolate_pos_encoding,
+            feature_sample_layers=feature_sample_layers,
         )
 
     def load_weights(self, weights: Iterable[Tuple[str,

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -456,14 +456,11 @@ class SiglipEncoder(nn.Module):
     ) -> torch.Tensor:
         hidden_states_pool = []
         hidden_states = inputs_embeds
-        # Initialize the hidden states to pool with the inputs if needed
-        if 0 in self.feature_sample_layers:
-            hidden_states_pool.append(hidden_states)
 
         # Process the encoder layers, and save hidden states that are
         # feature_sample_layers; post-norm will by applied later if it's
         # enabled for the last block.
-        for layer_idx, encoder_layer in enumerate(self.layers, start=1):
+        for layer_idx, encoder_layer in enumerate(self.layers):
             hidden_states, _ = encoder_layer(hidden_states)
             if layer_idx in self.feature_sample_layers:
                 hidden_states_pool.append(hidden_states)
@@ -576,7 +573,7 @@ class SiglipVisionTransformer(nn.Module):
             # Apply normalization if the last layer is one of the feature sample
             # layers; otherwise don't, since it's not stacked into the output
             if self.post_layernorm is not None and len(
-                    self.encoder.layers) in self.feature_sample_layers:
+                    self.encoder.layers) - 1 in self.feature_sample_layers:
                 hs_pool[-1] = self.post_layernorm(encoder_outputs)
             encoder_outputs = torch.cat(hs_pool, dim=-1)
 

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -424,16 +424,19 @@ class SiglipEncoderLayer(nn.Module):
 
 class SiglipEncoder(nn.Module):
 
-    def __init__(
-        self,
-        config: SiglipVisionConfig,
-        quant_config: Optional[QuantizationConfig] = None,
-        num_hidden_layers_override: Optional[int] = None,
-        prefix: str = "",
-    ) -> None:
+    def __init__(self,
+                 config: SiglipVisionConfig,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 num_hidden_layers_override: Optional[int] = None,
+                 prefix: str = "",
+                 feature_sample_layers: Optional[list] = None) -> None:
         super().__init__()
 
         self.config = config
+
+        # Feature sample layers need to be indices from 0 ->  # encoder layers
+        self.feature_sample_layers = (
+            feature_sample_layers if feature_sample_layers is not None else [])
 
         if num_hidden_layers_override is None:
             num_hidden_layers = config.num_hidden_layers
@@ -451,11 +454,21 @@ class SiglipEncoder(nn.Module):
         self,
         inputs_embeds: torch.Tensor,
     ) -> torch.Tensor:
+        hidden_states_pool = []
         hidden_states = inputs_embeds
-        for encoder_layer in self.layers:
-            hidden_states, _ = encoder_layer(hidden_states)
+        # Initialize the hidden states to pool with the inputs if needed
+        if 0 in self.feature_sample_layers:
+            hidden_states_pool.append(hidden_states)
 
-        return hidden_states
+        # Process the encoder layers, and save hidden states that are
+        # feature_sample_layers; post-norm will by applied later if it's
+        # enabled for the last block.
+        for layer_idx, encoder_layer in enumerate(self.layers, start=1):
+            hidden_states, _ = encoder_layer(hidden_states)
+            if layer_idx in self.feature_sample_layers:
+                hidden_states_pool.append(hidden_states)
+
+        return hidden_states, hidden_states_pool
 
 
 class SiglipMultiheadAttentionPoolingHead(nn.Module):
@@ -494,27 +507,29 @@ class SiglipMultiheadAttentionPoolingHead(nn.Module):
 
 class SiglipVisionTransformer(nn.Module):
 
-    def __init__(
-        self,
-        config: SiglipVisionConfig,
-        quant_config: Optional[QuantizationConfig] = None,
-        *,
-        num_hidden_layers_override: Optional[int] = None,
-        require_post_norm: Optional[bool] = None,
-        prefix: str = "",
-    ) -> None:
+    def __init__(self,
+                 config: SiglipVisionConfig,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 *,
+                 num_hidden_layers_override: Optional[int] = None,
+                 require_post_norm: Optional[bool] = None,
+                 prefix: str = "",
+                 feature_sample_layers: Optional[list] = None) -> None:
         super().__init__()
 
         self.config = config
         embed_dim = config.hidden_size
 
         self.embeddings = SiglipVisionEmbeddings(config)
+        self.feature_sample_layers = (
+            feature_sample_layers if feature_sample_layers is not None else [])
+
         self.encoder = SiglipEncoder(
             config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
             prefix=f"{prefix}.encoder",
-        )
+            feature_sample_layers=self.feature_sample_layers)
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:
@@ -552,32 +567,38 @@ class SiglipVisionTransformer(nn.Module):
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
 
-        encoder_outputs = self.encoder(inputs_embeds=hidden_states)
+        encoder_outputs, hs_pool = self.encoder(inputs_embeds=hidden_states)
 
-        if self.post_layernorm is None:
-            return encoder_outputs
+        if self.feature_sample_layers and self.post_layernorm is not None:
+            encoder_outputs = self.post_layernorm(encoder_outputs)
 
-        last_hidden_state = self.post_layernorm(encoder_outputs)
-        # TODO: add this back when pooled_output is used in inference
+        elif self.feature_sample_layers:
+            # Apply normalization if the last layer is one of the feature sample
+            # layers; otherwise don't, since it's not stacked into the output
+            if self.post_layernorm is not None and len(
+                    self.encoder.layers) in self.feature_sample_layers:
+                hs_pool[-1] = self.post_layernorm(encoder_outputs)
+            encoder_outputs = torch.cat(hs_pool, dim=-1)
+
+        # TODO: add this back when pooled_output is used in inference.
         # if self.use_head:
-        # pooled_output = self.head(last_hidden_state)
+        # pooled_output = self.head(encoder_outputs)
 
-        return last_hidden_state
+        return encoder_outputs
 
 
 class SiglipVisionModel(nn.Module):
     config_class = SiglipVisionConfig
     main_input_name = "pixel_values"
 
-    def __init__(
-        self,
-        config: SiglipVisionConfig,
-        quant_config: Optional[QuantizationConfig] = None,
-        *,
-        num_hidden_layers_override: Optional[int] = None,
-        require_post_norm: Optional[bool] = None,
-        prefix: str = "",
-    ) -> None:
+    def __init__(self,
+                 config: SiglipVisionConfig,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 *,
+                 num_hidden_layers_override: Optional[int] = None,
+                 require_post_norm: Optional[bool] = None,
+                 prefix: str = "",
+                 feature_sample_layers: Optional[list] = None) -> None:
         super().__init__()
 
         self.vision_model = SiglipVisionTransformer(
@@ -586,7 +607,7 @@ class SiglipVisionModel(nn.Module):
             num_hidden_layers_override=num_hidden_layers_override,
             require_post_norm=require_post_norm,
             prefix=f"{prefix}.vision_model",
-        )
+            feature_sample_layers=feature_sample_layers)
 
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -425,11 +425,13 @@ class SiglipEncoderLayer(nn.Module):
 
 class SiglipEncoder(nn.Module):
 
-    def __init__(self,
-                 config: SiglipVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 num_hidden_layers_override: Optional[int] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: SiglipVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        num_hidden_layers_override: Optional[int] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         self.config = config
@@ -501,13 +503,15 @@ class SiglipMultiheadAttentionPoolingHead(nn.Module):
 
 class SiglipVisionTransformer(nn.Module):
 
-    def __init__(self,
-                 config: SiglipVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 *,
-                 num_hidden_layers_override: Optional[int] = None,
-                 require_post_norm: Optional[bool] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: SiglipVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        *,
+        num_hidden_layers_override: Optional[int] = None,
+        require_post_norm: Optional[bool] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         self.config = config
@@ -519,7 +523,8 @@ class SiglipVisionTransformer(nn.Module):
             config,
             quant_config=quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
-            prefix=f"{prefix}.encoder")
+            prefix=f"{prefix}.encoder",
+        )
 
         num_hidden_layers = config.num_hidden_layers
         if len(self.encoder.layers) > config.num_hidden_layers:
@@ -584,13 +589,15 @@ class SiglipVisionModel(nn.Module):
     config_class = SiglipVisionConfig
     main_input_name = "pixel_values"
 
-    def __init__(self,
-                 config: SiglipVisionConfig,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 *,
-                 num_hidden_layers_override: Optional[int] = None,
-                 require_post_norm: Optional[bool] = None,
-                 prefix: str = "") -> None:
+    def __init__(
+        self,
+        config: SiglipVisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        *,
+        num_hidden_layers_override: Optional[int] = None,
+        require_post_norm: Optional[bool] = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
 
         self.vision_model = SiglipVisionTransformer(
@@ -598,7 +605,8 @@ class SiglipVisionModel(nn.Module):
             quant_config,
             num_hidden_layers_override=num_hidden_layers_override,
             require_post_norm=require_post_norm,
-            prefix=f"{prefix}.vision_model")
+            prefix=f"{prefix}.vision_model",
+        )
 
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -570,11 +570,8 @@ class SiglipVisionTransformer(nn.Module):
 
         # Handle post-norm (if applicable) and stacks feature layers if needed
         encoder_outputs = resolve_visual_encoder_outputs(
-            encoder_outputs,
-            feature_sample_layers,
-            self.post_layernorm,
-            len(self.encoder.layers),
-        )
+            encoder_outputs, feature_sample_layers, self.post_layernorm,
+            self.config.num_hidden_layers)
 
         # TODO: add this back when pooled_output is used in inference.
         # if self.use_head:

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -427,8 +427,7 @@ def resolve_visual_encoder_outputs(
     ]
 
     # Apply post-norm on the final hidden state if we are using it
-    uses_last_layer = ((len(hs_pool) - 1) in feature_sample_layers
-                       or -1 in feature_sample_layers)
+    uses_last_layer = feature_sample_layers[-1] in (len(hs_pool) - 1, -1)
     if post_layer_norm is not None and uses_last_layer:
         hs_pool[-1] = post_layer_norm(encoder_outputs)
     return torch.cat(hs_pool, dim=-1)

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -420,8 +420,8 @@ def resolve_visual_encoder_outputs(
     # Negative values are relative to the full visual encoder,
     # so offset them depending on how many layers were loaded.
     # NOTE: this assumes that encoder_outputs contains a list
-    # of hidden states in the same order in the same order as the
-    # encoder layers that produced them.
+    # of hidden states in the same order as the encoder layers
+    # that produced them.
     offset = max_possible_layers - len(encoder_outputs)
     hs_pool = [
         encoder_outputs[layer_idx]

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -419,6 +419,9 @@ def resolve_visual_encoder_outputs(
     # Get the hidden states corresponding to the layer indices.
     # Negative values are relative to the full visual encoder,
     # so offset them depending on how many layers were loaded.
+    # NOTE: this assumes that encoder_outputs contains a list
+    # of hidden states in the same order in the same order as the
+    # encoder layers that produced them.
     offset = max_possible_layers - len(encoder_outputs)
     hs_pool = [
         encoder_outputs[layer_idx]


### PR DESCRIPTION
This PR adds the main architectural change needed to support upcoming multimodal granite models from IBM, which are a variant of llava-next. To this end, we need to allow passing a list of `feature_sample_layers`, which are indices in the visual encoder whose hidden states will be concatenated and used as the visual encoder output as an alternative to the last layer. This change should not affect any existing llava next models, and is made in all of the supported visual encoders for Llava-based models in vLLM (clip/siglip/pixtral) to keep things as generic as possible.

These models have not been released quite yet, and we have not yet ported the change to transformers, which is why there are no new tests added. However, I have run my own benchmarks to ensure the results in vLLM are identical in quality to our own implementation, and verified that the `feature_sample_layers` can be passed through each supported visual encoder type as a sanity check. Once the models are out and supported in `transformers`, I can add it to the corresponding test here!

FYI @njhill

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


