### PR TITLE
[torch.compile] fix deprecated code

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -37,7 +37,7 @@ def wrap_inductor(graph,
             logger.info("Compiling a graph for shape %s", runtime_shape)
 
     from torch._inductor import config
-    current_config = config.shallow_copy_dict()
+    current_config = config.get_config_copy()
     from torch._inductor.compile_fx import compile_fx
 
     if additional_inductor_config is not None:


### PR DESCRIPTION
see https://github.com/pytorch/pytorch/blob/8fc6d3a5d85abaaed842bf79113bfae9b8a3a576/torch/utils/_config_module.py#L401-L408 , `shallow_copy_dict()` will be deprecated in future pytorch versions.