### PR TITLE
[misc] benchmark_throughput : Add LoRA

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -5,7 +5,7 @@ import json
 import random
 import time
 from functools import cache
-from typing import Tuple, Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import uvloop
@@ -74,11 +74,17 @@ def download_lora(lora_path: str) -> str:
     """
     return snapshot_download(lora_path)
 
+
 lora_tokenizer_cache: Dict[int, AnyTokenizer] = {}
-def get_random_lora_request(args: argparse.Namespace) -> Tuple[LoRARequest, AnyTokenizer]:
+
+
+def get_random_lora_request(
+        args: argparse.Namespace) -> Tuple[LoRARequest, AnyTokenizer]:
     global lora_tokenizer_cache
     lora_id = random.randint(0, args.max_loras)
-    lora_request = LoRARequest(lora_name=str(lora_id), lora_int_id=lora_id, lora_path=download_lora(args.lora_path))
+    lora_request = LoRARequest(lora_name=str(lora_id),
+                               lora_int_id=lora_id,
+                               lora_path=download_lora(args.lora_path))
     if lora_id not in lora_tokenizer_cache:
         lora_tokenizer_cache[lora_id] = get_lora_tokenizer(lora_request)
     return lora_request, lora_tokenizer_cache[lora_id]
@@ -376,7 +382,7 @@ def main(args: argparse.Namespace):
                 SampleRequest(prompt=candidate_prompt,
                               prompt_len=args.input_len,
                               expected_output_len=args.output_len,
-                              lora_request = lora_request))
+                              lora_request=lora_request))
     else:
         requests = sample_requests(tokenizer, args)
 

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -66,14 +66,19 @@ def _get_prompt_for_image_model(question: str, *, model: str) -> str:
     raise ValueError(f"Unsupported model {model}")
 
 
+@cache
+def download_lora(lora_path: str) -> str:
+    """
+    Given an huggingface path, downloads the LoRA model and returns the path
+    on disk.
+    """
+    return snapshot_download(lora_path)
+
 def get_random_lora_request(args: argparse.Namespace):
-    @cache
-    def lora_path() -> str:
-        return snapshot_download(args.lora_path)
     lora_id = random.randint(0, args.max_loras) 
     return LoRARequest(lora_name = str(lora_id),
                        lora_int_id = lora_id,
-                       lora_path = lora_path())
+                       lora_path = download_lora(args.lora_path))
 
 def sample_requests(tokenizer: PreTrainedTokenizerBase,
                     args: argparse.Namespace) -> List[SampleRequest]:

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -19,10 +19,10 @@ from vllm.entrypoints.openai.api_server import (
     build_async_engine_client_from_engine_args)
 from vllm.inputs import TextPrompt
 from vllm.lora.request import LoRARequest
+from vllm.lora.utils import get_adapter_absolute_path
 from vllm.multimodal import MultiModalDataDict
 from vllm.sampling_params import BeamSearchParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer, get_lora_tokenizer
-from vllm.lora.utils import get_adapter_absolute_path
 from vllm.utils import FlexibleArgumentParser, merge_async_iterators
 
 
@@ -75,7 +75,8 @@ lora_tokenizer_cache: Dict[int, AnyTokenizer] = {}
 
 
 def get_random_lora_request(
-        args: argparse.Namespace) -> Tuple[LoRARequest, Optional[AnyTokenizer]]:
+        args: argparse.Namespace
+) -> Tuple[LoRARequest, Optional[AnyTokenizer]]:
     global lora_tokenizer_cache
     lora_id = random.randint(0, args.max_loras)
     lora_request = LoRARequest(lora_name=str(lora_id),
@@ -353,7 +354,7 @@ def main(args: argparse.Namespace):
             if args.enable_lora:
                 lora_request, lora_tokenizer = get_random_lora_request(args)
                 if lora_tokenizer:
-                    request_tokenizer = lora_tokenizer 
+                    request_tokenizer = lora_tokenizer
 
             # Synthesize a prompt with the given input length.
             candidate_ids = [
@@ -482,10 +483,12 @@ if __name__ == "__main__":
                         default=False,
                         help="Disable decoupled async engine frontend.")
     # LoRA
-    parser.add_argument("--lora-path",
-                        type=str,
-                        default=None,
-                        help="Path to the lora adapters to use. This can be an absolute path, a relative path, or a Hugging Face model identifier.")
+    parser.add_argument(
+        "--lora-path",
+        type=str,
+        default=None,
+        help="Path to the lora adapters to use. This can be an absolute path, "
+        "a relative path, or a Hugging Face model identifier.")
 
     parser = AsyncEngineArgs.add_cli_args(parser)
     args = parser.parse_args()

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -78,7 +78,7 @@ def get_random_lora_request(
         args: argparse.Namespace
 ) -> Tuple[LoRARequest, Optional[AnyTokenizer]]:
     global lora_tokenizer_cache
-    lora_id = random.randint(0, args.max_loras)
+    lora_id = random.randint(1, args.max_loras)
     lora_request = LoRARequest(lora_name=str(lora_id),
                                lora_int_id=lora_id,
                                lora_path=lora_path_on_disk(args.lora_path))
@@ -230,7 +230,7 @@ async def run_vllm_async(
         # Add the requests to the engine.
         prompts: List[TextPrompt] = []
         sampling_params: List[SamplingParams] = []
-        lora_requests: List[LoRARequest] = []
+        lora_requests: List[Optional[LoRARequest]] = []
         for request in requests:
             prompts.append(
                 TextPrompt(prompt=request.prompt,


### PR DESCRIPTION
Update benchmark_throughput.py to support LoRA benchmarking.

Examples:
 Machine : 1xA100

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000`

Throughput: 11.45 requests/s, 5509.93 total tokens/s, 2693.62 output tokens/s

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --max-loras 1 --max-lora-rank 8  --enable-lora --lora-path "yard1/llama-2-7b-sql-lora-test"`

Throughput: 7.60 requests/s, 3656.98 total tokens/s, 1787.78 output tokens/s

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --max-loras 4 --max-lora-rank 8  --enable-lora --lora-path "yard1/llama-2-7b-sql-lora-test"`

Throughput: 7.61 requests/s, 3664.67 total tokens/s, 1791.53 output tokens/s

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --async-engine`

Throughput: 11.31 requests/s, 5441.21 total tokens/s, 2660.02 output tokens/s

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --async-engine --max-loras 1 --max-lora-rank 8  --enable-lora  --lora-path "yard1/llama-2-7b-sql-lora-test"`

Throughput: 7.59 requests/s, 3654.39 total tokens/s, 1786.51 output tokens/s

`python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --async-engine --max-loras 4 --max-lora-rank 8  --enable-lora --lora-path "yard1/llama-2-7b-sql-lora-test"`

Throughput: 7.55 requests/s, 3634.68 total tokens/s, 1776.87 output tokens/s

cc @mgoin @robertgshaw2-neuralmagic @jeejeelee


