### PR TITLE
[Feature] enable host memory for kv cache

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -733,6 +733,7 @@ class CacheConfig:
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
         cpu_offload_gb: float = 0,
+        enable_host_memory_caching: bool = False
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -743,6 +744,7 @@ class CacheConfig:
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
         self.cpu_offload_gb = cpu_offload_gb
+        self.enable_host_memory_caching = enable_host_memory_caching
 
         self._verify_args()
         self._verify_cache_dtype()

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -722,19 +722,17 @@ class CacheConfig:
             profiled num_gpu_blocks if specified. Does nothing if None.
     """
 
-    def __init__(
-        self,
-        block_size: int,
-        gpu_memory_utilization: float,
-        swap_space: float,
-        cache_dtype: str,
-        is_attention_free: bool = False,
-        num_gpu_blocks_override: Optional[int] = None,
-        sliding_window: Optional[int] = None,
-        enable_prefix_caching: bool = False,
-        cpu_offload_gb: float = 0,
-        enable_host_memory_caching: bool = False
-    ) -> None:
+    def __init__(self,
+                 block_size: int,
+                 gpu_memory_utilization: float,
+                 swap_space: float,
+                 cache_dtype: str,
+                 is_attention_free: bool = False,
+                 num_gpu_blocks_override: Optional[int] = None,
+                 sliding_window: Optional[int] = None,
+                 enable_prefix_caching: bool = False,
+                 cpu_offload_gb: float = 0,
+                 enable_host_memory_caching: bool = False) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
         self.swap_space_bytes = swap_space * GiB_bytes

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -21,13 +21,9 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
     """
 
     @staticmethod
-    def create(
-        allocator_type: str,
-        num_gpu_blocks: int,
-        num_cpu_blocks: int,
-        block_size: int,
-        enable_host_memory_caching: bool
-    ) -> DeviceAwareBlockAllocator:
+    def create(allocator_type: str, num_gpu_blocks: int, num_cpu_blocks: int,
+               block_size: int,
+               enable_host_memory_caching: bool) -> DeviceAwareBlockAllocator:
         """Creates a CpuGpuBlockAllocator instance with the specified
         configuration.
 
@@ -97,8 +93,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return CpuGpuBlockAllocator(
             cpu_block_allocator=cpu_allocator,
             gpu_block_allocator=gpu_allocator,
-            enable_host_memory_caching=enable_host_memory_caching
-        )
+            enable_host_memory_caching=enable_host_memory_caching)
 
     def __init__(self, cpu_block_allocator: BlockAllocator,
                  gpu_block_allocator: BlockAllocator,
@@ -165,9 +160,8 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         allow_swap = self._enable_host_memory_caching and device == Device.GPU
         current_swap_mapping: Dict[int, int] = {}
         blocks = self._allocators[device].allocate_immutable_blocks(
-            prev_block, block_token_ids,
-            allow_swap, self._allocators[Device.CPU],
-            current_swap_mapping)
+            prev_block, block_token_ids, allow_swap,
+            self._allocators[Device.CPU], current_swap_mapping)
         self._swap_mapping_cpu_to_gpu.update(current_swap_mapping)
         return blocks
 
@@ -219,8 +213,8 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
                     block.prev_block, block.token_ids)
                 dual_block_id = dual_block.block_id
                 assert dual_block_id is not None
-                dual_allocator.mark_blocks_as_accessed(
-                    [dual_block_id], last_access_time)
+                dual_allocator.mark_blocks_as_accessed([dual_block_id],
+                                                       last_access_time)
                 # If block not exists in CPU allocator, swap is needed.
                 if need_swap:
                     self._swap_mapping_gpu_to_cpu[block_id] = dual_block_id
@@ -368,8 +362,8 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         assert device in self._allocators
         return self._allocators[device].get_prefix_cache_hit_rate()
 
-    def get_and_reset_swaps(self
-        ) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
+    def get_and_reset_swaps(
+            self) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
         """Returns and clears the mapping of source to destination block IDs.
         Will be called after every swapping operations for now, and after every
         schedule when BlockManagerV2 become default. Currently not useful.
@@ -397,6 +391,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         self._swap_mapping_cpu_to_gpu.clear()
         return list(mapping_gpu_to_cpu.items()), \
             list(mapping_cpu_to_gpu.items())
