### PR TITLE
[Bugfix] Backport request id validation to v0

### DIFF
--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -576,6 +576,10 @@ class MQLLMEngineClient(EngineClient):
         if self._errored_with is not None:
             raise ENGINE_DEAD_ERROR(self._errored_with)
 
+        # Ensure the request id is unique among running requests
+        if request_id in self.output_queues:
+            raise ValueError(f"Request {request_id} already exists")
+
         # Constructing guided decoding logits processors is expensive, so we do
         # it here to avoid contending with cpu resources and the GIL on the
         # backend process.

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -142,7 +142,7 @@ class AsyncLLM(EngineClient):
         """Add new request to the AsyncLLM."""
 
         if self.detokenizer.is_request_active(request_id):
-            raise KeyError(f"Request {request_id} already exists.")
+            raise ValueError(f"Request {request_id} already exists.")
 
         # 1) Create a new AsyncStream for the request.
         stream = self._add_request_to_streams(request_id)


### PR DESCRIPTION
This PR:
- Backports the request id uniqueness validation from the v1 engine to the v0 engine. This prevents the engine from hanging on requests with duplicate request ids and failing to shutdown without `kill -9`
- Changes the `KeyError` to a `ValueError` for one of the two places where the request id validation is done in the v1 engine. This causes requests with duplicate IDs to result in a 400 instead of a 500 error

FIX #10583