### PR TITLE
[Bugfix] Check bnb_4bit_quant_storage for bitsandbytes

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -20,6 +20,7 @@ class BitsAndBytesConfig(QuantizationConfig):
         load_in_8bit: bool = False,
         load_in_4bit: bool = True,
         bnb_4bit_compute_dtype: str = "float32",
+        bnb_4bit_quant_storage: str = "uint8",
         bnb_4bit_quant_type: str = "fp4",
         bnb_4bit_use_double_quant: bool = False,
         llm_int8_enable_fp32_cpu_offload: bool = False,
@@ -31,6 +32,7 @@ class BitsAndBytesConfig(QuantizationConfig):
         self.load_in_8bit = load_in_8bit
         self.load_in_4bit = load_in_4bit
         self.bnb_4bit_compute_dtype = bnb_4bit_compute_dtype
+        self.bnb_4bit_quant_storage = bnb_4bit_quant_storage
         self.bnb_4bit_quant_type = bnb_4bit_quant_type
         self.bnb_4bit_use_double_quant = bnb_4bit_use_double_quant
         self.llm_int8_enable_fp32_cpu_offload = llm_int8_enable_fp32_cpu_offload
@@ -38,10 +40,17 @@ class BitsAndBytesConfig(QuantizationConfig):
         self.llm_int8_skip_modules = llm_int8_skip_modules or []
         self.llm_int8_threshold = llm_int8_threshold
 
+        if self.bnb_4bit_quant_storage not in ["uint8"]:
+            raise ValueError(
+                "Unsupported bnb_4bit_quant_storage: "
+                f"{self.bnb_4bit_quant_storage}"
+            )
+
     def __repr__(self) -> str:
         return (f"BitsAndBytesConfig(load_in_8bit={self.load_in_8bit}, "
                 f"load_in_4bit={self.load_in_4bit}, "
                 f"bnb_4bit_compute_dtype={self.bnb_4bit_compute_dtype}, "
+                f"bnb_4bit_quant_storage={self.bnb_4bit_quant_storage}, "
                 f"bnb_4bit_quant_type={self.bnb_4bit_quant_type}, "
                 f"llm_int8_skip_modules={self.llm_int8_skip_modules})")
 
@@ -80,6 +89,9 @@ class BitsAndBytesConfig(QuantizationConfig):
         bnb_4bit_compute_dtype = get_safe_value(config,
                                                 ["bnb_4bit_compute_dtype"],
                                                 default_value="float32")
+        bnb_4bit_quant_storage = get_safe_value(config,
+                                                ["bnb_4bit_quant_storage"],
+                                                default_value="uint8")
         bnb_4bit_quant_type = get_safe_value(config, ["bnb_4bit_quant_type"],
                                              default_value="fp4")
         bnb_4bit_use_double_quant = get_safe_value(
@@ -99,6 +111,7 @@ class BitsAndBytesConfig(QuantizationConfig):
             load_in_8bit=load_in_8bit,
             load_in_4bit=load_in_4bit,
             bnb_4bit_compute_dtype=bnb_4bit_compute_dtype,
+            bnb_4bit_quant_storage=bnb_4bit_quant_storage,
             bnb_4bit_quant_type=bnb_4bit_quant_type,
             bnb_4bit_use_double_quant=bnb_4bit_use_double_quant,
             llm_int8_enable_fp32_cpu_offload=llm_int8_enable_fp32_cpu_offload,

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -41,10 +41,8 @@ class BitsAndBytesConfig(QuantizationConfig):
         self.llm_int8_threshold = llm_int8_threshold
 
         if self.bnb_4bit_quant_storage not in ["uint8"]:
-            raise ValueError(
-                "Unsupported bnb_4bit_quant_storage: "
-                f"{self.bnb_4bit_quant_storage}"
-            )
+            raise ValueError("Unsupported bnb_4bit_quant_storage: "
+                             f"{self.bnb_4bit_quant_storage}")
 
     def __repr__(self) -> str:
         return (f"BitsAndBytesConfig(load_in_8bit={self.load_in_8bit}, "


### PR DESCRIPTION
Currently we only support `bnb_4bit_quant_storage="uint8"` but we do not check this parameter in the config. This PR adds the parameter and check if it is supported.

Uncovered by https://github.com/vllm-project/vllm/issues/10590