### PR TITLE
[bugfix] fixed parameter “n” not work when set parameter “bestof” > 1

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -293,8 +293,9 @@ class SamplingParams(
                 raise ValueError(
                     f"best_of must be greater than or equal to n, "
                     f"got n={self.n} and best_of={self.best_of}.")
-            self._real_n = self.n
-            self.n = self.best_of
+            if not self._real_n:
+                self._real_n = self.n
+                self.n = self.best_of
 
         if 0 < self.temperature < _MAX_TEMP:
             logger.warning(


### PR DESCRIPTION
[bugfix] fixed parameter “n” not work when set parameter “bestof” > 1

this PR fixed parameter “n” not work when set parameter “bestof” > 1. the key reason is that the class SamplingParams‘s clone() function will result in  SamplingParams‘s __post_init__() function invoked again.
