### PR TITLE
[V1][VLM] Proper memory profiling for image language models

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1186,6 +1186,14 @@ class SchedulerConfig:
 
     is_multimodal_model: bool = False
 
+    # Multimodal encoder run compute budget, only used in V1
+    # FIXME(woosuk & ywang96): Below are placeholder values. We need to
+    # calculate the actual values from the configurations.
+    max_num_encoder_input_tokens = 16384
+
+    # Multimodal encoder cache size, only used in V1
+    encoder_cache_size = 16384
+
     # Whether to perform preemption by swapping or
     # recomputation. If not specified, we determine the mode as follows:
     # We use recomputation by default since it incurs lower overhead than

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1186,9 +1186,9 @@ class SchedulerConfig:
 
     is_multimodal_model: bool = False
 
-    # Multimodal encoder run compute budget, only used in V1
     # FIXME(woosuk & ywang96): Below are placeholder values. We need to
     # calculate the actual values from the configurations.
+    # Multimodal encoder run compute budget, only used in V1
     max_num_encoder_input_tokens = 16384
 
     # Multimodal encoder cache size, only used in V1

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -245,6 +245,11 @@ class PixtralForConditionalGeneration(nn.Module, SupportsMultiModal,
             # Do not split, return as tensor of shape [1, fs, hs]
             return image_embeds.unsqueeze(0)
 
+        # If the last split index is the last index in image_tokens, we
+        # ignore it to avoid empty split tensor
+        if split_indices[-1] == len(image_tokens):
+            split_indices = split_indices[:-1]
+
         image_embeds = image_embeds.tensor_split(split_indices.cpu())
         return image_embeds
 

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -209,7 +209,7 @@ class MultiModalRegistry:
         for profiling the memory usage of a model.
 
         Note:
-            This is currently only used in V1.
+            This is currently directly used only in V1.
         """
 
         return {
@@ -233,9 +233,9 @@ class MultiModalRegistry:
         limits_per_plugin = self._limits_by_model[model_config]
 
         return {
-            key: (limits_per_plugin[key] *
-                  plugin.get_max_multimodal_tokens(model_config))
-            for key, plugin in self._plugins.items()
+            key: limits_per_plugin[key] * max_tokens_per_mm_item
+            for key, max_tokens_per_mm_item in
+            self.get_max_tokens_per_item_by_modality(model_config).items()
         }
 
     def get_max_multimodal_tokens(self, model_config: "ModelConfig") -> int:

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -200,6 +200,23 @@ class MultiModalRegistry:
         """
         return self.register_max_multimodal_tokens("image", max_mm_tokens)
 
+    def get_max_tokens_per_item_by_modality(
+        self,
+        model_config: "ModelConfig",
+    ) -> Mapping[str, int]:
+        """
+        Get the maximum number of tokens per data item from each modality
+        for profiling the memory usage of a model.
+
+        Note:
+            This is currently only used in V1.
+        """
+
+        return {
+            key: plugin.get_max_multimodal_tokens(model_config)
+            for key, plugin in self._plugins.items()
+        }
+
     def get_max_tokens_by_modality(
         self,
         model_config: "ModelConfig",

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -73,14 +73,13 @@ class Scheduler:
         # NOTE(woosuk): Here, "encoder" includes the vision encoder (and
         # projector if needed). Currently, we assume that the encoder also
         # has the Transformer architecture (e.g., ViT).
-        # FIXME(woosuk): Below are placeholder values. We need to calculate the
-        # actual values from the configurations.
-        self.max_num_encoder_input_tokens = 16384
+        self.max_num_encoder_input_tokens = self.scheduler_config.max_num_encoder_input_tokens  #noqa: E501
         # NOTE(woosuk): For the models without encoder (e.g., text-only models),
         # the encoder cache will not be initialized and used, regardless of
         # the cache size. This is because the memory space for the encoder cache
         # is preallocated in the profiling run.
-        self.encoder_cache_manager = EncoderCacheManager(cache_size=16384)
+        self.encoder_cache_manager = EncoderCacheManager(
+            cache_size=self.scheduler_config.encoder_cache_size)
 
     def schedule(self) -> "SchedulerOutput":
         # NOTE(woosuk) on the scheduling algorithm:

--- a/vllm/v1/engine/mm_input_mapper.py
+++ b/vllm/v1/engine/mm_input_mapper.py
@@ -54,6 +54,7 @@ class MMInputMapperClient:
             logger.debug("MMInputMapper: cache_hit_ratio = %.2f ",
                          self.mm_cache_hits / self.mm_cache_total)
 
+    # TODO: Support modalities beyond image.
     def process_inputs(
         self,
         mm_data: MultiModalDataDict,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -609,8 +609,8 @@ class GPUModelRunner:
         ]
 
         # Profile with multimodal encoder & encoder cache.
-        # TODO (ywang96): generalize this beyond image modality.
-        # since mm_input_mapper only supports image inputs.
+        # TODO (ywang96): generalize this beyond image modality since
+        # mm_input_mapper only supports image inputs.
         if self.is_multimodal_model:
 
             # Create dummy batch of multimodal inputs.
@@ -634,6 +634,9 @@ class GPUModelRunner:
                 self.max_num_encoder_input_tokens,
                 self.encoder_cache_size) // max_tokens_per_mm_item
 
+            # Dummy data definition in V0 may contain multiple items for
+            # a single request, therefore here we always replicate first
+            # item by max_num_mm_items times.
             batched_dummy_mm_inputs = MultiModalKwargs.batch(
                 [dummy_mm_kwargs[0] for _ in range(max_num_mm_items)])
             batched_dummy_mm_inputs = MultiModalKwargs.as_kwargs(


### PR DESCRIPTION
This PR adds memory profiling for image language models in V1 so that peak memory usage is correctly measured to avoid potential CUDA OOM.

A few things to note:
1. We still use the dummy `multi_modal_data` for memory profiling. This not only allows us to reuse the existing code, but is also developer-friendly since defining a dummy PIL image is much more intuitive than defining dummy pixel values. In order to do so, `mm_input_mapper` is added to model runner only for profiling purpose.

2. This current version only works for image (because of limitation on `mm_input_mapper`). The memory profiling section has supported profiling for other single non-text modality models, but may require some additional design to be extended to mixed non-text modality profiling.

3. Encoder compute budget and cache size are added to scheduler config, but they remain hardcoded and should be optimized in a later PR.

Verified with `VLLM_USE_V1=1 VLLM_ENABLE_V1_MULTIPROCESSING=1 python3 mmmu_bench.py --model OpenGVLab/InternVL2_5-8B --trust-remote-code --gpu-memory-utilization 0.99` from #11196 

Main branch:
```
...
INFO 12-15 10:18:11 uniproc_executor.py:64] # GPU blocks: 31207
...
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 322.00 MiB. GPU 0 has a total capacity of 79.10 GiB of which 249.88 MiB is free. 
```

This PR:
```
...
INFO 12-15 10:16:26 uniproc_executor.py:64] # GPU blocks: 30973
...
Request throughput: 8.13 req/s
Total generated tokens: 39100
Token generation rate: 317.89 tok/s
```
