### PR TITLE
[torch.compile] use size tuning for specific sizes

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -43,6 +43,12 @@ def wrap_inductor(graph,
     if additional_inductor_config is not None:
         current_config.update(additional_inductor_config)
 
+    if isinstance(runtime_shape, int):
+        # for a specific batchsize, tuning triton kernel parameters
+        # can be beneficial
+        current_config["max_autotune"] = True
+        current_config["coordinate_descent_tuning"] = True
+
     # inductor can inplace modify the graph, so we need to copy it
     # see https://github.com/pytorch/pytorch/issues/138980
     graph = copy.deepcopy(graph)


### PR DESCRIPTION
main branch:

```bash
$ python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1
Avg latency: 0.9704469823899369 seconds
10% percentile latency: 0.9701304599875584 seconds
25% percentile latency: 0.9702223120839335 seconds
50% percentile latency: 0.9703492529224604 seconds
75% percentile latency: 0.9705225366051309 seconds
90% percentile latency: 0.9707827469334006 seconds
99% percentile latency: 0.9715801884280517 seconds

$ python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 -O3
Avg latency: 0.9466459681823228 seconds
10% percentile latency: 0.9461254232097417 seconds
25% percentile latency: 0.9463142852764577 seconds
50% percentile latency: 0.9464886240893975 seconds
75% percentile latency: 0.9469943257863633 seconds
90% percentile latency: 0.9471873179078102 seconds
99% percentile latency: 0.9478284788667224 seconds

$ python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 -O '{"level": 3, "inductor_specialize_for_cudagraph_no_more_than": 1}'
Avg latency: 0.9388166528427974 seconds
10% percentile latency: 0.93808699301444 seconds
25% percentile latency: 0.9382225638837554 seconds
50% percentile latency: 0.9386444678530097 seconds
75% percentile latency: 0.9394201532122679 seconds
90% percentile latency: 0.9397746301721781 seconds
99% percentile latency: 0.9401532886968925 seconds
```

this pr:

```bash
$ python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 -O '{"level": 3, "inductor_specialize_for_cudagraph_no_more_than": 1}'
Avg latency: 0.8950413154981409 seconds
10% percentile latency: 0.8946002442156896 seconds
25% percentile latency: 0.8946926544886082 seconds
50% percentile latency: 0.8951514901127666 seconds
75% percentile latency: 0.8952897649724036 seconds
90% percentile latency: 0.895453859725967 seconds
99% percentile latency: 0.8957872873102315 seconds
```

this pr significantly improves the latency when we compile for specific sizes.