### PR TITLE
Support Lora prometheus metrics

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1221,8 +1221,13 @@ class LLMEngine:
         # LLMEngine/AsyncLLMEngine directly
         if is_async:
             # Log stats.
-            self.do_log_stats(scheduler_outputs, outputs, finished_before,
-                              skip)
+            self.do_log_stats(
+                scheduler_outputs,
+                outputs,
+                finished_before,
+                skip,
+                custom_labels={"model_name": seq_group.lora_request.lora_name}
+                if seq_group.lora_request else {})
 
             # Tracing
             self.do_tracing(scheduler_outputs, finished_before)
@@ -1454,7 +1459,18 @@ class LLMEngine:
                 self._process_model_outputs(ctx=ctx)
 
                 # Log stats.
-                self.do_log_stats(scheduler_outputs, outputs)
+                custom_labels = {}
+                if len(scheduler_outputs.scheduled_seq_groups) != 0:
+                    seq_groups = scheduler_outputs.scheduled_seq_groups
+                    scheduled_seq_group = seq_groups[0]
+                    seq_group = scheduled_seq_group.seq_group
+                    if seq_group.lora_request is not None:
+                        custom_labels = {
+                            "model_name": seq_group.lora_request.lora_name
+                        }
+                self.do_log_stats(scheduler_outputs,
+                                  outputs,
+                                  custom_labels=custom_labels)
 
                 # Tracing
                 self.do_tracing(scheduler_outputs)
@@ -1556,13 +1572,14 @@ class LLMEngine:
                      scheduler_outputs: Optional[SchedulerOutputs] = None,
                      model_output: Optional[List[SamplerOutput]] = None,
                      finished_before: Optional[List[int]] = None,
-                     skip: Optional[List[int]] = None) -> None:
+                     skip: Optional[List[int]] = None,
+                     custom_labels: Optional[Dict[str, str]] = None) -> None:
         """Forced log when no requests active."""
         if self.log_stats:
             stats = self._get_stats(scheduler_outputs, model_output,
                                     finished_before, skip)
             for logger in self.stat_loggers.values():
