### PR TITLE
[Doc] Add github links for source code references

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -17,3 +17,4 @@ aiohttp
 starlette
 openai # Required by docs/source/serving/openai_compatible_server.md's vllm.entrypoints.openai.cli_args
 partial-json-parser # Required by docs/source/serving/openai_compatible_server.md's vllm.entrypoints.openai.cli_args
+requests

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,7 +136,8 @@ def linkcode_resolve(domain, info):
         for part in info['fullname'].split('.'):
             obj = getattr(obj, part)
 
-            if not inspect.isclass(obj) and not inspect.isfunction(obj) and not inspect.ismethod(obj):
+            if not (inspect.isclass(obj) or inspect.isfunction(obj)
+                    or inspect.ismethod(obj)):
                 obj = obj.__class__  # Get the class of the instance
 
             lineno = inspect.getsourcelines(obj)[1]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -135,6 +135,10 @@ def linkcode_resolve(domain, info):
     try:
         for part in info['fullname'].split('.'):
             obj = getattr(obj, part)
+
+            if not inspect.isclass(obj) and not inspect.isfunction(obj) and not inspect.ismethod(obj):
+                obj = obj.__class__  # Get the class of the instance
+
             lineno = inspect.getsourcelines(obj)[1]
             filename = (inspect.getsourcefile(obj)
                         or f"{filename}.py").split("vllm/", 1)[1]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import inspect
 import logging
 import os
 import sys
@@ -34,6 +35,7 @@ author = 'the vLLM Team'
 extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.linkcode",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinx.ext.autodoc",
@@ -92,6 +94,25 @@ if READTHEDOCS_VERSION_TYPE == "tag":
 def setup(app):
     from docs.source.generate_examples import generate_examples
     generate_examples()
+
+
+def linkcode_resolve(domain, info):
+    if domain != 'py':
+        return None
+    if not info['module']:
+        return None
+    filename = info['module'].replace('.', '/')
+    module = info['module']
+    try:
+        obj = sys.modules[module]
+        for part in info['fullname'].split('.'):
+            obj = getattr(obj, part)
+        lineno = inspect.getsourcelines(obj)[1]
+        filename = (inspect.getsourcefile(obj)
+                    or f"{filename}.py").split("vllm/", 1)[1]
+        return f"https://github.com/vllm-project/vllm/blob/main/{filename}#L{lineno}"
+    except Exception:
+        return f"https://github.com/vllm-project/vllm/blob/main/{filename}.py"
 
 
 # Mock out external dependencies here, otherwise the autodoc pages may be blank.


### PR DESCRIPTION
Previously, the use of `sphinx.ext.viewcode` generated new pages that
included the raw source code. This change adds the
`sphinx.ext.linkcode` extension, which allows defining a custom method
for generating source code URLs given a code reference. This now
includes links to the appropriate file and line number on github for
code references.

For now I left the `viewcode` extension in place. The result is that
code references now have 2 `[source]` links - one for the copy of the
source in the docs, and one to github. If the github links seem to
work well enough, we can drop `viewcode` later.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
