### PR TITLE
[torch.compile] add dynamo time tracking

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -266,6 +266,10 @@ class VllmBackend:
     def __call__(self, graph: fx.GraphModule, example_inputs) -> Callable:
 
         compilation_counter.num_graphs_seen += 1
+        from .monitor import time_stamp
+        dynamo_time = time.time() - time_stamp
+        logger.info("Dynamo bytecode transform time: %.2f s", dynamo_time)
+        self.compilation_configs.compilation_time += dynamo_time
 
         # we control the compilation process, each instance can only be
         # called once

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -268,8 +268,8 @@ class VllmBackend:
         # when dynamo calls the backend, it means the bytecode
         # transform and analysis are done
         compilation_counter.num_graphs_seen += 1
-        from .monitor import time_stamp
-        dynamo_time = time.time() - time_stamp
+        from .monitor import torch_compile_start_time
+        dynamo_time = time.time() - torch_compile_start_time
         logger.info("Dynamo bytecode transform time: %.2f s", dynamo_time)
         self.compilation_configs.compilation_time += dynamo_time
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -265,6 +265,8 @@ class VllmBackend:
 
     def __call__(self, graph: fx.GraphModule, example_inputs) -> Callable:
 
+        # when dynamo calls the backend, it means the bytecode
+        # transform and analysis are done
         compilation_counter.num_graphs_seen += 1
         from .monitor import time_stamp
         dynamo_time = time.time() - time_stamp

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -145,6 +145,7 @@ def _support_torch_compile(
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = '', **kwargs):
         old_init(self, vllm_config=vllm_config, prefix=prefix, **kwargs)
+        self.vllm_config = vllm_config
         # for CompilationLevel.DYNAMO_AS_IS , the upper level model runner
         # will handle the compilation, so we don't need to do anything here.
         self.do_not_compile = \
@@ -183,6 +184,7 @@ def _support_torch_compile(
                         raise ValueError(
                             "Unsupported dynamic dimensions"
                             f" {dims} for argument {k} with type {type(arg)}.")
+            # here, it is the starting point of the `torch.compile` process
             start_monitoring_torch_compile(self.vllm_config.compilation_config)
 
         # if we don't use custom dispatcher, we can directly call the

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -157,9 +157,6 @@ def _support_torch_compile(
         TorchCompileWrapperWithCustomDispatcher.__init__(
             self, compilation_level=vllm_config.compilation_config.level)
 
-        if vllm_config.compilation_config.level == CompilationLevel.PIECEWISE:
-            start_monitoring_torch_compile(vllm_config.compilation_config)
-
     cls.__init__ = __init__
 
     def __call__(self, *args, **kwargs):
@@ -186,6 +183,7 @@ def _support_torch_compile(
                         raise ValueError(
                             "Unsupported dynamic dimensions"
                             f" {dims} for argument {k} with type {type(arg)}.")
+            start_monitoring_torch_compile(self.vllm_config.compilation_config)
 
         # if we don't use custom dispatcher, we can directly call the
         # compiled function and let torch.compile handle the dispatching,

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -5,12 +5,12 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-time_stamp: float = 0.0
+torch_compile_start_time: float = 0.0
 
 
 def start_monitoring_torch_compile(compilation_config: CompilationConfig):
-    global time_stamp
-    time_stamp = time.time()
+    global torch_compile_start_time
+    torch_compile_start_time = time.time()
 
 
 def end_monitoring_torch_compile(compilation_config: CompilationConfig):

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -15,5 +15,5 @@ def start_monitoring_torch_compile(compilation_config: CompilationConfig):
 
 def end_monitoring_torch_compile(compilation_config: CompilationConfig):
     if compilation_config.level == CompilationLevel.PIECEWISE:
-        logger.info("graph compilation takes %.2f s in total",
+        logger.info("torch.compile takes %.2f s in total",
                     compilation_config.compilation_time)

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -1,11 +1,16 @@
+import time
+
 from vllm.config import CompilationConfig, CompilationLevel
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+time_stamp: float = 0.0
+
 
 def start_monitoring_torch_compile(compilation_config: CompilationConfig):
-    pass
+    global time_stamp
+    time_stamp = time.time()
 
 
 def end_monitoring_torch_compile(compilation_config: CompilationConfig):


### PR DESCRIPTION
```bash
$ vllm serve meta-llama/Meta-Llama-3-8B
Graph capturing finished in 10 secs, took 0.32 GiB
init engine (profile, create kv cache, warmup model) took 14.18 seconds

$ vllm serve meta-llama/Meta-Llama-3-8B -O3
Dynamo bytecode transform time: 4.60 s
Compiling a graph for general shape takes 14.77 s
torch.compile takes 19.37 s in total
Graph capturing finished in 15 secs, took 0.33 GiB
init engine (profile, create kv cache, warmup model) took 39.34 seconds
```

This PR adds the missing piece of the compilation time.

By adding `-O 3`, the init time increases by `39.34 - 14.18 = 25.16` seconds, and the breakdown analysis is:

- Dynamo bytecode transform time: 4.60 s
- Compiling a graph for general shape takes 14.77 s
- triton compilation (shown by the increase of cudagraph capture time, which includes warmup triton kernels) takes 5 seconds