### PR TITLE
[Bugfix] using len(tokenizer) instead of tokenizer.vocab_size in AllowedTokenIdsLogitsProcessor

### DIFF
--- a/vllm/entrypoints/openai/logits_processors.py
+++ b/vllm/entrypoints/openai/logits_processors.py
@@ -71,7 +71,7 @@ def get_logits_processors(
 
         # Check if token_id is within the vocab size
         for token_id, bias in clamped_logit_bias.items():
-            if token_id < 0 or token_id >= tokenizer.vocab_size:
+            if token_id < 0 or token_id >= len(tokenizer):
                 raise ValueError(f"token_id {token_id} in logit_bias contains "
                                  "out-of-vocab token id")
 
@@ -81,6 +81,6 @@ def get_logits_processors(
     if allowed_token_ids is not None:
         logits_processors.append(
             _get_allowed_token_ids_logits_processor(
-                frozenset(allowed_token_ids), tokenizer.vocab_size))
+                frozenset(allowed_token_ids), len(tokenizer)))
 
     return logits_processors


### PR DESCRIPTION
As defined in [tokenization_utils_fast.py](https://github.com/huggingface/transformers/blob/main/src/transformers/tokenization_utils_fast.py), `len(tokenizer)` includes the added tokens but `tokenizer.vocab_size` does not.

```
    @property
    def __len__(self) -> int:
        """
        Size of the full vocabulary with the added tokens.
        """
        return self._tokenizer.get_vocab_size(with_added_tokens=True)

    @property
    def vocab_size(self) -> int:
        """
        `int`: Size of the base vocabulary (without the added tokens).
        """
        return self._tokenizer.get_vocab_size(with_added_tokens=False)
```

However, `AllowedTokenIdsLogitsProcessor` assumes all `allowed_token_ids` must be smaller than `tokenizer.vocab_size`.
```
    if allowed_token_ids is not None:
        logits_processors.append(
            _get_allowed_token_ids_logits_processor(
                frozenset(allowed_token_ids), tokenizer.vocab_size))
```
```
@lru_cache(maxsize=32)
def _get_allowed_token_ids_logits_processor(
    allowed_token_ids: FrozenSet[int],
    vocab_size: int,
) -> LogitsProcessor:
    if not allowed_token_ids:
        raise ValueError("Empty allowed_token_ids provided")
    if not all(0 <= tid < vocab_size for tid in allowed_token_ids):
        raise ValueError("allowed_token_ids contains "
                         "out-of-vocab token id")
    return AllowedTokenIdsLogitsProcessor(allowed_token_ids)
```
This could trigger error when specifying allowed_token_ids in SamplingParams with added tokens, e.g., `<|begin_of_text|>` and `<|end_of_text|>` in Llama3-8b (see below). In this PR, I replace `tokenizer.vocab_size` with `len(tokenizer)` in this context to avoid such error.

```
from transformers import AutoTokenizer
from vllm import LLM, SamplingParams
from vllm.entrypoints.openai.logits_processors import _get_allowed_token_ids_logits_processor

model = LLM(
    model="Llama3-8b",
    trust_remote_code=True,
    swap_space=32,
)
tokenizer = AutoTokenizer.from_pretrained("Llama3-8b")
print(f"tokenizer.vocab_size = {tokenizer.vocab_size}") # tokenizer.vocab_size = 128000
print(f"len(tokenizer) = {tokenizer.__len__()}") # len(tokenizer) = 128256

prompts = [
    "Does tokenizer.vocab_size include added tokens? Yes/No",
    "Does len(tokenizer) include added tokens? Yes/No",
]
choices = ["Yes", "No"]
choices_ids = tokenizer(choices).input_ids
allowed_token_ids = set(id for ids in choices_ids for id in ids)
print(f"choices_ids: {choices_ids}") # choices_ids: [[128000, 9642], [128000, 2822]]

# success
outputs = model.generate(
    prompts=prompts,
    sampling_params=SamplingParams(
        n=1, temperature=0.0,
        max_tokens=max([len(ids) for ids in choices_ids]),
        logits_processors=[
            _get_allowed_token_ids_logits_processor(
                frozenset(allowed_token_ids),
                len(tokenizer)
            ),
        ],
    )
)

# fail
outputs = model.generate(
    prompts=prompts,
    sampling_params=SamplingParams(
        n=1, temperature=0.0,
        max_tokens=max([len(ids) for ids in choices_ids]),
        allowed_token_ids=allowed_token_ids,
    )
)
```