### PR TITLE
Setting default for EmbeddingChatRequest.add_generation_prompt to False

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -747,7 +747,7 @@ class EmbeddingChatRequest(OpenAIBaseModel):
 
     # doc: begin-chat-embedding-extra-params
     add_generation_prompt: bool = Field(
-        default=True,
+        default=False,
         description=
         ("If true, the generation prompt will be added to the chat template. "
          "This is a parameter used by chat template in tokenizer config of the "


### PR DESCRIPTION
Continuing the excellent work done on reward modeling in vLLM, I believe that the default for this parameter should be false.
It was likely copied over from the chat request, where adding the assistant turn before the beginning of the completion is desired by default. However, in embedding / reward modeling, the model is not expected to generate a textual response, but to output an embedding vector.

I'm not even sure that these parameters should be optional, but at the very least they should default to False.

@DarkLight1337 what do you think?