### PR TITLE
[ci/build] Fix entrypoints test and pin outlines version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -18,7 +18,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines >= 0.1.8
+outlines == 0.1.9
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317

--- a/vllm/model_executor/guided_decoding/outlines_logits_processors.py
+++ b/vllm/model_executor/guided_decoding/outlines_logits_processors.py
@@ -25,7 +25,7 @@ from lark import Lark
 from outlines import grammars
 from outlines.caching import cache
 from outlines.fsm.guide import CFGGuide, Generate, Guide, RegexGuide, Write
-from outlines.fsm.json_schema import build_regex_from_schema
+from outlines_core.fsm.json_schema import build_regex_from_schema
 from pydantic import BaseModel
 from transformers import PreTrainedTokenizerBase
 


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/10576 ran CI and passed with `outlines==0.1.8` but `outline 0.1.9` released and had a change to use `outlines-core` instead of `outlines` for one of the import paths: https://github.com/dottxt-ai/outlines/pull/1311/files#diff-b29e16a237d75d6560f08ec4c09049474c96d34e4c4f544dde27002ae1f684d9L3 which broke CI since `outlines` version is not pinned.

This PR fixes the import path and also pins `outlines==0.1.9` 