### PR TITLE
[Core] Cleanup startup logging a bit

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -433,6 +433,7 @@ class EngineArgs:
                             'capping to sliding window size')
         parser.add_argument('--use-v2-block-manager',
                             action='store_true',
+                            default=True,
                             help='[DEPRECATED] block manager v1 has been '
                             'removed and SelfAttnBlockSpaceManager (i.e. '
                             'block manager v2) is now the default. '

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -249,8 +249,8 @@ def mount_metrics(app: FastAPI):
 
     prometheus_multiproc_dir_path = os.getenv("PROMETHEUS_MULTIPROC_DIR", None)
     if prometheus_multiproc_dir_path is not None:
-        logger.info("vLLM to use %s as PROMETHEUS_MULTIPROC_DIR",
-                    prometheus_multiproc_dir_path)
+        logger.debug("vLLM to use %s as PROMETHEUS_MULTIPROC_DIR",
+                     prometheus_multiproc_dir_path)
         registry = CollectorRegistry()
         multiprocess.MultiProcessCollector(registry)
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -175,8 +175,8 @@ async def build_async_engine_client_from_engine_args(
 
         # Select random path for IPC.
         ipc_path = get_open_zmq_ipc_path()
-        logger.info("Multiprocessing frontend to use %s for IPC Path.",
-                    ipc_path)
+        logger.debug("Multiprocessing frontend to use %s for IPC Path.",
+                     ipc_path)
 
         # Start RPCServer in separate process (holds the LLMEngine).
         # the current process might have CUDA context,

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -57,7 +57,7 @@ def load_general_plugins():
 
     discovered_plugins = entry_points(group='vllm.general_plugins')
     if len(discovered_plugins) == 0:
-        logger.info("No plugins found.")
+        logger.debug("No plugins found.")
         return
     logger.info("Available plugins:")
     for plugin in discovered_plugins:


### PR DESCRIPTION
The main message I wanted to remove was the deprecation message that implied
that use-v2-block-manager had been explicitly set to False when it hadn't been
specified at all. I dropped a few other messages while I was at it that don't
seem very interesting in the general case.


b002bf2ef Drop no-plugins log message to debug
f73950133 Move multiproc ipc message to debug
d7b4c2812 Don't show v2 block manager deprecation by default
6d6f38495 Move a prometheus related log message to debug

commit b002bf2ef1d59649263f32813083dab6d4452083
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Dec 6 19:37:27 2024 +0000

    Drop no-plugins log message to debug
    
    In the common case of having no plugins, vllm emits this message
    multiple times during startup:
    
        INFO 12-06 19:35:36 __init__.py:60] No plugins found.
    
    Change this to DEBUG, instead.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit f7395013366ff8bf72753aa3ebcc587beaaca4a0
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Dec 6 19:39:26 2024 +0000

    Move multiproc ipc message to debug
    
    At startup, this message is emitted:
    
        INFO 12-06 19:35:36 api_server.py:178] Multiprocessing frontend to
            use ipc:///tmp/4b737fec-e81d-430d-b0aa-d65b3bf27fa7 for IPC Path.
    
    This seems like an implementation detail that isn't particularly
    interesting unless you're debugging something very specific. Drop it
    to DEBUG instead.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d7b4c2812cbbcebf95945db61ce2978bf31c521b
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Dec 6 19:47:01 2024 +0000

    Don't show v2 block manager deprecation by default
    
    At startup, I was getting this message multiple times, despite not
    specifying this option anywhere. The reason is that the option
    defaulted to `False` when not specified with `vllm serve`. Default to
    `True` so that the deprecation message only occurs when someone
    explicitly sets it to `False`.
    
        WARNING 12-06 19:35:42 arg_utils.py:1133] [DEPRECATED] Block
            manager v1 has been removed, and setting
            --use-v2-block-manager to True or False has no effect on vLLM
            behavior. Please remove --use-v2-block-manager in your engine
            argument. If your use case is not supported by
            SelfAttnBlockSpaceManager (i.e. block manager v2), please file
            an issue with detailed information.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 6d6f38495fec19271e0de129d0e877d243ff27f2
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Dec 6 19:52:29 2024 +0000

    Move a prometheus related log message to debug
    
    At startup, I noticed this message.
    
        INFO 12-06 19:45:45 api_server.py:252] vLLM to use
          /tmp/tmpllec8im4 as PROMETHEUS_MULTIPROC_DIR
    
    This seems like an implementation detail of vLLM just doing the right
    thing. It doesn't seem interesting or relevant, except when debugging
    something very specific with prometheus integration.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
