### PR TITLE
[Frontend] Add `logits_processors` as an extra completion argument

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -299,18 +299,17 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "The request_id related to this request. If the caller does "
             "not set it, a random_uuid will be generated. This id is used "
             "through out the inference process and return in response."))
-    logits_processors: Optional[
-        List[Union[str, LogitsProcessorConstructor]]
-    ] = Field(
-        default=None,
-        description=(
-            "A list of either qualified names of logits processors, or "
-            "constructor objects, to apply when sampling. A constructor is "
-            "a JSON object with a required 'qualname' field specifying the "
-            "qualified name of the processor class/factory, and optional "
-            "'args' and 'kwargs' fields containing positional and keyword "
-            "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor',"
-            "'args': [1, 2], 'kwargs': {'param': 'value'}}."))
+    logits_processors: Optional[List[Union[
+        str, LogitsProcessorConstructor]]] = Field(
+            default=None,
+            description=
+            ("A list of either qualified names of logits processors, or "
+             "constructor objects, to apply when sampling. A constructor is "
+             "a JSON object with a required 'qualname' field specifying the "
+             "qualified name of the processor class/factory, and optional "
+             "'args' and 'kwargs' fields containing positional and keyword "
+             "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor'"
+             ", 'args': [1, 2], 'kwargs': {'param': 'value'}}."))
 
     # doc: end-chat-completion-extra-params
 
@@ -343,16 +342,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
             prompt_logprobs = self.top_logprobs
 
         if self.logits_processors:
-            logits_processors = [
-                (
-                    resolve_obj_by_qualname(p) 
-                    if isinstance(p, str) else
-                    resolve_obj_by_qualname(p.qualname)(
-                        *p.args or [], **p.kwargs or {}
-                    )
-                )
-                for p in self.logits_processors
-            ]
+            logits_processors = [(resolve_obj_by_qualname(p) if isinstance(
+                p, str) else resolve_obj_by_qualname(p.qualname)(
+                    *p.args or [], **p.kwargs or {}))
+                                 for p in self.logits_processors]
         else:
             logits_processors = None
 
@@ -632,18 +625,17 @@ class CompletionRequest(OpenAIBaseModel):
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."))
-    logits_processors: Optional[
-        List[Union[str, LogitsProcessorConstructor]]
-    ] = Field(
-        default=None,
-        description=(
-            "A list of either qualified names of logits processors, or "
-            "constructor objects, to apply when sampling. A constructor is "
-            "a JSON object with a required 'qualname' field specifying the "
-            "qualified name of the processor class/factory, and optional "
-            "'args' and 'kwargs' fields containing positional and keyword "
-            "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor',"
-            "'args': [1, 2], 'kwargs': {'param': 'value'}}."))
+    logits_processors: Optional[List[Union[
+        str, LogitsProcessorConstructor]]] = Field(
+            default=None,
+            description=
+            ("A list of either qualified names of logits processors, or "
+             "constructor objects, to apply when sampling. A constructor is "
+             "a JSON object with a required 'qualname' field specifying the "
+             "qualified name of the processor class/factory, and optional "
+             "'args' and 'kwargs' fields containing positional and keyword "
+             "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor'"
+             ", 'args': [1, 2], 'kwargs': {'param': 'value'}}."))
 
     # doc: end-completion-extra-params
 
@@ -676,16 +668,10 @@ class CompletionRequest(OpenAIBaseModel):
         echo_without_generation = self.echo and self.max_tokens == 0
 
         if self.logits_processors:
-            logits_processors = [
-                (
-                    resolve_obj_by_qualname(p) 
-                    if isinstance(p, str) else
-                    resolve_obj_by_qualname(p.qualname)(
-                        *p.args or [], **p.kwargs or {}
-                    )
-                )
-                for p in self.logits_processors
-            ]
+            logits_processors = [(resolve_obj_by_qualname(p) if isinstance(
+                p, str) else resolve_obj_by_qualname(p.qualname)(
+                    *p.args or [], **p.kwargs or {}))
+                                 for p in self.logits_processors]
         else:
             logits_processors = None
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -14,7 +14,7 @@ from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import (BeamSearchParams, GuidedDecodingParams,
                                   RequestOutputKind, SamplingParams)
 from vllm.sequence import Logprob
-from vllm.utils import random_uuid
+from vllm.utils import random_uuid, resolve_obj_by_qualname
 
 logger = init_logger(__name__)
 
@@ -146,6 +146,12 @@ class ChatCompletionNamedFunction(OpenAIBaseModel):
 class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
     function: ChatCompletionNamedFunction
     type: Literal["function"] = "function"
