### PR TITLE
[FIX] update openai version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -11,7 +11,7 @@ protobuf # Required by LlamaTokenizer.
 fastapi >= 0.107.0, < 0.113.0; python_version < '3.9'
 fastapi >= 0.107.0, != 0.113.*, != 0.114.0; python_version >= '3.9'
 aiohttp
-openai >= 1.45.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)
+openai >= 1.52.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)
 uvicorn[standard]
 pydantic >= 2.9  # Required for fastapi >= 0.113.0
 prometheus_client >= 0.18.0


### PR DESCRIPTION
PR #11027 import  `ChatCompletionContentPartInputAudioParam`. this is introduced in openai [1.52.0 ](https://github.com/openai/openai-python/releases/tag/v1.52.0) PR [1796](https://github.com/openai/openai-python/pull/1796)
