### PR TITLE
[Bugfix] GPU memory profiling should be per LLM instance

### DIFF
--- a/tests/entrypoints/llm/test_lazy_outlines.py
+++ b/tests/entrypoints/llm/test_lazy_outlines.py
@@ -36,7 +36,7 @@ def test_lazy_outlines(sample_regex):
     llm = LLM(model="facebook/opt-125m",
               enforce_eager=True,
               guided_decoding_backend="lm-format-enforcer",
-              gpu_memory_utilization=0.6)
+              gpu_memory_utilization=0.3)
     sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
     outputs = llm.generate(
         prompts=[

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -208,8 +208,8 @@ class Worker(LocalOrDistributedWorkerBase):
         torch.cuda.empty_cache()
         torch_allocated_bytes = torch.cuda.memory_stats(
         )["allocated_bytes.all.current"]
-        total_allocated_bytes = torch.cuda.mem_get_info(
-        )[1] - torch.cuda.mem_get_info()[0]
+        total_allocated_bytes = self.init_gpu_memory - torch.cuda.mem_get_info(
+        )[0]
         non_torch_allocations = total_allocated_bytes - torch_allocated_bytes
         if non_torch_allocations > 0:
             peak_memory += non_torch_allocations


### PR DESCRIPTION
`gpu_memory_utilization` was intended to limit the total memory allocation for an instance of an `LLM`. An [update to the memory profiling](https://github.com/vllm-project/vllm/pull/9352) changed the meaning of this parameter to be a global limit on GPU memory allocation (see [this comment](https://github.com/vllm-project/vllm/pull/9352#discussion_r1801771548)).

This PR reverts the change `gpu_memory_utilization` back to being a per-model-instance limit.

It also simplifies the memory profiling code, but removes some information from the "Memory profiling results" log message. I'm open to feedback on adding back more information.

Refer to #10451 for more background and discussion.

FIX #10451
