### PR TITLE
Bounded peak memory in Top-P-Top-K with chunked sorting

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -107,7 +107,8 @@ steps:
   - vllm/
   commands:
   - pip install -e ./plugins/vllm_add_dummy_model
-  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py
+  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py --ignore=entrypoints/llm/test_prompt_logprobs.py
+  - pytest -v -s entrypoints/llm/test_prompt_logprobs.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_lazy_outlines.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_generate_multiple_loras.py # it needs a clean process

--- a/tests/entrypoints/llm/test_prompt_logprobs.py
+++ b/tests/entrypoints/llm/test_prompt_logprobs.py
@@ -1,0 +1,10 @@
+from vllm import LLM, SamplingParams
+
+def test_prompt_logprobs():
+    llm = LLM(model="meta-llama/Meta-Llama-3-8B")
+
+    # stress the system by asking for prompt logprobs with a long prompt
+    sampling_params = SamplingParams(top_p=0.9, top_k=50, temperature=0.8, prompt_logprobs=10, max_tokens=1)
+    token_ids = list(range(2048))
+    # make sure sorting does not cause OOM
+    outputs = llm.generate(prompt_token_ids=token_ids, sampling_params=sampling_params)

--- a/tests/entrypoints/llm/test_prompt_logprobs.py
+++ b/tests/entrypoints/llm/test_prompt_logprobs.py
@@ -1,10 +1,15 @@
 from vllm import LLM, SamplingParams
 
+
 def test_prompt_logprobs():
     llm = LLM(model="meta-llama/Meta-Llama-3-8B")
 
     # stress the system by asking for prompt logprobs with a long prompt
-    sampling_params = SamplingParams(top_p=0.9, top_k=50, temperature=0.8, prompt_logprobs=10, max_tokens=1)
+    sampling_params = SamplingParams(top_p=0.9,
+                                     top_k=50,
+                                     temperature=0.8,
+                                     prompt_logprobs=10,
+                                     max_tokens=1)
     token_ids = list(range(2048))
     # make sure sorting does not cause OOM
-    outputs = llm.generate(prompt_token_ids=token_ids, sampling_params=sampling_params)
+    llm.generate(prompt_token_ids=token_ids, sampling_params=sampling_params)

--- a/tests/entrypoints/llm/test_prompt_logprobs.py
+++ b/tests/entrypoints/llm/test_prompt_logprobs.py
@@ -10,6 +10,11 @@ def test_prompt_logprobs():
                                      temperature=0.8,
                                      prompt_logprobs=10,
                                      max_tokens=1)
-    token_ids = list(range(2048))
+    # right now we use chunked sort and chunked logprobs to reduce
+    # the peak memory, it reduces the peak memory, however, they cannot
+    # make sure runtime peak memory <= profiling peak memory.
+    # To fully solve this issue (i.e. we can use 8192 to test prompt logprobs),
+    # we need to make sure the whole sampling process is chunked.
+    token_ids = list(range(1024))
     # make sure sorting does not cause OOM
     llm.generate(prompt_token_ids=token_ids, sampling_params=sampling_params)


### PR DESCRIPTION
This is the PR collaborated with @youkaichao for implementing chunked sorting to reduce peak memory (try to solve the OOM issue in computing logits in Issue #5907).

The issue we want to address here is that Pytorch sorting on logits would incur a significant peak memory usage, which turns out to be a major memory bottleneck during the decoding time, especially when users request to obtain logits. Our approach is that instead of sorting the large logits as a whole, we first split them into chunks and do sorting on each smaller chunk. In that way, intermediate variables that created during sorting will all become much smaller and the memory can be recycled timely. 

Effectiveness Proof:
We conducted a simple verification: On a standard 4 A40 GPU server, we ran `vllm serve meta-llama/Meta-Llama-3-8B --tensor_parallel_size 4` and monitored the memory usage. We have successfully managed to reduce the peak memory usage from 5.0 GB to 4.5 GB on Rank 0 (since sampling and sorting only happened at Rank 0) by setting `chunk_size=64` (1/4 of `max_num_seqs`). Considering roughly 3.7 GB non-deductible model weights (plus some minor usage by NCCL and CUDA graphs), and the relatively small code edits, we do see this peak memory reduction as a promising direction (i.e., reducing 50% peak memory usage) to work on.  


FIX #5907 (*link existing issues this PR will resolve*)

