### PR TITLE
Change granite chat template to keep json list formatting for tool calls

### DIFF
--- a/examples/tool_chat_template_granite.jinja
+++ b/examples/tool_chat_template_granite.jinja
@@ -21,11 +21,7 @@
     {{- '<|start_of_role|>user<|end_of_role|>' + message['content'] + '<|end_of_text|>
 ' }}
     {%- elif message['role'] == 'assistant_tool_call' or (message['role'] == 'assistant' and message.tool_calls is defined) %}
-    {{- '<|start_of_role|>assistant<|end_of_role|>' }}
-        {% for tc in message.tool_calls %}
-            {{- '<|tool_call|> ' + {'name': tc.function.name, 'arguments': tc.function.arguments}|tojson  }}
-        {% endfor %}
-    {{- '<|end_of_text|>
+    {{- '<|start_of_role|>assistant<|end_of_role|><|tool_call|>' + message.tool_calls|map(attribute='function')|list|tojson(indent=4) + '<|end_of_text|>
 ' }}
     {%- elif message['role'] == 'assistant' %}
     {{- '<|start_of_role|>assistant<|end_of_role|>'  + message['content'] + '<|end_of_text|>


### PR DESCRIPTION
This PR changes the granite chat template to change how tool calls are rendered so that the way in which the model reads the tool call input is the same as how it generates it.

FIX https://github.com/vllm-project/vllm/issues/10379

Taking an example from our unit tests, here is the effect of the change:

BEFORE:
```
<|start_of_role|>available_tools<|end_of_role|>
{
    "type": "function",
    "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
            "type": "object",
            "properties": {
                "city": {
                    "type": "string",
                    "description": "The city to find the weather for, e.g. 'San Francisco'"
                },
                "state": {
                    "type": "string",
                    "description": "the two-letter abbreviation for the state that the city is in, e.g. 'CA' which would mean 'California'"
                },
                "unit": {
                    "type": "string",
                    "description": "The unit to fetch the temperature in",
                    "enum": [
                        "celsius",
                        "fahrenheit"
                    ]
                }
            }
        }
    }
}

{
    "type": "function",
    "function": {
        "name": "web_search",
        "description": "Search the internet and get a summary of the top 10 webpages. Should only be used if you don't know the answer to a user query, and the results are likelyto be able to be found with a web search",
        "parameters": {
            "type": "object",
            "properties": {
                "search_term": {
                    "type": "string",
                    "description": "The term to use in the search. This shouldideally be keywords to search for, not anatural-language question"
                }
            },
            "required": [
                "search_term"
            ]
        }
    }
}<|end_of_text|>
<|start_of_role|>user<|end_of_role|>What is the weather in Dallas, Texas and Orlando, Florida in Fahrenheit?<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>
<|tool_call|> {"name": "get_current_weather", "arguments": "{\"city\": \"Dallas\", \"state\": \"TX\", \"unit\": \"fahrenheit\"}"}
<|tool_call|> {"name": "get_current_weather", "arguments": "{\"city\": \"Orlando\", \"state\": \"Fl\", \"unit\": \"fahrenheit\"}"}
<|end_of_text|>
<|start_of_role|>tool_response<|end_of_role|>The weather in Dallas TX is 98 degrees fahrenheit with mostly cloudy skies and a chance of rain in the evening.<|end_of_text|>
<|start_of_role|>tool_response<|end_of_role|>The weather in Orlando FL is 78 degrees fahrenheit with clearskies.<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>
```

AFTER:
```
<|start_of_role|>available_tools<|end_of_role|>
{
    "type": "function",
    "function": {
        "name": "get_current_weather",
        "description": "Get the current weather in a given location",
        "parameters": {
            "type": "object",
            "properties": {
                "city": {
                    "type": "string",
                    "description": "The city to find the weather for, e.g. 'San Francisco'"
                },
                "state": {
                    "type": "string",
                    "description": "the two-letter abbreviation for the state that the city is in, e.g. 'CA' which would mean 'California'"
                },
                "unit": {
                    "type": "string",
                    "description": "The unit to fetch the temperature in",
                    "enum": [
                        "celsius",
                        "fahrenheit"
                    ]
                }
            }
        }
    }
}

{
    "type": "function",
    "function": {
        "name": "web_search",
        "description": "Search the internet and get a summary of the top 10 webpages. Should only be used if you don't know the answer to a user query, and the results are likelyto be able to be found with a web search",
        "parameters": {
            "type": "object",
            "properties": {
                "search_term": {
                    "type": "string",
                    "description": "The term to use in the search. This shouldideally be keywords to search for, not anatural-language question"
                }
            },
            "required": [
                "search_term"
            ]
        }
    }
}<|end_of_text|>
<|start_of_role|>user<|end_of_role|>What is the weather in Dallas, Texas and Orlando, Florida in Fahrenheit?<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|><|tool_call|>[
    {
        "name": "get_current_weather",
        "arguments": "{\"city\": \"Dallas\", \"state\": \"TX\", \"unit\": \"fahrenheit\"}"
    },
    {
        "name": "get_current_weather",
        "arguments": "{\"city\": \"Orlando\", \"state\": \"Fl\", \"unit\": \"fahrenheit\"}"
    }
]<|end_of_text|>
<|start_of_role|>tool_response<|end_of_role|>The weather in Dallas TX is 98 degrees fahrenheit with mostly cloudy skies and a chance of rain in the evening.<|end_of_text|>
<|start_of_role|>tool_response<|end_of_role|>The weather in Orlando FL is 78 degrees fahrenheit with clearskies.<|end_of_text|>
<|start_of_role|>assistant<|end_of_role|>
```