### PR TITLE
[Bugfix][Hardware][POWERPC] Fix auto dtype failure in case of POWER10

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -22,7 +22,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import (QUANTIZATION_METHODS,
                                                      get_quantization_config)
 from vllm.model_executor.models import ModelRegistry
-from vllm.platforms import current_platform
+from vllm.platforms import current_platform, interface
 from vllm.tracing import is_otel_available, otel_import_error_traceback
 from vllm.transformers_utils.config import (
     ConfigFormat, get_config, get_hf_image_processor_config,
@@ -2144,7 +2144,14 @@ def _get_and_verify_dtype(
                     torch_dtype = torch.float16
             else:
                 torch_dtype = config_dtype
-
+    
+            if (current_platform.is_cpu() and  
+                current_platform.get_cpu_architecture() == interface.CpuArchEnum.POWERPC):
+                if config_dtype == torch.float16 or config_dtype == torch.float32:
+                    logger.info(
+                        "For POWERPC, we cast models to bfloat16 instead of"
+                        "using float16 by default. Float16 is not currently supported for POWERPC.")
+                    torch_dtype = torch.bfloat16
             if current_platform.is_hpu() and config_dtype == torch.float16:
                 logger.info(
                     "For HPU, we cast models to bfloat16 instead of"

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2144,14 +2144,18 @@ def _get_and_verify_dtype(
                     torch_dtype = torch.float16
             else:
                 torch_dtype = config_dtype
-    
-            if (current_platform.is_cpu() and  
-                current_platform.get_cpu_architecture() == interface.CpuArchEnum.POWERPC):
-                if config_dtype == torch.float16 or config_dtype == torch.float32:
-                    logger.info(
-                        "For POWERPC, we cast models to bfloat16 instead of"
-                        "using float16 by default. Float16 is not currently supported for POWERPC.")
-                    torch_dtype = torch.bfloat16
+
+            if (current_platform.is_cpu()
+                    and current_platform.get_cpu_architecture()
+                    == interface.CpuArchEnum.POWERPC
+                    and (config_dtype == torch.float16
+                         or config_dtype == torch.float32)):
+                logger.info(
+                    "For POWERPC, we cast models to bfloat16 instead of "
+                    "using float16 by default. Float16 is not currently "
+                    "supported for POWERPC.")
+                torch_dtype = torch.bfloat16
+
             if current_platform.is_hpu() and config_dtype == torch.float16:
                 logger.info(
                     "For HPU, we cast models to bfloat16 instead of"


### PR DESCRIPTION
FIX #11327
This PR fixes the `dtype="auto"` failure in case of POWEPC. 
The failure observed in above issue was due to **FP16** not supported in **ppc64le** architecture. With this PR we are making changes to select BF16 instead of FP16 when "auto" type is selected.
