### PR TITLE
[Bugfix] Embedding model pooling_type equals ALL and multi input's bug

### DIFF
--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -94,14 +94,10 @@ class Pooler(nn.Module):
             pooled_data = hidden_states[last_token_flat_indices]
         elif self.pooling_type == PoolingType.ALL:
             offset = 0
-            pooled_data_lst = []
+            pooled_data = []
             for prompt_len in prompt_lens:
-                pooled_data_i = hidden_states[offset:offset + prompt_len]
-
-                pooled_data_lst.append(pooled_data_i)
+                pooled_data.append(hidden_states[offset:offset + prompt_len])
                 offset += prompt_len
-
-            pooled_data = torch.stack(pooled_data_lst)
         elif self.pooling_type == PoolingType.MEAN:
             # Calculate mean pooling
             cumsum = torch.cumsum(hidden_states, dim=0)

--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -132,15 +132,18 @@ class Pooler(nn.Module):
 
         if self.normalize:
             if isinstance(pooled_data, list):
-                pooled_data = [nn.functional.normalize(data, p=2, dim=1) 
-                              for data in pooled_data]
+                pooled_data = [
+                    nn.functional.normalize(data, p=2, dim=1)
+                    for data in pooled_data
+                ]
             else:
                 pooled_data = nn.functional.normalize(pooled_data, p=2, dim=1)
 
         if self.softmax:
             if isinstance(pooled_data, list):
-                pooled_data = [nn.functional.softmax(data, dim=-1) 
-                              for data in pooled_data]
+                pooled_data = [
+                    nn.functional.softmax(data, dim=-1) for data in pooled_data
+                ]
             else:
                 pooled_data = nn.functional.softmax(pooled_data, dim=-1)
 

--- a/vllm/model_executor/layers/pooler.py
+++ b/vllm/model_executor/layers/pooler.py
@@ -117,7 +117,7 @@ class Pooler(nn.Module):
             step_tag_id = self.step_tag_id
 
             offset = 0
-            pooled_data_lst = []
+            pooled_data = []
             for prompt_len, seq_data_i in zip(
                     prompt_lens, pooling_metadata.seq_data.values()):
                 pooled_data_i = hidden_states[offset:offset + prompt_len]
@@ -126,17 +126,23 @@ class Pooler(nn.Module):
                     pooled_data_i = pooled_data_i[token_ids == step_tag_id]
 
                 offset += prompt_len
-                pooled_data_lst.append(pooled_data_i)
-
-            pooled_data = torch.stack(pooled_data_lst)
+                pooled_data.append(pooled_data_i)
         else:
             raise ValueError(f"Invalid pooling type: {self.pooling_type}")
 
         if self.normalize:
-            pooled_data = nn.functional.normalize(pooled_data, p=2, dim=1)
+            if isinstance(pooled_data, list):
+                pooled_data = [nn.functional.normalize(data, p=2, dim=1) 
+                              for data in pooled_data]
+            else:
+                pooled_data = nn.functional.normalize(pooled_data, p=2, dim=1)
 
         if self.softmax:
-            pooled_data = nn.functional.softmax(pooled_data, dim=-1)
+            if isinstance(pooled_data, list):
+                pooled_data = [nn.functional.softmax(data, dim=-1) 
+                              for data in pooled_data]
+            else:
+                pooled_data = nn.functional.softmax(pooled_data, dim=-1)
 
         pooled_outputs = [
             EmbeddingSequenceGroupOutput(data.tolist()) for data in pooled_data


### PR DESCRIPTION
When I run the following example code, it triggers an error:

```python
from openai import OpenAI

# Modify OpenAI's API key and API base to use vLLM's API server.
openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(
    # defaults to os.environ.get("OPENAI_API_KEY")
    api_key=openai_api_key,
    base_url=openai_api_base,
)

models = client.models.list()
model = models.data[0].id

responses = client.embeddings.create(
    input=[
        "Hello my name is",
        "The best thing about vLLM is that it supports many different models"
    ],
    model=model,
)

for data in responses.data:
    print(data.embedding)  # list of float of len 4096
```

```shell
NFO 11-20 19:56:18 engine.py:267] Added request embd-1ffc4573aa2b4189b2e2cd3a413127cd-0.
INFO 11-20 19:56:18 engine.py:267] Added request embd-1ffc4573aa2b4189b2e2cd3a413127cd-1.
CRITICAL 11-20 19:56:18 launcher.py:99] MQLLMEngine is already dead, terminating server process
INFO:     [127.0.0.1:34172](http://127.0.0.1:34172/) - "POST /v1/embeddings HTTP/1.1" 500 Internal Server Error
ERROR 11-20 19:56:18 engine.py:135] RuntimeError('stack expects each tensor to be equal size, but got [3, 1] at entry 0 and [1, 1] at entry 1')
ERROR 11-20 19:56:18 engine.py:135] Traceback (most recent call last):
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/engine/multiprocessing/engine.py", line 133, in start
ERROR 11-20 19:56:18 engine.py:135]     self.run_engine_loop()
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/engine/multiprocessing/engine.py", line 196, in run_engine_loop
ERROR 11-20 19:56:18 engine.py:135]     request_outputs = self.engine_step()
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/engine/multiprocessing/engine.py", line 214, in engine_step
ERROR 11-20 19:56:18 engine.py:135]     raise e
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/engine/multiprocessing/engine.py", line 205, in engine_step
ERROR 11-20 19:56:18 engine.py:135]     return self.engine.step()
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/engine/llm_engine.py", line 1454, in step
ERROR 11-20 19:56:18 engine.py:135]     outputs = self.model_executor.execute_model(
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/executor/gpu_executor.py", line 125, in execute_model
ERROR 11-20 19:56:18 engine.py:135]     output = self.driver_worker.execute_model(execute_model_req)
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/worker/worker_base.py", line 343, in execute_model
ERROR 11-20 19:56:18 engine.py:135]     output = self.model_runner.execute_model(
ERROR 11-20 19:56:18 engine.py:135]   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 11-20 19:56:18 engine.py:135]     return func(*args, **kwargs)
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/worker/embedding_model_runner.py", line 138, in execute_model
ERROR 11-20 19:56:18 engine.py:135]     self.model.pooler(hidden_states=hidden_or_intermediate_states,
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/model_executor/models/qwen2_rm.py", line 155, in pooler
ERROR 11-20 19:56:18 engine.py:135]     return self._pooler(hidden_states, pooling_metadata)
ERROR 11-20 19:56:18 engine.py:135]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
ERROR 11-20 19:56:18 engine.py:135]     return self._call_impl(*args, **kwargs)
ERROR 11-20 19:56:18 engine.py:135]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
ERROR 11-20 19:56:18 engine.py:135]     return forward_call(*args, **kwargs)
ERROR 11-20 19:56:18 engine.py:135]   File "/mnt/data/vllm/vllm/model_executor/layers/pooler.py", line 104, in forward
ERROR 11-20 19:56:18 engine.py:135]     pooled_data = torch.stack(pooled_data_lst)
ERROR 11-20 19:56:18 engine.py:135] RuntimeError: stack expects each tensor to be equal size, but got [3, 1] at entry 0 and [1, 1] at entry 1
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [52561]
```


I found that the bug is at [this commit](https://github.com/vllm-project/vllm/commit/2ac6d0e75bc846998da56b50bf4f8853cb36d484#diff-c247e62fce247c6c89d08cfac2c25b49d640b6f0f2f688fb64f2b3cdf33cea2fR115). Reverting this PR's pooling_type='ALL' change to the original logic allows the embedding model correctly infer multiple prompts of different lengths.