### PR TITLE
[Benchmark] Benchmark structured output with datasets

### DIFF
--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -142,10 +142,13 @@ async def run_vllm_async(requests: List[SampleRequest],
             generator = llm.generate(prompt, sp, request_id=f"test{i}")
             generators.append(generator)
         all_gens = merge_async_iterators(*generators)
-        ret = []
+        generated_texts = [''] * len(requests)
         async for i, res in all_gens:
-            generated_text = res.outputs[0].text
-            ret.append(generated_text)
+            generated_texts[i] = res.outputs[0].text
+        ret = [{
+            'generated': gt,
+            'expected': req.completion
+        } for gt, req in zip(generated_texts, requests)]
         end = time.perf_counter()
         if result_file_name:
             with open(result_file_name, 'w') as f:

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -3,12 +3,12 @@ import argparse
 import json
 import random
 import time
-from typing import List, Optional, Tuple
+from typing import List
 
 import uvloop
 from transformers import AutoTokenizer
 
-from vllm.engine.arg_utils import DEVICE_OPTIONS, AsyncEngineArgs, EngineArgs
+from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.entrypoints.openai.api_server import (
     build_async_engine_client_from_engine_args)
 from vllm.sampling_params import GuidedDecodingParams
@@ -128,52 +128,15 @@ SCHEMA = {
     ["userId", "personalInfo", "address", "accountStatus", "registrationDate"]
 }
 
-
 def run_vllm(
-    requests: List[Tuple[str, int, int]],
-    model: str,
-    tokenizer: str,
-    tensor_parallel_size: int,
-    seed: int,
+    requests: List[tuple[str, int, int]],
+    engine_args: EngineArgs,
     n: int,
-    trust_remote_code: bool,
-    dtype: str,
-    max_model_len: Optional[int],
-    enforce_eager: bool,
-    kv_cache_dtype: str,
-    device: str,
-    enable_prefix_caching: bool,
-    enable_chunked_prefill: bool,
-    max_num_batched_tokens: int,
-    distributed_executor_backend: Optional[str],
-    gpu_memory_utilization: float = 0.9,
-    num_scheduler_steps: int = 1,
-    disable_async_output_proc: bool = False,
     guided_decoding: bool = False,
     warmup: bool = False,
 ) -> float:
     from vllm import LLM, SamplingParams
-    llm = LLM(
-        model=model,
-        tokenizer=tokenizer,
-        tensor_parallel_size=tensor_parallel_size,
-        seed=seed,
-        trust_remote_code=trust_remote_code,
-        dtype=dtype,
-        max_model_len=max_model_len,
-        gpu_memory_utilization=gpu_memory_utilization,
-        enforce_eager=enforce_eager,
-        kv_cache_dtype=kv_cache_dtype,
-        device=device,
-        enable_prefix_caching=enable_prefix_caching,
-        enable_chunked_prefill=enable_chunked_prefill,
-        max_num_batched_tokens=max_num_batched_tokens,
-        distributed_executor_backend=distributed_executor_backend,
-        load_format=EngineArgs.load_format,
-        num_scheduler_steps=num_scheduler_steps,
-        disable_async_output_proc=disable_async_output_proc,
-        guided_decoding_backend="outlines",
-    )
+    llm = LLM(**vars(engine_args))
 
     # Add the requests to the engine.
     prompts: List[str] = []
@@ -196,55 +159,15 @@ def run_vllm(
     end = time.perf_counter()
     return end - start
 
-
 async def run_vllm_async(
-    requests: List[Tuple[str, int, int]],
-    model: str,
-    tokenizer: str,
-    tensor_parallel_size: int,
-    seed: int,
+    requests: List[tuple[str, int, int]],
+    engine_args: AsyncEngineArgs,
     n: int,
-    trust_remote_code: bool,
-    dtype: str,
-    max_model_len: Optional[int],
-    enforce_eager: bool,
-    kv_cache_dtype: str,
-    device: str,
-    enable_prefix_caching: bool,
-    enable_chunked_prefill: bool,
-    max_num_batched_tokens: int,
-    distributed_executor_backend: Optional[str],
-    gpu_memory_utilization: float = 0.9,
-    num_scheduler_steps: int = 1,
-    disable_async_output_proc: bool = False,
     guided_decoding: bool = False,
     warmup: bool = False,
     disable_frontend_multiprocessing: bool = False,
 ) -> float:
     from vllm import SamplingParams
-    engine_args = AsyncEngineArgs(
-        model=model,
-        tokenizer=tokenizer,
-        tensor_parallel_size=tensor_parallel_size,
-        seed=seed,
-        trust_remote_code=trust_remote_code,
-        dtype=dtype,
-        max_model_len=max_model_len,
-        gpu_memory_utilization=gpu_memory_utilization,
-        enforce_eager=enforce_eager,
-        kv_cache_dtype=kv_cache_dtype,
-        device=device,
-        enable_prefix_caching=enable_prefix_caching,
-        enable_chunked_prefill=enable_chunked_prefill,
-        max_num_batched_tokens=max_num_batched_tokens,
-        distributed_executor_backend=distributed_executor_backend,
-        load_format=EngineArgs.load_format,
-        num_scheduler_steps=num_scheduler_steps,
-        disable_async_output_proc=disable_async_output_proc,
-        worker_use_ray=False,
-        disable_log_requests=False,
-        guided_decoding_backend="outlines",
-    )
 
     async with build_async_engine_client_from_engine_args(
             engine_args, disable_frontend_multiprocessing) as llm:
@@ -273,7 +196,6 @@ async def run_vllm_async(
             for i, (prompt, sp) in enumerate(zip(prompts, sampling_params)):
                 generator = llm.generate(prompt, sp, request_id=f"test{i}")
                 generators.append(generator)
-            all_gens = merge_async_iterators(*generators)
             all_gens = merge_async_iterators(*generators)
             async for i, res in all_gens:
                 pass
@@ -304,7 +226,6 @@ async def run_vllm_async(
         end = time.perf_counter()
         return end - start
 
-
 def main(args: argparse.Namespace):
     print(args)
     random.seed(args.seed)
@@ -312,44 +233,40 @@ def main(args: argparse.Namespace):
     # Synthesize a prompt with the given input length.
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer, trust_remote_code=args.trust_remote_code)
-    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"  # noqa: E501
+    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"
     input_len = len(tokenizer(prompt).input_ids)
+    print(f"Input length of the prompt: {input_len} tokens")
     requests = [(prompt, input_len, args.output_len)
                 for _ in range(args.num_prompts)]
 
-    run_args = [
-        requests,
-        args.model,
-        args.tokenizer,
-        args.tensor_parallel_size,
-        args.seed,
-        args.n,
-        args.trust_remote_code,
-        args.dtype,
-        args.max_model_len,
-        args.enforce_eager,
-        args.kv_cache_dtype,
-        args.device,
-        args.enable_prefix_caching,
-        args.enable_chunked_prefill,
-        args.max_num_batched_tokens,
-        args.distributed_executor_backend,
-        args.gpu_memory_utilization,
-        args.num_scheduler_steps,
-        args.disable_async_output_proc,
-        args.guided_decoding,
-        args.warmup,
-    ]
-
     if args.async_engine:
-        run_args.append(args.disable_frontend_multiprocessing)
-        elapsed_time = uvloop.run(run_vllm_async(*run_args))
+        engine_args = AsyncEngineArgs.from_cli_args(args)
+        elapsed_time = uvloop.run(
+            run_vllm_async(
+                requests,
+                engine_args,
+                args.n,
+                args.guided_decoding,
+                args.warmup,
+                args.disable_frontend_multiprocessing,
+            ))
     else:
-        elapsed_time = run_vllm(*run_args)
+        engine_args = EngineArgs.from_cli_args(args)
+        elapsed_time = run_vllm(
+            requests,
+            engine_args,
+            args.n,
+            args.guided_decoding,
+            args.warmup,
+        )
+
     total_num_tokens = sum(prompt_len + output_len
                            for _, prompt_len, output_len in requests)
+    total_output_tokens = sum(output_len
+                              for _, _, output_len in requests)
     print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
-          f"{total_num_tokens / elapsed_time:.2f} tokens/s")
+          f"{total_num_tokens / elapsed_time:.2f} total tokens/s, "
+          f"{total_output_tokens / elapsed_time:.2f} output tokens/s")
 
     # Output JSON results if specified
     if args.output_json:
@@ -363,17 +280,14 @@ def main(args: argparse.Namespace):
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
 
-
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark guided decoding.")
+    parser = AsyncEngineArgs.add_cli_args(parser)
+
     parser.add_argument("--output-len",
                         type=int,
-                        default=None,
                         help="Output length for each request. Overrides the "
                         "output length from the dataset.")
-    parser.add_argument("--model", type=str, default="facebook/opt-125m")
-    parser.add_argument("--tokenizer", type=str, default=None)
-    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
     parser.add_argument("--n",
                         type=int,
                         default=1,
@@ -382,81 +296,10 @@ if __name__ == "__main__":
                         type=int,
                         default=10,
                         help="Number of prompts to process.")
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument('--trust-remote-code',
-                        action='store_true',
-                        help='trust remote code from huggingface')
-    parser.add_argument(
-        '--max-model-len',
-        type=int,
-        default=None,
-        help='Maximum length of a sequence (including prompt and output). '
-        'If None, will be derived from the model.')
-    parser.add_argument(
-        '--dtype',
-        type=str,
-        default='auto',
-        choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
-        help='data type for model weights and activations. '
-        'The "auto" option will use FP16 precision '
-        'for FP32 and FP16 models, and BF16 precision '
-        'for BF16 models.')
-    parser.add_argument('--gpu-memory-utilization',
-                        type=float,
-                        default=0.9,
-                        help='the fraction of GPU memory to be used for '
-                        'the model executor, which can range from 0 to 1.'
-                        'If unspecified, will use the default value of 0.9.')
-    parser.add_argument("--enforce-eager",
-                        action="store_true",
-                        help="enforce eager execution")
-    parser.add_argument(
-        '--kv-cache-dtype',
-        type=str,
-        choices=['auto', 'fp8', 'fp8_e5m2', 'fp8_e4m3'],
-        default="auto",
-        help='Data type for kv cache storage. If "auto", will use model '
-        'data type. CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. '
-        'ROCm (AMD GPU) supports fp8 (=fp8_e4m3)')
-    parser.add_argument("--device",
+    parser.add_argument('--output-json',
                         type=str,
-                        default="auto",
-                        choices=DEVICE_OPTIONS,
-                        help='device type for vLLM execution')
-    parser.add_argument(
-        "--num-scheduler-steps",
-        type=int,
-        default=1,
-        help="Maximum number of forward steps per scheduler call.")
-    parser.add_argument(
-        "--enable-prefix-caching",
-        action='store_true',
-        help="Enable automatic prefix caching for vLLM backend.")
-    parser.add_argument("--enable-chunked-prefill",
-                        action='store_true',
-                        help="enable chunked prefill for vLLM backend.")
-    parser.add_argument('--max-num-batched-tokens',
-                        type=int,
                         default=None,
-                        help='maximum number of batched tokens per '
-                        'iteration')
-    parser.add_argument(
-        '--output-json',
-        type=str,
-        default=None,
-        help='Path to save the throughput results in JSON format.')
-    parser.add_argument(
-        '--distributed-executor-backend',
-        choices=['ray', 'mp'],
-        default=None,
-        help='Backend to use for distributed serving. When more than 1 GPU '
-        'is used, will be automatically set to "ray" if installed '
-        'or "mp" (multiprocessing) otherwise.')
-    parser.add_argument(
-        "--disable-async-output-proc",
-        action='store_true',
-        default=False,
-        help="Disable async output processor for vLLM backend.")
+                        help='Path to save the throughput results in JSON format.')
     parser.add_argument("--async-engine",
                         action='store_true',
                         default=False,
@@ -469,7 +312,10 @@ if __name__ == "__main__":
                         action='store_true',
                         default=False,
                         help="Disable decoupled async engine frontend.")
-    parser.add_argument("--warmup", action="store_true", default=False)
+    parser.add_argument("--warmup",
+                        action="store_true",
+                        default=False,
+                        help="Run warmup prompts before benchmark.")
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -1,12 +1,14 @@
 """Benchmark guided decoding throughput."""
 import argparse
+import dataclasses
 import json
 import random
 import time
 from typing import List
 
+import datasets
 import uvloop
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.entrypoints.openai.api_server import (
@@ -129,46 +131,74 @@ SCHEMA = {
 }
 
 
-def run_vllm(
-    requests: List[tuple[str, int, int]],
-    engine_args: EngineArgs,
-    n: int,
-    guided_decoding: bool = False,
-    warmup: bool = False,
-) -> float:
+@dataclasses.dataclass
+class SampleRequest:
+    """A class representing a single inference request for benchmarking.
+
+    Attributes:
+        prompt: The input text prompt for the model.
+        multi_modal_data: Optional dictionary containing multi-modal data (e.g.
+            images).
+        prompt_len: The length of the prompt in tokens.
+        expected_output_len: The expected length of the output in tokens.
+    """
+    prompt: str
+    prompt_len: int
+    expected_output_len: int
+    schema: dict
+    completion: str = None
+
+
+def run_vllm(requests: List[SampleRequest],
+             engine_args: EngineArgs,
+             n: int,
+             guided_decoding: bool = False,
+             warmup: bool = False,
+             result_file_name: str = None) -> float:
     from vllm import LLM, SamplingParams
     llm = LLM(**vars(engine_args))
 
     # Add the requests to the engine.
     prompts: List[str] = []
     sampling_params: List[SamplingParams] = []
-    for prompt, _, output_len in requests:
-        prompts.append(prompt)
+    for request in requests:
+        prompts.append(request.prompt)
         sampling_params.append(
             SamplingParams(
                 n=n,
                 temperature=1.0,
                 top_p=1.0,
                 ignore_eos=True,
-                max_tokens=output_len,
+                max_tokens=request.expected_output_len,
                 guided_decoding=GuidedDecodingParams(
-                    json=SCHEMA) if guided_decoding else None,
+                    json=request.schema) if guided_decoding else None,
             ))
 
     start = time.perf_counter()
-    llm.generate(prompts, sampling_params, use_tqdm=True)
+    outputs = llm.generate(prompts, sampling_params, use_tqdm=True)
+    ret = []
+    for output, request in zip(outputs, requests):
+        generated_text = output.outputs[0].text
+        ret.append({
+            "generated": generated_text,
+            "expected": request.completion
+        })
     end = time.perf_counter()
+    # save ret list into a json
+    if result_file_name:
+        with open(result_file_name, 'w') as f:
+            json.dump(ret, f, indent=4)
+            f.write("\n")
     return end - start
 
 
-async def run_vllm_async(
-    requests: List[tuple[str, int, int]],
-    engine_args: AsyncEngineArgs,
-    n: int,
-    guided_decoding: bool = False,
-    warmup: bool = False,
-    disable_frontend_multiprocessing: bool = False,
-) -> float:
+async def run_vllm_async(requests: List[SampleRequest],
+                         engine_args: AsyncEngineArgs,
+                         n: int,
+                         guided_decoding: bool = False,
+                         warmup: bool = False,
+                         disable_frontend_multiprocessing: bool = False,
+                         result_file_name: str = None) -> float:
     from vllm import SamplingParams
 
     async with build_async_engine_client_from_engine_args(
@@ -182,17 +212,17 @@ async def run_vllm_async(
             # We setup the first 5 requests to warmup FSM
             warmup_requests = requests[:5]
             requests = requests[5:]
-            for prompt, _, output_len in warmup_requests:
-                prompts.append(prompt)
+            for request in warmup_requests:
+                prompts.append(request.prompt)
                 sampling_params.append(
                     SamplingParams(
                         n=n,
                         temperature=1.0,
                         top_p=1.0,
                         ignore_eos=True,
-                        max_tokens=output_len,
+                        max_tokens=request.expected_output_len,
                         guided_decoding=GuidedDecodingParams(
-                            json=SCHEMA) if guided_decoding else None,
+                            json=request.schema) if guided_decoding else None,
                     ))
             generators = []
             for i, (prompt, sp) in enumerate(zip(prompts, sampling_params)):
@@ -204,17 +234,17 @@ async def run_vllm_async(
 
         prompts = []
         sampling_params = []
-        for prompt, _, output_len in requests:
-            prompts.append(prompt)
+        for request in requests:
+            prompts.append(request.prompt)
             sampling_params.append(
                 SamplingParams(
                     n=n,
                     temperature=1.0,
                     top_p=1.0,
                     ignore_eos=True,
-                    max_tokens=output_len,
+                    max_tokens=request.expected_output_len,
                     guided_decoding=GuidedDecodingParams(
-                        json=SCHEMA) if guided_decoding else None,
+                        json=request.schema) if guided_decoding else None,
                 ))
 
         generators = []
@@ -223,24 +253,78 @@ async def run_vllm_async(
             generator = llm.generate(prompt, sp, request_id=f"test{i}")
             generators.append(generator)
         all_gens = merge_async_iterators(*generators)
+        ret = []
         async for i, res in all_gens:
-            pass
+            generated_text = res.outputs[0].text
+            ret.append(generated_text)
         end = time.perf_counter()
+        if result_file_name:
+            with open(result_file_name, 'w') as f:
+                json.dump(ret, f, indent=4)
+                f.write("\n")
         return end - start
+
+
+def sample_requests(tokenizer: PreTrainedTokenizerBase,
+                    args: argparse.Namespace) -> List[SampleRequest]:
+    if args.dataset == 'single_schema':
+        prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"  # noqa: E501
+        input_len = len(tokenizer(prompt).input_ids)
+        print(f"Input length of the prompt: {input_len} tokens")
+        requests = [
+            SampleRequest(prompt=prompt,
+                          prompt_len=input_len,
+                          expected_output_len=args.output_len,
+                          schema=SCHEMA) for _ in range(args.num_prompts)
+        ]
+
+    elif args.dataset == "xgrammar_bench":
+        requests: List[SampleRequest] = []
+        dataset = datasets.load_dataset("NousResearch/json-mode-eval",
+                                        split="train")
+        print(f"dataset has {len(dataset)} entries")
+        len_dataset = len(dataset)
+        for data_point_idx in range(args.num_prompts):
+            idx = data_point_idx
+            while idx >= len_dataset:
+                idx -= len_dataset
+            schema = dataset["schema"][idx]
+            prompt = tokenizer.apply_chat_template(dataset["prompt"][idx],
+                                                   tokenize=False)
+            input_len = len(tokenizer(prompt).input_ids)
+            completion = dataset["completion"][idx]
+
+            requests.append(
+                SampleRequest(prompt=prompt,
+                              prompt_len=input_len,
+                              expected_output_len=args.output_len,
+                              schema=schema,
+                              completion=completion))
+
+    return requests
 
 
 def main(args: argparse.Namespace):
     print(args)
     random.seed(args.seed)
 
+    if args.save_results:
+        result_file_name = 'guided' if args.guided_decoding else 'no_guided'
+        result_file_name += f"_{args.model.split('/')[-1]}"
+        result_file_name += f"_{args.dataset}"
+        result_file_name += f"_{args.num_prompts}"
+        result_file_name += f"_out{args.output_len}"
+        result_file_name += f"_async{args.async_engine}"
+        result_file_name += f"_warmup{args.warmup}"
+        result_file_name += f"_chunkedprefill{args.enable_chunked_prefill}"
+        result_file_name += ".txt"
+    else:
+        result_file_name = None
+
     # Synthesize a prompt with the given input length.
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer, trust_remote_code=args.trust_remote_code)
-    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"  # noqa: E501
-    input_len = len(tokenizer(prompt).input_ids)
-    print(f"Input length of the prompt: {input_len} tokens")
-    requests = [(prompt, input_len, args.output_len)
-                for _ in range(args.num_prompts)]
+    requests = sample_requests(tokenizer, args)
 
     if args.async_engine:
         engine_args = AsyncEngineArgs.from_cli_args(args)
@@ -252,6 +336,7 @@ def main(args: argparse.Namespace):
                 args.guided_decoding,
                 args.warmup,
                 args.disable_frontend_multiprocessing,
+                result_file_name,
             ))
     else:
         engine_args = EngineArgs.from_cli_args(args)
