### PR TITLE
[WIP] Xgrammar init in engine

### DIFF
--- a/benchmarks/benchmark_guided.py
+++ b/benchmarks/benchmark_guided.py
@@ -1,0 +1,466 @@
+"""Benchmark guided decoding throughput."""
+import argparse
+import dataclasses
+import json
+import os
+import random
+import time
+from typing import List
+
+import datasets
+import uvloop
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
+from vllm.entrypoints.openai.api_server import (
+    build_async_engine_client_from_engine_args)
+from vllm.sampling_params import GuidedDecodingParams
+from vllm.utils import FlexibleArgumentParser, merge_async_iterators
+
+
+@dataclasses.dataclass
+class SampleRequest:
+    """A class representing a single inference request for benchmarking.
+
+    Attributes:
+        prompt: The input text prompt for the model.
+        multi_modal_data: Optional dictionary containing multi-modal data (e.g.
+            images).
+        prompt_len: The length of the prompt in tokens.
+        expected_output_len: The expected length of the output in tokens.
+    """
+    prompt: str
+    prompt_len: int
+    expected_output_len: int
+    schema: dict
+    structure_type: str = 'json'
+    completion: str = None
+
+
+def run_vllm(requests: List[SampleRequest],
+             engine_args: EngineArgs,
+             n: int,
+             guided_decoding_rate: float = 1.0,
+             warmup: bool = False) -> float:
+    from vllm import LLM, SamplingParams
+    llm = LLM(**vars(engine_args))
+
+    # Add the requests to the engine.
+    prompts: List[str] = []
+    sampling_params: List[SamplingParams] = []
+    # create a list containing random selected true or false
+    guided_decoding_req_idx = random.sample(
+        range(len(requests)), int(len(requests) * guided_decoding_rate))
+
+    for i, request in enumerate(requests):
+        prompts.append(request.prompt)
+        sampling_params.append(
+            SamplingParams(
+                n=n,
+                temperature=1.0,
+                top_p=1.0,
+                ignore_eos=True,
+                max_tokens=request.expected_output_len,
+                guided_decoding=GuidedDecodingParams(
+                    **{request.structure_type: request.schema})
+                if i in guided_decoding_req_idx else None,
+            ))
+
+    start = time.perf_counter()
+    outputs = llm.generate(prompts, sampling_params, use_tqdm=True)
+    ret = []
+    for output, request in zip(outputs, requests):
+        generated_text = output.outputs[0].text
+        ret.append({
+            "generated": generated_text,
+            "expected": request.completion
+        })
+    end = time.perf_counter()
+    return end - start, ret
+
+
+async def run_vllm_async(
+        requests: List[SampleRequest],
+        engine_args: AsyncEngineArgs,
+        n: int,
+        guided_decoding_rate: float = 1.0,
+        warmup: bool = False,
+        disable_frontend_multiprocessing: bool = False) -> float:
+    from vllm import SamplingParams
+
+    async with build_async_engine_client_from_engine_args(
+            engine_args, disable_frontend_multiprocessing) as llm:
+
+        # Add the requests to the engine.
+        prompts: List[str] = []
+        sampling_params: List[SamplingParams] = []
+        guided_decoding_req_idx = random.sample(
+            range(len(requests)), int(len(requests) * guided_decoding_rate))
+
+        if warmup:
+            print("Running warmup prompt, for the first 5")
+            # We setup the first 5 requests to warmup FSM
+            warmup_requests = requests[:5]
+            requests = requests[5:]
+            for i, request in enumerate(warmup_requests):
+                prompts.append(request.prompt)
+                sampling_params.append(
+                    SamplingParams(
+                        n=n,
+                        temperature=1.0,
+                        top_p=1.0,
+                        ignore_eos=True,
+                        max_tokens=request.expected_output_len,
+                        guided_decoding=GuidedDecodingParams(
+                            json=request.schema)
+                        if i in guided_decoding_req_idx else None,
+                    ))
+            generators = []
+            for i, (prompt, sp) in enumerate(zip(prompts, sampling_params)):
+                generator = llm.generate(prompt, sp, request_id=f"test{i}")
+                generators.append(generator)
+            all_gens = merge_async_iterators(*generators)
+            async for i, res in all_gens:
+                pass
+
+        prompts = []
+        sampling_params = []
+        for i, request in enumerate(requests):
+            prompts.append(request.prompt)
+            sampling_params.append(
+                SamplingParams(
+                    n=n,
+                    temperature=1.0,
+                    top_p=1.0,
+                    ignore_eos=True,
+                    max_tokens=request.expected_output_len,
+                    guided_decoding=GuidedDecodingParams(json=request.schema)
+                    if i in guided_decoding_req_idx else None,
+                ))
+
+        generators = []
+        start_time = []
+        latencies = []
+        start = time.perf_counter()
+        for i, (prompt, sp) in enumerate(zip(prompts, sampling_params)):
+            generator = llm.generate(prompt, sp, request_id=f"test{i}")
+            generators.append(generator)
+            start_time.append(time.perf_counter())
+            latencies.append([])
+        all_gens = merge_async_iterators(*generators)
+        generated_texts = [''] * len(requests)
+        async for i, res in all_gens:
+            generated_texts[i] = res.outputs[0].text
+            lat = time.perf_counter() - start_time[i]
+            latencies[i].append(lat)
+        ret = [{
+            'generated': gt,
+            'expected': req.completion
+        } for gt, req in zip(generated_texts, requests)]
+        first_latency = sum([lat[0]
+                             for lat in latencies]) / len(latencies) * 1000
+        next_latency = sum([(lat[-1] - lat[0]) / len(lat[1:])
+                            for lat in latencies]) / len(latencies) * 1000
+        end = time.perf_counter()
+        return end - start, ret, (first_latency, next_latency)
+
+
+def sample_requests(tokenizer: PreTrainedTokenizerBase,
+                    args: argparse.Namespace) -> List[SampleRequest]:
+    if args.dataset == 'json':
+        if args.json_schema_path is None:
+            dir_path = os.path.dirname(os.path.realpath(__file__))
+            args.json_schema_path = os.path.join(dir_path,
+                                                 "structured_schemas",
+                                                 "structured_schema_1.json")
+        with open(args.json_schema_path) as f:
+            schema = json.load(f)
+        prompt = f"Generate an example of a user profile given the following schema: {json.dumps(schema)}"  # noqa: E501
+        input_len = len(tokenizer(prompt).input_ids)
+        print(f"Input length of the prompt: {input_len} tokens")
+        requests = [
+            SampleRequest(prompt=prompt,
+                          prompt_len=input_len,
+                          expected_output_len=args.output_len,
+                          schema=schema,
+                          structure_type=args.structure_type)
+            for _ in range(args.num_prompts)
+        ]
+
+    elif args.dataset == "grammar":
+        schema = """
+            ?start: select_statement
+
+            ?select_statement: "SELECT " column_list " FROM " table_name
+
+            ?column_list: column_name ("," column_name)*
+
+            ?table_name: identifier
+
+            ?column_name: identifier
+
+            ?identifier: /[a-zA-Z_][a-zA-Z0-9_]*/
+        """
+        prompt = "Generate an SQL query to show the 'username' \
+            and 'email' from the 'users' table."
+
+        input_len = len(tokenizer(prompt).input_ids)
+        print(f"Input length of the prompt: {input_len} tokens")
+        requests = [
+            SampleRequest(prompt=prompt,
+                          prompt_len=input_len,
+                          expected_output_len=args.output_len,
+                          schema=schema,
+                          structure_type=args.structure_type)
+            for _ in range(args.num_prompts)
+        ]
+
+    elif args.dataset == "regex":
+        regex = r"\w+@\w+\.com\n"
+        args.regex = regex
+        prompt = "Generate an email address for Alan Turing, \
+            who works in Enigma. End in .com and new line. \
+                Example result: alan.turing@enigma.com\n"
+
+        input_len = len(tokenizer(prompt).input_ids)
+        print(f"Input length of the prompt: {input_len} tokens")
+        requests = [
+            SampleRequest(prompt=prompt,
+                          prompt_len=input_len,
+                          expected_output_len=args.output_len,
+                          schema=regex,
+                          structure_type=args.structure_type)
+            for _ in range(args.num_prompts)
+        ]
+
+    elif args.dataset == "choice":
+        choice = ["Positive", "Negative"]
+        args.choice = choice
+        prompt = "Classify this sentiment: vLLM is wonderful!"
+        input_len = len(tokenizer(prompt).input_ids)
+        print(f"Input length of the prompt: {input_len} tokens")
+        requests = [
+            SampleRequest(prompt=prompt,
+                          prompt_len=input_len,
+                          expected_output_len=args.output_len,
+                          schema=choice,
+                          structure_type=args.structure_type)
+            for _ in range(args.num_prompts)
+        ]
+
+    elif args.dataset == "xgrammar_bench":
+        requests: List[SampleRequest] = []
+        dataset = datasets.load_dataset("NousResearch/json-mode-eval",
+                                        split="train")
+        print(f"dataset has {len(dataset)} entries")
+        len_dataset = len(dataset)
+        for data_point_idx in range(args.num_prompts):
+            idx = data_point_idx
+            while idx >= len_dataset:
+                idx -= len_dataset
+            schema = dataset["schema"][idx]
+            prompt = tokenizer.apply_chat_template(dataset["prompt"][idx],
+                                                   tokenize=False)
+            input_len = len(tokenizer(prompt).input_ids)
+            completion = dataset["completion"][idx]
+
+            requests.append(
+                SampleRequest(prompt=prompt,
+                              prompt_len=input_len,
+                              expected_output_len=args.output_len,
+                              schema=schema,
+                              completion=completion))
+
+    return requests
+
+
+def evaluate(ret, args):
+
+    def _eval_correctness_json(expected, actual):
+        # extract json string from string using regex
+        import re
+        actual = actual.replace('\n', '').replace(' ', '').strip()
+        try:
+            actual = re.search(r'\{.*\}', actual).group()
+            actual = json.loads(actual)
+        except Exception:
+            return False
+
+        return True
+
+    def _eval_correctness_choice(expected, actual):
+        return actual in args.choice
+
+    def _eval_correctness_regex(expected, actual):
+        import re
+        return re.match(args.regex, actual) is not None
+
+    def _eval_correctness(expected, actual):
+        if args.structure_type == 'json':
+            return _eval_correctness_json(expected, actual)
+        elif args.structure_type == 'regex':
+            return _eval_correctness_regex(expected, actual)
+        elif args.structure_type == 'choice':
+            return _eval_correctness_choice(expected, actual)
+        else:
+            return None
+
+    scores = []
+    for res in ret:
+        score = _eval_correctness(res['expected'], res['generated'])
+        res['correctness'] = score
+        scores.append(score)
+
+    not_none_scores = [score for score in scores if score is not None]
+
+    return (sum(not_none_scores) / len(not_none_scores) *
+            100) if len(not_none_scores) > 0 else None
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+
+    # async engine is working for 'regex', 'choice' and 'grammar'
+    if args.dataset == 'grammar':
+        args.structure_type = 'grammar'
+        args.async_engine = False
+    elif args.dataset == 'regex':
+        args.structure_type = 'regex'
+        args.async_engine = False
+    elif args.dataset == 'choice':
+        args.structure_type = 'choice'
+        args.async_engine = False
+    else:
+        args.structure_type = 'json'
+
+    if args.no_guided_decoding:
+        args.guided_decoding_ratio = 0
+    if args.save_results:
+        result_file_name = f'{args.guided_decoding_ratio}guided'
+        result_file_name += f"_{args.model.split('/')[-1]}"
+        result_file_name += f"_{args.dataset}"
+        result_file_name += f"_{args.num_prompts}"
+        result_file_name += f"_out{args.output_len}"
+        result_file_name += f"_async{args.async_engine}"
+        result_file_name += f"_warmup{args.warmup}"
+        result_file_name += f"_chunkedprefill{args.enable_chunked_prefill}"
+        result_file_name += ".txt"
+    else:
+        result_file_name = None
+
+    # Synthesize a prompt with the given input length.
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer, trust_remote_code=args.trust_remote_code)
+    requests = sample_requests(tokenizer, args)
+
+    if args.async_engine:
+        engine_args = AsyncEngineArgs.from_cli_args(args)
+        elapsed_time, ret, (first_latency, next_latency) = uvloop.run(
+            run_vllm_async(requests, engine_args, args.n,
+                           args.guided_decoding_ratio, args.warmup,
+                           args.disable_frontend_multiprocessing))
+    else:
+        engine_args = EngineArgs.from_cli_args(args)
+        elapsed_time, ret = run_vllm(requests, engine_args, args.n,
+                                     args.guided_decoding_ratio, args.warmup)
+        first_latency, next_latency = None, None
+
+    score = evaluate(ret, args)
+    total_num_tokens = sum(request.prompt_len + request.expected_output_len
+                           for request in requests)
+    total_output_tokens = sum(request.expected_output_len
+                              for request in requests)
+    if first_latency is not None:
+        latency_breakdown = f"First token latency: {first_latency:.2f} msecs"
+        latency_breakdown += f"Next token latency: {next_latency:.2f} msecs"
+    print(
+        f"Throughput: {len(requests) / elapsed_time:.2f} requests/s, "
+        f"{total_num_tokens / elapsed_time:.2f} total tokens/s, "
+        f"{total_output_tokens / elapsed_time:.2f} output tokens/s",
+        f"Correct rate is {score} %",
+        f"{latency_breakdown if first_latency is not None else ''}")
+
+    # Output JSON results if specified
+    if args.output_json or result_file_name:
+        results = {
+            "elapsed_time": elapsed_time,
+            "num_requests": len(requests),
+            "total_num_tokens": total_num_tokens,
+            "total_output_tokens": total_output_tokens,
+            "requests_per_second": len(requests) / elapsed_time,
+            "tokens_per_second": f"{total_num_tokens / elapsed_time:.2f}",
+            "output_tokens_per_second":
+            f"{total_output_tokens / elapsed_time:.2f}",
+            "correct_rate(%)": score
+        }
+        results = {"outputs": ret, **results}
+        if first_latency is not None:
+            results["first_token_latency(msecs)"] = first_latency
+            results["next_token_latency(msecs)"] = next_latency
+        if args.output_json:
+            with open(args.output_json, "w") as f:
+                json.dump(results, f, indent=4)
+        elif result_file_name:
+            with open(result_file_name, "w") as f:
+                json.dump(results, f, indent=4)
+
+
+if __name__ == "__main__":
+    parser = FlexibleArgumentParser(description="Benchmark guided decoding.")
+    parser = AsyncEngineArgs.add_cli_args(parser)
+
+    parser.add_argument("--output-len",
+                        type=int,
+                        default=512,
+                        help="Output length for each request. Overrides the "
+                        "output length from the dataset.")
+    parser.add_argument(
+        "--dataset",
+        default='json',
+        choices=['json', 'grammar', 'regex', 'choice', 'xgrammar_bench'])
+    parser.add_argument("--json_schema_path",
+                        type=str,
+                        default=None,
+                        help="Path to json schema.")
+    parser.add_argument("--n",
+                        type=int,
+                        default=1,
+                        help="Number of generated sequences per prompt.")
+    parser.add_argument("--num-prompts",
+                        type=int,
+                        default=10,
+                        help="Number of prompts to process.")
+    parser.add_argument(
+        '--output-json',
+        type=str,
+        default=None,
+        help='Path to save the throughput results in JSON format.')
+    parser.add_argument("--async-engine",
+                        action='store_true',
+                        default=False,
+                        help="Use vLLM async engine rather than LLM class.")
+    parser.add_argument("--no-guided-decoding",
+                        action='store_true',
+                        default=False,
+                        help="Whether to disable JSON decoding or not.")
+    parser.add_argument("--guided-decoding-ratio",
+                        type=float,
+                        default=1.0,
+                        help="Ratio of Guided Decoding requests")
+    parser.add_argument("--disable-frontend-multiprocessing",
+                        action='store_true',
+                        default=False,
+                        help="Disable decoupled async engine frontend.")
+    parser.add_argument("--warmup",
+                        action="store_true",
+                        default=False,
+                        help="Run warmup prompts before benchmark.")
+    parser.add_argument("--save-results",
+                        action="store_true",
+                        default=False,
+                        help="save output results.")
+    args = parser.parse_args()
+    if args.tokenizer is None:
+        args.tokenizer = args.model
+    main(args)

