### PR TITLE
[Bugfix] Quick fix to make Pixtral-HF load correctly again after 39e227c7ae.

### DIFF
--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -218,9 +218,6 @@ class LlavaProcessor(BaseMultiModalProcessor):
         image_processor = hf_processor.image_processor  # type: ignore
         hf_inputs = image_processor.preprocess(data['image'],
                                                return_tensors="pt")
-        if 'is_pixtral' not in hf_inputs:
-            hf_inputs['is_pixtral'] = isinstance(hf_processor,
-                                                 PixtralProcessor)
 
         return MultiModalKwargs(**hf_inputs)
 

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -218,11 +218,11 @@ class LlavaProcessor(BaseMultiModalProcessor):
         image_processor = hf_processor.image_processor  # type: ignore
         hf_inputs = image_processor.preprocess(data['image'],
                                                return_tensors="pt")
-        is_pixtral = isinstance(hf_processor, PixtralProcessor)
+        if 'is_pixtral' not in hf_inputs:
+            hf_inputs['is_pixtral'] = isinstance(hf_processor, PixtralProcessor)
 
         return MultiModalKwargs(
-            **hf_inputs,
-            is_pixtral=torch.tensor(is_pixtral),
+            **hf_inputs
         )
 
 

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -219,11 +219,10 @@ class LlavaProcessor(BaseMultiModalProcessor):
         hf_inputs = image_processor.preprocess(data['image'],
                                                return_tensors="pt")
         if 'is_pixtral' not in hf_inputs:
-            hf_inputs['is_pixtral'] = isinstance(hf_processor, PixtralProcessor)
+            hf_inputs['is_pixtral'] = isinstance(hf_processor,
+                                                 PixtralProcessor)
 
-        return MultiModalKwargs(
-            **hf_inputs
-        )
+        return MultiModalKwargs(**hf_inputs)
 
 
 class LlavaLikeConfig(Protocol):


### PR DESCRIPTION
After 39e227c7ae, I was unable to start my Pixtral-HF model due to this traceback
<details><summary>Traceback</summary>

