### PR TITLE
[Core] Support global prefix caching

### DIFF
--- a/examples/offline_inference_with_global_prefix.py
+++ b/examples/offline_inference_with_global_prefix.py
@@ -1,0 +1,122 @@
+from vllm import LLM, SamplingParams
+from vllm.distributed import cleanup_dist_env_and_memory
+
+# NOTE: This is just a running example. For benchmarking purpose,
+# please see benchmarks/benchmark_prefix_caching.py
+
+# Common prefix.
+prefix = (
+    "You are an expert school principal, skilled in effectively managing "
+    "faculty and staff. Draft 10-15 questions for a potential first grade "
+    "Head Teacher for my K-12, all-girls', independent school that emphasizes "
+    "community, joyful discovery, and life-long learning. The candidate is "
+    "coming in for a first-round panel interview for a 8th grade Math "
+    "teaching role. They have 5 years of previous teaching experience "
+    "as an assistant teacher at a co-ed, public school with experience "
+    "in middle school math teaching. Based on these information, fulfill "
+    "the following paragraph: ")
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+generating_prompts = [prefix + prompt for prompt in prompts]
+
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.0)
+
+# Create an LLM without prefix caching as a baseline.
+regular_llm = LLM(model="facebook/opt-125m", gpu_memory_utilization=0.4)
+
+print("Results without `enable_prefix_caching`")
+
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = regular_llm.generate(generating_prompts, sampling_params)
+
+regular_generated_texts = []
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    regular_generated_texts.append(generated_text)
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+print("-" * 80)
+
+# Destroy the LLM object and free up the GPU memory.
+del regular_llm
+cleanup_dist_env_and_memory()
+
+# Create an LLM with prefix caching enabled.
+prefix_cached_llm = LLM(model="facebook/opt-125m",
+                        enable_prefix_caching=True,
+                        num_global_cache_blocks=5000,
+                        gpu_memory_utilization=0.4)
+
+# Warmup so that the shared prompt's KV cache is computed.
+prefix_cached_llm.generate(generating_prompts[0], sampling_params)
+
+# Generate with prefix caching.
+outputs = prefix_cached_llm.generate(generating_prompts, sampling_params)
+
+print("Results with `enable_prefix_caching`")
+
+cached_generated_texts = []
+# Print the outputs. You should see the same outputs as before.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    cached_generated_texts.append(generated_text)
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+print("-" * 80)
+
+# Compare the results and display the speedup
+generated_same = all([
+    regular_generated_texts[i] == cached_generated_texts[i]
+    for i in range(len(prompts))
+])
+print(f"Generated answers are the same: {generated_same}")
+
+"""
+We can simulate the global prefix cache this way:
+1. Run the vllm instance with APC for some time, so some prompts may not hit APC as they are old and evicted
+2. Delete the first vllm instance and start a new one. In this case, global kv cache can be hit directly
+Here we demo the second option.
+"""
+# Destroy the LLM object and free up the GPU memory.
+del prefix_cached_llm
+cleanup_dist_env_and_memory()
+
+# Create an LLM with global prefix caching enabled.
+global_prefix_cached_llm = LLM(model="facebook/opt-125m",
+                        enable_prefix_caching=True,
+                        num_global_cache_blocks=5000,
+                        gpu_memory_utilization=0.4)
+
+# Generate with global prefix caching.
+outputs = global_prefix_cached_llm.generate(generating_prompts, sampling_params)
+
+print("Results with `enable_global_prefix_caching`")
+
+global_cached_generated_texts = []
+# Print the outputs. You should see the same outputs as before.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    global_cached_generated_texts.append(generated_text)
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+print("-" * 80)
+
+# Compare the results and display the speedup
+generated_same = all([
+    regular_generated_texts[i] == global_cached_generated_texts[i]
+    for i in range(len(prompts))
+])
+print(f"Generated answers are the same: {generated_same}")

--- a/examples/offline_inference_with_global_prefix.py
+++ b/examples/offline_inference_with_global_prefix.py
@@ -85,8 +85,10 @@ print(f"Generated answers are the same: {generated_same}")
 
 """
 We can simulate the global prefix cache this way:
-1. Run the vllm instance with APC for some time, so some prompts may not hit APC as they are old and evicted
-2. Delete the first vllm instance and start a new one. In this case, global kv cache can be hit directly
+1. Run the vllm instance with APC for some time, so some prompts may not 
+hit APC as they are old and evicted
+2. Delete the first vllm instance and start a new one. In this case, 
+global kv cache can be hit directly
 Here we demo the second option.
 """
 # Destroy the LLM object and free up the GPU memory.

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -126,6 +126,7 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
         self.prefill_seq_lens: List[int] = []
         self.context_lens: List[int] = []
         self.block_tables: List[List[int]] = []
+        self.block_hash_map: List[Dict[int, int]] = []
         self.curr_seq_lens: List[int] = []
         self.multimodal_placeholder_maps: Dict[
             str,
@@ -185,6 +186,8 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
                     block_table = block_tables[seq_id][
                         -curr_sliding_window_block:]
             self.block_tables.append(block_table)
+            if seq_id in inter_data.block_hash_map:
+                self.block_hash_map.append(inter_data.block_hash_map[seq_id])
 
             # Compute slot mapping.
             is_profile_run = is_block_tables_empty(block_tables)
@@ -275,6 +278,7 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             seq_start_loc=seq_start_loc_tensor,
             context_lens_tensor=context_lens_tensor,
             block_tables=block_tables,
+            block_hash_map=self.block_hash_map,
             use_cuda_graph=use_captured_graph,
         )
 
