### PR TITLE
[Hardware][CPU] Refactor CPU vector types for ISAs

### DIFF
--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -3,80 +3,37 @@
 namespace {
 
 template <typename scalar_t>
-struct KernelVecType {
-  using q_load_vec_type = void;
-  using q_vec_type = void;
-  using k_load_vec_type = void;
-  using k_vec_type = void;
-  using qk_acc_vec_type = void;
-  using v_load_vec_type = void;
-};
+struct KernelVecType;
 
 template <>
 struct KernelVecType<float> {
-  using q_load_vec_type = vec_op::FP32Vec4;
-  using q_vec_type = vec_op::FP32Vec16;
-  using k_load_vec_type = vec_op::FP32Vec16;
-  using k_vec_type = vec_op::FP32Vec16;
-  using qk_acc_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::FP32Vec16;
+  using q_load_vec_type = vec_op::AttnVecTypeISA<float>::q_load_vec_type;
+  using q_vec_type = vec_op::AttnVecTypeISA<float>::q_vec_type;
+  using k_load_vec_type = vec_op::AttnVecTypeISA<float>::k_load_vec_type;
+  using k_vec_type = vec_op::AttnVecTypeISA<float>::k_vec_type;
+  using qk_acc_vec_type = vec_op::AttnVecTypeISA<float>::qk_acc_vec_type;
+  using v_load_vec_type = vec_op::AttnVecTypeISA<float>::v_load_vec_type;
 };
 
 template <>
 struct KernelVecType<c10::Half> {
-#ifdef __powerpc64__
-  // Power architecture-specific vector types
-  using q_load_vec_type = vec_op::FP32Vec8;
-  using k_load_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::FP32Vec16;
-#else
-  // Fallback for other architectures, including x86
-  using q_load_vec_type = vec_op::FP16Vec8;
-  using k_load_vec_type = vec_op::FP16Vec16;
-  using v_load_vec_type = vec_op::FP16Vec16;
-#endif
-  using q_vec_type = vec_op::FP32Vec16;
-  using k_vec_type = vec_op::FP32Vec16;
-  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using q_load_vec_type = vec_op::AttnVecTypeISA<c10::Half>::q_load_vec_type;
+  using q_vec_type = vec_op::AttnVecTypeISA<c10::Half>::q_vec_type;
+  using k_load_vec_type = vec_op::AttnVecTypeISA<c10::Half>::k_load_vec_type;
+  using k_vec_type = vec_op::AttnVecTypeISA<c10::Half>::k_vec_type;
+  using qk_acc_vec_type = vec_op::AttnVecTypeISA<c10::Half>::qk_acc_vec_type;
+  using v_load_vec_type = vec_op::AttnVecTypeISA<c10::Half>::v_load_vec_type;
 };
 
-#ifdef __AVX512BF16__
 template <>
 struct KernelVecType<c10::BFloat16> {
-  using q_load_vec_type = vec_op::BF16Vec8;
-  using q_vec_type = vec_op::BF16Vec32;
-  using k_load_vec_type = vec_op::BF16Vec32;
-  using k_vec_type = vec_op::BF16Vec32;
-  using qk_acc_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::BF16Vec16;
+  using q_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::q_load_vec_type;
+  using q_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::q_vec_type;
+  using k_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::k_load_vec_type;
+  using k_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::k_vec_type;
+  using qk_acc_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::qk_acc_vec_type;
+  using v_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::v_load_vec_type;
 };
-#else
-  #ifdef __aarch64__
-    #ifndef ARM_BF16_SUPPORT
-    // pass
-    #else
-template <>
-struct KernelVecType<c10::BFloat16> {
-  using q_load_vec_type = vec_op::BF16Vec8;
-  using q_vec_type = vec_op::FP32Vec16;
-  using k_load_vec_type = vec_op::BF16Vec16;
-  using k_vec_type = vec_op::FP32Vec16;
-  using qk_acc_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::BF16Vec16;
-};
-    #endif
-  #else
-template <>
-struct KernelVecType<c10::BFloat16> {
-  using q_load_vec_type = vec_op::BF16Vec8;
-  using q_vec_type = vec_op::FP32Vec16;
-  using k_load_vec_type = vec_op::BF16Vec16;
-  using k_vec_type = vec_op::FP32Vec16;
-  using qk_acc_vec_type = vec_op::FP32Vec16;
-  using v_load_vec_type = vec_op::BF16Vec16;
-};
-  #endif
-#endif
 
 template <typename T>
 FORCE_INLINE std::pair<T, T> reduceSoftmax(T* data, const int size,

--- a/csrc/cpu/attention.cpp
+++ b/csrc/cpu/attention.cpp
@@ -27,12 +27,16 @@ struct KernelVecType<c10::Half> {
 
 template <>
 struct KernelVecType<c10::BFloat16> {
-  using q_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::q_load_vec_type;
+  using q_load_vec_type =
+      vec_op::AttnVecTypeISA<c10::BFloat16>::q_load_vec_type;
   using q_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::q_vec_type;
-  using k_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::k_load_vec_type;
+  using k_load_vec_type =
+      vec_op::AttnVecTypeISA<c10::BFloat16>::k_load_vec_type;
   using k_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::k_vec_type;
-  using qk_acc_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::qk_acc_vec_type;
-  using v_load_vec_type = vec_op::AttnVecTypeISA<c10::BFloat16>::v_load_vec_type;
+  using qk_acc_vec_type =
+      vec_op::AttnVecTypeISA<c10::BFloat16>::qk_acc_vec_type;
+  using v_load_vec_type =
+      vec_op::AttnVecTypeISA<c10::BFloat16>::v_load_vec_type;
 };
 
 template <typename T>

--- a/csrc/cpu/cpu_types_arm.hpp
+++ b/csrc/cpu/cpu_types_arm.hpp
@@ -1,3 +1,6 @@
+#ifndef CPU_TYPES_ARM_HPP
+#define CPU_TYPES_ARM_HPP
+
 #include <arm_neon.h>
 #include <torch/all.h> 
 #include <cmath>
@@ -5,14 +8,14 @@
 namespace vec_op {
 
 #ifdef ARM_BF16_SUPPORT
-  #define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)                                 \
-    AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                         \
-    AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)                         \
-    AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)  
+#define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)                                 \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                         \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)                          \
+  AT_DISPATCH_CASE(at::ScalarType::BFloat16, __VA_ARGS__)
 #else
-  #define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)                                 \
-    AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                         \
-    AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)
+#define VLLM_DISPATCH_CASE_FLOATING_TYPES(...)                                 \
+  AT_DISPATCH_CASE(at::ScalarType::Float, __VA_ARGS__)                         \
+  AT_DISPATCH_CASE(at::ScalarType::Half, __VA_ARGS__)
 #endif
 
 #define VLLM_DISPATCH_FLOATING_TYPES(TYPE, NAME, ...)                          \
@@ -430,18 +433,6 @@ struct FP32Vec16 : public Vec<FP32Vec16> {
   };
 };
 
