### PR TITLE
[V1] Supports scheduling asynchronousization on V1 version

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -116,7 +116,7 @@ class KVCacheManager:
             A list of new blocks if new blocks are allocated, or None
             if new blocks are required but cannot be allocated.
         """
-        num_required_blocks = cdiv(request.num_computed_tokens + num_tokens,
+        num_required_blocks = cdiv(request.scheduled_num_tokens + num_tokens,
                                    self.block_size)
         req_blocks = self.req_to_blocks[request.request_id]
 

--- a/vllm/v1/executor/gpu_executor.py
+++ b/vllm/v1/executor/gpu_executor.py
@@ -67,8 +67,9 @@ class GPUExecutor:
     def execute_model(
         self,
         scheduler_output,
+        last_batch,
     ) -> ModelRunnerOutput:
-        output = self.worker.execute_model(scheduler_output)
+        output = self.worker.execute_model(scheduler_output, last_batch)
         return output
 
     def check_health(self) -> None:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -44,6 +44,8 @@ class Request:
         self._output_token_ids: List[int] = []
         self._all_token_ids: List[int] = self.prompt_token_ids.copy()
         self.num_computed_tokens = 0
+        self.scheduled_num_tokens = 0
+        self.needed_schedule_tokens = 0
 
         mm_positions = self.inputs.multi_modal_placeholders
         if mm_positions:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -196,8 +196,9 @@ class Worker:
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
+        last_batch: "SchedulerOutput",
     ) -> ModelRunnerOutput:
-        output = self.model_runner.execute_model(scheduler_output)
+        output = self.model_runner.execute_model(scheduler_output, last_batch)
         # TODO(woosuk): Send the output to the engine process.
         return output
 


### PR DESCRIPTION
Hello @robertgshaw2-neuralmagic  @njhill   Based on the previous discussion https://github.com/vllm-project/vllm/issues/10634, I implemented a version of asynchronous scheduling. I measured the request locally with bs=256, which dropped from the original **5-6ms to 150-170us**. During the entire process, **gpu-util continued to be 100%**.

<img width="890" alt="image" src="https://github.com/user-attachments/assets/4c6d47af-caad-4c25-9c2a-ecac46bf2469" />

Now that the verification of correctness has been completed, I will continue to improve the pr
TODO：

1. - [ ] Support logits output

2. - [ ] Synchronize the latest code to support multiple cards with tp>1

3. - [ ] Repair corner cases

4.  - [ ] Clean up the code (such as setting the async-schedule switch, removing nvtx, etc.)

5.  - [ ] Continue to optimize and open the cudagraph token gap, which is currently 150-170us (when cudagrah is not used, prepare_input is processed in advance in the new stream and can be 50-70us).
But after turning on cudagraph, when using the new stream to process input, the precision is not aligned. Can we discuss this? Is there anything we noticed in cudagrpah?

In addition to the above, everyone is welcome to make suggestions