### PR TITLE
[Core] Add support for loading weight that has already done TP sharding

### DIFF
--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -307,9 +307,14 @@ class ScaledActivation(nn.Module):
         param_data = param.data
         if self.input_is_parallel:
             tp_rank = get_tensor_model_parallel_rank()
+            tp_size = get_tensor_model_parallel_world_size()
             shard_size = param_data.shape[0]
             start_idx = tp_rank * shard_size
-            loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
+            if shard_size * tp_size == loaded_weight.shape[0]:
+                loaded_weight = loaded_weight.narrow(0, start_idx, shard_size)
+            else:
+                # Assume sharding has been done on the weight.
+                assert shard_size == loaded_weight.shape[0]
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -334,6 +334,7 @@ class ColumnParallelLinear(LinearBase):
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
         tp_rank = get_tensor_model_parallel_rank()
+        tp_size = get_tensor_model_parallel_world_size()
         output_dim = getattr(param, "output_dim", None)
 
         is_sharded_weight = getattr(param, "is_sharded_weight", False)
@@ -361,8 +362,12 @@ class ColumnParallelLinear(LinearBase):
         if output_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[output_dim]
             start_idx = tp_rank * shard_size
-            loaded_weight = loaded_weight.narrow(output_dim, start_idx,
-                                                 shard_size)
+            if shard_size * tp_size == loaded_weight.shape[output_dim]:
+                loaded_weight = loaded_weight.narrow(output_dim, start_idx,
+                                                     shard_size)
+            else:
+                # Assume sharding has been done on the weight.
+                assert shard_size == loaded_weight.shape[output_dim]
 
         # Special case for loading scales off disk, which often do not
         # have a shape (such as in the case of AutoFP8).
@@ -466,9 +471,8 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                     for i, _ in enumerate(self.output_sizes)
                 }
             return
-
+        tp_size = get_tensor_model_parallel_world_size()
         if is_gguf_weight:
-            tp_size = get_tensor_model_parallel_world_size()
             tp_rank = get_tensor_model_parallel_rank()
 
             output_dim = getattr(param, "output_dim", None)
@@ -511,6 +515,14 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                 shard_offsets.append((i, current_shard_offset, output_size))
                 current_shard_offset += output_size
             packed_dim = getattr(param, "packed_dim", None)
+            if (loaded_weight.shape[output_dim] *
+                    tp_size == current_shard_offset):
+                # The loaded weight has already been tp-sharded,
+                # divide the shard_offset and shard_size with tp_size
+                shard_offsets = [
+                    (shard_id, shard_offset // tp_size, shard_size // tp_size)
+                    for shard_id, shard_offset, shard_size in shard_offsets
+                ]
             for shard_id, shard_offset, shard_size in shard_offsets:
                 # Special case for Quantization.
                 # If quantized, we need to adjust the offset and size to account
@@ -570,8 +582,12 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
                                            shard_size)
             start_idx = tp_rank * shard_size
             if not is_sharded_weight:
-                loaded_weight = loaded_weight.narrow(output_dim, start_idx,
-                                                     shard_size)
+                if shard_size * tp_size == loaded_weight.shape[output_dim]:
+                    loaded_weight = loaded_weight.narrow(
+                        output_dim, start_idx, shard_size)
+                else:
+                    # Assume sharding has been done on the weight.
+                    assert shard_size == loaded_weight.shape[output_dim]
         # Special case for AQLM codebooks.
         elif is_metadata:
             # metadata indicates fixed size concatenated along dim 0
@@ -842,8 +858,8 @@ class QKVParallelLinear(ColumnParallelLinear):
                 }
             return
 
+        tp_size = get_tensor_model_parallel_world_size()
         if is_gguf_weight:
-            tp_size = get_tensor_model_parallel_world_size()
             tp_rank = get_tensor_model_parallel_rank()
 
             output_dim = getattr(param, "output_dim", None)
@@ -891,6 +907,15 @@ class QKVParallelLinear(ColumnParallelLinear):
                                             False)
 
             packed_dim = getattr(param, "packed_dim", None)
