### PR TITLE
[CI/Build] Adds Modal runners for performance benchmark

### DIFF
--- a/.buildkite/nightly-benchmarks/benchmark-pipeline.yaml
+++ b/.buildkite/nightly-benchmarks/benchmark-pipeline.yaml
@@ -11,39 +11,19 @@ steps:
             - sh .buildkite/nightly-benchmarks/scripts/wait-for-image.sh
 
   - wait
-
+  
   - label: "A100"
-    # skip: "use this flag to conditionally skip the benchmark step, useful for PR testing"
     agents:
       queue: A100
-    plugins:
-    - kubernetes:
-        podSpec:
-          priorityClassName: perf-benchmark
-          containers:
-          - image: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT
-            command:
-            - bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
-            resources:
-              limits:
-                nvidia.com/gpu: 8
-            volumeMounts:
-            - name: devshm
-              mountPath: /dev/shm
-            env:
-            - name: VLLM_USAGE_SOURCE
-              value: ci-test
-            - name: HF_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hf-token-secret
-                  key: token
-          nodeSelector:
-            nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
-          volumes:
-          - name: devshm
-            emptyDir:
-              medium: Memory
+    env:
+      GPU: "A100"
+      VLLM_USAGE_SOURCE: "ci-test"
+      CMD: "bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
+    commands:
+      - pip install -U modal
+      - modal token set --token-id "$(buildkite-agent secret get modal_token_id)" --token-secret "$(buildkite-agent secret get modal_token_secret)"
+      - export HF_TOKEN="$(buildkite-agent secret get hf_token_secret)"
+      - modal run .buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
 
   - label: "H200"
     # skip: "use this flag to conditionally skip the benchmark step, useful for PR testing"
@@ -70,22 +50,15 @@ steps:
     depends_on: ~
 
   - label: "H100"
-    # skip: "use this flag to conditionally skip the benchmark step, useful for PR testing"
     agents:
       queue: H100
     depends_on: block-h100
-    plugins:
-    - docker#v5.12.0:
-        image: public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:$BUILDKITE_COMMIT
-        command:
-        - bash
-        - .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh
-        mount-buildkite-agent: true
-        propagate-environment: true
-        ipc: host
-        gpus: all # see CUDA_VISIBLE_DEVICES for actual GPUs used
-        volumes:
-          - /data/benchmark-hf-cache:/root/.cache/huggingface
-        environment:
-        - VLLM_USAGE_SOURCE
-        - HF_TOKEN
+    env:
+      GPU: "H100"
+      VLLM_USAGE_SOURCE: "ci-test"
+      CMD: "bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh"
+    commands:
+      - pip install -U modal
+      - modal token set --token-id "$(buildkite-agent secret get modal_token_id)" --token-secret "$(buildkite-agent secret get modal_token_secret)"
+      - export HF_TOKEN="$(buildkite-agent secret get hf_token_secret)"
+      - modal run .buildkite/nightly-benchmarks/scripts/launch-modal-runner.py