--- a/benchmarks/structured_schemas/structured_schema_1.json
+++ b/benchmarks/structured_schemas/structured_schema_1.json
@@ -1,0 +1,113 @@
+{
+    "$schema":
+    "https://json-schema.org/draft/2020-12/schema",
+    "title":
+    "User Profile",
+    "type":
+    "object",
+    "properties": {
+        "userId": {
+            "type": "string",
+            "description": "Unique identifier for the user."
+        },
+        "personalInfo": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string",
+                    "description": "The user's first name."
+                },
+                "lastName": {
+                    "type": "string",
+                    "description": "The user's last name."
+                },
+                "age": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "The user's age."
+                },
+                "phoneNumbers": {
+                    "type":
+                    "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["home", "work", "mobile"],
+                                "description": "Type of phone number."
+                            },
+                            "number": {
+                                "type": "string",
+                                "pattern": "^\\+?[1-9]\\d{1,14}$",
+                                "description": "Phone number in E.164 format."
+                            }
+                        },
+                        "required": ["type", "number"]
+                    },
+                    "description":
+                    "List of phone numbers associated with the user."
+                }
+            },
+            "required": ["firstName", "lastName"]
+        },
+        "address": {
+            "type": "object",
+            "properties": {
+                "street": {
+                    "type": "string",
+                    "description": "Street address."
+                },
+                "city": {
+                    "type": "string",
+                    "description": "City name."
+                },
+                "state": {
+                    "type": "string",
+                    "description": "State or province."
+                },
+                "postalCode": {
+                    "type": "string",
+                    "pattern": "^\\d{5}(-\\d{4})?$",
+                    "description": "Postal code."
+                },
+                "country": {
+                    "type": "string",
+                    "description": "Country name."
+                }
+            },
+            "required": ["street", "city", "state", "postalCode", "country"]
+        },
+        "preferences": {
+            "type": "object",
+            "properties": {
+                "newsletterSubscribed": {
+                    "type":
+                    "boolean",
+                    "description":
+                    "Indicates if the user is subscribed to the newsletter."
+                },
+                "favoriteCategories": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "List of user's favorite categories."
+                }
+            },
+            "required": ["newsletterSubscribed"]
+        },
+        "accountStatus": {
+            "type": "string",
+            "enum": ["active", "inactive", "suspended"],
+            "description": "Current status of the user's account."
+        },
+        "registrationDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 formatted date-time of user registration."
+        }
+    },
+    "required":
+    ["userId", "personalInfo", "address", "accountStatus", "registrationDate"]
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,7 @@ autodoc_mock_imports = [
     "tensorizer",
     "pynvml",
     "outlines",
+    "xgrammar,"
     "librosa",
     "soundfile",
     "gguf",

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,6 +19,7 @@ prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
 outlines >= 0.0.43, < 0.1
+xgrammar
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/tests/model_executor/test_guided_processors.py
+++ b/tests/model_executor/test_guided_processors.py
@@ -36,7 +36,7 @@ def test_guided_logits_processors(sample_regex, sample_json_schema):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("backend", ["outlines", "lm-format-enforcer"])
+@pytest.mark.parametrize("backend", ["outlines", "lm-format-enforcer", "xgrammar"])
 async def test_guided_logits_processor_black_box(backend: str, sample_regex,
                                                  sample_json_schema):
     tokenizer = AutoTokenizer.from_pretrained('HuggingFaceH4/zephyr-7b-beta')

--- a/tests/model_executor/test_guided_processors.py
+++ b/tests/model_executor/test_guided_processors.py
@@ -36,7 +36,8 @@ def test_guided_logits_processors(sample_regex, sample_json_schema):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("backend", ["outlines", "lm-format-enforcer", "xgrammar"])
+@pytest.mark.parametrize("backend",
+                         ["outlines", "lm-format-enforcer", "xgrammar"])
 async def test_guided_logits_processor_black_box(backend: str, sample_regex,
                                                  sample_json_schema):
     tokenizer = AutoTokenizer.from_pretrained('HuggingFaceH4/zephyr-7b-beta')

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -137,24 +137,6 @@ class ModelConfig:
             can not be gathered from the vllm arguments.
         override_pooler_config: Initialize non default pooling config or
             override default pooling config for the embedding model.
-        config_format: The config format which shall be loaded.
-            Defaults to 'auto' which defaults to 'hf'.
-        mm_processor_kwargs: Arguments to be forwarded to the model's processor
-            for multi-modal data, e.g., image processor.
-        pooling_type: Used to configure the pooling method in the embedding
-            model.
-        pooling_norm: Used to determine whether to normalize the pooled
-            data in the embedding model.
-        pooling_softmax: Used to determine whether to softmax the pooled
-            data in the embedding model.
-        pooling_step_tag_id: When pooling_step_tag_id is not -1, it indicates
-            that the score corresponding to the pooling_step_tag_id in the
-            generated sentence should be returned. Otherwise, it returns
-            the scores for all tokens.
-        pooling_returned_token_ids: pooling_returned_token_ids represents a
-            list of indices for the vocabulary dimensions to be extracted,
-            such as the token IDs of good_token and bad_token in the
-            math-shepherd-mistral-7b-prm model.
     """
 
     def __init__(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2031,7 +2031,8 @@ def get_served_model_name(model: str,
 class DecodingConfig:
     """Dataclass which contains the decoding strategy of the engine"""
 
-    # Which guided decoding algo to use. 'outlines' / 'lm-format-enforcer' / 'xgrammar'
+    # Which guided decoding algo to use.
+    # 'outlines' / 'lm-format-enforcer' / 'xgrammar'
     guided_decoding_backend: str = 'xgrammar'
 
     def __post_init__(self):

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -137,6 +137,24 @@ class ModelConfig:
             can not be gathered from the vllm arguments.
         override_pooler_config: Initialize non default pooling config or
             override default pooling config for the embedding model.
+        config_format: The config format which shall be loaded.
+            Defaults to 'auto' which defaults to 'hf'.
+        mm_processor_kwargs: Arguments to be forwarded to the model's processor
+            for multi-modal data, e.g., image processor.
+        pooling_type: Used to configure the pooling method in the embedding
+            model.
+        pooling_norm: Used to determine whether to normalize the pooled
+            data in the embedding model.
+        pooling_softmax: Used to determine whether to softmax the pooled
+            data in the embedding model.
+        pooling_step_tag_id: When pooling_step_tag_id is not -1, it indicates
+            that the score corresponding to the pooling_step_tag_id in the
+            generated sentence should be returned. Otherwise, it returns
+            the scores for all tokens.
+        pooling_returned_token_ids: pooling_returned_token_ids represents a
+            list of indices for the vocabulary dimensions to be extracted,
+            such as the token IDs of good_token and bad_token in the
+            math-shepherd-mistral-7b-prm model.
     """
 
     def __init__(
@@ -1789,15 +1807,15 @@ class PoolerConfig:
 
     step_tag_id: Optional[int] = None
     """
-    If set, only the score corresponding to the ``step_tag_id`` in the 
+    If set, only the score corresponding to the ``step_tag_id`` in the
     generated sentence should be returned. Otherwise, the scores for all tokens
     are returned.
     """
 
     returned_token_ids: Optional[List[int]] = None
     """
-    A list of indices for the vocabulary dimensions to be extracted, 
-    such as the token IDs of ``good_token`` and ``bad_token`` in the 
+    A list of indices for the vocabulary dimensions to be extracted,
+    such as the token IDs of ``good_token`` and ``bad_token`` in the
     ``math-shepherd-mistral-7b-prm`` model.
     """
 
@@ -2031,11 +2049,11 @@ def get_served_model_name(model: str,
 class DecodingConfig:
     """Dataclass which contains the decoding strategy of the engine"""
 
-    # Which guided decoding algo to use. 'outlines' / 'lm-format-enforcer'
-    guided_decoding_backend: str = 'outlines'
+    # Which guided decoding algo to use. 'outlines' / 'lm-format-enforcer' / 'xgrammar'
+    guided_decoding_backend: str = 'xgrammar'
 
     def __post_init__(self):
-        valid_guided_backends = ['outlines', 'lm-format-enforcer']
+        valid_guided_backends = ['outlines', 'lm-format-enforcer', 'xgrammar']
         backend = self.guided_decoding_backend
         if backend not in valid_guided_backends:
             raise ValueError(f"Invalid guided_decoding_backend '{backend},"
@@ -2222,7 +2240,7 @@ class CompilationConfig(BaseModel):
             from Python, functions can also be passed directly via Python object
             constructor, e.g. `CompilationConfig(inductor_passes={"a": func})`
         - custom inductor passes: see PassConfig for more details
-    
+
     Why we have different sizes for cudagraph and inductor:
     - cudagraph: a cudagraph captured for a specific size can only be used
         for the same size. We need to capture all the sizes we want to use.

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1383,6 +1383,7 @@ class Scheduler:
                     is_prompt=is_prompt,
                     seq_data=seq_data,
                     sampling_params=seq_group.sampling_params,
+                    logits_processors=seq_group.logits_processors,
                     block_tables=block_tables,
                     do_sample=do_sample,
                     pooling_params=seq_group.pooling_params,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -168,7 +168,7 @@ class EngineArgs:
     scheduler_delay_factor: float = 0.0
     enable_chunked_prefill: Optional[bool] = None
 
-    guided_decoding_backend: str = 'outlines'
+    guided_decoding_backend: str = 'xgrammar'
     # Speculative decoding configuration.
     speculative_model: Optional[str] = None
     speculative_model_quantization: Optional[str] = None
@@ -364,11 +364,12 @@ class EngineArgs:
         parser.add_argument(
             '--guided-decoding-backend',
             type=str,
-            default='outlines',
-            choices=['outlines', 'lm-format-enforcer'],
+            default='xgrammar',
+            choices=['outlines', 'lm-format-enforcer', 'xgrammar'],
             help='Which engine will be used for guided decoding'
             ' (JSON schema / regex etc) by default. Currently support '
-            'https://github.com/outlines-dev/outlines and '
+            'https://github.com/outlines-dev/outlines,'
+            'https://github.com/mlc-ai/xgrammar, and '
             'https://github.com/noamgat/lm-format-enforcer.'
             ' Can be overridden per request via guided_decoding_backend'
             ' parameter.')

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -22,8 +22,6 @@ from vllm.inputs import PromptType
 from vllm.inputs.preprocess import InputPreprocessor
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.model_executor.guided_decoding import (
-    get_guided_decoding_logits_processor)
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
@@ -494,19 +492,6 @@ class _AsyncLLMEngine(LLMEngine):
         )
         processed_inputs = self.input_processor(preprocessed_inputs)
 
-        if isinstance(params, SamplingParams) and \
-            params.guided_decoding is not None:
-            # Guided decoding has an async implementation for building logits
-            # processors in a separate threadpool.
-            # We want to invoke that here instead of using the blocking
-            # implementation in the LLMEngine
-            params = await build_guided_decoding_logits_processor_async(
-                sampling_params=params,
-                tokenizer=await self.get_tokenizer_async(lora_request),
-                default_guided_backend=self.decoding_config.
-                guided_decoding_backend,
-                model_config=self.model_config)
-
         self._add_processed_request(
             request_id=request_id,
             processed_inputs=processed_inputs,
@@ -522,39 +507,6 @@ class _AsyncLLMEngine(LLMEngine):
         if self.tokenizer:
             self.tokenizer.check_health()
         self.model_executor.check_health()
-
-
-async def build_guided_decoding_logits_processor_async(
-        sampling_params: SamplingParams, tokenizer: AnyTokenizer,
-        default_guided_backend: str,
-        model_config: ModelConfig) -> SamplingParams:
-    """Constructs logits processors based on the guided_decoding,
-    logits_bias, and allowed_token_ids fields in sampling_params. Deletes
-    those fields and adds the constructed logits processors to the
-    logits_processors field. Modifies sampling params in-place and returns
-    the modified sampling params."""
-    if (guided_decoding := sampling_params.guided_decoding) is None:
-        return sampling_params
-
-    logger.debug("Building guided decoding logits processor. "
-                 "Params: %s", guided_decoding)
-
-    guided_decoding.backend = guided_decoding.backend or default_guided_backend
-
-    processor = await get_guided_decoding_logits_processor(
-        guided_params=guided_decoding,
-        tokenizer=tokenizer,
-        model_config=model_config)
-
-    if processor:
-        if sampling_params.logits_processors is None:
-            sampling_params.logits_processors = []
-        sampling_params.logits_processors.append(processor)
-
-    # Unset guided decoding params after constructing the lp from them
-    sampling_params.guided_decoding = None
-
-    return sampling_params
 
 
 class AsyncLLMEngine(EngineClient):

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -504,7 +504,8 @@ class _AsyncLLMEngine(LLMEngine):
                 sampling_params=params,
                 tokenizer=await self.get_tokenizer_async(lora_request),
                 default_guided_backend=self.decoding_config.
-                guided_decoding_backend)
+                guided_decoding_backend,
+                model_config=self.model_config)
 
         self._add_processed_request(
             request_id=request_id,
@@ -525,7 +526,8 @@ class _AsyncLLMEngine(LLMEngine):
 
 async def build_guided_decoding_logits_processor_async(
         sampling_params: SamplingParams, tokenizer: AnyTokenizer,
-        default_guided_backend: str) -> SamplingParams:
+        default_guided_backend: str,
+        model_config: ModelConfig) -> SamplingParams:
     """Constructs logits processors based on the guided_decoding,
     logits_bias, and allowed_token_ids fields in sampling_params. Deletes
     those fields and adds the constructed logits processors to the
@@ -540,7 +542,9 @@ async def build_guided_decoding_logits_processor_async(
     guided_decoding.backend = guided_decoding.backend or default_guided_backend
 
     processor = await get_guided_decoding_logits_processor(
-        guided_params=guided_decoding, tokenizer=tokenizer)
+        guided_params=guided_decoding,
+        tokenizer=tokenizer,
+        model_config=model_config)
 
     if processor:
         if sampling_params.logits_processors is None:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -896,6 +896,8 @@ class LLMEngine:
             raise ValueError(f"Cannot request more than "
                              f"{max_logprobs} logprobs.")
 
+        # FIXME: do not mutate SamplingParams here - just store the
+        # created logits_processors list elsewhere
         sampling_params = self._build_logits_processors(
             sampling_params, lora_request)
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1023,9 +1023,9 @@ class LLMEngine:
         This function updates num_computed_tokens for prompt sequences
         when Multi-Step is enabled.
 
-        seq_group: SequenceGroup to update the num_computed_tokens for. 
+        seq_group: SequenceGroup to update the num_computed_tokens for.
         seq_group_meta: Metadata of the given SequenceGroup.
-        is_first_step_output: Optional[bool] - 
+        is_first_step_output: Optional[bool] -
             When available, is_first_step_output indicates if the appended
             output token is the output of the first-step in multi-step.
             A value of None indicates that outputs from all steps in
@@ -2046,7 +2046,9 @@ class LLMEngine:
                 self.decoding_config.guided_decoding_backend
 
             processor = get_local_guided_decoding_logits_processor(
-                guided_params=guided_decoding, tokenizer=tokenizer)
+                guided_params=guided_decoding,
+                tokenizer=tokenizer,
+                model_config=self.model_config)
             if processor:
                 logits_processors.append(processor)
 

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -472,8 +472,8 @@ class MQLLMEngineClient(EngineClient):
             trace_headers: OpenTelemetry trace headers.
             prompt_adapter_request: Prompt Adapter request to use
                                             for generation, if any.
-            priority: Priority of the request (lower means earlier handling). 
-                Any priority other than 0 will lead to an error if the 
+            priority: Priority of the request (lower means earlier handling).
+                Any priority other than 0 will lead to an error if the
                 scheduling policy is not "priority".
         """
         if inputs is not None:
@@ -586,6 +586,7 @@ class MQLLMEngineClient(EngineClient):
                     default_guided_backend=(self.decoding_config.guided_decoding_backend
                         if self.decoding_config
                         else DecodingConfig.guided_decoding_backend),
+                    model_config=self.model_config
                 )
 
         # 1) Create output queue for this requests.

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -16,10 +16,7 @@ from vllm import PoolingParams
 from vllm.config import DecodingConfig, ModelConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.engine.arg_utils import AsyncEngineArgs
-# yapf conflicts with isort for this block
 # yapf: disable
-from vllm.engine.async_llm_engine import (
-    build_guided_decoding_logits_processor_async)
 from vllm.engine.multiprocessing import (ENGINE_DEAD_ERROR, IPC_DATA_EXT,
                                          IPC_HEALTH_EXT, IPC_INPUT_EXT,
                                          IPC_OUTPUT_EXT, RPC_REQUEST_T,
@@ -574,38 +571,12 @@ class MQLLMEngineClient(EngineClient):
         if self._errored_with is not None:
             raise ENGINE_DEAD_ERROR(self._errored_with)
 
-        # Constructing guided decoding logits processors is expensive, so we do
-        # it here to avoid contending with cpu resources and the GIL on the
-        # backend process.
-        if isinstance(params, SamplingParams) and \
-            params.guided_decoding is not None:
-            params = await \
-                build_guided_decoding_logits_processor_async(
-                    sampling_params=params,
-                    tokenizer=await self.get_tokenizer(lora_request),
-                    default_guided_backend=(self.decoding_config.guided_decoding_backend
-                        if self.decoding_config
-                        else DecodingConfig.guided_decoding_backend),
-                    model_config=self.model_config
-                )
-
         # 1) Create output queue for this requests.
         queue: asyncio.Queue[Union[RequestOutput,
                                    BaseException]] = asyncio.Queue()
         self.output_queues[request_id] = queue
 
         try:
-            # 2) Detach logits processors so that they can be pickled
-            # separately (may require cloudpickle which is slower)
-            if isinstance(params, SamplingParams) and params.logits_processors:
-                # Defensive shallow copy
-                params = copy.copy(params)
-                logits_processors = params.logits_processors
-                params.logits_processors = None
-                lp_bytes = cloudpickle.dumps(logits_processors)
-            else:
-                lp_bytes = None
-
             request_bytes = pickle.dumps(
                 RPCProcessRequest(
                     prompt=prompt,
@@ -618,8 +589,8 @@ class MQLLMEngineClient(EngineClient):
                 ))
 
             # 3) Send the RPCGenerateRequest to the MQLLMEngine.
-            parts = (request_bytes,
-                     lp_bytes) if lp_bytes else (request_bytes, )
+            # FIXME: revert away from multipart
+            parts = (request_bytes, )
             await self.input_socket.send_multipart(parts, copy=False)
 
             # 4) Stream the RequestOutputs from the output queue. Note

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -221,11 +221,6 @@ class MQLLMEngine:
                 request = pickle.loads(frames[0].buffer)
 
                 if isinstance(request, RPCProcessRequest):
-                    if len(frames) > 1:
-                        # Use cloudpickle for logits processors
-                        assert isinstance(request.params, SamplingParams)
-                        lprocs = cloudpickle.loads(frames[1].buffer)
-                        request.params.logits_processors = lprocs
                     self._handle_process_request(request)
                 elif isinstance(request, RPCAbortRequest):
                     self._handle_abort_request(request)

--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Callable, List, Tuple, Union
 
 import torch
@@ -12,6 +13,21 @@ of previously generated tokens, the logits tensor
 for the next token and, optionally, prompt tokens as a
 first argument, and returns a modified tensor of logits
 to sample from."""
+
+
+class Readyable(ABC):
+    @abstractmethod
+    def ready(self):
+        pass
+
+
+def check_logits_processors_readiness(logits_processors):
+    if not logits_processors:
+        return True
+    return all(
+        not isinstance(lp, Readyable) or lp.ready()
+        for lp in logits_processors
+    )
 
 
 def get_bad_words_logits_processors(

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -14,7 +14,7 @@ async def get_guided_decoding_logits_processor(
         guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig) -> LogitsProcessor | None:
     # CFG grammar not supported by LMFE, so we use outlines instead
-    if guided_params.backend == 'outlines' or guided_params.grammar:
+    if guided_params.backend == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
         from vllm.model_executor.guided_decoding.outlines_decoding import (  # noqa
             get_outlines_guided_decoding_logits_processor)
@@ -40,7 +40,7 @@ def get_local_guided_decoding_logits_processor(
         guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig) -> LogitsProcessor | None:
     # CFG grammar not supported by LMFE, so we use outlines instead
-    if guided_params.backend == 'outlines' or guided_params.grammar:
+    if guided_params.backend == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
         from vllm.model_executor.guided_decoding.outlines_decoding import (  # noqa
             get_local_outlines_guided_decoding_logits_processor)

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from vllm.logits_process import LogitsProcessor
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 async def get_guided_decoding_logits_processor(
         guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
-        model_config: ModelConfig) -> Optional[LogitsProcessor]:
+        model_config: ModelConfig) -> LogitsProcessor | None:
     # CFG grammar not supported by LMFE, so we use outlines instead
     if guided_params.backend == 'outlines' or guided_params.grammar:
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
@@ -36,7 +36,7 @@ async def get_guided_decoding_logits_processor(
 
 def get_local_guided_decoding_logits_processor(
         guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
-        model_config: ModelConfig) -> Optional[LogitsProcessor]:
+        model_config: ModelConfig) -> LogitsProcessor | None:
     # CFG grammar not supported by LMFE, so we use outlines instead
     if guided_params.backend == 'outlines' or guided_params.grammar:
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -1,12 +1,17 @@
-from typing import Optional
+from __future__ import annotations
 
-from vllm.logits_process import LogitsProcessor
-from vllm.sampling_params import GuidedDecodingParams
+from typing import Optional, Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm.logits_process import LogitsProcessor
+    from vllm.sampling_params import GuidedDecodingParams
+    from vllm.config import ModelConfig
+    from transformers import PreTrainedTokenizer
 
 
 async def get_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
-        tokenizer) -> Optional[LogitsProcessor]:
+        guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
+        model_config: ModelConfig) -> Optional[LogitsProcessor]:
     # CFG grammar not supported by LMFE, so we use outlines instead
     if guided_params.backend == 'outlines' or guided_params.grammar:
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
@@ -19,15 +24,19 @@ async def get_guided_decoding_logits_processor(
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
+    if guided_params.backend == 'xgrammar':
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import get_local_xgrammar_guided_decoding_logits_processor
+        return get_local_xgrammar_guided_decoding_logits_processor(
+            guided_params, tokenizer, model_config)
 
     raise ValueError(
         f"Unknown guided decoding backend '{guided_params.backend}'. "
-        "Must be one of 'outlines, 'lm-format-enforcer'")
+        "Must be one of 'outlines, 'lm-format-enforcer', 'xgrammar'")
 
 
 def get_local_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
-        tokenizer) -> Optional[LogitsProcessor]:
+        guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizer,
+        model_config: ModelConfig) -> Optional[LogitsProcessor]:
     # CFG grammar not supported by LMFE, so we use outlines instead
     if guided_params.backend == 'outlines' or guided_params.grammar:
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
@@ -40,7 +49,11 @@ def get_local_guided_decoding_logits_processor(
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
+    if guided_params.backend == 'xgrammar':
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import get_local_xgrammar_guided_decoding_logits_processor
+        return get_local_xgrammar_guided_decoding_logits_processor(
+            guided_params, tokenizer, model_config)
 
     raise ValueError(
         f"Unknown guided decoding backend '{guided_params.backend}'. "
-        "Must be one of 'outlines, 'lm-format-enforcer'")
+        "Must be one of 'outlines, 'lm-format-enforcer', 'xgrammar'")

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
+
+    from vllm.config import ModelConfig
     from vllm.logits_process import LogitsProcessor
     from vllm.sampling_params import GuidedDecodingParams
-    from vllm.config import ModelConfig
-    from transformers import PreTrainedTokenizer
 
 
 async def get_guided_decoding_logits_processor(
@@ -25,7 +26,8 @@ async def get_guided_decoding_logits_processor(
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
     if guided_params.backend == 'xgrammar':
-        from vllm.model_executor.guided_decoding.xgrammar_decoding import get_local_xgrammar_guided_decoding_logits_processor
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
+            get_local_xgrammar_guided_decoding_logits_processor)
         return get_local_xgrammar_guided_decoding_logits_processor(
             guided_params, tokenizer, model_config)
 
@@ -50,7 +52,8 @@ def get_local_guided_decoding_logits_processor(
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
     if guided_params.backend == 'xgrammar':
-        from vllm.model_executor.guided_decoding.xgrammar_decoding import get_local_xgrammar_guided_decoding_logits_processor
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
+            get_local_xgrammar_guided_decoding_logits_processor)
         return get_local_xgrammar_guided_decoding_logits_processor(
             guided_params, tokenizer, model_config)
 

--- a/vllm/model_executor/guided_decoding/outlines_decoding.py
+++ b/vllm/model_executor/guided_decoding/outlines_decoding.py
@@ -46,34 +46,7 @@ pair   : UNESCAPED_STRING ":" value
 %ignore WS
 """
 
-global_thread_pool = None  # used for generating logits processor fsm
-
-
-async def get_outlines_guided_decoding_logits_processor(
-    guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizerBase
-) -> Union[JSONLogitsProcessor, RegexLogitsProcessor, CFGLogitsProcessor,
-           None]:
-    """
-    Given an OpenAI-compatible request, check for guided decoding parameters
-    and get the necessary logits processor for the given guide.
-    We cache logit processors by (guide, tokenizer), and on cache hit
-    we make a shallow copy to reuse the same underlying FSM.
-    """
-    global global_thread_pool
-    guide, mode = _get_guide_and_mode(guided_params)
-    if not guide or not mode:
-        return None
-
-    if global_thread_pool is None:
-        global_thread_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=2)
-    loop = asyncio.get_running_loop()
-
-    return await loop.run_in_executor(global_thread_pool,
-                                      _get_logits_processor, guide, tokenizer,
-                                      mode, guided_params.whitespace_pattern)
-
-
+# FIXME: rename to remove "local"
 def get_local_outlines_guided_decoding_logits_processor(
     guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizerBase
 ) -> Union[JSONLogitsProcessor, RegexLogitsProcessor, CFGLogitsProcessor,

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -28,13 +28,17 @@ from outlines.fsm.guide import CFGGuide, Generate, Guide, RegexGuide, Write
 from outlines.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
+from vllm.logits_process import Readyable
 
 
-class BaseLogitsProcessor:
+class BaseLogitsProcessor(Readyable):
 
     def __init__(self, guide: Guide):
         self._guide: Guide = guide
         self._fsm_state: DefaultDict[int, int] = defaultdict(int)
+
+    def ready(self):
+        return self._guide_future.done()
 
     def __call__(self, input_ids: List[int],
                  scores: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from vllm.config import ModelConfig
     from vllm.sampling_params import GuidedDecodingParams
 
+from vllm.logits_process import Readyable
+
 
 _thread_pool = None
 
@@ -175,7 +177,7 @@ class GrammarConfig:
 
 
 @dataclass
-class XGrammarLogitsProcessor:
+class XGrammarLogitsProcessor(Readyable):
     """Wrapper class to support pickle protocol"""
     config: GrammarConfig
 
@@ -190,6 +192,9 @@ class XGrammarLogitsProcessor:
 
     def async_init(self, thread_pool: concurrent.futures.ThreadPoolExecutor):
         self._future = thread_pool.submit(self._init_ctx)
+
+    def ready(self) -> bool:
+        return self.ctx is not None
 
     def __getstate__(self) -> dict[str, Any]:
         return {'config': self.config}

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Any, Optional
 
 try:
     import xgrammar as xgr
@@ -20,21 +22,71 @@ def get_local_xgrammar_guided_decoding_logits_processor(
         tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig,
         max_threads=8):
-    full_vocab_size = model_config.hf_config.vocab_size
-    tokenizer_info = xgr.TokenizerInfo.from_huggingface(
-        tokenizer, vocab_size=full_vocab_size)
-    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=max_threads)
+    config = GrammarConfig.from_guided_params(
+        guided_params, model_config, max_threads)
+    return XGrammarLogitsProcessor(config, tokenizer)
 
-    if guided_params.json:
-        if not isinstance(guided_params.json, str):
-            json_str = json.dumps(guided_params.json)
+@dataclass
+class GrammarConfig:
+    """Serializable configuration for grammar compilation"""
+    json_str: Optional[str] = None
+    grammar_str: Optional[str] = None
+    vocab_size: int = 0
+    max_threads: int = 8
+
+    @classmethod
+    def from_guided_params(cls,
+                          guided_params: GuidedDecodingParams,
+                          model_config: ModelConfig,
+                          max_threads: int = 8) -> GrammarConfig:
+        if guided_params.json:
+            if not isinstance(guided_params.json, str):
+                json_str = json.dumps(guided_params.json)
+            else:
+                json_str = guided_params.json
+            return cls(
+                json_str=json_str,
+                vocab_size=model_config.hf_config.vocab_size,
+                max_threads=max_threads
+            )
+        elif guided_params.grammar:
+            return cls(
+                grammar_str=guided_params.grammar,
+                vocab_size=model_config.hf_config.vocab_size,
+                max_threads=max_threads
+            )
         else:
-            json_str = guided_params.json
-        ctx = compiler.compile_json_schema(json_str)
-    elif guided_params.grammar:
-        ctx = compiler.compile_grammar(guided_params.grammar)
-    else:
-        raise ValueError(
-            "Currently only support JSON and EBNF grammar mode for xgrammar")
+            raise ValueError("Currently only support JSON and EBNF grammar mode for xgrammar")
 
-    return xgr.contrib.hf.LogitsProcessor(ctx)
+class XGrammarLogitsProcessor:
+    """Wrapper class that rebuilds CompiledGrammar in each worker process"""
+    def __init__(self, config: GrammarConfig, tokenizer: PreTrainedTokenizer):
+        self.config = config
+        self.tokenizer = tokenizer
+        self._processor = None
+
+    def __getstate__(self) -> Dict[str, Any]: return {'config': self.config}
+
+    def __setstate__(self, state: Dict[str, Any]):
+        self.config = state['config']
+        self._processor = None
+
+    def _ensure_processor(self):
+        """Lazily initialize the processor in the worker process"""
+        if self._processor is None:
+            tokenizer_info = xgr.TokenizerInfo.from_huggingface(
+                self.tokenizer, vocab_size=self.config.vocab_size)
+            compiler = xgr.GrammarCompiler(
+                tokenizer_info, max_threads=self.config.max_threads)
+
+            if self.config.json_str is not None:
+                ctx = compiler.compile_json_schema(self.config.json_str)
+            else:
+                ctx = compiler.compile_grammar(self.config.grammar_str)
+
+            self._processor = xgr.contrib.hf.LogitsProcessor(ctx)
+
+    def __call__(self, *args, **kwargs):
+        """Delegate to underlying processor after ensuring it's initialized"""
+        if self._processor is None: self._ensure_processor()
+        return self._processor(*args, **kwargs)

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import json
-import torch
-from transformers import PreTrainedTokenizerFast
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import PreTrainedTokenizerFast
 
 try:
     import xgrammar as xgr
@@ -14,9 +15,10 @@ except ImportError:
     pass
 
 if TYPE_CHECKING:
-    from vllm.sampling_params import GuidedDecodingParams
-    from vllm.config import ModelConfig
     from transformers import PreTrainedTokenizer
+
+    from vllm.config import ModelConfig
+    from vllm.sampling_params import GuidedDecodingParams
 
 
 # TODO: passing batch size to max threads here
@@ -59,20 +61,13 @@ class GrammarConfig:
             ]
         except AttributeError as e:
             raise ValueError(
-                f"Cannot get the vocabulary of the tokenizer {type(tokenizer)}. The tokenizer should have a get_vocab method."
-            ) from e
+                f"Cannot get the vocabulary of the tokenizer {type(tokenizer)}."
+                " The tokenizer should have a get_vocab method.") from e
 
         stop_token_ids = None
         backend_str = xgr.VocabType.RAW
         if isinstance(tokenizer, PreTrainedTokenizerFast):
