### PR TITLE
[Misc][XPU] Avoid torch compile for XPU platform

### DIFF
--- a/.buildkite/run-xpu-test.sh
+++ b/.buildkite/run-xpu-test.sh
@@ -12,5 +12,21 @@ remove_docker_container() { docker rm -f xpu-test || true; }
 trap remove_docker_container EXIT
 remove_docker_container
 
-# Run the image and launch offline inference
-docker run --network host --name xpu-test --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path --entrypoint="" xpu-test python3 examples/offline_inference.py
+# Run the image and test offline inference/tensor parallel
+docker run -it -d --name xpu-test --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path xpu-test /bin/bash
+docker exec xpu-test bash -c "python3 examples/offline_inference.py"
+docker exec xpu-test bash -c "
+wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
+python3 benchmarks/benchmark_throughput.py \
+  --backend=vllm \
+  --dataset=./ShareGPT_V3_unfiltered_cleaned_split.json \
+  --model meta-llama/Llama-3.2-1B-Instruct \
+  --num-prompts=10 \
+  -tp=2 \
+  --trust-remote-code \
+  --device=xpu \
+  --dtype=float16 \
+  --enforce-eager \
+  --distributed-executor-backend=ray \
+  --max-model-len=4096
+"

--- a/.buildkite/run-xpu-test.sh
+++ b/.buildkite/run-xpu-test.sh
@@ -15,18 +15,4 @@ remove_docker_container
 # Run the image and test offline inference/tensor parallel
 docker run -it -d --name xpu-test --device /dev/dri -v /dev/dri/by-path:/dev/dri/by-path xpu-test /bin/bash
 docker exec xpu-test bash -c "python3 examples/offline_inference.py"
-docker exec xpu-test bash -c "
-wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
-python3 benchmarks/benchmark_throughput.py \
-  --backend=vllm \
-  --dataset=./ShareGPT_V3_unfiltered_cleaned_split.json \
-  --model meta-llama/Llama-3.2-1B-Instruct \
-  --num-prompts=10 \
-  -tp=2 \
-  --trust-remote-code \
-  --device=xpu \
-  --dtype=float16 \
-  --enforce-eager \
-  --distributed-executor-backend=ray \
-  --max-model-len=4096
-"
+docker exec xpu-test bash -c "python3 examples/offline_inference_cli.py -tp 2" 

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -27,6 +27,7 @@ def load_general_plugins():
     # see https://github.com/vllm-project/vllm/issues/10619
     torch._inductor.config.compile_threads = 1
     if current_platform.is_xpu():
+        # see https://github.com/pytorch/pytorch/blob/8cada5cbe5450e17c26fb8b358116785324537b2/torch/_dynamo/config.py#L158  # noqa
         os.environ['TORCH_COMPILE_DISABLE'] = 'True'
     global plugins_loaded
     if plugins_loaded:

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -4,6 +4,7 @@ import os
 import torch
 
 import vllm.envs as envs
+from vllm.platforms import current_platform
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,8 @@ def load_general_plugins():
     os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
     # see https://github.com/vllm-project/vllm/issues/10619
     torch._inductor.config.compile_threads = 1
+    if current_platform.is_xpu():
+        os.environ['TORCH_COMPILE_DISABLE'] = 'True'
     global plugins_loaded
     if plugins_loaded:
         return


### PR DESCRIPTION
After torch.jit.script --> torch.compile in [PR](https://github.com/vllm-project/vllm/pull/10406), triton is eventually called during tensor parallel on XPU platform. We need disable torch.compile() for xpu.
