### PR TITLE
[Bugfix] Fix the default value for temperature in ChatCompletionRequest

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -211,7 +211,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = None
-    temperature: Optional[float] = 0.7
+    temperature: Optional[float] = 1.0
     top_p: Optional[float] = 1.0
     tools: Optional[List[ChatCompletionToolsParam]] = None
     tool_choice: Optional[Union[Literal["none"], Literal["auto"],


### PR DESCRIPTION
FIX #10930 

Set the default value for `temperature` in `ChatCompletionRequest` to 1.0.

References:

https://github.com/vllm-project/vllm/blob/571da8fc431ec36427ee1034a7779b23229b015e/vllm/sampling_params.py#L176

https://platform.openai.com/docs/api-reference/chat