@@ -261,26 +346,41 @@ def main(args: argparse.Namespace):
             args.n,
             args.guided_decoding,
             args.warmup,
+            result_file_name,
         )
 
-    total_num_tokens = sum(prompt_len + output_len
-                           for _, prompt_len, output_len in requests)
-    total_output_tokens = sum(output_len for _, _, output_len in requests)
+    total_num_tokens = sum(request.prompt_len + request.expected_output_len
+                           for request in requests)
+    total_output_tokens = sum(request.expected_output_len
+                              for request in requests)
     print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
           f"{total_num_tokens / elapsed_time:.2f} total tokens/s, "
           f"{total_output_tokens / elapsed_time:.2f} output tokens/s")
 
     # Output JSON results if specified
-    if args.output_json:
+    if args.output_json or result_file_name:
         results = {
-            "elapsed_time": elapsed_time,
-            "num_requests": len(requests),
-            "total_num_tokens": total_num_tokens,
-            "requests_per_second": len(requests) / elapsed_time,
-            "tokens_per_second": total_num_tokens / elapsed_time,
+            "elapsed_time":
+            elapsed_time,
+            "num_requests":
+            len(requests),
+            "total_num_tokens":
+            total_num_tokens,
+            "total_output_tokens":
+            total_output_tokens,
+            "requests_per_second":
+            len(requests) / elapsed_time,
+            "tokens_per_second":
+            f"{total_num_tokens / elapsed_time:.2f}",
+            "output_tokens_per_second":
+            f"{total_output_tokens / elapsed_time:.2f}",
         }
