### PR TITLE
[Bugfix] Don't log OpenAI field aliases as ignored

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -46,7 +46,15 @@ class OpenAIBaseModel(BaseModel):
     @classmethod
     def __log_extra_fields__(cls, data):
         if isinstance(data, dict):
-            extra_fields = data.keys() - cls.model_fields.keys()
+            # Get all class field names and their potential aliases
+            field_names = set()
+            for field_name, field in cls.model_fields.items():
+                field_names.add(field_name)
+                if hasattr(field, 'alias') and field.alias:
+                    field_names.add(field.alias)
+
+            # Compare against both field names and aliases
+            extra_fields = data.keys() - field_names
             if extra_fields:
                 logger.warning(
                     "The following fields were present in the request "


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/11363

This issue was found because we use an alias for `schema` in `JsonSchemaResponseFormat` due to conflicts with pydantic:
```python
class JsonSchemaResponseFormat(OpenAIBaseModel):
    name: str
    description: Optional[str] = None
    # schema is the field in openai but that causes conflicts with pydantic so
    # instead use json_schema with an alias
    json_schema: Optional[Dict[str, Any]] = Field(default=None, alias='schema')
    strict: Optional[bool] = None
```

Our logging for unused fields in requests was not taking into account aliases, so we were incorrectly reporting that fields were being ignored
```
WARNING 12-20 16:05:31 protocol.py:52] The following fields were present in the request but ignored: {'schema'}
```