+
+
+class LogitsProcessorConstructor(BaseModel):
+    qualname: str
+    args: Optional[List[Any]] = None
+    kwargs: Optional[Dict[str, Any]] = None
 
 
 class ChatCompletionRequest(OpenAIBaseModel):
@@ -293,6 +299,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "The request_id related to this request. If the caller does "
             "not set it, a random_uuid will be generated. This id is used "
             "through out the inference process and return in response."))
+    logits_processors: Optional[List[Union[str, LogitsProcessorConstructor]]] = Field(
+        default=None,
+        description=(
+            "A list of either qualified names of logits processors, or "
+            "constructor objects, to apply when sampling. A constructor is "
+            "a JSON object with a required 'qualname' field specifying the "
+            "qualified name of the processor class/factory, and optional "
+            "'args' and 'kwargs' fields containing positional and keyword "
+            "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor',"
+            "'args': [1, 2], 'kwargs': {'param': 'value'}}."))
 
     # doc: end-chat-completion-extra-params
 
@@ -323,6 +339,20 @@ class ChatCompletionRequest(OpenAIBaseModel):
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.top_logprobs
+
+        if self.logits_processors:
+            logits_processors = [
+                (
+                    resolve_obj_by_qualname(p) 
+                    if isinstance(p, str) else
+                    resolve_obj_by_qualname(p["qualname"])(
+                        *p.get("args", []), **p.get("kwargs", {})
+                    )
+                )
+                for p in self.logits_processors
+            ]
+        else:
+            logits_processors = None
 
         guided_json_object = None
         if self.response_format is not None:
@@ -364,6 +394,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_tokens=self.min_tokens,
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
+            logits_processors=logits_processors,
             include_stop_str_in_output=self.include_stop_str_in_output,
             truncate_prompt_tokens=self.truncate_prompt_tokens,
             output_kind=RequestOutputKind.DELTA if self.stream \
@@ -599,6 +630,16 @@ class CompletionRequest(OpenAIBaseModel):
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."))
+    logits_processors: Optional[List[Union[str, LogitsProcessorConstructor]]] = Field(
+        default=None,
+        description=(
+            "A list of either qualified names of logits processors, or "
+            "constructor objects, to apply when sampling. A constructor is "
+            "a JSON object with a required 'qualname' field specifying the "
+            "qualified name of the processor class/factory, and optional "
+            "'args' and 'kwargs' fields containing positional and keyword "
+            "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor',"
+            "'args': [1, 2], 'kwargs': {'param': 'value'}}."))
 
     # doc: end-completion-extra-params
 
@@ -629,6 +670,20 @@ class CompletionRequest(OpenAIBaseModel):
             prompt_logprobs = self.logprobs
 
         echo_without_generation = self.echo and self.max_tokens == 0
+
+        if self.logits_processors:
+            logits_processors = [
+                (
+                    resolve_obj_by_qualname(p) 
+                    if isinstance(p, str) else
+                    resolve_obj_by_qualname(p["qualname"])(
+                        *p.get("args", []), **p.get("kwargs", {})
+                    )
+                )
+                for p in self.logits_processors
+            ]
+        else:
+            logits_processors = None
 
         guided_json_object = None
         if (self.response_format is not None
@@ -665,6 +720,7 @@ class CompletionRequest(OpenAIBaseModel):
             skip_special_tokens=self.skip_special_tokens,
             spaces_between_special_tokens=self.spaces_between_special_tokens,
             include_stop_str_in_output=self.include_stop_str_in_output,
+            logits_processors=logits_processors,
             truncate_prompt_tokens=self.truncate_prompt_tokens,
             output_kind=RequestOutputKind.DELTA if self.stream \
                 else RequestOutputKind.FINAL_ONLY,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -308,8 +308,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
              "a JSON object with a required 'qualname' field specifying the "
              "qualified name of the processor class/factory, and optional "
              "'args' and 'kwargs' fields containing positional and keyword "
-             "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor'"
-             ", 'args': [1, 2], 'kwargs': {'param': 'value'}}."))
+             "arguments. For example: {'qualname': "
+             "'my_module.MyLogitsProcessor', 'args': [1, 2], 'kwargs': "
+             "{'param': 'value'}}."))
 
     # doc: end-chat-completion-extra-params
 
@@ -634,8 +635,9 @@ class CompletionRequest(OpenAIBaseModel):
              "a JSON object with a required 'qualname' field specifying the "
              "qualified name of the processor class/factory, and optional "
              "'args' and 'kwargs' fields containing positional and keyword "
