### PR TITLE
Support softcap in ROCm Flash Attention

### DIFF
--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -374,12 +374,11 @@ class ROCmFlashAttentionImpl(AttentionImpl):
         if self.use_triton_flash_attn:
             if logits_soft_cap is not None:
                 raise ValueError(
-                        "ROCm Triton FlashAttention does not support attention logits soft "
-                        "capping."
-                        "please try using the ROCm CK "
-                               "FA backend instead by setting the env var "
-                               "`VLLM_USE_TRITON_FLASH_ATTN=0`"
-                        )
+                    "ROCm Triton FlashAttention does not support attention"
+                    "logits soft capping."
+                    "please try using the ROCm CK "
+                    "FA backend instead by setting the env var "
+                    "`VLLM_USE_TRITON_FLASH_ATTN=0`")
 
             from vllm.attention.ops.triton_flash_attention import (  # noqa: F401
                 triton_attention)
@@ -407,8 +406,8 @@ class ROCmFlashAttentionImpl(AttentionImpl):
             if self.use_naive_attn:
                 if logits_soft_cap is not None:
                     raise ValueError(
-                            "ROCm Naive FlashAttention does not support attention logits soft "
-                            "capping.")
+                        "ROCm Naive FlashAttention does not support attention"
+                        "logits soft capping.")
 
                 self.attn_func = _sdpa_attention
                 logger.debug("Using naive attention in ROCmBackend")

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -342,10 +342,12 @@ class ROCmFlashAttentionImpl(AttentionImpl):
         if blocksparse_params is not None:
             raise ValueError(
                 "ROCmFlashAttention does not support blocksparse attention.")
-        if logits_soft_cap is not None:
-            raise ValueError(
-                "ROCmFlashAttention does not support attention logits soft "
-                "capping.")
+
+        if logits_soft_cap is None:
+            # In flash-attn, setting logits_soft_cap as 0 means no soft cap.
+            logits_soft_cap = 0
+        self.logits_soft_cap = logits_soft_cap
+
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)
@@ -370,6 +372,15 @@ class ROCmFlashAttentionImpl(AttentionImpl):
         # NOTE: Allow for switching between Triton and CK. Defaulting to triton.
         self.use_triton_flash_attn = envs.VLLM_USE_TRITON_FLASH_ATTN
         if self.use_triton_flash_attn:
+            if logits_soft_cap is not None:
+                raise ValueError(
+                        "ROCm Triton FlashAttention does not support attention logits soft "
+                        "capping."
+                        "please try using the ROCm CK "
+                               "FA backend instead by setting the env var "
+                               "`VLLM_USE_TRITON_FLASH_ATTN=0`"
+                        )
+
             from vllm.attention.ops.triton_flash_attention import (  # noqa: F401
                 triton_attention)
             self.attn_func = triton_attention
@@ -394,6 +405,11 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     self.use_naive_attn = True
 
             if self.use_naive_attn:
+                if logits_soft_cap is not None:
+                    raise ValueError(
+                            "ROCm Naive FlashAttention does not support attention logits soft "
+                            "capping.")
+
                 self.attn_func = _sdpa_attention
                 logger.debug("Using naive attention in ROCmBackend")
 
@@ -545,6 +561,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                         causal=True,
                         window_size=self.sliding_window,
                         alibi_slopes=self.alibi_slopes,
+                        softcap=self.logits_soft_cap,
                     )
 
                 # common code for prefill


### PR DESCRIPTION
The softcap is needed by gemma2 model, and this PR enables softcap for CK Flash attention.
