### PR TITLE
fix the issue that len(tokenizer(prompt)["input_ids"]) > prompt_len

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -54,6 +54,7 @@ async def async_request_tgi(
             "do_sample": True,
             "temperature": 0.01,  # TGI does not accept 0.0 temperature.
             "top_p": 0.99,  # TGI does not accept 1.0 top_p.
+            "truncate": request_func_input.prompt_len,
             # TGI does not accept ignore_eos flag.
         }
         payload = {


### PR DESCRIPTION
causing error like ""`inputs` tokens + `max_new_tokens` must be <= xxx. Given: xxx `inputs` tokens and xxx `max_new_tokens`"



