### PR TITLE
[Doc] Add contributor docs on installing vllm_test_utils

### DIFF
--- a/docs/source/contributing/overview.rst
+++ b/docs/source/contributing/overview.rst
@@ -34,6 +34,7 @@ Testing
     # Static type checking
     mypy
     # Unit tests
+    pip install -e tests/vllm_test_utils
     pytest tests/
 
 .. note:: Currently, the repository does not pass the ``mypy`` tests.


### PR DESCRIPTION
Since #10659 (commit 334d64d1), you need to install the `vllm_test_utils` package before running the unit tests.
