### PR TITLE
[Misc] Change RedundantReshapesPass and FusionPass logging from info to debug

### DIFF
--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -281,11 +281,11 @@ class FusionPass(InductorPass):
         self.dump_graph(graph, "before_fusion")
 
         count = self.patterns.apply(graph)
-        logger.info("Replaced %s patterns", count)
+        logger.debug("Replaced %s patterns", count)
         self.dump_graph(graph, "after_pattern_match")
 
         # Manually process multi-output matches (and run DCE)
         self.process_matches(graph)
-        logger.info("Post-processed %s matches", len(self.matches))
+        logger.debug("Post-processed %s matches", len(self.matches))
         self.dump_graph(graph, "after_fusion")
         self.matches.clear()

--- a/vllm/compilation/reshapes.py
+++ b/vllm/compilation/reshapes.py
@@ -53,7 +53,7 @@ class RedundantReshapesPass(InductorPass):
                     graph.erase_node(node)
                     count += 1
 
-        logger.info("Removed %s no-op reshapes", count)
+        logger.debug("Removed %s no-op reshapes", count)
 
         self.dump_graph(graph, "after_reshapes")
 


### PR DESCRIPTION
This log message is a little spammy -- looks like it prints out roughly once per layer per TP rank, so downgrading it to debug instead of info.

Log looks like this:
```
(VllmWorkerProcess pid=3178170) INFO 11-13 16:44:35 reshapes.py:56] Removed 0 no-op reshapes
(VllmWorkerProcess pid=3178171) INFO 11-13 16:44:35 reshapes.py:56] Removed 0 no-op reshapes
(VllmWorkerProcess pid=3178171) INFO 11-13 16:44:39 reshapes.py:56] Removed 0 no-op reshapes
...
(VllmWorkerProcess pid=3178170) INFO 11-13 16:45:21 reshapes.py:56] Removed 0 no-op reshapes
(VllmWorkerProcess pid=3178171) INFO 11-13 16:45:22 reshapes.py:56] Removed 0 no-op reshapes
(VllmWorkerProcess pid=3178170) INFO 11-13 16:45:22 reshapes.py:56] Removed 0 no-op reshapes
```