### PR TITLE
[ci/build] Fix AMD CI dependencies

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -5,6 +5,7 @@
 awscli
 boto3
 botocore
+datasets
 ray >= 2.10.0
 peft
 pytest-asyncio


### PR DESCRIPTION
https://github.com/vllm-project/vllm/commit/e7391949267a4eff3d84f02119f442f46b16d163 upgraded `outlines` to 0.1.8 but `outlines` has already removed `datasets` as required dependencies: https://github.com/dottxt-ai/outlines/pull/1296/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L39
AMD test failed because it didn't have `datasets` installed