### PR TITLE
Fix streaming for granite tool call when <|tool_call|> is present

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
@@ -88,7 +88,11 @@ class GraniteToolParser(ToolParser):
     ) -> Union[DeltaMessage, None]:
 
         start_idx = consume_space(0, current_text)
-        if not current_text or current_text[start_idx] != '[':
+        if current_text[start_idx:].startswith(self.bot_token):
+            start_idx = consume_space(start_idx + len(self.bot_token),
+                                      current_text)
+        if not current_text or start_idx >= len(current_text)\
+            or current_text[start_idx] != '[':
             return DeltaMessage(content=delta_text)
 
         # bit mask flags for partial JSON parsing. If the name hasn't been


### PR DESCRIPTION
This is a follow up for the streaming case for this PR: https://github.com/vllm-project/vllm/pull/11039

cc: @tjohnson31415 , @DarkLight1337 