### PR TITLE
Set vllm-hpu-extension to 50e10ea

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -8,4 +8,4 @@ pandas
 tabulate
 setuptools>=61
 setuptools-scm>=8
-vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@fd7f2e6
+vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@50e10ea


### PR DESCRIPTION
Update vllm-hpu-extension to 50e10ea, that corresponds to introducing PipelinedPA: 
https://github.com/HabanaAI/vllm-hpu-extension/pull/42