### PR TITLE
[Model] IBM Granite 3.1

### DIFF
--- a/docs/source/models/supported_models.rst
+++ b/docs/source/models/supported_models.rst
@@ -194,8 +194,8 @@ Text Generation (``--task generate``)
     -
     - ✅︎
   * - :code:`GraniteForCausalLM`
-    - Granite 3.0, PowerLM
-    - :code:`ibm-granite/granite-3.0-2b-base`, :code:`ibm-granite/granite-3.0-8b-instruct`, :code:`ibm/PowerLM-3b`, etc.
+    - Granite 3.0, Granite 3.1, PowerLM
+    - :code:`ibm-granite/granite-3.0-2b-base`, :code:`ibm-granite/granite-3.1-8b-instruct`, :code:`ibm/PowerLM-3b`, etc.
     - ✅︎
     - ✅︎
   * - :code:`GraniteMoeForCausalLM`

--- a/docs/source/usage/tool_calling.md
+++ b/docs/source/usage/tool_calling.md
@@ -170,6 +170,10 @@ Recommended flags: `--tool-call-parser granite --chat-template examples/tool_cha
 
 `examples/tool_chat_template_granite.jinja`: this is a modified chat template from the original on Huggingface. Parallel function calls are supported.
 
+* `ibm-granite/granite-3.1-8b-instruct`
+
+Recommended flags: `--tool-call-parser granite`
+
 * `ibm-granite/granite-20b-functioncalling`
 
 Recommended flags: `--tool-call-parser granite-20b-fc --chat-template examples/tool_chat_template_granite_20b_fc.jinja`
@@ -284,4 +288,3 @@ Then you can use this plugin in the command line like this.
     --tool-call-parser example \
     --chat-template <your chat template> \
 ```
-

--- a/docs/source/usage/tool_calling.md
+++ b/docs/source/usage/tool_calling.md
@@ -174,6 +174,8 @@ Recommended flags: `--tool-call-parser granite --chat-template examples/tool_cha
 
 Recommended flags: `--tool-call-parser granite`
 
+The chat template from Huggingface can be used directly. Parallel function calls are supported.
+
 * `ibm-granite/granite-20b-functioncalling`
 
 Recommended flags: `--tool-call-parser granite-20b-fc --chat-template examples/tool_chat_template_granite_20b_fc.jinja`

--- a/tests/tool_use/utils.py
+++ b/tests/tool_use/utils.py
@@ -103,13 +103,21 @@ CONFIGS: Dict[str, ServerConfig] = {
         "supports_rocm":
         False,
     },
-    "granite8b": {
+    "granite-3.0-8b": {
         "model":
         "ibm-granite/granite-3.0-8b-instruct",
         "arguments": [
             "--tool-call-parser", "granite", "--chat-template",
             str(VLLM_PATH / "examples/tool_chat_template_granite.jinja")
         ],
+    },
+    "granite-3.1-8b": {
+        "model": "ibm-granite/granite-3.1-8b-instruct",
+        "arguments": [
+            "--tool-call-parser",
+            "granite",
+        ],
+        "supports_parallel": True,
     },
     "internlm": {
         "model":

--- a/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
@@ -58,7 +58,6 @@ class GraniteToolParser(ToolParser):
                     f"Expected dict or list, got {type(raw_function_calls)}")
 
             logger.debug("Extracted %d tool calls", len(raw_function_calls))
-            print(raw_function_calls)
             tool_calls = [
                 ToolCall(
                     type="function",

--- a/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/granite_tool_parser.py
@@ -35,13 +35,18 @@ class GraniteToolParser(ToolParser):
 
     def __init__(self, tokenizer: AnyTokenizer):
         super().__init__(tokenizer)
+        # for granite 3.0, the token `<|tool_call|>`
         self.bot_token = "<|tool_call|>"
+        # for granite 3.1, the string `<tool_call>`
+        self.bot_string = "<tool_call>"
 
     def extract_tool_calls(
             self, model_output: str,
             request: ChatCompletionRequest) -> ExtractedToolCallInformation:
-        # remove whitespace and the BOT token if it exists
-        stripped = model_output.strip().removeprefix(self.bot_token).lstrip()
+        stripped = model_output.strip()\
+                    .removeprefix(self.bot_token)\
+                    .removeprefix(self.bot_string)\
+                    .lstrip()
         if not stripped or stripped[0] != '[':
             return ExtractedToolCallInformation(tools_called=False,
                                                 tool_calls=[],
@@ -53,6 +58,7 @@ class GraniteToolParser(ToolParser):
                     f"Expected dict or list, got {type(raw_function_calls)}")
 
             logger.debug("Extracted %d tool calls", len(raw_function_calls))
+            print(raw_function_calls)
             tool_calls = [
                 ToolCall(
                     type="function",
@@ -90,6 +96,9 @@ class GraniteToolParser(ToolParser):
         start_idx = consume_space(0, current_text)
         if current_text[start_idx:].startswith(self.bot_token):
             start_idx = consume_space(start_idx + len(self.bot_token),
+                                      current_text)
+        if current_text[start_idx:].startswith(self.bot_string):
+            start_idx = consume_space(start_idx + len(self.bot_string),
                                       current_text)
         if not current_text or start_idx >= len(current_text)\
             or current_text[start_idx] != '[':


### PR DESCRIPTION
IBM just released new Granite 3.1 models ([Press Release](https://www.ibm.com/new/announcements/ibm-granite-3-1-powerful-performance-long-context-and-more); [HF Hub](https://huggingface.co/ibm-granite/granite-3.1-8b-instruct)).

Tool calling with the new version is different becuase it uses a `<tool_call>` html-style string to mark the start of a tool call response instead of the `<|tool_call|>` token. The default chat template from HF Hub passes the unit tests, so I did not add a new chat template jinja file to the examples directory (but the current `tool_chat_template_granite.jinja` file should not be used with the 3.1 models).