-        with open(args.output_json, "w") as f:
-            json.dump(results, f, indent=4)
+        if args.output_json:
+            with open(args.output_json, "w") as f:
+                json.dump(results, f, indent=4)
+        elif result_file_name:
+            with open(result_file_name, "a") as f:
+                json.dump(results, f, indent=4)
 
 
 if __name__ == "__main__":
@@ -291,6 +391,8 @@ if __name__ == "__main__":
                         type=int,
                         help="Output length for each request. Overrides the "
                         "output length from the dataset.")
+    parser.add_argument("--dataset",
+                        choices=['single_schema', 'xgrammar_bench'])
     parser.add_argument("--n",
                         type=int,
                         default=1,
@@ -320,6 +422,10 @@ if __name__ == "__main__":
                         action="store_true",
                         default=False,
                         help="Run warmup prompts before benchmark.")
+    parser.add_argument("--save-results",
+                        action="store_true",
+                        default=False,
+                        help="save output results.")
     args = parser.parse_args()
     if args.tokenizer is None:
         args.tokenizer = args.model

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -1,0 +1,423 @@
+"""Benchmark guided decoding throughput."""
+import argparse, json, random, time
+import torch, uvloop
+
+from typing import List, Optional, Tuple
+from tqdm import tqdm
+from transformers import (AutoModelForCausalLM, AutoTokenizer,
+                          PreTrainedTokenizerBase)
+
+from vllm.engine.arg_utils import DEVICE_OPTIONS, AsyncEngineArgs, EngineArgs
+from vllm.entrypoints.openai.api_server import (
+    build_async_engine_client_from_engine_args)
+from vllm.sampling_params import GuidedDecodingParams
+from vllm.utils import FlexibleArgumentParser, merge_async_iterators
+
+SCHEMA = {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "User Profile",
+  "type": "object",
+  "properties": {
+    "userId": {
+      "type": "string",
+      "description": "Unique identifier for the user."
+    },
+    "personalInfo": {
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "The user's first name."
+        },
+        "lastName": {
+          "type": "string",
+          "description": "The user's last name."
+        },
+        "age": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The user's age."
+        },
+        "phoneNumbers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["home", "work", "mobile"],
+                "description": "Type of phone number."
+              },
+              "number": {
+                "type": "string",
+                "pattern": "^\\+?[1-9]\\d{1,14}$",
+                "description": "Phone number in E.164 format."
+              }
+            },
+            "required": ["type", "number"]
+          },
+          "description": "List of phone numbers associated with the user."
+        }
+      },
+      "required": ["firstName", "lastName"]
+    },
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string",
+          "description": "Street address."
+        },
+        "city": {
+          "type": "string",
+          "description": "City name."
+        },
+        "state": {
+          "type": "string",
+          "description": "State or province."
+        },
+        "postalCode": {
+          "type": "string",
+          "pattern": "^\\d{5}(-\\d{4})?$",
+          "description": "Postal code."
+        },
+        "country": {
+          "type": "string",
+          "description": "Country name."
+        }
+      },
+      "required": ["street", "city", "state", "postalCode", "country"]
+    },
+    "preferences": {
+      "type": "object",
+      "properties": {
+        "newsletterSubscribed": {
+          "type": "boolean",
+          "description": "Indicates if the user is subscribed to the newsletter."
+        },
+        "favoriteCategories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of user's favorite categories."
+        }
+      },
+      "required": ["newsletterSubscribed"]
+    },
+    "accountStatus": {
+      "type": "string",
+      "enum": ["active", "inactive", "suspended"],
+      "description": "Current status of the user's account."
+    },
+    "registrationDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 formatted date-time of user registration."
+    }
+  },
+  "required": ["userId", "personalInfo", "address", "accountStatus", "registrationDate"]
+}
+
+def run_vllm(
+    requests: List[Tuple[str, int, int]],
+    model: str,
+    tokenizer: str,
+    tensor_parallel_size: int,
+    seed: int,
+    n: int,
+    trust_remote_code: bool,
+    dtype: str,
+    max_model_len: Optional[int],
+    enforce_eager: bool,
+    kv_cache_dtype: str,
+    device: str,
+    enable_prefix_caching: bool,
+    enable_chunked_prefill: bool,
+    max_num_batched_tokens: int,
+    distributed_executor_backend: Optional[str],
+    gpu_memory_utilization: float = 0.9,
+    num_scheduler_steps: int = 1,
+    disable_async_output_proc: bool = False,
+    guided_decoding: bool = False,
+    debug: bool = False,
+) -> float:
+    from vllm import LLM, SamplingParams
+    llm = LLM(
+        model=model,
+        tokenizer=tokenizer,
+        tensor_parallel_size=tensor_parallel_size,
+        seed=seed,
+        trust_remote_code=trust_remote_code,
+        dtype=dtype,
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+        enforce_eager=enforce_eager,
+        kv_cache_dtype=kv_cache_dtype,
+        device=device,
+        enable_prefix_caching=enable_prefix_caching,
+        enable_chunked_prefill=enable_chunked_prefill,
+        max_num_batched_tokens=max_num_batched_tokens,
+        distributed_executor_backend=distributed_executor_backend,
+        load_format=EngineArgs.load_format,
+        num_scheduler_steps=num_scheduler_steps,
+        disable_async_output_proc=disable_async_output_proc,
+        guided_decoding_backend="outlines",
+    )
+
+    # Add the requests to the engine.
+    prompts: List[str] = []
+    sampling_params: List[SamplingParams] = []
+    for prompt, _, output_len in requests:
+        prompts.append(prompt)
+        sampling_params.append(
+            SamplingParams(
+                n=n,
+                temperature=1.0,
+                top_p=1.0,
+                ignore_eos=True,
+                max_tokens=output_len,
+                guided_decoding=GuidedDecodingParams(json=SCHEMA) if guided_decoding else None,
+            ))
+
+    start = time.perf_counter()
+    llm.generate(prompts, sampling_params, use_tqdm=True)
+    end = time.perf_counter()
+    return end - start
+
+
+async def run_vllm_async(
+    requests: List[Tuple[str, int, int]],
+    model: str,
+    tokenizer: str,
+    tensor_parallel_size: int,
+    seed: int,
+    n: int,
+    trust_remote_code: bool,
+    dtype: str,
+    max_model_len: Optional[int],
+    enforce_eager: bool,
+    kv_cache_dtype: str,
+    device: str,
+    enable_prefix_caching: bool,
+    enable_chunked_prefill: bool,
+    max_num_batched_tokens: int,
+    distributed_executor_backend: Optional[str],
+    gpu_memory_utilization: float = 0.9,
+    num_scheduler_steps: int = 1,
+    disable_async_output_proc: bool = False,
+    guided_decoding: bool = False,
+    debug: bool = False,
+    disable_frontend_multiprocessing: bool = False,
+) -> float:
+    from vllm import SamplingParams
+    engine_args = AsyncEngineArgs(
+        model=model,
+        tokenizer=tokenizer,
+        tensor_parallel_size=tensor_parallel_size,
+        seed=seed,
+        trust_remote_code=trust_remote_code,
+        dtype=dtype,
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+        enforce_eager=enforce_eager,
+        kv_cache_dtype=kv_cache_dtype,
+        device=device,
+        enable_prefix_caching=enable_prefix_caching,
+        enable_chunked_prefill=enable_chunked_prefill,
+        max_num_batched_tokens=max_num_batched_tokens,
+        distributed_executor_backend=distributed_executor_backend,
+        load_format=EngineArgs.load_format,
+        num_scheduler_steps=num_scheduler_steps,
+        disable_async_output_proc=disable_async_output_proc,
+        worker_use_ray=False,
+        disable_log_requests=False,
+        guided_decoding_backend="outlines",
+    )
+
+    async with build_async_engine_client_from_engine_args(
+            engine_args, disable_frontend_multiprocessing) as llm:
+
+        # Add the requests to the engine.
+        prompts: List[str] = []
+        sampling_params: List[SamplingParams] = []
+        for prompt, _, output_len in requests:
+            prompts.append(prompt)
+            sampling_params.append(
+                SamplingParams(
+                    n=n,
+                    temperature=1.0,
+                    top_p=1.0,
+                    ignore_eos=True,
+                    max_tokens=output_len,
+                    guided_decoding=GuidedDecodingParams(json=SCHEMA) if guided_decoding else None,
+                ))
+
+        generators = []
+        start = time.perf_counter()
+        for i, (prompt, sp) in enumerate(zip(prompts, sampling_params)):
+            generator = llm.generate(prompt, sp, request_id=f"test{i}")
+            generators.append(generator)
+        all_gens = merge_async_iterators(*generators)
+        async for i, res in all_gens:
+          if debug: print(res.outputs[0].text)
+        end = time.perf_counter()
+        return end - start
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+
+    # Synthesize a prompt with the given input length.
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer, trust_remote_code=args.trust_remote_code)
+    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"
+    input_len = len(tokenizer(prompt).input_ids)
+    requests = [(prompt, input_len, args.output_len)
+                for _ in range(args.num_prompts)]
+
+    run_args = [
+        requests, args.model, args.tokenizer,
+        args.tensor_parallel_size, args.seed, args.n,
+        args.trust_remote_code, args.dtype, args.max_model_len,
+        args.enforce_eager, args.kv_cache_dtype, args.device,
+        args.enable_prefix_caching, args.enable_chunked_prefill,
+        args.max_num_batched_tokens, args.distributed_executor_backend,
+        args.gpu_memory_utilization, args.num_scheduler_steps,
+        args.disable_async_output_proc, args.guided_decoding, args.debug,
+    ]
+
+    if args.async_engine:
+        run_args.append(args.disable_frontend_multiprocessing)
+        elapsed_time = uvloop.run(run_vllm_async(*run_args))
+    else:
+        elapsed_time = run_vllm(*run_args)
+    total_num_tokens = sum(prompt_len + output_len
+                           for _, prompt_len, output_len in requests)
+    print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
+          f"{total_num_tokens / elapsed_time:.2f} tokens/s")
+
+    # Output JSON results if specified
+    if args.output_json:
+        results = {
+            "elapsed_time": elapsed_time,
+            "num_requests": len(requests),
+            "total_num_tokens": total_num_tokens,
+            "requests_per_second": len(requests) / elapsed_time,
+            "tokens_per_second": total_num_tokens / elapsed_time,
+        }
+        with open(args.output_json, "w") as f:
+            json.dump(results, f, indent=4)
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(description="Benchmark guided decoding.")
+    parser.add_argument("--output-len",
+                        type=int,
+                        default=None,
+                        help="Output length for each request. Overrides the "
+                        "output length from the dataset.")
+    parser.add_argument("--model", type=str, default="facebook/opt-125m")
+    parser.add_argument("--tokenizer", type=str, default=None)
+    parser.add_argument("--tensor-parallel-size", "-tp", type=int, default=1)
+    parser.add_argument("--n",
+                        type=int,
+                        default=1,
+                        help="Number of generated sequences per prompt.")
+    parser.add_argument("--num-prompts",
+                        type=int,
+                        default=10,
+                        help="Number of prompts to process.")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument('--trust-remote-code',
+                        action='store_true',
+                        help='trust remote code from huggingface')
+    parser.add_argument(
+        '--max-model-len',
+        type=int,
+        default=None,
+        help='Maximum length of a sequence (including prompt and output). '
+        'If None, will be derived from the model.')
+    parser.add_argument(
+        '--dtype',
+        type=str,
+        default='auto',
+        choices=['auto', 'half', 'float16', 'bfloat16', 'float', 'float32'],
+        help='data type for model weights and activations. '
+        'The "auto" option will use FP16 precision '
+        'for FP32 and FP16 models, and BF16 precision '
+        'for BF16 models.')
+    parser.add_argument('--gpu-memory-utilization',
+                        type=float,
+                        default=0.9,
+                        help='the fraction of GPU memory to be used for '
+                        'the model executor, which can range from 0 to 1.'
+                        'If unspecified, will use the default value of 0.9.')
+    parser.add_argument("--enforce-eager",
+                        action="store_true",
+                        help="enforce eager execution")
+    parser.add_argument(
+        '--kv-cache-dtype',
+        type=str,
+        choices=['auto', 'fp8', 'fp8_e5m2', 'fp8_e4m3'],
+        default="auto",
+        help='Data type for kv cache storage. If "auto", will use model '
+        'data type. CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. '
+        'ROCm (AMD GPU) supports fp8 (=fp8_e4m3)')
+    parser.add_argument("--device",
+                        type=str,
+                        default="auto",
+                        choices=DEVICE_OPTIONS,
+                        help='device type for vLLM execution')
+    parser.add_argument(
+        "--num-scheduler-steps",
+        type=int,
+        default=1,
+        help="Maximum number of forward steps per scheduler call.")
+    parser.add_argument(
+        "--enable-prefix-caching",
+        action='store_true',
+        help="Enable automatic prefix caching for vLLM backend.")
+    parser.add_argument("--enable-chunked-prefill",
+                        action='store_true',
+                        help="enable chunked prefill for vLLM backend.")
+    parser.add_argument('--max-num-batched-tokens',
+                        type=int,
+                        default=None,
+                        help='maximum number of batched tokens per '
+                        'iteration')
+    parser.add_argument(
+        '--output-json',
+        type=str,
+        default=None,
+        help='Path to save the throughput results in JSON format.')
+    parser.add_argument(
+        '--distributed-executor-backend',
+        choices=['ray', 'mp'],
+        default=None,
+        help='Backend to use for distributed serving. When more than 1 GPU '
+        'is used, will be automatically set to "ray" if installed '
+        'or "mp" (multiprocessing) otherwise.')
+    parser.add_argument(
+        "--disable-async-output-proc",
+        action='store_true',
+        default=False,
+        help="Disable async output processor for vLLM backend.")
+    parser.add_argument("--async-engine",
+                        action='store_true',
+                        default=False,
+                        help="Use vLLM async engine rather than LLM class.")
+    parser.add_argument("--guided-decoding",
+                        action='store_true',
+                        default=False,
+                        help="Whether to enable JSON decoding or not.")
+    parser.add_argument("--disable-frontend-multiprocessing",
+                        action='store_true',
+                        default=False,
+                        help="Disable decoupled async engine frontend.")
+    parser.add_argument("--debug", action="store_true", default=False)
+    args = parser.parse_args()
+    if args.tokenizer is None:
+        args.tokenizer = args.model
+    main(args)

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -280,8 +280,8 @@ def evaluate(ret, args):
         # extract json string from string using regex
         import re
         actual = actual.replace('\n', '').replace(' ', '').strip()
