### PR TITLE
Add ray[default] to wget to run distributed inference out of box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN PYTHON_VERSION_STR=$(echo ${PYTHON_VERSION} | sed 's/\.//g') && \
 RUN echo 'tzdata tzdata/Areas select America' | debconf-set-selections \
     && echo 'tzdata tzdata/Zones/America select Los_Angeles' | debconf-set-selections \
     && apt-get update -y \
-    && apt-get install -y ccache software-properties-common git curl sudo vim python3-pip \
+    && apt-get install -y ccache software-properties-common git curl wget sudo vim python3-pip \
     && apt-get install -y ffmpeg libsm6 libxext6 libgl1 \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update -y \

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray >= 2.9
+ray[default] >= 2.9
 nvidia-ml-py >= 12.560.30 # for pynvml package
 torch == 2.5.1; platform_machine != 'aarch64'
 # These must be updated alongside torch


### PR DESCRIPTION
part of https://github.com/vllm-project/vllm/issues/11137

Why do we need such PR?
1. User wants to leverage vllm default image to manage RayCluster version instead of managing separate ray images and vLLM distributions which frequently surface version compatibility problems
2. `ray[default]` package provides more capabilities like submission api and dashboard which is essential to run vLLM distributed inference in cluster environment
3. `wget` is used in kubeRay prob.https://github.com/ray-project/kuberay/blob/e595ee4c6297fb6b385421f7ca34fbd7c1c0b49f/ray-operator/controllers/ray/common/pod.go#L253 and https://github.com/ray-project/kuberay/blob/e595ee4c6297fb6b385421f7ca34fbd7c1c0b49f/ray-operator/controllers/ray/utils/constant.go#L178.  This can be definitely changed to `curl` but I feel adding a new package won't take that many room here. 
4. Adding `wget` and `ray[default]` won't be risky. I notice some other files already include this change. 
- https://github.com/vllm-project/vllm/blob/f9ecbb18bf03338a4272c933a49a87021363b048/requirements-tpu.txt#L11
- https://github.com/vllm-project/vllm/blob/f9ecbb18bf03338a4272c933a49a87021363b048/Dockerfile.arm#L11



FIX 

