### PR TITLE
[V1][WIP] V1 supports LogitsProcessors

### DIFF
--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -76,7 +76,7 @@ class LogitsProcessor(nn.Module):
                 logits *= self.scale
 
             # Apply logits processors (if any).
-            if sampling_metadata is not None:
+            if is_v0_sampling_or_no_metadata and sampling_metadata is not None:
                 logits = _apply_logits_processors(logits, sampling_metadata)
 
         return logits

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -51,10 +51,16 @@ class LogitsProcessor(nn.Module):
         sampling_metadata: Optional[SamplingMetadata] = None,
         embedding_bias: Optional[torch.Tensor] = None,
     ) -> Optional[torch.Tensor]:
+
+        # TODO: better way to branch logits processor behavior based on
+        # v1 vs v0 (possibly by having a v1 LogitsProcessor class)
+        is_v0_sampling_or_no_metadata = (sampling_metadata is None or hasattr(
+            sampling_metadata, "selected_token_indices"))
+
         if self.logits_as_input:
             logits = hidden_states
         else:
-            if sampling_metadata is not None:
+            if is_v0_sampling_or_no_metadata and sampling_metadata is not None:
                 hidden_states = _prune_hidden_states(hidden_states,
                                                      sampling_metadata)
 


### PR DESCRIPTION
Add v1 logits processor support (towards enabling v1 guided decoding)

* v1 model runner passes `sampling_metadata` to `model.compute_logits()`
* v0 `LogitsProcessor` layer gracefully handles v1 `SamplingMetadata` when no logits processors are configured (TODO: generally speaking we have not been upgrading v0 layers to v1, but instead have been reusing them. So we should decide whether the v0 `LogitsProcessor` should support both v0 and v1 engines (i.e. the approach which would be most consistent with what we have been doing), or whether to create a v1 `LogitsProcessor`)
* [WIP] v1 supports logits processors

