### PR TITLE
[Bugfix] Restore support for larger block sizes

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -917,11 +917,10 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
-        if (current_platform.is_cuda()
-                and self.block_size not in [None, 8, 16, 32]):
-            raise ValueError(
-                "CUDA Paged Attention kernel only supports "
-                f"block sizes [8, 16, 32]. Got {self.block_size}.")
+        if (current_platform.is_cuda() and self.block_size is not None
+                and self.block_size > 32):
+            raise ValueError("CUDA Paged Attention kernel only supports "
+                             f"block sizes up to 32. Got {self.block_size}.")
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -917,7 +917,7 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
-        if (current_platform.is_cuda_alike()
+        if (current_platform.is_cuda()
                 and self.block_size not in [8, 16, 32]):
             raise ValueError(
                 "CUDA Paged Attention kernel only supports "

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -917,6 +917,11 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
+        if (current_platform.is_cuda_alike()
+                and self.block_size not in [8, 16, 32]):
+            raise ValueError(
+                "CUDA Paged Attention kernel only supports "
+                f"block sizes [8, 16, 32]. Got {self.block_size}.")
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -917,7 +917,8 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
-        if current_platform.is_cuda() and self.block_size not in [8, 16, 32]:
+        if (current_platform.is_cuda()
+                and self.block_size not in [None, 8, 16, 32]):
             raise ValueError(
                 "CUDA Paged Attention kernel only supports "
                 f"block sizes [8, 16, 32]. Got {self.block_size}.")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -917,8 +917,7 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
-        if (current_platform.is_cuda()
-                and self.block_size not in [8, 16, 32]):
+        if current_platform.is_cuda() and self.block_size not in [8, 16, 32]:
             raise ValueError(
                 "CUDA Paged Attention kernel only supports "
                 f"block sizes [8, 16, 32]. Got {self.block_size}.")

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -423,7 +423,7 @@ class EngineArgs:
         parser.add_argument('--block-size',
                             type=int,
                             default=EngineArgs.block_size,
-                            choices=[8, 16, 32],
+                            choices=[8, 16, 32, 64, 128],
                             help='Token block size for contiguous chunks of '
                             'tokens. This is ignored on neuron devices and '
                             'set to max-model-len')

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -426,7 +426,9 @@ class EngineArgs:
                             choices=[8, 16, 32, 64, 128],
                             help='Token block size for contiguous chunks of '
                             'tokens. This is ignored on neuron devices and '
-                            'set to max-model-len')
+                            'set to max-model-len. On CUDA devices, '
+                            'only block sizes up to 32 are supported. '
+                            'On HPU devices, block size defaults to 128.')
 
         parser.add_argument(
             "--enable-prefix-caching",


### PR DESCRIPTION
This PR reverts vllm-project/vllm#10938, expands description of block size and adds assertion for CUDA-supported block sizes in CacheConfig. 
While GPU kernels might not support block sizes greater than 32, other accelerators do. On HPU, going below block size 128 is very detrimental to performance, and 128 is used there by default.