### PR TITLE
[Cleanup][Kernel] Remove if-else with identical branches in marlin 2:4

### DIFF
--- a/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
+++ b/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu
@@ -296,13 +296,9 @@ __global__ void Marlin_24(
   // We use a different scale layout for grouped and column-wise quantization as
   // we scale a `half2` tile in column-major layout in the former and in
   // row-major in the latter case.
-  if (group_blocks != -1) {
-    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
-              (threadIdx.x % 32) / 4;
-  } else {
-    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
-              (threadIdx.x % 32) / 4;
-  }
+  s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) +
+            (threadIdx.x % 32) / 4;  // Note that in the original Marlin kernel
+                                     // this is (threadIdx.x % 32) / 4
 
   // Precompute which thread should not read memory in which iterations; this is
   // needed if there are more threads than required for a certain tilesize or


### PR DESCRIPTION
Clean up a useless if-else in `marlin_24_cuda_kernel.cu`:
https://github.com/vllm-project/vllm/blob/0a4d96850013eb2c295b25df53177ad2302110ca/csrc/quantization/marlin/sparse/marlin_24_cuda_kernel.cu#L299-L305

See the equivalent if-else in `marlin_cuda_kernel.cu`:
https://github.com/vllm-project/vllm/blob/80ca1e6a3a28a0373dc00c5b4fe956c16de952fa/csrc/quantization/marlin/dense/marlin_cuda_kernel.cu#L367-L372

See discussion in https://github.com/vllm-project/vllm/issues/6030

From @alexm-neuralmagic in that issue:
>this is a leftover from a copy-paste from the original (dense) marlin that had different branches. We have tests to verify all of these cases inside test_marlin_gemm.py that verify both dense and sparse and group_size == -1 and other group_sizes as well. 

I'd love to leave a better explanation for the discrepancy between the equivalent if statement in `marlin_cuda_kernel.cu`, because this looks very suspicious.

(closes https://github.com/vllm-project/vllm/issues/6030)