### PR TITLE
[Core] Fix broken log configuration

### DIFF
--- a/examples/logging_configuration.md
+++ b/examples/logging_configuration.md
@@ -118,7 +118,7 @@ configuration for the root vLLM logger and for the logger you wish to silence:
 {
   "formatters": {
     "vllm": {
-      "class": "vllm.logging.NewLineFormatter",
+      "class": "vllm.logging_utils.NewLineFormatter",
       "datefmt": "%m-%d %H:%M:%S",
       "format": "%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s"
     }

--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -50,7 +50,7 @@ DEFAULT_LOGGING_CONFIG = {
 
 
 def _configure_vllm_root_logger() -> None:
-    logging_config: Optional[Dict] = None
+    logging_config: Dict = {}
 
     if not VLLM_CONFIGURE_LOGGING and VLLM_LOGGING_CONFIG_PATH:
         raise RuntimeError(
@@ -74,6 +74,11 @@ def _configure_vllm_root_logger() -> None:
             raise ValueError("Invalid logging config. Expected Dict, got %s.",
                              type(custom_config).__name__)
         logging_config = custom_config
+
+    for formatter in logging_config.get("formatters", {}).values():
+        # This provides backwards compatibility after #10134.
+        if formatter.get("class") == "vllm.logging.NewLineFormatter":
+            formatter["class"] = "vllm.logging_utils.NewLineFormatter"
 
     if logging_config:
         dictConfig(logging_config)


### PR DESCRIPTION
`logging_configuration.md` provides some sample logger configuration
that is no logner valid after #10134. This PR fixes the sample config,
as well as provides backwards compatibility so that existing
configuration files won't break.

Closes #10457

Signed-off-by: Russell Bryant <rbryant@redhat.com>