+
 
 class NullBlock(Block):
     """

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -26,6 +26,7 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         num_gpu_blocks: int,
         num_cpu_blocks: int,
         block_size: int,
+        enable_host_memory_caching: bool
     ) -> DeviceAwareBlockAllocator:
         """Creates a CpuGpuBlockAllocator instance with the specified
         configuration.
@@ -61,6 +62,9 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         gpu_block_ids = block_ids[:num_gpu_blocks]
         cpu_block_ids = block_ids[num_gpu_blocks:]
 
+        if enable_host_memory_caching:
+            assert allocator_type == "prefix_caching"
+
         if allocator_type == "naive":
             gpu_allocator: BlockAllocator = NaiveBlockAllocator(
                 create_block=NaiveBlock,  # type: ignore
@@ -93,10 +97,12 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         return CpuGpuBlockAllocator(
             cpu_block_allocator=cpu_allocator,
             gpu_block_allocator=gpu_allocator,
+            enable_host_memory_caching=enable_host_memory_caching
         )
 
     def __init__(self, cpu_block_allocator: BlockAllocator,
-                 gpu_block_allocator: BlockAllocator):
+                 gpu_block_allocator: BlockAllocator,
+                 enable_host_memory_caching: bool):
         assert not (
             cpu_block_allocator.all_block_ids
             & gpu_block_allocator.all_block_ids
@@ -108,6 +114,9 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         }
 
         self._swap_mapping: Dict[int, int] = {}
+        self._enable_host_memory_caching = enable_host_memory_caching
+        self._swap_mapping_cpu_to_gpu: Dict[int, int] = {}
+        self._swap_mapping_gpu_to_cpu: Dict[int, int] = {}
         self._null_block: Optional[Block] = None
 
         self._block_ids_to_allocator: Dict[int, BlockAllocator] = {}
@@ -152,8 +161,15 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             List[Block]: The newly allocated list of immutable blocks 
                 containing the provided block token IDs.
         """
-        return self._allocators[device].allocate_immutable_blocks(
-            prev_block, block_token_ids)
+        # Swap from CPU to GPU if block hit CPU cache.
+        allow_swap = self._enable_host_memory_caching and device == Device.GPU
+        current_swap_mapping: Dict[int, int] = {}
+        blocks = self._allocators[device].allocate_immutable_blocks(
+            prev_block, block_token_ids,
+            allow_swap, self._allocators[Device.CPU],
+            current_swap_mapping)
+        self._swap_mapping_cpu_to_gpu.update(current_swap_mapping)
+        return blocks
 
     def allocate_immutable_block(self, prev_block: Optional[Block],
                                  token_ids: List[int],
@@ -186,7 +202,29 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
             return
         block_id = block.block_id
         assert block_id is not None
+        # Swap blocks from GPU to CPU evictor.
+        allow_swap = self._enable_host_memory_caching and \
+            block_id in self._allocators[Device.GPU].all_block_ids
         allocator = self._block_ids_to_allocator[block_id]
+        if allow_swap and block.content_hash is not None:
+            dual_allocator = self._allocators[Device.CPU]
+            ref_count = allocator.get_block_ref_count(block)
+            if allocator.is_block_cached(block) and ref_count == 1:
+                # In this case, the GPU block will be added to GPU evictor,
+                # we add it to CPU evictor as well.
+                need_swap = not dual_allocator.is_block_cached(block)
+                last_access_time = allocator.get_block_last_access_time(block)
+                # Allocate and free, to update block state in CPU evictor.
+                dual_block = dual_allocator.allocate_immutable_block(
+                    block.prev_block, block.token_ids)
+                dual_block_id = dual_block.block_id
+                assert dual_block_id is not None
+                dual_allocator.mark_blocks_as_accessed(
+                    [dual_block_id], last_access_time)
+                # If block not exists in CPU allocator, swap is needed.
+                if need_swap:
+                    self._swap_mapping_gpu_to_cpu[block_id] = dual_block_id
+                dual_allocator.free(dual_block)
         allocator.free(block)
 
     def fork(self, last_block: Block) -> List[Block]:
@@ -330,7 +368,8 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         assert device in self._allocators
         return self._allocators[device].get_prefix_cache_hit_rate()
 
-    def get_and_reset_swaps(self) -> List[Tuple[int, int]]:
+    def get_and_reset_swaps(self
+        ) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
         """Returns and clears the mapping of source to destination block IDs.
         Will be called after every swapping operations for now, and after every
         schedule when BlockManagerV2 become default. Currently not useful.