+            if (loaded_weight.shape[output_dim] *
+                    tp_size == (self.total_num_heads +
+                                2 * self.total_num_kv_heads) * self.head_size):
+                # The loaded weight has already been tp-sharded,
+                # divide the shard_offset and shard_size with tp_size
+                shard_offsets = [
+                    (shard_id, shard_offset // tp_size, shard_size // tp_size)
+                    for shard_id, shard_offset, shard_size in shard_offsets
+                ]
             for shard_id, shard_offset, shard_size in shard_offsets:
                 # Special case for Quantized Weights.
                 # If quantized, we need to adjust the offset and size to account
@@ -983,8 +1008,12 @@ class QKVParallelLinear(ColumnParallelLinear):
             start_idx = shard_id * shard_size
 
             if not is_sharded_weight:
-                loaded_weight = loaded_weight.narrow(output_dim, start_idx,
-                                                     shard_size)
+                if shard_size * tp_size == loaded_weight.shape[output_dim]:
+                    loaded_weight = loaded_weight.narrow(
+                        output_dim, start_idx, shard_size)
+                else:
+                    # Assume sharding has been done on the weight.
+                    assert shard_size == loaded_weight.shape[output_dim]
 
         # Special case for for AQLM codebooks.
         elif is_metadata:
@@ -1109,9 +1138,13 @@ class RowParallelLinear(LinearBase):
         param_data = param.data
         if input_dim is not None and not is_sharded_weight:
             shard_size = param_data.shape[input_dim]
-            start_idx = tp_rank * shard_size
-            loaded_weight = loaded_weight.narrow(input_dim, start_idx,
-                                                 shard_size)
+            if shard_size * tp_size == loaded_weight.shape[input_dim]:
+                start_idx = tp_rank * shard_size
+                loaded_weight = loaded_weight.narrow(input_dim, start_idx,
+                                                     shard_size)
+            else:
+                # Assume sharding has been done on the weight.
+                assert shard_size == loaded_weight.shape[input_dim]
 
         # Special case for loading scales off disk, which often do not
         # have a shape (such as in the case of AutoFP8).

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -371,20 +371,24 @@ class VocabParallelEmbedding(torch.nn.Module):
         start_idx = self.shard_indices.org_vocab_start_index
         shard_size = self.shard_indices.org_vocab_end_index - start_idx
 
+        size_to_check = self.org_vocab_size
+
         # If param packed on the same dim we are sharding on, then
         # need to adjust offsets of loaded weight by pack_factor.
         if packed_dim is not None and packed_dim == output_dim:
             packed_factor = param.packed_factor if isinstance(
                 param, BasevLLMParameter) else param.pack_factor
-            assert loaded_weight.shape[output_dim] == (self.org_vocab_size //
-                                                       param.packed_factor)
+            size_to_check = self.org_vocab_size // param.packed_factor
             start_idx = start_idx // packed_factor
             shard_size = shard_size // packed_factor
-        else:
-            assert loaded_weight.shape[output_dim] == self.org_vocab_size
 
-        # Copy the data. Select chunk corresponding to current shard.
-        loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
+        if loaded_weight.shape[output_dim] == size_to_check:
+            # Copy the data.
+            loaded_weight = loaded_weight.narrow(output_dim, start_idx,
+                                                 shard_size)
+        else:
+            # Assume sharding has been done on the weight.
+            assert loaded_weight.shape[output_dim] == shard_size
 
         if current_platform.is_hpu():
             # FIXME(kzawora): Weight copy with slicing bugs out on Gaudi here,


### PR DESCRIPTION
This PR will be very useful, if we want to sync weights between different vLLM instances with tensor parallel enabled, so that we don't need to all-gather the parameters before-hand, but instead:

1. Collect the model weight from an available vllm.worker.worker.Worker, via iterating through self.model_runner.model.named_parameters().
2. Send the weight to the workers that are with the same tp rank as the source, then we can load the weight directly via
`self.model_runner.model.load_weights()`.

Tested the PR with llama models with maximum tp size = 4.
