### PR TITLE
[V1] Replace traversal search with lookup table

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -586,10 +586,16 @@ class GPUModelRunner:
                             device=self.device))
 
     def _get_padded_batch_size(self, batch_size: int) -> Optional[int]:
-        # TODO: Optimize this?
-        for size in self.cudagraph_batch_sizes:
-            if batch_size <= size:
-                return size
+        left, right = 0, len(self.cudagraph_batch_sizes) - 1
+        while left <= right:
+            mid = (left + right) // 2
+            mid_size = self.cudagraph_batch_sizes[mid]
+            if batch_size == mid_size:
+                return mid_size
+            elif batch_size < mid_size:
+                right = mid - 1
+            else:
+                left = mid + 1
         return None
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -587,16 +587,22 @@ class GPUModelRunner:
 
     def _get_padded_batch_size(self, batch_size: int) -> Optional[int]:
         left, right = 0, len(self.cudagraph_batch_sizes) - 1
+        result = None
+
         while left <= right:
             mid = (left + right) // 2
             mid_size = self.cudagraph_batch_sizes[mid]
+
             if batch_size == mid_size:
                 return mid_size
             elif batch_size < mid_size:
                 right = mid - 1
+                if result is None or mid_size < result:
+                    result = mid_size
             else:
                 left = mid + 1
-        return None
+
+        return result
 
 
 @dataclass

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -99,7 +99,7 @@ class GPUModelRunner:
                                and not self.model_config.enforce_eager)
         # TODO(woosuk): Provide an option to tune the max cudagraph batch size.
         self.cudagraph_batch_sizes = [1, 2, 4] + [i for i in range(8, 513, 8)]
-        self.cudagraph_lookup_table = self.build_cudagraph_lookup_table()
+        self.cudagraph_lookup_table = self._build_cudagraph_lookup_table()
         self.positions = torch.zeros(self.max_num_tokens,
                                      dtype=torch.int64,
                                      device=self.device)
@@ -586,7 +586,7 @@ class GPUModelRunner:
                             dtype=self.kv_cache_dtype,
                             device=self.device))
 
-    def build_cudagraph_lookup_table(self):
+    def _build_cudagraph_lookup_table(self):
         lookup_table = [None] * (self.cudagraph_batch_sizes[-1] + 1)
         idx = 0
         for batch_size in range(1, self.cudagraph_batch_sizes[-1] + 1):


### PR DESCRIPTION
1. Replace traversal search with lookup table for `_get_padded_batch_size`.

Test
``` python
from typing import Optional

class GPUModelRunner:
    def __init__(self):
        self.cudagraph_batch_sizes = [1, 2, 4] + [i for i in range(8, 513, 8)]
        self.cudagraph_lookup_table = self._build_cudagraph_lookup_table()

    def _build_cudagraph_lookup_table(self):
        lookup_table = [None] * (self.cudagraph_batch_sizes[-1] + 1)
        idx = 0
        for batch_size in range(1, self.cudagraph_batch_sizes[-1] + 1):
            if batch_size > self.cudagraph_batch_sizes[idx]:
                idx += 1
            lookup_table[batch_size] = self.cudagraph_batch_sizes[idx]
        return lookup_table

    def _get_padded_batch_size(self, batch_size: int) -> Optional[int]:
        if batch_size >= len(self.cudagraph_lookup_table):
            return None
        return self.cudagraph_lookup_table[batch_size]

    def test(self):
        print(self._get_padded_batch_size(0))
        print(self._get_padded_batch_size(1))
        print(self._get_padded_batch_size(13))
        print(self._get_padded_batch_size(89))
        print(self._get_padded_batch_size(126))
        print(self._get_padded_batch_size(239))
        print(self._get_padded_batch_size(255))
        print(self._get_padded_batch_size(365))
        print(self._get_padded_batch_size(511))
        print(self._get_padded_batch_size(512))
        print(self._get_padded_batch_size(513))
        print(self._get_padded_batch_size(576))
        print(self._get_padded_batch_size(987))
        print(self._get_padded_batch_size(1023))

runner = GPUModelRunner()
runner.test()
```

Output

```bash
None
1
16
96
128
240
256
368
512
512
None
None
None
None
```