### PR TITLE
[Bugfix]: allow extra fields in requests to openai compatible server

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -899,19 +899,19 @@ async def test_response_format_json_schema(client: openai.AsyncOpenAI):
 
 
 @pytest.mark.asyncio
-async def test_extra_fields(client: openai.AsyncOpenAI):
-    with pytest.raises(BadRequestError) as exc_info:
-        await client.chat.completions.create(
-            model=MODEL_NAME,
-            messages=[{
-                "role": "system",
-                "content": "You are a helpful assistant.",
-                "extra_field": "0",
-            }],  # type: ignore
-            temperature=0,
-            seed=0)
+async def test_extra_fields_allowed(client: openai.AsyncOpenAI):
+    resp = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{
+            "role": "user",
+            "content": "what is 1+1?",
+            "extra_field": "0",
+        }],  # type: ignore
+        temperature=0,
+        seed=0)
 
-    assert "extra_forbidden" in exc_info.value.message
+    content = resp.choices[0].message.content
+    assert content is not None
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -35,8 +35,8 @@ assert _LONG_INFO.max == _MOCK_LONG_INFO.max
 
 
 class OpenAIBaseModel(BaseModel):
-    # OpenAI API does not allow extra fields
-    model_config = ConfigDict(extra="forbid")
+    # OpenAI API does allow extra fields
+    model_config = ConfigDict(extra="allow")
 
 
 class ErrorResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -9,11 +9,14 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Annotated
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.logger import init_logger
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import (BeamSearchParams, GuidedDecodingParams,
                                   RequestOutputKind, SamplingParams)
 from vllm.sequence import Logprob
 from vllm.utils import random_uuid
+
+logger = init_logger(__name__)
 
 # torch is mocked during docs generation,
 # so we have to provide the values as literals
@@ -37,6 +40,16 @@ assert _LONG_INFO.max == _MOCK_LONG_INFO.max
 class OpenAIBaseModel(BaseModel):
     # OpenAI API does allow extra fields
     model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="before")
