### PR TITLE
[ci] fix slow tests

### DIFF
--- a/tests/entrypoints/llm/test_lazy_outlines.py
+++ b/tests/entrypoints/llm/test_lazy_outlines.py
@@ -1,6 +1,7 @@
 import sys
+from contextlib import nullcontext
 
-from vllm_test_utils import blame
+from vllm_test_utils import BlameResult, blame
 
 from vllm import LLM, SamplingParams
 from vllm.distributed import cleanup_dist_env_and_memory
@@ -56,9 +57,20 @@ def test_lazy_outlines(sample_regex):
     """
     # make sure outlines is not imported
     module_name = "outlines"
-    with blame(lambda: module_name in sys.modules) as result:
+    # In CI, we only check finally if the module is imported.
+    # If it is indeed imported, we can rerun the test with `use_blame=True`,
+    # which will trace every function call to find the first import location,
+    # and help find the root cause.
+    # We don't run it in CI by default because it is slow.
+    use_blame = False
+    context = blame(
+        lambda: module_name in sys.modules) if use_blame else nullcontext()
+    with context as result:
         run_normal()
         run_lmfe(sample_regex)
-    assert not result.found, (
-        f"Module {module_name} is already imported, the"
-        f" first import location is:\n{result.trace_stack}")
+    assert module_name not in sys.modules, (
+        f"Module {module_name} is imported. To see the first"
+        f" import location, run the test with `use_blame=True`.")
+    if use_blame:
+        assert isinstance(result, BlameResult)
+        print(f"the first import location is:\n{result.trace_stack}")

--- a/tests/entrypoints/llm/test_lazy_outlines.py
+++ b/tests/entrypoints/llm/test_lazy_outlines.py
@@ -68,9 +68,9 @@ def test_lazy_outlines(sample_regex):
     with context as result:
         run_normal()
         run_lmfe(sample_regex)
-    assert module_name not in sys.modules, (
-        f"Module {module_name} is imported. To see the first"
-        f" import location, run the test with `use_blame=True`.")
     if use_blame:
         assert isinstance(result, BlameResult)
         print(f"the first import location is:\n{result.trace_stack}")
+    assert module_name not in sys.modules, (
+        f"Module {module_name} is imported. To see the first"
+        f" import location, run the test with `use_blame=True`.")

--- a/tests/test_lazy_torch_compile.py
+++ b/tests/test_lazy_torch_compile.py
@@ -2,15 +2,27 @@
 # The utility function cannot be placed in `vllm.utils`
 # this needs to be a standalone script
 import sys
+from contextlib import nullcontext
 
-from vllm_test_utils import blame
+from vllm_test_utils import BlameResult, blame
 
 module_name = "torch._inductor.async_compile"
 
-with blame(lambda: module_name in sys.modules) as result:
+# In CI, we only check finally if the module is imported.
+# If it is indeed imported, we can rerun the test with `use_blame=True`,
+# which will trace every function call to find the first import location,
+# and help find the root cause.
+# We don't run it in CI by default because it is slow.
+use_blame = False
+context = blame(
+    lambda: module_name in sys.modules) if use_blame else nullcontext()
+with context as result:
     import vllm  # noqa
 
-assert not result.found, (f"Module {module_name} is already imported, the"
-                          f" first import location is:\n{result.trace_stack}")
+assert module_name not in sys.modules, (
+    f"Module {module_name} is imported. To see the first"
+    f" import location, run the test with `use_blame=True`.")
 
-print(f"Module {module_name} is not imported yet")
+if use_blame:
+    assert isinstance(result, BlameResult)
+    print(f"the first import location is:\n{result.trace_stack}")

--- a/tests/test_lazy_torch_compile.py
+++ b/tests/test_lazy_torch_compile.py
@@ -19,10 +19,10 @@ context = blame(
 with context as result:
     import vllm  # noqa
 
-assert module_name not in sys.modules, (
-    f"Module {module_name} is imported. To see the first"
-    f" import location, run the test with `use_blame=True`.")
-
 if use_blame:
     assert isinstance(result, BlameResult)
     print(f"the first import location is:\n{result.trace_stack}")
+
+assert module_name not in sys.modules, (
+    f"Module {module_name} is imported. To see the first"
+    f" import location, run the test with `use_blame=True`.")

--- a/tests/vllm_test_utils/vllm_test_utils/blame.py
+++ b/tests/vllm_test_utils/vllm_test_utils/blame.py
@@ -46,8 +46,8 @@ def blame(func: Callable) -> Generator[BlameResult, None, None]:
                 pass
         return _trace_calls
 
-    sys.settrace(_trace_calls)
-
-    yield result
-
-    sys.settrace(None)
+    try:
+        sys.settrace(_trace_calls)
+        yield result
+    finally:
+        sys.settrace(None)


### PR DESCRIPTION
the ci machine might have less powerful cpus, and i observed that in https://buildkite.com/vllm/ci/builds/10175#01936aa9-a7a8-4aff-8ced-d4cfca8223a1 , these tests need to run for half an hour. (need to download the full log to see the details)