### PR TITLE
[bugfix] fix the default value of llm_int8_threshold in BitsAndBytesConfig

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -25,7 +25,7 @@ class BitsAndBytesConfig(QuantizationConfig):
         llm_int8_enable_fp32_cpu_offload: bool = False,
         llm_int8_has_fp16_weight: bool = False,
         llm_int8_skip_modules: Optional[List[str]] = None,
-        llm_int8_threshold: float = 0.0,
+        llm_int8_threshold: float = 6.0,
     ) -> None:
 
         self.load_in_8bit = load_in_8bit
@@ -93,7 +93,7 @@ class BitsAndBytesConfig(QuantizationConfig):
                                                ["llm_int8_skip_modules"],
                                                default_value=[])
         llm_int8_threshold = get_safe_value(config, ["llm_int8_threshold"],
-                                            default_value=0.0)
+                                            default_value=6.0)
 
         return cls(
             load_in_8bit=load_in_8bit,


### PR DESCRIPTION
reference: 

https://github.com/huggingface/transformers/blob/bdb29ff9f3b8030772bd4be037d061f253c0e928/src/transformers/utils/quantization_config.py#L328
