### PR TITLE
[3/N][torch.compile] consolidate custom op logging

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2161,6 +2161,10 @@ class CompilationConfig(BaseModel):
     compile_sizes: List[int] = PrivateAttr
     capture_sizes: List[int] = PrivateAttr
 
+    # keep track of enabled and disabled custom ops
+    enabled_custom_ops: Set[str] = PrivateAttr
+    disabled_custom_ops: Set[str] = PrivateAttr
+
     def model_post_init(self, __context: Any) -> None:
         self.level = envs.VLLM_TORCH_COMPILE_LEVEL
 
@@ -2181,6 +2185,9 @@ class CompilationConfig(BaseModel):
             func_name = names[-1]
             func = __import__(module).__dict__[func_name]
             self.inductor_compile_config[k] = func
+
+        self.enabled_custom_ops = set()
+        self.disabled_custom_ops = set()
 
     def init_during_runtime(self):
         """To complete the initialization of config,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4,8 +4,9 @@ import json
 import warnings
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Dict, Final, List,
-                    Literal, Mapping, Optional, Set, Tuple, Type, Union)
+from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Counter, Dict,
+                    Final, List, Literal, Mapping, Optional, Set, Tuple, Type,
+                    Union)
 
 import torch
 from pydantic import BaseModel, Field, PrivateAttr
@@ -2162,8 +2163,8 @@ class CompilationConfig(BaseModel):
     capture_sizes: List[int] = PrivateAttr
 
     # keep track of enabled and disabled custom ops
-    enabled_custom_ops: Set[str] = PrivateAttr
-    disabled_custom_ops: Set[str] = PrivateAttr
+    enabled_custom_ops: Counter[str] = PrivateAttr
+    disabled_custom_ops: Counter[str] = PrivateAttr
 
     def model_post_init(self, __context: Any) -> None:
         self.level = envs.VLLM_TORCH_COMPILE_LEVEL
@@ -2186,8 +2187,8 @@ class CompilationConfig(BaseModel):
             func = __import__(module).__dict__[func_name]
             self.inductor_compile_config[k] = func
 
-        self.enabled_custom_ops = set()
-        self.disabled_custom_ops = set()
+        self.enabled_custom_ops = Counter()
+        self.disabled_custom_ops = Counter()
 
     def init_during_runtime(self):
         """To complete the initialization of config,

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -64,9 +64,10 @@ class CustomOp(nn.Module):
         compilation_config = get_current_vllm_config().compilation_config
         enabled = self.enabled()
         if enabled:
-            compilation_config.enabled_custom_ops.add(self.__class__.name)
+            compilation_config.enabled_custom_ops.update([self.__class__.name])
         else:
-            compilation_config.disabled_custom_ops.add(self.__class__.name)
+            compilation_config.disabled_custom_ops.update(
+                [self.__class__.name])
 
         if not enabled:
             return self.forward_native

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -61,10 +61,12 @@ class CustomOp(nn.Module):
     def dispatch_forward(self):
         # NOTE(woosuk): Here we assume that vLLM was built for only one
         # specific backend. Currently, we do not support dynamic dispatching.
-
+        compilation_config = get_current_vllm_config().compilation_config
         enabled = self.enabled()
-        logger.debug("custom op %s %s", self.__class__.name,
-                     "enabled" if enabled else "disabled")
+        if enabled:
+            compilation_config.enabled_custom_ops.add(self.__class__.name)
+        else:
+            compilation_config.disabled_custom_ops.add(self.__class__.name)
 
         if not enabled:
             return self.forward_native

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -92,6 +92,10 @@ def set_current_vllm_config(vllm_config: VllmConfig):
         _current_vllm_config = vllm_config
         yield
     finally:
+        logger.debug("enabled custom ops: %s",
+                     vllm_config.compilation_config.enabled_custom_ops)
+        logger.debug("disabled custom ops: %s",
+                     vllm_config.compilation_config.disabled_custom_ops)
         _current_vllm_config = old_vllm_config
 
 


### PR DESCRIPTION
previously the custom op logging is too verbose.

after https://github.com/vllm-project/vllm/pull/10383 , we now have global control and aggregation of the custom op statistics.