### PR TITLE
[Bugfix] fix minicpmv test

### DIFF
--- a/tests/lora/test_minicpmv.py
+++ b/tests/lora/test_minicpmv.py
@@ -67,7 +67,6 @@ def test_minicpmv_lora(minicpmv_lora_files):
         max_loras=4,
         max_lora_rank=64,
         trust_remote_code=True,
-        gpu_memory_utilization=0.97,  # This model is pretty big for CI gpus
         enable_chunked_prefill=True,
     )
     output1 = do_sample(llm, minicpmv_lora_files, lora_id=1)


### PR DESCRIPTION
Context: https://vllm-dev.slack.com/archives/C07QT0LUF4K/p1734490695369139

This test now reserves too much memory after the profiling changes