-            # huggingface fast tokenizer
-            # - the vocabulary is directly obtained from tokenizer.get_vocab()
-            #   (tokenizer.backend_tokenizer.to_str() may not contain the full vocab, special
-            #   tokens may be omitted)
-            # - the vocab size is obtained from len(tokenizer.get_vocab()) or provided by user
-            # - the vocab type and prepend_space_in_tokenization are obtained from
-            #   tokenizer.backend_tokenizer.to_str()
-            # - stop token id is provided by user, or auto detected.
+            #  the vocabulary is directly obtained from tokenizer.get_vocab()
             backend_str = tokenizer.backend_tokenizer.to_str()
             if stop_token_ids is None and hasattr(
                     tokenizer,

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+try:
+    import xgrammar as xgr
+except ImportError:
+    pass
+
+if TYPE_CHECKING:
+    from vllm.sampling_params import GuidedDecodingParams
+    from vllm.config import ModelConfig
+    from transformers import PreTrainedTokenizer
+
+
+# TODO: passing batch size to max threads here
+def get_local_xgrammar_guided_decoding_logits_processor(
+        guided_params: GuidedDecodingParams,
+        tokenizer: PreTrainedTokenizer,
+        model_config: ModelConfig,
+        max_threads=8):
+    full_vocab_size = model_config.hf_config.vocab_size
+    tokenizer_info = xgr.TokenizerInfo.from_huggingface(
+        tokenizer, vocab_size=full_vocab_size)
+    compiler = xgr.GrammarCompiler(tokenizer_info, max_threads=max_threads)
+
+    if guided_params.json:
+        if not isinstance(guided_params.json, str):
+            json_str = json.dumps(guided_params.json)
+        else:
+            json_str = guided_params.json
+        ctx = compiler.compile_json_schema(json_str)
+    elif guided_params.grammar:
+        ctx = compiler.compile_grammar(guided_params.grammar)
+    else:
+        raise ValueError(
+            "Currently only support JSON and EBNF grammar mode for xgrammar")
+
+    return xgr.contrib.hf.LogitsProcessor(ctx)

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-import json
+import json, torch
 
+from transformers import PreTrainedTokenizerFast
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Any, Optional
+from typing import TYPE_CHECKING, Dict, Any, Optional, List
 
 try:
     import xgrammar as xgr
+    from xgrammar.base import _core as xgr_core
 except ImportError:
     pass
 
@@ -23,22 +25,62 @@ def get_local_xgrammar_guided_decoding_logits_processor(
         model_config: ModelConfig,
         max_threads=8):
     config = GrammarConfig.from_guided_params(
-        guided_params, model_config, max_threads)
-    return XGrammarLogitsProcessor(config, tokenizer)
+        guided_params=guided_params, model_config=model_config, tokenizer=tokenizer, max_threads=max_threads)
+    return XGrammarLogitsProcessor(config)
 
 @dataclass
 class GrammarConfig:
     """Serializable configuration for grammar compilation"""
