### PR TITLE
[Misc]Minor Changes about Worker

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -131,7 +131,6 @@ class Worker:
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
         self.model_runner.profile_run()
-        torch.cuda.synchronize()
 
         free_gpu_memory, _ = torch.cuda.mem_get_info()
         # NOTE(woosuk): Here we assume that the other processes using the same

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -200,7 +200,6 @@ class Worker(LocalOrDistributedWorkerBase):
                               weights_memory_in_bytes=self.model_runner.
                               model_memory_usage) as result:
             self.model_runner.profile_run()
-            torch.cuda.synchronize()
 
         self._assert_memory_footprint_increased_during_profiling()
 


### PR DESCRIPTION
`torch.cuda.synchronize()` has been executed in the `profile_run` method. There is no need to repeat it externally.
<img width="744" alt="image" src="https://github.com/user-attachments/assets/7aed6e31-4ee4-4326-9104-526179e4a88f" />
