### PR TITLE
fix block-size description

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -415,7 +415,7 @@ class EngineArgs:
         parser.add_argument('--block-size',
                             type=int,
                             default=EngineArgs.block_size,
-                            choices=[8, 16, 32, 64, 128],
+                            choices=[8, 16, 32],
                             help='Token block size for contiguous chunks of '
                             'tokens. This is ignored on neuron devices and '
                             'set to max-model-len')


### PR DESCRIPTION
Per vllm official doc in https://docs.vllm.ai/en/stable/models/engine_args.html, the parameter of --block-size can take the value of {8,16,32,64,128}. However, I hit error "RuntimeError: Unsupported block size: 128" when I tried out "--block-size 128"

I hunted the code and saw the following logic in csrc/attention/paged_attention_v2.cu:
```
#define CALL_V2_LAUNCHER_BLOCK_SIZE(T, CACHE_T, KV_DTYPE)         \
  switch (block_size) {                                           \
    case 8:                                                       \
      CALL_V2_LAUNCHER_SPARSITY(T, CACHE_T, 8, KV_DTYPE);         \
      break;                                                      \
    case 16:                                                      \
      CALL_V2_LAUNCHER_SPARSITY(T, CACHE_T, 16, KV_DTYPE);        \
      break;                                                      \
    case 32:                                                      \
      CALL_V2_LAUNCHER_SPARSITY(T, CACHE_T, 32, KV_DTYPE);        \
      break;                                                      \
    default:                                                      \
      TORCH_CHECK(false, "Unsupported block size: ", block_size); \
      break;                                                      \
  }
```

Similar logic is also seen in csrc/attention/paged_attention_v1.cu.

Updated the parameter allowed value per the real logic. 