@@ -326,6 +330,7 @@ class CommonAttentionState(AttentionState):
             seq_start_loc=None,
             context_lens_tensor=None,
             block_tables=self._graph_block_tables[:batch_size],
+            block_hash_map={},
             use_cuda_graph=True,
         )
         if is_encoder_decoder_model:

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -223,6 +223,7 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             query_start_loc=query_start_loc,
             context_lens_tensor=context_lens_tensor,
             block_tables=block_tables,
+            block_hash_map=self.block_hash_map,
             use_cuda_graph=False,
             # Begin encoder & cross attn fields below...
             encoder_seq_lens=self.encoder_seq_lens,
@@ -263,6 +264,7 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             max_prefill_seq_len=0,
             max_decode_seq_len=self.max_decode_seq_len,
             block_tables=block_tables,
+            block_hash_map=self.block_hash_map,
             use_cuda_graph=self.use_cuda_graph,
             # Begin encoder & cross attn fields below...
             encoder_seq_lens=self.encoder_seq_lens,

--- a/vllm/attention/ops/paged_attn.py
+++ b/vllm/attention/ops/paged_attn.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 import torch
 
@@ -28,6 +28,7 @@ class PagedAttentionMetadata:
     # 2nd dimensions are padded up to max_blocks_per_seq if it is cuda-graph
     # captured.
     block_tables: Optional[torch.Tensor]
+    block_hash_map: Optional[List[Dict[int, int]]]
 
 
 class PagedAttention:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -886,6 +886,7 @@ class CacheConfig:
         num_gpu_blocks_override: Optional[int] = None,
         sliding_window: Optional[int] = None,
         enable_prefix_caching: bool = False,
+        num_global_cache_blocks: int = 0,
         cpu_offload_gb: float = 0,
     ) -> None:
         self.block_size = block_size
@@ -896,6 +897,7 @@ class CacheConfig:
         self.is_attention_free = is_attention_free
         self.sliding_window = sliding_window
         self.enable_prefix_caching = enable_prefix_caching
+        self.num_global_cache_blocks = num_global_cache_blocks
         self.cpu_offload_gb = cpu_offload_gb
 
         self._verify_args()

--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from vllm.core.block.common import BlockList
 from vllm.core.block.interfaces import Block, DeviceAwareBlockAllocator
@@ -256,6 +256,14 @@ class BlockTable:
                 BlockTable.
         """
         return self._blocks.ids()
+
+    @property
+    def block_hashes(self) -> Dict[int, int]:
+        return self._blocks.hashes()
+
+    @property
+    def global_computed_list(self) -> List[int]:
+        return self._blocks.global_computed_list()
 
     def get_unseen_token_ids(self, sequence_token_ids: List[int]) -> List[int]:
         """Get the number of "unseen" tokens in the sequence.

--- a/vllm/core/block/cpu_gpu_block_allocator.py
+++ b/vllm/core/block/cpu_gpu_block_allocator.py
@@ -417,6 +417,14 @@ class NullBlock(Block):
         self._proxy.computed = value
 
     @property
+    def global_computed(self):
+        return self._proxy.global_computed
+
+    @global_computed.setter
+    def global_computed(self, value):
+        self._proxy.global_computed = value        
+
+    @property
     def last_accessed(self) -> float:
         return self._proxy.last_accessed
 

--- a/vllm/core/block/interfaces.py
+++ b/vllm/core/block/interfaces.py
@@ -68,6 +68,16 @@ class Block(ABC):
 
     @property
     @abstractmethod
+    def global_computed(self) -> bool:
+        raise NotImplementedError
+
+    @global_computed.setter
+    @abstractmethod
+    def global_computed(self, value) -> bool:
+        raise NotImplementedError        
+
+    @property
+    @abstractmethod
     def last_accessed(self) -> float:
         raise NotImplementedError
 

--- a/vllm/core/block/naive_block.py
+++ b/vllm/core/block/naive_block.py
@@ -405,6 +405,14 @@ class NaiveBlock(Block):
         raise NotImplementedError
 
     @property
+    def global_computed(self) -> bool:
+        raise NotImplementedError
+
+    @global_computed.setter
+    def global_computed(self, value) -> None:
+        raise NotImplementedError        
+
+    @property
     def last_accessed(self) -> float:
         raise NotImplementedError
 

--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -280,6 +280,12 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         block_ids = self.block_tables[seq.seq_id].physical_block_ids
         return block_ids  # type: ignore
 
+    def get_block_hashes(self, seq: Sequence) -> Dict[int, int]:
+        return self.block_tables[seq.seq_id].block_hashes
+
+    def get_global_computed_list(self, seq: Sequence) -> List[int]:
+        return self.block_tables[seq.seq_id].global_computed_list
+
     def get_cross_block_table(self, seq_group: SequenceGroup) -> List[int]:
         request_id = seq_group.request_id
         assert request_id in self.cross_block_tables

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1339,19 +1339,10 @@ class Scheduler:
                 if (self.cache_config.enable_prefix_caching and 
                     self.cache_config.num_global_cache_blocks > 0 and 
                     seq_group.is_prefill()):