-        actual = re.search(r'\{.*\}', actual).group()
         try:
+            actual = re.search(r'\{.*\}', actual).group()
             actual = json.loads(actual)
         except Exception:
             return False

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -128,6 +128,7 @@ SCHEMA = {
     ["userId", "personalInfo", "address", "accountStatus", "registrationDate"]
 }
 
+
 def run_vllm(
     requests: List[tuple[str, int, int]],
     engine_args: EngineArgs,
@@ -158,6 +159,7 @@ def run_vllm(
     llm.generate(prompts, sampling_params, use_tqdm=True)
     end = time.perf_counter()
     return end - start
+
 
 async def run_vllm_async(
     requests: List[tuple[str, int, int]],
@@ -226,6 +228,7 @@ async def run_vllm_async(
         end = time.perf_counter()
         return end - start
 
+
 def main(args: argparse.Namespace):
     print(args)
     random.seed(args.seed)
@@ -233,7 +236,7 @@ def main(args: argparse.Namespace):
     # Synthesize a prompt with the given input length.
     tokenizer = AutoTokenizer.from_pretrained(
         args.tokenizer, trust_remote_code=args.trust_remote_code)
-    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"
+    prompt = f"Generate an example of a user profile given the following schema: {json.dumps(SCHEMA)}"  # noqa: E501
     input_len = len(tokenizer(prompt).input_ids)
     print(f"Input length of the prompt: {input_len} tokens")
     requests = [(prompt, input_len, args.output_len)
@@ -262,8 +265,7 @@ def main(args: argparse.Namespace):
 
     total_num_tokens = sum(prompt_len + output_len
                            for _, prompt_len, output_len in requests)
-    total_output_tokens = sum(output_len
-                              for _, _, output_len in requests)
+    total_output_tokens = sum(output_len for _, _, output_len in requests)
     print(f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
           f"{total_num_tokens / elapsed_time:.2f} total tokens/s, "
           f"{total_output_tokens / elapsed_time:.2f} output tokens/s")
@@ -279,6 +281,7 @@ def main(args: argparse.Namespace):
         }
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
+
 
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark guided decoding.")
@@ -296,10 +299,11 @@ if __name__ == "__main__":
                         type=int,
                         default=10,
                         help="Number of prompts to process.")
-    parser.add_argument('--output-json',
-                        type=str,
-                        default=None,
-                        help='Path to save the throughput results in JSON format.')
+    parser.add_argument(
+        '--output-json',
+        type=str,
+        default=None,
+        help='Path to save the throughput results in JSON format.')
     parser.add_argument("--async-engine",
                         action='store_true',
                         default=False,

--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -285,10 +285,6 @@ def evaluate(ret, args):
             actual = json.loads(actual)
         except Exception:
             return False
-        if expected is not None:
-            expected = expected.replace('\n', '').replace(' ', '').strip()
-            expected = json.loads(expected)
-            return expected.keys() == actual.keys()
 
         return True
 

--- a/benchmarks/structured_schemas/structured_schema_1.json
+++ b/benchmarks/structured_schemas/structured_schema_1.json
@@ -1,0 +1,113 @@
+{
+    "$schema":
+    "https://json-schema.org/draft/2020-12/schema",
+    "title":
+    "User Profile",
+    "type":
+    "object",
+    "properties": {
+        "userId": {
+            "type": "string",
+            "description": "Unique identifier for the user."
+        },
+        "personalInfo": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string",
+                    "description": "The user's first name."
+                },
+                "lastName": {
+                    "type": "string",
+                    "description": "The user's last name."
+                },
+                "age": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "The user's age."
+                },
+                "phoneNumbers": {
+                    "type":
+                    "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["home", "work", "mobile"],
+                                "description": "Type of phone number."
+                            },
+                            "number": {
+                                "type": "string",
+                                "pattern": "^\\+?[1-9]\\d{1,14}$",
+                                "description": "Phone number in E.164 format."
+                            }
+                        },
+                        "required": ["type", "number"]
+                    },
+                    "description":
+                    "List of phone numbers associated with the user."
+                }
+            },
+            "required": ["firstName", "lastName"]
+        },
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": {
+                    "type": "string",
+                    "description": "Street address."
+                },
+                "city": {
+                    "type": "string",
+                    "description": "City name."
+                },
+                "state": {
+                    "type": "string",
+                    "description": "State or province."
+                },
+                "postalCode": {
+                    "type": "string",
+                    "pattern": "^\\d{5}(-\\d{4})?$",
+                    "description": "Postal code."
+                },
+                "country": {
+                    "type": "string",
+                    "description": "Country name."
+                }
+            },
+            "required": ["street", "city", "state", "postalCode", "country"]
+        },
+        "preferences": {
+            "type": "object",
+            "properties": {
+                "newsletterSubscribed": {
+                    "type":
+                    "boolean",
+                    "description":
+                    "Indicates if the user is subscribed to the newsletter."
+                },
+                "favoriteCategories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of user's favorite categories."
+                }
+            },
+            "required": ["newsletterSubscribed"]
+        },
+        "accountStatus": {
+            "type": "string",
+            "enum": ["active", "inactive", "suspended"],
+            "description": "Current status of the user's account."
+        },
+        "registrationDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 formatted date-time of user registration."
+        }
+    },
+    "required":
+    ["userId", "personalInfo", "address", "accountStatus", "registrationDate"]
+}