@@ -338,10 +377,26 @@ class CpuGpuBlockAllocator(DeviceAwareBlockAllocator):
         Returns:
             List[Tuple[int, int]]: A mapping of source to destination block IDs.
         """
-        mapping = self._swap_mapping.copy()
-        self._swap_mapping.clear()
-        return list(mapping.items())
+        # mapping = self._swap_mapping.copy()
+        # self._swap_mapping.clear()
 
+        self._swap_mapping.clear()
+        mapping_gpu_to_cpu = {
+            self.get_physical_block_id(Device.GPU, gpu_block_id):
+            self.get_physical_block_id(Device.CPU, cpu_block_id)
+            for gpu_block_id, cpu_block_id in \
+                self._swap_mapping_gpu_to_cpu.items()
+        }
+        mapping_cpu_to_gpu = {
+            self.get_physical_block_id(Device.CPU, cpu_block_id):
+            self.get_physical_block_id(Device.GPU, gpu_block_id)
+            for cpu_block_id, gpu_block_id in \
+                self._swap_mapping_cpu_to_gpu.items()
+        }
+        self._swap_mapping_gpu_to_cpu.clear()
+        self._swap_mapping_cpu_to_gpu.clear()
+        return list(mapping_gpu_to_cpu.items()), \
+            list(mapping_cpu_to_gpu.items())
 
 class NullBlock(Block):
     """

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -110,7 +110,10 @@ class BlockAllocator(ABC):
     @abstractmethod
     def allocate_immutable_blocks(
             self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]]) -> List[Block]:
+            block_token_ids: List[List[int]],
+            allow_swap: Optional[bool] = False,
+            dual_allocator: Optional['BlockAllocator'] = None,
+            swap_mapping: Optional[Dict[int, int]] = None,) -> List[Block]:
         pass
 
     @abstractmethod
@@ -189,6 +192,20 @@ class BlockAllocator(ABC):
         """Prefix cache hit rate. -1 means not supported or disabled."""
         pass
 
+    @abstractmethod
+    def get_block_ref_count(self, block: Block) -> int:
+        '''Get reference count of block.'''
+        pass
+
+    @abstractmethod
+    def get_block_last_access_time(self, block: Block) -> float:
+        '''Get last access time of block.'''
+        pass
+
+    @abstractmethod
+    def is_block_cached(self, block: Block) -> bool:
+        pass
+
     class NoFreeBlocksError(ValueError):
         pass
 
@@ -260,6 +277,11 @@ class DeviceAwareBlockAllocator(ABC):
     @abstractmethod
     def get_num_full_blocks_touched(self, blocks: List[Block],
                                     device: Device) -> int:
+        pass
+
+    @abstractmethod
+    def get_and_reset_swaps(
+            self) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
         pass
 
     @abstractmethod

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -109,11 +109,13 @@ class BlockAllocator(ABC):
 
     @abstractmethod
     def allocate_immutable_blocks(
-            self, prev_block: Optional[Block],
-            block_token_ids: List[List[int]],
-            allow_swap: Optional[bool] = False,
-            dual_allocator: Optional['BlockAllocator'] = None,
-            swap_mapping: Optional[Dict[int, int]] = None,) -> List[Block]:
+        self,
+        prev_block: Optional[Block],
+        block_token_ids: List[List[int]],
+        allow_swap: Optional[bool] = False,
+        dual_allocator: Optional['BlockAllocator'] = None,
+        swap_mapping: Optional[Dict[int, int]] = None,
+    ) -> List[Block]:
         pass
 
     @abstractmethod

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Dict, Deque, FrozenSet, Iterable, List, Optional, Tuple
+from typing import Deque, Dict, FrozenSet, Iterable, List, Optional, Tuple
 
 from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
                                     get_all_blocks_recursively)

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Deque, FrozenSet, Iterable, List, Optional, Tuple, Dict
+from typing import Dict, Deque, FrozenSet, Iterable, List, Optional, Tuple
 
 from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
                                     get_all_blocks_recursively)

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Deque, FrozenSet, Iterable, List, Optional, Tuple
+from typing import Deque, FrozenSet, Iterable, List, Optional, Tuple, Dict
 
 from vllm.core.block.common import (BlockPool, CopyOnWriteTracker, RefCounter,
                                     get_all_blocks_recursively)
