### PR TITLE
[Bugfix] Ignore ray reinit error when current platform is ROCm or XPU

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -234,7 +234,7 @@ def initialize_ray_cluster(
     if current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
-            ray.init("auto")
+            ray.init("auto", ignore_reinit_error=True)
         except ConnectionError:
             logger.warning(
                 "No existing RAY instance detected. "


### PR DESCRIPTION
Just like the else branch, we should also add `ignore_reinit_error=True` when calling ray.init, so that the reinit error can be ignored if vLLM is called by another program and ray has already been initialized:

```
 File "vllm/vllm/entrypoints/llm.py", line 213, in __init__
   self.llm = vllm.LLM(*args, **kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
 File "vllm/vllm/utils.py", line 1024, in inner
   return fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
   self.llm_engine = self.engine_class.from_engine_args(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "vllm/vllm/engine/llm_engine.py", line 580, in from_engine_args
   executor_class = cls._get_executor_cls(engine_config)
 File "vllm/vllm/engine/llm_engine.py", line 555, in _get_executor_cls
   initialize_ray_cluster(engine_config.parallel_config)
 File "vllm/vllm/executor/ray_utils.py", line 237, in initialize_ray_cluster
   ray.init("auto")
          ^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Maybe you called ray.init twice by accident? This error can be suppressed by passing in 'ignore_reinit_error=True' or by calling 'ray.shutdown()' prior to 'ray.init()'.
```