### PR TITLE
[Misc] Optimize ray worker initialization time

### DIFF
--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -174,10 +174,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
         for ip in worker_ips:
             ip_counts[ip] = ip_counts.get(ip, 0) + 1
 
-        worker_to_ip = {
-            worker: ip
-            for worker, ip in zip(self.workers, worker_ips)
-        }
+        worker_to_ip = dict(zip(self.workers, worker_ips))
 
         def sort_by_driver_then_worker_ip(worker):
             """

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -123,6 +123,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
 
         # Create the workers.
         driver_ip = get_ip()
+        workers = []
         for bundle_id, bundle in enumerate(placement_group.bundle_specs):
             if not bundle.get("GPU", 0):
                 continue
@@ -138,21 +139,28 @@ class RayGPUExecutor(DistributedGPUExecutor):
                 scheduling_strategy=scheduling_strategy,
                 **ray_remote_kwargs,
             )(RayWorkerWrapper).remote(vllm_config=self.vllm_config)
+            workers.append(worker)
 
-            if (not self.use_ray_spmd_worker
-                    and self.driver_dummy_worker is None):
-                worker_ip = ray.get(worker.get_node_ip.remote())
-                if worker_ip == driver_ip:
+        worker_ip_refs = [
+            worker.get_node_ip.remote()  # type: ignore[attr-defined]
+            for worker in workers
+        ]
+        worker_ips = ray.get(worker_ip_refs)
+
+        if not self.use_ray_spmd_worker:
+            for i in range(len(workers)):
+                worker = workers[i]
+                worker_ip = worker_ips[i]
+                if self.driver_dummy_worker is None and worker_ip == driver_ip:
                     # If the worker is on the same node as the driver, we use it
                     # as the resource holder for the driver process.
                     self.driver_dummy_worker = worker
                     self.driver_worker = RayWorkerWrapper(
                         vllm_config=self.vllm_config)
-                else:
-                    # Else, added to the list of workers.
-                    self.workers.append(worker)
-            else:
-                self.workers.append(worker)
+                    workers.pop(i)
+                    worker_ips.pop(i)
+                    self.workers = workers
+                    break
 
         logger.debug("workers: %s", self.workers)
         logger.debug("driver_dummy_worker: %s", self.driver_dummy_worker)
@@ -162,13 +170,14 @@ class RayGPUExecutor(DistributedGPUExecutor):
                 "adjusting the Ray placement group or running the driver on a "
                 "GPU node.")
 
-        worker_ips = [
-            ray.get(worker.get_node_ip.remote())  # type: ignore[attr-defined]
-            for worker in self.workers
-        ]
         ip_counts: Dict[str, int] = {}
         for ip in worker_ips:
             ip_counts[ip] = ip_counts.get(ip, 0) + 1
+
+        worker_to_ip = {
+            worker: ip
+            for worker, ip in zip(self.workers, worker_ips)
+        }
 
         def sort_by_driver_then_worker_ip(worker):
             """
@@ -180,7 +189,7 @@ class RayGPUExecutor(DistributedGPUExecutor):
             3. Finally, if the work is on a node with smaller IP address, it
                 should be placed first.
             """
-            ip = ray.get(worker.get_node_ip.remote())
+            ip = worker_to_ip[worker]
             return (ip != driver_ip, ip_counts[ip], ip)
 
         # After sorting, the workers on the same node will be

--- a/vllm/executor/ray_gpu_executor.py
+++ b/vllm/executor/ray_gpu_executor.py
@@ -161,6 +161,8 @@ class RayGPUExecutor(DistributedGPUExecutor):
                     worker_ips.pop(i)
                     self.workers = workers
                     break
+        else:
+            self.workers = workers
 
         logger.debug("workers: %s", self.workers)
         logger.debug("driver_dummy_worker: %s", self.driver_dummy_worker)


### PR DESCRIPTION
This PR optimizes ray worker initialization time.

In the current code base, `ray.get(worker.get_node_ip.remote())` is called for each worker right after we get its handle, and it takes ~3s. This call is expensive because when `RayWorkerWrapper.remote()` just returns, we get an actor handle, but the actor itself may not be fully initialized yet. At this time, any method call on the actor would need to wait for actor initialization to happen, which can take some time (~3s in this case).

And since we are calling `ray.get(worker.get_node_ip.remote())` in a serialized manner for each newly created actor handle, this time adds up. For example, when we have TP=4, this would take ~12 seconds.

We optimize this by making `ray.get(worker.get_node_ip.remote())` calls on all the actor handles after they are created. And since these run in parallel, the total time taken is ~3s. So for TP = 4, this reduces ~9 seconds.

I tested the following command:
```
python3 benchmarks/benchmark_latency.py --model meta-llama/Llama-3.1-8B-Instruct --tensor-parallel-size 4  --num-iters-warmup 5 --num-iters 20  --batch-size 8 --input-len 128 --output-len 256 --max-model-len 2048 --no-enable-prefix-caching --distributed-executor-backend ray
```

Without this PR, `_init_workers_ray` takes ~18 seconds. And with it, it takes ~9 seconds.

FIX #10283 

