### PR TITLE
[Bugfix][Hardware][CPU] Enable Gemma2 with SDPA on CPU backend

### DIFF
--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -13,7 +13,7 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.attention.ops.ipex_attn import PagedAttention
 from vllm.attention.ops.paged_attn import PagedAttentionMetadata
-from vllm.utils import make_tensor_with_pad
+from vllm.utils import make_tensor_with_pad, print_warning_once
 from vllm.worker.cpu_model_runner import ModelInputForCPUBuilder
 
 
@@ -395,7 +395,8 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
             raise ValueError(
                 "Torch SPDA does not support block-sparse attention.")
         if logits_soft_cap is not None:
-            raise ValueError("Torch SPDA does not support logits soft cap.")
+            print_warning_once("Torch SPDA does not support logits soft cap. "
+                               "Outputs may be slightly off.")
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -619,7 +619,7 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
                 value[None, :, start_kv:end_kv, :],
                 attn_mask=mask,
                 dropout_p=0.0,
-                is_causal=causal_attn and not self.need_mask,
+                is_causal=causal_attn and mask is None,
                 scale=self.scale).squeeze(0).movedim(query.dim() - 2, 0)
             output[start_q:end_q, :, :] = sub_out
             start_q, start_kv = end_q, end_kv


### PR DESCRIPTION
Make sure is_causal is only True when mask is None as required by SDPA otherwise there is an error raised

`RuntimeError: _scaled_dot_product_attention: Explicit attn_mask should not be set when is_causal=True`

With models such as Gemma2, that have alternating layers of sliding window attention and full attention, while self.need_mask is correctly set for each layer, the mask itself is set once via attn_metadata.set_attn_bias() and is
not None even for the layers that need_mask is False for.

This is the minimal change that fixes Gemma 2 and more clearly expresses what the SDPA API requires.

Another way would be to have attn_masks explicitly set to None when self.need_mask is False, inside or right after the  initial attn_metadata set/get_attn_bias() block.

