### PR TITLE
[Bugfix] Allow token ID-only inputs in Qwen2-Audio

### DIFF
--- a/vllm/model_executor/models/qwen2_audio.py
+++ b/vllm/model_executor/models/qwen2_audio.py
@@ -212,7 +212,7 @@ def input_processor_for_qwen2_audio(
 
     return token_inputs(
         prompt_token_ids=new_input_ids,
-        prompt=inputs['prompt'],
+        prompt=inputs.get("prompt"),
         multi_modal_data=multi_modal_data,
     )
 


### PR DESCRIPTION
FIX #10493