### PR TITLE
Bump outlines version to 0.1.11 to include ARM support, FIX #11178

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,7 +19,7 @@ prometheus_client >= 0.18.0
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines == 0.1.9
+outlines == 0.1.11
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317


### PR DESCRIPTION
Bump `outlines` version to 0.1.11. Currently vLLM depends on outlines v0.1.9 which was breaking on ARM due to missing arch support on outlines-core for ARM (https://github.com/dottxt-ai/outlines-core/issues/122).

`outlines` has resolved this issue in their latest release v0.1.11.

FIXES #11178 