### PR TITLE
[Bugfix] Handle <|tool_call|> token in granite tool parser

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
@@ -35,11 +35,13 @@ class GraniteToolParser(ToolParser):
 
     def __init__(self, tokenizer: AnyTokenizer):
         super().__init__(tokenizer)
+        self.bot_token = "<|tool_call|>"
 
     def extract_tool_calls(
             self, model_output: str,
             request: ChatCompletionRequest) -> ExtractedToolCallInformation:
-        stripped = model_output.strip()
+        # remove whitespace and the BOT token if it exists
+        stripped = model_output.strip().removeprefix(self.bot_token).lstrip()
         if not stripped or stripped[0] != '[':
             return ExtractedToolCallInformation(tools_called=False,
                                                 tool_calls=[],


### PR DESCRIPTION
Small tweak to the granite tool parser to support handle the `<|tool_call|>` token that can be generated, eg.

```
<|start of role|>user<|end of role|>What is temperature in Boston?<|end of text|>
<|start of role|>assistant<|end of role|><|tool call|>[{“name”: “get temp”, ...}]<|end of text|>
<|start of role|>tool response<|end of role|>{“temp”: 20.5, “unit”: “C”}<|end of text|>
```
REF: Table 3 on page 14 in https://github.com/ibm-granite/granite-3.0-language-models/blob/main/paper.pdf

Supporting this matters if the request has `skip_special_tokens=False`. Currently, the parser will not parse out the tool call when the output starts with `<|tool_call|>`.

I have also noticed interesting behavior between the granite model and llama w.r.t handling the tool call special token. With `meta-llama/Llama-3.1-8B-Instruct`, including `skip_special_tokens=True` on the vLLM request does not skip generation of the `<|python_tag|>` special token.

cc: @maxdebayser 