### PR TITLE
[fix] Correct num_accepted_tokens counting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ share/python-wheels/
 MANIFEST
 /.deps/
 
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/vllm/model_executor/layers/spec_decode_base_sampler.py
+++ b/vllm/model_executor/layers/spec_decode_base_sampler.py
@@ -109,7 +109,7 @@ class SpecDecodeBaseSampler(nn.Module):
         output.mul_(~after_false_mask).add_(
             substitute_token_ids.mul(after_false_mask))
 
-        self.num_accepted_tokens += accepted.sum()
+        self.num_accepted_tokens += accepted_mask.sum()
         self.num_emitted_tokens += (output_with_bonus_tokens != -1).sum()
         self.num_draft_tokens += batch_size * k
 


### PR DESCRIPTION

There is a bug in counting the `num_accepted_tokens`.  Tensor `accepted` might be `[False True False False False]`, in which case the `num_accepted_tokens` yield `1` while the correct result is supposed to be `0`. Using `accepted_mask.sum()` will fix it.