-                    global_computed_list = []
-                    block_h_dict = {}
-                    for block_id in block_tables[seq_id]:
-                        for block in \
-                            self.block_manager.block_tables[seq_id].blocks:
-                            if block.block_id == block_id:
-                                if block.global_computed:
-                                    global_computed_list.append(block_id)
-                                if block.content_hash is not None:
-                                    block_h_dict[block_id] = block.content_hash
-                                break
-                    block_global_computed_tables[seq_id] = global_computed_list
-                    block_hash_map[seq_id] = block_h_dict
+                    block_global_computed_tables[seq_id] = \
+                        self.block_manager.get_global_computed_list(seq)
+                    block_hash_map[seq_id] = \
+                        self.block_manager.get_block_hashes(seq)
                 
                 self.block_manager.access_all_blocks_in_seq(seq, now)
 

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1336,19 +1336,22 @@ class Scheduler:
                 seq_data[seq_id] = seq.data
                 block_tables[seq_id] = self.block_manager.get_block_table(seq)
 
-                if self.cache_config.enable_prefix_caching and self.cache_config.num_global_cache_blocks > 0 and seq_group.is_prefill():
+                if (self.cache_config.enable_prefix_caching and 
+                    self.cache_config.num_global_cache_blocks > 0 and 
+                    seq_group.is_prefill()):
                     global_computed_list = []
-                    block_hash_dict = {}
+                    block_h_dict = {}
                     for block_id in block_tables[seq_id]:
-                        for block in self.block_manager.block_tables[seq_id].blocks:
+                        for block in \
+                            self.block_manager.block_tables[seq_id].blocks:
                             if block.block_id == block_id:
                                 if block.global_computed:
                                     global_computed_list.append(block_id)
                                 if block.content_hash is not None:
-                                    block_hash_dict[block_id] = block.content_hash
+                                    block_h_dict[block_id] = block.content_hash
                                 break
                     block_global_computed_tables[seq_id] = global_computed_list
-                    block_hash_map[seq_id] = block_hash_dict
+                    block_hash_map[seq_id] = block_h_dict
                 
                 self.block_manager.access_all_blocks_in_seq(seq, now)
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -114,6 +114,7 @@ class EngineArgs:
     max_parallel_loading_workers: Optional[int] = None
     block_size: Optional[int] = None
     enable_prefix_caching: Optional[bool] = None
+    num_global_cache_blocks: int = 0
     disable_sliding_window: bool = False
     use_v2_block_manager: bool = True
     swap_space: float = 4  # GiB
@@ -438,6 +439,11 @@ class EngineArgs:
             help="Enables automatic prefix caching. "
             "Use --no-enable-prefix-caching to disable explicitly.",
         )
+        parser.add_argument(
+            "--num-global-cache-blocks",
+            type=int,
+            default=EngineArgs.num_global_cache_blocks,
+            help="number of global kv cache blocks, 0 for disable. ")        
         parser.add_argument('--disable-sliding-window',
                             action='store_true',
                             help='Disables sliding window, '
@@ -1044,6 +1050,7 @@ class EngineArgs:
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=model_config.get_sliding_window(),
             enable_prefix_caching=self.enable_prefix_caching,
+            num_global_cache_blocks=self.num_global_cache_blocks,
             cpu_offload_gb=self.cpu_offload_gb,
         )
         parallel_config = ParallelConfig(

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -371,8 +371,12 @@ class LLMEngine:
                 if self.model_config.use_async_output_proc else None)
             for v_id in range(self.parallel_config.pipeline_parallel_size)
         ]
-        if self.cache_config.enable_prefix_caching and self.cache_config.num_global_cache_blocks > 0:
-            global_cache_instance.setGlabalCacheBlockNum(self.model_config, self.cache_config, self.model_executor.driver_worker.cache_engine[0].dtype)
+        if (self.cache_config.enable_prefix_caching and 
+            self.cache_config.num_global_cache_blocks > 0):
+            global_cache_instance.setGlabalCacheBlockNum(
+                self.model_config, 
+                self.cache_config, 
+                self.model_executor.driver_worker.cache_engine[0].dtype)
 
         # Metric Logging.
         if self.log_stats:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -62,6 +62,8 @@ from vllm.usage.usage_lib import (UsageContext, is_usage_stats_enabled,
 from vllm.utils import Counter, Device, deprecate_kwargs, weak_bind
 from vllm.version import __version__ as VLLM_VERSION
 
+from vllm.global_cache import global_cache_instance
+
 logger = init_logger(__name__)
 _LOCAL_LOGGING_INTERVAL_SEC = 5
 
@@ -369,6 +371,8 @@ class LLMEngine:
                 if self.model_config.use_async_output_proc else None)
             for v_id in range(self.parallel_config.pipeline_parallel_size)
         ]
