### PR TITLE
[cd][release] add pypi index for every commit and nightly build

### DIFF
--- a/.buildkite/generate_index.py
+++ b/.buildkite/generate_index.py
@@ -1,5 +1,4 @@
 import argparse
-import html
 import os
 
 template = """<!DOCTYPE html>
@@ -19,6 +18,7 @@ filename = os.path.basename(args.wheel)
 
 with open("index.html", "w") as f:
     print(f"Generated index.html for {args.wheel}")
+    # cloudfront requires escaping the '+' character
     f.write(
         template.format(wheel=filename,
-                        wheel_html_escaped=html.escape(filename)))
+                        wheel_html_escaped=filename.replace("+", "%2B")))

--- a/.buildkite/generate_index.py
+++ b/.buildkite/generate_index.py
@@ -1,12 +1,12 @@
 import argparse
-import hashlib
+import html
 import os
 
 template = """<!DOCTYPE html>
 <html>
     <body>
     <h1>Links for vLLM</h1/>
-        <a href="../{wheel}#sha256={sha256}">{wheel}</a><br/>
+        <a href="../{wheel_html_escaped}">{wheel}</a><br/>
     </body>
 </html>
 """
@@ -18,10 +18,7 @@ args = parser.parse_args()
 filename = os.path.basename(args.wheel)
 
 with open("index.html", "w") as f:
-    # calculate sha256
-    sha256 = hashlib.sha256()
-    with open(args.wheel, "rb") as wheel:
-        sha256.update(wheel.read())
-    sha256_value = sha256.hexdigest()
-    print(f"Generated index.html with sha256: {sha256_value} for {args.wheel}")
-    f.write(template.format(wheel=filename, sha256=sha256_value))
+    print(f"Generated index.html for {args.wheel}")
+    f.write(
+        template.format(wheel=filename,
+                        wheel_html_escaped=html.escape(filename)))

--- a/.buildkite/generate_index.py
+++ b/.buildkite/generate_index.py
@@ -6,7 +6,7 @@ template = """<!DOCTYPE html>
 <html>
     <body>
     <h1>Links for vLLM</h1/>
-        <a href="../{wheel}#{sha256}">{wheel}</a><br/>
+        <a href="../{wheel}#sha256={sha256}">{wheel}</a><br/>
     </body>
 </html>
 """

--- a/.buildkite/generate_index.py
+++ b/.buildkite/generate_index.py
@@ -1,3 +1,7 @@
+import argparse
+import hashlib
+import os
+
 template = """<!DOCTYPE html>
 <html>
     <body>
@@ -7,9 +11,6 @@ template = """<!DOCTYPE html>
 </html>
 """
 
-import argparse
-import hashlib
-import os
 parser = argparse.ArgumentParser()
 parser.add_argument("--wheel", help="The wheel path.", required=True)
 args = parser.parse_args()

--- a/.buildkite/generate_index.py
+++ b/.buildkite/generate_index.py
@@ -1,0 +1,26 @@
+template = """<!DOCTYPE html>
+<html>
+    <body>
+    <h1>Links for vLLM</h1/>
+        <a href="../{wheel}#{sha256}">{wheel}</a><br/>
+    </body>
+</html>
+"""
+
+import argparse
+import hashlib
+import os
+parser = argparse.ArgumentParser()
+parser.add_argument("--wheel", help="The wheel path.", required=True)
+args = parser.parse_args()
+
+filename = os.path.basename(args.wheel)
+
+with open("index.html", "w") as f:
+    # calculate sha256
+    sha256 = hashlib.sha256()
+    with open(args.wheel, "rb") as wheel:
+        sha256.update(wheel.read())
+    sha256_value = sha256.hexdigest()
+    print(f"Generated index.html with sha256: {sha256_value} for {args.wheel}")
+    f.write(template.format(wheel=filename, sha256=sha256_value))

--- a/.buildkite/upload-wheels.sh
+++ b/.buildkite/upload-wheels.sh
@@ -23,6 +23,8 @@ wheel="$new_wheel"
 version=$(unzip -p "$wheel" '**/METADATA' | grep '^Version: ' | cut -d' ' -f2)
 echo "Version: $version"
 
+normal_wheel="$wheel" # Save the original wheel filename
+
 # If the version contains "dev", rename it to v1.0.0.dev for consistency
 if [[ $version == *dev* ]]; then
     suffix="${version##*.}"
@@ -32,12 +34,24 @@ if [[ $version == *dev* ]]; then
         new_version="1.0.0.dev"
     fi
     new_wheel="${wheel/$version/$new_version}"
-    mv -- "$wheel" "$new_wheel"
+    # use cp to keep both files in the artifacts directory
+    cp -- "$wheel" "$new_wheel"
     wheel="$new_wheel"
     version="$new_version"
 fi
 
 # Upload the wheel to S3
+python3 generate_index.py --wheel "$normal_wheel"
+
+# generate index for this commit
 aws s3 cp "$wheel" "s3://vllm-wheels/$BUILDKITE_COMMIT/"
+aws s3 cp "$normal_wheel" "s3://vllm-wheels/$BUILDKITE_COMMIT/"
+aws s3 cp index.html "s3://vllm-wheels/$BUILDKITE_COMMIT/vllm/index.html"
+aws s3 cp "s3://vllm-wheels/nightly/index.html" "s3://vllm-wheels/$BUILDKITE_COMMIT/index.html"
+
+# generate index for nightly
 aws s3 cp "$wheel" "s3://vllm-wheels/nightly/"
+aws s3 cp "$normal_wheel" "s3://vllm-wheels/nightly/"
+aws s3 cp index.html "s3://vllm-wheels/nightly/vllm/index.html"
+
 aws s3 cp "$wheel" "s3://vllm-wheels/$version/"

--- a/.buildkite/upload-wheels.sh
+++ b/.buildkite/upload-wheels.sh
@@ -41,7 +41,7 @@ if [[ $version == *dev* ]]; then
 fi
 
 # Upload the wheel to S3
-python3 generate_index.py --wheel "$normal_wheel"
+python3 .buildkite/generate_index.py --wheel "$normal_wheel"
 
 # generate index for this commit
 aws s3 cp "$wheel" "s3://vllm-wheels/$BUILDKITE_COMMIT/"


### PR DESCRIPTION
verified that `pip install --pre -U vllm --extra-index-url=https://dsefy9jmd4lqu.cloudfront.net/nightly/` works now.

cc @simon-mo to set up an alias to `wheels.vllm.ai`

see https://github.com/dtrifiro/vllm-wheels-bucket-indexer/issues/3 for more details.