-    json_str: Optional[str] = None
-    grammar_str: Optional[str] = None
     vocab_size: int = 0
     max_threads: int = 8
+    json_str: Optional[str] = None
+    grammar_str: Optional[str] = None
+    encoded_vocab: Optional[Dict[str, int]] = None
+    stop_token_ids: Optional[List[int]] = None
+    backend_str: str = ""
 
     @classmethod
     def from_guided_params(cls,
                           guided_params: GuidedDecodingParams,
                           model_config: ModelConfig,
+                          tokenizer: PreTrainedTokenizer,
                           max_threads: int = 8) -> GrammarConfig:
+
+        # Vendorred from xgrammar logics
+        try:
+            encoded_vocab = tokenizer.get_vocab()
+            encoded_vocab = [
+                token for token, _ in sorted(encoded_vocab.items(), key=lambda x: x[1])
+            ]
+        except AttributeError as e:
+            msg = (
+                f"Cannot get the vocabulary of the tokenizer {type(tokenizer)}. The tokenizer "
+                "should have a get_vocab method."
+            )
+            raise ValueError(msg) from e
+
+        stop_token_ids = None
+        backend_str = xgr.VocabType.RAW
+        if isinstance(tokenizer, PreTrainedTokenizerFast):
+            # huggingface fast tokenizer
+            # - the vocabulary is directly obtained from tokenizer.get_vocab()
+            #   (tokenizer.backend_tokenizer.to_str() may not contain the full vocab, special
+            #   tokens may be omitted)
+            # - the vocab size is obtained from len(tokenizer.get_vocab()) or provided by user
+            # - the vocab type and prepend_space_in_tokenization are obtained from
+            #   tokenizer.backend_tokenizer.to_str()
+            # - stop token id is provided by user, or auto detected.
+            backend_str = tokenizer.backend_tokenizer.to_str()
+            if stop_token_ids is None:
+                if hasattr(tokenizer, "eos_token_id") and tokenizer.eos_token_id is not None:
+                    stop_token_ids = [tokenizer.eos_token_id]
+                else:
+                    logger.warning(
+                        "When constructing TokenizerInfo from a huggingface tokenizer, "
+                        "stop_token_ids is neither provided by user nor found from the tokenizer. "
+                        "It will be automatically detected."
+                    )
+
         if guided_params.json:
             if not isinstance(guided_params.json, str):
                 json_str = json.dumps(guided_params.json)
