### PR TITLE
[Bugfix] Fix request disconnect check when BaseHTTPMiddleware is present

### DIFF
--- a/tests/async_engine/test_api_server.py
+++ b/tests/async_engine/test_api_server.py
@@ -25,7 +25,8 @@ def _query_server_long(prompt: str) -> dict:
 
 
 @pytest.fixture
-def api_server(tokenizer_pool_size: int, worker_use_ray: bool):
+def api_server(tokenizer_pool_size: int, worker_use_ray: bool,
+               add_middleware: bool):
     script_path = Path(__file__).parent.joinpath(
         "api_server_async_engine.py").absolute()
     commands = [
@@ -37,15 +38,19 @@ def api_server(tokenizer_pool_size: int, worker_use_ray: bool):
 
     if worker_use_ray:
         commands.append("--worker-use-ray")
+    if add_middleware:
+        commands.append("--add-middleware")
     uvicorn_process = subprocess.Popen(commands)
     yield
     uvicorn_process.terminate()
 
 
-@pytest.mark.parametrize("tokenizer_pool_size", [0, 2])
-@pytest.mark.parametrize("worker_use_ray", [False, True])
-def test_api_server(api_server, tokenizer_pool_size: int,
-                    worker_use_ray: bool):
+@pytest.mark.parametrize(
+    ["tokenizer_pool_size", "worker_use_ray", "add_middleware"],
+    [(0, False, False), (0, False, True), (2, False, False), (0, True, False),
+     (2, True, False)])
+def test_api_server(api_server, tokenizer_pool_size: int, worker_use_ray: bool,
+                    add_middleware: bool):
     """
     Run the API server and test it.
 

--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -18,11 +18,12 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.entrypoints.launcher import serve_http
+from vllm.entrypoints.utils import is_disconnected_patch
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
 from vllm.usage.usage_lib import UsageContext
-from vllm.utils import (FlexibleArgumentParser, is_disconnected_patch,
-                        iterate_with_cancellation, random_uuid)
+from vllm.utils import (FlexibleArgumentParser, iterate_with_cancellation,
+                        random_uuid)
 from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger("vllm.entrypoints.api_server")

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from functools import partial
 from typing import (AsyncGenerator, AsyncIterator, Callable, Dict, Final, List,
                     Optional)
 from typing import Sequence as GenericSequence
@@ -32,7 +33,7 @@ from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.sequence import Logprob
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.transformers_utils.tokenizers import maybe_serialize_tool_calls
-from vllm.utils import iterate_with_cancellation
+from vllm.utils import is_disconnected_patch, iterate_with_cancellation
 
 logger = init_logger(__name__)
 
@@ -233,7 +234,8 @@ class OpenAIServingChat(OpenAIServing):
 
         if raw_request:
             result_generator = iterate_with_cancellation(
-                result_generator, raw_request.is_disconnected)
+                result_generator,
+                partial(is_disconnected_patch, request=raw_request))
 
         # Streaming response
         if request.stream:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -27,13 +27,14 @@ from vllm.entrypoints.openai.serving_engine import (BaseModelPath,
                                                     OpenAIServing,
                                                     PromptAdapterPath)
 from vllm.entrypoints.openai.tool_parsers import ToolParser, ToolParserManager
+from vllm.entrypoints.utils import is_disconnected_patch
 from vllm.logger import init_logger
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.sequence import Logprob
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.transformers_utils.tokenizers import maybe_serialize_tool_calls
-from vllm.utils import is_disconnected_patch, iterate_with_cancellation
+from vllm.utils import iterate_with_cancellation
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -26,12 +26,13 @@ from vllm.entrypoints.openai.serving_engine import (BaseModelPath,
                                                     LoRAModulePath,
                                                     OpenAIServing,
                                                     PromptAdapterPath)
+from vllm.entrypoints.utils import is_disconnected_patch
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams, SamplingParams
 from vllm.sequence import Logprob
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-from vllm.utils import is_disconnected_patch, merge_async_iterators
+from vllm.utils import merge_async_iterators
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -18,9 +18,10 @@ from vllm.entrypoints.openai.protocol import (EmbeddingChatRequest,
                                               EmbeddingResponseData,
                                               ErrorResponse, UsageInfo)
 from vllm.entrypoints.openai.serving_engine import BaseModelPath, OpenAIServing
+from vllm.entrypoints.utils import is_disconnected_patch
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
-from vllm.utils import is_disconnected_patch, merge_async_iterators
+from vllm.utils import merge_async_iterators
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import time
+from functools import partial
 from typing import AsyncGenerator, Final, List, Literal, Optional, Union, cast
 
 import numpy as np
@@ -19,7 +20,7 @@ from vllm.entrypoints.openai.protocol import (EmbeddingChatRequest,
 from vllm.entrypoints.openai.serving_engine import BaseModelPath, OpenAIServing
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
-from vllm.utils import merge_async_iterators
+from vllm.utils import is_disconnected_patch, merge_async_iterators
 
 logger = init_logger(__name__)
 
@@ -201,7 +202,8 @@ class OpenAIServingEmbedding(OpenAIServing):
 
         result_generator = merge_async_iterators(
             *generators,
-            is_cancelled=raw_request.is_disconnected if raw_request else None,
+            is_cancelled=partial(is_disconnected_patch, request=raw_request)
+            if raw_request else None,
         )
 
         num_prompts = len(engine_prompts)

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from functools import partial
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union, cast
 
 from fastapi import Request
@@ -15,7 +16,7 @@ from vllm.inputs.data import TokensPrompt
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-from vllm.utils import make_async, merge_async_iterators
+from vllm.utils import is_disconnected_patch, make_async, merge_async_iterators
 
 logger = init_logger(__name__)
 
@@ -188,7 +189,8 @@ class OpenAIServingScores(OpenAIServing):
 
         result_generator = merge_async_iterators(
             *generators,
-            is_cancelled=raw_request.is_disconnected if raw_request else None,
+            is_cancelled=partial(is_disconnected_patch, request=raw_request)
+            if raw_request else None,
         )
 
         num_prompts = len(engine_prompts)

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -12,11 +12,12 @@ from vllm.entrypoints.openai.protocol import (ErrorResponse, ScoreRequest,
                                               ScoreResponse, ScoreResponseData,
                                               UsageInfo)
 from vllm.entrypoints.openai.serving_engine import BaseModelPath, OpenAIServing
+from vllm.entrypoints.utils import is_disconnected_patch
 from vllm.inputs.data import TokensPrompt
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-from vllm.utils import is_disconnected_patch, make_async, merge_async_iterators
+from vllm.utils import make_async, merge_async_iterators
 
 logger = init_logger(__name__)
 

--- a/vllm/entrypoints/utils.py
+++ b/vllm/entrypoints/utils.py
@@ -1,0 +1,37 @@
+import anyio
+from starlette.requests import Request
+from starlette.types import Message
+
+
+async def is_disconnected_patch(request: Request) -> bool:
+    """This is a patch for starlette's Request.is_disconnected(), which,
+    if a BaseHTTPMiddleware is added to the server, returns False even if
+    the client disconnects.
+    See discussion here: https://github.com/encode/starlette/discussions/2094
+    This workaround is based on the code in comment
+    https://github.com/encode/starlette/discussions/2094#discussioncomment-9084737
+    It can be removed if and when the starlette issue is resolved.
+    """
+    assert hasattr(request,
+                   '_is_disconnected'), "private API in starlette changed"
+    assert isinstance(request._is_disconnected,
+                      bool), "private API in starlette changed"
+
+    if request._is_disconnected:
+        return True
+
+    message: Message = {}
+
+    # this timeout may need to be tweaked.
+    # Ideally request.receive() is non-blocking, in which case the timeout
+    # doesn't matter. But the ASGI spec seems to imply it should be a blocking
+    # callable, as it doesn't specify what should be returned in case of
+    # no new messages. In this situation you can return an empty dict,
+    # but given that it's against the spec it seems inadvisable.
+    with anyio.move_on_after(0.01):
+        message = await request.receive()
+
+    if message.get("type") == "http.disconnect":
+        request._is_disconnected = True
+
+    return request._is_disconnected

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -30,7 +30,6 @@ from typing import (TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable,
                     OrderedDict, Set, Tuple, Type, TypeVar, Union, overload)
 from uuid import uuid4
 
-import anyio
 import numpy as np
 import numpy.typing as npt
 import psutil
@@ -38,8 +37,6 @@ import torch
 import torch.types
 import yaml
 from packaging.version import Version
-from starlette.requests import Request
-from starlette.types import Message
 from torch.library import Library
 from typing_extensions import ParamSpec, TypeIs, assert_never
 
@@ -371,40 +368,6 @@ def _next_task(iterator: AsyncGenerator[T, None],
                loop: AbstractEventLoop) -> Task:
     # Can use anext() in python >= 3.10
     return loop.create_task(iterator.__anext__())  # type: ignore[arg-type]
-
-
-async def is_disconnected_patch(request: Request) -> bool:
-    """This is a patch for starlette's Request.is_disconnected(), which,
-    if a BaseHTTPMiddleware is added to the server, returns False even if
-    the client disconnects.
-    See discussion here: https://github.com/encode/starlette/discussions/2094
-    This workaround is based on the code in comment
-    https://github.com/encode/starlette/discussions/2094#discussioncomment-9084737
-    It can be removed if and when the starlette issue is resolved.
-    """
-    assert hasattr(request,
-                   '_is_disconnected'), "private API in starlette changed"
-    assert isinstance(request._is_disconnected,
-                      bool), "private API in starlette changed"
-
-    if request._is_disconnected:
-        return True
-
-    message: Message = {}
-
-    # this timeout may need to be tweaked.
-    # Ideally request.receive() is non-blocking, in which case the timeout
-    # doesn't matter. But the ASGI spec seems to imply it should be a blocking
-    # callable, as it doesn't specify what should be returned in case of
-    # no new messages. In this situation you can return an empty dict,
-    # but given that it's against the spec it seems inadvisable.
-    with anyio.move_on_after(0.01):
-        message = await request.receive()
-
-    if message.get("type") == "http.disconnect":
-        request._is_disconnected = True
-
-    return request._is_disconnected
 
 
 async def iterate_with_cancellation(

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -30,6 +30,7 @@ from typing import (TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable,
                     OrderedDict, Set, Tuple, Type, TypeVar, Union, overload)
 from uuid import uuid4
 
+import anyio
 import numpy as np
 import numpy.typing as npt
 import psutil
@@ -37,6 +38,8 @@ import torch
 import torch.types
 import yaml
 from packaging.version import Version
+from starlette.requests import Request
+from starlette.types import Message
 from torch.library import Library
 from typing_extensions import ParamSpec, TypeIs, assert_never
 
@@ -368,6 +371,40 @@ def _next_task(iterator: AsyncGenerator[T, None],
                loop: AbstractEventLoop) -> Task:
     # Can use anext() in python >= 3.10
     return loop.create_task(iterator.__anext__())  # type: ignore[arg-type]
+
+
+async def is_disconnected_patch(request: Request) -> bool:
+    """This is a patch for starlette's Request.is_disconnected(), which,
+    if a BaseHTTPMiddleware is added to the server, returns False even if
+    the client disconnects.
+    See discussion here: https://github.com/encode/starlette/discussions/2094
+    This workaround is based on the code in comment
+    https://github.com/encode/starlette/discussions/2094#discussioncomment-9084737
+    It can be removed if and when the starlette issue is resolved.
+    """
+    assert hasattr(request,
+                   '_is_disconnected'), "private API in starlette changed"
+    assert isinstance(request._is_disconnected,
+                      bool), "private API in starlette changed"
+
+    if request._is_disconnected:
+        return True
+
+    message: Message = {}
+
+    # this timeout may need to be tweaked.
+    # Ideally request.receive() is non-blocking, in which case the timeout
+    # doesn't matter. But the ASGI spec seems to imply it should be a blocking
+    # callable, as it doesn't specify what should be returned in case of
+    # no new messages. In this situation you can return an empty dict,
+    # but given that it's against the spec it seems inadvisable.
+    with anyio.move_on_after(0.01):
+        message = await request.receive()
+
+    if message.get("type") == "http.disconnect":
+        request._is_disconnected = True
+
+    return request._is_disconnected
 
 
 async def iterate_with_cancellation(


### PR DESCRIPTION
This PR fixes https://github.com/vllm-project/vllm/issues/10087, by using a different method to check if a request has disconnected (instead of starlette's `Request.is_disconnected()`, which doesn't work as expected in case a BaseHTTPMiddleware is added to the server - see here - https://github.com/encode/starlette/discussions/2094).

The PR uses the method suggested in https://github.com/encode/starlette/discussions/2094#discussioncomment-9084737

Added a test that fails on `main`, and is fixed with this PR

### Benchmark
Model: Qwen/Qwen2.5-1.5B-Instruct
Hardware: single H100
Serve run command: `vllm serve Qwen/Qwen2.5-1.5B-Instruct`

Endpoint: `v1/completions`
(benchmark run command: `python3 benchmark_serving.py --model Qwen/Qwen2.5-1.5B-Instruct --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json`)

| branch | throughput (requests/s) | mean TTFT (msec) | mean TPOT (msec) | Total generated tokens |
|--------|--------|--------|--------|--------|
| main (commit 82c73fd5104e010c2c98820f3e761e1e4f36c135) | 52.12 | 6117.88 | 24.92 | 189868 |
| pr (commit  0ba0ff8791b62a7104cc7387a863a03e40c1d493) | 52.52 | 6064.14 | 24.20 | 190241 |

Conclusion: The fix doesn't hurt performance at all. I guess this is because `request.recieve()` used [here](https://github.com/vllm-project/vllm/pull/11096/files#diff-dab7693bd00a09e22d39aee684a7e419aa358a47c4bd20df33d44f5adf60d304R402) is generally non-blocking