### PR TITLE
[Bugfix] Reduce prefix prefill block size for Pascal

### DIFF
--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -10,7 +10,15 @@ import triton.language as tl
 from vllm.platforms import current_platform
 
 # Static kernels parameters
-BASE_BLOCK = 128 if current_platform.has_device_capability(80) else 64
+if current_platform.get_device_capability() == (6, 0):  # P100 has 24 KB SM
+    BASE_BLOCK = 16
+elif current_platform.get_device_capability() == (6, 1):  # P40 has 48 KB SM
+    BASE_BLOCK = 32
+elif not current_platform.has_device_capability(80):
+    BASE_BLOCK = 64
+else:
+    BASE_BLOCK = 128
+
 NUM_WARPS = 4 if current_platform.is_rocm() else 8
 
 # To check compatibility


### PR DESCRIPTION
Block size `64` causes

```
triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 65536, Hardware limit: 49152. Reducing block sizes or `num_stages` may help.
```

on Pascal (NVIDIA Tesla P40). This PR fixes this. I'm not sure why `64` worked before.