@@ -47,22 +89,34 @@ class GrammarConfig:
             return cls(
                 json_str=json_str,
                 vocab_size=model_config.hf_config.vocab_size,
-                max_threads=max_threads
+                max_threads=max_threads,
+                encoded_vocab=encoded_vocab,
+                stop_token_ids=stop_token_ids,
+                backend_str=backend_str
             )
         elif guided_params.grammar:
             return cls(
                 grammar_str=guided_params.grammar,
                 vocab_size=model_config.hf_config.vocab_size,
-                max_threads=max_threads
+                max_threads=max_threads,
+                encoded_vocab=encoded_vocab,
+                stop_token_ids=stop_token_ids,
+                backend_str=backend_str
             )
         else:
             raise ValueError("Currently only support JSON and EBNF grammar mode for xgrammar")
 
+    def create_tokenizer_info(self):
+        return xgr.TokenizerInfo._create_from_handle(
+            xgr_core.TokenizerInfo.from_huggingface(
+                self.encoded_vocab, self.backend_str, self.vocab_size, self.stop_token_ids
+            )
+        )
+
 class XGrammarLogitsProcessor:
-    """Wrapper class that rebuilds CompiledGrammar in each worker process"""
-    def __init__(self, config: GrammarConfig, tokenizer: PreTrainedTokenizer):
+    """Wrapper class to support pickle protocol"""
+    def __init__(self, config: GrammarConfig):
         self.config = config
