### PR TITLE
[Platform] More consistent entrypoints across different platforms

### DIFF
--- a/Dockerfile.neuron
+++ b/Dockerfile.neuron
@@ -42,4 +42,4 @@ RUN --mount=type=bind,source=.git,target=.git \
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -25,4 +25,4 @@ COPY benchmarks/ /workspace/benchmarks
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -171,4 +171,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -25,4 +25,4 @@ RUN python3 setup.py develop
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils
 
-CMD ["/bin/bash"]
+ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]


### PR DESCRIPTION
This PR makes the entrypoint consistent across different platforms. Previously both `/bin/bash` are `apiserver` are used.