### PR TITLE
[V1][VLM] Fix edge case bug for InternVL2

### DIFF
--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -670,7 +670,8 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP):
 
         patches_per_image = image_input["patches_per_image"]
         if len(patches_per_image) == 1:
-            image_embeds = image_embeds.unsqueeze(0)
+            image_embeds = image_embeds.view(
+                -1, self.config.text_config.hidden_size).unsqueeze(0)
             return image_embeds
 
         # NOTE: Image embeddings are split into separate tensors for each image

--- a/vllm/model_executor/models/internvl.py
+++ b/vllm/model_executor/models/internvl.py
@@ -669,6 +669,8 @@ class InternVLChatModel(nn.Module, SupportsMultiModal, SupportsPP):
         image_embeds = self.extract_feature(image_input["data"])
 
         patches_per_image = image_input["patches_per_image"]
+
+        # Only one image in the current batch
         if len(patches_per_image) == 1:
             image_embeds = image_embeds.view(
                 -1, self.config.text_config.hidden_size).unsqueeze(0)


### PR DESCRIPTION
When there's only one image in the batch, the `image_embeds` needs to be reshaped to `[feature_size, hidden_size]` from `[num_patches, feature_size_per_patch, hidden_size]` before getting unsqueezed. 

This was previously not observed during offline mode because the default `max_num_batched_tokens=8196` is always bigger than max image size of internVL2, but discovered when running online benchmark with the default `max_num_batched_tokens=2048` where chunked prefill is needed.