### PR TITLE
Update Dockerfile.tpu pin to nightly torch_xla

### DIFF
--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,5 +1,5 @@
 ARG NIGHTLY_DATE="20241017"
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"
+ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm"
 
 FROM $BASE_IMAGE
 WORKDIR /workspace/vllm

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -16,8 +16,8 @@ ray[default]
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.6.0.dev20241126+cpu
-torchvision==0.20.0.dev20241126+cpu
-torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0.dev20241126-cp310-cp310-linux_x86_64.whl
-jaxlib==0.4.36.dev20241122
-jax==0.4.36.dev20241122
+torch
+torchvision
+torch_xla[tpu] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev-cp310-cp310-linux_x86_64.whl
+jaxlib
+jax


### PR DESCRIPTION
Switch vLLM docker image build with torch_xla from specific-data-10/17 to nightly

torch_xla docker image at Dec18 passed `import torch; import torch_xla`
