### PR TITLE
[v1] fix use compile sizes

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2533,6 +2533,7 @@ class VllmConfig:
             self.compilation_config.custom_ops = ["none"]
             self.compilation_config.use_cudagraph = True
             self.compilation_config.use_inductor = True
+            self.compilation_config.cudagraph_num_of_warmups = 1
             self.compilation_config.pass_config.enable_fusion = False
             self.compilation_config.pass_config.enable_reshape = False
             self.compilation_config.level = CompilationLevel.PIECEWISE

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -583,6 +583,9 @@ class GPUModelRunner:
         # can reuse the memory pool allocated for the large shapes.
         with graph_capture():
             for num_tokens in reversed(self.cudagraph_batch_sizes):
+                for _ in range(self.vllm_config.compilation_config.
+                               cudagraph_num_of_warmups):
+                    self._dummy_run(self.model, num_tokens, self.kv_caches)
                 self._dummy_run(self.model, num_tokens, self.kv_caches)
 
         end_time = time.perf_counter()


### PR DESCRIPTION
followup of https://github.com/vllm-project/vllm/pull/10933 

v1 needs to use warmup before capturing cudagraph, for autotuning.

the latency benchmark is similar to #10933 : 

```bash
$ VLLM_USE_V1=1 VLLM_ENABLE_V1_MULTIPROCESSING=1 python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1
Avg latency: 0.9447320922433088 seconds
10% percentile latency: 0.9443556445185095 seconds
25% percentile latency: 0.9445381900877692 seconds
50% percentile latency: 0.9446770950453356 seconds
75% percentile latency: 0.944886727957055 seconds
90% percentile latency: 0.9450768627692014 seconds
99% percentile latency: 0.9457558847730979 seconds

$ VLLM_USE_V1=1 VLLM_ENABLE_V1_MULTIPROCESSING=1 python benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 -O "{'level': 3, 'candidate_compile_sizes': [1]}"
Avg latency: 0.8917956192822506 seconds
10% percentile latency: 0.8910040674265474 seconds
25% percentile latency: 0.8911891020252369 seconds
50% percentile latency: 0.8916284444276243 seconds
75% percentile latency: 0.8919473403948359 seconds
90% percentile latency: 0.8929442570079118 seconds
99% percentile latency: 0.8948280606139452 seconds

```