### PR TITLE
[Bugfix] 500 Internal Server Error when tool_choice is incorrect.

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -829,6 +829,20 @@ async def test_inconsistent_tool_choice_and_tools(client: openai.AsyncOpenAI,
                     "name": "nondefined_function_name"
                 }
             })
+    with pytest.raises(openai.BadRequestError):
+        await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=messages,
+            max_completion_tokens=1000,
+            tools=[{
+                "type": "function",
+                "function": {
+                    "name": "dummy_function_name",
+                    "description": "This is a dummy function",
+                    "parameters": sample_json_schema
+                }
+            }],
+            tool_choice={})
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -478,13 +478,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
             # it matches a valid tool
             if isinstance(data["tool_choice"], dict):
                 valid_tool = False
-                specified_function = data["tool_choice"]["function"]
+                specified_function = data["tool_choice"].get("function")
                 if not specified_function:
                     raise ValueError(
                         "Incorrectly formatted `tool_choice`. Should be like "
                         "`{\"type\": \"function\","
                         " \"function\": {\"name\": \"my_function\"}}`")
-                specified_function_name = specified_function["name"]
+                specified_function_name = specified_function.get("name")
                 if not specified_function_name:
                     raise ValueError(
                         "Incorrectly formatted `tool_choice`. Should be like "

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -481,14 +481,14 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 specified_function = data["tool_choice"].get("function")
                 if not specified_function:
                     raise ValueError(
-                        "Incorrectly formatted `tool_choice`. Should be like "
-                        "`{\"type\": \"function\","
+                        "Expected field `function` in `tool_choice`."
+                        " Correct usage: `{\"type\": \"function\","
                         " \"function\": {\"name\": \"my_function\"}}`")
                 specified_function_name = specified_function.get("name")
                 if not specified_function_name:
                     raise ValueError(
-                        "Incorrectly formatted `tool_choice`. Should be like "
-                        "`{\"type\": \"function\", "
+                        "Expected field `name` in `function` in `tool_choice`."
+                        "Correct usage: `{\"type\": \"function\", "
                         "\"function\": {\"name\": \"my_function\"}}`")
                 for tool in data["tools"]:
                     if tool["function"]["name"] == specified_function_name:


### PR DESCRIPTION
## Summary
This PR fixes the KeyError when tool_choice is incorrectly provided.
```

Request:
		{
	    "model": "vllm-model",
	    "messages": [ {"role": "user", "content": "what is 5+3"}],
	    "tool_choice": {},
	    "tools": [
	        {
	                "type": "function",
	                "name": "my_caculator",
	                "description": "A simple caculator takes an expression to caculate.",
	                "parameters": {
	                    "type": "object",
	                    "properties": {
	                        "expression": {
	                            "type": "string",
	                            "description": "A expressoin to caculate."
	                        }
	                    },
	                    "required": ["expression"]
	                }
	        }
	    ]
	}
Output:
Internal Server Error(base)
```
<img width="964" alt="Screenshot 2024-11-21 at 11 04 08 PM" src="https://github.com/user-attachments/assets/87aa3b27-2cdb-433c-9345-59365774c691">


### Checklist
- Tested using curl
- After fix:
```
{
    "object": "error",
    "message": "[{'type': 'value_error', 'loc': ('body',), 'msg': 'Value error, Incorrectly formatted `tool_choice`. Should be like `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}`', 'input': {'model': 'vllm-model', 'messages': [{'role': 'user', 'content': 'what is 5+3'}], 'tool_choice': {}, 'tools': [{'type': 'function', 'name': 'my_caculator', 'description': 'A simple caculator takes an expression to caculate.', 'parameters': {'type': 'object', 'properties': {'expression': {'type': 'string', 'description': 'A expressoin to caculate.'}}, 'required': ['expression']}}]}, 'ctx': {'error': ValueError('Incorrectly formatted `tool_choice`. Should be like `{\"type\": \"function\", \"function\": {\"name\": \"my_function\"}}`')}}]",
    "type": "BadRequestError",
    "param": null,
    "code": 400
}
```
- Lint
- pytest
 