+        if self.cache_config.enable_prefix_caching and self.cache_config.num_global_cache_blocks > 0:
+            global_cache_instance.setGlabalCacheBlockNum(self.model_config, self.cache_config, self.model_executor.driver_worker.cache_engine[0].dtype)
 
         # Metric Logging.
         if self.log_stats:

--- a/vllm/global_cache.py
+++ b/vllm/global_cache.py
@@ -1,0 +1,69 @@
+from collections import deque
+from typing import Deque, Dict
+import torch
+from vllm.config import ModelConfig, CacheConfig
+from vllm.logger import init_logger
+import psutil
+
+logger = init_logger(__name__)
+
+class GlobalCache:
+    """
+    For now just use a simple Dict to store golbal kv cache and a Deque to evict the least used key.
+    It can be easily extended and integrated with other kv cache pools that shared with other vllm instances. 
+    """
+    def __init__(self, max_mem_util: float):
+        self.cachedBlockNum: int = 0
+        self.max_mem_util: float = max_mem_util
+        self.blockHashDict_k: Dict[int, Dict[int, torch.Tensor]] = {}
+        self.blockHashDict_v: Dict[int, Dict[int, torch.Tensor]] = {}
+        self.cachedBlockHashQ: Deque[int] = deque()
+
+    def setGlabalCacheBlockNum(self, model_config: ModelConfig, cache_config: CacheConfig, dtype: torch.dtype):
+        if self.cachedBlockNum > 0:
+            logger.warning("global kv cache already enabled")
+            return        
+        if cache_config.num_global_cache_blocks <= 0:
+            logger.warning("num_global_cache_blocks is not valid")
+            return
+        available_mem = psutil.virtual_memory().available * self.max_mem_util
+        num_kv_heads = model_config.hf_text_config.num_attention_heads
+        head_size = model_config.hf_text_config.hidden_size // model_config.hf_text_config.num_attention_heads
+        num_attention_layers = model_config.hf_config.num_hidden_layers
+        dtype_size = torch.tensor([], dtype=dtype).element_size()
+        key_size_bytes = dtype_size * cache_config.block_size * num_kv_heads * head_size * num_attention_layers
+        if key_size_bytes * 2 * cache_config.num_global_cache_blocks > available_mem:
+            logger.warning("num_global_cache_blocks too large, can not enable global kv cache, at most %d blocks can be used", available_mem // (key_size_bytes * 2))
+            return
+        self.cachedBlockNum = cache_config.num_global_cache_blocks     
+        logger.info("global kv cache enabled")   
+
+    def writeCache(self, block_hash: int, layer_idx: int, k_block_tensor: torch.Tensor, v_block_tensor: torch.Tensor):
+        if self.cachedBlockNum == 0:
+            return
+        if len(self.cachedBlockHashQ) == self.cachedBlockNum:
+            poped_block_hash = self.cachedBlockHashQ.popleft()
+            del self.blockHashDict_k[poped_block_hash]
+            del self.blockHashDict_v[poped_block_hash]
+        if block_hash not in self.blockHashDict_k or block_hash not in self.blockHashDict_v:
+            self.blockHashDict_k[block_hash] = {}
+            self.blockHashDict_v[block_hash] = {}
+        else:
+            self.cachedBlockHashQ.remove(block_hash)
+        self.blockHashDict_k[block_hash][layer_idx] = k_block_tensor.to(device="cpu", non_blocking=True)
+        self.blockHashDict_v[block_hash][layer_idx] = v_block_tensor.to(device="cpu", non_blocking=True)
+        self.cachedBlockHashQ.append(block_hash)
+
+    def readCache(self, block_hash: int, layer_idx: int, device: torch.device):
+        if self.cachedBlockNum == 0:
+            return
+        if not self.checkExist(block_hash):
+            return
+        self.cachedBlockHashQ.remove(block_hash)
+        self.cachedBlockHashQ.append(block_hash)
+        return self.blockHashDict_k[block_hash][layer_idx].to(torch.device(device), non_blocking=True), self.blockHashDict_v[block_hash][layer_idx].to(torch.device(device), non_blocking=True)
+    
+    def checkExist(self, block_hash: int):
+        return block_hash in self.blockHashDict_k and block_hash in self.blockHashDict_v
+
+global_cache_instance = GlobalCache(max_mem_util=0.8)

--- a/vllm/global_cache.py
+++ b/vllm/global_cache.py
@@ -1,5 +1,5 @@
 from collections import deque
-from typing import Deque, Dict
+from typing import Deque, Dict, Optional
 import torch
 from vllm.config import ModelConfig, CacheConfig
 from vllm.logger import init_logger
@@ -9,8 +9,10 @@ logger = init_logger(__name__)
 
 class GlobalCache:
     """
-    For now just use a simple Dict to store golbal kv cache and a Deque to evict the least used key.
-    It can be easily extended and integrated with other kv cache pools that shared with other vllm instances. 
+    For now just use a simple Dict to store golbal kv cache 
+    and a Deque to evict the least used key.
+    It can be easily extended and integrated with other kv cache pools 
+    that shared with other vllm instances. 
     """
     def __init__(self, max_mem_util: float):
         self.cachedBlockNum: int = 0
@@ -19,7 +21,10 @@ class GlobalCache:
         self.blockHashDict_v: Dict[int, Dict[int, torch.Tensor]] = {}
         self.cachedBlockHashQ: Deque[int] = deque()
 
-    def setGlabalCacheBlockNum(self, model_config: ModelConfig, cache_config: CacheConfig, dtype: torch.dtype):
+    def setGlabalCacheBlockNum(
+            self, model_config: ModelConfig, 
+            cache_config: CacheConfig, 
+            dtype: torch.dtype):
         if self.cachedBlockNum > 0:
             logger.warning("global kv cache already enabled")
             return        
@@ -28,42 +33,54 @@ class GlobalCache:
             return
         available_mem = psutil.virtual_memory().available * self.max_mem_util
         num_kv_heads = model_config.hf_text_config.num_attention_heads
-        head_size = model_config.hf_text_config.hidden_size // model_config.hf_text_config.num_attention_heads
+        head_size = (model_config.hf_text_config.hidden_size // 
+            model_config.hf_text_config.num_attention_heads)
         num_attention_layers = model_config.hf_config.num_hidden_layers
         dtype_size = torch.tensor([], dtype=dtype).element_size()
-        key_size_bytes = dtype_size * cache_config.block_size * num_kv_heads * head_size * num_attention_layers
-        if key_size_bytes * 2 * cache_config.num_global_cache_blocks > available_mem:
-            logger.warning("num_global_cache_blocks too large, can not enable global kv cache, at most %d blocks can be used", available_mem // (key_size_bytes * 2))
+        key_size_bytes = (dtype_size * cache_config.block_size * 
+            num_kv_heads * head_size * num_attention_layers)
+        if (key_size_bytes * 2 * cache_config.num_global_cache_blocks > 
+            available_mem):
+            logger.warning("num_global_cache_blocks too large, can not enable "
+                "global kv cache, at most %d blocks can be used", 
+                available_mem // (key_size_bytes * 2))
             return
         self.cachedBlockNum = cache_config.num_global_cache_blocks     
-        logger.info("global kv cache enabled")   
+        logger.info("global kv cache enabled: %d", self.cachedBlockNum)
 
-    def writeCache(self, block_hash: int, layer_idx: int, k_block_tensor: torch.Tensor, v_block_tensor: torch.Tensor):
+    def writeCache(
+            self, h: int, idx: int, 
+            k_block_tensor: torch.Tensor, v_block_tensor: torch.Tensor):
         if self.cachedBlockNum == 0:
             return
         if len(self.cachedBlockHashQ) == self.cachedBlockNum:
             poped_block_hash = self.cachedBlockHashQ.popleft()
             del self.blockHashDict_k[poped_block_hash]
             del self.blockHashDict_v[poped_block_hash]
-        if block_hash not in self.blockHashDict_k or block_hash not in self.blockHashDict_v:
-            self.blockHashDict_k[block_hash] = {}
-            self.blockHashDict_v[block_hash] = {}
+        if (h not in self.blockHashDict_k or 
+            h not in self.blockHashDict_v):
+            self.blockHashDict_k[h] = {}
+            self.blockHashDict_v[h] = {}
         else:
-            self.cachedBlockHashQ.remove(block_hash)
-        self.blockHashDict_k[block_hash][layer_idx] = k_block_tensor.to(device="cpu", non_blocking=True)
-        self.blockHashDict_v[block_hash][layer_idx] = v_block_tensor.to(device="cpu", non_blocking=True)
-        self.cachedBlockHashQ.append(block_hash)
+            self.cachedBlockHashQ.remove(h)
 
-    def readCache(self, block_hash: int, layer_idx: int, device: torch.device):
+        self.blockHashDict_k[h][idx] = \
+            k_block_tensor.to(device="cpu", non_blocking=True)
+        self.blockHashDict_v[h][idx] = \
+            v_block_tensor.to(device="cpu", non_blocking=True)
+        self.cachedBlockHashQ.append(h)
+
+    def readCache(self, h: int, idx: int, device: torch.device):
         if self.cachedBlockNum == 0:
             return
-        if not self.checkExist(block_hash):
+        if not self.checkExist(h):
             return
-        self.cachedBlockHashQ.remove(block_hash)
-        self.cachedBlockHashQ.append(block_hash)
-        return self.blockHashDict_k[block_hash][layer_idx].to(torch.device(device), non_blocking=True), self.blockHashDict_v[block_hash][layer_idx].to(torch.device(device), non_blocking=True)
+        self.cachedBlockHashQ.remove(h)
+        self.cachedBlockHashQ.append(h)
+        return self.blockHashDict_k[h][idx].to(device, non_blocking=True), \
+                self.blockHashDict_v[h][idx].to(device, non_blocking=True)
     
-    def checkExist(self, block_hash: int):
-        return block_hash in self.blockHashDict_k and block_hash in self.blockHashDict_v
+    def checkExist(self, h: Optional[int]):
+        return h in self.blockHashDict_k and h in self.blockHashDict_v
 
 global_cache_instance = GlobalCache(max_mem_util=0.8)

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -921,6 +921,8 @@ class SequenceGroupMetadata(
     seq_data: Dict[int, SequenceData]
     sampling_params: Optional[SamplingParams]
     block_tables: Dict[int, List[int]]
+    block_global_computed_tables: Dict[int, List[int]]
+    block_hash_map: Optional[Dict[int, Dict[int, int]]] = {}
     do_sample: bool = True
     pooling_params: Optional[PoolingParams] = None
     lora_request: Optional[LoRARequest] = None

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -436,7 +436,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
     def __init__(self,
                  runner: "GPUModelRunnerBase",
                  finished_requests_ids: Optional[List[str]] = None,
-                 kv_caches: Optional[List[torch.Tensor]] = []):
+                 kv_caches: Optional[List[torch.Tensor]] = None):
         super().__init__()
         # Compute functions for each sequence in a sequence group.
         # WARNING: The order of the functions matters!
@@ -1246,7 +1246,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
         finished_requests_ids: Optional[List[str]] = None,
-        kv_caches: Optional[List[torch.Tensor]] = [],
+        kv_caches: Optional[List[torch.Tensor]] = None,
     ) -> TModelInputForGPU:
         """Helper method to prepare the model input based on a given sequence
         group. Prepares metadata needed for the base model forward pass but not
@@ -1621,7 +1621,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         seq_group_metadata_list: List[SequenceGroupMetadata],
         virtual_engine: int = 0,
         finished_requests_ids: Optional[List[str]] = None,
-        kv_caches: Optional[List[torch.Tensor]] = [],
+        kv_caches: Optional[List[torch.Tensor]] = None,
     ) -> ModelInputForGPUWithSamplingMetadata:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -56,6 +56,8 @@ from vllm.worker.model_runner_base import (
     _init_attn_metadata_from_tensor_dict,
     _init_sampling_metadata_from_tensor_dict, dump_input_when_exception)
 
+from vllm.global_cache import global_cache_instance
+
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
 
@@ -212,6 +214,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             seq_ids: List[int],
             is_prompt: bool,
             block_tables: Optional[Dict[int, List[int]]],
+            block_global_computed_tables: Optional[Dict[int, List[int]]],
+            block_hash_map: Optional[Dict[int, Dict[int, int]]],
             computed_block_nums: List[int],
             n_seqs: int = 0,
 
@@ -264,6 +268,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             self.request_id = request_id
             self.is_prompt = is_prompt
             self.block_tables = block_tables
+            self.block_global_computed_tables = block_global_computed_tables
+            self.block_hash_map = block_hash_map
             self.computed_block_nums = computed_block_nums
             self.n_seqs = n_seqs
             self.encoder_seq_len = encoder_seq_len
@@ -403,6 +409,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             seq_ids=[0] * num_seqs,
             is_prompt=True,
             block_tables=None,
+            block_hash_map=None,
+            block_global_computed_tables=None,
             computed_block_nums=[])
 
     def init_cached_inter_data(self, *args, **kwargs):
@@ -427,7 +435,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
     def __init__(self,
                  runner: "GPUModelRunnerBase",
-                 finished_requests_ids: Optional[List[str]] = None):
+                 finished_requests_ids: Optional[List[str]] = None,
+                 kv_caches: Optional[List[torch.Tensor]] = []):
         super().__init__()
         # Compute functions for each sequence in a sequence group.
         # WARNING: The order of the functions matters!
@@ -444,6 +453,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             self._compute_multi_modal_input,
         ]
 
+        self.kv_caches = kv_caches
         self.runner = runner
         self.model_input_cls = self.runner._model_input_cls
         self.attn_backend = self.runner.attn_backend
@@ -529,22 +539,39 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         remaining blocks.
         """
         computed_block_nums = inter_data.computed_block_nums
+        block_global_computed_tables = inter_data.block_global_computed_tables[inter_data.seq_ids[seq_idx]] if inter_data.block_global_computed_tables is not None and len(inter_data.block_global_computed_tables) > 0 else []
 
         # Note that prefix caching does not support sliding window.
         prefix_cache_hit = (computed_block_nums is not None
                             and len(computed_block_nums) > 0
                             and self.sliding_window is None
                             and inter_data.is_prompt)
-        inter_data.prefix_cache_hit = prefix_cache_hit
 
-        if not prefix_cache_hit:
+        global_prefix_cache_hit = (block_global_computed_tables is not None
+                            and len(block_global_computed_tables) > 0
+                            and self.sliding_window is None
+                            and inter_data.is_prompt)
+
+        inter_data.prefix_cache_hit = prefix_cache_hit or global_prefix_cache_hit
+
+        if not inter_data.prefix_cache_hit:
             return
 
-        assert computed_block_nums is not None
+        assert computed_block_nums is not None or block_global_computed_tables is not None
+
+        computed_max_len = max(len(computed_block_nums), len(block_global_computed_tables))
+        if len(block_global_computed_tables) > len(computed_block_nums):
+            block_global_computed = [block for block in block_global_computed_tables if block not in computed_block_nums]
+            for block_id in block_global_computed:
+                content_hash = inter_data.block_hash_map[inter_data.seq_ids[seq_idx]][block_id]
+                for layer_idx in range(self.runner.model_config.hf_config.num_hidden_layers):
+                    self.kv_caches[layer_idx][0][block_id], self.kv_caches[layer_idx][1][block_id] = global_cache_instance.readCache(content_hash, layer_idx, self.runner.device)
+            torch.cuda.synchronize()           
+
         # The cache hit prompt tokens in this sequence. Note that
         # this may be larger than the sequence length if chunked
         # prefill is enabled.
-        prefix_cache_len = len(computed_block_nums) * self.block_size
+        prefix_cache_len = computed_max_len * self.block_size
         seq_group_metadata.seq_data[inter_data.seq_ids[
             seq_idx]].update_num_cached_tokens(prefix_cache_len)
 
@@ -736,6 +763,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             seq_ids=seq_ids,
             is_prompt=is_prompt,
             block_tables=seq_group_metadata.block_tables,
+            block_hash_map=seq_group_metadata.block_hash_map,
+            block_global_computed_tables=seq_group_metadata.block_global_computed_tables,
             computed_block_nums=seq_group_metadata.computed_block_nums,
             reinit=True,
             reinit_use_defaults=True,
@@ -1201,7 +1230,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
     def _prepare_model_input_tensors(
         self,
         seq_group_metadata_list: List[SequenceGroupMetadata],
-        finished_requests_ids: Optional[List[str]] = None
+        finished_requests_ids: Optional[List[str]] = None,
+        kv_caches: Optional[List[torch.Tensor]] = [],
     ) -> TModelInputForGPU:
         """Helper method to prepare the model input based on a given sequence
         group. Prepares metadata needed for the base model forward pass but not
@@ -1217,7 +1247,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
 
         If cuda graph is required, this API automatically pads inputs.
         """
-        builder = self._builder_cls(weakref.proxy(self), finished_requests_ids)
+        builder = self._builder_cls(weakref.proxy(self), finished_requests_ids, kv_caches)
         for seq_group_metadata in seq_group_metadata_list:
             builder.add_seq_group(seq_group_metadata)
 
@@ -1296,6 +1326,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                 seq_data={group_id: dummy_data.seq_data},
                 sampling_params=sampling_params,
                 block_tables=None,
+                block_global_computed_tables=None,
                 lora_request=dummy_lora_requests_per_seq[group_id]
                 if dummy_lora_requests_per_seq else None,
                 multi_modal_data=dummy_data.multi_modal_data,
@@ -1574,6 +1605,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         seq_group_metadata_list: List[SequenceGroupMetadata],
         virtual_engine: int = 0,
         finished_requests_ids: Optional[List[str]] = None,
+        kv_caches: Optional[List[torch.Tensor]] = [],
     ) -> ModelInputForGPUWithSamplingMetadata:
         """Prepare the model input based on a given sequence group, including
         metadata for the sampling step.
@@ -1589,7 +1621,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         If cuda graph is required, this API automatically pads inputs.
         """
         model_input = self._prepare_model_input_tensors(
-            seq_group_metadata_list, finished_requests_ids)
+            seq_group_metadata_list, finished_requests_ids, kv_caches)
         if get_pp_group().is_last_rank:
             # Sampling metadata is only required for the final pp group
             generators = self.get_generators(finished_requests_ids)
