### PR TITLE
Don't try to add special tokens to the matcher in XGrammar.

### DIFF
--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -229,6 +229,7 @@ class XGrammarLogitsProcessor:
                  scores: torch.Tensor) -> torch.Tensor:
         if self.ctx is None:
             self._ensure_ctx()
+            assert self.ctx is not None
 
         if len(self.matchers) == 0:
             self.matchers = [
@@ -243,6 +244,9 @@ class XGrammarLogitsProcessor:
         else:
             for i, matcher in enumerate(self.matchers):
                 if not matcher.is_terminated():
+                    if input_ids[
+                            -1] in self.ctx.tokenizer_info.special_token_ids:
+                        continue
                     sampled_token = input_ids[-1]
                     assert self.matchers[i].accept_token(sampled_token)
 


### PR DESCRIPTION
Prevent XGrammar from attempting to match on special tokens. XGrammar throws the assertion on the C++ side if we send it a special token for acceptance, which crashes the whole engine. This fix uses XGrammar's `tokenizer_info` to skip over these tokens before we submit them and get crashed.

FIX #11044 ; see that issue for the original traceback.

There may be a better way to do this than just continuing over the last token while it's special, but this is sufficient to resolve the crash for me and I'm noticing no slowdown or additional issues in outputs. Thanks!