### PR TITLE
[Bugfix] Fix fully sharded LoRAs with Mixtral

### DIFF
--- a/tests/lora/test_mixtral.py
+++ b/tests/lora/test_mixtral.py
@@ -62,8 +62,9 @@ def test_mixtral_lora(mixtral_lora_files, tp_size):
 
 
 @pytest.mark.parametrize("tp_size", [4])
+@pytest.mark.parametrize("fully_shard", [True, False])
 def test_mixtral_lora_all_target_modules(mixtral_lora_files_all_target_modules,
-                                         tp_size):
+                                         tp_size, fully_shard):
     """This LoRA model has all supported Mixtral target modules"""
 
     if torch.cuda.device_count() < tp_size:
@@ -82,6 +83,7 @@ def test_mixtral_lora_all_target_modules(mixtral_lora_files_all_target_modules,
         max_loras=4,
         distributed_executor_backend="ray",
         tensor_parallel_size=tp_size,
+        fully_sharded_loras=fully_shard,
         max_lora_rank=32,
     )
 

--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -425,8 +425,9 @@ class ReplicatedLinearWithLoRA(BaseLinearLayerWithLoRA):
                        if self.base_layer.skip_bias_add else None)
         return output, output_bias
 
+    # ReplicatedLinear should always be replaced, regardless of the fully
+    # sharded LoRAs setting, because it is, by definition, copied per GPU.
     @classmethod
-    @_not_fully_sharded_can_replace
     def can_replace_layer(
         cls,
         source_layer: nn.Module,


### PR DESCRIPTION
Fixes a regression introduced by #9008 , which leads to an assertion error when `--fully-sharded-loras` is enabled with an adaptor that includes a gate target:

```
vllm/lora/models.py:352: in __init__
    self._create_lora_modules()
vllm/lora/models.py:506: in _create_lora_modules
    self.register_module(module_name, new_module)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <vllm.lora.models.LRUCacheLoRAModelManager object at 0x7ff5ea843e10>, module_name = 'model.layers.0.block_sparse_moe.gate'
module = ReplicatedLinear(in_features=4096, output_features=8, bias=False)

    def register_module(self, module_name: str, module: "BaseLayerWithLoRA"):
>       assert isinstance(module, BaseLayerWithLoRA)
E       AssertionError
```

This occurs because [Mixtral includes a ReplicatedLinear layer for the MoE gate](https://github.com/vllm-project/vllm/blob/47a0b615b45efd0a9ed57049d8ca6eff1c249844/vllm/model_executor/models/mixtral.py#L78), and #7081 marked it as `@_not_fully_sharded_can_replace`. Since these are per-GPU and the implementation looks safe I assume this was just an unintentional copy of the decorator. 

This PR removes it so that ReplicatedLinearWithLora will replace ReplicatedLinear regardless of whether fully shared LoRAs are enabled, and updates the test scenario to cover both values.

Let me know if I am missing anything.

Thanks!