### PR TITLE
[Doc] fix a small typo in docstring of llama_tool_parser

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/llama_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/llama_tool_parser.py
@@ -29,7 +29,8 @@ class Llama3JsonToolParser(ToolParser):
     Tool call parser for Llama 3.1 models intended for use with the
     examples/tool_chat_template_llama.jinja template.
 
-    Used when --enable-auto-tool-choice --tool-call-parser llama3_json are all set
+    Used when --enable-auto-tool-choice --tool-call-parser llama3_json 
+    are all set
     """
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase):

--- a/vllm/entrypoints/openai/tool_parsers/llama_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/llama_tool_parser.py
@@ -29,7 +29,7 @@ class Llama3JsonToolParser(ToolParser):
     Tool call parser for Llama 3.1 models intended for use with the
     examples/tool_chat_template_llama.jinja template.
 
-    Used when --enable-auto-tool-choice --tool-call-parser mistral are all set
+    Used when --enable-auto-tool-choice --tool-call-parser llama3_json are all set
     """
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase):


### PR DESCRIPTION
Fix a small typo in the docstring of openai/tool_parsers/llama_tool_parser.py
