### PR TITLE
[Doc] Installed version of llmcompressor for int8/fp8 quantization

### DIFF
--- a/docs/source/quantization/fp8.rst
+++ b/docs/source/quantization/fp8.rst
@@ -45,7 +45,7 @@ To produce performant FP8 quantized models with vLLM, you'll need to install the
 
 .. code-block:: console
 
-   $ pip install llmcompressor==0.1.0
+   $ pip install llmcompressor
 
 Quantization Process
 --------------------

--- a/docs/source/quantization/int8.rst
+++ b/docs/source/quantization/int8.rst
@@ -19,7 +19,7 @@ To use INT8 quantization with vLLM, you'll need to install the `llm-compressor <
 
 .. code-block:: console
 
-   $ pip install llmcompressor==0.1.0
+   $ pip install llmcompressor
 
 Quantization Process
 --------------------


### PR DESCRIPTION
After installing using `pip install llmcompressor==0.1.0`, as the default installed version of `compressed-tensors` is 0.8.0, it causes errors like `ImportError: cannot import name 'freeze_module_quantization' from 'compressed_tensors.quantization'` when `from llmcompressor.modifiers.quantization import QuantizationModifier`, as mentioned in https://github.com/vllm-project/llm-compressor/issues/910.

Removing the indicated version and directly using `pip install llmcompressor` work well.

