### PR TITLE
[attn][tiny fix] fix attn backend in MultiHeadAttention

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -191,6 +191,7 @@ class MultiHeadAttention(nn.Module):
                                         kv_cache_dtype=None,
                                         block_size=16,
                                         is_attention_free=False)
+        attn_backend = backend_name_to_enum(attn_backend.get_name())
         if attn_backend in {_Backend.FLASH_ATTN, _Backend.FLASH_ATTN_VLLM_V1}:
             attn_backend = _Backend.XFORMERS
 


### PR DESCRIPTION
The original logic will never step into `xformer` backend branch, because `attn_backend` is the class object of a certain attention backend. 
This pr fix that.