### PR TITLE
Avoid mistakenly picking Gaudi/HPU if XPU is requested.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -332,6 +332,8 @@ def _is_hpu() -> bool:
             except (ValueError, FileNotFoundError, PermissionError,
                     subprocess.CalledProcessError):
                 is_hpu_available = False
+    if VLLM_TARGET_DEVICE != "hpu":
+        return False
     return is_hpu_available or VLLM_TARGET_DEVICE == "hpu"
 
 


### PR DESCRIPTION
In setup.py _is_hpu() will return true when  /dev/accel/accel0 is present but that can happen with XPU devices also (Intel iGPU).

This change allows  VLLM_TARGET_DEVICE="xpu" to override that and proceed with an XPU install.

Maybe a simpler is_hpu() that solely relies on VLLM_TARGET_DEVICE="hpu" would be cleaner but the current setup is probably needed for some existing setups.