### PR TITLE
[Bugfix]: Clamp `-inf` logprob values in prompt_logprobs

### DIFF
--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -392,6 +392,12 @@ class OpenAIServingCompletion(OpenAIServing):
             prompt_token_ids = final_res.prompt_token_ids
             assert prompt_token_ids is not None
             prompt_logprobs = final_res.prompt_logprobs
+            if prompt_logprobs:
+                for logprob_dict in prompt_logprobs:
+                    if logprob_dict:
+                        for logprob_values in logprob_dict.values():
+                            if logprob_values.logprob == float('-inf'):
+                                logprob_values.logprob = -9999.0
             prompt_text = final_res.prompt
 
             token_ids: GenericSequence[int]


### PR DESCRIPTION
Logprobs with an `-inf` value are clamped to `-9999.0` in other parts of the code but not here, resulting in a JSON compliance error in cases where the `top_k` sampling parameter is used too. 

Fixes #10234 