-                logger.log(stats)
+                logger.log(stats, custom_labels)
 
     def _get_stats(self,
                    scheduler_outputs: Optional[SchedulerOutputs],

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -87,7 +87,9 @@ class StatLoggerBase(ABC):
         self.spec_decode_metrics: Optional[SpecDecodeWorkerMetrics] = None
 
     @abstractmethod
-    def log(self, stats: Stats) -> None:
+    def log(self,
+            stats: Stats,
+            custom_labels: Optional[Dict[str, str]] = None) -> None:
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/11091, part of #6275 

Summaries
- Extend `log` interface to accept new argument `custom_labels`.
- Add `_merge_labels` and `use_labels` context manager. 
- Move metric logging logic under `with self.use_labels(custom_labels):`. This a minimum change to existing code base. 
- Beside the cpu & gpu prefix cache are device level, and some lora metadata information, rest application metrics have been updated with custom labels if loraRequest is not None. 


Here's a metrics example. 1 lora request and 2 base model requests. 

<details>
  <summary>Click me to see the metrics result</summary>
  
  ### Some Javascript
  ```text
# HELP vllm:num_requests_running Number of requests currently running on GPU.
# TYPE vllm:num_requests_running gauge
vllm:num_requests_running{model_name="sql-lora"} 0.0
vllm:num_requests_running{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:num_requests_swapped Number of requests swapped to CPU.
# TYPE vllm:num_requests_swapped gauge
vllm:num_requests_swapped{model_name="sql-lora"} 0.0
vllm:num_requests_swapped{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
# TYPE vllm:num_requests_waiting gauge
vllm:num_requests_waiting{model_name="sql-lora"} 0.0
vllm:num_requests_waiting{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:gpu_cache_usage_perc GPU KV-cache usage. 1 means 100 percent usage.
# TYPE vllm:gpu_cache_usage_perc gauge
vllm:gpu_cache_usage_perc{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:cpu_cache_usage_perc CPU KV-cache usage. 1 means 100 percent usage.
# TYPE vllm:cpu_cache_usage_perc gauge
vllm:cpu_cache_usage_perc{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:cpu_prefix_cache_hit_rate CPU prefix cache block hit rate.
# TYPE vllm:cpu_prefix_cache_hit_rate gauge
vllm:cpu_prefix_cache_hit_rate{model_name="meta-llama/Llama-2-7b-hf"} -1.0
# HELP vllm:gpu_prefix_cache_hit_rate GPU prefix cache block hit rate.
# TYPE vllm:gpu_prefix_cache_hit_rate gauge
vllm:gpu_prefix_cache_hit_rate{model_name="meta-llama/Llama-2-7b-hf"} -1.0
# HELP vllm:avg_prompt_throughput_toks_per_s Average prefill throughput in tokens/s.
# TYPE vllm:avg_prompt_throughput_toks_per_s gauge
vllm:avg_prompt_throughput_toks_per_s{model_name="sql-lora"} 0.5145061827286537
vllm:avg_prompt_throughput_toks_per_s{model_name="meta-llama/Llama-2-7b-hf"} 0.6961264482953126
# HELP vllm:avg_generation_throughput_toks_per_s Average generation throughput in tokens/s.
# TYPE vllm:avg_generation_throughput_toks_per_s gauge
vllm:avg_generation_throughput_toks_per_s{model_name="sql-lora"} 0.10290123654573075
vllm:avg_generation_throughput_toks_per_s{model_name="meta-llama/Llama-2-7b-hf"} 0.1392252896590625
# HELP vllm:num_preemptions_total Cumulative number of preemption from the engine.
# TYPE vllm:num_preemptions_total counter
vllm:num_preemptions_total{model_name="sql-lora"} 0.0
vllm:num_preemptions_total{model_name="meta-llama/Llama-2-7b-hf"} 0.0
# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
# TYPE vllm:prompt_tokens_total counter
vllm:prompt_tokens_total{model_name="sql-lora"} 5.0
vllm:prompt_tokens_total{model_name="meta-llama/Llama-2-7b-hf"} 10.0
# HELP vllm:generation_tokens_total Number of generation tokens processed.
# TYPE vllm:generation_tokens_total counter
vllm:generation_tokens_total{model_name="sql-lora"} 7.0
vllm:generation_tokens_total{model_name="meta-llama/Llama-2-7b-hf"} 14.0
# HELP vllm:request_success_total Count of successfully processed requests.
# TYPE vllm:request_success_total counter
vllm:request_success_total{finished_reason="length",model_name="sql-lora"} 1.0
vllm:request_success_total{finished_reason="length",model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig
# TYPE vllm:cache_config_info gauge
vllm:cache_config_info{block_size="16",cache_dtype="auto",cpu_offload_gb="0",enable_prefix_caching="False",gpu_memory_utilization="0.9",is_attention_free="False",num_cpu_blocks="512",num_gpu_blocks="860",num_gpu_blocks_override="None",sliding_window="None",swap_space_bytes="4294967296"} 1.0
# HELP vllm:iteration_tokens_total Histogram of number of tokens per engine_step.
# TYPE vllm:iteration_tokens_total histogram
vllm:iteration_tokens_total_sum{model_name="sql-lora"} 12.0
vllm:iteration_tokens_total_sum{model_name="meta-llama/Llama-2-7b-hf"} 24.0
vllm:iteration_tokens_total_bucket{le="1.0",model_name="sql-lora"} 7.0
vllm:iteration_tokens_total_bucket{le="2.0",model_name="sql-lora"} 7.0
vllm:iteration_tokens_total_bucket{le="4.0",model_name="sql-lora"} 7.0
vllm:iteration_tokens_total_bucket{le="8.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="16.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="24.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="32.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="40.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="48.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="56.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="64.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="72.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="80.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="88.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="96.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="104.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="112.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="120.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="128.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="136.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="144.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="152.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="160.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="168.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="176.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="184.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="192.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="200.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="208.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="216.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="224.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="232.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="240.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="248.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="256.0",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="+Inf",model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_count{model_name="sql-lora"} 8.0
vllm:iteration_tokens_total_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 31.0
vllm:iteration_tokens_total_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 31.0
vllm:iteration_tokens_total_bucket{le="4.0",model_name="meta-llama/Llama-2-7b-hf"} 31.0
vllm:iteration_tokens_total_bucket{le="8.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="16.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="24.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="32.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="48.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="56.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="64.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="72.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="80.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="88.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="96.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="104.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="112.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="120.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="128.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="136.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="144.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="152.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="160.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="168.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="176.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="184.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="192.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="200.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="208.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="216.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="224.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="232.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="240.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="248.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="256.0",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 33.0
vllm:iteration_tokens_total_count{model_name="meta-llama/Llama-2-7b-hf"} 33.0
# HELP vllm:time_to_first_token_seconds Histogram of time to first token in seconds.
# TYPE vllm:time_to_first_token_seconds histogram
vllm:time_to_first_token_seconds_sum{model_name="sql-lora"} 0.20657062530517578
vllm:time_to_first_token_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.07143115997314453
vllm:time_to_first_token_seconds_bucket{le="0.001",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.005",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.01",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.02",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.04",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.06",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.08",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.1",model_name="sql-lora"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.25",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="0.75",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="7.5",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_count{model_name="sql-lora"} 1.0
vllm:time_to_first_token_seconds_bucket{le="0.001",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.005",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.01",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.02",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_to_first_token_seconds_bucket{le="0.04",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.06",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.08",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.1",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.25",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="0.75",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="7.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_to_first_token_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:time_per_output_token_seconds Histogram of time per output token in seconds.
# TYPE vllm:time_per_output_token_seconds histogram
vllm:time_per_output_token_seconds_sum{model_name="sql-lora"} 0.18538975715637207
vllm:time_per_output_token_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.36735963821411133
vllm:time_per_output_token_seconds_bucket{le="0.01",model_name="sql-lora"} 0.0
vllm:time_per_output_token_seconds_bucket{le="0.025",model_name="sql-lora"} 0.0
vllm:time_per_output_token_seconds_bucket{le="0.05",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.075",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.1",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.15",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.2",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.3",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.4",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.5",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.75",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="1.0",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="2.5",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="+Inf",model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_count{model_name="sql-lora"} 6.0
vllm:time_per_output_token_seconds_bucket{le="0.01",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_per_output_token_seconds_bucket{le="0.025",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:time_per_output_token_seconds_bucket{le="0.05",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.075",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.1",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.15",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.2",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.4",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="0.75",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 12.0
vllm:time_per_output_token_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 12.0
# HELP vllm:e2e_request_latency_seconds Histogram of end to end request latency in seconds.
# TYPE vllm:e2e_request_latency_seconds histogram
vllm:e2e_request_latency_seconds_sum{model_name="sql-lora"} 0.39196038246154785
vllm:e2e_request_latency_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.43879079818725586
vllm:e2e_request_latency_seconds_bucket{le="0.3",model_name="sql-lora"} 0.0
vllm:e2e_request_latency_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_count{model_name="sql-lora"} 1.0
vllm:e2e_request_latency_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:e2e_request_latency_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_queue_time_seconds Histogram of time spent in WAITING phase for request.
# TYPE vllm:request_queue_time_seconds histogram
vllm:request_queue_time_seconds_sum{model_name="sql-lora"} 0.09591865539550781
vllm:request_queue_time_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.0011463165283203125
vllm:request_queue_time_seconds_bucket{le="0.3",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_count{model_name="sql-lora"} 1.0
vllm:request_queue_time_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_queue_time_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_inference_time_seconds Histogram of time spent in RUNNING phase for request.
# TYPE vllm:request_inference_time_seconds histogram
vllm:request_inference_time_seconds_sum{model_name="sql-lora"} 0.29604172706604004
vllm:request_inference_time_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.43764448165893555
vllm:request_inference_time_seconds_bucket{le="0.3",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_count{model_name="sql-lora"} 1.0
vllm:request_inference_time_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_inference_time_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_prefill_time_seconds Histogram of time spent in PREFILL phase for request.
# TYPE vllm:request_prefill_time_seconds histogram
vllm:request_prefill_time_seconds_sum{model_name="sql-lora"} 0.1105186939239502
vllm:request_prefill_time_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.07007884979248047
vllm:request_prefill_time_seconds_bucket{le="0.3",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_count{model_name="sql-lora"} 1.0
vllm:request_prefill_time_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prefill_time_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_decode_time_seconds Histogram of time spent in DECODE phase for request.
# TYPE vllm:request_decode_time_seconds histogram
vllm:request_decode_time_seconds_sum{model_name="sql-lora"} 0.18552303314208984
vllm:request_decode_time_seconds_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.3675656318664551
vllm:request_decode_time_seconds_bucket{le="0.3",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_count{model_name="sql-lora"} 1.0
vllm:request_decode_time_seconds_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_decode_time_seconds_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:time_in_queue_requests Histogram of time the request spent in the queue in seconds.
# TYPE vllm:time_in_queue_requests histogram
vllm:time_in_queue_requests_sum{model_name="sql-lora"} 0.09591865539550781
vllm:time_in_queue_requests_sum{model_name="meta-llama/Llama-2-7b-hf"} 0.0011463165283203125
vllm:time_in_queue_requests_bucket{le="0.3",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="0.5",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="0.8",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="1.5",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="2.5",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="15.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="30.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="40.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="60.0",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_count{model_name="sql-lora"} 1.0
vllm:time_in_queue_requests_bucket{le="0.3",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="0.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="0.8",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="1.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="2.5",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="15.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="30.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="40.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="60.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:time_in_queue_requests_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_prompt_tokens Number of prefill tokens processed.
# TYPE vllm:request_prompt_tokens histogram
vllm:request_prompt_tokens_sum{model_name="sql-lora"} 5.0
vllm:request_prompt_tokens_sum{model_name="meta-llama/Llama-2-7b-hf"} 10.0
vllm:request_prompt_tokens_bucket{le="1.0",model_name="sql-lora"} 0.0
vllm:request_prompt_tokens_bucket{le="2.0",model_name="sql-lora"} 0.0
vllm:request_prompt_tokens_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="100.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="200.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="500.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="1000.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="2000.0",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_count{model_name="sql-lora"} 1.0
vllm:request_prompt_tokens_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_prompt_tokens_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_prompt_tokens_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="100.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="200.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="500.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="1000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="2000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_prompt_tokens_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_generation_tokens Number of generation tokens processed.
# TYPE vllm:request_generation_tokens histogram
vllm:request_generation_tokens_sum{model_name="sql-lora"} 7.0
vllm:request_generation_tokens_sum{model_name="meta-llama/Llama-2-7b-hf"} 14.0
vllm:request_generation_tokens_bucket{le="1.0",model_name="sql-lora"} 0.0
vllm:request_generation_tokens_bucket{le="2.0",model_name="sql-lora"} 0.0
vllm:request_generation_tokens_bucket{le="5.0",model_name="sql-lora"} 0.0
vllm:request_generation_tokens_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="100.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="200.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="500.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="1000.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="2000.0",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_generation_tokens_count{model_name="sql-lora"} 1.0
vllm:request_generation_tokens_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_generation_tokens_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_generation_tokens_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_generation_tokens_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="100.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="200.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="500.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="1000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="2000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_generation_tokens_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_params_n Histogram of the n request parameter.
# TYPE vllm:request_params_n histogram
vllm:request_params_n_sum{model_name="sql-lora"} 1.0
vllm:request_params_n_sum{model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="1.0",model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="2.0",model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="5.0",model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_params_n_count{model_name="sql-lora"} 1.0
vllm:request_params_n_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_n_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_max_num_generation_tokens Histogram of maximum number of requested generation tokens.
# TYPE vllm:request_max_num_generation_tokens histogram
vllm:request_max_num_generation_tokens_sum{model_name="sql-lora"} 7.0
vllm:request_max_num_generation_tokens_sum{model_name="meta-llama/Llama-2-7b-hf"} 14.0
vllm:request_max_num_generation_tokens_bucket{le="1.0",model_name="sql-lora"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="2.0",model_name="sql-lora"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="5.0",model_name="sql-lora"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="100.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="200.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="500.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="1000.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="2000.0",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_count{model_name="sql-lora"} 1.0
vllm:request_max_num_generation_tokens_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_max_num_generation_tokens_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="100.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="200.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="500.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="1000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="2000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_max_num_generation_tokens_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:request_params_max_tokens Histogram of the max_tokens request parameter.
# TYPE vllm:request_params_max_tokens histogram
vllm:request_params_max_tokens_sum{model_name="sql-lora"} 7.0
vllm:request_params_max_tokens_sum{model_name="meta-llama/Llama-2-7b-hf"} 14.0
vllm:request_params_max_tokens_bucket{le="1.0",model_name="sql-lora"} 0.0
vllm:request_params_max_tokens_bucket{le="2.0",model_name="sql-lora"} 0.0
vllm:request_params_max_tokens_bucket{le="5.0",model_name="sql-lora"} 0.0
vllm:request_params_max_tokens_bucket{le="10.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="20.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="50.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="100.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="200.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="500.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="1000.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="2000.0",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="+Inf",model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_count{model_name="sql-lora"} 1.0
vllm:request_params_max_tokens_bucket{le="1.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_params_max_tokens_bucket{le="2.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_params_max_tokens_bucket{le="5.0",model_name="meta-llama/Llama-2-7b-hf"} 0.0
vllm:request_params_max_tokens_bucket{le="10.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="20.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="50.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="100.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="200.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="500.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="1000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="2000.0",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_bucket{le="+Inf",model_name="meta-llama/Llama-2-7b-hf"} 2.0
vllm:request_params_max_tokens_count{model_name="meta-llama/Llama-2-7b-hf"} 2.0
# HELP vllm:lora_requests_info Running stats on lora requests.
# TYPE vllm:lora_requests_info gauge
vllm:lora_requests_info{max_lora="1",running_lora_adapters="sql-lora",waiting_lora_adapters=""} 1.7344241371850073e+09
vllm:lora_requests_info{max_lora="1",running_lora_adapters="",waiting_lora_adapters=""} 1.7344243223737974e+09  ```
</details>


