### PR TITLE
[Distributed] Tensor Parallel RMSNorm

### DIFF
--- a/tests/distributed/test_distributed_layernorm.py
+++ b/tests/distributed/test_distributed_layernorm.py
@@ -1,0 +1,87 @@
+import os
+import random
+
+import pytest
+import ray
+import torch
+import torch.distributed as dist
+
+from ..utils import (ensure_model_parallel_initialized,
+                     init_test_distributed_environment, multi_process_parallel)
+
+from vllm.distributed import tensor_model_parallel_all_gather
+
+def parallel_rms_norm_test(tp_size, pp_size, rank, distributed_init_port):
+    """Test function that runs on each GPU to compare RMSNorm implementations."""
+    # Setup distributed environment
+    del os.environ["CUDA_VISIBLE_DEVICES"]
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+    ensure_model_parallel_initialized(tp_size, pp_size)
+
+    hidden_size = 1024
+    num_tokens = 16
+    dtype = torch.float16
+
+    # Create both norm layers
+    standard_norm = RMSNorm(hidden_size, eps=1e-6).to(device)
+    parallel_norm = ParallelRMSNorm(hidden_size, eps=1e-6).to(device)
+
+    # Create input tensor
+    torch.manual_seed(42 + rank)  # Ensure deterministic but different inputs per rank
+    parallel_input = torch.randn(num_tokens, hidden_size // tp_size, dtype=dtype, device=device)
+    reference_input = tensor_model_parallel_all_gather(parallel_input)
+    
+    # Create a residual tensor for testing residual path
+    residual = torch.randn_like(input_tensor)
+    reference_residual = tensor_model_parallel_all_gather(residual)
+
+    # Run forward passes
+    with torch.no_grad():
+        # Test without residual
+        standard_out = standard_norm.forward(input_tensor)
+        parallel_out = parallel_norm.forward(input_tensor)
+        
+        # Test with residual
+        standard_out_residual, residual1 = standard_norm.forward_native(reference_input_tensor, reference_residual.clone())
+        parallel_out_residual, residual2 = parallel_norm.forward_native(input_tensor, residual.clone())
+
+    # Synchronize before comparing
+    torch.cuda.synchronize()
+
+    gathered_parallel_output = tensor_model_parallel_all_gather(parallel_out)
+    gathered_parallel_residual = tensor_model_parallel_all_gather(residual2)
+    
+    # Convert to float32 for comparison
+    standard_out = standard_out.float()
+    parallel_out = parallel_out.float()
+    standard_out_residual = standard_out_residual.float()
+    parallel_out_residual = parallel_out_residual.float()
+
+    # Compare outputs
+    rtol = 1e-3 if dtype == torch.float16 else 1e-5
+    atol = 1e-3 if dtype == torch.float16 else 1e-5
+    
+    assert torch.allclose(standard_out, parallel_out, rtol=rtol, atol=atol), \
+        f"Outputs without residual don't match. Max diff: {(standard_out - parallel_out).abs().max()}"
+    
+    assert torch.allclose(standard_out_residual, parallel_out_residual, rtol=rtol, atol=atol), \
+        f"Outputs with residual don't match. Max diff: {(standard_out_residual - parallel_out_residual).abs().max()}"
+    
+    assert torch.allclose(residual1, residual2, rtol=rtol, atol=atol), \
+        f"Residual outputs don't match. Max diff: {(residual1 - residual2).abs().max()}"
+
+@pytest.mark.parametrize("tp_size", [2])
+def test_parallel_rms_norm(tp_size):
+    """Main test function that spawns multiple processes."""
+    world_size = tp_size
+    if world_size > torch.cuda.device_count():
+        pytest.skip("Not enough GPUs to run the test.")
+    
+    multi_process_parallel(
+        tp_size=tp_size,
+        pp_size=1,  # We only need TP for this test
+        test_target=parallel_rms_norm_test
+    )
+

--- a/tests/distributed/test_distributed_layernorm.py
+++ b/tests/distributed/test_distributed_layernorm.py
@@ -1,23 +1,26 @@
 import os
-import random
 
 import pytest
 import ray
 import torch
-import torch.distributed as dist
+import torch.distributed
+
+from vllm.distributed import tensor_model_parallel_all_gather
+from vllm.model_executor.layers.layernorm import ParallelRMSNorm, RMSNorm
 
 from ..utils import (ensure_model_parallel_initialized,
                      init_test_distributed_environment, multi_process_parallel)
 
-from vllm.distributed import tensor_model_parallel_all_gather
 
+@ray.remote(num_gpus=1, max_calls=1)
 def parallel_rms_norm_test(tp_size, pp_size, rank, distributed_init_port):
-    """Test function that runs on each GPU to compare RMSNorm implementations."""
+    """Test function that runs on each GPU comparing RMSNorm implementations."""
     # Setup distributed environment
     del os.environ["CUDA_VISIBLE_DEVICES"]
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
-    init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
+    init_test_distributed_environment(tp_size, pp_size, rank,
+                                      distributed_init_port)
     ensure_model_parallel_initialized(tp_size, pp_size)
 
     hidden_size = 1024
@@ -25,52 +28,57 @@ def parallel_rms_norm_test(tp_size, pp_size, rank, distributed_init_port):
     dtype = torch.float16
 
     # Create both norm layers
-    standard_norm = RMSNorm(hidden_size, eps=1e-6).to(device)
+    reference_norm = RMSNorm(hidden_size, eps=1e-6).to(device)
     parallel_norm = ParallelRMSNorm(hidden_size, eps=1e-6).to(device)
 
     # Create input tensor
-    torch.manual_seed(42 + rank)  # Ensure deterministic but different inputs per rank
-    parallel_input = torch.randn(num_tokens, hidden_size // tp_size, dtype=dtype, device=device)
+    torch.manual_seed(
+        42 + rank)  # Ensure deterministic but different inputs per rank
+    parallel_input = torch.randn(num_tokens,
+                                 hidden_size // tp_size,
+                                 dtype=dtype,
+                                 device=device)
     reference_input = tensor_model_parallel_all_gather(parallel_input)
-    
+
     # Create a residual tensor for testing residual path
-    residual = torch.randn_like(input_tensor)
+    residual = torch.randn_like(parallel_input)
     reference_residual = tensor_model_parallel_all_gather(residual)
 
     # Run forward passes
     with torch.no_grad():
         # Test without residual
-        standard_out = standard_norm.forward(input_tensor)
-        parallel_out = parallel_norm.forward(input_tensor)
-        
+        reference_out = reference_norm.forward(reference_input)
+        parallel_out = parallel_norm.forward(parallel_input)
+
         # Test with residual
-        standard_out_residual, residual1 = standard_norm.forward_native(reference_input_tensor, reference_residual.clone())
-        parallel_out_residual, residual2 = parallel_norm.forward_native(input_tensor, residual.clone())
+        reference_out_residual, residual1 = reference_norm.forward_native(
+            reference_input, reference_residual.clone())
+        parallel_out_residual, residual2 = parallel_norm.forward_native(
+            parallel_input, residual.clone())
 
     # Synchronize before comparing
     torch.cuda.synchronize()
 
     gathered_parallel_output = tensor_model_parallel_all_gather(parallel_out)
     gathered_parallel_residual = tensor_model_parallel_all_gather(residual2)
-    
+
     # Convert to float32 for comparison
-    standard_out = standard_out.float()
-    parallel_out = parallel_out.float()
-    standard_out_residual = standard_out_residual.float()
-    parallel_out_residual = parallel_out_residual.float()
+    reference_out = reference_out.float()
+    parallel_out = gathered_parallel_output.float()
+    reference_out_residual = reference_out_residual.float()
+    parallel_out_residual = gathered_parallel_residual.float()
 
     # Compare outputs
     rtol = 1e-3 if dtype == torch.float16 else 1e-5
     atol = 1e-3 if dtype == torch.float16 else 1e-5
-    
-    assert torch.allclose(standard_out, parallel_out, rtol=rtol, atol=atol), \
-        f"Outputs without residual don't match. Max diff: {(standard_out - parallel_out).abs().max()}"
-    
-    assert torch.allclose(standard_out_residual, parallel_out_residual, rtol=rtol, atol=atol), \
-        f"Outputs with residual don't match. Max diff: {(standard_out_residual - parallel_out_residual).abs().max()}"
-    
-    assert torch.allclose(residual1, residual2, rtol=rtol, atol=atol), \
-        f"Residual outputs don't match. Max diff: {(residual1 - residual2).abs().max()}"
+
+    assert torch.allclose(reference_out, parallel_out, rtol=rtol, atol=atol)
+    assert torch.allclose(reference_out_residual,
+                          parallel_out_residual,
+                          rtol=rtol,
+                          atol=atol)
+    assert torch.allclose(residual1, residual2, rtol=rtol, atol=atol)
+
 
 @pytest.mark.parametrize("tp_size", [2])
 def test_parallel_rms_norm(tp_size):
@@ -78,10 +86,8 @@ def test_parallel_rms_norm(tp_size):
     world_size = tp_size
     if world_size > torch.cuda.device_count():
         pytest.skip("Not enough GPUs to run the test.")
-    
+
     multi_process_parallel(
         tp_size=tp_size,
         pp_size=1,  # We only need TP for this test
-        test_target=parallel_rms_norm_test
-    )
-
+        test_target=parallel_rms_norm_test)

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -4,6 +4,9 @@ from typing import Optional, Tuple, Union
 import torch
 import torch.nn as nn
 
+from vllm.distributed import (tensor_model_parallel_all_reduce,
+                              get_tensor_model_parallel_world_size,
+                              get_tensor_model_parallel_rank)
 from vllm.model_executor.custom_op import CustomOp
 
 
@@ -134,6 +137,81 @@ class RMSNorm(CustomOp):
             self.weight.data,
             self.variance_epsilon,
         )
