### PR TITLE
[V1] [1/N] [Breaking Change] API Server  (Remove Proxy) 

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -585,12 +585,18 @@ def build_app(args: Namespace) -> FastAPI:
                                     status_code=401)
             return await call_next(request)
 
-    @app.middleware("http")
-    async def add_request_id(request: Request, call_next):
-        request_id = request.headers.get("X-Request-Id") or uuid.uuid4().hex
-        response = await call_next(request)
-        response.headers["X-Request-Id"] = request_id
-        return response
+    if args.enable_request_id_headers:
+        logger.warning(
+            "CAUTION: Enabling X-Request-Id headers in the API Server. "
+            "This can harm performance at high QPS.")
+
+        @app.middleware("http")
+        async def add_request_id(request: Request, call_next):
+            request_id = request.headers.get(
+                "X-Request-Id") or uuid.uuid4().hex
+            response = await call_next(request)
+            response.headers["X-Request-Id"] = request_id
+            return response
 
     for middleware in args.middleware:
         module_path, object_name = middleware.rsplit(".", 1)

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -196,7 +196,11 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         action="store_true",
         help="If specified, will run the OpenAI frontend server in the same "
         "process as the model serving engine.")
-
+    parser.add_argument(
+        "--enable-request-id-headers",
+        action="store_true",
+        help="If specified, API server will add X-Request-Id header to "
+        "responses. Caution: this hurts performance at high QPS.")
     parser.add_argument(
         "--enable-auto-tool-choice",
         action="store_true",


### PR DESCRIPTION
## SUMMARY
* Splitting https://github.com/vllm-project/vllm/pull/11237 into separate PRs
* Remove proxy by default

## Performance
- launch:
```bash
VLLM_USE_V1=1 vllm serve meta-llama/Meta-Llama-3.1-8B-Instruct --disable-log-requests --no-enable-prefix-caching --max-num-batched-tokens 8192
```

- benchmark:
```bash
python3 benchmark_serving.py --model $MODEL --dataset-name sonnet --dataset-path sonnet.txt --port 8001 --sonnet-input-len 250 --sonnet-output-len 200
```

- `pr`: 48 reqs/sec 
- `main`: 34 reqs/sec

