### PR TITLE
[platform] Add verify_quantization in platform.

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -19,6 +19,7 @@ logger = init_logger(__name__)
 
 class CpuPlatform(Platform):
     _enum = PlatformEnum.CPU
+    device_name: str = "cpu"
     device_type: str = "cpu"
     dispatch_key: str = "CPU"
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -72,6 +72,7 @@ def with_nvml_context(fn: Callable[_P, _R]) -> Callable[_P, _R]:
 
 class CudaPlatformBase(Platform):
     _enum = PlatformEnum.CUDA
+    device_name: str = "cuda"
     device_type: str = "cuda"
     dispatch_key: str = "CUDA"
 

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -12,6 +12,7 @@ else:
 
 class HpuPlatform(Platform):
     _enum = PlatformEnum.HPU
+    device_name: str = "hpu"
     device_type: str = "hpu"
     dispatch_key: str = "HPU"
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -56,11 +56,13 @@ class DeviceCapability(NamedTuple):
 
 class Platform:
     _enum: PlatformEnum
+    device_name: str
     device_type: str
     # available dispatch keys:
     # check https://github.com/pytorch/pytorch/blob/313dac6c1ca0fa0cde32477509cce32089f8532a/torchgen/model.py#L134 # noqa
     # use "CPU" as a fallback for platforms not registered in PyTorch
     dispatch_key: str = "CPU"
+    supported_quantization: list[str] = []
 
     def is_cuda(self) -> bool:
         return self._enum == PlatformEnum.CUDA
@@ -170,6 +172,17 @@ class Platform:
         The config is passed by reference, so it can be modified in place.
         """
         pass
+
+    @classmethod
+    def verify_quantization(cls, quant: str) -> None:
+        """
+        Verify whether the quantization is supported by the current platform.
+        """
+        if cls.supported_quantization and \
+            quant not in cls.supported_quantization:
+            raise ValueError(
+                f"{quant} quantization is currently not supported in "
+                f"{cls.device_name}.")
 
 
 class UnspecifiedPlatform(Platform):

--- a/vllm/platforms/neuron.py
+++ b/vllm/platforms/neuron.py
@@ -10,7 +10,9 @@ else:
 
 class NeuronPlatform(Platform):
     _enum = PlatformEnum.NEURON
+    device_name: str = "neuron"
     device_type: str = "neuron"
+    supported_quantization: list[str] = ["neuron_quant"]
 
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:

--- a/vllm/platforms/openvino.py
+++ b/vllm/platforms/openvino.py
@@ -23,6 +23,7 @@ except ImportError as e:
 
 class OpenVinoPlatform(Platform):
     _enum = PlatformEnum.OPENVINO
+    device_name: str = "openvino"
     device_type: str = "openvino"
     dispatch_key: str = "CPU"
 

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -16,8 +16,10 @@ logger = init_logger(__name__)
 
 class TpuPlatform(Platform):
     _enum = PlatformEnum.TPU
+    device_name: str = "tpu"
     device_type: str = "tpu"
     dispatch_key: str = "XLA"
+    supported_quantization: list[str] = ["tpu_int8"]
 
     @classmethod
     def get_default_attn_backend(cls, selected_backend: _Backend) -> _Backend:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -16,6 +16,7 @@ logger = init_logger(__name__)
 
 class XPUPlatform(Platform):
     _enum = PlatformEnum.XPU
+    device_name: str = "xpu"
     device_type: str = "xpu"
     dispatch_key: str = "XPU"
 


### PR DESCRIPTION
Part of https://github.com/vllm-project/vllm/issues/9268

1. Add `verify_quantization` function and move `supported_quantization` to platform to avoid unlimited `if else` usage.
2. Add `device_name` to  each platform  to distinguish the device name. such as, rocm and cuda