### PR TITLE
[Model][BugFix] Mamba/Jamba exceed mamba cache slots

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_MAMBA_NUM_OF_SLOTS_MULTIPLIER: float = 1.5
 
 
 def get_default_cache_root():
@@ -466,6 +467,8 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+    "VLLM_MAMBA_NUM_OF_SLOTS_MULTIPLIER":
+    lambda: float(os.getenv("VLLM_MAMBA_NUM_OF_SLOTS_MULTIPLIER", "1.5")),
 }
 
 # end-env-vars-definition

--- a/vllm/model_executor/models/jamba.py
+++ b/vllm/model_executor/models/jamba.py
@@ -423,12 +423,13 @@ class JambaForCausalLM(nn.Module, HasInnerState, SupportsLoRA, SupportsPP,
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
 
-        effective_max_batch_size = int(self.vllm_config.scheduler_config.max_num_seqs * 2)
+        effective_max_batch_size = int(
+            self.vllm_config.scheduler_config.max_num_seqs * 2)
         if not self.model_config.enforce_eager \
             and effective_max_batch_size <= \
                 vllm_config.compilation_config.max_capture_size:
             self.max_batch_size = vllm_config.pad_for_cudagraph(
-               effective_max_batch_size)
+                effective_max_batch_size)
         else:
             self.max_batch_size = effective_max_batch_size
 

--- a/vllm/model_executor/models/jamba.py
+++ b/vllm/model_executor/models/jamba.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 from transformers import JambaConfig
 
+from vllm import envs
 from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.attention.layer import Attention
 from vllm.config import CacheConfig, VllmConfig
@@ -424,7 +425,9 @@ class JambaForCausalLM(nn.Module, HasInnerState, SupportsLoRA, SupportsPP,
             self.model.make_empty_intermediate_tensors)
 
         effective_max_batch_size = int(
-            self.vllm_config.scheduler_config.max_num_seqs * 2)
+            self.vllm_config.scheduler_config.max_num_seqs * \
+                envs.VLLM_MAMBA_NUM_OF_SLOTS_MULTIPLIER
+        )
         if not self.model_config.enforce_eager \
             and effective_max_batch_size <= \
                 vllm_config.compilation_config.max_capture_size:

--- a/vllm/model_executor/models/jamba.py
+++ b/vllm/model_executor/models/jamba.py
@@ -422,17 +422,15 @@ class JambaForCausalLM(nn.Module, HasInnerState, SupportsLoRA, SupportsPP,
 
         self.make_empty_intermediate_tensors = (
             self.model.make_empty_intermediate_tensors)
-        if self.scheduler_config is not None and \
-            not self.model_config.enforce_eager:
-            if self.scheduler_config.max_num_seqs > \
+
+        effective_max_batch_size = int(self.vllm_config.scheduler_config.max_num_seqs * 2)
+        if not self.model_config.enforce_eager \
+            and effective_max_batch_size <= \
                 vllm_config.compilation_config.max_capture_size:
-                self.max_batch_size = \
-                    vllm_config.compilation_config.max_capture_size
-            else:
-                self.max_batch_size = vllm_config.pad_for_cudagraph(
-                    self.scheduler_config.max_num_seqs)
+            self.max_batch_size = vllm_config.pad_for_cudagraph(
+               effective_max_batch_size)
         else:
-            self.max_batch_size = 8192 + 2
+            self.max_batch_size = effective_max_batch_size
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)

--- a/vllm/model_executor/models/mamba.py
+++ b/vllm/model_executor/models/mamba.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 from transformers import MambaConfig
 
+from vllm import envs
 from vllm.attention.backends.abstract import AttentionMetadata
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
@@ -195,17 +196,18 @@ class MambaForCausalLM(nn.Module, HasInnerState, IsAttentionFree, SupportsPP):
 
         self.make_empty_intermediate_tensors = (
             self.backbone.make_empty_intermediate_tensors)
-        if self.scheduler_config is not None and \
-            not self.model_config.enforce_eager:
-            if self.scheduler_config.max_num_seqs > \
+
+        effective_max_batch_size = int(
+            self.vllm_config.scheduler_config.max_num_seqs * \
+                envs.VLLM_MAMBA_NUM_OF_SLOTS_MULTIPLIER
+        )
+        if not self.model_config.enforce_eager \
+            and effective_max_batch_size <= \
                 vllm_config.compilation_config.max_capture_size:
-                self.max_batch_size = \
-                    vllm_config.compilation_config.max_capture_size
-            else:
-                self.max_batch_size = vllm_config.pad_for_cudagraph(
-                    self.scheduler_config.max_num_seqs)
+            self.max_batch_size = vllm_config.pad_for_cudagraph(
+                effective_max_batch_size)
         else:
-            self.max_batch_size = 8192 + 2
+            self.max_batch_size = effective_max_batch_size
 
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.backbone.get_input_embeddings(input_ids)


### PR DESCRIPTION
In recent vLLM versions (since v0.6.4) running requests are not capped anymore by `scheduler_config.max_num_seqs` which causes an issue on Jamba/Mamba models on high loads. 
Mamba models keeps a state inside the modeling file and defines the max running sequences/slots as `max_num_seqs`. exceeding this number of slots causes an error that crashes vLLM.

to solve that, I've introduced an envar that multiplies the mamba cache slots by a certain amount (x1.5 by default) .
The default is x1.5 as I've seen it's quite sufficient in my tests. 

CC @tlrmchlsmth 
