### PR TITLE
[CI/Build] fix pre-compiled wheel install for exact tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -466,7 +466,7 @@ def get_vllm_version() -> str:
             version += f"{sep}empty"
     elif _is_cuda():
         if envs.VLLM_USE_PRECOMPILED:
-            version += ".precompiled"
+            version += f"{sep}precompiled"
         else:
             cuda_version = str(get_nvcc_cuda_version())
             if cuda_version != MAIN_CUDA_VERSION:


### PR DESCRIPTION
Fixes the precompiled wheel version for exact tags: a valid version [must respect](https://packaging.python.org/en/latest/specifications/version-specifiers/#public-version-identifiers) the following format `[N!]N(.N)*[{a|b|rc}N][.postN][.devN]
` 

fixes https://github.com/vllm-project/vllm/issues/11321