### PR TITLE
[Hardware][Gaudi]add get_name method for HPUAttentionBackend

### DIFF
--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -23,6 +23,10 @@ logger = init_logger(__name__)
 class HPUAttentionBackend(AttentionBackend):
 
     @staticmethod
+    def get_name() -> str:
+        return "HPU_ATTN"
+
+    @staticmethod
     def get_impl_cls() -> Type["HPUAttentionImpl"]:
         return HPUAttentionImpl
 


### PR DESCRIPTION

`HPUAttentionBackend` lack of `get_name` method. will throw error when choose backend.

cc @kzawora-intel

