### PR TITLE
[Bugfix] Ensure special tokens are properly filtered out for guided structured output with MistralTokenizer

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -17,7 +17,7 @@ pillow  # Required for image processing
 prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
-lm-format-enforcer == 0.10.6
+lm-format-enforcer >= 0.10.9, < 0.11
 outlines >= 0.0.43, < 0.1
 typing_extensions >= 4.10
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -174,18 +174,29 @@ class MistralTokenizer:
                                          revision=revision)
         return tokenizer_file
 
-    # the following attributes are set to fit VLLM's design
+    # the following attributes are set to fit VLLM's design and are used
+    # by the guided structured output backends.
     @property
     def all_special_tokens_extended(self) -> List[str]:
-        return []
+        # tekken defines its own extended special tokens list
+        if hasattr(self.tokenizer, "SPECIAL_TOKENS"):
+            special_tokens = self.tokenizer.SPECIAL_TOKENS
+        else:
+            special_tokens = list(SpecialTokens)
+        return [
+            s.value if isinstance(s, SpecialTokens) else s
+            for s in special_tokens
+        ]
 
     @property
     def all_special_tokens(self) -> List[str]:
-        return []
+        return self.all_special_tokens_extended
 
     @property
     def all_special_ids(self) -> List[int]:
-        return []
+        return [
+            self.all_special_tokens.index(t) for t in self.all_special_tokens
+        ]
 
     @property
     def bos_token_id(self) -> int:


### PR DESCRIPTION
This PR improves the support of the vllm `MistralTokenizer` with the guided structured output functionalities.

In particular:
- the version of `lm-format-enforcer` is bumped to the latest version, so it includes the support of the vllm MistralTokenizer (https://github.com/noamgat/lm-format-enforcer/pull/142) 
- the vllm `MistralTokenizer` methods leveraged by the structured output libraries are now properly populated so that the list of possible tokens generated based on the chosen grammar/constraints (e.g.: `json` output) correctly filters out the special tokens. Note that this problem was present before, but masked by the fact that the special tokens were automatically filtered out of the conversion from ids to string: the [recent vllm support for automatic mistral tool parsing](https://github.com/vllm-project/vllm/pull/10333) allowed to reveal the bug (also see [this comment #10333](https://github.com/vllm-project/vllm/pull/10333#discussion_r1843457699)). As a benefit, this should also make the structured output generation by Mistral models more reliable. 


cc: @patrickvonplaten 


Example: code that would break without this PR but passes with it

```
"""
vllm openai server started with the following arguments:
    --model=mistralai/Pixtral-12B-2409
    --guided-decoding-backend=lm-format-enforcer 
    --enable-auto-tool-choice 
    --tool-call-parser=mistral 
    --tokenizer-mode=mistral
"""

from openai import OpenAI
import json
from pydantic import BaseModel

client = OpenAI(
    base_url="http://localhost:8000/v1",
    api_key="none",
)

######################################
# Example 1: using `client.beta.chat.completions.parse`
######################################

class CalendarEvent(BaseModel):
    name: str
    date: str
    participants: list[str]

completion = client.beta.chat.completions.parse(
    model="mistralai/Pixtral-12B-2409",
    messages=[
        {"role": "system", "content": "Extract the event information."},
        {"role": "user", "content": "Alice and Bob are going to a science fair on Friday."},
    ],
    response_format=CalendarEvent,
    max_completion_tokens=10000,
)

event = completion.choices[0].message.parsed
print(event.__dict__)

######################################
# Example 2: using `client.chat.completions.create`
######################################

class Step(BaseModel):
    explanation: str
    output: str

class MathReasoning(BaseModel):
    steps: list[Step]
    final_answer: str

completion = client.chat.completions.create(
    model="mistralai/Pixtral-12B-2409",
    messages=[
        {"role": "system", "content": "You are a helpful math tutor. Guide the user through the solution step by step."},
        {"role": "user", "content": "how can I solve 8x + 7 = -23"}
    ],
    response_format={
        "type": "json_schema",
        "json_schema": {
            "name": "toto",
            "schema": MathReasoning.model_json_schema()
        }
    },
    max_completion_tokens=10000,
)

math_reasoning = completion.choices[0].message.content
print(json.loads(json.dumps(math_reasoning, indent=2)))
```

