### PR TITLE
[2/N] Proper handling of placeholders in merged multi-modal processor

### DIFF
--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -1,9 +1,6 @@
 import pytest
-from transformers import PreTrainedTokenizerBase
 
-from vllm.multimodal.processing import (find_token_match_by_text,
-                                        iter_token_runs, replace_by_text)
-from vllm.multimodal.utils import cached_get_tokenizer
+from vllm.multimodal.processing import iter_token_matches, iter_token_runs
 
 
 # yapf: disable
@@ -11,17 +8,20 @@ from vllm.multimodal.utils import cached_get_tokenizer
     ("token_ids", "expected"),
     [
         ([], []),
-        ([32000, 32000, 32000], [(32000, { "offset": 0, "length": 3 })]),
+        (
+            [32000, 32000, 32000],
+            [{ "token_id": 32000, "start_idx": 0, "length": 3 }],
+        ),
         (
             [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
             [
-                (9833, { "offset": 0, "length": 1 }),
-                (28747, { "offset": 1, "length": 1 }),
-                (32000, { "offset": 2, "length": 3 }),
-                (9833, { "offset": 5, "length": 1 }),
-                (28747, { "offset": 6, "length": 1 }),
-                (32000, { "offset": 7, "length": 2 }),
-                (918, { "offset": 9, "length": 1 }),
+                { "token_id": 9833, "start_idx": 0, "length": 1 },
+                { "token_id": 28747, "start_idx": 1, "length": 1 },
+                { "token_id": 32000, "start_idx": 2, "length": 3 },
+                { "token_id": 9833, "start_idx": 5, "length": 1 },
+                { "token_id": 28747, "start_idx": 6, "length": 1 },
+                { "token_id": 32000, "start_idx": 7, "length": 2 },
+                { "token_id": 918, "start_idx": 9, "length": 1 },
             ],
         ),
     ],
@@ -30,155 +30,71 @@ from vllm.multimodal.utils import cached_get_tokenizer
 def test_iter_token_runs(token_ids, expected):
     result = list(iter_token_runs(token_ids))
 
-    # Invariants
-    assert sum(run_info["length"] for _, run_info in result) == len(token_ids)
-
     # Manually constructed results
     assert result == expected
 
-
-@pytest.mark.parametrize("tokenizer_id", [
-    "llava-hf/llava-1.5-7b-hf",
-    "meta-llama/Llama-3.2-11B-Vision-Instruct",
-    "microsoft/Phi-3.5-vision-instruct",
-    "Qwen/Qwen2-VL-2B-Instruct",
-])
-@pytest.mark.parametrize(
-    "text",
-    [
-        "What is in this image?",
-        # LLaVA
-        "<image>What is in this image?",
-        "What is<image>in this image?",
-        "What is in this image?<image>",
-        # LLama-3.2
-        "<|image|>What is in this image?",
-        "What is<|image|>in this image?",
-        "What is in this image?<|image|>",
-        # Phi-3-vision
-        "<image_1>What is in this image?",
-        "What is<image_1>in this image?",
-        "What is in this image?<image_1>",
-        # Qwen2-VL
-        "<|vision_start|><|image_pad|><|vision_end|>What is in this image?",
-        "What is<|vision_start|><|image_pad|><|vision_end|>in this image?",
-        "What is in this image?<|vision_start|><|image_pad|><|vision_end|>",
-    ])
-@pytest.mark.parametrize(
-    "match_str",
-    [
-        # No match
-        "No",
-        # Has match
-        "i",
-        "What",
-        "What is",
-        "image",
-        "image?",
-        "<image>",
-        "<|image|>",
-        "<image_1>",
-        "<|vision_start|><|image_pad|><|vision_end|>",
-        "<s>",
-        "</s>",
-    ])
-@pytest.mark.parametrize("add_special_tokens", [True, False])
-def test_token_match_by_text(
-    tokenizer_id,
-    text,
-    match_str,
-    add_special_tokens,
-):
-    tokenizer = cached_get_tokenizer(tokenizer_id)
-    assert isinstance(tokenizer, PreTrainedTokenizerBase)
-
-    token_ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
-    match = find_token_match_by_text(tokenizer, token_ids, text, match_str)
-
-    # These are only shown in the output if the test fails
-    print("token_ids:", token_ids)
-    print("match:", match)
-
     # Invariants
-    if (match_str in text
-            or match_str in tokenizer.decode(token_ids,
-                                             skip_special_tokens=False)):
-        assert match is not None
-        match_start_idx, match_end_idx, *_ = match
-
-        assert match_str in tokenizer.decode(
-            token_ids[match_start_idx:match_end_idx],
-            skip_special_tokens=False,
-        )
-        assert match_str not in tokenizer.decode(
-            token_ids[match_start_idx + 1:match_end_idx],
-            skip_special_tokens=False,
-        )
-        assert match_str not in tokenizer.decode(
-            token_ids[match_start_idx:match_end_idx - 1],
-            skip_special_tokens=False,
-        )
-    else:
-        assert match is None
+    assert sum(run_info["length"] for run_info in result) == len(token_ids)
 
 
-@pytest.mark.parametrize("tokenizer_id", ["llava-hf/llava-1.5-7b-hf"])
-@pytest.mark.parametrize(("input_text", "replacement_count", "expected_text"),
-                         [
-                             ("foo", 0, ""),
-                             ("bar", 0, "bar"),
-                             ("food", 0, "d"),
-                             ("foo", 1, "bar"),
-                             ("bar", 1, "bar"),
-                             ("food", 1, "bard"),
-                             ("foo", 2, "barbar"),
-                             ("bar", 2, "bar"),
-                             ("food", 2, "barbard"),
-                         ])
-@pytest.mark.parametrize("add_special_tokens", [True, False])
-def test_replace_by_text(
-    tokenizer_id,
-    input_text,
-    replacement_count,
-    expected_text,
-    add_special_tokens,
-):
-    tokenizer = cached_get_tokenizer(tokenizer_id)
-    assert isinstance(tokenizer, PreTrainedTokenizerBase)
-
-    vocab = tokenizer.get_vocab()
-    missing_tokens = {"▁foo", "▁bar", "▁food"} - vocab.keys()
-    assert not missing_tokens, missing_tokens
-    assert "▁bard" not in vocab
-
-    input_ids = tokenizer.encode(input_text,
-                                 add_special_tokens=add_special_tokens)
-    bar_id = vocab["bar"]
-
-    output_ids, output_text, replacement = replace_by_text(
-        tokenizer,
-        input_ids[:],  # Copy
-        input_text,
-        "foo",
-        bar_id,
-        replacement_count,
-    )
-
-    # These are only shown in the output if the test fails
-    print("input_ids:", input_ids)
-    print("output_ids:", output_ids)
-    print("output_text:", output_text)
-    print("replacement:", replacement)
-
-    # Invariants
-    if replacement is None:
-        assert output_ids == input_ids
-    else:
-        offset = replacement["offset"]
-        repl_len = replacement["length"]
-
-        assert output_ids[offset:offset + repl_len] == [bar_id] * repl_len
-        assert repl_len == replacement_count
+# yapf: disable
+@pytest.mark.parametrize(
+    ("token_ids", "match_ids", "expected"),
+    [
+        ([], [], [{ "start_idx": 0, "end_idx": 0 }]),
+        ([], [32000], []),
+        (
+            [32000, 32000, 32000],
+            [32000],
+            [
+                { "start_idx": 0, "end_idx": 1 },
+                { "start_idx": 1, "end_idx": 2 },
+                { "start_idx": 2, "end_idx": 3 },
+            ],
+        ),
+        (
+            [32000, 32000, 32000],
+            [32000, 32000],
+            [
+                { "start_idx": 0, "end_idx": 2 },
+                { "start_idx": 1, "end_idx": 3 },
+            ],
+        ),
+        (
+            [32000, 32000, 32000],
+            [32000, 32000, 32000],
+            [{ "start_idx": 0, "end_idx": 3 }],
+        ),
+        (
+            [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
+            [28747, 32000],
+            [
+                { "start_idx": 1, "end_idx": 3 },
+                { "start_idx": 6, "end_idx": 8 },
+            ],
+        ),
+        (
+            [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
+            [28747, 32000, 32000, 32000],
+            [
+                { "start_idx": 1, "end_idx": 5 },
+            ],
+        ),
+        (
+            [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
+            [28747, 0, 32000],
+            [],
+        ),
+    ],
+)
+# yapf: enable
+def test_iter_token_matches(token_ids, match_ids, expected):
+    result = list(iter_token_matches(token_ids, match_ids))
 
     # Manually constructed results
-    assert output_text == expected_text
+    assert [item._asdict() for item in result] == expected
+
+    # Invariants
+    match_lens = [end - start for start, end in result]
+    print("match_lens:", match_lens)  # Only displayed on error
+    assert all(match_len == len(match_ids) for match_len in match_lens)

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -104,7 +104,7 @@ def test_token_match_by_text(
             or match_str in tokenizer.decode(token_ids,
                                              skip_special_tokens=False)):
         assert match is not None
-        match_start_idx, match_end_idx = match
+        match_start_idx, match_end_idx, *_ = match
 
         assert match_str in tokenizer.decode(
             token_ids[match_start_idx:match_end_idx],

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -3,12 +3,11 @@ from typing import cast
 import pytest
 from transformers import BatchFeature
 
-from vllm.config import ModelConfig
-from vllm.multimodal.processing import (InputProcessingContext,
-                                        ModalityProcessingMetadata,
-                                        MultiModalProcessor, PromptReplacement,
-                                        iter_token_matches, iter_token_runs)
-from vllm.multimodal.utils import cached_get_tokenizer
+from vllm.multimodal.processing import (PromptReplacement, find_text_matches,
+                                        find_token_matches, iter_token_matches,
+                                        iter_token_runs, replace_text_matches)
+from vllm.transformers_utils.tokenizer import AnyTokenizer
+from vllm.utils import full_groupby
 
 
 # yapf: disable
@@ -38,6 +37,9 @@ from vllm.multimodal.utils import cached_get_tokenizer
 def test_iter_token_runs(token_ids, expected):
     result = list(iter_token_runs(token_ids))
 
+    # Only displayed on error
+    print("result:", result)
+
     # Manually constructed results
     assert result == expected
 
@@ -63,10 +65,7 @@ def test_iter_token_runs(token_ids, expected):
         (
             [32000, 32000, 32000],
             [32000, 32000],
-            [
-                { "start_idx": 0, "end_idx": 2 },
-                { "start_idx": 1, "end_idx": 3 },
-            ],
+            [{ "start_idx": 0, "end_idx": 2 }],
         ),
         (
             [32000, 32000, 32000],
@@ -108,112 +107,256 @@ def test_iter_token_matches(token_ids, match_ids, expected):
     assert all(match_len == len(match_ids) for match_len in match_lens)
 
 
-@pytest.mark.parametrize("tokenizer_id", [
-    "llava-hf/llava-1.5-7b-hf",
-    "meta-llama/Llama-3.2-11B-Vision-Instruct",
-    "microsoft/Phi-3.5-vision-instruct",
-    "Qwen/Qwen2-VL-2B-Instruct",
-])
+# yapf: disable
 @pytest.mark.parametrize(
-    "prompt_str",
+    ("prompt", "target_by_key", "expected_by_key"),
     [
-        "What is in this image?",
-        # LLaVA
-        "<image>What is in this image?",
-        "What is<image>in this image?",
-        "What is in this image?<image>",
-        # LLama-3.2
-        "<|image|>What is in this image?",
-        "What is<|image|>in this image?",
-        "What is in this image?<|image|>",
-        # Phi-3-vision
-        "<image_1>What is in this image?",
-        "What is<image_1>in this image?",
-        "What is in this image?<image_1>",
-        # Qwen2-VL
-        "<|vision_start|><|image_pad|><|vision_end|>What is in this image?",
-        "What is<|vision_start|><|image_pad|><|vision_end|>in this image?",
-        "What is in this image?<|vision_start|><|image_pad|><|vision_end|>",
-    ])
-@pytest.mark.parametrize(
-    "repl_target_str",
-    [
-        # No match
-        "No",
-        # Has match
-        "i",
-        "image",
-        "image?",
-        "<image>",
-        "<|image|>",
-        "<image_1>",
-        "<|vision_start|><|image_pad|><|vision_end|>",
-        "<s>",
-    ])
-@pytest.mark.parametrize(
-    "repl_unit_str",
-    [
-        # No match
-        "No",
-        # Has match
-        "i",
-        "image",
-        "image?",
-        "<image>",
-        "<|image|>",
-        "<image_1>",
-        "<|vision_start|><|image_pad|><|vision_end|>",
-        "<s>",
-    ])
-@pytest.mark.parametrize("repl_count", [0, 1, 2])
-@pytest.mark.parametrize("mm_count", [0, 1, 2])
-def test_processor_prompt_replacements(
-    tokenizer_id,
-    prompt_str,
-    repl_target_str,
-    repl_unit_str,
-    repl_count,
-    mm_count,
-):
-    mock_config = cast(ModelConfig, object())
-    tokenizer = cached_get_tokenizer(tokenizer_id)
+        (
+            [],
+            {
+                "pattern_1": [],
+                "pattern_2": [32000],
+            },
+            {
+                "pattern_1": [{ "start_idx": 0, "end_idx": 0 }],
+                "pattern_2": [],
+            }
+        ),
+        (
+            [32000, 32000, 32000, 32000],
+            {
+                "pattern_1": [32000],
+                "pattern_2": [32000, 32000],
+                "pattern_3": [32000, 32000, 32000],
+            },
+            {
+                "pattern_1": [
+                    { "start_idx": 0, "end_idx": 1 },
+                    { "start_idx": 1, "end_idx": 2 },
+                    { "start_idx": 2, "end_idx": 3 },
+                    { "start_idx": 3, "end_idx": 4 },
+                ],
+                "pattern_2": [
+                    { "start_idx": 0, "end_idx": 2 },
+                    { "start_idx": 2, "end_idx": 4 },
+                ],
+                "pattern_3": [
+                    { "start_idx": 0, "end_idx": 3 },
+                ],
+            },
+        ),
+        (
+            [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
+            {
+                "pattern_1": [28747, 32000],
+                "pattern_2": [28747, 32000, 32000, 32000],
+                "pattern_3": [28747, 0, 32000],
+            },
+            {
+                "pattern_1": [
+                    { "start_idx": 1, "end_idx": 3 },
+                    { "start_idx": 6, "end_idx": 8 },
+                ],
+                "pattern_2": [
+                    { "start_idx": 1, "end_idx": 5 },
+                ],
+                "pattern_3": [],
+            },
+        ),
+    ],
+)
+# yapf: enable
+def test_find_token_matches(prompt, target_by_key, expected_by_key):
+    # Should not be used since there is nothing to convert to token IDs
+    mock_tokenizer = cast(AnyTokenizer, object())
 
-    ctx = InputProcessingContext(mock_config, tokenizer)
-    metadata = ModalityProcessingMetadata(prompt_repls=[
-        PromptReplacement(repl_target_str, repl_unit_str,
-                          lambda *args, **kwargs: repl_count),
-    ])
-    modality = "image"
-
-    dummy_metadata = {modality: metadata}
-    dummy_mm_data = {modality: list(range(mm_count))}
-    prompt_ids = tokenizer.encode(prompt_str)
-
-    processor = MultiModalProcessor(ctx, dummy_metadata)
-    new_token_ids, placeholder_ranges = processor._apply_prompt_replacements(
-        dummy_mm_data,
-        BatchFeature(),
-        prompt_ids,
-        processor._bind_prompt_replacements(dummy_mm_data),
+    result = find_token_matches(
+        prompt,
+        [
+            PromptReplacement(target, [], 0).bind(key, mock_tokenizer)
+            for key, target in target_by_key.items()
+        ],
     )
 
-    repl_unit_ids = tokenizer.encode(repl_unit_str)
+    # Only displayed on error
+    print("result:", result)
+
+    # Manually constructed results
+    result_groups = dict(full_groupby(result, key=lambda x: x.modality))
+    assert {
+        key: [
+            dict(start_idx=item.start_idx, end_idx=item.end_idx)
+            for item in result_groups.get(key, [])
+        ]
+        for key in expected_by_key
+    } == expected_by_key
+
+
+# yapf: disable
+@pytest.mark.parametrize(
+    ("prompt", "target_by_key", "expected_by_key"),
+    [
+        # Detokenized test cases of `test_find_token_matches`
+        # using the vocab of llava-hf/llava-v1.6-mistral-7b-hf
+        (
+            "",
+            {
+                "pattern_1": "",
+                "pattern_2": "<image>",
+            },
+            {
+                "pattern_1": [{ "start_idx": 0, "end_idx": 0 }],
+                "pattern_2": [],
+            }
+        ),
+        (
+            "<image><image><image><image>",
+            {
+                "pattern_1": "<image>",
+                "pattern_2": "<image><image>",
+                "pattern_3": "<image><image><image>",
+            },
+            {
+                "pattern_1": [
+                    { "start_idx": 0, "end_idx": 7 },
+                    { "start_idx": 7, "end_idx": 14 },
+                    { "start_idx": 14, "end_idx": 21 },
+                    { "start_idx": 21, "end_idx": 28 },
+                ],
+                "pattern_2": [
+                    { "start_idx": 0, "end_idx": 14 },
+                    { "start_idx": 14, "end_idx": 28 },
+                ],
+                "pattern_3": [
+                    { "start_idx": 0, "end_idx": 21 },
+                ],
+            },
+        ),
+        (
+            "Image:<image><image><image>Image:<image><image>!",
+            {
+                "pattern_1": "Image:<image>",
+                "pattern_2": "Image:<image><image><image>",
+                "pattern_3": "Image:<unk><image>",
+            },
+            {
+                "pattern_1": [
+                    { "start_idx": 0, "end_idx": 13 },
+                    { "start_idx": 27, "end_idx": 40 },
+                ],
+                "pattern_2": [
+                    { "start_idx": 0, "end_idx": 27 },
+                ],
+                "pattern_3": [],
+            },
+        ),
+        # Test regex escape
+        (
+            "<|image|><image><|image|><image>",
+            {
+                "pattern_1": "<|image|>",
+                "pattern_2": "<|image|><image>",
+                "pattern_3": "<|image|><image><|image|>",
+            },
+            {
+                "pattern_1": [
+                    { "start_idx": 0, "end_idx": 9 },
+                    { "start_idx": 16, "end_idx": 25 },
+                ],
+                "pattern_2": [
+                    { "start_idx": 0, "end_idx": 16 },
+                    { "start_idx": 16, "end_idx": 32 },
+                ],
+                "pattern_3": [
+                    { "start_idx": 0, "end_idx": 25 },
+                ],
+            },
+        ),
+    ],
+)
+# yapf: enable
+def test_find_text_matches(prompt, target_by_key, expected_by_key):
+    # Should not be used since there is nothing to convert to text
+    mock_tokenizer = cast(AnyTokenizer, object())
+
+    result = find_text_matches(
+        prompt,
+        [
+            PromptReplacement(target, [], 0).bind(key, mock_tokenizer)
+            for key, target in target_by_key.items()
+        ],
+    )
 
     # Only displayed on error
-    print("prompt_ids:", prompt_ids)
-    print("repl_unit_ids:", repl_unit_ids)
-    print("new_token_ids:", new_token_ids)
-    print("placeholder_ranges:", placeholder_ranges)
+    print("result:", result)
 
-    # Invariants
-    if mm_count == 0:
-        assert new_token_ids == prompt_ids
+    # Manually constructed results
+    result_groups = dict(full_groupby(result, key=lambda x: x.modality))
+    assert {
+        key: [
+            dict(start_idx=item.start_idx, end_idx=item.end_idx)
+            for item in result_groups.get(key, [])
+        ]
+        for key in expected_by_key
+    } == expected_by_key
 
-    assert len(placeholder_ranges) <= mm_count
 
-    for placeholder_range in placeholder_ranges:
-        repl_offset = placeholder_range["offset"]
-        repl_len = placeholder_range["length"]
+# yapf: disable
+@pytest.mark.parametrize(
+    ("prompt", "target_by_key", "repl_by_key", "expected_by_mm_count"),
+    [
+        (
+            "Image:<image>Image:<image><image>!",
+            {
+                "pattern_1": "<image>",
+                "pattern_2": "Image:",
+                "pattern_3": "!",
+            },
+            {
+                "pattern_1": ("<image><image>", 1),
+                "pattern_2": ("", 1),
+                "pattern_3": ("?", 2),
+            },
+            {
+                0: "Image:<image>Image:<image><image>!",
+                1: "<image><image>Image:<image><image>??",
+                2: "<image><image><image><image><image>??",
+            },
+        ),
+    ]
+)
+# yapf: enable
+def test_find_replace_text(
+    prompt,
+    target_by_key,
+    repl_by_key,
+    expected_by_mm_count,
+):
+    # Should not be used since there is nothing to convert to text
+    mock_tokenizer = cast(AnyTokenizer, object())
 
-        assert new_token_ids[repl_offset:repl_offset +
-                             repl_len] == repl_unit_ids * repl_count
+    matches = find_text_matches(
+        prompt,
+        [
+            PromptReplacement(target, *repl_by_key[key]) \
+                .bind(key, mock_tokenizer)
+            for key, target in target_by_key.items()
+        ],
+    )
+    result_by_mm_count = {
+        mm_count: replace_text_matches(
+            prompt,
+            matches,
+            {key: list(range(mm_count))
+             for key in repl_by_key},
+            BatchFeature(),
+        )
+        for mm_count in expected_by_mm_count
+    }
+
+    # Only displayed on error
+    print("matches:", matches)
+    print("result_by_mm_count:", result_by_mm_count)
+
+    # Manually constructed results
+    assert result_by_mm_count == expected_by_mm_count

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -308,18 +308,26 @@ def test_find_text_matches(prompt, target_by_key, expected_by_key):
         (
             "Image:<image>Image:<image><image>!",
             {
+                # We use `<image>` before `Image:` to test matches that
+                # occur out of order
                 "pattern_1": "<image>",
                 "pattern_2": "Image:",
                 "pattern_3": "!",
             },
             {
+                # Test whether target is confused with repl_unit
                 "pattern_1": ("<image><image>", 1),
+                # Test empty repl_unit
                 "pattern_2": ("", 1),
+                # Test multiple repl_count
                 "pattern_3": ("?", 2),
             },
             {
+                # Test no replacement
                 0: "Image:<image>Image:<image><image>!",
+                # Test single replacement
                 1: "<image><image>Image:<image><image>??",
+                # Test repeated replacement
                 2: "<image><image><image><image><image>??",
             },
         ),

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -3,6 +3,7 @@ import pytest
 from vllm.multimodal.processing import apply_placeholders, iter_token_runs
 
 
+# yapf: disable
 @pytest.mark.parametrize(
     ("token_ids", "expected"),
     [
@@ -20,18 +21,20 @@ from vllm.multimodal.processing import apply_placeholders, iter_token_runs
                 (918, { "offset": 9, "length": 1 }),
             ],
         ),
-    ],  # yapf: disable
+    ],
 )
+# yapf: enable
 def test_iter_token_runs(token_ids, expected):
     result = list(iter_token_runs(token_ids))
     assert result == expected
 
 
+# yapf: disable
 @pytest.mark.parametrize(
     (
         "token_ids", "match_ids", "replacement_id", "replacement_count",
         "expected_new_token_ids", "expected_range",
-    ),  # yapf: disable
+    ),
     [
         # Empty
         (
@@ -95,8 +98,9 @@ def test_iter_token_runs(token_ids, expected):
             [32000, 32000, 32000], [32000], +1, 2,
             [+1, +1, 32000, 32000],  { "offset": 0, "length": 2 },
         ),
-    ],  # yapf: disable
+    ],
 )
+# yapf: enable
 def test_apply_placeholders(
     token_ids,
     match_ids,

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -175,10 +175,10 @@ def test_processor_prompt_replacements(
     repl_count,
     mm_count,
 ):
-    model_config = cast(ModelConfig, object())
+    mock_config = cast(ModelConfig, object())
     tokenizer = cached_get_tokenizer(tokenizer_id)
 
-    ctx = InputProcessingContext(model_config, tokenizer)
+    ctx = InputProcessingContext(mock_config, tokenizer)
     metadata = ModalityProcessingMetadata(prompt_repls=[
         PromptReplacement(repl_target_str, repl_unit_str,
                           lambda *args, **kwargs: repl_count),
@@ -194,6 +194,7 @@ def test_processor_prompt_replacements(
         dummy_mm_data,
         BatchFeature(),
         prompt_ids,
+        processor._bind_prompt_replacements(dummy_mm_data),
     )
 
     repl_unit_ids = tokenizer.encode(repl_unit_str)

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -41,10 +41,10 @@ def test_iter_token_runs(token_ids, expected):
     print("result:", result)
 
     # Manually constructed results
-    assert result == expected
+    assert [item._asdict() for item in result] == expected
 
     # Invariants
-    assert sum(run_info["length"] for run_info in result) == len(token_ids)
+    assert sum(run_info.length for run_info in result) == len(token_ids)
 
 
 # yapf: disable

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -1,0 +1,116 @@
+import pytest
+
+from vllm.multimodal.processing import apply_placeholders, iter_token_runs
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "expected"),
+    [
+        ([], []),
+        ([32000, 32000, 32000], [(32000, { "offset": 0, "length": 3 })]),
+        (
+            [9833, 28747, 32000, 32000, 32000, 9833, 28747, 32000, 32000, 918],
+            [
+                (9833, { "offset": 0, "length": 1 }),
+                (28747, { "offset": 1, "length": 1 }),
+                (32000, { "offset": 2, "length": 3 }),
+                (9833, { "offset": 5, "length": 1 }),
+                (28747, { "offset": 6, "length": 1 }),
+                (32000, { "offset": 7, "length": 2 }),
+                (918, { "offset": 9, "length": 1 }),
+            ],
+        ),
+    ],  # yapf: disable
+)
+def test_iter_token_runs(token_ids, expected):
+    result = list(iter_token_runs(token_ids))
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    (
+        "token_ids", "match_ids", "replacement_id", "replacement_count",
+        "expected_new_token_ids", "expected_range",
+    ),  # yapf: disable
+    [
+        # Empty
+        (
+            [], [-1], +1, 0,
+            [], None,
+        ),
+        # No match
+        (
+            [32000, 32000, 32000], [-1], +1, 0,
+            [32000, 32000, 32000], None,
+        ),
+        # Match first
+        (
+            [-1, 32000, 32000], [-1], +1, 0,
+            [32000, 32000], { "offset": 0, "length": 0 },
+        ),
+        (
+            [-1, 32000, 32000], [-1], +1, 1,
+            [+1, 32000, 32000], { "offset": 0, "length": 1 },
+        ),
+        (
+            [-1, 32000, 32000], [-1], +1, 2,
+            [+1, +1, 32000, 32000], { "offset": 0, "length": 2 },
+        ),
+        # Match middle
+        (
+            [32000, -1, 32000], [-1], +1, 0,
+            [32000, 32000], { "offset": 1, "length": 0 },
+        ),
+        (
+            [32000, -1, 32000], [-1], +1, 1,
+            [32000, +1, 32000], { "offset": 1, "length": 1 },
+        ),
+        (
+            [32000, -1, 32000], [-1], +1, 2,
+            [32000, +1, +1, 32000], { "offset": 1, "length": 2},
+        ),
+        # Match last
+        (
+            [32000, 32000, -1], [-1], +1, 0,
+            [32000, 32000], { "offset": 2, "length": 0 },
+        ),
+        (
+            [32000, 32000, -1], [-1], +1, 1,
+            [32000, 32000, +1], { "offset": 2, "length": 1 },
+        ),
+        (
+            [32000, 32000, -1], [-1], +1, 2,
+            [32000, 32000, +1, +1], { "offset": 2, "length": 2},
+        ),
+        # Match all
+        (
+            [32000, 32000, 32000], [32000], +1, 0,
+            [32000, 32000], { "offset": 0, "length": 0 },
+        ),
+        (
+            [32000, 32000, 32000], [32000], +1, 1,
+            [+1, 32000, 32000], { "offset": 0, "length": 1 },
+        ),
+        (
+            [32000, 32000, 32000], [32000], +1, 2,
+            [+1, +1, 32000, 32000],  { "offset": 0, "length": 2 },
+        ),
+    ],  # yapf: disable
+)
+def test_apply_placeholders(
+    token_ids,
+    match_ids,
+    replacement_id,
+    replacement_count,
+    expected_new_token_ids,
+    expected_range,
+):
+    placeholder_range = apply_placeholders(
+        token_ids,
+        match_ids,
+        replacement_id,
+        replacement_count,
+    )
+
+    assert token_ids == expected_new_token_ids
+    assert placeholder_range == expected_range

--- a/tests/multimodal/test_processing.py
+++ b/tests/multimodal/test_processing.py
@@ -1,6 +1,14 @@
-import pytest
+from typing import cast
 
-from vllm.multimodal.processing import iter_token_matches, iter_token_runs
+import pytest
+from transformers import BatchFeature
+
+from vllm.config import ModelConfig
+from vllm.multimodal.processing import (InputProcessingContext,
+                                        ModalityProcessingMetadata,
+                                        MultiModalProcessor, PromptReplacement,
+                                        iter_token_matches, iter_token_runs)
+from vllm.multimodal.utils import cached_get_tokenizer
 
 
 # yapf: disable
@@ -98,3 +106,113 @@ def test_iter_token_matches(token_ids, match_ids, expected):
     match_lens = [end - start for start, end in result]
     print("match_lens:", match_lens)  # Only displayed on error
     assert all(match_len == len(match_ids) for match_len in match_lens)
+
+
+@pytest.mark.parametrize("tokenizer_id", [
+    "llava-hf/llava-1.5-7b-hf",
+    "meta-llama/Llama-3.2-11B-Vision-Instruct",
+    "microsoft/Phi-3.5-vision-instruct",
+    "Qwen/Qwen2-VL-2B-Instruct",
+])
+@pytest.mark.parametrize(
+    "prompt_str",
+    [
+        "What is in this image?",
+        # LLaVA
+        "<image>What is in this image?",
+        "What is<image>in this image?",
+        "What is in this image?<image>",
+        # LLama-3.2
+        "<|image|>What is in this image?",
+        "What is<|image|>in this image?",
+        "What is in this image?<|image|>",
+        # Phi-3-vision
+        "<image_1>What is in this image?",
+        "What is<image_1>in this image?",
+        "What is in this image?<image_1>",
+        # Qwen2-VL
+        "<|vision_start|><|image_pad|><|vision_end|>What is in this image?",
+        "What is<|vision_start|><|image_pad|><|vision_end|>in this image?",
+        "What is in this image?<|vision_start|><|image_pad|><|vision_end|>",
+    ])
+@pytest.mark.parametrize(
+    "repl_target_str",
+    [
+        # No match
+        "No",
+        # Has match
+        "i",
+        "image",
+        "image?",
+        "<image>",
+        "<|image|>",
+        "<image_1>",
+        "<|vision_start|><|image_pad|><|vision_end|>",
+        "<s>",
+    ])
+@pytest.mark.parametrize(
+    "repl_unit_str",
+    [
+        # No match
+        "No",
+        # Has match
+        "i",
+        "image",
+        "image?",
+        "<image>",
+        "<|image|>",
+        "<image_1>",
+        "<|vision_start|><|image_pad|><|vision_end|>",
+        "<s>",
+    ])
+@pytest.mark.parametrize("repl_count", [0, 1, 2])
+@pytest.mark.parametrize("mm_count", [0, 1, 2])
+def test_processor_prompt_replacements(
+    tokenizer_id,
+    prompt_str,
+    repl_target_str,
+    repl_unit_str,
+    repl_count,
+    mm_count,
+):
+    model_config = cast(ModelConfig, object())
+    tokenizer = cached_get_tokenizer(tokenizer_id)
+
+    ctx = InputProcessingContext(model_config, tokenizer)
+    metadata = ModalityProcessingMetadata(prompt_repls=[
+        PromptReplacement(repl_target_str, repl_unit_str,
+                          lambda *args, **kwargs: repl_count),
+    ])
+    modality = "image"
+
+    dummy_metadata = {modality: metadata}
+    dummy_mm_data = {modality: list(range(mm_count))}
+    prompt_ids = tokenizer.encode(prompt_str)
+
+    processor = MultiModalProcessor(ctx, dummy_metadata)
+    new_token_ids, placeholder_ranges = processor._apply_prompt_replacements(
+        dummy_mm_data,
+        BatchFeature(),
+        prompt_ids,
+    )
+
+    repl_unit_ids = tokenizer.encode(repl_unit_str)
+
+    # Only displayed on error
+    print("prompt_ids:", prompt_ids)
+    print("repl_unit_ids:", repl_unit_ids)
+    print("new_token_ids:", new_token_ids)
+    print("placeholder_ranges:", placeholder_ranges)
+
+    # Invariants
+    if mm_count == 0:
+        assert new_token_ids == prompt_ids
+
+    assert len(placeholder_ranges) <= mm_count
+
+    for placeholder_range in placeholder_ranges:
+        repl_offset = placeholder_range["offset"]
+        repl_len = placeholder_range["length"]
+
+        assert new_token_ids[repl_offset:repl_offset +
+                             repl_len] == repl_unit_ids * repl_count

--- a/tests/multimodal/test_utils.py
+++ b/tests/multimodal/test_utils.py
@@ -139,7 +139,8 @@ def test_repeat_and_pad_placeholder_tokens(model):
             2,
             "<image><image><image>",
             [32000, 32000, 32000],
-            [{ "offset": 0, "length": 2 }]),
+            [{ "offset": 0, "length": 2 }],
+        ),
         (
             "<image><image>",
             [3, 2],

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -203,14 +203,7 @@ class MultiModalInputsV2(TypedDict):
     """The type of inputs."""
 
     prompt: str
-    """
-    The original, unprocessed prompt text.
-
-    Note:
-        Since prompt text is not required by vLLM internals, we leave this
-        unprocessed to save CPU computation. You can still call
-        :code:`tokenizer.decode(prompt_token_ids)` to get the processed text.
-    """
+    """The processed prompt text."""
 
     prompt_token_ids: List[int]
     """The processed token IDs which includes placeholder tokens."""

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -278,6 +278,7 @@ class MultiModalProcessor:
                 if new_token_id in repl_token_ids:
                     modality_placeholders.append(run_info)
 
+            # Otherwise, we insert them ourselves
             if not modality_placeholders:
                 for item_idx, orig_item in enumerate(orig_inputs):
                     for match_str, replacement in placeholder_repls.items():

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -648,6 +648,8 @@ class MultiModalProcessor:
             matched_repls = [match.prompt_repl for match in text_matches]
 
         placeholders = self._find_placeholders(matched_repls, token_ids)
+
+        # Sanity check
         assert len(placeholders) == len(matched_repls), dict(
             # Log this information for easier debugging
             text=text,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -91,8 +91,7 @@ _T = TypeVar("_T")
 _S = TypeVar("_S", str, list[int])
 _S_co = TypeVar("_S_co", bound=PromptSegment, covariant=True)
 
-ReplacementCount: TypeAlias = Union[Callable[[_T, BatchFeature, int], int],
-                                    int]
+ReplacementCount = Union[Callable[[_T, BatchFeature, int], int], int]
 """
 Given the original data item, HF-processed data, and index of the processed
 item, output the number of repetitions.

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -24,7 +24,7 @@ def bind_prompt_sequence(
     tokenizer: AnyTokenizer,
 ) -> "_BoundPromptSequence":
     """
-    Bind text or token sequences to a tokenizer so that it can be
+    Bind a text or token sequence to a tokenizer so that it can be
     lazily converted into the other format on demand.
     """
     return _BoundPromptSequence(

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -296,7 +296,7 @@ def find_token_match_by_text(
     )
 
 
-def apply_placeholders(
+def replace_by_text(
     tokenizer: AnyTokenizer,
     token_ids: List[int],
     token_text: str,
@@ -417,7 +417,7 @@ class MultiModalProcessor:
                             new_token_ids,
                             new_prompt,
                             placeholders,
-                        ) = apply_placeholders(
+                        ) = replace_by_text(
                             tokenizer,
                             new_token_ids,
                             new_prompt,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -562,7 +562,8 @@ class MultiModalProcessor:
         new_token_ids: list[int],
         *,
         # To avoid false positives from multi-input when detecting
-        # whether HF processor already inserts placeholder tokens
+        # whether placeholder tokens have been inserted, in case
+        # the target sequence is a subset of the replacement tokens
         min_placeholder_count: int = 16,
     ) -> list[_PlaceholderInfo]:
         return list(

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -675,6 +675,8 @@ class MultiModalProcessor:
         2. Find and replace sequences in the token IDs with placeholder tokens.
            The number of placeholder tokens equals the feature size of the
            multi-modal data outputted by the multi-modal encoder.
+        3. Extract information about the placeholder tokens from the
+           processed token IDs.
         """
         tokenizer = self.ctx.tokenizer
 

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -209,10 +209,12 @@ def find_token_match_by_text(
 
     left_idx = len(_encode(tokenizer, left_text, add_special_tokens=False))
     right_idx = len(_encode(tokenizer, right_text, add_special_tokens=True))
+    avg_idx = (left_idx + right_idx) // 2
     window_size = len(match_ids)
 
     valid_candidates = list[_Candidate]()
-    for start_idx in range(left_idx, right_idx - window_size + 1):
+    for start_idx in sorted(range(left_idx, right_idx - window_size + 1),
+                            key=lambda x: abs(x - avg_idx)):
         end_idx = start_idx + window_size
         candidate_text = tokenizer.decode(
             token_ids[start_idx:end_idx],

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -276,7 +276,7 @@ def iter_token_runs(token_ids: list[int]) -> Iterable[_TokenRun]:
         start_idx += length
 
 
-class _BoundPlaceholderInfo(NamedTuple):
+class _PlaceholderInfo(NamedTuple):
     modality: str
     offset: int
     length: int
@@ -290,7 +290,7 @@ def iter_placeholders(
     token_ids: list[int],
     *,
     min_placeholder_count: int,
-) -> Iterable[_BoundPlaceholderInfo]:
+) -> Iterable[_PlaceholderInfo]:
     """Yield each set of placeholder tokens found in :code:`token_ids`."""
     repls_by_modality = full_groupby_modality(prompt_repls)
 
@@ -308,7 +308,7 @@ def iter_placeholders(
             for (modality,
                  placeholder_ids) in placeholder_ids_by_modality.items():
                 if run_info.token_id in placeholder_ids:
-                    yield _BoundPlaceholderInfo(
+                    yield _PlaceholderInfo(
                         modality=modality,
                         offset=run_info.start_idx,
                         length=run_info.length,
@@ -564,7 +564,7 @@ class MultiModalProcessor:
         # To avoid false positives from multi-input when detecting
         # whether HF processor already inserts placeholder tokens
         min_placeholder_count: int = 16,
-    ) -> list[_BoundPlaceholderInfo]:
+    ) -> list[_PlaceholderInfo]:
         return list(
             iter_placeholders(
                 all_prompt_repls,
@@ -604,7 +604,7 @@ class MultiModalProcessor:
         hf_inputs: BatchFeature,
         token_ids: list[int],
         prompt_repls: Sequence[_BoundPromptReplacement[Any]],
-    ) -> tuple[list[int], str, list[_BoundPlaceholderInfo]]:
+    ) -> tuple[list[int], str, list[_PlaceholderInfo]]:
         tokenizer = self.ctx.tokenizer
         mm_items = to_multi_format(mm_data)
         token_matches = find_token_matches(token_ids, prompt_repls)
@@ -680,7 +680,6 @@ class MultiModalProcessor:
         # there is no need for us to insert them
         all_placeholders = self._find_placeholders(all_prompt_repls,
                                                    prompt_ids)
-
         if all_placeholders:
             prompt_text = _decode(tokenizer, prompt_ids)
         else:

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -605,6 +605,7 @@ class MultiModalProcessor:
         prompt_repls: Sequence[_BoundPromptReplacement[Any]],
     ) -> tuple[list[int], str, list[_PlaceholderInfo]]:
         tokenizer = self.ctx.tokenizer
+
         mm_items = to_multi_format(mm_data)
         token_matches = find_token_matches(token_ids, prompt_repls)
 

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -209,23 +209,26 @@ def find_token_match_by_text(
 
     left_idx = len(_encode(tokenizer, left_text, add_special_tokens=False))
     right_idx = len(_encode(tokenizer, right_text, add_special_tokens=True))
+    window_size = len(match_ids)
 
     valid_candidates = list[_Candidate]()
-    for window_size in (len(match_ids) - 1, len(match_ids)):
-        for start_idx in range(left_idx, right_idx - window_size + 1):
-            end_idx = start_idx + window_size
-            candidate_text = tokenizer.decode(
-                token_ids[start_idx:end_idx],
-                skip_special_tokens=False,
-            )
+    for start_idx in range(left_idx, right_idx - window_size + 1):
+        end_idx = start_idx + window_size
+        candidate_text = tokenizer.decode(
+            token_ids[start_idx:end_idx],
+            skip_special_tokens=False,
+        )
 
-            if match_text in candidate_text:
-                candidate = _Candidate(
-                    start_idx=start_idx,
-                    end_idx=end_idx,
-                    distance=len(candidate_text) - len(match_text),
-                )
-                valid_candidates.append(candidate)
+        if match_text in candidate_text:
+            candidate = _Candidate(
+                start_idx=start_idx,
+                end_idx=end_idx,
+                distance=len(candidate_text) - len(match_text),
+            )
+            valid_candidates.append(candidate)
+
+            if candidate.distance == 0:
+                break
 
     assert len(valid_candidates) > 0, dict(
         # To facilitate debugging

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -648,6 +648,13 @@ class MultiModalProcessor:
             matched_repls = [match.prompt_repl for match in text_matches]
 
         placeholders = self._find_placeholders(matched_repls, token_ids)
+        assert len(placeholders) == len(matched_repls), dict(
+            # Log this information for easier debugging
+            text=text,
+            token_ids=token_ids,
+            placeholders=placeholders,
+            matched_repls=matched_repls,
+        )
 
         return token_ids, text, placeholders
 

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -91,15 +91,6 @@ _T = TypeVar("_T")
 _S = TypeVar("_S", str, list[int])
 _S_co = TypeVar("_S_co", bound=PromptSegment, covariant=True)
 
-ReplacementCount = Union[Callable[[_T, BatchFeature, int], int], int]
-"""
-Given the original data item, HF-processed data, and index of the processed
-item, output the number of repetitions.
-
-For convenience, you can pass in an integer if the number of repetitions is
-a constant.
-"""
-
 
 @dataclass
 class PromptReplacement(Generic[_S_co, _T]):
@@ -113,10 +104,14 @@ class PromptReplacement(Generic[_S_co, _T]):
     See :code:`repl_count` for more details.
     """
 
-    repl_count: ReplacementCount[_T]
+    repl_count: Union[Callable[[_T, BatchFeature, int], int], int]
     """
-    The number of repetitions of :code:`repl_unit` to build up the
+    Given the original data item, HF-processed data, and index of the processed
+    item, output the number of repetitions of :code:`repl_unit` to build up the
     replacement prompt segment.
+
+    For convenience, you can pass in an integer if the number of repetitions is
+    a constant.
     """
 
     def __repr__(self) -> str:
@@ -205,7 +200,7 @@ class _BoundPromptReplacement(Generic[_T]):
     modality: str
     target: _BoundPromptSegment
     repl_unit: _BoundPromptSegment
-    repl_count: ReplacementCount[_T]
+    repl_count: Union[Callable[[_T, BatchFeature, int], int], int]
 
     def get_count(
         self,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -358,6 +358,8 @@ class MultiModalProcessor:
                               end_idx)) in enumerate(sorted_matches):
             prompt_repl = prompt_repls_by_target_text[target_text]
             mm_items = mm_items_by_modality[prompt_repl.modality]
+            if i >= len(mm_items):
+                break
 
             repl_count = prompt_repl.repl_count(mm_items[i], hf_inputs, i)
             repl_ids = prompt_repl.repl_unit.token_ids * repl_count
@@ -405,6 +407,8 @@ class MultiModalProcessor:
         for i, (target_text, match) in enumerate(sorted_matches):
             prompt_repl = prompt_repls_by_target_text[target_text]
             mm_items = mm_items_by_modality[prompt_repl.modality]
+            if i >= len(mm_items):
+                break
 
             repl_count = prompt_repl.repl_count(mm_items[i], hf_inputs, i)
             repl_text = prompt_repl.repl_unit.text * repl_count
@@ -455,7 +459,7 @@ class MultiModalProcessor:
                 all_prompt_repls,
             )
 
-            if len(token_id_matches) == len(mm_items):
+            if len(token_id_matches) >= len(mm_items):
                 new_token_ids = self._replace_token_id_matches(
                     new_token_ids,
                     all_prompt_repls,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -292,15 +292,13 @@ def iter_placeholders(
     min_placeholder_count: int,
 ) -> Iterable[_PlaceholderInfo]:
     """Yield each set of placeholder tokens found in :code:`token_ids`."""
-    repls_by_modality = full_groupby_modality(prompt_repls)
-
     placeholder_ids_by_modality = {
         modality: {
             token_id
             for prompt_repl in repls
             for token_id in prompt_repl.repl_unit.token_ids
         }
-        for modality, repls in repls_by_modality
+        for modality, repls in full_groupby_modality(prompt_repls)
     }
 
     for run_info in iter_token_runs(token_ids):

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -19,7 +19,8 @@ import uuid
 import warnings
 import weakref
 from asyncio import FIRST_COMPLETED, AbstractEventLoop, Future, Task
-from collections.abc import Mapping
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from functools import lru_cache, partial, wraps
 from platform import uname
 from typing import (Any, AsyncGenerator, Awaitable, Callable, Dict, Generic,
@@ -897,6 +898,23 @@ def json_map_leaves(func: Callable[[T], U], value: JSONTree[T]) -> JSONTree[U]:
 def flatten_2d_lists(lists: List[List[T]]) -> List[T]:
     """Flatten a list of lists to a single list."""
     return [item for sublist in lists for item in sublist]
+
+
+_K = TypeVar("_K", bound=Hashable)
+_V = TypeVar("_V")
+
+
+def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
+    """
+    Unlike :class:`itertools.groupby`, groups are not broken by
+    non-contiguous data.
+    """
+    groups: dict[_K, list[_V]] = defaultdict(list)
+
+    for value in values:
+        groups[key(value)].append(value)
+
+    return groups.items()
 
 
 # TODO: This function can be removed if transformer_modules classes are

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -909,7 +909,7 @@ def full_groupby(values: Iterable[_V], *, key: Callable[[_V], _K]):
     Unlike :class:`itertools.groupby`, groups are not broken by
     non-contiguous data.
     """
-    groups: dict[_K, list[_V]] = defaultdict(list)
+    groups = defaultdict[_K, list[_V]](list)
 
     for value in values:
         groups[key(value)].append(value)


### PR DESCRIPTION
Part of https://github.com/vllm-project/vllm/issues/10114

This PR updates #10044 to handle transformers v4.47 processors (huggingface/transformers#30962), which directly contain placeholder tokens in the processed `input_ids`.

I have also updated our code to properly replace targets with placeholders inside the processed prompt, and added unit tests for it.