### PR TITLE
Configuration of the model parallelism does not make sense

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1001,6 +1001,10 @@ def initialize_model_parallel(
     are on the same DGX box. For example if we are using 2 DGX-1 boxes
     with a total of 16 GPUs, rank 0 to 7 belong to the first box and
     ranks 8 to 15 belong to the second box.
+    It is not possible for the model parallelism to be configured as [g0, g2, g4, g6], [g1, g3, g5, g7].Instead, it should be 
+    [g0, g1 g2, g3], [g4, g5, g6, g7].This is because the tensor parallelism configuration [g0, g1], [g2, g3], [g4, g5], [g6, g7] requires GPUs within the same tensor parallel group to share a part of the model. 
+    This condition cannot be satisfied with the given pipeline parallelism groups of [g0, g2, g4, g6], [g1, g3, g5, g7].
+
     """
     # Get world size and rank. Ensure some consistencies.
     assert torch.distributed.is_initialized()


### PR DESCRIPTION
Hi
I have read the model parallel configuration, and I think this configuration conflicts with the tensor parallelism requirement, where GPUs in the same group must share parts of the model. With the given configuration, the tensor parallelism groups [g0, g1], [g2, g3], [g4, g5], [g6, g7] cannot exist. 
I think the solution is to update the model parallelism groups are set as [g0, g1 g2, g3], [g4, g5, g6, g7].This ensures compatibility with the tensor parallelism configuration.
Thanks