### PR TITLE
[core] Avoid metrics log noise when idle - include speculative decodi…

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -473,13 +473,13 @@ class LoggingStatLogger(StatLoggerBase):
             )
             if (stats.cpu_prefix_cache_hit_rate >= 0
                     or stats.gpu_prefix_cache_hit_rate >= 0):
-                logger.info(
+                log_fn(
                     "Prefix cache hit rate: GPU: %.2f%%, CPU: %.2f%%",
                     stats.gpu_prefix_cache_hit_rate * 100,
                     stats.cpu_prefix_cache_hit_rate * 100,
                 )
             if self.spec_decode_metrics is not None:
-                logger.info(
+                log_fn(
                     self._format_spec_decode_metrics_str(
                         self.spec_decode_metrics))
 


### PR DESCRIPTION
…ng and prefix cache noise

Patch #8868 reduces log noise when idle, but misses log noise from speculative decoding and prefix cache metrics. 

This patch brings these into the same filter.

FIX #8868 https://github.com/vllm-project/vllm/pull/8868