### PR TITLE
[Misc] Adding `MMMU-Pro` vision dataset to serving benchmark

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -213,11 +213,12 @@ def sample_mmmu_pro_vision_requests(
 
         # MMMU-Pro vision direct prompt
         # Ref: https://github.com/MMMU-Benchmark/MMMU/blob/6ce42f4d8f70c1841c67867152648974415b5cac/mmmu-pro/prompts.yaml#L5
-        prompt = """
-        Answer with the option letter from the given choices directly. 
-        The last line of your response should be of the following format: 
-        'Answer: $LETTER' (without quotes) where LETTER is one of options.
-        """
+        prompt = (
+            "Answer with the option letter from the given choices directly. "
+            "The last line of your response should be of the following "
+            "format: 'Answer: $LETTER' (without quotes) where LETTER is one of "
+            "options.")
+
         prompt_token_ids = tokenizer(prompt).input_ids
         if fixed_output_len is None:
             # Default max output len is set to 128

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -227,21 +227,22 @@ def sample_mmmu_pro_vision_requests(
 
         prompt_len = len(prompt_token_ids)
         output_len = fixed_output_len
-        if "image" in data and isinstance(data["image"], Image):
-            image: Image = data["image"]
-            image = image.convert("RGB")
-            image_data = io.BytesIO()
-            image.save(image_data, format='JPEG')
-            image_base64 = base64.b64encode(
-                image_data.getvalue()).decode("utf-8")
-            mm_content = {
-                "type": "image_url",
-                "image_url": {
-                    "url": f"data:image/jpeg;base64,{image_base64}"
-                },
-            }
-        else:
-            raise ValueError("Image not found in the dataset.")
+
+        assert isinstance(
+            data["image"],
+            Image), ("Input image format must be `PIL.Image.Image`, "
+                     f"given {type(data['image'])}.")
+        image: Image = data["image"]
+        image = image.convert("RGB")
+        image_data = io.BytesIO()
+        image.save(image_data, format='JPEG')
+        image_base64 = base64.b64encode(image_data.getvalue()).decode("utf-8")
+        mm_content = {
+            "type": "image_url",
+            "image_url": {
+                "url": f"data:image/jpeg;base64,{image_base64}"
+            },
+        }
 
         sampled_requests.append((prompt, prompt_len, output_len, mm_content))
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -265,7 +265,8 @@ def sample_hf_requests(
                                name=dataset_subset,
                                split=dataset_split,
                                streaming=True)
-        assert "image" in dataset.features, ("MMMU dataset must have 'image' column.")
+        assert "image" in dataset.features, (
+            "MMMU/MMMU_Pro vision dataset must have 'image' column.")
         filter_func = lambda x: isinstance(x["image"], Image)
         dataset = dataset.shuffle(seed=random_seed).filter(filter_func)
         return sample_mmmu_pro_vision_requests(dataset, num_requests,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -199,6 +199,55 @@ def sample_sonnet_requests(
     return sampled_requests
 
 
+def sample_mmmu_pro_vision_requests(
+    dataset,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+    fixed_output_len: Optional[int] = None,
+) -> List[Tuple[str, str, int, Optional[Dict[str, Collection[str]]]]]:
+    dataset = dataset.shuffle()
+    sampled_requests: List[Tuple[str, int, int, Dict[str,
+                                                     Collection[str]]]] = []
+    for data in dataset:
+        if len(sampled_requests) == num_requests:
+            break
+
+        # MMMU-Pro vision direct prompt
+        # Ref: https://github.com/MMMU-Benchmark/MMMU/blob/6ce42f4d8f70c1841c67867152648974415b5cac/mmmu-pro/prompts.yaml#L5
+        prompt = """
+        Answer with the option letter from the given choices directly. 
+        The last line of your response should be of the following format: 
+        'Answer: $LETTER' (without quotes) where LETTER is one of options.
+        """
+        prompt_token_ids = tokenizer(prompt).input_ids
+        if fixed_output_len is None:
+            # Default max output len is set to 128
+            print("--hf-output-len is not provided. Using default value 128.")
+            fixed_output_len = 128
+
+        prompt_len = len(prompt_token_ids)
+        output_len = fixed_output_len
+        if "image" in data and isinstance(data["image"], Image):
+            image: Image = data["image"]
+            image = image.convert("RGB")
+            image_data = io.BytesIO()
+            image.save(image_data, format='JPEG')
+            image_base64 = base64.b64encode(
+                image_data.getvalue()).decode("utf-8")
+            mm_content = {
+                "type": "image_url",
+                "image_url": {
+                    "url": f"data:image/jpeg;base64,{image_base64}"
+                },
+            }
+        else:
+            raise ValueError("Image not found in the dataset.")
+
+        sampled_requests.append((prompt, prompt_len, output_len, mm_content))
+
+    return sampled_requests
+
+
 def sample_hf_requests(
     dataset_path: str,
     dataset_subset: str,
@@ -208,6 +257,18 @@ def sample_hf_requests(
     random_seed: int,
     fixed_output_len: Optional[int] = None,
 ) -> List[Tuple[str, str, int, Optional[Dict[str, Collection[str]]]]]:
+
+    # Special case for MMMU-Pro vision dataset
+    if dataset_path == 'MMMU/MMMU_Pro' and dataset_subset == 'vision':
+        assert dataset_split == "test"
+        dataset = load_dataset(dataset_path,
+                               name=dataset_subset,
+                               split=dataset_split,
+                               streaming=True)
+
+        return sample_mmmu_pro_vision_requests(dataset, num_requests,
+                                               tokenizer, fixed_output_len)
+
     dataset = load_dataset(dataset_path,
                            name=dataset_subset,
                            split=dataset_split,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -265,7 +265,9 @@ def sample_hf_requests(
                                name=dataset_subset,
                                split=dataset_split,
                                streaming=True)
-        dataset = dataset.shuffle(seed=random_seed)
+        assert "image" in dataset.features, ("MMMU dataset must have 'image' column.")
+        filter_func = lambda x: isinstance(x["image"], Image)
+        dataset = dataset.shuffle(seed=random_seed).filter(filter_func)
         return sample_mmmu_pro_vision_requests(dataset, num_requests,
                                                tokenizer, fixed_output_len)
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -205,7 +205,6 @@ def sample_mmmu_pro_vision_requests(
     tokenizer: PreTrainedTokenizerBase,
     fixed_output_len: Optional[int] = None,
 ) -> List[Tuple[str, str, int, Optional[Dict[str, Collection[str]]]]]:
-    dataset = dataset.shuffle()
     sampled_requests: List[Tuple[str, int, int, Dict[str,
                                                      Collection[str]]]] = []
     for data in dataset:
@@ -265,7 +264,7 @@ def sample_hf_requests(
                                name=dataset_subset,
                                split=dataset_split,
                                streaming=True)
-
+        dataset = dataset.shuffle(seed=random_seed)
         return sample_mmmu_pro_vision_requests(dataset, num_requests,
                                                tokenizer, fixed_output_len)
 


### PR DESCRIPTION
This PR adds the support for [MMMU-Pro vision](https://huggingface.co/datasets/MMMU/MMMU_Pro/viewer/vision) dataset to the serving benchmark. This dataset is image-token-heavy (single image with average resolution of 1700x1600) and comes with a [generic short text prompt](https://github.com/MMMU-Benchmark/MMMU/blob/6ce42f4d8f70c1841c67867152648974415b5cac/mmmu-pro/prompts.yaml#L5), as describe in the dataset model card:
> Vision: In this subset, questions are embedded within screenshots or photos, and models must integrate visual and textual information to answer correctly. No separate text is fed into the model.

Example command to run the benchmark
```
vllm serve llava-hf/llava-v1.6-mistral-7b-hf

python3 benchmarks/benchmark_serving.py \
--dataset-path MMMU/MMMU_Pro \
--dataset-name hf \
--hf-subset "vision" \
--hf-split test \
--model llava-hf/llava-v1.6-mistral-7b-hf  \
--backend openai-chat \
--endpoint /v1/chat/completions \
--num-prompts 100
```

Co-authored-by: @heheda12345