@@ -85,6 +85,9 @@ class NaiveBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
+            allow_swap: Optional[bool] = False,
+            dual_allocator: Optional[BlockAllocator] = None,
+            swap_mapping: Optional[Dict[int, int]] = None,
             device: Optional[Device] = None) -> List[Block]:
         assert device is None
         num_blocks = len(block_token_ids)
@@ -328,6 +331,17 @@ class NaiveBlockAllocator(BlockAllocator):
 
     def get_prefix_cache_hit_rate(self) -> float:
         return -1
+
+    def get_block_ref_count(self, block: Block) -> int:
+        block_id = block.block_id
+        assert block_id is not None
+        return self._refcounter.get(block_id)
+
+    def get_block_last_access_time(self, block: Block) -> float:
+        return -1
+
+    def is_block_cached(self, block: Block) -> bool:
+        return False
 
 
 class NaiveBlock(Block):

--- a/vllm/core/block/prefix_caching_block.py
+++ b/vllm/core/block/prefix_caching_block.py
@@ -1,4 +1,5 @@
 """Token blocks."""
+import time
 from os.path import commonprefix
 from typing import Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
 
@@ -176,6 +177,9 @@ class PrefixCachingBlockAllocator(BlockAllocator):
             self,
             prev_block: Optional[Block],
             block_token_ids: List[List[int]],
+            allow_swap: Optional[bool] = False,
+            dual_allocator: Optional[BlockAllocator] = None,
+            swap_mapping: Optional[Dict[int, int]] = None,
             device: Optional[Device] = None) -> List[Block]:
         blocks = []
         for token_ids in block_token_ids:
@@ -183,6 +187,28 @@ class PrefixCachingBlockAllocator(BlockAllocator):
                                                        token_ids=token_ids,
                                                        device=device)
             blocks.append(prev_block)
