### PR TITLE
[Neuron] Upgrade neuron to 2.20.2

### DIFF
--- a/Dockerfile.neuron
+++ b/Dockerfile.neuron
@@ -1,5 +1,6 @@
 # default base image
-ARG BASE_IMAGE="public.ecr.aws/neuron/pytorch-inference-neuronx:2.1.2-neuronx-py310-sdk2.20.0-ubuntu20.04"
+# https://gallery.ecr.aws/neuron/pytorch-inference-neuronx
+ARG BASE_IMAGE="public.ecr.aws/neuron/pytorch-inference-neuronx:2.1.2-neuronx-py310-sdk2.20.2-ubuntu20.04"
 
 FROM $BASE_IMAGE
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1628,7 +1628,7 @@ def direct_register_custom_op(
     library object. If you want to bind the operator to a different library,
     make sure the library object is alive when the operator is used.
     """
-    if is_in_doc_build():
+    if is_in_doc_build() or not supports_custom_op():
         return
     import torch.library
     if hasattr(torch.library, "infer_schema"):


### PR DESCRIPTION
This change also fixed loading Neuron models. Neuron uses old pytorch,
 before the change I was getting

```
TypeError: infer_schema() takes 1 positional argument but 2 were given
```

which was caused by custom_op direct registration. I'm disabling that if custom_op is not available.

I tested this using 

```
vllm serve openlm-research/open_llama_3b_v2 --tensor-parallel-size 2 --device neuron --max-num-seqs 8 --max-model-len 1024
```

FIX #10932