### PR TITLE
fix json serialization issue

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,5 +1,4 @@
 import itertools
-import json
 import warnings
 from contextlib import contextmanager
 from typing import (Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type,
@@ -185,8 +184,12 @@ class LLM:
             kwargs["disable_log_stats"] = True
 
         if compilation_config is not None:
-            compilation_config_instance = CompilationConfig.from_cli(
-                json.dumps(compilation_config))
+            if type(compilation_config) is int:
+                compilation_config_instance = CompilationConfig(
+                    level=compilation_config)
+            else:
+                compilation_config_instance = CompilationConfig.model_validate(
+                    compilation_config)
         else:
             compilation_config_instance = None
 


### PR DESCRIPTION
The `compile/test_full_graph.py` tests were failing because a `CompilationConfig` object containing non serializable attributes was being dumped to json to be parsed from json again.

Here is an example of a failed run: https://buildkite.com/vllm/ci-aws/builds/11643#_
```
Traceback (most recent call last):
  File "tests/utils.py", line 658, in wrapper
    f(*args, **kwargs)
  File "tests/compile/test_full_graph.py", line 17, in test_full_graph
    check_full_graph_support(model,
  File "tests/compile/utils.py", line 84, in check_full_graph_support
    llm = LLM(model=model,
          ^^^^^^^^^^^^^^^^
  File "/vllm/vllm/utils.py", line 1034, in inner
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/vllm/vllm/entrypoints/llm.py", line 189, in __init__
    json.dumps(compilation_config))
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".pyenv/versions/3.11.6/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".pyenv/versions/3.11.6/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".pyenv/versions/3.11.6/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File ".pyenv/versions/3.11.6/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type CompilationConfig is not JSON serializable
```

Printing the model dump of the CompilationConfig object show a non serializable PosixPath object as well as two functions:
```
{'level': 2, 'backend': '', 'custom_ops': [], 'splitting_ops': ['vllm.unified_flash_attention', 'vllm.unified_flash_infer', 'vllm.unified_v1_flash_attention'], 'use_inductor': True, 'inductor_specialize_for_cudagraph_no_more_than': None, 'inductor_compile_sizes': {}, 'inductor_compile_config': {}, 'inductor_passes': {}, 'use_cudagraph': False, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': None, 'cudagraph_copy_inputs': False, 'pass_config': {'dump_graph_stages': [], 'dump_graph_dir': PosixPath('.'), 'enable_fusion': True, 'enable_reshape': True}, 'compile_sizes': <function PrivateAttr at 0x7f5906143ce0>, 'capture_sizes': <function PrivateAttr at 0x7f5906143ce0>, 'enabled_custom_ops': {}, 'disabled_custom_ops': {}}```

cc: @youkaichao 