### PR TITLE
[V1][Bugfix] Fix EngineCoreProc profile

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -325,7 +325,7 @@ class EngineCoreProc(EngineCore):
         if isinstance(request, EngineCoreRequest):
             self.add_request(request)
         elif isinstance(request, EngineCoreProfile):
-            self.model_executor.worker.profile(request.is_start)
+            self.model_executor.profile(request.is_start)
         else:
             # TODO: make an EngineCoreAbort wrapper
             assert isinstance(request, list)


### PR DESCRIPTION
Small bugfix when profiling in V1 with `VLLM_ENABLE_V1_MULTIPROCESSING` and TP size > 1