+
+    def extra_repr(self) -> str:
+        s = f"hidden_size={self.weight.data.size(0)}"
+        s += f", eps={self.variance_epsilon}"
+        return s
+
+@CustomOp.register("parallel_rms_norm")
+class ParallelRMSNorm(CustomOp):
+    """Root mean square normalization.
+
+    Computes x -> w * x / sqrt(E[x^2] + eps) where w is the learned weight.
+    Refer to https://arxiv.org/abs/1910.07467
+
+    This operation supports tensor parallelism along the hidden dimension
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        var_hidden_size: Optional[int] = None,
+    ) -> None:
+        super().__init__()
+
+        # TODO: For tp size == 1, I think this should instantiate an RMSNorm
+        # and use its forward method
+
+        self.hidden_size = hidden_size
+        self.variance_epsilon = eps
+        self.variance_size_override = (None if var_hidden_size == hidden_size
+                                       else var_hidden_size)
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+        assert(hidden_size % tp_size == 0)
+        hidden_size = hidden_size // self.tp_size
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        set_weight_attrs(self.weight,
+        {"weight_loader": self._parallel_weight_loader})
+
+    # TODO: can this use a built-in util now that it's it's only 1D TP?
+    def _parallel_weight_loader(self, param: torch.Tensor,
+                                loaded_weight: torch.Tensor):
+        tp_rank = get_tensor_parallel_rank()
+        shard_size = param.data.shape[0]
+        start_idx = tp_rank * shard_size
+        loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
+        param.data.copy_(loaded_weight)
+
+    def forward_native(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """PyTorch-native implementation equivalent to forward()."""
+        orig_dtype = x.dtype
+        x = x.to(torch.float32)
+        if residual is not None:
+            assert (residual.shape == x.shape)
+            x = x + residual.to(torch.float32)
+            residual = x.to(orig_dtype)
+
+        # Compute local sum and then reduce to obtain global sum
+        local_sums = x.pow(2).sum(dim=-1, keepdim=False)
+        global_sums = tensor_parallel_all_reduce(local_sums)
+
+        # Calculate the variance
+        count = self.tp_size * x.shape[-1]
+        variance = (global_sums / count)
+
+        x = x * torch.rsqrt(variance.unsqueeze(-1) + self.variance_epsilon)
+        x = x.to(orig_dtype) * self.weight
+        if residual is None:
+            return x
+        else:
+            return x, residual
 
     def extra_repr(self) -> str:
         s = f"hidden_size={self.weight.data.size(0)}"


### PR DESCRIPTION
Implement tensor-parallel RMS Norm for activations that are distributed along the hidden dimension.

Looks like we might want to do something like this for the RMS Norms on Q and K for the new OLMo model (#10503)