+    @classmethod
+    def __log_extra_fields__(cls, values):
+        extra_fields = values.keys() - cls.model_fields.keys()
+        if extra_fields:
+            logger.warning(
+                "The following fields were present in the request "
+                "but ignored: %s", extra_fields)
+        return values
 
 
 class ErrorResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -43,13 +43,14 @@ class OpenAIBaseModel(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def __log_extra_fields__(cls, values):
-        extra_fields = values.keys() - cls.model_fields.keys()
-        if extra_fields:
-            logger.warning(
-                "The following fields were present in the request "
-                "but ignored: %s", extra_fields)
-        return values
+    def __log_extra_fields__(cls, data):
+        if isinstance(data, dict):
+            extra_fields = data.keys() - cls.model_fields.keys()
+            if extra_fields:
+                logger.warning(
+                    "The following fields were present in the request "
+                    "but ignored: %s", extra_fields)
+        return data
 
 
 class ErrorResponse(OpenAIBaseModel):


### PR DESCRIPTION
There are been several reports of `BadRequestError: Error code: 400` due to the vLLM OpenAI compatible server not accepting extra arguments in the requests' payloads, while the same requests would work with the official OpenAI API.

e.g.:
- #10093
- #5797
- #10015
- #6890

Similarly, code completion plugins like [CodeCompanion](https://github.com/olimorris/codecompanion.nvim) are currently not working with models served with the vLLM OpenAI compatible server, failing with the same `BadRequestError: Error code: 400` error, while the plugin is working fine with the official OpenAI API:

```
Error: {"object":"error","message":"[{'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, ' typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'literal_error', 'loc': ('body', 'messages', 0, 'typed-dict', 'role'), 'msg': \"Input should be 'user'\", 'input': 'system', 'ctx': {'expected': \"'user'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'literal_error', 'loc': ('body', 'messages', 0, 'typed-dict', 'role'), 'msg': \"Input should be 'assistant'\", 'input': 'system', 'ctx': {'expected': \"'assistant'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'literal_error', 'loc': ('body', 'messages', 0, 'typed-dict', 'role'), 'msg': \"Input should be 'tool'\", 'input': 'system', 'ctx': {'expected': \"'tool'\"}}, {'type': 'missing', 'loc': ('body', 'messages', 0, 'typed-dict', 'tool_call_id'), 'msg': 'Field required', 'input': {'content': 'You are an AI programming assistant named \"CodeCompanion\".\\nYou are currently plugged in to the Neovim text editor on a user\\'s machine.\\n\\nYour core tasks include:\\n- Answering general programming questions.\\n- Explaining how the code in a Neovim buffer works.\\n- Reviewing the selected code in a Neovim buffer.\\n- Generating unit tests for the selected code.\\n- Proposing fixes for problems in the selected code.\\n- Scaffolding code for a new workspace.\\n- Finding relevant code to the user\\'s query.\\n- Proposing fixes for test failures.\\n- Answering questions about Neovim.\\n- Running tools.\\n\\nYou must:\\n- Follow the user\\'s requirements carefully and to the letter.\\n- Keep your answers short and impersonal, especially if the user responds with context outside of your tasks.\\n- Minimize other prose.\\n- Use Markdown formatting in your answers.\\n- Include the programming language name at the start of the Markdown code blocks.\\n- Avoid line numbers in code blocks.\\n- Avoid wrapping the whole response in triple backticks.\\n- Only return code that\\'s relevant to the task at hand. You may not need to return all of the code that the user has shared.\\n- Use actual line breaks instead of \\'\\\\n\\' in your response to begin new lines.\\n- Use \\'\\\\n\\' only when you want a literal backslash followed by a character \\'n\\'.\\n- All non-code responses must use English.\\n\\nWhen given a task:\\n1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.\\n2. Output the code in a single code block, being careful to only return relevant code.\\n3. You should always generate short suggestions for the next user turns that are relevant to the conversation.\\n4. You can only give one reply for each conversation turn.', 'role': 'system', 'id': 1947269257, 'opts': {'visible': False}}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'missing', 'loc': ('body', 'messages', 0, 'typed-dict', 'name'), 'msg': 'Field required', 'input': {'content': 'You are an AI programming assistant named \"CodeCompanion\".\\nYou are currently plugged in to the Neovim text editor on a user\\'s machine.\\n\\nYour core tasks include:\\n- Answering general programming questions.\\n- Explaining how the code in a Neovim buffer works.\\n- Reviewing the selected code in a Neovim buffer.\\n- Generating unit tests for the selected code.\\n- Proposing fixes for problems in the selected code.\\n- Scaffolding code for a new workspace.\\n- Finding relevant code to the user\\'s query.\\n- Proposing fixes for test failures.\\n- Answering questions about Neovim.\\n- Running tools.\\n\\nYou must:\\n- Follow the user\\'s requirements carefully and to the letter.\\n- Keep your answers short and impersonal, especially if the user responds with context outside of your tasks.\\n- Minimize other prose.\\n- Use Markdown formatting in your answers.\\n- Include the programming language name at the start of the Markdown code blocks.\\n- Avoid line numbers in code blocks.\\n- Avoid wrapping the whole response in triple backticks.\\n- Only return code that\\'s relevant to the task at hand. You may not need to return all of the code that the user has shared.\\n- Use actual line breaks instead of \\'\\\\n\\' in your response to begin new lines.\\n- Use \\'\\\\n\\' only when you want a literal backslash followed by a character \\'n\\'.\\n- All non-code responses must use English.\\n\\nWhen given a task:\\n1. Think step-by-step and describe your plan for what to build in pseudocode, written out in great detail, unless asked not to do so.\\n2. Output the code in a single code block, being careful to only return relevant code.\\n3. You should always generate short suggestions for the next user turns that are relevant to the conversation.\\n4. You can only give one reply for each conversation turn.', 'role': 'system', 'id': 1947269257, 'opts': {'visible': False}}}, {'type': 'literal_error', 'loc': ('body', 'messages', 0, 'typed-dict', 'role'), 'msg': \"Input should be 'function'\", 'input': 'system', 'ctx': {'expected': \"'function'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': 1947269257}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': False}}, {'type': 'literal_error', 'loc': ('body', 'messages', 1, 'typed-dict', 'role'), 'msg': \"Input should be 'system'\", 'input': 'user', 'ctx': {'expected': \"'system'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'literal_error', 'loc': ('body', 'messages', 1, 'typed-dict', 'role'), 'msg': \"Input should be 'assistant'\", 'input': 'user', 'ctx': {'expected': \"'assistant'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'literal_error', 'loc': ('body', 'messages', 1, 'typed-dict', 'role'), 'msg': \"Input should be 'tool'\", 'input': 'user', 'ctx': {'expected': \"'tool'\"}}, {'type': 'missing', 'loc': ('body', 'messages', 1, 'typed-dict', 'tool_call_id'), 'msg': 'Field required', 'input': {'content': 'what is a function in python?', 'role': 'user', 'id': -2096855750, 'opts': {'visible': True}}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'missing', 'loc': ('body', 'messages', 1, 'typed-dict', 'name'), 'msg': 'Field required', 'input': {'content': 'what is a function in python?', 'role': 'user', 'id': -2096855750, 'opts': {'visible': True}}}, {'type': 'literal_error', 'loc': ('body', 'messages', 1, 'typed-dict', 'role'), 'msg': \"Input should be 'function'\", 'input': 'user', 'ctx': {'expected': \"'function'\"}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'id'), 'msg': 'Extra inputs are not permitted', 'input': -2096855750}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 1, 'typed-dict', 'opts'), 'msg': 'Extra inputs are not permitted', 'input': {'visible': True}}, {'type': 'extra_forbidden', 'loc': ('body', 'options'), 'msg': 'Extra inputs are not permitted', 'input': {'top_k': 40, 'mirostat': 0, 'num_predict': -1, 'num_ctx': 2048, 'tfs_z': 1, 'temperature': 0.8, 'seed': 0, 'repeat_penalty': 1.1, 'repeat_last_n': 64, 'top_p': 0.9, 'mirostat_tau': 5, 'mirostat_eta': 0.1}}]","type":"BadRequestError","param":null,"code":400}
```

The reason of the error is that currently the vLLM OpenAI-compatible server [forbids extra field](https://github.com/vllm-project/vllm/blob/803f37eaaa11568f65acbf0bcd1044fb9b1610bf/vllm/entrypoints/openai/protocol.py#L39) in its base pydantic model (introduced by [#4355](https://github.com/vllm-project/vllm/pull/4355)) while OpenAI native pydantic definitions all inherit from a BaseModel that explicitely [allow extra fields](https://github.com/openai/openai-python/blob/7cdc6ddbdd3c09e567c5582490aec9d7f99c468e/src/openai/_models.py#L88) in their [model_config](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.extra)

This PR updates the vLLM `OpenAIBaseModel` to allow extra fields, like the official OpenAI API.

cc: @DarkLight1337 @simon-mo 


