### PR TITLE
[Platform] Move get_punica_wrapper() function to Platform

### DIFF
--- a/vllm/lora/punica_wrapper/punica_selector.py
+++ b/vllm/lora/punica_wrapper/punica_selector.py
@@ -1,5 +1,6 @@
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils import resolve_obj_by_qualname
 
 from .punica_base import PunicaWrapperBase
 
@@ -7,20 +8,11 @@ logger = init_logger(__name__)
 
 
 def get_punica_wrapper(*args, **kwargs) -> PunicaWrapperBase:
-    if current_platform.is_cuda_alike():
-        # Lazy import to avoid ImportError
-        from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
-        logger.info_once("Using PunicaWrapperGPU.")
-        return PunicaWrapperGPU(*args, **kwargs)
-    elif current_platform.is_cpu():
-        # Lazy import to avoid ImportError
-        from vllm.lora.punica_wrapper.punica_cpu import PunicaWrapperCPU
-        logger.info_once("Using PunicaWrapperCPU.")
-        return PunicaWrapperCPU(*args, **kwargs)
-    elif current_platform.is_hpu():
-        # Lazy import to avoid ImportError
-        from vllm.lora.punica_wrapper.punica_hpu import PunicaWrapperHPU
-        logger.info_once("Using PunicaWrapperHPU.")
-        return PunicaWrapperHPU(*args, **kwargs)
-    else:
-        raise NotImplementedError
+    punica_wrapper_qualname = current_platform.get_punica_wrapper()
+    punica_wrapper_cls = resolve_obj_by_qualname(punica_wrapper_qualname)
+    punica_wrapper = punica_wrapper_cls(*args, **kwargs)
+    assert punica_wrapper is not None, \
+        "the punica_wrapper_qualname(" + punica_wrapper_qualname + ") is wrong."
+    logger.info_once("Using " + punica_wrapper_qualname.rsplit(".", 1)[1] +
+                     ".")
+    return punica_wrapper

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -109,3 +109,7 @@ class CpuPlatform(Platform):
     def is_pin_memory_available(cls) -> bool:
         logger.warning("Pin memory is not supported on CPU.")
         return False
+
+    @classmethod
+    def get_punica_wrapper(cls) -> str:
+        return "vllm.lora.punica_wrapper.punica_cpu.PunicaWrapperCPU"

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -15,6 +15,8 @@ from typing_extensions import ParamSpec
 import vllm._C  # noqa
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
+from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 
@@ -215,6 +217,11 @@ class CudaPlatformBase(Platform):
 
         logger.info("Using Flash Attention backend.")
         return "vllm.attention.backends.flash_attn.FlashAttentionBackend"
+
+    @classmethod
+    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
+        logger.info_once("Using PunicaWrapperGPU.")
+        return PunicaWrapperGPU(*args, **kwargs)
 
 
 # NVML utils

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -15,8 +15,6 @@ from typing_extensions import ParamSpec
 import vllm._C  # noqa
 import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
-from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 
@@ -219,9 +217,8 @@ class CudaPlatformBase(Platform):
         return "vllm.attention.backends.flash_attn.FlashAttentionBackend"
 
     @classmethod
-    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
-        logger.info_once("Using PunicaWrapperGPU.")
-        return PunicaWrapperGPU(*args, **kwargs)
+    def get_punica_wrapper(cls) -> str:
+        return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
 
 
 # NVML utils

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -3,8 +3,6 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from vllm.logger import init_logger
-from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
-from vllm.lora.punica_wrapper.punica_hpu import PunicaWrapperHPU
 
 from .interface import Platform, PlatformEnum, _Backend
 
@@ -65,6 +63,5 @@ class HpuPlatform(Platform):
         return False
 
     @classmethod
-    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
-        logger.info_once("Using PunicaWrapperHPU.")
-        return PunicaWrapperHPU(*args, **kwargs)
+    def get_punica_wrapper(cls) -> str:
+        return "vllm.lora.punica_wrapper.punica_hpu.PunicaWrapperHPU"

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from vllm.logger import init_logger
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
+from vllm.lora.punica_wrapper.punica_hpu import PunicaWrapperHPU
 
 from .interface import Platform, PlatformEnum, _Backend
 
@@ -61,3 +63,8 @@ class HpuPlatform(Platform):
     def is_pin_memory_available(cls):
         logger.warning("Pin memory is not supported on HPU.")
         return False
+
+    @classmethod
+    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
+        logger.info_once("Using PunicaWrapperHPU.")
+        return PunicaWrapperHPU(*args, **kwargs)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -8,7 +8,6 @@ import numpy as np
 import torch
 
 from vllm.logger import init_logger
-from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -264,7 +263,7 @@ class Platform:
         return True
 
     @classmethod
-    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
+    def get_punica_wrapper(cls) -> str:
         """
         Return the punica wrapper for current platform.
         """

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from vllm.logger import init_logger
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -261,6 +262,13 @@ class Platform:
                            "This may slow down the performance.")
             return False
         return True
+
+    @classmethod
+    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
+        """
+        Return the punica wrapper for current platform.
+        """
+        raise NotImplementedError
 
 
 class UnspecifiedPlatform(Platform):

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -6,6 +6,8 @@ import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
+from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 
@@ -149,3 +151,8 @@ class RocmPlatform(Platform):
                 "Using AWQ quantization with ROCm, but VLLM_USE_TRITON_AWQ"
                 " is not set, enabling VLLM_USE_TRITON_AWQ.")
         envs.VLLM_USE_TRITON_AWQ = True
+
+    @classmethod
+    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
+        logger.info_once("Using PunicaWrapperGPU.")
+        return PunicaWrapperGPU(*args, **kwargs)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -6,8 +6,6 @@ import torch
 
 import vllm.envs as envs
 from vllm.logger import init_logger
-from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
-from vllm.lora.punica_wrapper.punica_gpu import PunicaWrapperGPU
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 
@@ -153,6 +151,5 @@ class RocmPlatform(Platform):
         envs.VLLM_USE_TRITON_AWQ = True
 
     @classmethod
-    def get_punica_wrapper(cls, *args, **kwargs) -> PunicaWrapperBase:
-        logger.info_once("Using PunicaWrapperGPU.")
-        return PunicaWrapperGPU(*args, **kwargs)
+    def get_punica_wrapper(cls) -> str:
+        return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"


### PR DESCRIPTION
# What does this PR do?

This PR is a refactoring of punica wrapper, enabling the code of multi-lora to be platform-agnostic for better extensibility.

The `get_punica_wrapper()` function will dynamically load object according to `current_platform`.

## Related works

Please see https://github.com/vllm-project/vllm/issues/11162.