### PR TITLE
Update default max_num_batch_tokens for chunked prefill to 2048

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1110,9 +1110,9 @@ class SchedulerConfig:
                     # max_num_batched_tokens.
                     max_num_batched_tokens = max(max_model_len, 2048)
                 else:
-                    # It is the values that have the best balance between ITL
-                    # and TTFT on A100. Note it is not optimized for throughput.
-                    max_num_batched_tokens = 512
+                    # This value is chosen to have a balance between ITL
+                    # and TTFT. Note it is not optimized for throughput.
+                    max_num_batched_tokens = 2048
             else:
                 # If max_model_len is too short, use 2048 as the default value
                 # for higher throughput.


### PR DESCRIPTION
We have seen that 512 is a very conservative value, especially once on H100. Increasing this is 2048 is still a bit conservative but a definite improvement in processing large prefills or throughput.