### PR TITLE
[Feature] enable host memory for kv cache

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -733,6 +733,7 @@ class CacheConfig:
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
         cpu_offload_gb: float = 0,
+        enable_host_memory_caching: bool = False
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -743,6 +744,7 @@ class CacheConfig:
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
         self.cpu_offload_gb = cpu_offload_gb
+        self.enable_host_memory_caching = enable_host_memory_caching
 
         self._verify_args()
         self._verify_cache_dtype()

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -189,6 +189,16 @@ class BlockAllocator(ABC):
         """Prefix cache hit rate. -1 means not supported or disabled."""
         pass
 
+    @abstractmethod
+    def get_block_ref_count(self, block: Block) -> int:
+        '''Get reference count of block.'''
+        pass
+
+    @abstractmethod
+    def get_block_last_access_time(self, block: Block) -> float:
+        '''Get last access time of block.'''
+        pass
+
     class NoFreeBlocksError(ValueError):
         pass
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -329,6 +329,12 @@ class NaiveBlockAllocator(BlockAllocator):
     def get_prefix_cache_hit_rate(self) -> float:
         return -1
 
+    def get_block_ref_count(self, block: Block) -> int:
+        return self._refcounter.get(block.block_id)
+
+    def get_block_last_access_time(self, block: Block) -> float:
+        return -1
+
 
 class NaiveBlock(Block):
     """An implementation of the Block class that does not support prefix

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -334,7 +334,9 @@ class Scheduler:
             num_gpu_blocks=num_gpu_blocks,
             num_cpu_blocks=num_cpu_blocks,
             sliding_window=self.cache_config.sliding_window,
-            enable_caching=self.cache_config.enable_prefix_caching)
+            enable_caching=self.cache_config.enable_prefix_caching,
+            enable_host_memory_caching=self.cache_config.enable_host_memory_caching
+        )
 
         # Sequence groups in the WAITING state.
         # Contain new prefill or preempted requests.
@@ -1223,6 +1225,12 @@ class Scheduler:
             common_computed_block_nums = []
 
         allow_async_output_proc: bool = self.use_async_output_proc
+
+        if len(scheduler_outputs.scheduled_seq_groups) != 0:
+            blocks_to_swap_out, blocks_to_swap_in = \
+                self.block_manager.get_and_reset_swaps()
+            scheduler_outputs.blocks_to_swap_out.extend(blocks_to_swap_out)
+            scheduler_outputs.blocks_to_swap_in.extend(blocks_to_swap_in)
 
         # Create input data structures.
         seq_group_metadata_list: List[SequenceGroupMetadata] = []

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -115,6 +115,7 @@ class EngineArgs:
     # smaller sizes still work, but very inefficiently
     block_size: int = 16 if not current_platform.is_hpu() else 128
     enable_prefix_caching: bool = False
+    enable_host_memory_caching: bool = False
     disable_sliding_window: bool = False
     use_v2_block_manager: bool = True
     swap_space: float = 4  # GiB
@@ -415,6 +416,9 @@ class EngineArgs:
         parser.add_argument('--enable-prefix-caching',
                             action='store_true',
                             help='Enables automatic prefix caching.')
+        parser.add_argument('--enable-host-memory-caching',
+                            action='store_true',
+                            help='Enables host memory for prefix kv caching.')
         parser.add_argument('--disable-sliding-window',
                             action='store_true',
                             help='Disables sliding window, '
@@ -1031,6 +1035,7 @@ class EngineArgs:
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
+            enable_host_memory_caching=self.enable_host_memory_caching,
             cpu_offload_gb=self.cpu_offload_gb,
         )
         parallel_config = ParallelConfig(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -261,6 +261,7 @@ class LLMEngine:
             "seed=%d, served_model_name=%s, "
             "num_scheduler_steps=%d, chunked_prefill_enabled=%s "
             "multi_step_stream_outputs=%s, enable_prefix_caching=%s, "
+            "enable_host_memory_caching=%s, "
             "use_async_output_proc=%s, use_cached_outputs=%s, "
             "chat_template_text_format=%s, mm_processor_kwargs=%s, "
             "pooler_config=%r)",
@@ -294,6 +295,7 @@ class LLMEngine:
             scheduler_config.chunked_prefill_enabled,
             scheduler_config.multi_step_stream_outputs,
             cache_config.enable_prefix_caching,
+            cache_config.enable_host_memory_caching,
             model_config.use_async_output_proc,
             use_cached_outputs,
             model_config.chat_template_text_format,
@@ -380,6 +382,8 @@ class LLMEngine:
                     bool(prompt_adapter_config),
                     "enable_prefix_caching":
                     cache_config.enable_prefix_caching,
+                    "enable_host_memory_caching":
+                    cache_config.enable_host_memory_caching,
                     "enforce_eager":
                     model_config.enforce_eager,
                     "disable_custom_all_reduce":


### PR DESCRIPTION
# Optimal conditions for this feature:
1. The token count of your prompt significantly exceeds that of the generated output.
2. The commonly used prompt prefix length is substantial, leading to a high cache hit rate.
3. Your machine's GPU memory is insufficient to accommodate enough prefix key-value caches, resulting in a reduced cache hit rate.

# Main idea
In the scenario described above, offloading key-value caches to host memory could be advantageous. The implementation is straightforward: we already have CPU blocks within the block manager, although they are currently designed exclusively for sequence preemption. Since CPU and GPU blocks share the same underlying block structure, we can store computed key-value cache blocks within CPU blocks.

With this approach, each time a GPU block is freed, we add it to the CPU allocator via swapping. When allocating immutable blocks, we first search the GPU allocator. If a GPU cache hit occurs, we proceed with the cached GPU block as usual. If no hit is found, we additionally check the CPU allocator, and in the event of a CPU cache hit, we swap the CPU block back to the GPU.

Originally, the block allocation logic without preemption:

![image](https://github.com/user-attachments/assets/75ea9802-fed0-4ac0-9665-403225ab3c26)

Now we utilize the CPU blocks:

![image](https://github.com/user-attachments/assets/5aa0f1c1-4253-4288-b727-39312103e2e6)

Note that the computed blocks in the CPU allocator are stored only in the evictor, and this change will not impact the original preemption logic.

# Usage
Launch the vllm engine with
```bash
--enable-prefix-caching --enable-host-memory-caching --swap-space 48
```
in which --swap-space configures the host memory for both kv cache and preemption.

# Shortages
If host memory for the KV cache is enabled, each GPU block added to the evictor will be swapped to host memory, potentially leading to a performance drop. Therefore, ensure that enabling the host memory KV cache will significantly improve your cache hit rate. In our case (4090*1), if the cache hit rate is below 20%, enabling this feature will result in a performance degradation.

I’ve marked this PR as a draft because I’m uncertain whether it will be useful for the main users. Please provide feedback if you think it is beneficial, and I look forward to hearing your thoughts.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


