### PR TITLE
[Doc] Explicitly state that PP isn't compatible with speculative decoding yet

### DIFF
--- a/docs/source/usage/spec_decode.rst
+++ b/docs/source/usage/spec_decode.rst
@@ -8,6 +8,9 @@ Speculative decoding
     not usually yield inter-token latency reductions for all prompt datasets or sampling parameters. The work
     to optimize it is ongoing and can be followed in `this issue. <https://github.com/vllm-project/vllm/issues/4630>`_
 
+.. warning::
+    Currently, speculative decoding in vLLM is not compatible with pipeline parallelism.
+
 This document shows how to use `Speculative Decoding <https://x.com/karpathy/status/1697318534555336961>`_ with vLLM.
 Speculative decoding is a technique which improves inter-token latency in memory-bound LLM inference.
 

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -26,9 +26,6 @@ class ParallelSetup(NamedTuple):
     pp_size: int
     eager_mode: bool
     chunked_prefill: bool
-    speculative_model: Optional[str] = None
-    num_speculative_tokens: Optional[int] = None
-    ngram_prompt_lookup_max: Optional[int] = None
 
 
 class PPTestOptions(NamedTuple):
@@ -80,13 +77,6 @@ class PPTestSettings:
                               pp_size=pp_base,
                               eager_mode=True,
                               chunked_prefill=False),
-                ParallelSetup(tp_size=tp_base,
-                              pp_size=pp_base,
-                              eager_mode=False,
-                              chunked_prefill=False,
-                              speculative_model="[ngram]",
-                              num_speculative_tokens=5,
-                              ngram_prompt_lookup_max=3),
             ],
             distributed_backends=["mp", "ray"],
             task=task,
@@ -262,9 +252,6 @@ def _compare_tp(
         pp_size,
         eager_mode,
         chunked_prefill,
-        speculative_model,
-        num_speculative_tokens,
-        ngram_prompt_lookup_max,
     ) = parallel_setup
     (
         multi_node_only,
@@ -305,16 +292,6 @@ def _compare_tp(
         common_args.extend(["--load-format", load_format])
     if hf_overrides:
         common_args.extend(["--hf-overrides", hf_overrides])
-    if speculative_model:
-        common_args.extend(["--speculative-model", speculative_model])
-    if num_speculative_tokens:
-        common_args.extend(
-            ["--num-speculative-tokens",
-             str(num_speculative_tokens)])
-    if ngram_prompt_lookup_max:
-        common_args.extend(
-            ["--ngram-prompt-lookup-max",
-             str(ngram_prompt_lookup_max)])
 
     if (distributed_backend == "ray" and tp_size == 2 and pp_size == 2
             and chunked_prefill):

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -28,6 +28,7 @@ class ParallelSetup(NamedTuple):
     chunked_prefill: bool
     speculative_model: Optional[str] = None
     num_speculative_tokens: Optional[int] = None
+    ngram_prompt_lookup_max: Optional[int] = None
 
 
 class PPTestOptions(NamedTuple):
@@ -84,7 +85,8 @@ class PPTestSettings:
                               eager_mode=False,
                               chunked_prefill=False,
                               speculative_model="[ngram]",
-                              num_speculative_tokens=5),
+                              num_speculative_tokens=5,
+                              ngram_prompt_lookup_max=3),
             ],
             distributed_backends=["mp", "ray"],
             task=task,
@@ -262,6 +264,7 @@ def _compare_tp(
         chunked_prefill,
         speculative_model,
         num_speculative_tokens,
+        ngram_prompt_lookup_max,
     ) = parallel_setup
     (
         multi_node_only,
@@ -308,6 +311,10 @@ def _compare_tp(
         common_args.extend(
             ["--num-speculative-tokens",
              str(num_speculative_tokens)])
+    if ngram_prompt_lookup_max:
+        common_args.extend(
+            ["--ngram-prompt-lookup-max",
+             str(ngram_prompt_lookup_max)])
 
     if (distributed_backend == "ray" and tp_size == 2 and pp_size == 2
             and chunked_prefill):

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -83,7 +83,7 @@ class PPTestSettings:
                               pp_size=pp_base,
                               eager_mode=False,
                               chunked_prefill=False,
-                              speculative_model="ngram",
+                              speculative_model="[ngram]",
                               num_speculative_tokens=5),
             ],
             distributed_backends=["mp", "ray"],

--- a/vllm/model_executor/models/exaone.py
+++ b/vllm/model_executor/models/exaone.py
@@ -469,13 +469,13 @@ class ExaoneForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.transformer.wte.weight
 
-            logit_scale = getattr(config, "logit_scale", 1.0)
-            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                    config.vocab_size,
-                                                    logit_scale)
-            self.sampler = get_sampler()
         else:
             self.lm_head = PPMissingLayer()
+
+        logit_scale = getattr(config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.vocab_size, logit_scale)
+        self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (
             self.transformer.make_empty_intermediate_tensors)

--- a/vllm/model_executor/models/exaone.py
+++ b/vllm/model_executor/models/exaone.py
@@ -469,12 +469,13 @@ class ExaoneForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.transformer.wte.weight
 
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                    config.vocab_size,
+                                                    logit_scale)
         else:
             self.lm_head = PPMissingLayer()
 
