### PR TITLE
[Bugfix] Check prompt length < max_model_len for all models in AsyncLLMEngine

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2011,21 +2011,20 @@ class LLMEngine:
         if prompt_ids is None or len(prompt_ids) == 0:
             raise ValueError("Prompt cannot be empty")
 
-        if self.model_config.is_multimodal_model:
-            max_prompt_len = self.model_config.max_model_len
+        max_prompt_len = self.model_config.max_model_len
 
-            if len(prompt_ids) > max_prompt_len:
-                raise ValueError(
-                    f"The prompt (total length {len(prompt_ids)}) is too long "
-                    f"to fit into the model (context length {max_prompt_len}). "
-                    "Make sure that `max_model_len` is no smaller than the "
-                    "number of text tokens plus multimodal tokens. For image "
-                    "inputs, the number of image tokens depends on the number "
-                    "of images, and possibly their aspect ratios as well.")
+        if len(prompt_ids) > max_prompt_len:
+            raise ValueError(
+                f"The prompt (total length {len(prompt_ids)}) is too long "
+                f"to fit into the model (context length {max_prompt_len}). "
+                "Make sure that `max_model_len` is no smaller than the "
+                "number of text tokens plus multimodal tokens. For image "
+                "inputs, the number of image tokens depends on the number "
+                "of images, and possibly their aspect ratios as well.")
 
-            # TODO: Find out how many placeholder tokens are there so we can
-            # check that chunked prefill does not truncate them
-            # max_batch_len = self.scheduler_config.max_num_batched_tokens
+        # TODO: For multi-modal models, find out how many placeholder tokens
+        # there are to check that chunked prefill does not truncate them
+        # max_batch_len = self.scheduler_config.max_num_batched_tokens
 
     def _build_logits_processors(
             self, sampling_params: SamplingParams,


### PR DESCRIPTION
Currently, for text-only models, if submitting a request > max_model_len through the AsyncLLMEngine, will trigger an assert failure:

```
  File "vllm/core/scheduler.py", line 1176, in _schedule                
    return self._schedule_chunked_prefill()                                                    
  File "vllm/core/scheduler.py", line 1112, in _schedule_chunked_prefill
    running_scheduled = self._schedule_running(budget,                                         
  File "vllm/core/scheduler.py", line 541, in _schedule_running         
    assert len(self._async_stopped) == 0                                                       
AssertionError     
```

There is already a prompt length check for multi-modal models in AsyncLLMEngine so we just expand that to all models.