-        self.tokenizer = tokenizer
         self._processor = None
 
     def __getstate__(self) -> Dict[str, Any]: return {'config': self.config}
@@ -74,8 +128,7 @@ class XGrammarLogitsProcessor:
     def _ensure_processor(self):
         """Lazily initialize the processor in the worker process"""
         if self._processor is None:
-            tokenizer_info = xgr.TokenizerInfo.from_huggingface(
-                self.tokenizer, vocab_size=self.config.vocab_size)
+            tokenizer_info = self.config.create_tokenizer_info()
             compiler = xgr.GrammarCompiler(
                 tokenizer_info, max_threads=self.config.max_threads)
 
@@ -86,7 +139,7 @@ class XGrammarLogitsProcessor:
 
             self._processor = xgr.contrib.hf.LogitsProcessor(ctx)
 
-    def __call__(self, *args, **kwargs):
-        """Delegate to underlying processor after ensuring it's initialized"""
-        if self._processor is None: self._ensure_processor()
-        return self._processor(*args, **kwargs)
+    def __call__(self, input_ids: List[int], scores: torch.Tensor) -> torch.Tensor:
+      if self._processor is None: self._ensure_processor()
+      if not input_ids: return scores
+      return self._processor(input_ids, scores)

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json, torch
 
 from transformers import PreTrainedTokenizerFast
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, Any, Optional, List
 
 try:
