### PR TITLE
[torch.compile] allow tracking forward time

### DIFF
--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -81,9 +81,9 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
                     if len(times) <= 1:
                         # can be cudagraph / profiling run
                         continue
-                    forward_stats.append((bs, len(times),
-                                          torch.quantile(torch.tensor(times),
-                                                         q=0.5).item()))
+                    medium = torch.quantile(torch.tensor(times), q=0.5).item()
+                    medium = f"{medium:.2f}"
+                    forward_stats.append((bs, len(times), medium))
                 forward_stats.sort(key=lambda x: x[1], reverse=True)
                 logger.info(("Batchsize forward time stats "
                              "(batchsize, count, median_time(ms)): %s"),

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -46,7 +46,7 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
     global forward_start_time
     need_to_track_batchsize = track_batchsize and context is not None
     if need_to_track_batchsize:
-        forward_start_time = time.monotonic()
+        forward_start_time = time.perf_counter()
     global _forward_context
     prev_context = _forward_context
     _forward_context = ForwardContext(
@@ -70,7 +70,7 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
             # adding a sync point here should not affect
             # scheduling of the next batch
             torch.cuda.synchronize()
-            now = time.monotonic()
+            now = time.perf_counter()
             # time measurement is in milliseconds
             batchsize_forward_time[batchsize].append(
                 (now - forward_start_time) * 1000)

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -85,7 +85,8 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
                     medium = round(medium, 2)
                     forward_stats.append((bs, len(times), medium))
                 forward_stats.sort(key=lambda x: x[1], reverse=True)
-                logger.info(("Batchsize forward time stats "
-                             "(batchsize, count, median_time(ms)): %s"),
-                            forward_stats)
+                if forward_stats:
+                    logger.info(("Batchsize forward time stats "
+                                 "(batchsize, count, median_time(ms)): %s"),
+                                forward_stats)
         _forward_context = prev_context

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -82,7 +82,7 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
                         # can be cudagraph / profiling run
                         continue
                     medium = torch.quantile(torch.tensor(times), q=0.5).item()
-                    medium = f"{medium:.2f}"
+                    medium = round(medium, 2)
                     forward_stats.append((bs, len(times), medium))
                 forward_stats.sort(key=lambda x: x[1], reverse=True)
                 logger.info(("Batchsize forward time stats "

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -84,8 +84,9 @@ def set_forward_context(context: Any, vllm_config: VllmConfig):
                 forward_stats = []
                 for bs, _ in sorted_by_count:
                     times = batchsize_forward_time[bs]
-                    forward_stats.append(
-                        (bs, len(times), torch.quantile(times, q=0.5).item()))
+                    forward_stats.append((bs, len(times),
+                                          torch.quantile(torch.tensor(times),
+                                                         q=0.5).item()))
                 logger.info(("Batchsize forward time stats "
                              "(batchsize, count, median_time): %s"),
                             forward_stats)


### PR DESCRIPTION
when benchmarking `torch.compile` performance, I always get this question: if the performance gain is not satisfactory, is it because `torch.compile` does not optimize the model well, or is it because of the scheduling overhead?

this pr adds the tracking for forward time, so that we can directly test the perf of `torch.compile` for certain sizes.

e.g.

```bash
$ VLLM_LOG_BATCHSIZE_INTERVAL=1.0 python3 benchmarks/benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 --load-format dummy
INFO 12-10 19:52:26 forward_context.py:88] Batchsize forward time stats (batchsize, count, median_time(ms)): [(1, 5054, 6.5), (32, 41, 7.51)]

$ VLLM_LOG_BATCHSIZE_INTERVAL=1.0 python3 benchmarks/benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --batch-size 1 --load-format dummy -O "{'level': 3, 'candidate_compile_sizes': [1]}"
INFO 12-10 19:54:34 forward_context.py:88] Batchsize forward time stats (batchsize, count, median_time(ms)): [(1, 5049, 5.93), (32, 41, 7.35)]
```

then it is clear that the forward time improves from 6.5ms to 5.93ms, 8.8% improvement. And the end-to-end 7.7% improvement in latency in https://github.com/vllm-project/vllm/pull/11078 is shadowed a little bit in the end-to-end pipeline.