@@ -1690,6 +1722,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                                                  device=self.device),
                     **seqlen_agnostic_kwargs)
 
+            if model_input.is_prompt and self.cache_config.num_global_cache_blocks > 0:
+                self.write_global_cache(model_input, kv_caches)
+
         if (self.observability_config is not None
                 and self.observability_config.collect_model_forward_time):
             model_forward_end.record()
@@ -1773,6 +1808,23 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             output.hidden_states = hidden_states
 
         return [output]
+
+    def write_global_cache(self, model_input: ModelInputForGPUWithSamplingMetadata, kv_caches: List[torch.Tensor]):
+        """
+        for each layer and seq, get the block id and block hash, then write to global kv cache
+        """
+        for i in range(self.model_config.hf_config.num_hidden_layers):
+            seq_start_index = 0
+            if len(model_input.attn_metadata.block_hash_map) > 0 and model_input.attn_metadata.block_tables.numel() == 0:
+                for seq_idx, seq_length in enumerate(model_input.attn_metadata.seq_lens):
+                    num_blocks = seq_length // self.cache_config.block_size
+                    for idx in range(num_blocks):
+                        block_id = model_input.attn_metadata.slot_mapping[seq_start_index + idx * self.cache_config.block_size].item() // self.cache_config.block_size
+                        if block_id in model_input.attn_metadata.block_hash_map[seq_idx] and model_input.attn_metadata.block_hash_map[seq_idx][block_id] is not None:
+                            block_hash = model_input.attn_metadata.block_hash_map[seq_idx][block_id]
+                            global_cache_instance.writeCache(block_hash, i, kv_caches[i][0][block_id], kv_caches[i][1][block_id])
+
+                    seq_start_index += seq_length
 
     def need_recv_kv(self, model_input, kv_caches) -> bool:
         """Check if we need to receive kv-cache from the other worker.

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -258,7 +258,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         return model_input, worker_input, kwargs
 
     def _get_driver_input_and_broadcast(
-        self, execute_model_req: ExecuteModelRequest, kv_caches: Optional[List[torch.Tensor]] = [],
+        self, execute_model_req: ExecuteModelRequest, 
+        kv_caches: Optional[List[torch.Tensor]] = [],
     ) -> Tuple[BroadcastableModelInput, WorkerInput, Dict[str, torch.Tensor]]:
         """ Get the driver input and broadcast it to other workers.  """
         assert self.is_driver_worker
@@ -306,7 +307,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     # notify all other workers to stop their execution loop.
                     broadcast_tensor_dict({}, src=0)
                 return None
-            return self._get_driver_input_and_broadcast(execute_model_req, kv_caches)
+            return self._get_driver_input_and_broadcast(execute_model_req, 
+                kv_caches)
         else:
             return self._get_worker_input_from_broadcast()
 
@@ -318,7 +320,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         sequences are provided."""
         start_time = time.perf_counter()
 
