### PR TITLE
[V1] VLM prefix caching: Add hashing of images

### DIFF
--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -508,6 +508,7 @@ class NewRequestData:
     req_id: str
     prompt_token_ids: List[int]
     prompt: Optional[str]
+    mm_hash: List[str]
     mm_inputs: List["MultiModalKwargs"]
     mm_positions: List["PlaceholderRange"]
     sampling_params: SamplingParams
@@ -525,6 +526,7 @@ class NewRequestData:
             req_id=request.request_id,
             prompt_token_ids=request.prompt_token_ids,
             prompt=request.prompt,
+            mm_hash=request.mm_hash,
             mm_inputs=request.mm_inputs,
             mm_positions=request.mm_positions,
             sampling_params=request.sampling_params,

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -36,6 +36,7 @@ class EngineCoreRequest:
     prompt: Optional[str]
     prompt_token_ids: List[int]
     mm_data: Optional[MultiModalDataDict]
+    mm_hash: List[str]
     mm_placeholders: Optional[MultiModalPlaceholderDict]
     mm_processor_kwargs: Optional[Dict[str, Any]]
     sampling_params: SamplingParams

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -114,6 +114,7 @@ class Processor:
             decoder_inputs.prompt,
             decoder_inputs.prompt_token_ids,
             decoder_inputs.multi_modal_data,
+            [],  # Initially, mm hash is empty
             decoder_inputs.multi_modal_placeholders,
             decoder_inputs.mm_processor_kwargs,
             sampling_params,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -57,6 +57,9 @@ class Request:
         # Output of the mm input mapper (e.g., image tensors).
         self.mm_inputs: List[MultiModalKwargs] = []
 
+        # FIXME(alexm): Support other modalities (not just image)
+        self.mm_hash: List[int] = []
+
     @classmethod
     def from_engine_core_request(cls, request: EngineCoreRequest) -> "Request":
         return cls(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -169,6 +169,7 @@ class GPUModelRunner:
                 req_id=req_id,
                 prompt_token_ids=req_data.prompt_token_ids,
                 prompt=req_data.prompt,
+                mm_hash=req_data.mm_hash,
                 mm_inputs=req_data.mm_inputs,
                 mm_positions=req_data.mm_positions,
                 sampling_params=sampling_params,
@@ -599,6 +600,7 @@ class CachedRequestState:
     req_id: str
     prompt_token_ids: List[int]
     prompt: Optional[str]
+    mm_hash: List[str]
     mm_inputs: List[MultiModalKwargs]
     mm_positions: List["PlaceholderRange"]
     sampling_params: SamplingParams


### PR DESCRIPTION
As part of V1 VLM prefix caching, we need to support hashing of images. This PR adds logic to hash images and pipes the hashes down to the model runner (if needed). Currently, it uses a cryptographic hash so the match between image and hash is precise, however, it is also possible to use a less precise hash to match "similar" images. The library used for hashing is blake3 ([](https://www.infoq.com/news/2020/01/blake3-fast-crypto-hash/)), which seems to be pretty efficient. 

As an example to hash a 1770x1180 RGB PIL image, it takes 1.6ms to perform image.tobytes() and 0.8ms to hash all of the image bytes (1770*1180*3 = 6265800 bytes). Log print:

```
req.mm_data = {'image': <PIL.Image.Image image mode=RGB size=1770x1180 at 0x7E871606C1F0>}
tobytes time = 0.0016231536865234375
hash time = 0.0008261203765869141
hash value = 9de5230fb3052dee056a26e71a545552207495528a763a15ad98d31961f53578

```

As a reference, to run the HF mapper/preprocessor it may take 10-50ms per image.




