### PR TITLE
[Distributed] Allow the placement group more time to wait for resources to be ready

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -277,10 +277,14 @@ def initialize_ray_cluster(
                 f"Total number of devices: {device_bundles}.")
     else:
         num_devices_in_cluster = ray.cluster_resources().get(device_str, 0)
+        # Log a warning message and delay resource allocation failure response.
+        # Avoid immediate rejection to allow user-initiated placement group
+        # created and wait cluster to be ready
         if parallel_config.world_size > num_devices_in_cluster:
-            raise ValueError(
-                f"The number of required {device_str}s exceeds the total "
-                f"number of available {device_str}s in the placement group.")
+            logger.warning(
+                "The number of required %ss exceeds the total "
+                "number of available %ss in the placement group.", device_str,
+                device_str)
         # Create a new placement group
         placement_group_specs: List[Dict[str, float]] = ([{
             device_str: 1.0


### PR DESCRIPTION
FIX #11134 

### Case 1: Waiting resource to be ready
1. start a ray cluster `ray start --head --dashboard-host 0.0.0.0 --disable-usage-stats --block  --num-gpus 1`
2. launch vLLM `python -m vllm.entrypoints.openai.api_server     --model Qwen/Qwen2.5-1.5B-Instruct     --trust-remote-code     --distributed-executor-backend ray     --tensor-parallel-size 2`
3. launch a ray worker node `ray start --address='192.168.2.2:6379' --num-gpus 1`

The primary difference between current PR and baseline is it won't early reject the placement group request but waiting until placement group timeout.

![image](https://github.com/user-attachments/assets/57327a2a-02ea-4c3c-860d-1877b92c0177)

### Case 2: Timeout case

![image](https://github.com/user-attachments/assets/f8db5558-80ed-41e6-b5bd-c17ba225e829)