### PR DESCRIPTION
Add structure output benchmark.

Base PR: https://github.com/vllm-project/vllm/pull/10046
Additional work:
1. add 4 guided options -  'grammar', 'choice', 'regex' and 'json'; For Json, add single-json and use 'xgrammar_benchmark'(multi-schema)
2. add option for guided_decoding_ratio, default is 1.0, ratio < 1.0 provided a mixed requests containing both regular/guided
3. add correctness rate check
4. add first and next token latency when testing with AsyncEngine

How to test:
* with guided decoding
```
python benchmarks/benchmark_guided.py --model meta-llama/Llama-3.2-3B-Instruct --dataset xgrammar_bench --async-engine --output-len 512 --num-prompts 10 --enable-chunked-prefill --guided-decoding-ratio 1.0 --save-results
```

How to test:
* with no guided decoding
```
python benchmarks/benchmark_guided.py --model meta-llama/Llama-3.2-3B-Instruct --dataset xgrammar_bench --output-len 512 --num-prompts 10 --no-guided-decoding --save-results
```

Expected output
FileName: 1.0guided_Llama-3.2-3B-Instruct_xgrammar_bench_10_out512_asyncTrue_warmupTrue_chunkedprefillTrue.txt

```
    "elapsed_time": 50.00640656100586,
    "num_requests": 10,
    "total_num_tokens": 8086,
    "total_output_tokens": 5120,
    "requests_per_second": 0.1999743770390778,
    "tokens_per_second": "161.70",
    "output_tokens_per_second": "102.39",
    "correct_rate(%)": 100.0,
    "first_token_latency(msecs)": {
        "count": 10.0,
        "mean": 33074.16370075662,
        "std": 9578.487238858703,
        "min": 19958.579740021378,
        "25%": 25430.36330281757,
        "50%": 33561.18999654427,
        "75%": 40371.71240762109,
        "max": 46179.445307003334
    },
    "next_token_latency(msecs)": {
        "count": 10.0,
        "mean": 7.487070074518177,
        "std": 0.21345235857034978,
        "min": 7.0583598064933035,
        "25%": 7.452180709461126,
        "50%": 7.483904802198513,
        "75%": 7.609307728370618,
        "max": 7.772003888715707
    }
```

