### PR TITLE
Fill TorchSDPAAttentionMetadata seq_lens_field for prefill

### DIFF
--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -341,7 +341,11 @@ class TorchSDPAMetadataBuilder(AttentionMetadataBuilder[TorchSDPAMetadata]):
             )
         else:
             block_tables = torch.tensor([])
-            seq_lens_tensor = torch.tensor([])
+            seq_lens_tensor = torch.tensor(
+                input_data.seq_lens[:input_data.num_prefills],
+                dtype=torch.int32,
+                device="cpu",
+            )
 
         # For multi-modal models
         placeholder_index_maps = None


### PR DESCRIPTION
Fix attempt for https://github.com/vllm-project/vllm/issues/10738

In the TorchSDPAAttentionMetadata the seq_lens_tensor is empty for prefill. It looks like this is the case because it was assumed that this field is not necessary for prefill since it's not used for `_run_sdpa_forward`. But in Roberta models we need to know how long each sequence is during prefill to fix the position_ids tensor.

cc: @DarkLight1337 , @bigPYJ1151 