+
+        if allow_swap:
+            assert dual_allocator is not None and swap_mapping is not None
+            for block in blocks:
+                assert block.content_hash is not None
+                block_id = block.block_id
+                assert block_id is not None
+                # Check uncomputed blocks
+                if not self.block_is_computed(block_id) and \
+                        dual_allocator.is_block_cached(block):
+                    block.computed = True
+                    self._block_tracker[block_id].computed = True
+                    dual_block = dual_allocator.allocate_immutable_block(
+                        block.prev_block, block.token_ids)
+                    dual_block_id = dual_block.block_id
+                    assert dual_block_id is not None
+                    swap_mapping[dual_block_id] = block_id
+                    dual_allocator.free(dual_block)
+            # Update last access time of dual blocks
+            if len(swap_mapping) != 0:
+                dual_allocator.mark_blocks_as_accessed(
+                    list(swap_mapping.keys()), time.time())
         return blocks
 
     def allocate_mutable_block(self,
@@ -413,6 +439,16 @@ class PrefixCachingBlockAllocator(BlockAllocator):
 
     def get_prefix_cache_hit_rate(self) -> float:
         return self.metric_data.get_hit_rate()
+
+    def get_block_ref_count(self, block: Block) -> int:
+        block_id = block.block_id
+        assert block_id is not None
+        return self._refcounter.get(block_id)
+
+    def get_block_last_access_time(self, block: Block) -> float:
+        block_id = block.block_id
+        assert block_id is not None
+        return self._block_tracker[block_id].last_accessed
 
     def is_block_cached(self, block: Block) -> bool:
         assert block.content_hash is not None

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -57,16 +57,14 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             enabled. Defaults to False.
     """
 
-    def __init__(
-        self,
-        block_size: int,
-        num_gpu_blocks: int,
-        num_cpu_blocks: int,
-        watermark: float = 0.01,
-        sliding_window: Optional[int] = None,
-        enable_caching: bool = False,
-        enable_host_memory_caching: bool = False
-    ) -> None:
+    def __init__(self,
+                 block_size: int,
+                 num_gpu_blocks: int,
+                 num_cpu_blocks: int,
+                 watermark: float = 0.01,
+                 sliding_window: Optional[int] = None,
+                 enable_caching: bool = False,
+                 enable_host_memory_caching: bool = False) -> None:
         self.block_size = block_size
         self.num_total_gpu_blocks = num_gpu_blocks
         self.num_total_cpu_blocks = num_cpu_blocks
@@ -96,8 +94,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
             num_gpu_blocks=num_gpu_blocks,
             num_cpu_blocks=num_cpu_blocks,
             block_size=block_size,
-            enable_host_memory_caching=enable_host_memory_caching
-        )
+            enable_host_memory_caching=enable_host_memory_caching)
 
         self.block_tables: Dict[SeqId, BlockTable] = {}
         self.cross_block_tables: Dict[EncoderSeqId, BlockTable] = {}
@@ -337,8 +334,8 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         self._computed_blocks_tracker.add_seq(child_seq.seq_id)
         self._last_access_blocks_tracker.add_seq(child_seq.seq_id)
 
-    def get_and_reset_swaps(self
-        ) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
+    def get_and_reset_swaps(
+            self) -> Tuple[List[Tuple[int, int]], List[Tuple[int, int]]]:
         """Returns the block mapping of both GPU to CPU and CPU to GPU.
         """
         mapping_gpu_to_cpu, mapping_cpu_to_gpu = \

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -335,8 +335,8 @@ class Scheduler:
             num_cpu_blocks=num_cpu_blocks,
             sliding_window=self.cache_config.sliding_window,
             enable_caching=self.cache_config.enable_prefix_caching,
-            enable_host_memory_caching=self.cache_config.enable_host_memory_caching
-        )
+            enable_host_memory_caching=self.cache_config.
+            enable_host_memory_caching)
 
         # Sequence groups in the WAITING state.
         # Contain new prefill or preempted requests.

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -334,7 +334,9 @@ class Scheduler:
             num_gpu_blocks=num_gpu_blocks,
             num_cpu_blocks=num_cpu_blocks,
             sliding_window=self.cache_config.sliding_window,
-            enable_caching=self.cache_config.enable_prefix_caching)
+            enable_caching=self.cache_config.enable_prefix_caching,
+            enable_host_memory_caching=self.cache_config.enable_host_memory_caching
+        )
 
         # Sequence groups in the WAITING state.
         # Contain new prefill or preempted requests.
@@ -1223,6 +1225,12 @@ class Scheduler:
             common_computed_block_nums = []
 
         allow_async_output_proc: bool = self.use_async_output_proc
+
+        if len(scheduler_outputs.scheduled_seq_groups) != 0:
+            blocks_to_swap_out, blocks_to_swap_in = \
+                self.block_manager.get_and_reset_swaps()
+            scheduler_outputs.blocks_to_swap_out.extend(blocks_to_swap_out)
+            scheduler_outputs.blocks_to_swap_in.extend(blocks_to_swap_in)
 
         # Create input data structures.
         seq_group_metadata_list: List[SequenceGroupMetadata] = []

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -115,6 +115,7 @@ class EngineArgs:
     # smaller sizes still work, but very inefficiently
     block_size: int = 16 if not current_platform.is_hpu() else 128
     enable_prefix_caching: bool = False
+    enable_host_memory_caching: bool = False
     disable_sliding_window: bool = False
     use_v2_block_manager: bool = True
     swap_space: float = 4  # GiB
@@ -415,6 +416,9 @@ class EngineArgs:
         parser.add_argument('--enable-prefix-caching',
                             action='store_true',
                             help='Enables automatic prefix caching.')
+        parser.add_argument('--enable-host-memory-caching',
+                            action='store_true',
+                            help='Enables host memory for prefix kv caching.')
         parser.add_argument('--disable-sliding-window',
                             action='store_true',
                             help='Disables sliding window, '
@@ -1031,6 +1035,7 @@ class EngineArgs:
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
+            enable_host_memory_caching=self.enable_host_memory_caching,
             cpu_offload_gb=self.cpu_offload_gb,
         )
         parallel_config = ParallelConfig(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -261,6 +261,7 @@ class LLMEngine:
             "seed=%d, served_model_name=%s, "
             "num_scheduler_steps=%d, chunked_prefill_enabled=%s "
             "multi_step_stream_outputs=%s, enable_prefix_caching=%s, "
+            "enable_host_memory_caching=%s, "
             "use_async_output_proc=%s, use_cached_outputs=%s, "
             "chat_template_text_format=%s, mm_processor_kwargs=%s, "
             "pooler_config=%r)",
@@ -294,6 +295,7 @@ class LLMEngine:
             scheduler_config.chunked_prefill_enabled,
             scheduler_config.multi_step_stream_outputs,
             cache_config.enable_prefix_caching,
+            cache_config.enable_host_memory_caching,
             model_config.use_async_output_proc,
             use_cached_outputs,
             model_config.chat_template_text_format,
@@ -380,6 +382,8 @@ class LLMEngine:
                     bool(prompt_adapter_config),
                     "enable_prefix_caching":
                     cache_config.enable_prefix_caching,
+                    "enable_host_memory_caching":
+                    cache_config.enable_host_memory_caching,
                     "enforce_eager":
                     model_config.enforce_eager,
                     "disable_custom_all_reduce":


### PR DESCRIPTION
# Optimal conditions for this feature:
1. The token count of your prompt significantly exceeds that of the generated output.
2. The commonly used prompt prefix length is substantial, leading to a high cache hit rate.
3. Your machine's GPU memory is insufficient to accommodate enough prefix key-value caches, resulting in a reduced cache hit rate.

# Main idea
In the scenario described above, offloading key-value caches to host memory could be advantageous. The implementation is straightforward: we already have CPU blocks within the block manager, although they are currently designed exclusively for sequence preemption. Since CPU and GPU blocks share the same underlying block structure, we can store computed key-value cache blocks within CPU blocks.

With this approach, each time a GPU block is freed, we add it to the CPU allocator via swapping. When allocating immutable blocks, we first search the GPU allocator. If a GPU cache hit occurs, we proceed with the cached GPU block as usual. If no hit is found, we additionally check the CPU allocator, and in the event of a CPU cache hit, we swap the CPU block back to the GPU and eliminate the recomputation.

Originally, the block allocation logic without preemption:
![image](https://github.com/user-attachments/assets/6bb58876-cd82-4f65-9e2b-eda55c07a22c)

Now we utilize the CPU blocks:
![image](https://github.com/user-attachments/assets/efd9b5d0-73f0-447d-b40f-35a3792dddca)

Note that the computed blocks in the CPU allocator are stored only in the evictor, and this change will not impact the original preemption logic.

# Usage
Launch the vllm engine with
```bash
--enable-prefix-caching --enable-host-memory-caching --swap-space 48
```
in which --swap-space configures the host memory for both kv cache and preemption.

# Shortages
If host memory for the KV cache is enabled, each GPU block added to the evictor will be swapped to host memory, potentially leading to a performance drop. Therefore, ensure that enabling the host memory KV cache will significantly improve your cache hit rate. In our case (4090*1), if the cache hit rate is below 20%, enabling this feature will result in a performance degradation.

I’ve marked this PR as a draft because I’m not sure whether it will be useful for the main users, and the modification of the code is somewhat intrusive. Please provide feedback if you think it is beneficial, and I look forward to hearing your thoughts.

---

<details>
<!-- inside this <details> section, markdown rendering does not work, so we use raw html here. -->
<summary><b> PR Checklist (Click to Expand) </b></summary>

<p>Thank you for your contribution to vLLM! Before submitting the pull request, please ensure the PR meets the following criteria. This helps vLLM maintain the code quality and improve the efficiency of the review process.</p>

<h3>PR Title and Classification</h3>
<p>Only specific types of PRs will be reviewed. The PR title is prefixed appropriately to indicate the type of change. Please use one of the following:</p>
<ul>
    <li><code>[Bugfix]</code> for bug fixes.</li>
    <li><code>[CI/Build]</code> for build or continuous integration improvements.</li>
    <li><code>[Doc]</code> for documentation fixes and improvements.</li>
    <li><code>[Model]</code> for adding a new model or improving an existing model. Model name should appear in the title.</li>
    <li><code>[Frontend]</code> For changes on the vLLM frontend (e.g., OpenAI API server, <code>LLM</code> class, etc.) </li>
    <li><code>[Kernel]</code> for changes affecting CUDA kernels or other compute kernels.</li>
    <li><code>[Core]</code> for changes in the core vLLM logic (e.g., <code>LLMEngine</code>, <code>AsyncLLMEngine</code>, <code>Scheduler</code>, etc.)</li>
    <li><code>[Hardware][Vendor]</code> for hardware-specific changes. Vendor name should appear in the prefix (e.g., <code>[Hardware][AMD]</code>).</li>
    <li><code>[Misc]</code> for PRs that do not fit the above categories. Please use this sparingly.</li>
</ul>
<p><strong>Note:</strong> If the PR spans more than one category, please include all relevant prefixes.</p>

<h3>Code Quality</h3>

<p>The PR need to meet the following code quality standards:</p>

<ul>
    <li>We adhere to <a href="https://google.github.io/styleguide/pyguide.html">Google Python style guide</a> and <a href="https://google.github.io/styleguide/cppguide.html">Google C++ style guide</a>.</li>
    <li>Pass all linter checks. Please use <a href="https://github.com/vllm-project/vllm/blob/main/format.sh"><code>format.sh</code></a> to format your code.</li>
    <li>The code need to be well-documented to ensure future contributors can easily understand the code.</li>
    <li>Include sufficient tests to ensure the project to stay correct and robust. This includes both unit tests and integration tests.</li>
    <li>Please add documentation to <code>docs/source/</code> if the PR modifies the user-facing behaviors of vLLM. It helps vLLM user understand and utilize the new features or changes.</li>
</ul>

<h3>Adding or changing kernels</h3>
<p>Each custom kernel needs a schema and one or more implementations to be registered with PyTorch.</p>
<ul>
    <li>Make sure custom ops are registered following PyTorch guidelines: <a href="https://pytorch.org/tutorials/advanced/cpp_custom_ops.html#cpp-custom-ops-tutorial">Custom C++ and CUDA Operators</a> and <a href="https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU">The Custom Operators Manual</a></li>
    <li>Custom operations that return <code>Tensors</code> require meta-functions. Meta-functions should be implemented and registered in python so that dynamic dims can be handled automatically. See above documents for a description of meta-functions.</li>
    <li>Use <a href="https://pytorch.org/docs/stable/library.html#torch.library.opcheck"><code>torch.libary.opcheck()</code></a> to test the function registration and meta-function for any registered ops.  See <code>tests/kernels</code> for examples.</li>
    <li>When changing the C++ signature of an existing op, the schema must be updated to reflect the changes.</li>
    <li>If a new custom type is needed, see the following document: <a href="https://docs.google.com/document/d/18fBMPuOJ0fY5ZQ6YyrHUppw9FA332CpNtgB6SOIgyuA">Custom Class Support in PT2</a>.
</ul>

<h3>Notes for Large Changes</h3>
<p>Please keep the changes as concise as possible. For major architectural changes (>500 LOC excluding kernel/data/config/test), we would expect a GitHub issue (RFC) discussing the technical design and justification. Otherwise, we will tag it with <code>rfc-required</code> and might not go through the PR.</p>

<h3>What to Expect for the Reviews</h3>

<p>The goal of the vLLM team is to be a <i>transparent reviewing machine</i>. We would like to make the review process transparent and efficient and make sure no contributor feel confused or frustrated. However, the vLLM team is small, so we need to prioritize some PRs over others. Here is what you can expect from the review process: </p>

<ul>
    <li> After the PR is submitted, the PR will be assigned to a reviewer. Every reviewer will pick up the PRs based on their expertise and availability.</li>
    <li> After the PR is assigned, the reviewer will provide status update every 2-3 days. If the PR is not reviewed within 7 days, please feel free to ping the reviewer or the vLLM team.</li>
    <li> After the review, the reviewer will put an <code> action-required</code> label on the PR if there are changes required. The contributor should address the comments and ping the reviewer to re-review the PR.</li>
    <li> Please respond to all comments within a reasonable time frame. If a comment isn't clear or you disagree with a suggestion, feel free to ask for clarification or discuss the suggestion.
 </li>
</ul>

<h3>Thank You</h3>

<p> Finally, thank you for taking the time to read these guidelines and for your interest in contributing to vLLM. Your contributions make vLLM a great tool for everyone! </p>


</details>