-        inputs = self.prepare_input(execute_model_req, kv_caches=self.kv_cache[execute_model_req.virtual_engine])
+        inputs = self.prepare_input(execute_model_req, 
+            kv_caches=self.kv_cache[execute_model_req.virtual_engine])
         if inputs is None:
             return None
 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -259,7 +259,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
     def _get_driver_input_and_broadcast(
         self, execute_model_req: ExecuteModelRequest, 
-        kv_caches: Optional[List[torch.Tensor]] = [],
+        kv_caches: Optional[List[torch.Tensor]] = None,
     ) -> Tuple[BroadcastableModelInput, WorkerInput, Dict[str, torch.Tensor]]:
         """ Get the driver input and broadcast it to other workers.  """
         assert self.is_driver_worker
@@ -291,7 +291,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
     def prepare_input(
         self,
         execute_model_req: Optional[ExecuteModelRequest] = None,
-        kv_caches: Optional[List[torch.Tensor]] = [],
+        kv_caches: Optional[List[torch.Tensor]] = None,
     ) -> Optional[Tuple[BroadcastableModelInput, WorkerInput, Dict[
             str, torch.Tensor]]]:
         """

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -258,7 +258,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         return model_input, worker_input, kwargs
 
     def _get_driver_input_and_broadcast(
-        self, execute_model_req: ExecuteModelRequest
+        self, execute_model_req: ExecuteModelRequest, kv_caches: Optional[List[torch.Tensor]] = [],
     ) -> Tuple[BroadcastableModelInput, WorkerInput, Dict[str, torch.Tensor]]:
         """ Get the driver input and broadcast it to other workers.  """
         assert self.is_driver_worker
@@ -269,7 +269,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
             self.model_runner.prepare_model_input(
                 execute_model_req.seq_group_metadata_list,
                 execute_model_req.virtual_engine,
-                execute_model_req.finished_requests_ids))
+                execute_model_req.finished_requests_ids,
+                kv_caches))
 
         kwargs = extract_previous_hidden_states(execute_model_req)
 
@@ -288,7 +289,8 @@ class LocalOrDistributedWorkerBase(WorkerBase):
 
     def prepare_input(
         self,
-        execute_model_req: Optional[ExecuteModelRequest] = None
+        execute_model_req: Optional[ExecuteModelRequest] = None,
+        kv_caches: Optional[List[torch.Tensor]] = [],
     ) -> Optional[Tuple[BroadcastableModelInput, WorkerInput, Dict[
             str, torch.Tensor]]]:
         """
