### PR TITLE
[ci/build] Have dependabot ignore all patch update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
     allow:
       - dependency-type: "all"
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
       - dependency-name: "torch"
       - dependency-name: "torchvision"
       - dependency-name: "xformers"
@@ -24,9 +26,6 @@ updates:
       - dependency-name: "ray[adag]"
       - dependency-name: "lm-eval"
     groups:
-      patch-update:
-        applies-to: version-updates
-        update-types: ["patch"]
       minor-update:
         applies-to: version-updates
         update-types: ["minor"]


### PR DESCRIPTION
We have too many dependencies and all patch updates can be a little noisy. This is to have dependabot ignore all patch version updates. 