### PR TITLE
[Core] Free CPU pinned memory on environment cleanup

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1194,6 +1194,11 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     gc.collect()
     if not current_platform.is_cpu():
         torch.cuda.empty_cache()
+    try:
+        torch._C._host_emptyCache()
+    except AttributeError:
+        logger.warning(
+            "torch._C._host_emptyCache() only available in Pytorch >=2.5")
 
 
 def in_the_same_node_as(pg: ProcessGroup, source_rank: int = 0) -> List[bool]:


### PR DESCRIPTION
When using pinned memory, such as with CPU offload, the physical RAM will not be freed on shutdown, only when the process exits or at some unknown time in the future. To permit subsequent runs not OOMing, we can free it using a call introduced in Pytorch 2.5.

vLLM depends on Pytorch 2.5 but I put in the check defensively.

Context:
https://github.com/pytorch/pytorch/issues/134332