### PR TITLE
[Core] Update outlines and increase its threadpool size

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,7 +19,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines == 0.1.9
+outlines == 0.1.10
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,7 +19,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines == 0.1.10
+outlines == 0.1.11
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317


### PR DESCRIPTION
6c2b68e0a [Build/CI] Update outlines to 0.10.0
a07b90830 outlines: Scale thread pool size based on cpu count
fc1ce151a Update to outlines-0.1.11

commit 6c2b68e0a98ac9e02d75be9a99ae0e2a07d58170
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Dec 12 14:33:15 2024 +0000

    [Build/CI] Update outlines to 0.10.0
    
    outlines 0.10.0 was just released and includes some performance
    improvements. I tested it successfully in my env and saw some
    improvement, so I think we should bump the version.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit a07b90830ea87d1091b645c3254b4262846044b2
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Dec 12 15:09:20 2024 +0000

    outlines: Scale thread pool size based on cpu count
    
    outlines 0.1.10 includes some improvements to parallelization. I
    noticed that this threadpool was hard-coded to a size of 2. This uses
    the host's CPU count instead. The improvement is not huge, but is
    measurable.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit fc1ce151acd64e344fb969a3f9dbb042696a9ee7
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Dec 13 15:05:07 2024 +0000

    Update to outlines-0.1.11
    
    As of this version, arm wheels should be available!
    
    https://github.com/dottxt-ai/outlines-core/issues/122
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

Closes #11178 

-----

Before (closer to 0.1.8):

<img width="646" alt="image" src="https://github.com/user-attachments/assets/1cf355f2-d36c-4f0c-8c0a-c5bc7cd207ba" />

After (with 0.1.10):

<img width="656" alt="image" src="https://github.com/user-attachments/assets/7c48eb47-db28-4236-b1e6-52b0a6b8b811" />

with 0.1.10 + threadpool size increase:

<img width="520" alt="image" src="https://github.com/user-attachments/assets/db105abc-2431-4254-aed4-b57890ee2b49" />