-template <typename T> struct VecType { using vec_type = void; };
-
-template <typename T> using vec_t = typename VecType<T>::vec_type;
-
-template <> struct VecType<float> { using vec_type = FP32Vec8; };
-
-template <> struct VecType<c10::Half> { using vec_type = FP16Vec8; };
-
-#ifdef ARM_BF16_SUPPORT
-template <> struct VecType<c10::BFloat16> { using vec_type = BF16Vec8; };
-#endif
-
 template <typename T> void storeFP32(float v, T *ptr) { *ptr = v; }
 
 template <> inline void storeFP32<c10::Half>(float v, c10::Half *ptr) {
@@ -512,4 +503,67 @@ inline void storeFP32<c10::BFloat16>(float v, c10::BFloat16 *ptr) {
   *reinterpret_cast<__bf16 *>(ptr) = vcvth_bf16_f32(v);
 };
 #endif
+
+/***********************************/
+/*           OpsVecType            */
+/***********************************/
+template <typename T> struct OpsVecType { using vec_type = void; };
+
+template <typename T> using vec_t = typename OpsVecType<T>::vec_type;
+
+template <> struct OpsVecType<float> { using vec_type = vec_op::FP32Vec8; };
+
+template <> struct OpsVecType<c10::Half> { using vec_type = vec_op::FP16Vec8; };
+
+#ifdef ARM_BF16_SUPPORT
+template <> struct OpsVecType<c10::BFloat16> { using vec_type = vec_op::BF16Vec8; };
+#endif
+
+/***********************************/
+/*           AttnVecType           */
+/***********************************/
+template <typename scalar_t>
+struct AttnVecTypeISA {
+  using q_load_vec_type = void;
+  using q_vec_type = void;
+  using k_load_vec_type = void;
+  using k_vec_type = void;
+  using qk_acc_vec_type = void;
+  using v_load_vec_type = void;
 };
+
+template <>
+struct AttnVecTypeISA<float> {
+  using q_load_vec_type = vec_op::FP32Vec4;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::FP32Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::FP32Vec16;
+};
+
+template <>
+struct AttnVecTypeISA<c10::Half> {
+  using q_load_vec_type = vec_op::FP16Vec8;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::FP16Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::FP16Vec16;
+};
+
+#ifdef ARM_BF16_SUPPORT
+template <>
+struct AttnVecTypeISA<c10::BFloat16> {
+  using q_load_vec_type = vec_op::BF16Vec8;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::BF16Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::BF16Vec16;
+};
+#endif  // ARM_BF16_SUPPORT
+
+};  // namespace vec_op
+
+#endif

