### PR TITLE
[Bugfix] update should_ignore_layer

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -30,7 +30,7 @@ def should_ignore_layer(layer_name: Optional[str],
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that
     # each shard of the fused layer has the same scheme.
-    if proj_name in FUSED_LAYER_NAME_MAPPING:
+    if proj_name in FUSED_LAYER_NAME_MAPPING and layer_name not in ignore:
         shard_proj_names = FUSED_LAYER_NAME_MAPPING[proj_name]
 
         # Convert fused_name --> [shard_names]


### PR DESCRIPTION
FIX ignore logic in Compressed Tensors utils. 

Previously for fused layers, it automatically uses the shared_proj_names logic without considering the ignore list provided by the input arg. 

Fix considers the ignore list for fused layers

Tested with this previously failing model:
```
vllm serve horheynm/Phi-3-mini-4k-instruct-kv_cache
```