### PR TITLE
[Bugfix][Hardware][CPU] Fix CPU `input_positions` creation for text-only inputs with mrope

### DIFF
--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -205,7 +205,7 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
                             seq_group_metadata, seq_data)
                     else:
                         # disable mrope for text-only inputs
-                        self.use_mrope = False
+                        self.input_data.use_mrope = False
                 else:
                     self._compute_decode_input_tokens(self.input_data,
                                                       seq_group_metadata,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -129,7 +129,8 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
             self.multi_modal_placeholder_maps: Dict[
                 str, MultiModalPlaceholderMap] = defaultdict(
                     MultiModalPlaceholderMap)
-            self.input_mrope_positions: List[List[int]] = [[] for _ in range(3)]
+            self.input_mrope_positions: List[List[int]] = [[]
+                                                           for _ in range(3)]
 
     def __init__(self,
                  runner: "CPUModelRunner",

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -196,6 +196,8 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
     def _build_input_data(self):
         for seq_group_metadata in self.seq_group_metadata_list:
             for seq_id, seq_data in seq_group_metadata.seq_data.items():
+                if not seq_group_metadata.multi_modal_data:
+                    self.input_data.use_mrope = False
                 if seq_group_metadata.is_prompt:
                     self._compute_prompt_input_tokens(self.input_data,
                                                       seq_group_metadata,
@@ -203,9 +205,6 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
                     if seq_group_metadata.multi_modal_data:
                         self._compute_multi_modal_input(
                             seq_group_metadata, seq_data)
-                    else:
-                        # disable mrope for text-only inputs
-                        self.input_data.use_mrope = False
                 else:
                     self._compute_decode_input_tokens(self.input_data,
                                                       seq_group_metadata,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -166,7 +166,7 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
                                     device="cpu")
         input_positions = torch.tensor(
             input_data.input_positions
-            if not self.use_mrope else input_data.input_mrope_positions,
+            if not input_data.use_mrope else input_data.input_mrope_positions,
             dtype=torch.long,
             device="cpu")
         token_type_ids = torch.tensor(input_data.token_type_ids,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -114,8 +114,7 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
         def __init__(self, use_mrope: bool):
             self.use_mrope = use_mrope
             self.input_tokens: List[int] = []
-            self.input_positions: Optional[
-                List[int]] = [] if not self.use_mrope else None
+            self.input_positions: Optional[List[int]] = []
             self.token_type_ids: Optional[List[int]] = []
             self.seq_lens: List[int] = []
             self.query_lens: List[int] = []
@@ -165,9 +164,12 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
         input_tokens = torch.tensor(input_data.input_tokens,
                                     dtype=torch.long,
                                     device="cpu")
+        has_mrope_positions = all(
+            x for x in input_data.input_mrope_positions
+        ) if input_data.input_mrope_positions is not None else False
         input_positions = torch.tensor(
             input_data.input_positions
-            if not input_data.use_mrope else input_data.input_mrope_positions,
+            if not has_mrope_positions else input_data.input_mrope_positions,
             dtype=torch.long,
             device="cpu")
         token_type_ids = torch.tensor(input_data.token_type_ids,

--- a/vllm/worker/cpu_model_runner.py
+++ b/vllm/worker/cpu_model_runner.py
@@ -114,7 +114,7 @@ class ModelInputForCPUBuilder(ModelRunnerInputBuilderBase[ModelInputForCPU]):
         def __init__(self, use_mrope: bool):
             self.use_mrope = use_mrope
             self.input_tokens: List[int] = []
-            self.input_positions: Optional[List[int]] = []
+            self.input_positions: List[int] = []
             self.token_type_ids: Optional[List[int]] = []
             self.seq_lens: List[int] = []
             self.query_lens: List[int] = []


### PR DESCRIPTION

FIX #11154

- MRope position should not be used to create `input_positions` for text-only inputs

