### PR TITLE
[CI] Adding CPU docker pipeline

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -56,17 +56,17 @@ steps:
     env:
       DOCKER_BUILDKIT: "1"
 
+  - block: "Build CPU docker on release only"
+    depends_on: ~
+
   - label: "Build and publish CPU release image"
     depends_on: ~
     if: build.tag != null
     agents:
       queue: cpu_queue_postmerge
     commands:
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag vllm/vllm-cpu:$BUILDKITE_TAG --progress plain -f Dockerfile.cpu ."
-      - "docker push vllm/vllm-cpu:$BUILDKITE_TAG"
-    plugins:
-      - docker-login#v3.0.0:
-          username: vllm
-          password-env: DOCKERHUB_TOKEN
+      - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_TAG --progress plain -f Dockerfile.cpu ."
+      - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_TAG"
     env:
       DOCKER_BUILDKIT: "1"

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -62,12 +62,11 @@ steps:
 
   - label: "Build and publish CPU release image"
     depends_on: block-cpu-release-image-build
-    if: build.tag != null
     agents:
       queue: cpu_queue_postmerge
     commands:
       - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_TAG --progress plain -f Dockerfile.cpu ."
-      - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_TAG"
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$RELEASE_VERSION --progress plain -f Dockerfile.cpu ."
+      - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$RELEASE_VERSION"
     env:
       DOCKER_BUILDKIT: "1"

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -56,11 +56,12 @@ steps:
     env:
       DOCKER_BUILDKIT: "1"
 
-  - block: "Build CPU docker on release only"
+  - block: "Build CPU release image"
+    key: block-cpu-release-image-build
     depends_on: ~
 
   - label: "Build and publish CPU release image"
-    depends_on: ~
+    depends_on: block-cpu-release-image-build
     if: build.tag != null
     agents:
       queue: cpu_queue_postmerge

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -55,3 +55,18 @@ steps:
           password-env: DOCKERHUB_TOKEN
     env:
       DOCKER_BUILDKIT: "1"
+
+  - label: "Build and publish CPU release image"
+    depends_on: ~
+    if: build.tag != null
+    agents:
+      queue: cpu_queue_postmerge
+    commands:
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag vllm/vllm-cpu:$BUILDKITE_TAG --progress plain -f Dockerfile.cpu ."
+      - "docker push vllm/vllm-cpu:$BUILDKITE_TAG"
+    plugins:
+      - docker-login#v3.0.0:
+          username: vllm
+          password-env: DOCKERHUB_TOKEN
+    env:
+      DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
This patch adds the pipeline for CPU docker image. On each release(tag) it will build push the image to vllm/vllm-cpu
Fixes: #4771

