### PR TITLE
Update outlines support to v0.1.4

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -18,7 +18,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines >= 0.0.43, < 0.1
+outlines >= 0.0.43, < 0.1.4
 typing_extensions >= 4.10
 filelock >= 3.10.4 # filelock starts to support `mode` argument from 3.10.4
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
Upgrades (or loosens) the outlines dependency.
It out of the box supports a higher version which improves speed.

FIX #10489 
