### PR TITLE
[v1][bugfix] fix cudagraph with inplace buffer assignment

### DIFF
--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -28,11 +28,12 @@ class TorchCompileWrapperWithCustomDispatcher:
                  compiled_callable: Optional[Callable] = None,
                  compilation_level: int = 0):
 
+        vllm_config = get_current_vllm_config()
+        self.vllm_config = vllm_config
         if compiled_callable is None:
             # default compilation settings
             # compiling the forward method
 
-            vllm_config = get_current_vllm_config()
             backend = vllm_config.compilation_config.init_backend(vllm_config)
 
             compiled_callable = torch.compile(
@@ -81,6 +82,13 @@ class TorchCompileWrapperWithCustomDispatcher:
             return
 
         self.compiled_codes.append(new_code)
+
+        if self.vllm_config.compilation_config.use_cudagraph and \
+            "update" in new_code.co_names:
+            import depyf
+            src = depyf.decompile(new_code)
+            msg = "Assigning / modifying buffers of nn.Module during forward pass is not allowed when using cudagraph inside the compiler. Please use eager mode or fix the code. The following code contains clues about which buffer is being modified:\n" + src  # noqa
+            raise RuntimeError(msg)
 
     @contextmanager
     def dispatch_to_code(self, index: int):

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -87,7 +87,7 @@ class TorchCompileWrapperWithCustomDispatcher:
             "update" in new_code.co_names:
             import depyf
             src = depyf.decompile(new_code)
-            msg = "Assigning / modifying buffers of nn.Module during forward pass is not allowed when using cudagraph inside the compiler. Please use eager mode or fix the code. The following code contains clues about which buffer is being modified:\n" + src  # noqa
+            msg = "Assigning / modifying buffers of nn.Module during forward pass is not allowed when using cudagraph inside the compiler because it will cause silent errors. Please use eager mode or fix the code. The following code contains clues about which buffer is being modified:\n" + src  # noqa
             raise RuntimeError(msg)
 
     @contextmanager

--- a/vllm/compilation/wrapper.py
+++ b/vllm/compilation/wrapper.py
@@ -87,7 +87,7 @@ class TorchCompileWrapperWithCustomDispatcher:
             "update" in new_code.co_names:
             import depyf
             src = depyf.decompile(new_code)
-            msg = "Assigning / modifying buffers of nn.Module during forward pass is not allowed when using cudagraph inside the compiler because it will cause silent errors. Please use eager mode or fix the code. The following code contains clues about which buffer is being modified:\n" + src  # noqa
+            msg = "Assigning / modifying buffers of nn.Module during forward pass is not allowed when using cudagraph inside the compiler because it will cause silent errors. Please use eager mode or fix the code. The following code contains clues about which buffer is being modified (please search for the usage of the function `update`):\n" + src  # noqa
             raise RuntimeError(msg)
 
     @contextmanager

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -586,7 +586,6 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
                               torch.full_like(positions, k)).long()
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)
-
         idx = torch.add(idx, offsets) if offsets is not None else idx
         cos_sin = torch.index_select(self.long_short_cos_sin_cache, 0, idx)
 

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -541,19 +541,12 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         short_cache = self._compute_cos_sin_cache(
             original_max_position_embeddings, short_factor, short_mscale)
         short_cache = short_cache.to(dtype)
-        self.register_buffer("short_cos_sin_cache",
-                             short_cache,
-                             persistent=False)
 
         long_cache = self._compute_cos_sin_cache(max_position_embeddings,
                                                  long_factor, long_mscale)
         long_cache = long_cache.to(dtype)
-        self.register_buffer("long_cos_sin_cache",
-                             long_cache,
-                             persistent=False)
 
-        long_short_cache = torch.cat(
-            [self.short_cos_sin_cache, self.long_cos_sin_cache], dim=0)
+        long_short_cache = torch.cat([short_cache, long_cache], dim=0)
         self.register_buffer("long_short_cos_sin_cache",
                              long_short_cache,
                              persistent=False)
@@ -593,8 +586,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
                               torch.full_like(positions, k)).long()
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)
-        self.long_short_cos_sin_cache: torch.Tensor = (
-            self.long_short_cos_sin_cache.to(idx.device))
+
         idx = torch.add(idx, offsets) if offsets is not None else idx
         cos_sin = torch.index_select(self.long_short_cos_sin_cache, 0, idx)
 


### PR DESCRIPTION
@WoosukKwon and @ywang96 found this super-complicated bug:

```bash
VLLM_USE_V1=1 python3 mmmu_bench.py --model microsoft/Phi-3.5-vision-instruct --num-prompts 3 --trust-remote-code --disable-sliding-window --image-hit-rate 1 --no-enable-prefix-caching --disable-mm-preprocessor-cache --max-num-batched-tokens 32768 --gpu-memory-utilization 0.3 --max-model-len 8192 --max-num-seqs 2
```

the command will cause silent errors with garbage outputs. and it only appears in `microsoft/Phi-3.5-vision-instruct` .

After hours of debugging, I find the root cause is inplace buffer assignment: 

Here is a simple code snippet to demonstrate:

```python
import torch

class Mod(torch.nn.Module):
    def __init__(self):
        super(Mod, self).__init__()
        buffer = torch.nn.Parameter(torch.tensor([1.0]))
        self.register_buffer("buffer", buffer)

    def forward(self, x):
        self.buffer = self.buffer.to(self.buffer.device) # no-op
        return x + self.buffer

x = torch.tensor([1.0])
mod = torch.compile(Mod(), backend="eager")

import depyf
with depyf.prepare_debug("dump_dir"):
    mod(x)
```

`self.buffer = self.buffer.to(self.buffer.device)` looks like a no-op, but with `torch.compile`, it will become:

```python
def __transformed_code_0_for_forward(self, x):
    graph_out_0 = __compiled_fn_1(self._buffers['buffer'], x)
    self._buffers.clear()
    self._buffers.update({})
    self._parameters.clear()
    self._parameters.update({'buffer': graph_out_0[1]})
    return graph_out_0[0]

def __compiled_fn_1(L_self_buffers_buffer_: "f32[1]", L_x_: "f32[1]"):
    l_self_buffers_buffer_ = L_self_buffers_buffer_
    l_x_ = L_x_
    
    to: "f32[1]" = l_self_buffers_buffer_.to(device(type='cpu'));  l_self_buffers_buffer_ = None
    
    add: "f32[1]" = l_x_ + to;  l_x_ = None
    return (add, to)
```

The line `self.buffer = self.buffer.to(self.buffer.device)` is split into two parts:

- `self.buffer.to(self.buffer.device)` is part of the computation graph, and becomes the output of the computation graph
- `self.buffer = ` becomes `self._parameters.update({'buffer': graph_out_0[1]})`

Typically it works, but with vLLM's cudagraph integration inside `torch.compile`, we will only keep a weak reference of the final output tensor. Therefore, that line essentially becomes `self.buffer = weak_ref_tensors(self.buffer.to(self.buffer.device))` , and pytorch will gc-collect the tensor. Later, that memory can be claimed by some other tensors.

To prevent it from happening again, I added some runtime check, if we find `update` is used in the `torch.compile` -transformed bytecode, we will raise an error, and decompile the bytecode to tell users which buffer is causing the problem.