### PR TITLE
[Minor] Add username to filelock for model weights

### DIFF
--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -61,9 +61,11 @@ def get_lock(model_name_or_path: str, cache_dir: Optional[str] = None):
     lock_dir = cache_dir or temp_dir
     os.makedirs(os.path.dirname(lock_dir), exist_ok=True)
     model_name = model_name_or_path.replace("/", "-")
-    hash_name = hashlib.sha256(model_name.encode()).hexdigest()
     # add hash to avoid conflict with old users' lock files
-    lock_file_name = hash_name + model_name + ".lock"
+    hash_name = hashlib.sha256(model_name.encode()).hexdigest()
+    # Include the user name to avoid conflicts between different users
+    user_name = os.environ.get("USER", "")
+    lock_file_name = user_name + hash_name + model_name + ".lock"
     # mode 0o666 is required for the filelock to be shared across users
     lock = filelock.FileLock(os.path.join(lock_dir, lock_file_name),
                              mode=0o666)


### PR DESCRIPTION
This PR adds the user name to the name of the file lock used in downloading/loading the model weights. This is to avoid conflicts between different users sharing the machine.