### PR TITLE
[Bugfix][V1] Re-compute an entire block when fully cache hit

### DIFF
--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -199,9 +199,13 @@ class Scheduler:
                 if num_new_tokens == 0:
                     # The happens when prompt length is divisible by the block
                     # size and all blocks are cached. Now we force to recompute
-                    # the last token.
-                    num_computed_tokens -= 1
-                    num_new_tokens = 1
+                    # the last block. Note that we have to re-compute an entire
+                    # block because allocate_slots() assumes num_computed_tokens
+                    # is always a multiple of the block size. This limitation
+                    # can potentially be removed in the future to slightly
+                    # improve the performance.
+                    num_computed_tokens -= self.block_size
+                    num_new_tokens = self.block_size
                     computed_blocks.pop()
                 num_new_tokens = min(num_new_tokens, token_budget)
                 assert num_new_tokens > 0


### PR DESCRIPTION
Previously we re-compute the last token when the prompt is fully cache hit. However, since `allocate_slots()` calculates number of computed tokens based on the number of computed blocks, the number of computed tokens `allocate_slots()` inferred is always multiply by the block size. This results in the last block fails to be cached in the right way, and breaks the hash block chain in prefix caching. While this doesn't affect the accuracy, it hurts the cache hit rate a bit.

cc @WoosukKwon 