### PR TITLE
[ROCm][bugfix] Setting the value for the scpecilative decoding worker class on rocm platform

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -93,6 +93,8 @@ class RocmPlatform(Platform):
             elif vllm_config.speculative_config:
                 parallel_config.worker_cls = \
                     "vllm.spec_decode.spec_decode_worker.create_spec_worker"
+                parallel_config.sd_worker_cls = \
+                    "vllm.worker.worker.Worker"
             else:
                 parallel_config.worker_cls = "vllm.worker.worker.Worker"
 


### PR DESCRIPTION
sd_worker_cls was left to its default value of 'auto', which led to a subsequent crash in trying to .rsplit('.') and extract 2 values out of it