### PR TITLE
[V1] `get_computed_blocks` avoids recompute

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -79,7 +79,7 @@ class KVCacheManager:
 
         computed_blocks = []
 
-        req_blocks = self.req_to_blocks[request.request_id]
+        req_blocks = self.req_to_blocks.get(request.request_id, [])
         num_full_blocks = len(request.all_token_ids) // self.block_size
         parent_block_hash = None
         for idx in range(num_full_blocks):

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -83,13 +83,13 @@ class KVCacheManager:
         if num_full_blocks <= num_computed_blocks:
             return computed_blocks
 
-        parent_block_hash = computed_blocks[-1].block_hash if num_computed_blocks > 0 else None
+        parent_block_hash = computed_blocks[
+            -1].block_hash if num_computed_blocks > 0 else None
         for idx in range(num_computed_blocks, num_full_blocks):
             block_token_ids = tuple(
                 request.all_token_ids[idx * self.block_size:(idx + 1) *
                                       self.block_size])
-            block_hash = hash_block_tokens(parent_block_hash,
-                                           block_token_ids)
+            block_hash = hash_block_tokens(parent_block_hash, block_token_ids)
             parent_block_hash = block_hash
             if cached_block := self._get_cached_block(block_hash):
                 computed_blocks.append(cached_block)

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -86,7 +86,8 @@ class KVCacheManager:
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
             # not computed yet for sure.
-            if cached_block := req_blocks[idx]:
+            cached_block = req_blocks[idx] if idx < len(req_blocks) else None
+            if cached_block:
                 computed_blocks.append(cached_block)
                 parent_block_hash = cached_block.block_hash
                 assert parent_block_hash

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -4,8 +4,7 @@ from typing import Dict, List, Optional
 from vllm.logger import init_logger
 from vllm.utils import cdiv
 from vllm.v1.core.kv_cache_utils import (BlockHashType, FreeKVCacheBlockQueue,
-                                         KVCacheBlock, hash_block_tokens,
-                                         hash_request_tokens)
+                                         KVCacheBlock, hash_block_tokens)
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
@@ -92,8 +91,11 @@ class KVCacheManager:
                 parent_block_hash = cached_block.block_hash
                 assert parent_block_hash
             else:
-                block_token_ids = tuple(request.all_token_ids[idx * self.block_size : (idx + 1) * self.block_size])
-                block_hash = hash_block_tokens(parent_block_hash, block_token_ids)
+                block_token_ids = tuple(
+                    request.all_token_ids[idx * self.block_size:(idx + 1) *
+                                          self.block_size])
+                block_hash = hash_block_tokens(parent_block_hash,
+                                               block_token_ids)
                 if cached_block := self._get_cached_block(block_hash):
                     computed_blocks.append(cached_block)
                 else:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -96,6 +96,7 @@ class KVCacheManager:
                                           self.block_size])
                 block_hash = hash_block_tokens(parent_block_hash,
                                                block_token_ids)
+                parent_block_hash = block_hash
                 if cached_block := self._get_cached_block(block_hash):
                     computed_blocks.append(cached_block)
                 else:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -4,7 +4,8 @@ from typing import Dict, List, Optional
 from vllm.logger import init_logger
 from vllm.utils import cdiv
 from vllm.v1.core.kv_cache_utils import (BlockHashType, FreeKVCacheBlockQueue,
-                                         KVCacheBlock, hash_block_tokens, hash_request_tokens)
+                                         KVCacheBlock, hash_block_tokens,
+                                         hash_request_tokens)
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
@@ -78,12 +79,12 @@ class KVCacheManager:
             return []
 
         computed_blocks = self.req_to_blocks.get(request.request_id, [])
-        parent_block_hash = computed_blocks[
-            -1].block_hash if len(computed_blocks) > 0 else None
-        block_hashes = hash_request_tokens(self.block_size,
-                                           request.all_token_ids[
-                                           len(computed_blocks) * self.block_size:],
-                                           parent_block_hash)
+        parent_block_hash = computed_blocks[-1].block_hash if len(
+            computed_blocks) > 0 else None
+        block_hashes = hash_request_tokens(
+            self.block_size,
+            request.all_token_ids[len(computed_blocks) * self.block_size:],
+            parent_block_hash)
 
         for block_hash in block_hashes:
             # block_hashes is a chain of block hashes. If a block hash is not

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -176,7 +176,8 @@ def hash_block_tokens(parent_block_hash: Optional[int],
 
 
 def hash_request_tokens(block_size: int,
-                        token_ids: List[int]) -> List[BlockHashType]:
+                        token_ids: List[int],
+                        parent_block_hash: Optional[int] = None) -> List[BlockHashType]:
     """Computes hash values of a chain of blocks given a sequence of
     token IDs. The hash value is used for prefix caching.
 
@@ -188,7 +189,6 @@ def hash_request_tokens(block_size: int,
         The list of computed hash values.
     """
     ret = []
-    parent_block_hash = None
     for start in range(0, len(token_ids), block_size):
         end = start + block_size
         block_token_ids = tuple(token_ids[start:end])

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -180,13 +180,13 @@ def hash_request_tokens(
         token_ids: List[int],
         parent_block_hash: Optional[int] = None) -> List[BlockHashType]:
     """Computes hash values of a chain of blocks given a sequence of
-    token IDs and a parent block hash.
+    token IDs and the hash of last computed block(default None).
     The hash value is used for prefix caching.
 
     Args:
         block_size: The size of each block.
         token_ids: A sequence of token ids in the request.
-        parent_block_hash: The hash of last computed block in the request.
+        parent_block_hash: The hash of last computed block(default None).
 
     Returns:
         The list of computed hash values.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -175,15 +175,18 @@ def hash_block_tokens(parent_block_hash: Optional[int],
         (parent_block_hash, *curr_block_token_ids)), curr_block_token_ids)
 
 
-def hash_request_tokens(block_size: int,
-                        token_ids: List[int],
-                        parent_block_hash: Optional[int] = None) -> List[BlockHashType]:
+def hash_request_tokens(
+        block_size: int,
+        token_ids: List[int],
+        parent_block_hash: Optional[int] = None) -> List[BlockHashType]:
     """Computes hash values of a chain of blocks given a sequence of
-    token IDs. The hash value is used for prefix caching.
+    token IDs and a parent block hash.
+    The hash value is used for prefix caching.
 
     Args:
         block_size: The size of each block.
         token_ids: A sequence of token ids in the request.
+        parent_block_hash: The hash of last computed block in the request.
 
     Returns:
         The list of computed hash values.


### PR DESCRIPTION
Use `self.req_to_blocks[request.request_id]` instead of recompute.
