### PR TITLE
[Misc] Allow initializing KV cache transfer agent when `kv_parallel_size==1`

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2589,7 +2589,7 @@ class KVTransferConfig(BaseModel):
 
     @property
     def need_kv_transfer_agent(self) -> bool:
-        # Need to initialize the KV transfer agent when the connector is set.
+        # Need to initialize the KV transfer agent when `kv_connector` is set.
         return self.kv_connector is not None
 
     @property

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2560,6 +2560,14 @@ class KVTransferConfig(BaseModel):
         return KVTransferConfig.model_validate_json(cli_value)
 
     def model_post_init(self, __context: Any) -> None:
+        supported_kv_connector = ["PyNcclConnector", "MooncakeConnector"]
+        if all([
+                self.kv_connector is not None, self.kv_connector
+                not in supported_kv_connector
+        ]):
+            raise ValueError(f"Unsupported kv_connector: {self.kv_connector}. "
+                             f"Supported connectors are "
+                             f"{supported_kv_connector}.")
 
         if self.kv_role is not None and self.kv_role not in [
                 "kv_producer", "kv_consumer", "kv_both"

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2560,14 +2560,6 @@ class KVTransferConfig(BaseModel):
         return KVTransferConfig.model_validate_json(cli_value)
 
     def model_post_init(self, __context: Any) -> None:
-        supported_kv_connector = ["PyNcclConnector", "MooncakeConnector"]
-        if all([
-                self.kv_connector is not None, self.kv_connector
-                not in supported_kv_connector
-        ]):
-            raise ValueError(f"Unsupported kv_connector: {self.kv_connector}. "
-                             f"Supported connectors are "
-                             f"{supported_kv_connector}.")
 
         if self.kv_role is not None and self.kv_role not in [
                 "kv_producer", "kv_consumer", "kv_both"
@@ -2588,10 +2580,9 @@ class KVTransferConfig(BaseModel):
             self.kv_role in ["kv_producer", "kv_consumer", "kv_both"]
 
     @property
-    def need_kv_parallel_group(self) -> bool:
-        # for those database-based connector, vLLM does not need to create
-        # parallel group, and in that case the kv parallel size will be 1.
-        return self.kv_connector is not None and self.kv_parallel_size > 1
+    def need_kv_transfer(self) -> bool:
+        # When `kv_connector` is set, it means that this instance needs to 
+        return self.kv_connector is not None
 
     @property
     def is_kv_producer(self) -> bool:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2580,8 +2580,8 @@ class KVTransferConfig(BaseModel):
             self.kv_role in ["kv_producer", "kv_consumer", "kv_both"]
 
     @property
-    def need_kv_transfer(self) -> bool:
-        # When `kv_connector` is set, it means that this instance needs to 
+    def need_kv_transfer_agent(self) -> bool:
+        # Need to initialize the KV transfer agent when the connector is set.
         return self.kv_connector is not None
 
     @property

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1077,7 +1077,7 @@ def ensure_kv_transfer_initialized(vllm_config: "VllmConfig") -> None:
         return
 
     if all([
-            vllm_config.kv_transfer_config.need_kv_transfer,
+            vllm_config.kv_transfer_config.need_kv_transfer_agent,
             _KV_TRANSFER is None
     ]):
         logger.info("Need to transfer KV caches."

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1077,13 +1077,18 @@ def ensure_kv_transfer_initialized(vllm_config: "VllmConfig") -> None:
         return
 
     if all([
-            vllm_config.kv_transfer_config.need_kv_parallel_group,
+            vllm_config.kv_transfer_config.need_kv_transfer,
             _KV_TRANSFER is None
     ]):
+        logger.info("Need to transfer KV caches."
+                    " Initializing transfer agent...")
         _KV_TRANSFER = kv_transfer.KVTransferAgent(
             rank=get_world_group().rank,
             local_rank=get_world_group().local_rank,
             config=vllm_config)
+    else:
+        logger.info("KV cache transfer not needed. "
+                    "Skip initializing the transfer agent.")
 
 
 def ensure_model_parallel_initialized(


### PR DESCRIPTION
Allow initializing the KV cache transfer agent even when `kv_parallel_size==1`.

This is because when connecting to a KV cache database, each process acts as an independent database reader / writer and does not need to be aware of other processes (thus `kv_parallel_size==1`).

