### PR TITLE
Update link to LlamaStack remote vLLM guide in serving_with_llamastack.rst

### DIFF
--- a/docs/source/serving/serving_with_llamastack.rst
+++ b/docs/source/serving/serving_with_llamastack.rst
@@ -24,7 +24,7 @@ Then start Llama Stack server pointing to your vLLM server with the following co
         config:
           url: http://127.0.0.1:8000
 
-Please refer to `this guide <https://github.com/meta-llama/llama-stack/blob/main/docs/source/getting_started/distributions/self_hosted_distro/remote_vllm.md>`_ for more details on this remote vLLM provider.
+Please refer to `this guide <https://llama-stack.readthedocs.io/en/latest/distributions/self_hosted_distro/remote-vllm.html>`_ for more details on this remote vLLM provider.
 
 Inference via Embedded vLLM
 ---------------------------


### PR DESCRIPTION
The link has been updated and published to LlamaStack website.
