### PR TITLE
[Hardware][CPU] Just warn on missing logits soft cap implementation.

### DIFF
--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -13,7 +13,7 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.attention.ops.ipex_attn import PagedAttention
 from vllm.attention.ops.paged_attn import PagedAttentionMetadata
-from vllm.utils import make_tensor_with_pad
+from vllm.utils import make_tensor_with_pad, print_warning_once
 from vllm.worker.cpu_model_runner import ModelInputForCPUBuilder
 
 
@@ -395,7 +395,8 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
             raise ValueError(
                 "Torch SPDA does not support block-sparse attention.")
         if logits_soft_cap is not None:
-            raise ValueError("Torch SPDA does not support logits soft cap.")
+            print_warning_once("Torch SPDA does not support logits soft cap. "
+                               "Outputs may be slightly off.")
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)


### PR DESCRIPTION
Turn an error into a warning and allow Gemma2 and PaliGemma 2 to run on the CPU backend with seemingly normal outputs.

From https://huggingface.co/blog/gemma2

"The Gemma 2 team observed very minor differences when soft-capping is removed during inference."