--- a/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
+++ b/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
@@ -19,7 +19,6 @@ PASSTHROUGH_ENV_VARS = {
 app = modal.App("buildkite-runner")
 hf_cache = modal.Volume.from_name("vllm-benchmark-hf-cache", create_if_missing=True)
 
-print(f"Building image for commit: {BUILDKITE_COMMIT}")
 # Image to use for runner
 BASE_IMG = f"public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:{BUILDKITE_COMMIT}"
 image = (

--- a/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
+++ b/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
@@ -1,0 +1,91 @@
+import modal
+import subprocess
+import os
+import sys
+
+# Env vars used for constructing modal image
+BUILDKITE_COMMIT = os.getenv("BUILDKITE_COMMIT")
+GPU = os.getenv("GPU")
+CMD = os.getenv("CMD")
+
+# Local env vars from buildkite job that we'll want to drill through to GPU container
+PASSTHROUGH_ENV_VARS = {
+    "BUILDKITE_COMMIT": BUILDKITE_COMMIT,
+    "HF_TOKEN": os.getenv("HF_TOKEN"),
+    "VLLM_USAGE_SOURCE": os.getenv("VLLM_USAGE_SOURCE"),
+}
+
+# Modal app and associated volumes
+app = modal.App("buildkite-runner")
+hf_cache = modal.Volume.from_name("vllm-benchmark-hf-cache", create_if_missing=True)
+
+print(f"Building image for commit: {BUILDKITE_COMMIT}")
+# Image to use for runner
+BASE_IMG = f"public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:{BUILDKITE_COMMIT}"
+image = (
+    modal.Image.from_registry(BASE_IMG, add_python="3.12")
+    .workdir("/vllm-workspace")
+    .env(PASSTHROUGH_ENV_VARS)
+)
+
+# Remote function to run in the container
+HOURS = 60 * 60
+@app.function(
+    image=image,
+    gpu=GPU, # GPU can be "A100", "A10G", "H100", "T4"
+    timeout=4 * HOURS,
+    volumes={"/root/.cache/huggingface": hf_cache},
+)
+def runner(env: dict, cmd: str = ""):
+    # Set passthrough environment variables in remote container
+    for k, v in env.items():
+        os.environ[k] = v
+
+    # TODO: the vllm-ci-postmerge-repo does not contain the VLLM package itself
+    # we need to figure out how to install from source.
+    # currently, vllm install fails, logs: https://gist.github.com/erik-dunteman/f75f0733ac6a78de73d25220a4a3f58a
+    print("Installing VLLM from source, commit:", BUILDKITE_COMMIT)
+    # Install vllm from source
+    subprocess.run(["pip", "install", f"git+https://github.com/vllm-project/vllm.git@{BUILDKITE_COMMIT}"])
+
+    # Debug Python environment
+    print("\n=== Python Environment Info ===")
+    print(f"Python Version: {sys.version}")
+    print(f"Python Executable: {sys.executable}")
+    print(f"Python Path: {sys.path}")
+    
+    # List all installed packages
+    print("\n=== Installed Packages ===")
+    subprocess.run(["pip", "list"])
+    
+    # Try to get vllm package info specifically
+    print("\n=== VLLM Package Info ===")
+    subprocess.run(["pip", "show", "vllm"])
+    
+    # Show current working directory and its contents
+    print("\n=== Working Directory Info ===")
+    print(f"Current Directory: {os.getcwd()}")
+    subprocess.run(["ls", "-la"])
+
+    # TODO: remove this cmd override
+    # cmd = "python3 -m vllm.entrypoints.openai.api_server --model meta-llama/Meta-Llama-3.1-8B-Instruct"
+    cmd = "nvidia-smi"
+
+    print("\n=== Executing Command ===")
+    print(f"Command: {cmd}")
+    
+    # Execute the command
+    subprocess.run(cmd.split(" "))
+
+@app.local_entrypoint()
+def main():
+    print("Modal client started:")
+    required_env_vars = ["BUILDKITE_COMMIT", "GPU", "CMD"]
+    for env_var in required_env_vars:
+        if not os.getenv(env_var):
+            print(f"Missing required environment variable: {env_var}")
+            sys.exit(1)
+    print(f"\t- Commit:  {BUILDKITE_COMMIT}")
+    print(f"\t- GPU:     {GPU}")
+    print(f"\t- Command: {CMD}")
+    runner.remote(env=PASSTHROUGH_ENV_VARS, cmd=CMD)

--- a/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
+++ b/.buildkite/nightly-benchmarks/scripts/launch-modal-runner.py
@@ -43,31 +43,27 @@ def runner(env: dict, cmd: str = ""):
 
     # TODO: the vllm-ci-postmerge-repo does not contain the VLLM package itself
     # we need to figure out how to install from source.
-    # currently, vllm install fails, logs: https://gist.github.com/erik-dunteman/f75f0733ac6a78de73d25220a4a3f58a
+    # I tried doing this in the build step but it appears to fail without an underlying GPU
+    # So I am doing here on the runner GPU. 
+    # The VLLM install still fails, logs: https://gist.github.com/erik-dunteman/f75f0733ac6a78de73d25220a4a3f58a
     print("Installing VLLM from source, commit:", BUILDKITE_COMMIT)
     # Install vllm from source
     subprocess.run(["pip", "install", f"git+https://github.com/vllm-project/vllm.git@{BUILDKITE_COMMIT}"])
 
-    # Debug Python environment
+    # TODO: remove below env debugging code
     print("\n=== Python Environment Info ===")
     print(f"Python Version: {sys.version}")
     print(f"Python Executable: {sys.executable}")
     print(f"Python Path: {sys.path}")
-    
-    # List all installed packages
     print("\n=== Installed Packages ===")
     subprocess.run(["pip", "list"])
-    
-    # Try to get vllm package info specifically
     print("\n=== VLLM Package Info ===")
     subprocess.run(["pip", "show", "vllm"])
-    
-    # Show current working directory and its contents
     print("\n=== Working Directory Info ===")
     print(f"Current Directory: {os.getcwd()}")
     subprocess.run(["ls", "-la"])
 
-    # TODO: remove this cmd override
+    # TODO: remove these cmd overrides
     # cmd = "python3 -m vllm.entrypoints.openai.api_server --model meta-llama/Meta-Llama-3.1-8B-Instruct"
     cmd = "nvidia-smi"
 


### PR DESCRIPTION
This PR is to improve performance benchmark by:
- decreasing overall GPU spend by scaling to zero when not in use
- allowing concurrent jobs to run

We do this by moving from single always-on GPU agents to CPU-based runners running [Modal](modal.com) client to spawn GPUs as needed. Currently for `A100` and `H100`.

### Structure
`launch-modal-runner.py` is our new job script, which will build and launch the following image onto the targeted GPU, and execute the bash command just as is done in the current docker plugin setup.
```python
BASE_IMG = f"public.ecr.aws/q9t5s3a7/vllm-ci-postmerge-repo:{BUILDKITE_COMMIT}"
```

### Admin changes required:
- change A100 and H100 buildkite queue to CPU agents
- add `modal_token_id` and `modal_token_secret` to buildkite agent secrets