### PR TITLE
[Misc][Gaudi] Avoid torch.compile and enable lazy collectives by default for HPU lazy backend

### DIFF
--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -29,6 +29,20 @@ def load_general_plugins():
     if current_platform.is_xpu():
         # see https://github.com/pytorch/pytorch/blob/8cada5cbe5450e17c26fb8b358116785324537b2/torch/_dynamo/config.py#L158  # noqa
         os.environ['TORCH_COMPILE_DISABLE'] = 'True'
+    if current_platform.is_hpu():
+        # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1) 
+        # does not support torch.compile
+        # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
+        # torch.compile support
+        is_lazy = os.environ.get('PT_HPU_LAZY_MODE', '1') == '1'
+        if is_lazy:
+            # see https://github.com/pytorch/pytorch/blob/43c5f59/torch/_dynamo/config.py#L158
+            torch._dynamo.config.disable = True
+            # NOTE(kzawora) mutli-HPU inference with HPUGraphs (lazy-only) 
+            # requires enabling lazy collectives
+            # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html # noqa: E501
+            os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
+
     global plugins_loaded
     if plugins_loaded:
         return

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -30,7 +30,7 @@ def load_general_plugins():
         # see https://github.com/pytorch/pytorch/blob/8cada5cbe5450e17c26fb8b358116785324537b2/torch/_dynamo/config.py#L158  # noqa
         os.environ['TORCH_COMPILE_DISABLE'] = 'True'
     if current_platform.is_hpu():
-        # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1) 
+        # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
         # does not support torch.compile
         # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
         # torch.compile support
@@ -38,7 +38,7 @@ def load_general_plugins():
         if is_lazy:
             # see https://github.com/pytorch/pytorch/blob/43c5f59/torch/_dynamo/config.py#L158
             torch._dynamo.config.disable = True
-            # NOTE(kzawora) mutli-HPU inference with HPUGraphs (lazy-only) 
+            # NOTE(kzawora) multi-HPU inference with HPUGraphs (lazy-only)
             # requires enabling lazy collectives
             # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html # noqa: E501
             os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'


### PR DESCRIPTION
Similar to #10747, but applied specifically to PT HPU lazy backend. While PyTorch for Gaudi has torch.compile support, it currently needs to be enabled explicitly, and best performance is achieved with HPUGraphs instead. This patch disables torch.compile for PT lazy mode and HPUGraphs (HPU execution modes for reference: https://docs.vllm.ai/en/latest/getting_started/gaudi-installation.html#execution-modes), and leaves it on for PT eager/torch.compile mode. Additionaly, it automatically sets the flag for enabling lazy collectives required in multi-HPU inference with HPUGraphs, fixing frequently reported `RuntimeError: collective nonSFG is not supported during hpu graph capturing` error.