@@ -304,7 +306,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
                     # notify all other workers to stop their execution loop.
                     broadcast_tensor_dict({}, src=0)
                 return None
-            return self._get_driver_input_and_broadcast(execute_model_req)
+            return self._get_driver_input_and_broadcast(execute_model_req, kv_caches)
         else:
             return self._get_worker_input_from_broadcast()
 
@@ -316,7 +318,7 @@ class LocalOrDistributedWorkerBase(WorkerBase):
         sequences are provided."""
         start_time = time.perf_counter()
 
-        inputs = self.prepare_input(execute_model_req)
+        inputs = self.prepare_input(execute_model_req, kv_caches=self.kv_cache[execute_model_req.virtual_engine])
         if inputs is None:
             return None
 


### PR DESCRIPTION
# An extension of APC to implement global prefix cache
Global prefix cache can be useful in the following use cases:

1. When the APC cache is evicted and can't hit, the processing of new prompts in prefill phase can reuse the KV cache in global KV cache pool and skip the re-computation
2. Another vllm instance can use the KV cache in global KV cache pool directly even if it runs the prompts the first time(which means no APC cache available yet)

This PR extends APC to implement global prefix cache. It simply uses a local Dict as the global prefix KV cache pool, write to it when KV cache computing in prefill phase is done and read from it when updating input_tokens in model_runner. Currently the implementation is simple, it doesn't involve model/cuda change and I can observe some performance improvement in my environment. I tested with some papers(10-40KB) on dataset Long-document-dataset on L4, compared with vanilla vllm, APC+this PR reduces the generation time around 10%~28% with the same result. 

## Next Steps
In theory it should work better when the prompt is longer, based on the assumption that CPU->GPU copy is faster than GPU KV cache re-computation in prefill phase, but I will do more testing on other datasets and hardware. The cpu<->gpu memory copy can be optimized to improve performance. It can also be integrated with other distributed KV cache pool projects. Please leave comments and feedbacks, thanks.
