### PR TITLE
[Perf] Reduce peak memory usage of llama

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -90,8 +90,8 @@ class LlamaMLP(nn.Module):
         self.act_fn = SiluAndMul()
 
     def forward(self, x):
-        gate_up, _ = self.gate_up_proj(x)
-        x = self.act_fn(gate_up)
+        x, _ = self.gate_up_proj(x)
+        x = self.act_fn(x)
         x, _ = self.down_proj(x)
         return x
 


### PR DESCRIPTION
Maintaining multiple names here will cause both to be refcounted which increases the peak memory. This will manifest as more blocks on top of each other in the memory profile:
![image](https://github.com/user-attachments/assets/de09f1df-0247-400f-9930-576cece77b18)

This change will increase the number of available blocks as a result of profiling *especially* with longer context lengths. I will follow up with a more detailed investigation in another PR/Issue that discusses this in more depth. However, creating this PR as well now as this is more or less a well-contained low-risk change. Can add to more models as well once we review this.