```
INFO 12-09 08:47:15 model_runner.py:1094] Loading model weights took 8.2663 GB
ERROR 12-09 08:47:16 engine.py:366] vllm.multimodal.inputs.MultiModalKwargs() got multiple values for keyword argument 'is_pixtral'
ERROR 12-09 08:47:16 engine.py:366] Traceback (most recent call last):
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 357, in run_mp_engine
ERROR 12-09 08:47:16 engine.py:366]     engine = MQLLMEngine.from_engine_args(engine_args=engine_args,
ERROR 12-09 08:47:16 engine.py:366]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 119, in from_engine_args
ERROR 12-09 08:47:16 engine.py:366]     return cls(ipc_path=ipc_path,
ERROR 12-09 08:47:16 engine.py:366]            ^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 71, in __init__
ERROR 12-09 08:47:16 engine.py:366]     self.engine = LLMEngine(*args, **kwargs)
ERROR 12-09 08:47:16 engine.py:366]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 291, in __init__
ERROR 12-09 08:47:16 engine.py:366]     self._initialize_kv_caches()
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 430, in _initialize_kv_caches
ERROR 12-09 08:47:16 engine.py:366]     self.model_executor.determine_num_available_blocks())
ERROR 12-09 08:47:16 engine.py:366]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/executor/gpu_executor.py", line 68, in determine_num_available_blocks
ERROR 12-09 08:47:16 engine.py:366]     return self.driver_worker.determine_num_available_blocks()
ERROR 12-09 08:47:16 engine.py:366]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 12-09 08:47:16 engine.py:366]     return func(*args, **kwargs)
ERROR 12-09 08:47:16 engine.py:366]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/worker/worker.py", line 199, in determine_num_available_blocks
ERROR 12-09 08:47:16 engine.py:366]     self.model_runner.profile_run()
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 12-09 08:47:16 engine.py:366]     return func(*args, **kwargs)
ERROR 12-09 08:47:16 engine.py:366]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/worker/model_runner.py", line 1285, in profile_run
ERROR 12-09 08:47:16 engine.py:366]     .dummy_data_for_profiling(self.model_config,
ERROR 12-09 08:47:16 engine.py:366]      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/inputs/registry.py", line 249, in dummy_data_for_profiling
ERROR 12-09 08:47:16 engine.py:366]     dummy_data = processor.get_dummy_data(seq_len, mm_counts,
ERROR 12-09 08:47:16 engine.py:366]                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/multimodal/processing.py", line 795, in get_dummy_data
ERROR 12-09 08:47:16 engine.py:366]     multi_modal_data=self._get_dummy_mm_kwargs(mm_counts),
ERROR 12-09 08:47:16 engine.py:366]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366]   File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/model_executor/models/llava.py", line 223, in _get_dummy_mm_kwargs
ERROR 12-09 08:47:16 engine.py:366]     return MultiModalKwargs(
ERROR 12-09 08:47:16 engine.py:366]            ^^^^^^^^^^^^^^^^^
ERROR 12-09 08:47:16 engine.py:366] TypeError: vllm.multimodal.inputs.MultiModalKwargs() got multiple values for keyword argument 'is_pixtral'
Process SpawnProcess-1:
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 368, in run_mp_engine
    raise e
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 357, in run_mp_engine
    engine = MQLLMEngine.from_engine_args(engine_args=engine_args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 119, in from_engine_args
    return cls(ipc_path=ipc_path,
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/engine.py", line 71, in __init__
    self.engine = LLMEngine(*args, **kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 291, in __init__
    self._initialize_kv_caches()
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 430, in _initialize_kv_caches
    self.model_executor.determine_num_available_blocks())
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/executor/gpu_executor.py", line 68, in determine_num_available_blocks
    return self.driver_worker.determine_num_available_blocks()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/worker/worker.py", line 199, in determine_num_available_blocks
    self.model_runner.profile_run()
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/worker/model_runner.py", line 1285, in profile_run
    .dummy_data_for_profiling(self.model_config,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/inputs/registry.py", line 249, in dummy_data_for_profiling
    dummy_data = processor.get_dummy_data(seq_len, mm_counts,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/multimodal/processing.py", line 795, in get_dummy_data
    multi_modal_data=self._get_dummy_mm_kwargs(mm_counts),
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/model_executor/models/llava.py", line 223, in _get_dummy_mm_kwargs
    return MultiModalKwargs(
           ^^^^^^^^^^^^^^^^^
TypeError: vllm.multimodal.inputs.MultiModalKwargs() got multiple values for keyword argument 'is_pixtral'
[rank0]:[W1209 08:47:17.951197986 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/entrypoints/openai/api_server.py", line 683, in <module>
    uvloop.run(run_server(args))
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvloop/__init__.py", line 109, in run
    return __asyncio.run(
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvloop/__init__.py", line 61, in wrapper
    return await main
           ^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/entrypoints/openai/api_server.py", line 649, in run_server
    async with build_async_engine_client(args) as engine_client:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/entrypoints/openai/api_server.py", line 116, in build_async_engine_client
    async with build_async_engine_client_from_engine_args(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/entrypoints/openai/api_server.py", line 213, in build_async_engine_client_from_engine_args
    raise RuntimeError(
RuntimeError: Engine process failed to start. See stack trace for the root cause.
```

</details>

 Quick search didn't show any open issues reporting this error yet.

This is a quick minimal fix that ensures `is_pixtral` only appears in the `hf_inputs` once, adding it only in cases where it's not already into `hf_inputs` by the `preprocess` function (as currently done in https://github.com/vllm-project/vllm/blob/d1c2e15eb31ef12e688ce0cb71895f88eaf4cd4f/vllm/model_executor/models/llava.py#L184).

This gets my model started again and seems to be working fine.