### PR TITLE
[Bugfix] Fix some cases of `The client socket has timed out after 600s while trying to connect to`

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
+    HOST_IP: str = ""
     VLLM_PORT: Optional[int] = None
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
     VLLM_USE_MODELSCOPE: bool = False
@@ -153,7 +154,13 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # If you are using multi-node inference, you should set this differently
     # on each node.
     'VLLM_HOST_IP':
-    lambda: os.getenv('VLLM_HOST_IP', "") or os.getenv("HOST_IP", ""),
+    lambda: os.getenv('VLLM_HOST_IP', ""),
+
+    # used in distributed environment to determine the ip address
+    # of the current node, when the env variable VLLM_HOST_IP is not set
+    # and the it's hard to get the host ip.
+    'HOST_IP':
+    lambda: os.getenv('HOST_IP', ""),
 
     # used in distributed environment to manually set the communication port
     # Note: if VLLM_PORT is set, and some code asks for multiple ports, the

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -479,6 +479,11 @@ def get_ip() -> str:
     except Exception:
         pass
 
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except Exception:
+        pass
+
     # try ipv6
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
@@ -489,12 +494,15 @@ def get_ip() -> str:
     except Exception:
         pass
 
-    warnings.warn(
-        "Failed to get the IP address, using 0.0.0.0 by default."
-        "The value can be set by the environment variable"
-        " VLLM_HOST_IP or HOST_IP.",
-        stacklevel=2)
-    return "0.0.0.0"
+    if envs.HOST_IP:
+        return envs.HOST_IP
+    else:
+        warnings.warn(
+            "Failed to get the IP address, using 0.0.0.0 by default."
+            "The value can be set by the environment variable"
+            " VLLM_HOST_IP or HOST_IP.",
+            stacklevel=2)
+        return "0.0.0.0"
 
 
 def is_valid_ipv6_address(address: str) -> bool:


### PR DESCRIPTION
vLLM works fine in most of my environments. However, there are always some envs that have following error:
`The client socket has timed out after 600s while trying to connect to`
![image](https://github.com/user-attachments/assets/b48a01c3-6f45-4a90-b88f-ee8dbb334b4c)

In this case, I need to set the environment variable `export VLLM_HOST_IP="127.0.0.1"`. However, for a new user, he/she may not realize what happens.
After digging into this problem, I found that this is caused by the automatically set environment variable `HOST_IP`. 

In many cases, we use vLLM in a container. The container may use the Bridge Mode for the network, which means the container has different IP from the host machine. And sometimes, the container is started with the environment variable `HOST_IP` set to the host machine's IP. In current logic of `get_ip()` function and `env.VLLM_HOST_IP`, if `HOST_IP` is set but `VLLM_HOST_IP` is not set, `get_ip()` will return `HOST_IP` without trying to get a real IP.

The solution is to try the best to find the local IP first. The env `HOST_IP` is used only when we cannot find the local IP from code and `VLLM_HOST_IP` is not set.

May FIX https://github.com/vllm-project/vllm/issues/5779 https://github.com/vllm-project/vllm/issues/6650 https://github.com/vllm-project/vllm/issues/7136

