### PR TITLE
[Doc] fix link for page that was renamed

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -105,7 +105,7 @@ def _initialize_model(vllm_config: VllmConfig, prefix: str = "") -> nn.Module:
     msg = ("vLLM model class should accept `vllm_config` and `prefix` as "
            "input arguments. Possibly you have an old-style model class"
            " registered from out of tree and it is used for new vLLM version. "
-           "Check https://docs.vllm.ai/en/latest/design/class_hierarchy.html "
+           "Check https://docs.vllm.ai/en/latest/design/arch_overview.html "
            "for the design and update the model class accordingly.")
     logger.warning(msg)
     logger.warning(


### PR DESCRIPTION
PR #10368 combined the content from `class_hierarchy` into an expanded
`arch_overview` page. I missed that a link to the old page existed
here in the code.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
