### PR TITLE
Fix logging of the vLLM Config

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -248,7 +248,7 @@ class LLMEngine:
         )
 
         logger.info(
-            "Initializing an LLM engine (v%s) with config: %r,"
+            "Initializing an LLM engine (v%s) with config: %s, "
             "use_cached_outputs=%s, ",
             VLLM_VERSION,
             vllm_config,


### PR DESCRIPTION
The llm_engine logs its VllmConfig during initialization.  A recent change to the logging (#10999) has resulted in this log entry containing python object references rather than the actual details of the config, e.g.:

VllmConfig(model_config=<vllm.config.ModelConfig object at 0x7f123b55db50>, cache_config=<vllm.config.CacheConfig object at 0x7f1239087920>

This commit logs the VllmConfig using %s so that the string representation of the VllmConfig is logged, e.g.:

model='amd/Mixtral-8x22B-Instruct-v0.1-FP8-KV', speculative_config=None, ...