### PR TITLE
[Misc] Remove the backend  restrictions for vision model benchmark

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -547,10 +547,7 @@ async def benchmark(
     print("Starting initial single prompt test run...")
     test_prompt, test_prompt_len, test_output_len, test_mm_content = (
         input_requests[0])
-    if backend != "openai-chat" and test_mm_content is not None:
-        # multi-modal benchmark is only available on OpenAI Chat backend.
-        raise ValueError(
-            "Multi-modal content is only supported on 'openai-chat' backend.")
+
     test_input = RequestFuncInput(
         model=model_id,
         prompt=test_prompt,


### PR DESCRIPTION
I tried following commands, it can work, so I removed the backend restrictions.

` python3 benchmark_serving.py --backend vllm     --endpoint /v1/completions --host 10.112.228.151 --port 6910     --model llava-hf/llava-v1.6-mistral-7b-hf     --dataset-path Lin-Chen/ShareGPT4V     --dataset-name hf --hf-subset ShareGPT4V     --hf-split train     --num-prompts=100`

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/208b5eb2-85c7-46c3-b40e-2af92f56a53c" />

`python3 benchmark_serving.py --backend tgi     --endpoint /generate_stream --host 0.0.0.0 --port 8089     --model llava-hf/llava-v1.6-mistral-7b-hf     --dataset-path Lin-Chen/ShareGPT4V     --dataset-name hf --hf-subset ShareGPT4V     --hf-split train     --num-prompts=100`

<img width="1142" alt="image" src="https://github.com/user-attachments/assets/c7d29880-aeff-4253-a901-9181903e7f3e" />




