### PR TITLE
[Bugfix] Set temperature=0.7 in test_guided_choice_chat

### DIFF
--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -482,6 +482,7 @@ async def test_guided_choice_chat(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_completion_tokens=10,
+        temperature=0.7,
         extra_body=dict(guided_choice=sample_guided_choice,
                         guided_decoding_backend=guided_decoding_backend))
     choice1 = chat_completion.choices[0].message.content
@@ -496,6 +497,7 @@ async def test_guided_choice_chat(client: openai.AsyncOpenAI,
         model=MODEL_NAME,
         messages=messages,
         max_completion_tokens=10,
+        temperature=0.7,
         extra_body=dict(guided_choice=sample_guided_choice,
                         guided_decoding_backend=guided_decoding_backend))
     choice2 = chat_completion.choices[0].message.content


### PR DESCRIPTION
This unfortunately seems to resolve the entrypoints flaky error 
```
[2024-12-17T12:42:23Z] FAILED entrypoints/openai/test_chat.py::test_guided_choice_chat[outlines] - AssertionError: assert 'Ruby' != 'Ruby'
```
Instances seen:
https://buildkite.com/organizations/vllm/pipelines/fastcheck/builds/10058/jobs/0193d4d3-5b6b-484b-a1f9-1e5f0a52d32a/log
https://buildkite.com/organizations/vllm/pipelines/fastcheck/builds/10048/jobs/0193d44c-65bb-442f-a20c-0418455b0d0a/log