### PR TITLE
[Bugfix][Frontend] correctly record prefill and decode time metrics 

### DIFF
--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -599,9 +599,9 @@ class PrometheusStatLogger(StatLoggerBase):
                             stats.time_queue_requests)
         self._log_histogram(self.metrics.histogram_inference_time_request,
                             stats.time_inference_requests)
-        self._log_histogram(self.metrics.histogram_decode_time_request,
-                            stats.time_prefill_requests)
         self._log_histogram(self.metrics.histogram_prefill_time_request,
+                            stats.time_prefill_requests)
+        self._log_histogram(self.metrics.histogram_decode_time_request,
                             stats.time_decode_requests)
         self._log_histogram(self.metrics.histogram_time_in_queue_request,
                             stats.time_in_queue_requests)


### PR DESCRIPTION
This PR fixes a small bug where `vllm:request_prefill_time_seconds` metric recorded the decode time and `vllm:request_decode_time_seconds` recorded the prefill time