### PR TITLE
[Bugfix] cuda error running llama 3.2

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -4,7 +4,8 @@ pynvml. However, it should not initialize cuda context.
 
 import os
 from functools import lru_cache, wraps
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar, Union
+from typing import (TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar,
+                    Union)
 
 import pynvml
 import torch
@@ -77,7 +78,9 @@ class CudaPlatformBase(Platform):
     dispatch_key: str = "CUDA"
 
     @classmethod
-    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
+    def get_device_capability(cls,
+                              device_id: int = 0
+                              ) -> Optional[DeviceCapability]:
         raise NotImplementedError
 
     @classmethod
@@ -132,7 +135,9 @@ class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     @lru_cache(maxsize=8)
     @with_nvml_context
-    def get_device_capability(cls, device_id: int = 0) -> Optional[DeviceCapability]:
+    def get_device_capability(cls,
+                              device_id: int = 0
+                              ) -> Optional[DeviceCapability]:
         try:
             physical_device_id = device_id_to_physical_device_id(device_id)
             handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)


### PR DESCRIPTION
Re: https://github.com/vllm-project/vllm/pull/9850/files#diff-107fd4a59dcd0831ff802fefe9c49eac02432b6a6d1f508075a8b1809c1468b4R11-R15 

Those `.get_device_capability` and `.has_device_capability` are now called on module loading of prefix prefill, however, they can throw errors when using it with cuda. This PR catches those unexpected runtime errors and returns the corresponding value (`None` and `False`) in the failure cases so the module can be loaded successfully.   