### PR TITLE
make `fused_moe_kernel`'s `EM` and `num_valid_tokens` arguments `do_not_specialize`

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1,5 +1,6 @@
 """Fused MoE kernel."""
 import functools
+import inspect
 import json
 import os
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -13,7 +14,6 @@ from vllm import _custom_ops as ops
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
-import inspect
 
 logger = init_logger(__name__)
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -17,17 +17,13 @@ from vllm.utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
-if (
-    "do_not_specialize_on_alignment"
-    in inspect.getfullargspec(triton.jit).kwonlyargs
-):
+if ("do_not_specialize_on_alignment"
+        in inspect.getfullargspec(triton.jit).kwonlyargs):
     moe_triton_jit = functools.partial(
-        triton.jit, do_not_specialize_on_alignment=["EM", "num_valid_tokens"]
-    )
+        triton.jit, do_not_specialize_on_alignment=["EM", "num_valid_tokens"])
 else:
     moe_triton_jit = functools.partial(
-        triton.jit, do_not_specialize=["EM", "num_valid_tokens"]
-    )
+        triton.jit, do_not_specialize=["EM", "num_valid_tokens"])
 
 
 @moe_triton_jit

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -17,10 +17,18 @@ import inspect
 
 logger = init_logger(__name__)
 
-if "do_not_specialize_on_alignment" in inspect.getfullargspec(triton.jit).kwonlyargs:
-    moe_triton_jit = functools.partial(triton.jit, do_not_specialize_on_alignment=["EM", "num_valid_tokens"])
+if (
+    "do_not_specialize_on_alignment"
+    in inspect.getfullargspec(triton.jit).kwonlyargs
+):
+    moe_triton_jit = functools.partial(
+        triton.jit, do_not_specialize_on_alignment=["EM", "num_valid_tokens"]
+    )
 else:
-    moe_triton_jit = functools.partial(triton.jit, do_not_specialize=["EM", "num_valid_tokens"])
+    moe_triton_jit = functools.partial(
+        triton.jit, do_not_specialize=["EM", "num_valid_tokens"]
+    )
+
 
 @moe_triton_jit
 def fused_moe_kernel(


### PR DESCRIPTION
see #11056 for more details.

In the latest Triton release 3.1.0, `do_not_specialize` is used to indicate arguments that do not require kernel specialization. However, in the latest Triton main branch, a new `do_not_specialize_on_alignment` has been added to specify arguments that should not be specialized due to memory alignment reasons, which is more precisely what we need. 
see: https://github.com/triton-lang/triton/blob/main/python/test/unit/runtime/test_cache.py#L56-L60

Therefore, I have added compatibility in my code: if the `do_not_specialize_on_alignment` is available, it will be used; if not, it will fall back to using `do_not_specialize`.

results:
```
# with A100
python ./benchmark_throughput.py --model=Qwen/Qwen2-57B-A14B-Instruct -tp 4 --dataset=./ShareGPT_V3_unfiltered_cleaned_split.json

w/o this fix:
Throughput: 10.60 requests/s, 4443.34 total tokens/s, 2139.29 output tokens/s

w/ this fix:
Throughput: 13.46 requests/s, 5640.88 total tokens/s, 2715.86 output tokens/s
```
