### PR TITLE
[do not merge] measure dynamo guard evaluation overhead

### DIFF
--- a/examples/offline_inference.py
+++ b/examples/offline_inference.py
@@ -1,22 +1,13 @@
 from vllm import LLM, SamplingParams
+import math
 
-# Sample prompts.
-prompts = [
-    "Hello, my name is",
-    "The president of the United States is",
-    "The capital of France is",
-    "The future of AI is",
-]
-# Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+llm = LLM(model="meta-llama/Meta-Llama-3-8B", enforce_eager=True)
 
-# Create an LLM.
-llm = LLM(model="facebook/opt-125m")
-# Generate texts from the prompts. The output is a list of RequestOutput objects
-# that contain the prompt, generated text, and other information.
-outputs = llm.generate(prompts, sampling_params)
-# Print the outputs.
-for output in outputs:
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+bs = 4
+# in the beginning, we have bs number of sequences, in total about 512 tokens for the prefill
+prompt_token_ids = [[0] * math.floor(512 / bs)] * bs
+
+# all sequence generates 30 tokens
+sampling_params = SamplingParams(temperature=0, max_tokens=30, ignore_eos=True)
+
+outputs = llm.generate(prompt_token_ids=prompt_token_ids, sampling_params=sampling_params)

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -199,7 +199,7 @@ def _support_torch_compile(
         output = self.compiled_callable(*args, **kwargs)
 
         if self.num_runs >= 3:
-            logger.info("Time taken for dynamo guard evaluation: %f", after_dynamo_time - before_dynamo_time)
+            logger.info("Time taken for dynamo guard evaluation: %f (ms)", (after_dynamo_time - before_dynamo_time) * 1000)
 
         return output
 

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -30,6 +30,15 @@ def support_torch_compile(
 def support_torch_compile(cls: _T) -> _T:
     ...
 
+import time
+after_dynamo_time: float = 0
+
+def simple_backend(gm, example_inputs):
+    def returned_gm(*args):
+        global after_dynamo_time
+        after_dynamo_time = time.perf_counter()
+        return gm(*args)
+    return returned_gm
 
 def support_torch_compile(
     cls: Optional[_T] = None,
@@ -132,14 +141,14 @@ def _support_torch_compile(
     """
     A decorator to add support for compiling the forward method of a class.
     """
-    if TorchCompileWrapperWithCustomDispatcher in cls.__bases__:
-        # support decorating multiple times
-        return cls
+    # if TorchCompileWrapperWithCustomDispatcher in cls.__bases__:
+    #     # support decorating multiple times
+    #     return cls
 
-    # take care of method resolution order
-    # make sure super().__init__ is called on the base class
-    #  other than TorchCompileWrapperWithCustomDispatcher
-    cls.__bases__ = cls.__bases__ + (TorchCompileWrapperWithCustomDispatcher, )
+    # # take care of method resolution order
+    # # make sure super().__init__ is called on the base class
+    # #  other than TorchCompileWrapperWithCustomDispatcher
+    # cls.__bases__ = cls.__bases__ + (TorchCompileWrapperWithCustomDispatcher, )
 
     old_init = cls.__init__
 
@@ -148,27 +157,24 @@ def _support_torch_compile(
         self.vllm_config = vllm_config
         # for CompilationLevel.DYNAMO_AS_IS , the upper level model runner
         # will handle the compilation, so we don't need to do anything here.
-        self.do_not_compile = \
-            vllm_config.compilation_config.level in [
-            CompilationLevel.NO_COMPILATION, CompilationLevel.DYNAMO_AS_IS
-        ] or not supports_dynamo()
-        if self.do_not_compile:
-            return
+        self.do_not_compile = False
         compilation_counter.num_models_seen += 1
-        TorchCompileWrapperWithCustomDispatcher.__init__(
-            self, compilation_level=vllm_config.compilation_config.level)
+        self.num_runs = 0
+        self.compiled_callable = torch.compile(self.forward, backend=simple_backend)
 
     cls.__init__ = __init__
 
     def __call__(self, *args, **kwargs):
+        self.num_runs += 1
         # torch.compiler.is_compiling() means we are inside the compilation
         # e.g. TPU has the compilation logic in model runner, so we don't
         # need to compile the model inside.
-        if self.do_not_compile or torch.compiler.is_compiling():
+        if self.num_runs <= 1:
+            # profile run, skip compilation
             return self.forward(*args, **kwargs)
 
         # the first compilation needs to have dynamic shapes marked
-        if len(self.compiled_codes) < 1:
+        if self.num_runs == 2:
             sig = inspect.signature(self.__class__.forward)
             bound_args = sig.bind(self, *args, **kwargs)
             bound_args.apply_defaults()
@@ -187,23 +193,15 @@ def _support_torch_compile(
             # here, it is the starting point of the `torch.compile` process
             start_monitoring_torch_compile(self.vllm_config)
 
-        # if we don't use custom dispatcher, we can directly call the
-        # compiled function and let torch.compile handle the dispatching,
-        # with the overhead of guard evaluation and recompilation.
-        if len(self.compiled_codes) < 1 or not self.use_custom_dispatcher:
-            # it seems Dynamo reuse the compilation across instances,
-            # while we need to make sure the compiled code is not reused.
-            # we need to control all the compilation of the model.
-            torch._dynamo.eval_frame.remove_from_cache(
-                self.original_code_object)
-            return self.compiled_callable(*args, **kwargs)
+        if self.num_runs == 3:
+            before_dynamo_time = time.perf_counter()
 
-        # usually, capturing the model once is enough, and then we can
-        # dispatch to the compiled code directly, without going through
-        # the Dynamo guard mechanism.
-        with self.dispatch_to_code(0):
-            model_output = self.forward(*args, **kwargs)
-            return model_output
+        output = self.compiled_callable(*args, **kwargs)
+
+        if self.num_runs == 3:
+            logger.info("Time taken for dynamo guard evaluation: %f", after_dynamo_time - before_dynamo_time)
+
+        return output
 
     cls.__call__ = __call__
     return cls

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -193,12 +193,12 @@ def _support_torch_compile(
             # here, it is the starting point of the `torch.compile` process
             start_monitoring_torch_compile(self.vllm_config)
 
-        if self.num_runs == 3:
+        if self.num_runs >= 3:
             before_dynamo_time = time.perf_counter()
 
         output = self.compiled_callable(*args, **kwargs)
 
-        if self.num_runs == 3:
+        if self.num_runs >= 3:
             logger.info("Time taken for dynamo guard evaluation: %f", after_dynamo_time - before_dynamo_time)
 
         return output


### PR DESCRIPTION
1. run with `TORCH_LOGS=recompiles_verbose python examples/offline_inference.py` , we do not observe any recompilation. therefore, dynamo only needs to evaluate one guard entry.
2. run with `python examples/offline_inference.py` , we can see the log:

```text
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.315360 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.296514 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.288737 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.286343 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.286627 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.288285 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.285351 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.548341 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.289180 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.294789 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.290396 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.288922 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.289075 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.289262 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.284737 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.291041 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.284954 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.292907 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.288243 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.290108 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.285586 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.283885 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.285807 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.286617 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.288213 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.286459 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.289882 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.284809 (ms)
INFO 12-15 15:19:26 decorators.py:202] Time taken for dynamo guard evaluation: 0.287222 (ms)
```

For an 8B-sized model, the guard evaluation overhead can be about `0.3ms`.