### PR TITLE
[V1][Bugfix] Always set enable_chunked_prefill = True for V1

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1242,7 +1242,7 @@ class EngineArgs:
         # too small to achieve the best performance in V1.
         self.max_num_seqs = 1024
         logger.warning("Setting max_num_seqs to %d for %s usage context.",
-                        self.max_num_seqs, usage_context.value)
+                       self.max_num_seqs, usage_context.value)
 
     def _override_v1_engine_config(self, engine_config: VllmConfig) -> None:
         """


### PR DESCRIPTION
This PR fixes a bug in initializing the OpenAI server with V1: Currently, the server fails for some models with the error message: `ValueError: max_num_batched_tokens (2048) is smaller than max_model_len (8192).` This is because `enable_chunked_prefill` is not properly set.