--- a/csrc/cpu/cpu_types_x86.hpp
+++ b/csrc/cpu/cpu_types_x86.hpp
@@ -1,4 +1,3 @@
-
 #ifndef CPU_TYPES_X86_HPP
 #define CPU_TYPES_X86_HPP
 
@@ -540,16 +539,6 @@ struct INT8Vec16: public Vec<INT8Vec16> {
 };
 #endif
 
-template <typename T> struct VecType { using vec_type = void; };
-
-template <typename T> using vec_t = typename VecType<T>::vec_type;
-
-template <> struct VecType<float> { using vec_type = FP32Vec8; };
-
-template <> struct VecType<c10::Half> { using vec_type = FP16Vec8; };
-
-template <> struct VecType<c10::BFloat16> { using vec_type = BF16Vec8; };
-
 template <typename T> void storeFP32(float v, T *ptr) { *ptr = v; }
 
 inline void fma(FP32Vec16 &acc, FP32Vec16 &a, FP32Vec16 &b) {
@@ -626,6 +615,94 @@ inline BF16Vec16::BF16Vec16(const FP32Vec16 &v) {
 #endif // __AVX512BF16__
 
 inline void prefetch(const void *addr) { _mm_prefetch(addr, _MM_HINT_T1); }
+
+/***********************************/
+/*           OpsVecType            */
+/***********************************/
+template <typename T> struct OpsVecType { using vec_type = void; };
+
+template <typename T> using vec_t = typename OpsVecType<T>::vec_type;
+
+template <> struct OpsVecType<float> { using vec_type = vec_op::FP32Vec8; };
+
+template <> struct OpsVecType<c10::Half> { using vec_type = vec_op::FP16Vec8; };
+
+template <> struct OpsVecType<c10::BFloat16> { using vec_type = vec_op::BF16Vec8; };
+
+/***********************************/
+/*           AttnVecType           */
+/***********************************/
+template <typename scalar_t>
+struct AttnVecTypeISA;
+
+template <>
+struct AttnVecTypeISA<float> {
+  using q_load_vec_type = vec_op::FP32Vec4;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::FP32Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::FP32Vec16;
+};
+
+template <>
+struct AttnVecTypeISA<c10::Half> {
+  using q_load_vec_type = vec_op::FP16Vec8;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::FP16Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::FP16Vec16;
+};
+
+#ifdef __AVX512BF16__
+template <>
+struct AttnVecTypeISA<c10::BFloat16> {
+  using q_load_vec_type = vec_op::BF16Vec8;
+  using q_vec_type = vec_op::BF16Vec32;
+  using k_load_vec_type = vec_op::BF16Vec32;
+  using k_vec_type = vec_op::BF16Vec32;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::BF16Vec16;
+};
+#else
+template <>
+struct AttnVecTypeISA<c10::BFloat16> {
+  using q_load_vec_type = vec_op::BF16Vec8;
+  using q_vec_type = vec_op::FP32Vec16;
+  using k_load_vec_type = vec_op::BF16Vec16;
+  using k_vec_type = vec_op::FP32Vec16;
+  using qk_acc_vec_type = vec_op::FP32Vec16;
+  using v_load_vec_type = vec_op::BF16Vec16;
+};
+#endif
+
+/***********************************/
+/*          QuantVecType           */
+/***********************************/
+template <typename scalar_t>
+struct QuantVecTypeISA;
+
+template <>
+struct QuantVecTypeISA<float> {
+  using load_vec_type = vec_op::FP32Vec16;
+  using azp_adj_load_vec_type = vec_op::INT32Vec16;
+  using cvt_vec_type = vec_op::FP32Vec16;
+};
+
+template <>
+struct QuantVecTypeISA<c10::BFloat16> {
+  using load_vec_type = vec_op::BF16Vec16;
+  using azp_adj_load_vec_type = vec_op::INT32Vec16;
+  using cvt_vec_type = vec_op::FP32Vec16;
+};
+
+template <>
+struct QuantVecTypeISA<c10::Half> {
+  using load_vec_type = vec_op::FP16Vec16;
+  using azp_adj_load_vec_type = vec_op::INT32Vec16;
+  using cvt_vec_type = vec_op::FP32Vec16;
+};
 
 }; // namespace vec_op
 

--- a/csrc/cpu/quant.cpp
+++ b/csrc/cpu/quant.cpp
@@ -8,21 +8,24 @@ struct KernelVecType;
 template <>
 struct KernelVecType<float> {
   using load_vec_type = vec_op::QuantVecTypeISA<float>::load_vec_type;
-  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<float>::azp_adj_load_vec_type;
+  using azp_adj_load_vec_type =
+      vec_op::QuantVecTypeISA<float>::azp_adj_load_vec_type;
   using cvt_vec_type = vec_op::QuantVecTypeISA<float>::cvt_vec_type;
 };
 
 template <>
 struct KernelVecType<c10::BFloat16> {
   using load_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::load_vec_type;
-  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::azp_adj_load_vec_type;
+  using azp_adj_load_vec_type =
+      vec_op::QuantVecTypeISA<c10::BFloat16>::azp_adj_load_vec_type;
   using cvt_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::cvt_vec_type;
 };
 
 template <>
 struct KernelVecType<c10::Half> {
   using load_vec_type = vec_op::QuantVecTypeISA<c10::Half>::load_vec_type;
-  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<c10::Half>::azp_adj_load_vec_type;
+  using azp_adj_load_vec_type =
+      vec_op::QuantVecTypeISA<c10::Half>::azp_adj_load_vec_type;
   using cvt_vec_type = vec_op::QuantVecTypeISA<c10::Half>::cvt_vec_type;
 };
 

--- a/csrc/cpu/quant.cpp
+++ b/csrc/cpu/quant.cpp
@@ -3,37 +3,27 @@
 
 namespace {
 template <typename scalar_t>
-struct KernelVecType {
-  using load_vec_type = void;
-  using azp_adj_load_vec_type = void;
-  using cvt_vec_type = void;
-};
+struct KernelVecType;
 
 template <>
 struct KernelVecType<float> {
-  using load_vec_type = vec_op::FP32Vec16;
-  using azp_adj_load_vec_type = vec_op::INT32Vec16;
-  using cvt_vec_type = vec_op::FP32Vec16;
+  using load_vec_type = vec_op::QuantVecTypeISA<float>::load_vec_type;
+  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<float>::azp_adj_load_vec_type;
+  using cvt_vec_type = vec_op::QuantVecTypeISA<float>::cvt_vec_type;
 };
 
 template <>
 struct KernelVecType<c10::BFloat16> {
-  using load_vec_type = vec_op::BF16Vec16;
-  using azp_adj_load_vec_type = vec_op::INT32Vec16;
-  using cvt_vec_type = vec_op::FP32Vec16;
+  using load_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::load_vec_type;
+  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::azp_adj_load_vec_type;
+  using cvt_vec_type = vec_op::QuantVecTypeISA<c10::BFloat16>::cvt_vec_type;
 };
 
 template <>
 struct KernelVecType<c10::Half> {
-#ifdef __powerpc64__
-  // Power architecture-specific vector type
-  using load_vec_type = vec_op::FP32Vec16;
-#else
-  // Fallback for other architectures
-  using load_vec_type = vec_op::FP16Vec16;
-#endif
-  using azp_adj_load_vec_type = vec_op::INT32Vec16;
-  using cvt_vec_type = vec_op::FP32Vec16;
+  using load_vec_type = vec_op::QuantVecTypeISA<c10::Half>::load_vec_type;
+  using azp_adj_load_vec_type = vec_op::QuantVecTypeISA<c10::Half>::azp_adj_load_vec_type;
+  using cvt_vec_type = vec_op::QuantVecTypeISA<c10::Half>::cvt_vec_type;
 };
 
 #ifdef __AVX512F__


### PR DESCRIPTION
Abstract three types of vectors: OpsVecType, AttnVecType, and QuantVecType. Also move ISA specifics back to their implementations where they belong, which cleans up the less readable and less maintainable macros in attention and quant.

No functionality change.

@mgoin @bigPYJ1151 @sanketkaleoss @ChipKerchner 