### PR TITLE
[Bugfix] Fix xgrammar failing to read a vocab_size from LlavaConfig on PixtralHF.

### DIFF
--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -148,7 +148,7 @@ class GrammarConfig:
             else:
                 json_str = guided_params.json
             return cls(json_str=json_str,
-                       vocab_size=model_config.hf_config.vocab_size,
+                       vocab_size=model_config.hf_text_config.vocab_size,
                        encoded_vocab=encoded_vocab,
                        stop_token_ids=stop_token_ids,
                        backend_str=backend_str,
@@ -168,7 +168,7 @@ class GrammarConfig:
             else:
                 grammar_str = guided_params.grammar
             return cls(grammar_str=grammar_str,
-                       vocab_size=model_config.hf_config.vocab_size,
+                       vocab_size=model_config.hf_text_config.vocab_size,
                        encoded_vocab=encoded_vocab,
                        stop_token_ids=stop_token_ids,
                        backend_str=backend_str,
@@ -176,7 +176,7 @@ class GrammarConfig:
                        max_threads=max_threads)
         elif guided_params.json_object:
             return cls(json_object=True,
-                       vocab_size=model_config.hf_config.vocab_size,
+                       vocab_size=model_config.hf_text_config.vocab_size,
                        encoded_vocab=encoded_vocab,
                        stop_token_ids=stop_token_ids,
                        backend_str=backend_str,


### PR DESCRIPTION
In trying to use an updated Pixtral-HF with xgrammar, I got `AttributeError: 'LlavaConfig' object has no attribute 'vocab_size'`. Full traceback:

<details><summary>Traceback</summary>

```text
Traceback (most recent call last):
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/applications.py", line 113, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/middleware/base.py", line 185, in __call__
    with collapse_excgroups():
         ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/responses.py", line 255, in wrap
    await func()
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/starlette/responses.py", line 244, in stream_response
    async for chunk in self.body_iterator:
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py", line 319, in chat_completion_stream_generator
    async for res in result_generator:
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/utils.py", line 399, in iterate_with_cancellation
    item = await awaits[0]
           ^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/multiprocessing/client.py", line 584, in _process_request
    params = await \
             ^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/engine/async_llm_engine.py", line 553, in build_guided_decoding_logits_processor_async
    processor = await get_guided_decoding_logits_processor(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/model_executor/guided_decoding/__init__.py", line 107, in get_guided_decoding_logits_processor
    return get_local_xgrammar_guided_decoding_logits_processor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 33, in get_local_xgrammar_guided_decoding_logits_processor
    config = GrammarConfig.from_guided_params(guided_params=guided_params,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 151, in from_guided_params
    vocab_size=model_config.hf_config.vocab_size,
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jeff/.virtualenvs/vllm312/lib/python3.12/site-packages/transformers/configuration_utils.py", line 210, in __getattribute__
    return super().__getattribute__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LlavaConfig' object has no attribute 'vocab_size'
```
</details>

Indeed the `LlavaConfig` class of transformers has no `vocab_size`. Fixed this by requesting the text config specifically with `vocab_size=model_config.hf_text_config`. Sounds right to me!