### PR TITLE
[Doc] Update mllama example based on official doc

### DIFF
--- a/examples/offline_inference_vision_language.py
+++ b/examples/offline_inference_vision_language.py
@@ -308,7 +308,20 @@ def run_mllama(question: str, modality: str):
         disable_mm_preprocessor_cache=args.disable_mm_preprocessor_cache,
     )
 
-    prompt = f"<|image|><|begin_of_text|>{question}"
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    messages = [{
+        "role":
+        "user",
+        "content": [{
+            "type": "image"
+        }, {
+            "type": "text",
+            "text": f"{question}"
+        }]
+    }]
+    prompt = tokenizer.apply_chat_template(messages,
+                                           add_generation_prompt=True,
+                                           tokenize=False)
     stop_token_ids = None
     return llm, prompt, stop_token_ids
 


### PR DESCRIPTION
Based on the [official doc](https://github.com/meta-llama/llama-models/blob/main/models/llama3_2/vision_prompt_format.md#user-and-assistant-conversation-with-images), the instruct model should be used with chat template. This pr updates `examples/offline_inference_vision_language.py` to follow this guide.

I didn't update the multi_image example as I fail to find the recommended input format from the official doc.