### PR TITLE
[Core] v1: Use atexit to handle engine core client shutdown

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1,3 +1,4 @@
+import atexit
 import multiprocessing
 from typing import List, Union
 
@@ -157,6 +158,7 @@ class MPClient(EngineCoreClient):
             should_shutdown=self.should_shutdown,
             **kwargs,
         )
+        atexit.register(self.shutdown)
 
     def shutdown(self):
         # Send shutdown signal to background process.


### PR DESCRIPTION
While testing V1 + multiprocessing, I observed that my offline
inference test script would hang at the end and not exit. There was
shutdown code here that depended on garbage collection to trigger it,
but it wouldn't get far enough for that to happen.

This approach of using `atexit` to register the cleanup handler is the
same as is used in the `multiproc_executor`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
