### PR TITLE
[Misc] Add image repeat option to benchmark_serving.py (to test hit/miss of MM cache)

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -781,6 +781,7 @@ def main(args: argparse.Namespace):
     backend = args.backend
     model_id = args.model
     tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
+    tokenizer_mode = args.tokenizer_mode
 
     if args.base_url is not None:
         api_url = f"{args.base_url}{args.endpoint}"
@@ -790,6 +791,7 @@ def main(args: argparse.Namespace):
         base_url = f"http://{args.host}:{args.port}"
 
     tokenizer = get_tokenizer(tokenizer_id,
+                              tokenizer_mode=tokenizer_mode,
                               trust_remote_code=args.trust_remote_code)
 
     if args.dataset is not None:
@@ -1209,6 +1211,16 @@ if __name__ == "__main__":
         help="Output length for each request. Overrides the output lengths "
         "from the sampled HF dataset.",
     )
+
+    parser.add_argument(
+        '--tokenizer-mode',
+        type=str,
+        default="auto",
+        choices=['auto', 'slow', 'mistral'],
+        help='The tokenizer mode.\n\n* "auto" will use the '
+        'fast tokenizer if available.\n* "slow" will '
+        'always use the slow tokenizer. \n* '
+        '"mistral" will always use the `mistral_common` tokenizer.')
 
     args = parser.parse_args()
     main(args)

--- a/vllm/v1/engine/mm_input_mapper.py
+++ b/vllm/v1/engine/mm_input_mapper.py
@@ -45,14 +45,14 @@ class MMInputMapperClient:
         self.mm_cache = LRUDictCache(MM_CACHE_SIZE)
 
         # DEBUG: Set to None to disable
-        self.mm_debug_cache_hit_ratio_steps = None
+        self.mm_debug_cache_hit_ratio_steps = 32
         self.mm_cache_hits = 0
         self.mm_cache_total = 0
 
     def cache_hit_ratio(self, steps) -> float:
         if self.mm_cache_total > 0 and self.mm_cache_total % steps == 0:
-            logger.debug("MMInputMapper: cache_hit_ratio = %.2f ",
-                         self.mm_cache_hits / self.mm_cache_total)
+            print("MMInputMapper: cache_hit_ratio = %.2f ",
+                  self.mm_cache_hits / self.mm_cache_total)
 
     def process_inputs(
         self,


### PR DESCRIPTION
benchmark_serving.py: This PR adds the option to repeat images with specific probability so we can test HIT/MISS of MM cache.