### PR TITLE
fix(docs): typo in helm install instructions

### DIFF
--- a/docs/source/serving/deploying_with_helm.rst
+++ b/docs/source/serving/deploying_with_helm.rst
@@ -25,7 +25,7 @@ To install the chart with the release name ``test-vllm``:
 
 .. code-block:: console
 
-    helm upgrade --install --create-namespace --namespace=ns-vllm test-vllm . -f values.yaml --set secrets.s3endpoint=$ACCESS_POINT --set secrets.s3buckername=$BUCKET --set secrets.s3accesskeyid=$ACCESS_KEY --set secrets.s3accesskey=$SECRET_KEY
+    helm upgrade --install --create-namespace --namespace=ns-vllm test-vllm . -f values.yaml --set secrets.s3endpoint=$ACCESS_POINT --set secrets.s3bucketname=$BUCKET --set secrets.s3accesskeyid=$ACCESS_KEY --set secrets.s3accesskey=$SECRET_KEY
 
 Uninstalling the Chart
 ----------------------


### PR DESCRIPTION
Fix typo `s3buckername`.