-             "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor'"
-             ", 'args': [1, 2], 'kwargs': {'param': 'value'}}."))
+             "arguments. For example: {'qualname': "
+             "'my_module.MyLogitsProcessor', 'args': [1, 2], 'kwargs': "
+             "{'param': 'value'}}."))
 
     # doc: end-completion-extra-params
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -299,7 +299,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "The request_id related to this request. If the caller does "
             "not set it, a random_uuid will be generated. This id is used "
             "through out the inference process and return in response."))
-    logits_processors: Optional[List[Union[str, LogitsProcessorConstructor]]] = Field(
+    logits_processors: Optional[
+        List[Union[str, LogitsProcessorConstructor]]
+    ] = Field(
         default=None,
         description=(
             "A list of either qualified names of logits processors, or "
@@ -630,7 +632,9 @@ class CompletionRequest(OpenAIBaseModel):
             "The priority of the request (lower means earlier handling; "
             "default: 0). Any priority other than 0 will raise an error "
             "if the served model does not use priority scheduling."))
-    logits_processors: Optional[List[Union[str, LogitsProcessorConstructor]]] = Field(
+    logits_processors: Optional[
+        List[Union[str, LogitsProcessorConstructor]]
+    ] = Field(
         default=None,
         description=(
             "A list of either qualified names of logits processors, or "

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -345,8 +345,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 (
                     resolve_obj_by_qualname(p) 
                     if isinstance(p, str) else
-                    resolve_obj_by_qualname(p["qualname"])(
-                        *p.get("args", []), **p.get("kwargs", {})
+                    resolve_obj_by_qualname(p.qualname)(
+                        *p.args or [], **p.kwargs or {}
                     )
                 )
                 for p in self.logits_processors
@@ -676,8 +676,8 @@ class CompletionRequest(OpenAIBaseModel):
                 (
                     resolve_obj_by_qualname(p) 
                     if isinstance(p, str) else
-                    resolve_obj_by_qualname(p["qualname"])(
-                        *p.get("args", []), **p.get("kwargs", {})
+                    resolve_obj_by_qualname(p.qualname)(
+                        *p.args or [], **p.kwargs or {}
                     )
                 )
                 for p in self.logits_processors

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -343,10 +343,11 @@ class ChatCompletionRequest(OpenAIBaseModel):
             prompt_logprobs = self.top_logprobs
 
         if self.logits_processors:
-            logits_processors = [(resolve_obj_by_qualname(p) if isinstance(
-                p, str) else resolve_obj_by_qualname(p.qualname)(
-                    *p.args or [], **p.kwargs or {}))
-                                 for p in self.logits_processors]
+            logits_processors = [
+                (resolve_obj_by_qualname(p) if isinstance(p, str) else
+                 resolve_obj_by_qualname(p.qualname)(*p.args, **p.kwargs))
+                for p in self.logits_processors
+            ]
         else:
             logits_processors = None
 
@@ -670,10 +671,11 @@ class CompletionRequest(OpenAIBaseModel):
         echo_without_generation = self.echo and self.max_tokens == 0
 
         if self.logits_processors:
-            logits_processors = [(resolve_obj_by_qualname(p) if isinstance(
-                p, str) else resolve_obj_by_qualname(p.qualname)(
-                    *p.args or [], **p.kwargs or {}))
-                                 for p in self.logits_processors]
+            logits_processors = [
+                (resolve_obj_by_qualname(p) if isinstance(p, str) else
+                 resolve_obj_by_qualname(p.qualname)(*p.args, **p.kwargs))
+                for p in self.logits_processors
+            ]
         else:
             logits_processors = None
 


### PR DESCRIPTION
Adds `logits_processors` as an extra (optional) argument to `ChatCompletionRequest` and `CompletionRequest`:

```python
    logits_processors: Optional[List[Union[str, LogitsProcessorConstructor]]] = Field(
        default=None,
        description=(
            "A list of either qualified names of logits processors, or "
            "constructor objects, to apply when sampling. A constructor is "
            "a JSON object with a required 'qualname' field specifying the "
            "qualified name of the processor class/factory, and optional "
            "'args' and 'kwargs' fields containing positional and keyword "
            "arguments. For example: {'qualname': 'my_module.MyLogitsProcessor',"
            "'args': [1, 2], 'kwargs': {'param': 'value'}}."))
 ```
 
 This enables passing built-in or custom logits processors to direct the sampling process.
