### PR TITLE
[Core] Do async init of xgrammar in the engine

### DIFF
--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -3,10 +3,9 @@ import signal
 from contextlib import contextmanager
 from typing import Iterator, List, Optional, Union
 
-import cloudpickle
 import zmq
 
-from vllm import AsyncEngineArgs, SamplingParams
+from vllm import AsyncEngineArgs
 from vllm.engine.llm_engine import LLMEngine
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -221,11 +220,6 @@ class MQLLMEngine:
                 request = pickle.loads(frames[0].buffer)
 
                 if isinstance(request, RPCProcessRequest):
-                    if len(frames) > 1:
-                        # Use cloudpickle for logits processors
-                        assert isinstance(request.params, SamplingParams)
-                        lprocs = cloudpickle.loads(frames[1].buffer)
-                        request.params.logits_processors = lprocs
                     self._handle_process_request(request)
                 elif isinstance(request, RPCAbortRequest):
                     self._handle_abort_request(request)


### PR DESCRIPTION
This PR does two key things:

1. Remove logit processor initialization from the client side and move it back
   to its original spot within the engine. This allows us to avoid having to
   serialize the logits processors and send them over zmq to the worker.

2. Perform the xgrammar initialization asynchronously in a thread. XGrammar
   releases the Python GIL during this process, so the worker will continue in
   parallel. This allows the first forward pass to proceed while initialization
   occurs.

This is a draft until PR #10576 is complee, updating outlines to a new version
that is much more performant. Otherwise, performance with outlines will be
unacceptable with these changes.

Here are some test results on a system with NVIDIA L4 GPUs from before and after
these changes.

```
$ python benchmarks/benchmark_guided.py --model meta-llama/Llama-3.2-1B-Instruct --dataset xgrammar_bench --async-engine --output-len 512 --num-prompts 20 --enable-chunked-prefill --guided-decoding-ratio 1


main @ 2f2cdc745a7a569637c58cfd5f6789c1d0741c84

Throughput: 1.70 requests/s, 1384.55 total tokens/s, 870.93 output tokens/s Correct rate is 95.0 % First token latency: 2069.74 msecs Next token latency: 18.92 msecs

Throughput: 1.70 requests/s, 1383.59 total tokens/s, 870.32 output tokens/s Correct rate is 95.0 % First token latency: 2048.76 msecs Next token latency: 18.98 msecs

Throughput: 1.70 requests/s, 1384.31 total tokens/s, 870.78 output tokens/s Correct rate is 95.0 % First token latency: 2037.78 msecs Next token latency: 18.99 msecs


xgrammar-init-in-engine-rebase branch

Throughput: 1.88 requests/s, 1528.67 total tokens/s, 961.58 output tokens/s Correct rate is 95.0 % First token latency: 1001.18 msecs Next token latency: 18.85 msecs

Throughput: 1.87 requests/s, 1523.59 total tokens/s, 958.39 output tokens/s Correct rate is 95.0 % First token latency: 1065.43 msecs Next token latency: 18.79 msecs

Throughput: 1.89 requests/s, 1536.15 total tokens/s, 966.29 output tokens/s Correct rate is 95.0 % First token latency: 1013.37 msecs Next token latency: 18.72 msecs
```

0d07f6832 MQ engine: remove guided decoding init from the client
aba968856 xgrammar: run grammar compilation async

commit 0d07f68322d7d6647d52d3623ed84bccb1551755
Author: Mark McLoughlin <markmc@redhat.com>
Date:   Mon Nov 25 13:59:04 2024 -0500

    MQ engine: remove guided decoding init from the client
    
    Currently with MQLLMEngine, we are initializing LogitsProcessors
    on the client side, pickling the entire list of LogitsProcessors,
    and sending them over ZeroMQ to the engine.
    
    This was put in place so that the expensive initialization (tens
    of second) of the Outlines LogitsProcessor could happen in a thread,
    such that the client could defer submitting the request to the engine
    until the initialization had completed.
    
    This became an issue because recent (Rust-based) Outlines does not
    support pickle serialization, but this has resolved by
    dottxt-ai/outlines-core#99.
    
    However, this approach is also not desirable in the case of
    XGrammar because the initialization is not expensive (hundreds of
    milliseconds) and the serialization is just unnecessary complexity.
    
    And so, let's remove the code from the client side of MQLLMEngine
    to special case the creation of logits_processors based on guided
    decoding params. This will now happen on the engine side once
    again.
    
    Signed-off-by: Mark McLoughlin <markmc@redhat.com>

commit aba968856d55cdd4a97b41fe2146fd866ffb66c2
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Dec 2 17:58:16 2024 +0000

    xgrammar: run grammar compilation async
    
    This runs xgrammar compilation async in a way that's not very
    invasive. Compilation will get kicked off when the logit processor is
    first created, but blocking on its completion will not occur until
    later, the first time it's needed.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
