### PR TITLE
[Bugfix] torch nightly version in ROCm installation guide

### DIFF
--- a/docs/source/getting_started/amd-installation.rst
+++ b/docs/source/getting_started/amd-installation.rst
@@ -145,7 +145,7 @@ Note to get your gfx architecture, run `rocminfo |grep gfx`.
 
         $ # Install PyTorch
         $ pip uninstall torch -y
-        $ pip install --no-cache-dir --pre torch==2.6.0.dev20240918 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+        $ pip install --no-cache-dir --pre torch==2.6.0.dev20241024 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
 
         $ # Build & install AMD SMI
         $ pip install /opt/rocm/share/amd_smi


### PR DESCRIPTION
This fixes the following error when using this guide:

```
Looking in indexes: https://download.pytorch.org/whl/nightly/rocm6.2
ERROR: Could not find a version that satisfies the requirement torch==2.6.0.dev20240918 (from versions: 2.6.0.dev20241024+rocm6.2, 2.6.0.dev20241026+rocm6.2, 2.6.0.dev20241027+rocm6.2, 2.6.0.dev20241028+rocm6.2, 2.6.0.dev20241029+rocm6.2, 2.6.0.dev20241030+rocm6.2, 2.6.0.dev20241031+rocm6.2, 2.6.0.dev20241101+rocm6.2, 2.6.0.dev20241102+rocm6.2, 2.6.0.dev20241103+rocm6.2, 2.6.0.dev20241104+rocm6.2, 2.6.0.dev20241105+rocm6.2, 2.6.0.dev20241106+rocm6.2, 2.6.0.dev20241107+rocm6.2, 2.6.0.dev20241108+rocm6.2, 2.6.0.dev20241109+rocm6.2, 2.6.0.dev20241110+rocm6.2, 2.6.0.dev20241111+rocm6.2, 2.6.0.dev20241112+rocm6.2, 2.6.0.dev20241113+rocm6.2, 2.6.0.dev20241114+rocm6.2, 2.6.0.dev20241115+rocm6.2, 2.6.0.dev20241116+rocm6.2, 2.6.0.dev20241117+rocm6.2, 2.6.0.dev20241118+rocm6.2, 2.6.0.dev20241119+rocm6.2, 2.6.0.dev20241120+rocm6.2, 2.6.0.dev20241121+rocm6.2, 2.6.0.dev20241122+rocm6.2)
ERROR: No matching distribution found for torch==2.6.0.dev20240918

```

References:

- https://download.pytorch.org/whl/nightly/torch/
- https://download.pytorch.org/whl/nightly/rocm6.2