@@ -24,9 +24,12 @@ def get_local_xgrammar_guided_decoding_logits_processor(
         tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig,
         max_threads=8):
-    config = GrammarConfig.from_guided_params(
-        guided_params=guided_params, model_config=model_config, tokenizer=tokenizer, max_threads=max_threads)
+    config = GrammarConfig.from_guided_params(guided_params=guided_params,
+                                              model_config=model_config,
+                                              tokenizer=tokenizer,
+                                              max_threads=max_threads)
     return XGrammarLogitsProcessor(config)
+
 
 @dataclass
 class GrammarConfig:
@@ -41,22 +44,22 @@ class GrammarConfig:
 
     @classmethod
     def from_guided_params(cls,
-                          guided_params: GuidedDecodingParams,
-                          model_config: ModelConfig,
-                          tokenizer: PreTrainedTokenizer,
-                          max_threads: int = 8) -> GrammarConfig:
+                           guided_params: GuidedDecodingParams,
+                           model_config: ModelConfig,
+                           tokenizer: PreTrainedTokenizer,
+                           max_threads: int = 8) -> GrammarConfig:
 
         # Vendorred from xgrammar logics
         try:
             encoded_vocab = tokenizer.get_vocab()
             encoded_vocab = [
-                token for token, _ in sorted(encoded_vocab.items(), key=lambda x: x[1])
+                token for token, _ in sorted(encoded_vocab.items(),
+                                             key=lambda x: x[1])
             ]
         except AttributeError as e:
             msg = (
                 f"Cannot get the vocabulary of the tokenizer {type(tokenizer)}. The tokenizer "
-                "should have a get_vocab method."
-            )
+                "should have a get_vocab method.")
             raise ValueError(msg) from e
 
         stop_token_ids = None
@@ -72,74 +75,97 @@ class GrammarConfig:
             # - stop token id is provided by user, or auto detected.
             backend_str = tokenizer.backend_tokenizer.to_str()
             if stop_token_ids is None:
-                if hasattr(tokenizer, "eos_token_id") and tokenizer.eos_token_id is not None:
+                if hasattr(
+                        tokenizer,
+                        "eos_token_id") and tokenizer.eos_token_id is not None:
                     stop_token_ids = [tokenizer.eos_token_id]
                 else:
                     logger.warning(
                         "When constructing TokenizerInfo from a huggingface tokenizer, "
                         "stop_token_ids is neither provided by user nor found from the tokenizer. "
-                        "It will be automatically detected."
-                    )
+                        "It will be automatically detected.")
 
         if guided_params.json:
             if not isinstance(guided_params.json, str):
                 json_str = json.dumps(guided_params.json)
             else:
                 json_str = guided_params.json
-            return cls(
-                json_str=json_str,
-                vocab_size=model_config.hf_config.vocab_size,
-                max_threads=max_threads,
-                encoded_vocab=encoded_vocab,
-                stop_token_ids=stop_token_ids,
-                backend_str=backend_str
-            )
+            return cls(json_str=json_str,
+                       vocab_size=model_config.hf_config.vocab_size,
+                       max_threads=max_threads,
+                       encoded_vocab=encoded_vocab,
+                       stop_token_ids=stop_token_ids,
+                       backend_str=backend_str)
         elif guided_params.grammar:
-            return cls(
-                grammar_str=guided_params.grammar,
-                vocab_size=model_config.hf_config.vocab_size,
-                max_threads=max_threads,
-                encoded_vocab=encoded_vocab,
-                stop_token_ids=stop_token_ids,
-                backend_str=backend_str
-            )
+            return cls(grammar_str=guided_params.grammar,
+                       vocab_size=model_config.hf_config.vocab_size,
+                       max_threads=max_threads,
+                       encoded_vocab=encoded_vocab,
+                       stop_token_ids=stop_token_ids,
+                       backend_str=backend_str)
         else:
-            raise ValueError("Currently only support JSON and EBNF grammar mode for xgrammar")
+            raise ValueError(
+                "Currently only support JSON and EBNF grammar mode for xgrammar"
+            )
 
     def create_tokenizer_info(self):
         return xgr.TokenizerInfo._create_from_handle(
-            xgr_core.TokenizerInfo.from_huggingface(
-                self.encoded_vocab, self.backend_str, self.vocab_size, self.stop_token_ids
-            )
-        )
+            xgr_core.TokenizerInfo.from_huggingface(self.encoded_vocab,
+                                                    self.backend_str,
+                                                    self.vocab_size,
+                                                    self.stop_token_ids))
 
+
+@dataclass
 class XGrammarLogitsProcessor:
     """Wrapper class to support pickle protocol"""
-    def __init__(self, config: GrammarConfig):
-        self.config = config
-        self._processor = None
+    config: GrammarConfig
 
-    def __getstate__(self) -> Dict[str, Any]: return {'config': self.config}
+    ctx: Optional[xgr.CompiledGrammar] = None
+    matchers: List[xgr.GrammarMatcher] = field(default_factory=list)
+    batch_size: int = 1
+    token_bitmask: Optional[torch.Tensor]  = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        return {'config': self.config}
 
     def __setstate__(self, state: Dict[str, Any]):
         self.config = state['config']
-        self._processor = None
 
-    def _ensure_processor(self):
+        self.ctx = None
+        self.matchers = []
+        self.batch_size = 1
+        self.token_bitmask = None
+
+    def _ensure_ctx(self):
         """Lazily initialize the processor in the worker process"""
-        if self._processor is None:
-            tokenizer_info = self.config.create_tokenizer_info()
-            compiler = xgr.GrammarCompiler(
-                tokenizer_info, max_threads=self.config.max_threads)
+        if self.ctx is None:
+            compiler = xgr.GrammarCompiler(self.config.create_tokenizer_info(),
+                                           max_threads=self.config.max_threads)
 
             if self.config.json_str is not None:
-                ctx = compiler.compile_json_schema(self.config.json_str)
+                self.ctx = compiler.compile_json_schema(self.config.json_str)
             else:
-                ctx = compiler.compile_grammar(self.config.grammar_str)
+                self.ctx = compiler.compile_grammar(self.config.grammar_str)
 
