### PR TITLE
[V1][Core] Use weakref.finalize instead of atexit

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1,6 +1,6 @@
-import atexit
 import os
 from typing import List, Optional
+import weakref
 
 import msgspec
 import zmq
@@ -165,15 +165,9 @@ class MPClient(EngineCoreClient):
             ready_path=ready_path,  # type: ignore[misc]
             **kwargs,
         )
-        atexit.register(self.shutdown)
+        self._finalizer = weakref.finalize(self, self.shutdown)
 
     def shutdown(self):
-        # During final garbage collection in process shutdown, atexit may be
-        # None.
-        if atexit:
-            # in case shutdown gets called via __del__ first
-            atexit.unregister(self.shutdown)
-
         # Shut down the zmq context.
         self.ctx.destroy(linger=0)
 
@@ -196,9 +190,6 @@ class MPClient(EngineCoreClient):
                 if os and os.path.exists(socket_file):
                     os.remove(socket_file)
             self.proc_handle = None
-
-    def __del__(self):
-        self.shutdown()
 
 
 class SyncMPClient(MPClient):

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1,6 +1,6 @@
 import os
-from typing import List, Optional
 import weakref
+from typing import List, Optional
 
 import msgspec
 import zmq


### PR DESCRIPTION
It's nicer this way, since we no longer need to unregister `shutdown` from `atexit`