### PR TITLE
[Bugfix]  Qwen-vl output is inconsistent in speculative decoding

### DIFF
--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -353,6 +353,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         seq_data = seq_group_metadata.seq_data[seq_id]
         prompt_token_ids = seq_data.prompt_token_ids_array
         new_output_token_ids = [*seq_data.get_output_token_ids(), *token_ids]
+        mrope_position_delta = seq_data.mrope_position_delta
 
         new_seq_data_dict = {
             target_seq_id:
@@ -368,6 +369,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         # the kv cache is filled by a previous batch in the batch expansion.
         for data in new_seq_data_dict.values():
             data.update_num_computed_tokens(data.get_len() - 1)
+            data.mrope_position_delta = mrope_position_delta
 
         return SequenceGroupMetadata(
             request_id=seq_group_metadata.request_id,


### PR DESCRIPTION
Qwen-vl uses speculative decoding and does not use speculative decoding to have inconsistent output. We tested ngram and medusa, and this situation exists. After investigation, we found that there was an error position_id, and further because the new seq_data was created during the batch_expansion process without passing mrope_position_delta information.

![image](https://github.com/user-attachments/assets/0d5918a2-0688-462d-9101-412e6eb381e4)
