### PR TITLE
[V1] Do not store `None` in self.generators

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -102,6 +102,8 @@ class InputBatch:
         self.top_k_reqs: Set[str] = set()
 
         # req_index -> generator
+        # NOTE(woosuk): The indices of the requests that do not have their own
+        # generator should not be included in the dictionary.
         self.generators: Dict[int, torch.Generator] = {}
 
         self.num_logprobs: Dict[str, int] = {}
@@ -147,7 +149,10 @@ class InputBatch:
         if sampling_params.top_k > 0:
             self.top_k_reqs.add(req_id)
 
-        self.generators[req_index] = request.generator
+        # NOTE(woosuk): self.generators should not include the requests that
+        # do not have their own generator.
+        if request.generator is not None:
+            self.generators[req_index] = request.generator
 
         num_logprobs = sampling_params.logprobs
         if num_logprobs is not None and num_logprobs > 0:


### PR DESCRIPTION
This PR fixes a bug in V1 model runner that stores `None` generator for requests without seeds. This made `random_sample` method of the sampler process each request sequentially, causing unnecessary perf decrease.