### PR TITLE
[torch.compile] add a flag to track batchsize statistics

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -181,7 +181,7 @@ def _support_torch_compile(
             # ignore kv cache tensors and empty tensors
             bs = [
                 tensor.shape[0] for tensor in tensors
-                if len(tensor.shape) <= 2 and tensor.shape[0] > 1
+                if len(tensor.shape) <= 2 and tensor.shape[0] >= 1
             ]
             for b in bs:
                 assert b == bs[0]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     VLLM_DISABLED_KERNELS: List[str] = []
     VLLM_USE_V1: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = False
+    VLLM_TRACK_BATCHSIZE: bool = False
 
 
 def get_default_cache_root():
@@ -452,6 +453,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # If set, enable multiprocessing in LLM for the V1 code path.
     "VLLM_ENABLE_V1_MULTIPROCESSING":
     lambda: bool(int(os.getenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0"))),
+    "VLLM_TRACK_BATCHSIZE":
+    lambda: os.getenv("VLLM_TRACK_BATCHSIZE", "0").lower() in ("1", "true"),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
     VLLM_DISABLED_KERNELS: List[str] = []
     VLLM_USE_V1: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = False
-    VLLM_TRACK_BATCHSIZE: bool = False
+    VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
 
 
 def get_default_cache_root():
@@ -453,8 +453,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # If set, enable multiprocessing in LLM for the V1 code path.
     "VLLM_ENABLE_V1_MULTIPROCESSING":
     lambda: bool(int(os.getenv("VLLM_ENABLE_V1_MULTIPROCESSING", "0"))),
-    "VLLM_TRACK_BATCHSIZE":
-    lambda: os.getenv("VLLM_TRACK_BATCHSIZE", "0").lower() in ("1", "true"),
+    "VLLM_LOG_BATCHSIZE_INTERVAL":
+    lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
 }
 
 # end-env-vars-definition

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -10,10 +10,10 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-track_batchsize = envs.VLLM_LOG_BATCHSIZE_INTERVAL >= 0
-batchsize_counter = Counter()
+track_batchsize: bool = envs.VLLM_LOG_BATCHSIZE_INTERVAL >= 0
+batchsize_counter: Counter = Counter()
 last_logging_time: float = 0
-batchsize_logging_interval = envs.VLLM_LOG_BATCHSIZE_INTERVAL
+batchsize_logging_interval: float = envs.VLLM_LOG_BATCHSIZE_INTERVAL
 
 
 @dataclass

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -52,7 +52,7 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
         batchsize_counter[batchsize] += 1
         if time.monotonic() - last_logging_time > batchsize_logging_interval:
             last_logging_time = time.monotonic()
-            sorted_data = sorted(list(batchsize_counter.items()),
+            sorted_data = sorted(batchsize_counter.items(),
                                  key=lambda x: x[1],
                                  reverse=True)
             logger.info("Batchsize distribution (batchsize, count): %s",

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -50,6 +50,7 @@ class FlashAttentionMetadata:
     #                                   |-- query_len ---|
 
     num_actual_tokens: int  # Number of tokens excluding padding.
+    num_input_tokens: int = 0  # Number of tokens including padding.
     max_query_len: int
     query_start_loc: torch.Tensor
     max_seq_len: int

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -50,13 +50,13 @@ class FlashAttentionMetadata:
     #                                   |-- query_len ---|
 
     num_actual_tokens: int  # Number of tokens excluding padding.
-    num_input_tokens: int = 0  # Number of tokens including padding.
     max_query_len: int
     query_start_loc: torch.Tensor
     max_seq_len: int
     seq_start_loc: torch.Tensor
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
+    num_input_tokens: int = 0  # Number of tokens including padding.
 
 
 class FlashAttentionImpl(AttentionImpl):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -445,6 +445,8 @@ class GPUModelRunner:
             # Eager mode.
             num_input_tokens = num_scheduled_tokens
 
+        attn_metadata.num_input_tokens = num_input_tokens
+
         # Get the inputs embeds.
         if encoder_outputs:
             inputs_embeds = self.model.get_input_embeddings(


### PR DESCRIPTION
I find that https://github.com/vllm-project/vllm/pull/11031 only records the statistics from the engine level, which is not enough.

we need to record the forward batchsize for every model forward, including using cudagraph or not.

then we can have accurate statistics of batchsizes, and can optimize the shapes we want to compile.