### PR TITLE
support download Lora Model from ModelScope and download private mode…

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -399,6 +399,12 @@ async def async_request_openai_chat_completions(
 
 def get_model(pretrained_model_name_or_path: str) -> str:
     if os.getenv('VLLM_USE_MODELSCOPE', 'False').lower() == 'true':
+        if os.getenv('MODELSCOPE_ACCESS_TOKEN', ''):
+            from modelscope.hub.api import HubApi
+            access_token = os.getenv('MODELSCOPE_ACCESS_TOKEN')
+            api = HubApi()
+            api.login(access_token)
+
         from modelscope import snapshot_download
 
         model_path = snapshot_download(

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -176,7 +176,8 @@ def get_adapter_absolute_path(lora_path: str) -> str:
     if os.path.exists(lora_path):
         return os.path.abspath(lora_path)
 
-    # If the path does not exist locally, assume it's a Hugging Face repo or ModelScope repo.
+    # If the path does not exist locally,
+    # assume it's a Hugging Face repo or ModelScope repo.
     try:
         if os.getenv('VLLM_USE_MODELSCOPE', 'False').lower() == 'true':
             if os.getenv('MODELSCOPE_ACCESS_TOKEN', ''):
@@ -191,10 +192,11 @@ def get_adapter_absolute_path(lora_path: str) -> str:
         else:
             local_snapshot_path = huggingface_hub.snapshot_download(
                 repo_id=lora_path)
-    except Exception as e:
+    except Exception:
         # Handle errors that may occur during the download
         # Return original path instead instead of throwing error here
-        logger.exception("Error downloading the HuggingFace or ModelScope model")
+        logger.exception(
+            "Error downloading the HuggingFace or ModelScope model")
         return lora_path
 
     return local_snapshot_path

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -178,15 +178,25 @@ def get_adapter_absolute_path(lora_path: str) -> str:
     if os.path.exists(lora_path):
         return os.path.abspath(lora_path)
 
-    # If the path does not exist locally, assume it's a Hugging Face repo.
+    # If the path does not exist locally, assume it's a Hugging Face repo or ModelScope repo.
     try:
-        local_snapshot_path = huggingface_hub.snapshot_download(
-            repo_id=lora_path)
-    except (HfHubHTTPError, RepositoryNotFoundError, EntryNotFoundError,
-            HFValidationError):
+        if os.getenv('VLLM_USE_MODELSCOPE', 'False').lower() == 'true':
+            if os.getenv('MODELSCOPE_ACCESS_TOKEN', ''):
+                from modelscope.hub.api import HubApi
+                access_token = os.getenv('MODELSCOPE_ACCESS_TOKEN')
+                api = HubApi()
+                api.login(access_token)
+
+            from modelscope import snapshot_download
+
+            local_snapshot_path = snapshot_download(model_id=lora_path)
+        else:
+            local_snapshot_path = huggingface_hub.snapshot_download(
+                repo_id=lora_path)
+    except Exception as e:
         # Handle errors that may occur during the download
         # Return original path instead instead of throwing error here
-        logger.exception("Error downloading the HuggingFace model")
+        logger.exception("Error downloading the HuggingFace or ModelScope model")
         return lora_path
 
     return local_snapshot_path

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -3,8 +3,6 @@ import re
 from typing import List, Optional, Set, Tuple, Type, Union
 
 import huggingface_hub
-from huggingface_hub.utils import (EntryNotFoundError, HfHubHTTPError,
-                                   HFValidationError, RepositoryNotFoundError)
 from torch import nn
 from transformers import PretrainedConfig
 


### PR DESCRIPTION
Currently, vllm can't loading Lora models from modelscope.
Beside, If a model from modelscope is private, it can't load from modelscope, have to login manually before starting vllm.
this pull request fix two problems below.
If you want to using private models, you can set MODELSCOPE_ACCESS_TOKEN as environmental variables
