### PR TITLE
[Doc] Fix typo in the help message of '--guided-decoding-backend'

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -373,7 +373,7 @@ class EngineArgs:
             choices=['outlines', 'lm-format-enforcer', 'xgrammar'],
             help='Which engine will be used for guided decoding'
             ' (JSON schema / regex etc) by default. Currently support '
-            'https://github.com/outlines-dev/outlines,'
+            'https://github.com/outlines-dev/outlines, '
             'https://github.com/mlc-ai/xgrammar, and '
             'https://github.com/noamgat/lm-format-enforcer.'
             ' Can be overridden per request via guided_decoding_backend'


### PR DESCRIPTION
Added a space, otherwise the effect is as shown in the picture below.

<img width="775" alt="image" src="https://github.com/user-attachments/assets/3c4416d4-5f7b-4a13-a14f-3b7b2bf99c71" />

