### PR TITLE
[Misc] Add __setitem__ for LazyDict

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1491,6 +1491,9 @@ class LazyDict(Mapping, Generic[T]):
             self._dict[key] = self._factory[key]()
         return self._dict[key]
 
+    def __setitem__(self, key:str, value: Callable[[], T]):
+        self._factory[key] = value
+
     def __iter__(self):
         return iter(self._factory)
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1491,7 +1491,7 @@ class LazyDict(Mapping, Generic[T]):
             self._dict[key] = self._factory[key]()
         return self._dict[key]
 
-    def __setitem__(self, key:str, value: Callable[[], T]):
+    def __setitem__(self, key: str, value: Callable[[], T]):
         self._factory[key] = value
 
     def __iter__(self):


### PR DESCRIPTION
Our internal codebase is using vllm to deploy private models. We need to register custom activation functions to the Registry, but currently, LazyDict does not support item assignment and throws the following error:
```
TypeError: 'LazyDict' object does not support item assignment
```

This simple modification can support the set method, for example:
```
_ACTIVATION_REGISTRY["silu"] = lambda: nn.SiLU()
```