### PR TITLE
[Core] Update to outlines >= 0.1.8

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -18,7 +18,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines >= 0.0.43, < 0.1
+outlines >= 0.1.8
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -99,7 +99,7 @@ class RegexLogitsProcessor(BaseLogitsProcessor):
     def _get_guide(cls, regex_string: str,
                    tokenizer: PreTrainedTokenizerBase) -> Guide:
         tokenizer = _adapt_tokenizer(tokenizer)
-        return RegexGuide(regex_string, tokenizer)
+        return RegexGuide.from_regex(regex_string, tokenizer)
 
     def __init__(self, regex_string: str, tokenizer: PreTrainedTokenizerBase):
         """Compile the FSM that drives the regex-structured generation.


### PR DESCRIPTION
This PR updates to the latest release of `outlines` that works with vllm.

It is a draft while we wait for 0.1.8 to be on pypi.

FIX https://github.com/vllm-project/vllm/issues/3794 
FIX https://github.com/vllm-project/vllm/issues/10489

279ccc9dd [Core] Update to outlines >= 0.1.8

commit 279ccc9ddd20094b8ac94e245718d534515ac6b9
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Nov 21 21:25:22 2024 +0000

    [Core] Update to outlines >= 0.1.8
    
    0.1.x prior to 0.1.8 + outlines-core 0.1.18 had issues with
    serialization that broke vllm integration.
    
    Also change our code slightly to account for an API change in
    outlines.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
