### PR TITLE
Remove print statement in DeepseekScalingRotaryEmbedding

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -668,7 +668,6 @@ class DeepseekScalingRotaryEmbedding(RotaryEmbedding):
         cos = (freqs.cos() * self.mscale)
         sin = (freqs.sin() * self.mscale)
         cache = torch.cat((cos, sin), dim=-1)
-        print("Cache shape", cache.shape)
         return cache
 
     def forward(


### PR DESCRIPTION
Noticed while loading deepseek_v3:
```
(VllmWorkerProcess pid=950654) Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950652) Cache shape torch.Size([163840, 64])
Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950650) Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950664) Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950655) Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950656) Cache shape torch.Size([163840, 64])
(VllmWorkerProcess pid=950653) Cache shape torch.Size([163840, 64])
```