### PR TITLE
[Misc] Update llama 3.2 template to support system prompt with images

### DIFF
--- a/examples/tool_chat_template_llama3.2_json.jinja
+++ b/examples/tool_chat_template_llama3.2_json.jinja
@@ -26,13 +26,11 @@
     {%- endfor %}
 {%- endfor %}
 
-
 {#- This block extracts the system message, so we can slot it into the right place. #}
 {%- if messages[0]['role'] == 'system' %}
     {%- if messages[0]['content'] is string %}
         {%- set system_message = messages[0]['content']|trim %}
     {%- else %}
-        {#- Support vLLM's transforming of a content string to JSON. #}
         {%- set system_message = messages[0]['content'][0]['text']|trim %}
     {%- endif %}
     {%- set messages = messages[1:] %}
@@ -44,14 +42,8 @@
     {%- endif %}
 {%- endif %}
 
-{#- Including an image is not compatible with a system message #}
-{%- if image_ns.has_images and not system_message == "" %}
-    {{- raise_exception("Prompting with images is incompatible with system messages and tool use.") }}
-{%- endif %}
-
-
-{#- System message, if there are no images #}
-{%- if not image_ns.has_images %}
+{#- System message if there are no images, if the user supplied one, or if tools are used (default tool system message) #}
+{%- if system_message or not image_ns.has_images %}
     {{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
     {%- if tools is not none %}
         {{- "Environment: ipython\n" }}


### PR DESCRIPTION
Update the example chat template to support using a system prompt with images:
- remove the exception raised if sending a system message and images
- when prompting with an image, render the system message if the user supplied a prompt or if tools are requested

The coresponding change was recently made to the chat template in HF Hub:
https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct/discussions/84