-        logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
         self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/model_executor/models/granite.py
+++ b/vllm/model_executor/models/granite.py
@@ -399,16 +399,16 @@ class GraniteForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            if hasattr(config, "logits_scaling"):
+                logit_scale /= config.logits_scaling
+
+            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                    config.vocab_size,
+                                                    scale=logit_scale)
         else:
             self.lm_head = PPMissingLayer()
 
-            logit_scale = getattr(config, "logit_scale", 1.0)
-
-        if hasattr(config, "logits_scaling"):
-            logit_scale /= config.logits_scaling
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size,
-                                                scale=logit_scale)
         self.sampler = get_sampler()
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/granite.py
+++ b/vllm/model_executor/models/granite.py
@@ -399,16 +399,17 @@ class GraniteForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
-            logit_scale = getattr(config, "logit_scale", 1.0)
-
-            if hasattr(config, "logits_scaling"):
-                logit_scale /= config.logits_scaling
-            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                    config.vocab_size,
-                                                    scale=logit_scale)
-            self.sampler = get_sampler()
         else:
             self.lm_head = PPMissingLayer()
+
+            logit_scale = getattr(config, "logit_scale", 1.0)
+
+        if hasattr(config, "logits_scaling"):
+            logit_scale /= config.logits_scaling
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.vocab_size,
+                                                scale=logit_scale)
+        self.sampler = get_sampler()
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -535,14 +535,13 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head = self.lm_head.tie_weights(
                     self.model.embed_tokens)
-
-            logit_scale = getattr(config, "logit_scale", 1.0)
-            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                    config.vocab_size,
-                                                    logit_scale)
-            self.sampler = get_sampler()
         else:
             self.lm_head = PPMissingLayer()
+
+        logit_scale = getattr(config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.vocab_size, logit_scale)
+        self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -535,12 +535,14 @@ class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head = self.lm_head.tie_weights(
                     self.model.embed_tokens)
+
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                    config.vocab_size,
+                                                    logit_scale)
         else:
             self.lm_head = PPMissingLayer()
 
-        logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
         self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/model_executor/models/nemotron.py
+++ b/vllm/model_executor/models/nemotron.py
@@ -431,13 +431,14 @@ class NemotronForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
-            logit_scale = getattr(config, "logit_scale", 1.0)
-            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                    config.vocab_size,
-                                                    logit_scale)
-            self.sampler = get_sampler()
         else:
             self.lm_head = PPMissingLayer()
+
+        logit_scale = getattr(config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.vocab_size, logit_scale)
+        self.sampler = get_sampler()
+
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
 

--- a/vllm/model_executor/models/nemotron.py
+++ b/vllm/model_executor/models/nemotron.py
@@ -431,12 +431,13 @@ class NemotronForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                    config.vocab_size,
+                                                    logit_scale)
         else:
             self.lm_head = PPMissingLayer()
 
-        logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
         self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/model_executor/models/solar.py
+++ b/vllm/model_executor/models/solar.py
@@ -439,13 +439,13 @@ class SolarForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
-            logit_scale = getattr(config, "logit_scale", 1.0)
-            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                    config.vocab_size,
-                                                    logit_scale)
-            self.sampler = get_sampler()
         else:
             self.lm_head = PPMissingLayer()
+
+        logit_scale = getattr(config, "logit_scale", 1.0)
+        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                config.vocab_size, logit_scale)
+        self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)

--- a/vllm/model_executor/models/solar.py
+++ b/vllm/model_executor/models/solar.py
@@ -439,12 +439,13 @@ class SolarForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             if config.tie_word_embeddings:
                 self.lm_head.weight = self.model.embed_tokens.weight
 
+            logit_scale = getattr(config, "logit_scale", 1.0)
+            self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
+                                                    config.vocab_size,
+                                                    logit_scale)
         else:
             self.lm_head = PPMissingLayer()
 
-        logit_scale = getattr(config, "logit_scale", 1.0)
-        self.logits_processor = LogitsProcessor(self.unpadded_vocab_size,
-                                                config.vocab_size, logit_scale)
         self.sampler = get_sampler()
 
         self.make_empty_intermediate_tensors = (

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -54,6 +54,10 @@ def create_spec_worker(*args, **kwargs) -> "SpecDecodeWorker":
     speculative_config: SpeculativeConfig = vllm_config.speculative_config
     assert speculative_config is not None
 
+    if vllm_config.parallel_config.pipeline_parallel_size > 1:
+        raise NotImplementedError("Speculative decoding is currently "
+                                  "incompatible with pipeline parallelism")
+
     draft_worker_kwargs = kwargs.copy()
 
     kwargs["model_runner_cls"] = TargetModelRunner


### PR DESCRIPTION
PP isn't compatible with speculative decoding, so let's throw an error explicitly.

To make PP compatible with speculative decoding:
- Make `sampler` available in the model regardless of PP (done in this PR)
- Resolve https://buildkite.com/vllm/ci/builds/10343#0193a03c-9df2-4587-824a-93ddc33ef66b/198-3687