### PR TITLE
[Bugfix] Use .clone() for sampling params and deepcopy XGrammarLogitsProcessor 

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -450,15 +450,16 @@ class SamplingParams(
         return self._all_stop_token_ids
 
     def clone(self) -> "SamplingParams":
-        """Deep copy excluding LogitsProcessor objects.
+        """Deep copy, but maybe not the LogitsProcessor objects.
 
-        LogitsProcessor objects are excluded because they may contain an
-        arbitrary, nontrivial amount of data.
+        LogitsProcessor objects may contain an arbitrary, nontrivial amount of
+        data that is expensive to copy. However, if not copied, the processor
+        needs to support parallel decoding for multiple sequences
         See https://github.com/vllm-project/vllm/issues/3087
         """
 
         logit_processor_refs = None if self.logits_processors is None else {
-            id(lp): lp
+            id(lp): lp.clone() if hasattr(lp, 'clone') else lp
             for lp in self.logits_processors
         }
         return copy.deepcopy(self, memo=logit_processor_refs)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1366,9 +1366,9 @@ class SequenceGroupBase:
 class ParallelSampleSequenceGroup(SequenceGroupBase):
 
     @staticmethod
-    def add_request(request_id: str, engine, params, **kwargs):
+    def add_request(request_id: str, engine, params: Union[SamplingParams, PoolingParams], **kwargs):
         original_params = params
-        params = copy.deepcopy(original_params)
+        params = original_params.clone()
         params.n = 1
         group = ParallelSampleSequenceGroup(request_id)
         seqs = []


### PR DESCRIPTION
XGrammar is now the default decoding backend, but it breaks when doing parallel decoding with `n>1` in Server mode. There is internal state in `self.prefilled` and per-sequence state in the matchers, but parallel decoding uses the same `XGrammarLogitsProcessor` instance for every parallel sequence.

The fix here for `prefilled` is just to remove the flag and use the length of input_ids as the check to avoid an `IndexError: tuple index out of range`. The fix for the matchers state is to deepcopy the processor for each sequence instead of sharing the reference to prevent an `AssertionError` at `assert self.matchers[i].accept_token(sampled_token)`.

NOTE: I noticed the `batch_size` field on the processor and the creation of mulitple matchers based on that, but those don't seem to be used (i.e. `batch_size==1` even if `n>1`). I'm not sure if the "batch" was intended to handle parallel decoding instead of doing a deepcopy like I do in this fix, but I also didn't see a good way to index into the batch based on the sequence in the sequence group.

DRAFT: Looking to add a test that would have caught this and I'm looking to understand the differences between LP processing for server mode vs oflfine mode.

FIX #11312 