-            self._processor = xgr.contrib.hf.LogitsProcessor(ctx)
+    def __call__(self, input_ids: List[int],
+                 scores: torch.Tensor) -> torch.Tensor:
+        if self.ctx is None: self._ensure_ctx()
+        if len(self.matchers) == 0:
+            self.matchers = [
+                xgr.GrammarMatcher(self.ctx) for _ in range(self.batch_size)
+            ]
+            self.token_bitmask = xgr.allocate_token_bitmask(
+                self.batch_size, self.config.vocab_size)
 
-    def __call__(self, input_ids: List[int], scores: torch.Tensor) -> torch.Tensor:
-      if self._processor is None: self._ensure_processor()
-      if not input_ids: return scores
-      return self._processor(input_ids, scores)
+        for i, matcher in enumerate(self.matchers):
+            if not matcher.is_terminated():
+                matcher.fill_next_token_bitmask(self.token_bitmask, i)
+
+        device_type = scores.device.type
+        if device_type != "cuda": scores = scores.to("cpu")
+        xgr.apply_token_bitmask_inplace(scores,
+                                        self.token_bitmask.to(scores.device))
+        if device_type != "cuda": scores = scores.to(device_type)
+
+        return scores

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -129,8 +129,7 @@ def _apply_logits_processors(
     logits_processed = 0
     for seq_group in sampling_metadata.seq_groups:
         seq_ids = seq_group.seq_ids
-        sampling_params = seq_group.sampling_params
-        logits_processors = sampling_params.logits_processors
+        logits_processors = seq_group.logits_processors
         if logits_processors:
             found_logits_processors = True
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -194,6 +194,9 @@ class SamplingParams(
     spaces_between_special_tokens: bool = True
     # Optional[List[LogitsProcessor]] type. We use Any here because
     # Optional[List[LogitsProcessor]] type is not supported by msgspec.
+    # Note - this parameter only contains the user-supplied processors,
+    # not the processors that implement guided_decoding, logit_bias,
+    # allowed_token_ids, and bad_words
     logits_processors: Optional[Any] = None
     include_stop_str_in_output: bool = False
     truncate_prompt_tokens: Optional[Annotated[int, msgspec.Meta(ge=1)]] = None
@@ -448,6 +451,7 @@ class SamplingParams(
     def all_stop_token_ids(self) -> Set[int]:
         return self._all_stop_token_ids
 
+    # FIXME: probably not needed anymore
     def clone(self) -> "SamplingParams":
         """Deep copy excluding LogitsProcessor objects.
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -451,20 +451,8 @@ class SamplingParams(
     def all_stop_token_ids(self) -> Set[int]:
         return self._all_stop_token_ids
 
-    # FIXME: probably not needed anymore
-    def clone(self) -> "SamplingParams":
-        """Deep copy excluding LogitsProcessor objects.
-
-        LogitsProcessor objects are excluded because they may contain an
-        arbitrary, nontrivial amount of data.
-        See https://github.com/vllm-project/vllm/issues/3087
-        """
-
-        logit_processor_refs = None if self.logits_processors is None else {
-            id(lp): lp
-            for lp in self.logits_processors
-        }
-        return copy.deepcopy(self, memo=logit_processor_refs)
+    def clone(self):
+        return copy.deepcopy(self)
 
     def __repr__(self) -> str:
         return (

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -14,6 +14,7 @@ import msgspec
 import torch
 
 from vllm.inputs import SingletonInputs, SingletonInputsAdapter
+from vllm.logits_process import LogitsProcessor
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MultiModalDataDict, MultiModalPlaceholderDict
 from vllm.pooling_params import PoolingParams
@@ -615,6 +616,7 @@ class SequenceGroup:
         request_id: The ID of the request.
         seqs: The list of sequences.
         sampling_params: The sampling parameters used to generate the outputs.
+        logits_processors: FIXME
         arrival_time: The arrival time of the request.
         lora_request: LoRA request.
         embeddings: The embeddings vectors of the prompt of the sequence group
@@ -634,6 +636,7 @@ class SequenceGroup:
         seqs: List[Sequence],
         arrival_time: float,
         sampling_params: Optional[SamplingParams] = None,
+        logits_processors: List[LogitsProcessor] = None,
         lora_request: Optional[LoRARequest] = None,
         embeddings: Optional[List[float]] = None,
         pooling_params: Optional[PoolingParams] = None,
@@ -650,6 +653,7 @@ class SequenceGroup:
         self.seqs_dict = {seq.seq_id: seq for seq in seqs}
 
         self.sampling_params = sampling_params
+        self.logits_processors = logits_processors
         self.metrics = RequestMetrics(arrival_time=arrival_time,
                                       last_token_time=arrival_time,
                                       first_scheduled_time=None,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -636,7 +636,7 @@ class SequenceGroup:
         seqs: List[Sequence],
         arrival_time: float,
         sampling_params: Optional[SamplingParams] = None,
-        logits_processors: List[LogitsProcessor] = None,
+        logits_processors: Optional[List[LogitsProcessor]] = None,
         lora_request: Optional[LoRARequest] = None,
         embeddings: Optional[List[float]] = None,
         pooling_params: Optional[PoolingParams] = None,
@@ -914,6 +914,7 @@ class SequenceGroupMetadata(
     sampling_params: Optional[SamplingParams]
     block_tables: Dict[int, List[int]]
     do_sample: bool = True
+    logits_processors: Optional[List[LogitsProcessor]] = None
     pooling_params: Optional[PoolingParams] = None
     lora_request: Optional[LoRARequest] = None
     computed_block_nums: Optional[List[int]] = None

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -5,6 +5,7 @@ from typing import Iterator, List, Optional, Tuple
 import torch
 
 from vllm import SamplingParams
+from vllm.logits_process import LogitsProcessor
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import (VLLM_INVALID_TOKEN_ID, VLLM_TOKEN_ID_ARRAY_TYPE,
                            ExecuteModelRequest, SequenceData,
@@ -308,6 +309,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             proposal_token_ids[batch_index])
 
         sampling_params = input_seq_group_metadata.sampling_params
+        logits_processors = input_seq_group_metadata.logits_processors
         target_seq_group_metadata_list: List[SequenceGroupMetadata] = []
         for i, token_ids in enumerate(token_ids_to_score):
             target_seq_group_metadata_list.append(
@@ -317,6 +319,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
                     next(target_seq_ids_iter),
                     token_ids,
                     sampling_params=sampling_params,
+                    logits_processors=logits_processors,
                 ))
 
         return target_seq_group_metadata_list
@@ -328,6 +331,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         target_seq_id: TargetSeqId,
         token_ids: List[TokenId],
         sampling_params: SamplingParams,
+        logits_processors: List[LogitsProcessor],
     ) -> SequenceGroupMetadata:
         """Create a single target SequenceGroupMetadata.
 
@@ -364,6 +368,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             is_prompt=seq_group_metadata.is_prompt,
             seq_data=new_seq_data_dict,
             sampling_params=sampling_params,
+            logits_processors=logits_processors,
             block_tables={
                 target_seq_id: seq_group_metadata.block_tables[seq_id],
             },

--- a/vllm/spec_decode/mqa_scorer.py
+++ b/vllm/spec_decode/mqa_scorer.py
@@ -54,6 +54,7 @@ class MQAScorer(SpeculativeScorer):
                 is_prompt=seq_group_metadata.is_prompt,
                 seq_data=new_seq_data_dict,
                 sampling_params=seq_group_metadata.sampling_params,
+                logits_processors=seq_group_metadata.logits_processors,
                 block_tables={
                     target_seq_id: seq_group_metadata.block_tables[seq_id],
                 },


### PR DESCRIPTION
Allowing for a single warmup request to pre-build the base GrammarCompiler, we are now very close on TTFT

Non-guided baseline:
```
python benchmark_guided.py --model meta-llama/Llama-3.1-8B-Instruct --dataset xgrammar_bench --async-engine --output-len 512 --num-prompts 20 --enable-chunked-prefill --guided-decoding-ratio 0
Throughput: 4.32 requests/s, 3517.24 total tokens/s, 2212.46 output tokens/s Correct rate is 0.0 % 
First token latency(msecs):
count     20.000000
mean     204.032341
std       39.066801
min      157.981163
25%      158.030014
50%      208.593769
75%      252.300794
max      252.433462
dtype: float64
Next token latency(msecs):
count    20.000000
mean      8.639268
std       0.062102
min       8.562491
25%       8.562785
50%       8.631658
75%       8.712362
max       8.713751
dtype: float64
```

XGrammar:
```
python benchmark_guided.py --model meta-llama/Llama-3.1-8B-Instruct --dataset xgrammar_bench --async-engine --output-len 512 --num-prompts 20 --enable-chunked-prefill --guided-decoding-ratio 1
Throughput: 3.06 requests/s, 2489.39 total tokens/s, 1565.90 output tokens/s Correct rate is 95.0 % 
First token latency(msecs):
count     20.000000
mean     311.953656
std       50.462834
min      245.234521
25%      245.279388
50%      342.209829
75%      354.407698
max      354.529298
dtype: float64
Next token latency(msecs):
count    20.000000
mean     12.163825
std       0.083723
min      12.102339
25%      12.102611
50%      12.105587
75%      12.275507
max      12.275782
dtype: float64
```