### PR TITLE
[V1][Bugfix] Fix V1 TP trust-remote-code

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -14,6 +14,8 @@ from msgspec import msgpack
 
 from vllm.config import CacheConfig, VllmConfig
 from vllm.logger import init_logger
+from vllm.transformers_utils.config import (
+    maybe_register_config_serialize_by_value)
 from vllm.usage.usage_lib import UsageContext
 from vllm.v1.core.scheduler import Scheduler
 from vllm.v1.engine import (EngineCoreOutput, EngineCoreOutputs,
@@ -244,6 +246,9 @@ class EngineCoreProc(EngineCore):
         # SystemExit exception is only raised once to allow this and worker
         # processes to terminate without error
         shutdown_requested = False
+
+        # Ensure we can serialize transformer config after spawning
+        maybe_register_config_serialize_by_value()
 
         def signal_handler(signum, frame):
             nonlocal shutdown_requested


### PR DESCRIPTION
When running in V1 with TP:
```
VLLM_USE_V1=1 VLLM_ENABLE_V1_MULTIPROCESSING=1 vllm serve deepseek-ai/DeepSeek-V2-Lite --tensor-parallel-size 2 --trust-remote-code
```

This fixes the following error
```
_pickle.PicklingError: Can't pickle <class 'transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config'>: it's not the same object as transformers_modules.deepseek-ai.DeepSeek-V2-Lite.604d5664dddd88a0433dbae533b7fe9472482de0.configuration_deepseek.DeepseekV2Config
```