### PR TITLE
[Bugfix] Fix broken phi3-v mm_processor_kwargs tests

### DIFF
--- a/tests/models/decoder_only/vision_language/mm_processor_kwargs/test_phi3v.py
+++ b/tests/models/decoder_only/vision_language/mm_processor_kwargs/test_phi3v.py
@@ -58,16 +58,14 @@ def test_max_tokens_override(get_max_phi3v_image_tokens, model: str,
 
 @pytest.mark.parametrize("model", models)
 @pytest.mark.parametrize(
-    "num_crops,expected_toks_per_img,num_imgs",
+    "num_crops,expected_toks_per_img",
     [
-        (4, 757, 1),
-        (4, 757, 2),
-        (16, 1921, 1),
-        (16, 1921, 2),
+        (4, 757),
+        (16, 1921),
         # the default num_crops of phi-3.5-vision is 4
-        (None, 757, 2),
-        (None, 757, 2),
+        (None, 757),
     ])
+@pytest.mark.parametrize("num_imgs", [1, 2])
 def test_processor_override(processor_for_phi3v, image_assets: _ImageAssets,
                             model: str, num_crops: Optional[int],
                             expected_toks_per_img: int, num_imgs: int):

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -312,9 +312,8 @@ def get_max_phi3v_image_tokens(
         mm_processor_kwargs["num_crops"] = num_crops
 
     processor = ctx.get_hf_processor(**mm_processor_kwargs)
-    image_processor = processor.image_processor  # type: ignore
 
-    return image_processor.calc_num_image_tokens_from_image_size(
+    return processor.calc_num_image_tokens_from_image_size(
         width=MAX_IMAGE_FEATURE_SIZE_WIDTH,
         height=MAX_IMAGE_FEATURE_SIZE_HEIGHT,
     )

--- a/vllm/model_executor/models/phi3v.py
+++ b/vllm/model_executor/models/phi3v.py
@@ -302,8 +302,16 @@ class Phi3HDImageEmbedding(Phi3ImageEmbeddingBase):
         return image_features_hd_newline
 
 
-def get_max_phi3v_image_tokens(ctx: InputContext) -> int:
-    processor = ctx.get_hf_processor()
+def get_max_phi3v_image_tokens(
+    ctx: InputContext,
+    *,
+    num_crops: Optional[int] = None,
+) -> int:
+    mm_processor_kwargs = {}
+    if num_crops:
+        mm_processor_kwargs["num_crops"] = num_crops
+
+    processor = ctx.get_hf_processor(**mm_processor_kwargs)
     image_processor = processor.image_processor  # type: ignore
 
     return image_processor.calc_num_image_tokens_from_image_size(


### PR DESCRIPTION
- Fix broken mm_processor_kwargs tests for phi3-v, because `num_crops` is not exposed in `get_max_phi3v_image_tokens`.
- The mm_processor_kwargs tests were not triggered in #11199 CI and before, because the test-pipeline hadn't updated at that time.

