### PR TITLE
[Bugfix] Fix issues in CPU build Dockerfile. Fixes #9182

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -26,10 +26,10 @@ RUN pip install intel_extension_for_pytorch==2.5.0
 
 WORKDIR /workspace
 
+COPY requirements-build.txt requirements-build.txt
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,src=requirements-build.txt,target=requirements-build.txt \
     pip install --upgrade pip && \
     pip install -r requirements-build.txt
 
@@ -37,9 +37,9 @@ FROM cpu-test-1 AS build
 
 WORKDIR /workspace/vllm
 
+COPY requirements-common.txt requirements-common.txt
+COPY requirements-cpu.txt requirements-cpu.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,src=requirements-common.txt,target=requirements-common.txt \
-    --mount=type=bind,src=requirements-cpu.txt,target=requirements-cpu.txt \
     pip install -v -r requirements-cpu.txt
 
 COPY . .

--- a/setup.py
+++ b/setup.py
@@ -455,9 +455,12 @@ def get_gaudi_sw_version():
 
 
 def get_vllm_version() -> str:
-    version = get_version(
-        write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
-    )
+    try:
+        version = get_version(
+            write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
+        )
+    except LookupError:
+        version = "0.0.0"
 
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 

--- a/setup.py
+++ b/setup.py
@@ -455,6 +455,7 @@ def get_gaudi_sw_version():
 
 
 def get_vllm_version() -> str:
+    # TODO: Revisit this temporary approach: https://github.com/vllm-project/vllm/issues/9182#issuecomment-2404860236
     try:
         version = get_version(
             write_to="vllm/_version.py",  # TODO: move this to pyproject.toml


### PR DESCRIPTION
Fixes #9182. This fixes the following two issues. Verified that build is successful after these changes.

Issue 1: 
```
ERROR: Could not open requirements file: [Errno 13] Permission denied: 'requirements-build.txt'
```

Issue 2:
```
LookupError: setuptools-scm was unable to detect version for /workspace/vllm
```

Related issues https://github.com/vllm-project/vllm/issues/9182 and https://github.com/vllm-project/vllm/issues/8502