### PR TITLE
[Pixtral-Large] Pixtral actually has no bias in vision-lang adapter

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -331,6 +331,7 @@ class VisionEncoderArgs:
     num_attention_heads: int
     rope_theta: float  # for rope-2D
     image_token_id: int
+    adapter_bias: bool = True
 
 
 def _reshape_for_broadcast(freqs_cis: torch.Tensor,
@@ -595,10 +596,10 @@ class VisionLanguageAdapter(nn.Module):
         self.w_in = nn.Linear(
             args.hidden_size,
             dim,
-            bias=True,
+            bias=args.adapter_bias,
         )
         self.gelu = nn.GELU()
-        self.w_out = nn.Linear(dim, dim, bias=True)
+        self.w_out = nn.Linear(dim, dim, bias=args.adapter_bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.w_out(self.gelu(self.w_in(x)))


### PR DESCRIPTION
Pixtral-Large doesn't have any bias in the vision lang adapter as can be seen from: https://huggingface.co/mistralai/Pixtral-Large-Instruct-2411/tree/main?show_file_info=consolidated.safetensors.index.json

Before this PR the bias weights were initialized to such small values that it essentially didn't make a difference in inference. 
This PR is tested with: https://huggingface.co/mistralai/Pixtral-Large-Instruct-2411/discussions/7 and gives the exact same results as before, but is "correcter" since we don't materialize any biases this way.