### PR TITLE
[V1][Bugfix] Skip hashing empty or None mm_data

### DIFF
--- a/vllm/v1/engine/mm_input_mapper.py
+++ b/vllm/v1/engine/mm_input_mapper.py
@@ -180,6 +180,10 @@ class MMHasher:
             return None
 
         mm_data = prompt["multi_modal_data"]
+        if not mm_data:
+            # mm_data can be None or an empty dict.
+            return None
+
         image_inputs = mm_data["image"]
 
         return self.hash_images(image_inputs)


### PR DESCRIPTION
`prompt["multi_modal_data"]` can be None or an empty dict. In such a case, vLLM currently errors at the `hash_prompt_mm_data` method. This PR fixes the bug.

I met this bug when running `benchmark_throughput.py`. Not sure why this was not detected in earlier PRs.