### PR TITLE
[platforms] improve error message for unspecified platforms

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1191,12 +1191,13 @@ class SchedulerConfig:
 
 class DeviceConfig:
     device: Optional[torch.device]
+    device_type: str
 
     def __init__(self, device: str = "auto") -> None:
         if device == "auto":
             # Automated device type detection
             self.device_type = current_platform.device_type
-            if self.device_type is None:
+            if not self.device_type:
                 raise RuntimeError("Failed to infer device type")
         else:
             # Device type is assigned explicitly

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -170,3 +170,4 @@ class Platform:
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED
+    device_type = ""


### PR DESCRIPTION
fixes https://github.com/vllm-project/vllm/pull/10508#discussion_r1851447301

to test the effect of the change, add one line of `current_platform = UnspecifiedPlatform()` in https://github.com/vllm-project/vllm/blob/8b0fe06c890a202eba24d517cc77562e4a8b0d0c/vllm/platforms/__init__.py#L114 