### PR TITLE
[Misc] Validate grammar and fail early

### DIFF
--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -167,6 +167,15 @@ class GrammarConfig:
                         f"Conversion error: {str(e)}") from e
             else:
                 grammar_str = guided_params.grammar
+
+            # Validate the grammar and raise ValueError here if it is invalid.
+            # This is to avoid exceptions in model execution, which will crash
+            # the engine worker process.
+            try:
+                xgr.Grammar.from_ebnf(grammar_str)
+            except RuntimeError as err:
+                raise ValueError(str(err)) from err
+
             return cls(grammar_str=grammar_str,
                        vocab_size=model_config.hf_text_config.vocab_size,
                        encoded_vocab=encoded_vocab,

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -142,6 +142,9 @@ class GrammarConfig:
             else:
                 json_str = guided_params.json
 
+            # Validate the schmea and raise ValueError here if it is invalid.
+            # This is to avoid exceptions in model execution, which will crash
+            # the engine worker process.
             try:
                 xgr.Grammar.from_json_schema(json_str)
             except RuntimeError as err:

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -131,22 +131,22 @@ class GrammarConfig:
                            max_threads: int = 8) -> GrammarConfig:
 
         tokenizer_hash = hash(tokenizer)
-        # Only get tokenizer data if not already cached
-        if tokenizer_hash in TokenizerDataCache._cache:
-            encoded_vocab = None
-            stop_token_ids = None
-            backend_str = None
-        else:
-            tokenizer_data = TokenizerDataCache.get_tokenizer_data(tokenizer)
-            encoded_vocab = tokenizer_data.encoded_vocab
-            stop_token_ids = tokenizer_data.stop_token_ids
-            backend_str = tokenizer_data.backend_str
+        tokenizer_data = TokenizerDataCache.get_tokenizer_data(tokenizer)
+        encoded_vocab = tokenizer_data.encoded_vocab
+        stop_token_ids = tokenizer_data.stop_token_ids
+        backend_str = tokenizer_data.backend_str
 
         if guided_params.json:
             if not isinstance(guided_params.json, str):
                 json_str = json.dumps(guided_params.json)
             else:
                 json_str = guided_params.json
+
+            try:
+                xgr.Grammar.from_json_schema(json_str)
+            except RuntimeError as err:
+                raise ValueError(str(err)) from err
+
             return cls(json_str=json_str,
                        vocab_size=model_config.hf_text_config.vocab_size,
                        encoded_vocab=encoded_vocab,

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -142,7 +142,7 @@ class GrammarConfig:
             else:
                 json_str = guided_params.json
 
-            # Validate the schmea and raise ValueError here if it is invalid.
+            # Validate the schema and raise ValueError here if it is invalid.
             # This is to avoid exceptions in model execution, which will crash
             # the engine worker process.
             try:

--- a/vllm/model_executor/guided_decoding/xgrammar_utils.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_utils.py
@@ -26,8 +26,8 @@ def grammar_is_likely_lark(grammar_str: str) -> bool:
         if not line:
             continue
 
-        # Look for Lark rule definition
-        if ':' in line:
+        # Look for Lark-style rule definitions
+        if ':' in line and '::=' not in line:
             return True
 
     return False

--- a/vllm/model_executor/guided_decoding/xgrammar_utils.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_utils.py
@@ -26,13 +26,9 @@ def grammar_is_likely_lark(grammar_str: str) -> bool:
         if not line:
             continue
 
-        # Look for Lark-style rule definitions
-        if ':' in line and '::=' not in line:
-            return True
-
-        # Look for Lark-specific features
-        if any(pattern in line for pattern in ['?start:', '|', '~']):
-            return True
+        # Look for GBNF rule definition
+        if '::=' in line:
+            return False
 
     return False
 

--- a/vllm/model_executor/guided_decoding/xgrammar_utils.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_utils.py
@@ -26,11 +26,11 @@ def grammar_is_likely_lark(grammar_str: str) -> bool:
         if not line:
             continue
 
-        # Look for Lark-style rule definitions
-        if ':' in line and '::=' not in line:
-            return True
+        # Look for GBNF rule definition
+        if '::=' in line:
+            return False
 
-    return False
+    return True
 
 
 def convert_lark_to_gbnf(grammar_str: str) -> str:

--- a/vllm/model_executor/guided_decoding/xgrammar_utils.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_utils.py
@@ -26,9 +26,9 @@ def grammar_is_likely_lark(grammar_str: str) -> bool:
         if not line:
             continue
 
-        # Look for GBNF rule definition
-        if '::=' in line:
-            return False
+        # Look for Lark rule definition
+        if ':' in line:
+            return True
 
     return False
 


### PR DESCRIPTION
If the grammar is invalid, we now let xGrammar throw RuntimeError when compiling it. However, this happens in logits processor, so the exception is raised from model executor. Since we don't expect model executor to throw any exception now, the exception will crash the engine and kill the worker process.

This PR adds a validation to make sure the grammar is valid when constructing the GrammarConfig to solve this issue.

~~Note that there is another issue with the xgrammar backend that isn't addressed by this PR #11118~~

cc @mgoin 