### PR TITLE
[Do Not Merge] - LoRA V1 Reference PR

### DIFF
--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -306,3 +306,20 @@ def llama_2_7b_engine_extra_embeddings():
 def llama_2_7b_model_extra_embeddings(llama_2_7b_engine_extra_embeddings):
     yield (llama_2_7b_engine_extra_embeddings.model_executor.driver_worker.
            model_runner.model)
+
+
+@pytest.fixture(params=[False, True])
+def run_with_both_engines_lora(request):
+    # Automatically runs tests twice, once with V1 and once without
+    use_v1 = request.param
+    # Tests decorated with `@skip_v1` are only run without v1
+    skip_v1 = request.node.get_closest_marker("skip_v1")
+
+    if use_v1:
+        if skip_v1:
+            pytest.skip("Skipping test on vllm V1")
+        with patch('vllm.envs.VLLM_USE_V1', True):
+            yield
+    else:
+        with patch('vllm.envs.VLLM_USE_V1', False):
+            yield

--- a/tests/lora/test_baichuan.py
+++ b/tests/lora/test_baichuan.py
@@ -42,6 +42,14 @@ def do_sample(llm: vllm.LLM, lora_path: str, lora_id: int) -> List[str]:
     return generated_texts
 
 
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
 def test_baichuan_lora(baichuan_lora_files):
     llm = vllm.LLM(MODEL_PATH,
                    max_model_len=1024,

--- a/tests/lora/test_chatglm3_tp.py
+++ b/tests/lora/test_chatglm3_tp.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+import pytest
+
 import vllm
 from tests.utils import fork_new_process_for_each_test
 from vllm.lora.request import LoRARequest
@@ -45,6 +47,14 @@ def do_sample(llm: vllm.LLM, lora_path: str, lora_id: int) -> List[str]:
         generated_texts.append(generated_text)
         print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
     return generated_texts
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
 
 
 @fork_new_process_for_each_test

--- a/tests/lora/test_gemma.py
+++ b/tests/lora/test_gemma.py
@@ -33,6 +33,14 @@ def do_sample(llm: vllm.LLM, lora_path: str, lora_id: int) -> List[str]:
     return generated_texts
 
 
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
 @pytest.mark.xfail(current_platform.is_rocm(),
                    reason="There can be output mismatch on ROCm")
 def test_gemma_lora(gemma_lora_files):

--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -2,6 +2,7 @@
 
 from typing import List
 
+import pytest
 import ray
 
 import vllm
@@ -71,6 +72,14 @@ def generate_and_test(llm, sql_lora_files):
     assert do_sample(llm, sql_lora_files, lora_id=2) == EXPECTED_LORA_OUTPUT
 
     print("removing lora")
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
 
 
 @fork_new_process_for_each_test

--- a/tests/lora/test_lora_bias_e2e.py
+++ b/tests/lora/test_lora_bias_e2e.py
@@ -30,6 +30,14 @@ def do_sample(llm: vllm.LLM, lora_path: str, lora_id: int) -> List[str]:
     return generated_texts
 
 
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
 @pytest.mark.parametrize("lora_bias", [True])
 @pytest.mark.parametrize("fully_sharded", [True, False])
 def test_lora_bias(lora_bias_files: str, lora_bias: bool, fully_sharded: bool):

--- a/tests/lora/test_phi.py
+++ b/tests/lora/test_phi.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+import pytest
+
 import vllm
 from vllm.lora.request import LoRARequest
 
@@ -46,6 +48,14 @@ def do_sample(llm: vllm.LLM, lora_path: str, lora_id: int) -> List[str]:
         generated_texts.append(generated_text)
         print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
     return generated_texts
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
 
 
 def test_phi2_lora(phi2_lora_files):

--- a/tests/lora/test_punica_ops_sizes.py
+++ b/tests/lora/test_punica_ops_sizes.py
@@ -6,6 +6,7 @@ whether the corresponding Triton kernel can run normally when tensor parallelism
 is set to [1, 2, 4, 8, 16, 32, 64].
 """
 from threading import Lock
+from typing import Tuple
 
 import pytest
 import torch
@@ -13,9 +14,12 @@ import torch
 import vllm.lora.ops.triton_ops  # noqa: F401
 from vllm.lora.ops.torch_ops import (bgmv_expand, bgmv_expand_slice,
                                      bgmv_shrink, sgmv_expand,
-                                     sgmv_expand_slice, sgmv_shrink)
+                                     sgmv_expand_slice, sgmv_shrink,
+                                     )
 from vllm.lora.ops.triton_ops.utils import _LORA_A_PTR_DICT, _LORA_B_PTR_DICT
 from vllm.platforms import current_platform
+
+from tests.kernels.utils import override_backend_env_variable
 
 from .utils import (assert_close, generate_data,
                     generate_data_for_expand_nslices,
@@ -118,41 +122,332 @@ DEVICES = [f"cuda:{0}"]
 _dict_lock = Lock()
 
 
+#@pytest.mark.parametrize("batches", BATCHES)
+#@pytest.mark.parametrize("num_loras", NUM_LORA)
+#@pytest.mark.parametrize("rank", MAX_RANKS)
+#@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+#@pytest.mark.parametrize("scaling", SCALES)
+#@pytest.mark.parametrize("nslices", [1, 2, 3])
+#@pytest.mark.parametrize("dtype", DTYPES)
+#@pytest.mark.parametrize("op_type", ["shrink", "expand"])
+#@pytest.mark.parametrize("seed", SEED)
+#@pytest.mark.parametrize("device", DEVICES)
+#def test_punica_sgmv(
+#    batches: int,
+#    num_loras: int,
+#    rank: int,
+#    hidden_size: int,
+#    scaling: float,
+#    nslices: int,
+#    dtype: torch.dtype,
+#    op_type: str,
+#    seed: int,
+#    device: str,
+#):
+#    torch.set_default_device(device)
+#    current_platform.seed_everything(seed)
+#
+#    seq_length = 128
+#    (
+#        inputs_tensor,
+#        lora_weights_lst,
+#        our_out_tensor,
+#        ref_out_tensor,
+#        b_seq_start_loc,
+#        lora_indices_tensor,
+#        seq_len_tensor,
+#        indices,
+#    ) = generate_data_for_nslices(
+#        batches,
+#        hidden_size,
+#        num_loras,
+#        rank,
+#        seq_length,
+#        nslices,
+#        dtype,
+#        op_type,
+#        device,
+#    )
+#    max_seq_length = seq_len_tensor.max()
+#    token_nums = seq_len_tensor.sum().item()
+#    if isinstance(max_seq_length, tuple):
+#        max_seq_length = max_seq_length[0].item()
+#    else:
+#        max_seq_length = max_seq_length.item()
+#    if op_type == "shrink":
+#        # Preventing cache error pointer.
+#        with _dict_lock:
+#            _LORA_A_PTR_DICT.clear()
+#            torch.ops.vllm.sgmv_shrink(
+#                inputs_tensor,
+#                lora_weights_lst,
+#                our_out_tensor,
+#                b_seq_start_loc,
+#                seq_len_tensor,
+#                lora_indices_tensor,
+#                batches,
+#                max_seq_length,
+#                token_nums,
+#                scaling,
+#            )
+#        for index in range(nslices):
+#            sgmv_shrink(
+#                inputs_tensor,
+#                lora_weights_lst[index],
+#                ref_out_tensor[index],
+#                b_seq_start_loc,
+#                seq_len_tensor,
+#                lora_indices_tensor,
+#                batches,
+#                max_seq_length,
+#                token_nums,
+#                scaling,
+#            )
+#
+#    else:
+#        with _dict_lock:
+#            _LORA_B_PTR_DICT.clear()
+#            torch.ops.vllm.sgmv_expand(
+#                inputs_tensor,
+#                lora_weights_lst,
+#                our_out_tensor,
+#                b_seq_start_loc,
+#                seq_len_tensor,
+#                lora_indices_tensor,
+#                batches,
+#                max_seq_length,
+#                token_nums,
+#                offset_start=0,
+#                add_inputs=True,
+#            )
+#        if nslices == 1:
+#            # Verify the torch's sgmv_expand op
+#            sgmv_expand(
+#                inputs_tensor[0],
+#                lora_weights_lst[0],
+#                ref_out_tensor,
+#                b_seq_start_loc,
+#                seq_len_tensor,
+#                lora_indices_tensor,
+#                batches,
+#                max_seq_length,
+#                token_nums,
+#                add_inputs=True,
+#            )
+#        else:
+#            slice_offset = 0
+#            for index in range(nslices):
+#                lora_weights = lora_weights_lst[index]
+#                sgmv_expand_slice(
+#                    inputs_tensor[index],
+#                    lora_weights,
+#                    ref_out_tensor,
+#                    b_seq_start_loc,
+#                    seq_len_tensor,
+#                    lora_indices_tensor,
+#                    batches,
+#                    max_seq_length,
+#                    token_nums,
+#                    slice_offset,
+#                    hidden_size,
+#                    add_inputs=True,
+#                )
+#                slice_offset += hidden_size
+#
+#    assert_close(our_out_tensor, ref_out_tensor)
+#
+#
+#@pytest.mark.parametrize("batches", BATCHES)
+#@pytest.mark.parametrize("num_loras", NUM_LORA)
+#@pytest.mark.parametrize("rank", MAX_RANKS)
+#@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+#@pytest.mark.parametrize("scaling", SCALES)
+#@pytest.mark.parametrize("dtype", DTYPES)
+#@pytest.mark.parametrize("op_type", ["shrink", "expand"])
+#@pytest.mark.parametrize("seed", SEED)
+#@pytest.mark.parametrize("device", DEVICES)
+#def test_punica_bgmv(
+#    batches: int,
+#    num_loras: int,
+#    rank: int,
+#    hidden_size: int,
+#    scaling: float,
+#    dtype: torch.dtype,
+#    op_type: str,
+#    seed: int,
+#    device: str,
+#):
+#    torch.set_default_device(device)
+#    current_platform.seed_everything(seed)
+#
+#    seq_length = 1
+#    (
+#        inputs_tensor,
+#        lora_weights,
+#        our_out_tensor,
+#        ref_out_tensor,
+#        b_seq_start_loc,
+#        lora_indices_tensor,
+#        seq_len_tensor,
+#        indices,
+#    ) = generate_data(
+#        batches,
+#        hidden_size,
+#        num_loras,
+#        rank,
+#        seq_length,
+#        dtype,
+#        op_type,
+#        device,
+#    )
+#    if op_type == "shrink":
+#        torch.ops.vllm.bgmv_shrink(
+#            inputs_tensor,
+#            lora_weights,
+#            our_out_tensor,
+#            indices,
+#            scaling,
+#        )
+#
+#        bgmv_shrink(
+#            inputs_tensor,
+#            lora_weights,
+#            ref_out_tensor,
+#            indices,
+#            scaling,
+#        )
+#
+#    else:
+#        torch.ops.vllm.bgmv_expand(
+#            inputs_tensor,
+#            lora_weights,
+#            our_out_tensor,
+#            indices,
+#            add_inputs=True,
+#        )
+#        bgmv_expand(
+#            inputs_tensor,
+#            lora_weights,
+#            ref_out_tensor,
+#            indices,
+#            add_inputs=True,
+#        )
+#
+#    if op_type == "shrink":
+#        ref_out_tensor = ref_out_tensor.to(torch.float32)
+#    assert_close(our_out_tensor, ref_out_tensor)
+#
+#
+#@pytest.mark.parametrize("batches", BATCHES)
+#@pytest.mark.parametrize("num_loras", NUM_LORA)
+#@pytest.mark.parametrize("rank", MAX_RANKS)
+#@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+#@pytest.mark.parametrize("nslices", [2, 3])
+#@pytest.mark.parametrize("dtype", DTYPES)
+#@pytest.mark.parametrize("seed", SEED)
+#@pytest.mark.parametrize("device", DEVICES)
+#def test_punica_bgmv_expand_nslices(
+#    batches: int,
+#    num_loras: int,
+#    rank: int,
+#    hidden_size: int,
+#    nslices: int,
+#    dtype: torch.dtype,
+#    seed: int,
+#    device: str,
+#):
+#    torch.set_default_device(device)
+#    current_platform.seed_everything(seed)
+#
+#    seq_length = 1
+#    (
+#        inputs_tensor,
+#        lora_weights_lst,
+#        our_outputs,
+#        ref_outputs,
+#        b_seq_start_loc,
+#        lora_indices_tensor,
+#        seq_len_tensor,
+#        indices,
+#    ) = generate_data_for_expand_nslices(
+#        batches,
+#        hidden_size,
+#        num_loras,
+#        rank,
+#        seq_length,
+#        dtype,
+#        nslices,
+#        device,
+#    )
+#    slice_offset = 0
+#    for index in range(nslices):
+#        lora_weights = lora_weights_lst[index]
+#        torch.ops.vllm.bgmv_expand_slice(
+#            inputs_tensor,
+#            lora_weights,
+#            our_outputs,
+#            indices,
+#            slice_offset,
+#            slice_size=hidden_size,
+#            add_inputs=True,
+#        )
+#        bgmv_expand_slice(
+#            inputs_tensor,
+#            lora_weights,
+#            ref_outputs,
+#            indices,
+#            slice_offset,
+#            slice_size=hidden_size,
+#            add_inputs=True,
+#        )
+#
+#        slice_offset += hidden_size
+#    assert_close(our_outputs, ref_outputs)
+
+
+BATCHES = [609, 621, 1176]
+HIDDEN_SIZES = [4096, 11008]
+MAX_RANKS = [8]
+NUM_LORA=[2,4]
+
 @pytest.mark.parametrize("batches", BATCHES)
 @pytest.mark.parametrize("num_loras", NUM_LORA)
 @pytest.mark.parametrize("rank", MAX_RANKS)
 @pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
 @pytest.mark.parametrize("scaling", SCALES)
-@pytest.mark.parametrize("nslices", [1, 2, 3])
 @pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("nslices", [1, 2, 3])
 @pytest.mark.parametrize("op_type", ["shrink", "expand"])
+@pytest.mark.parametrize("seq_length", [1, 128])
 @pytest.mark.parametrize("seed", SEED)
 @pytest.mark.parametrize("device", DEVICES)
-def test_punica_sgmv(
+def test_v1_shrink_expand(
     batches: int,
     num_loras: int,
     rank: int,
     hidden_size: int,
     scaling: float,
-    nslices: int,
     dtype: torch.dtype,
+    nslices: int,
     op_type: str,
+    seq_length: int,
     seed: int,
     device: str,
+    monkeypatch,
 ):
+    monkeypatch.setenv("VLLM_USE_V1", "1")
     torch.set_default_device(device)
     current_platform.seed_everything(seed)
 
-    seq_length = 128
     (
         inputs_tensor,
         lora_weights_lst,
         our_out_tensor,
         ref_out_tensor,
         b_seq_start_loc,
-        lora_indices_tensor,
+        prompt_lora_mapping,
         seq_len_tensor,
-        indices,
+        token_lora_mapping,
     ) = generate_data_for_nslices(
         batches,
         hidden_size,
@@ -164,28 +459,47 @@ def test_punica_sgmv(
         op_type,
         device,
     )
+
+    def prepare_tensors(token_lora_mapping: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        # token_indices_sorted_by_lora_ids
+        _, token_indices_sorted_by_lora_ids = torch.sort(token_lora_mapping,
+                                                         stable=True)
+
+        # active_lora_ids, num_tokens_per_lora
+        lora_ids, num_tokens_per_lora = torch.unique(token_lora_mapping,
+                                                     sorted=False,
+                                                     return_counts=True)
+
+        # lora_token_start_loc
+        lora_token_start_loc = torch.zeros(num_tokens_per_lora.size(0) + 1,
+                                           dtype=torch.int32,
+                                           device=device)
+        lora_token_start_loc[1:] = torch.cumsum(num_tokens_per_lora, dim = 0)
+        return token_indices_sorted_by_lora_ids, num_tokens_per_lora, lora_token_start_loc, lora_ids
+
+    token_indices_sorted_by_lora_ids, num_tokens_per_lora, lora_token_start_loc, lora_ids = prepare_tensors(token_lora_mapping)
+
     max_seq_length = seq_len_tensor.max()
     token_nums = seq_len_tensor.sum().item()
     if isinstance(max_seq_length, tuple):
         max_seq_length = max_seq_length[0].item()
     else:
         max_seq_length = max_seq_length.item()
+
     if op_type == "shrink":
-        # Preventing cache error pointer.
         with _dict_lock:
             _LORA_A_PTR_DICT.clear()
-            torch.ops.vllm.sgmv_shrink(
-                inputs_tensor,
-                lora_weights_lst,
-                our_out_tensor,
-                b_seq_start_loc,
-                seq_len_tensor,
-                lora_indices_tensor,
-                batches,
-                max_seq_length,
-                token_nums,
-                scaling,
-            )
+            torch.ops.vllm.v1_shrink(inputs_tensor,
+                      lora_weights_lst,
+                      our_out_tensor,
+                      token_lora_mapping,
+                      token_indices_sorted_by_lora_ids,
+                      num_tokens_per_lora,
+                      lora_token_start_loc,
+                      lora_ids,
+                      scaling = scaling
+                )
+
         for index in range(nslices):
             sgmv_shrink(
                 inputs_tensor,
@@ -193,7 +507,7 @@ def test_punica_sgmv(
                 ref_out_tensor[index],
                 b_seq_start_loc,
                 seq_len_tensor,
-                lora_indices_tensor,
+                prompt_lora_mapping,
                 batches,
                 max_seq_length,
                 token_nums,
@@ -203,19 +517,18 @@ def test_punica_sgmv(
     else:
         with _dict_lock:
             _LORA_B_PTR_DICT.clear()
-            torch.ops.vllm.sgmv_expand(
-                inputs_tensor,
-                lora_weights_lst,
-                our_out_tensor,
-                b_seq_start_loc,
-                seq_len_tensor,
-                lora_indices_tensor,
-                batches,
-                max_seq_length,
-                token_nums,
-                offset_start=0,
-                add_inputs=True,
-            )
+            torch.ops.vllm.v1_expand(inputs_tensor,
+                      lora_weights_lst,
+                      our_out_tensor,
+                      token_lora_mapping,
+                      token_indices_sorted_by_lora_ids,
+                      num_tokens_per_lora,
+                      lora_token_start_loc,
+                      lora_ids,
+                      offset_start = 0,
+                      add_inputs = True,
+                    )
+
         if nslices == 1:
             # Verify the torch's sgmv_expand op
             sgmv_expand(
@@ -224,7 +537,7 @@ def test_punica_sgmv(
                 ref_out_tensor,
                 b_seq_start_loc,
                 seq_len_tensor,
-                lora_indices_tensor,
+                prompt_lora_mapping,
                 batches,
                 max_seq_length,
                 token_nums,
@@ -240,7 +553,7 @@ def test_punica_sgmv(
                     ref_out_tensor,
                     b_seq_start_loc,
                     seq_len_tensor,
-                    lora_indices_tensor,
+                    prompt_lora_mapping,
                     batches,
                     max_seq_length,
                     token_nums,
@@ -253,149 +566,3 @@ def test_punica_sgmv(
     assert_close(our_out_tensor, ref_out_tensor)
 
 
-@pytest.mark.parametrize("batches", BATCHES)
-@pytest.mark.parametrize("num_loras", NUM_LORA)
-@pytest.mark.parametrize("rank", MAX_RANKS)
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
-@pytest.mark.parametrize("scaling", SCALES)
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("op_type", ["shrink", "expand"])
-@pytest.mark.parametrize("seed", SEED)
-@pytest.mark.parametrize("device", DEVICES)
-def test_punica_bgmv(
-    batches: int,
-    num_loras: int,
-    rank: int,
-    hidden_size: int,
-    scaling: float,
-    dtype: torch.dtype,
-    op_type: str,
-    seed: int,
-    device: str,
-):
-    torch.set_default_device(device)
-    current_platform.seed_everything(seed)
-
-    seq_length = 1
-    (
-        inputs_tensor,
-        lora_weights,
-        our_out_tensor,
-        ref_out_tensor,
-        b_seq_start_loc,
-        lora_indices_tensor,
-        seq_len_tensor,
-        indices,
-    ) = generate_data(
-        batches,
-        hidden_size,
-        num_loras,
-        rank,
-        seq_length,
-        dtype,
-        op_type,
-        device,
-    )
-    if op_type == "shrink":
-        torch.ops.vllm.bgmv_shrink(
-            inputs_tensor,
-            lora_weights,
-            our_out_tensor,
-            indices,
-            scaling,
-        )
-
-        bgmv_shrink(
-            inputs_tensor,
-            lora_weights,
-            ref_out_tensor,
-            indices,
-            scaling,
-        )
-
-    else:
-        torch.ops.vllm.bgmv_expand(
-            inputs_tensor,
-            lora_weights,
-            our_out_tensor,
-            indices,
-            add_inputs=True,
-        )
-        bgmv_expand(
-            inputs_tensor,
-            lora_weights,
-            ref_out_tensor,
-            indices,
-            add_inputs=True,
-        )
-
-    if op_type == "shrink":
-        ref_out_tensor = ref_out_tensor.to(torch.float32)
-    assert_close(our_out_tensor, ref_out_tensor)
-
-
-@pytest.mark.parametrize("batches", BATCHES)
-@pytest.mark.parametrize("num_loras", NUM_LORA)
-@pytest.mark.parametrize("rank", MAX_RANKS)
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
-@pytest.mark.parametrize("nslices", [2, 3])
-@pytest.mark.parametrize("dtype", DTYPES)
-@pytest.mark.parametrize("seed", SEED)
-@pytest.mark.parametrize("device", DEVICES)
-def test_punica_bgmv_expand_nslices(
-    batches: int,
-    num_loras: int,
-    rank: int,
-    hidden_size: int,
-    nslices: int,
-    dtype: torch.dtype,
-    seed: int,
-    device: str,
-):
-    torch.set_default_device(device)
-    current_platform.seed_everything(seed)
-
-    seq_length = 1
-    (
-        inputs_tensor,
-        lora_weights_lst,
-        our_outputs,
-        ref_outputs,
-        b_seq_start_loc,
-        lora_indices_tensor,
-        seq_len_tensor,
-        indices,
-    ) = generate_data_for_expand_nslices(
-        batches,
-        hidden_size,
-        num_loras,
-        rank,
-        seq_length,
-        dtype,
-        nslices,
-        device,
-    )
-    slice_offset = 0
-    for index in range(nslices):
-        lora_weights = lora_weights_lst[index]
-        torch.ops.vllm.bgmv_expand_slice(
-            inputs_tensor,
-            lora_weights,
-            our_outputs,
-            indices,
-            slice_offset,
-            slice_size=hidden_size,
-            add_inputs=True,
-        )
-        bgmv_expand_slice(
-            inputs_tensor,
-            lora_weights,
-            ref_outputs,
-            indices,
-            slice_offset,
-            slice_size=hidden_size,
-            add_inputs=True,
-        )
-
-        slice_offset += hidden_size
-    assert_close(our_outputs, ref_outputs)

--- a/tests/lora/test_quant_model.py
+++ b/tests/lora/test_quant_model.py
@@ -70,6 +70,14 @@ def do_sample(llm: vllm.LLM,
     return generated_texts
 
 
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("tp_size", [1])
 def test_quant_model_lora(tinyllama_lora_files, num_gpus_available, model,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2114,6 +2114,13 @@ class LoRAConfig:
         # no factors to consider.
         # LoRA is not compatible with `torch.compile` .
         factors: List[Any] = []
+        factors.append(self.max_lora_rank)
+        factors.append(self.max_loras)
+        factors.append(self.fully_sharded_loras)
+        factors.append(self.lora_dtype)
+        factors.append(self.lora_extra_vocab_size)
+        factors.append(self.long_lora_scaling_factors)
+        factors.append(self.bias_enabled)
         hash_str = hashlib.md5(str(factors).encode()).hexdigest()
         return hash_str
 
@@ -3263,11 +3270,11 @@ class VllmConfig:
                 " Disabling `torch.compile`.")
             self.compilation_config.level = CompilationLevel.NO_COMPILATION
 
-        if self.lora_config is not None and self.compilation_config.level !=\
-             CompilationLevel.NO_COMPILATION:
-            logger.warning("LoRA is not supported with `torch.compile` yet. "
-                           "Disabling `torch.compile`.")
-            self.compilation_config.level = CompilationLevel.NO_COMPILATION
+        #if self.lora_config is not None and self.compilation_config.level !=\
+        #     CompilationLevel.NO_COMPILATION:
+        #    logger.warning("LoRA is not supported with `torch.compile` yet. "
+        #                   "Disabling `torch.compile`.")
+        #    self.compilation_config.level = CompilationLevel.NO_COMPILATION
 
         current_platform.check_and_update_config(self)
 

--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -16,8 +16,7 @@ from vllm.distributed import (get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size,
                               split_tensor_along_last_dim,
                               tensor_model_parallel_all_gather,
-                              tensor_model_parallel_all_reduce,
-                              tensor_model_parallel_gather)
+                              tensor_model_parallel_all_reduce)
 from vllm.distributed.utils import divide
 # yapf: disable
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
@@ -1043,7 +1042,10 @@ class LogitsProcessorWithLoRA(BaseLayerWithLoRA):
         logits = lm_head.linear_method.apply(lm_head, hidden_states)
         if embedding_bias is not None:
             logits += embedding_bias
-        logits = tensor_model_parallel_gather(logits)
+
+        # Gather logits for TP
+        logits = self.base_layer._gather_logits(logits)
+
         if logits is None:
             return None
 

--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -237,16 +237,22 @@ class VocabParallelEmbeddingWithLoRA(BaseLayerWithLoRA):
                 self.embeddings_weights[:embeddings.shape[0]].copy_(embeddings)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        added_tokens_mask = x > self.base_layer.org_vocab_size - 1
-        embeddings_indices = self.punica_wrapper.embeddings_indices
+
+        added_tokens_mask = torch.where(x > self.base_layer.org_vocab_size - 1,
+                                        1, 0)
+        embeddings_indices = torch.narrow(
+            self.punica_wrapper._embeddings_indices, 1, 0, x.size(0))
+
         indices = embeddings_indices[1].view_as(x)
         full_lora_a_embeddings = F.embedding(
             x + indices,
             self.lora_a_stacked_2d,
         )
         indices = embeddings_indices[0].view_as(x)
-        full_output = self.base_layer.forward(
-            x.add_(indices * added_tokens_mask))
+        #full_output = self.base_layer.forward(
+        #    x.add_(indices * added_tokens_mask))
+        full_output = self.base_layer.forward( 
+            x + (indices * added_tokens_mask))
 
         full_output_org = full_output
         if full_output.ndim == 3:

--- a/vllm/lora/models.py
+++ b/vllm/lora/models.py
@@ -326,7 +326,8 @@ class LoRAModelManager(AdapterModelManager):
         self.long_lora_context: Optional[LongContextLoRAContext] = None
         self.punica_wrapper = get_punica_wrapper(max_num_batched_tokens,
                                                  max_batches=self.max_num_seqs,
-                                                 device=self.device)
+                                                 device=self.device,
+                                                 max_loras=self.lora_config.max_loras)
         # Scaling factor -> offset to the sin_cos_cache to it.
         # Used for long context lora.
         self.scaling_factor_to_offset: Dict[float, int] = {}

--- a/vllm/lora/ops/triton_ops/__init__.py
+++ b/vllm/lora/ops/triton_ops/__init__.py
@@ -5,6 +5,8 @@ from vllm.lora.ops.triton_ops.bgmv_expand_slice import bgmv_expand_slice
 from vllm.lora.ops.triton_ops.bgmv_shrink import bgmv_shrink
 from vllm.lora.ops.triton_ops.sgmv_expand import sgmv_expand
 from vllm.lora.ops.triton_ops.sgmv_shrink import sgmv_shrink  # noqa: F401
+from vllm.lora.ops.triton_ops.v1_expand import v1_expand
+from vllm.lora.ops.triton_ops.v1_shrink import v1_shrink
 
 __all__ = [
     "bgmv_expand",
@@ -12,4 +14,6 @@ __all__ = [
     "bgmv_shrink",
     "sgmv_expand",
     "sgmv_shrink",
+    "v1_expand",
+    "v1_shrink"
 ]

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_EXPAND_FALSE.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_EXPAND_FALSE.json
@@ -1,0 +1,4643 @@
+{
+  "1": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_EXPAND_TRUE.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_EXPAND_TRUE.json
@@ -1,0 +1,4643 @@
+{
+  "1": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_SHRINK.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_A100_SXM4_80GB_SHRINK.json
@@ -1,0 +1,6038 @@
+{
+  "1": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 512,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_EXPAND_FALSE.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_EXPAND_FALSE.json
@@ -1,0 +1,4643 @@
+{
+  "1": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 512,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_EXPAND_TRUE.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_EXPAND_TRUE.json
@@ -1,0 +1,4643 @@
+{
+  "1": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 64,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 64,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 64,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "16": {
+        "2048": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "16": {
+        "2048": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 64,
+          "block_n": 32,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 16,
+          "block_n": 128,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "16": {
+        "2048": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "4096": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "6144": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "8192": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "12288": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "15360": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "16384": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "20480": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "23552": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "28672": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        },
+        "32768": {
+          "block_m": 32,
+          "block_n": 256,
+          "block_k": 16,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_SHRINK.json
+++ b/vllm/lora/ops/triton_ops/configs/NVIDIA_H100_80GB_HBM3_SHRINK.json
@@ -1,0 +1,6038 @@
+{
+  "1": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 512,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 512,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 512,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 512,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "2": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  },
+  "3": {
+    "1": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "16": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "32": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "64": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 64,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "128": {
+      "2048": {
+        "16": {
+          "block_m": 16,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "256": {
+      "2048": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 32,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 256,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 32,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "512": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "1024": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "2048": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "3072": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "4096": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "5120": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 8,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "6144": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "7168": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    },
+    "8192": {
+      "2048": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 32,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "4096": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "6144": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 64,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "8192": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "12288": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "15360": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "16384": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "20480": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "23552": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "28672": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      },
+      "32768": {
+        "16": {
+          "block_m": 64,
+          "block_n": 16,
+          "block_k": 128,
+          "split_k": 8,
+          "num_warps": 4,
+          "num_ctas": 1,
+          "num_stages": 2,
+          "max_nreg": null
+        }
+      }
+    }
+  }
+}

--- a/vllm/lora/ops/triton_ops/kernel_utils.py
+++ b/vllm/lora/ops/triton_ops/kernel_utils.py
@@ -1,0 +1,203 @@
+import triton
+import triton.language as tl
+
+@triton.jit
+def mm_k(a_ptr,
+         b_ptr,
+         ak_stride,
+         bk_stride,
+         offset_k,
+         K: tl.constexpr,
+         BLOCK_M: tl.constexpr,
+         BLOCK_N: tl.constexpr,
+         BLOCK_K: tl.constexpr,
+         EVEN_K: tl.constexpr,
+         SPLIT_K: tl.constexpr,
+         CAST_TYPE: tl.constexpr,
+         b_dtype: tl.constexpr):
+
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        if EVEN_K:
+            tiled_a = tl.load(a_ptr)
+            tiled_b = tl.load(b_ptr)
+        else:
+            tiled_a = tl.load(a_ptr,
+                              mask=offset_k[None, :] < K - k * (BLOCK_K * SPLIT_K),
+                              other=0)
+            tiled_b = tl.load(b_ptr,
+                              mask=offset_k[:, None] < K - k * (BLOCK_K * SPLIT_K),
+                              other=0)
+        if CAST_TYPE:
+            tiled_a = tiled_a.to(b_dtype)
+        accumulator += tl.dot(
+            tiled_a,
+            tiled_b,
+        )
+        a_ptr += BLOCK_K * SPLIT_K * ak_stride 
+        b_ptr += BLOCK_K * SPLIT_K * bk_stride 
+    return accumulator
+
+
+@triton.jit
+def do_expand_kernel(pid_m,
+                     pid_n,
+                     lora_index,
+                     slice_id,
+                     input_ptr,
+                     lora_ptr,
+                     out_ptr,
+                     N,
+                     K,
+                     M_LEN,
+                     ram, # array identifying the rows of Input ptr to operate on
+                     slice_start_loc,
+                     # input ptr strides
+                     input_d0_stride,
+                     input_d1_stride,
+                     input_d2_stride,
+                     # lora ptr strides
+                     ls_d0_ptr,
+                     ls_d1_ptr,
+                     ls_d2_ptr,
+                     # out ptr strides
+                     output_d0_stride,
+                     output_d1_stride,
+                     # constants
+                     BLOCK_M: tl.constexpr,
+                     BLOCK_N: tl.constexpr,
+                     BLOCK_K: tl.constexpr,
+                     SAME_STRIDE: tl.constexpr,
+                     SLICE_NUM: tl.constexpr,
+                     EVEN_K: tl.constexpr,
+                     CAST_TYPE: tl.constexpr,
+                     ADD_INPUTS: tl.constexpr,
+                     ):
+
+    offset_n = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    offset_k = tl.arange(0, BLOCK_K)
+
+    rbn = tl.max_contiguous(tl.multiple_of(offset_n % N, BLOCK_N),
+                            BLOCK_N)
+
+    # ls_d*_ptr can be either an integer or a pointer
+    if SAME_STRIDE:
+        # integer
+        cur_lora_d0_stride = ls_d0_ptr
+        cur_lora_d1_stride = ls_d1_ptr
+        cur_lora_d2_stride = ls_d2_ptr
+    else:
+        # pointer
+        cur_lora_d0_stride = tl.load(ls_d0_ptr + slice_id)
+        cur_lora_d1_stride = tl.load(ls_d1_ptr + slice_id)
+        cur_lora_d2_stride = tl.load(ls_d2_ptr + slice_id)
+    if SLICE_NUM == 1:
+        cur_input_ptr = input_ptr
+        cur_lora_ptr = lora_ptr
+
+    else:
+        cur_input_ptr = input_ptr + slice_id * input_d0_stride
+        cur_lora_ptr = tl.load(lora_ptr + slice_id).to(
+            tl.pointer_type(out_ptr.dtype.element_ty))
+
+    a_ptr = (cur_input_ptr +
+             ram[:, None] * input_d1_stride +
+             offset_k[None, :] * input_d2_stride, )
+    b_ptr = (cur_lora_ptr + cur_lora_d0_stride * lora_index +
+             offset_k[:, None] * cur_lora_d2_stride +
+             rbn[None, :] * cur_lora_d1_stride)
+
+    SPLIT_K = 1
+    accumulator = mm_k(a_ptr, b_ptr, input_d2_stride, cur_lora_d2_stride, offset_k, K,
+                        BLOCK_M, BLOCK_N, BLOCK_K, EVEN_K, SPLIT_K,
+                        CAST_TYPE, cur_lora_ptr.dtype.element_ty)
+
+    tiled_c = accumulator.to(cur_lora_ptr.dtype.element_ty)
+    if SLICE_NUM == 1:
+        cur_slice_start = slice_start_loc
+    else:
+        cur_slice_start = tl.load(slice_start_loc + slice_id)
+
+    offset_cn = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N + cur_slice_start
+    offset_cm = tl.arange(0, BLOCK_M)
+    c_ptr = (out_ptr + ram[:, None] * output_d0_stride +
+             offset_cn[None, :] * output_d1_stride)
+    c_mask = (offset_cm[:, None] < M_LEN) & (offset_cn[None, :] < (cur_slice_start + N))
+
+    if ADD_INPUTS:
+        tiled_out = tl.load(c_ptr, mask=c_mask)
+        tiled_c += tiled_out
+    tl.store(c_ptr, tiled_c, mask=c_mask)
+
+@triton.jit
+def do_shrink_kernel(pid_m,
+                      pid_n,
+                      pid_sk,
+                      slice_id,
+                      lora_index,
+                      input_ptr,
+                      lora_ptr,
+                      out_ptr,
+                      N,
+                      K,
+                      M_LEN,
+                      ram,
+                      # input strides
+                      input_d0_stride,
+                      input_d1_stride,
+                      # lora strides
+                      lora_d0_stride,
+                      lora_d1_stride,
+                      lora_d2_stride,
+                      # output strides
+                      output_d0_stride,
+                      output_d1_stride,
+                      output_d2_stride,
+                      scaling,
+                      BLOCK_M : tl.constexpr,
+                      BLOCK_N : tl.constexpr,
+                      BLOCK_K : tl.constexpr,
+                      EVEN_K : tl.constexpr,
+                      SPLIT_K : tl.constexpr,
+                      SLICE_NUM: tl.constexpr,):
+
+    offset_n = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    offset_k = pid_sk * BLOCK_K + tl.arange(0, BLOCK_K)
+
+    rbn = tl.max_contiguous(tl.multiple_of(offset_n % N, BLOCK_N), BLOCK_N)
+    # input ptr
+    a_ptr = (input_ptr +
+             ram[:, None] * input_d0_stride +
+             offset_k[None, :] * input_d1_stride)
+
+    if SLICE_NUM == 1:
+        # current lora ptr
+        cur_lora_ptr = lora_ptr
+    else:
+        # current lora ptr
+        cur_lora_ptr = tl.load(lora_ptr + slice_id).to(
+            tl.pointer_type(input_ptr.dtype.element_ty))
+
+    b_ptr = (cur_lora_ptr + lora_d0_stride * lora_index +
+             rbn[None, :] * lora_d1_stride +
+             offset_k[:, None] * lora_d2_stride)
+
+    accumulator = mm_k(a_ptr, b_ptr, input_d1_stride, lora_d2_stride, offset_k, K,
+                        BLOCK_M, BLOCK_N, BLOCK_K, EVEN_K, SPLIT_K,
+                        False, cur_lora_ptr.dtype.element_ty)
+
+    offset_cn = tl.arange(0, BLOCK_N) + pid_n * BLOCK_N
+    cur_out_ptr = (out_ptr if SLICE_NUM == 1 else out_ptr +
+                   slice_id * output_d0_stride)
+    c_ptr = cur_out_ptr + ram[:, None] * output_d1_stride + offset_cn[
+        None, :] * output_d2_stride
+
+    offset_cm = tl.arange(0, BLOCK_M)
+    c_mask = (offset_cm[:, None] < M_LEN) & (offset_cn[None, :] < N)
+
+    accumulator *= scaling
+    # handles write-back with reduction-splitting
+    if SPLIT_K == 1:
+        tl.store(c_ptr, accumulator, mask=c_mask)
+    else:
+        tl.atomic_add(c_ptr, accumulator, mask=c_mask)

--- a/vllm/lora/ops/triton_ops/v1_expand.py
+++ b/vllm/lora/ops/triton_ops/v1_expand.py
@@ -1,4 +1,3 @@
-# SPDX-License-Identifier: Apache-2.0
 """
 Based on:
 Chen, L., Ye, Z., Wu, Y., Zhuo, D., Ceze, L., & Krishnamurthy, A. (2023).
@@ -14,20 +13,22 @@ import triton.language as tl
 
 from vllm.utils import direct_register_custom_op
 
-from .utils import _get_lora_b_ptr
+from .utils import _get_lora_b_ptr, get_v1_op_configs
 from .kernel_utils import do_expand_kernel
 
 
 @triton.jit
-def _sgmv_expand_kernel(
+def _v1_expand_kernel(
         input_ptr,
         lora_ptr,
         out_ptr,
+        M,
         N,
         K,
-        b_seq_start_loc,
-        seq_lens,
-        lora_indices,
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
         slice_start_loc,
         input_d0_stride,
         input_d1_stride,
@@ -54,40 +55,53 @@ def _sgmv_expand_kernel(
     achieve the current functionality instead of having to call it multiple
     times.
     """
-    pid = tl.program_id(axis=0)
-    cur_batch = tl.program_id(axis=1)
-    slice_id = tl.program_id(axis=2)
+
+    pid_lmn = tl.program_id(axis=0)
+    slice_id = tl.program_id(axis=1)
+
     cta_n_num = tl.cdiv(N, BLOCK_N)
+    cta_m_num = tl.cdiv(M, BLOCK_M)
+
+    lora_idx = pid_lmn // (cta_m_num * cta_n_num)
+    pid_n = (pid_lmn // cta_m_num) % cta_n_num
+    pid_m = pid_lmn % cta_m_num
+
+    lora_id = tl.load(lora_ids + lora_idx)
+    if lora_id == -1:
+        # early exit for the no-lora case.
+        return
+
+    # lora m indices offsets
+    lora_m_indices_start = tl.load(lora_token_start_loc + lora_idx)
+    lora_m_size = tl.load(num_tokens_per_lora + lora_idx)
+
+    cta_m_offset = pid_m * BLOCK_M
+    if cta_m_offset >= lora_m_size:
+        # early exit CTA
+        return
+
     # When the output dimensions of each slice are the same,cur_n=N, otherwise
     # cur_n=tl.load(output_hs_ptr + slice_id), this situation exists in GQA's
     # qkv linear.
     curr_N = N if SAME_STRIDE else tl.load(output_hs_ptr + slice_id)
-    pid_m = pid // cta_n_num
-    pid_n = pid % cta_n_num
+    if pid_n * BLOCK_N > curr_N:
+        return
 
-    M_LEN = tl.load(seq_lens + cur_batch)
-    if pid_m * BLOCK_M >= M_LEN:
-        return            
-    if pid_n * BLOCK_N >= curr_N: 
-        return
-    lora_index = tl.load(lora_indices + cur_batch)
-    if lora_index == -1:
-        return
-    
-    M_OFFSET = tl.load(b_seq_start_loc + cur_batch)
-    
-    CTA_M_LEN = min(BLOCK_M, M_LEN - (pid_m * BLOCK_M))
-    CTA_M_OFFSET = M_OFFSET + (pid_m * BLOCK_M)
-    offset_m = tl.arange(0, BLOCK_M) 
-    ram = CTA_M_OFFSET + tl.max_contiguous(tl.multiple_of(offset_m % CTA_M_LEN, BLOCK_M), BLOCK_M)
+    CTA_M_LEN = min(BLOCK_M, lora_m_size - cta_m_offset)
+    offset_m = tl.arange(0, BLOCK_M) % CTA_M_LEN 
+
+    cta_lora_seq_indices = (token_indices_sorted_by_lora_ids +
+                            lora_m_indices_start + cta_m_offset)
+    ram = tl.load(cta_lora_seq_indices + offset_m)
+
     do_expand_kernel(pid_m,
                      pid_n,
-                     lora_index,
-                     slice_id, 
+                     lora_id,
+                     slice_id,
                      input_ptr,
                      lora_ptr,
                      out_ptr,
-                     curr_N,
+                     N,
                      K,
                      CTA_M_LEN,
                      ram, # array identifying the rows of Input ptr to operate on
@@ -111,20 +125,18 @@ def _sgmv_expand_kernel(
                      SLICE_NUM,
                      EVEN_K,
                      CAST_TYPE,
-                     ADD_INPUTS,
-                     )
+                     ADD_INPUTS)
 
 @torch.inference_mode()
-def _sgmv_expand(
+def _v1_expand(
     inputs: torch.Tensor,
     lora_b_weights: List[torch.Tensor],
     output_tensor: torch.Tensor,
-    b_seq_start_loc: torch.Tensor,
-    seq_len_tensor: torch.Tensor,
-    lora_indices_tensor: torch.Tensor,
-    batches: int,
-    max_seq_length: int,
-    token_nums: int,
+    token_lora_mapping: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,  # inputs.size(0)
+    num_tokens_per_lora: torch.Tensor,  # max-loras + 1
+    lora_token_start_loc: torch.Tensor,  # max-loras + 2
+    lora_ids: torch.Tensor,  # max-loras + 1
     offset_start: int = 0,
     add_inputs: bool = False,
 ) -> None:
@@ -133,20 +145,19 @@ def _sgmv_expand(
         inputs (torch.Tensor): input tensor
         lora_b_weights (List[torch.Tensor]): lora'b weight
         output_tensor (torch.Tensor): output tensor
-        b_seq_start_loc (torch.Tensor): (batch_size,). The cumulative
-            sequence lengths of the sequences in the batch, used to index
-            into sequence. E.g., if the sequence length is [4, 6], it is
-            [0, 4].
-        seq_len_tensor (torch.Tensor): (batch_size,). Record the sequence
-            length of the sequences in the batch.
-        lora_indices_tensor (torch.Tensor): (batch_size,). The LoRA index
-            corresponding to each batch. An index of -1 means no lora should be
-            applied.
-        batches (int): batch size
-        max_seq_length (int): The max sequence lengths of the sequences in the 
-            batch.
-        token_nums (int): The token numbers in the batch. Used to verify if the 
-            token numbers in the inputs matches the one in the metadata.
+        token_lora_mapping (torch.Tensor): A tensor mapping each input token to the lora-id
+            related to that token. A value of -1 indicates that LoRA doesn't apply to that
+            token.
+        token_indices_sorted_by_lora_ids (torch.Tensor): Row/Token indices from the A matrix
+            grouped by LoRA IDs.
+        num_tokens_per_lora (torch.Tensor): num_tokens_per_lora[i] is the number of tokens
+            that are to be processed by LoRA ID lora_ids[i] 
+        lora_token_start_loc (torch.Tensor): A cumulative sum of num_tokens_per_lora.
+            lora_token_start_loc[0] is always 0 so that lora_token_start_loc[i],
+            along with num_tokens_per_lora[i] identifies the the region in
+            token_indices_sorted_by_lora_ids that LoRA lora_ids[i] should
+            process.
+        lora_ids (torch.Tensor): LoRA ids to process.
         offset_start (int, optional): Offset start for output_tensor. 
             Defaults to 0.
         add_inputs (bool, optional): Whether to add the input tensor to the 
@@ -156,46 +167,58 @@ def _sgmv_expand(
     for weight in lora_b_weights:
         assert weight.dtype in [torch.float16, torch.bfloat16]
 
-    assert inputs.size(1) == token_nums
     assert inputs.size(0) == len(lora_b_weights)
 
-    assert b_seq_start_loc.size(0) == batches
-    assert lora_indices_tensor.size(0) == batches
     assert output_tensor.is_contiguous()
     (slice_start_tensor, lora_ptr_tensor, lora_strides_d0_tensor,
      lora_strides_d1_tensor, lora_strides_d2_tensor, hidden_sizes_tensor,
      same_stride, MAX_N) = _get_lora_b_ptr(lora_b_weights, offset_start,
-                                           b_seq_start_loc.device)
+                                           inputs.device)
 
     # TODO tuning this config
     K = lora_b_weights[0].shape[-1]  # K= rank
 
-    BLOCK_M = 64
-    BLOCK_N = 128
-    BLOCK_K = 16
-    EVEN_K = K % BLOCK_K == 0
+    M = inputs.size(1)
     ADD_INPUTS = add_inputs
+    MAX_LORAS = lora_ids.size(0)
     CAST_TYPE = False
+    NUM_SLICES = len(lora_b_weights)
+
+    kernel_config = get_v1_op_configs(op_type="expand",
+                                        batch = M,
+                                        hidden_size=MAX_N,
+                                        rank = K,
+                                        num_slices = NUM_SLICES,
+                                        add_inputs = add_inputs)
+    BLOCK_M = kernel_config['block_m']
+    BLOCK_N = kernel_config['block_n']
+    BLOCK_K = kernel_config['block_k']
+    EVEN_K = K % BLOCK_K == 0
 
     if inputs.dtype == torch.float32 and lora_b_weights[0].dtype in [
             torch.float16,
             torch.bfloat16,
     ]:
         CAST_TYPE = True
+
+
     grid = (
-        triton.cdiv(max_seq_length, BLOCK_M) * triton.cdiv(MAX_N, BLOCK_N),
-        batches,
-        len(lora_b_weights),
+        MAX_LORAS * triton.cdiv(M, BLOCK_M) * triton.cdiv(MAX_N, BLOCK_N),
+        NUM_SLICES,
     )
-    _sgmv_expand_kernel[grid](
+    _v1_expand_kernel[grid](
         inputs,
         lora_ptr_tensor,
         output_tensor,
+        M,
         MAX_N,
         K,
-        b_seq_start_loc,
-        seq_len_tensor,
-        lora_indices_tensor,
+        # V1 new
+        token_indices_sorted_by_lora_ids,
+        num_tokens_per_lora,
+        lora_token_start_loc,
+        lora_ids,
+        # ---
         slice_start_tensor,
         inputs.stride(0),
         inputs.stride(1),
@@ -212,22 +235,25 @@ def _sgmv_expand(
         EVEN_K,
         ADD_INPUTS,
         CAST_TYPE,
-        len(lora_b_weights),
+        NUM_SLICES,
         same_stride,
+        num_warps = kernel_config['num_warps'],
+        num_ctas = kernel_config['num_ctas'],
+        num_stages = kernel_config['num_stages'],
+        maxnreg = kernel_config['max_nreg'],
     )
     return
 
 
-def _sgmv_expand_fake(
+def _v1_expand_fake(
     inputs: torch.Tensor,
     lora_b_weights: List[torch.Tensor],
     output_tensor: torch.Tensor,
-    b_seq_start_loc: torch.Tensor,
-    seq_len_tensor: torch.Tensor,
-    lora_indices_tensor: torch.Tensor,
-    batches: int,
-    max_seq_length: int,
-    token_nums: int,
+    token_lora_mapping: torch.Tensor,
+    token_indices_sorted_by_lora_ids: torch.Tensor,  # inputs.size(0)
+    num_tokens_per_lora: torch.Tensor,  # max-loras + 1
+    lora_token_start_loc: torch.Tensor,  # max-loras + 2
+    lora_ids: torch.Tensor,  # max-loras + 1
     offset_start: int = 0,
     add_inputs: bool = False,
 ) -> None:
@@ -236,12 +262,12 @@ def _sgmv_expand_fake(
 
 try:
     direct_register_custom_op(
-        op_name="sgmv_expand",
-        op_func=_sgmv_expand,
+        op_name="v1_expand",
+        op_func=_v1_expand,
         mutates_args=["output_tensor"],
-        fake_impl=_sgmv_expand_fake,
+        fake_impl=_v1_expand_fake,
     )
-    sgmv_expand = torch.ops.vllm.sgmv_expand
+    v1_expand = torch.ops.vllm.v1_expand
 
 except AttributeError:
-    sgmv_expand = _sgmv_expand
+    v1_expand = _v1_expand

--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -168,7 +168,7 @@ class PunicaWrapperBase(PunicaWrapperABC):
         self.is_prefill = False
         self.no_lora = False
 
-    def _update_base_metadata(
+    def update_base_metadata(
         self,
         mapping: "LoRAMapping",
         lora_index_to_id: List[Optional[int]],
@@ -329,7 +329,7 @@ class PunicaWrapperBase(PunicaWrapperABC):
             long_lora_context: Optional["LongContextLoRAContext"] = None,
             **kwargs):
 
-        self._update_base_metadata(mapping, lora_index_to_id, max_loras,
+        self.update_base_metadata(mapping, lora_index_to_id, max_loras,
                                    vocab_size, extra_vocab_size,
                                    long_lora_context)
         if mapping.is_prefill:

--- a/vllm/lora/punica_wrapper/v1_gpu.py
+++ b/vllm/lora/punica_wrapper/v1_gpu.py
@@ -1,0 +1,384 @@
+"""
+Based on:
+Chen, L., Ye, Z., Wu, Y., Zhuo, D., Ceze, L., & Krishnamurthy, A. (2023). 
+Punica: Multi-Tenant LoRA Serving. 
+https://arxiv.org/abs/2310.18547
+"""
+
+from typing import Optional, Tuple, Union, final, TYPE_CHECKING, List
+
+import torch
+
+from vllm.lora.layers import LoRAMapping
+from vllm.triton_utils import HAS_TRITON
+from dataclasses import dataclass
+
+if HAS_TRITON:
+    from vllm.lora.ops.triton_ops import v1_expand
+    from vllm.lora.ops.triton_ops import v1_shrink
+
+from .punica_base import PunicaWrapperBase
+
+if TYPE_CHECKING:
+    # avoid circuit import
+    from vllm.lora.models import LongContextLoRAContext
+
+@dataclass
+class V1KernelMeta:
+    token_lora_mapping: torch.Tensor
+    token_indices_sorted_by_lora_ids: torch.Tensor
+    active_lora_ids: torch.Tensor
+    num_tokens_per_lora: torch.Tensor
+    lora_token_start_loc: torch.Tensor
+
+    @staticmethod
+    def make(max_loras: int, max_num_tokens: int,
+             device: torch.device) -> "V1KernelMeta":
+
+        token_lora_mapping = torch.empty(max_num_tokens,
+                                         dtype=torch.int32,
+                                         device=device)
+
+        token_indices_sorted_by_lora_ids = torch.empty(max_num_tokens,
+                                                       dtype=torch.int32,
+                                                       device=device)
+
+        # +1 because "no-lora" is also a possibility
+        # example: let max_loras be 3, active_lora_ids of [-1, 0, 2, 1]
+        # is a possibility.
+        active_lora_ids = torch.empty(max_loras + 1,
+                                      dtype=torch.int32,
+                                      device=device)
+
+        # using running example, [3, 10, 5, 2] is a possibility.
+        num_tokens_per_lora = torch.zeros(max_loras + 1,
+                                          dtype=torch.int32,
+                                          device=device)
+
+        # +2 for this because, the first index is always 0
+        # for example: let max loras be 3, then lora_token_start_loc,
+        # can be [0, 3, 13, 18, 20].
+        lora_token_start_loc = torch.zeros(max_loras + 2,
+                                           dtype=torch.int32,
+                                           device=device)
+        return V1KernelMeta(
+            token_lora_mapping=token_lora_mapping,
+            token_indices_sorted_by_lora_ids=token_indices_sorted_by_lora_ids,
+            active_lora_ids=active_lora_ids,
+            num_tokens_per_lora=num_tokens_per_lora,
+            lora_token_start_loc=lora_token_start_loc)
+
+    def reset(self):
+        self.active_lora_ids.fill_(-1)
+        self.num_tokens_per_lora.fill_(0)
+        self.lora_token_start_loc.fill_(0)
+
+    def prepare_tensors(self, token_lora_mapping: torch.Tensor) -> None:
+        num_tokens = token_lora_mapping.size(0)
+
+        # copy token lora mapping
+        self.token_lora_mapping[:num_tokens].copy_(token_lora_mapping,
+                                                   non_blocking=True)
+
+        # token_indices_sorted_by_lora_ids
+        _, token_indices_sorted_by_lora_ids = torch.sort(token_lora_mapping,
+                                                         stable=True)
+        # start gpu transfer
+        self.token_indices_sorted_by_lora_ids[:num_tokens].copy_(
+            token_indices_sorted_by_lora_ids, non_blocking=True)
+
+        # active_lora_ids, num_tokens_per_lora
+        lora_ids, num_tokens_per_lora = torch.unique(token_lora_mapping,
+                                                     sorted=False,
+                                                     return_counts=True)
+        self.active_lora_ids[:lora_ids.size(0)].copy_(lora_ids,
+                                                      non_blocking=True)
+        self.num_tokens_per_lora[:num_tokens_per_lora.size(0)].copy_(
+            num_tokens_per_lora, non_blocking=True)
+
+        # lora_token_start_loc
+        lora_token_start_loc = torch.cumsum(num_tokens_per_lora, dim=0)
+        self.lora_token_start_loc[1:1 + lora_token_start_loc.size(0)].copy_(
+            lora_token_start_loc, non_blocking=True)
+
+    def meta_args(
+        self, num_tokens: int
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor,
+               torch.Tensor]:
+        return (self.token_lora_mapping[:num_tokens],
+                self.token_indices_sorted_by_lora_ids[:num_tokens],
+                self.num_tokens_per_lora, self.lora_token_start_loc,
+                self.active_lora_ids)
+
+@final
+class V1LoRAGPU(PunicaWrapperBase):
+
+    def __init__(self, max_num_batched_tokens: int, max_batches: int,
+                 device: Union[torch.device, str], **kwargs):
+        PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches,
+                                   device)
+        self.max_loras = kwargs['max_loras']
+        self.token_mapping_v1_meta = V1KernelMeta.make(self.max_loras,
+                                                       max_num_batched_tokens,
+                                                       device=device)
+        self.prompt_mapping_v1_meta = V1KernelMeta.make(self.max_loras,
+                                                        max_batches,
+                                                        device=device)
+
+    def update_metadata(
+            self,
+            mapping: LoRAMapping,
+            lora_index_to_id: List[Optional[int]],
+            max_loras: int,
+            vocab_size: int,
+            extra_vocab_size: int,
+            long_lora_context: Optional["LongContextLoRAContext"] = None,
+            **kwargs):
+        self.token_mapping_v1_meta.reset()
+        self.prompt_mapping_v1_meta.reset()
+
+        self.update_base_metadata(mapping, lora_index_to_id, max_loras,
+                                  vocab_size, extra_vocab_size,
+                                  long_lora_context)
+
+        self.token_mapping_v1_meta.prepare_tensors(self.token_lora_indices)
+        self.prompt_mapping_v1_meta.prepare_tensors(self.sampler_indices)
+
+    def _apply_shrink(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: Tuple[torch.Tensor, ...],
+        scale: float,
+    ):
+        #No LoRA request, so return directly
+        if self.no_lora:
+            return
+
+        v1_shrink(
+            x,
+            w_t_all,
+            y,
+            *self.token_mapping_v1_meta.meta_args(x.size(0)),
+            scale,
+        )
+
+    def _apply_expand(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        offset_start: int,
+        add_inputs: bool,
+    ):
+        v1_expand(
+            x,
+            w_t_all,
+            y,
+            *self.token_mapping_v1_meta.meta_args(x.size(0)),
+            offset_start=offset_start,
+            add_inputs=add_inputs,
+        )
+
+    def add_shrink(self, y: Union[Tuple[torch.Tensor, ...], torch.Tensor],
+                   x: torch.Tensor, lora_a_stacked: Tuple[torch.Tensor, ...],
+                   scale: float, **kwargs):
+        """
+        Performs GEMM  for multiple slices of lora_a.
+        When `is_prefill is` true, it indicates that it is currently the
+        prefill stage, and the `_shrink_prefill` function should be called.
+        Otherwise, it is the decode stage, and the _shrink_decode function
+        should be called.
+            
+        Semantics:
+        for i in range(len(lora_a_stacked)):
+            y[i] += (x @ lora_a_stacked[i]) * scale
+        
+        Args:
+            y (Union[Tuple[torch.Tensor, ...], torch.Tensor]): Output tensors
+            x (torch.Tensor): Input tensor
+            lora_a_stacked (Tuple[torch.Tensor, ...]): lora_a's weights
+            scale (float): Scaling factor for the operation
+        """
+
+        x = x.view(-1, x.shape[-1])
+        self._apply_shrink(y, x, lora_a_stacked, scale)
+
+    def add_expand(self,
+                   y: torch.Tensor,
+                   x: Union[Tuple[torch.Tensor, ...], torch.Tensor],
+                   lora_b_stacked: Tuple[torch.Tensor, ...],
+                   lora_bias_stacked: Optional[Tuple[torch.Tensor, ...]],
+                   output_slices: Tuple[int, ...],
+                   offset_start: int = 0,
+                   add_inputs=True,
+                   **kwargs) -> None:
+        """
+        Performs GEMM and bias addition for multiple slices of lora_b.
+      
+        Semantics:
+            for i in range(len(lora_b_stacked)):
+                slice = output_slices[i]
+                y[:, offset:offset+slice] += x[i] @ lora_b_stacked[i] + 
+                    lora_bias_stacked[i] 
+                offset += slice
+            
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (Union[Tuple[torch.Tensor, ...], torch.Tensor]): Input tensors
+            lora_b_stacked (Tuple[torch.Tensor, ...]): lora_b's weight
+            lora_bias_stacked (Optional[Tuple[torch.Tensor, ...]]): 
+                bias's weight
+            output_slices (Tuple[int, ...]): Every slice's size
+            add_inputs (bool):  Defaults to True.
+        """
+        y_org = y
+        y = y.view(-1, y.shape[-1])
+        if lora_bias_stacked is not None:
+            self._apply_bias(self.token_lora_indices, y, output_slices,
+                             lora_bias_stacked)
+
+        # NOTE fused kernel
+        self._apply_expand(y,
+                           x,
+                           lora_b_stacked,
+                           offset_start,
+                           add_inputs=True)
+        y = y.view_as(y_org)
+
+    def add_lora_embedding(self,
+                           y: torch.Tensor,
+                           x: torch.Tensor,
+                           lora_b_stacked: torch.Tensor,
+                           add_inputs: bool = True,
+                           **kwargs) -> None:
+        """
+        Applies lora  specifically for VocabParallelEmbeddingWithLoRA.
+
+        Semantics:
+            y += x @ lora_b_stacked
+
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (torch.Tensor): Input tensor.
+            lora_b_stacked (torch.Tensor): lora_b's weights.
+            add_inputs (bool): Default to True.
+        """
+        v1_expand(
+                x.unsqueeze(dim=0),
+                [lora_b_stacked],
+                y,
+                *self.token_mapping_v1_meta.meta_args(x.size(1)),
+                offset_start=0,
+                add_inputs=add_inputs,
+            )
+
+    def add_lora_linear(self,
+                        y: torch.Tensor,
+                        x: torch.Tensor,
+                        lora_a_stacked: Tuple[torch.Tensor, ...],
+                        lora_b_stacked: Tuple[torch.Tensor, ...],
+                        lora_bias_stacked: Optional[Tuple[torch.Tensor, ...]],
+                        scale: float,
+                        output_slices: Tuple[int, ...],
+                        *,
+                        buffer: Optional[Tuple[torch.Tensor, ...]] = None,
+                        **kwargs) -> None:
+        """
+        Applicable to linear-related lora. 
+
+        Semantics:
+            for i in range(len(lora_a_stacked)):
+                y[i] += (
+                    x[i].unsqueeze(0)
+                    @ lora_a_stacked[indices[i], layer_idx, :, :]
+                    @ lora_b_stacked[indices[i], layer_idx, :, :]
+                    * scale
+                    ).squeeze(0)+lora_bias_stacked[i]
+
+        Args:
+            y (torch.Tensor): Output tensor. Will be changed in-place.
+            x (torch.Tensor): Input tensor
+            lora_a_stacked (Tuple[torch.Tensor, ...]): lora_a's weight.
+            lora_b_stacked (Tuple[torch.Tensor, ...]): lora_b's weight.
+            lora_bias_stacked (Optional[Tuple[torch.Tensor, ...]]): lora's bias.
+            scale (float): Scaling factor.
+            output_slices (Tuple[int, ...]): Every slice's size.
+            buffer (Optional[Tuple[torch.Tensor, ...]]): Defaults to None.
+        """
+
+        assert len(lora_a_stacked) == len(lora_b_stacked) == len(output_slices)
+        if lora_bias_stacked is not None:
+            assert len(lora_bias_stacked) == len(output_slices)
+            y = self._apply_bias(self.token_lora_indices, y, output_slices,
+                                 lora_bias_stacked)
+
+        if buffer is None:
+            r = lora_b_stacked[0].size(-1)
+            # We set the buffer to be float32 by default ,refer to:
+            # https://github.com/triton-lang/triton/issues/1387
+            buffer = torch.zeros(
+                (len(output_slices), x.size(0), r),
+                dtype=torch.float32,
+                device=x.device,
+            )
+        self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
+        self.add_expand(y,
+                        buffer,
+                        lora_b_stacked,
+                        None,
+                        output_slices,
+                        add_inputs=True,
+                        **kwargs)
+
+    def add_lora_logits(self,
+                        y: torch.Tensor,
+                        x: torch.Tensor,
+                        lora_a_stacked: torch.Tensor,
+                        lora_b_stacked: torch.Tensor,
+                        scale,
+                        *,
+                        buffer: Optional[torch.Tensor] = None,
+                        **kwargs) -> None:
+        """
+        Applies lora  specifically for LogitsProcessorWithLoRA.
+        
+        Semantics:
+            buffer = (x @ lora_a_stacked) * scale
+            y += buffer @ lora_b_stacked
+
+        Args:
+            y (torch.Tensor): Output tensor.
+            x (torch.Tensor): Input tensor.
+            lora_a_stacked (torch.Tensor): lora_a's weights.
+            lora_b_stacked (torch.Tensor):lora_b's weights.
+            scale (float): Scaling factor.
+            buffer (Optional[torch.Tensor]):Default to None.
+        """
+
+        y_org = y
+        y = y.view(-1, y.shape[-1])
+        x = x.view(-1, x.shape[-1])
+        r = lora_b_stacked.size(-1)
+        num_slices = lora_a_stacked.size(1) 
+        assert num_slices == 1, "lora for logits always has only 1 slice"
+
+        if buffer is None:
+            # We set the buffer to be float32 by default ,refer to:
+            # https://github.com/triton-lang/triton/issues/1387
+            buffer = torch.zeros((num_slices, x.size(0), r),
+                                 dtype=torch.float32,
+                                 device=x.device)
+
+        v1_shrink(x,
+                  [lora_a_stacked], 
+                  buffer, 
+                  *self.prompt_mapping_v1_meta.meta_args(x.size(0)),
+                  scale)
+
+        v1_expand(buffer,
+                  [lora_b_stacked],
+                  y,
+                  *self.prompt_mapping_v1_meta.meta_args(buffer.size(0)),
+                  add_inputs=True)
+        y = y.view_as(y_org)

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -45,7 +45,6 @@ class LogitsProcessor(nn.Module):
         # Soft cap the logits. Used in Gemma 2.
         self.soft_cap = soft_cap
         # Whether to use gather or all-gather to gather the logits.
-
         parallel_config = get_current_vllm_config().parallel_config
         self.use_all_gather = current_platform.is_tpu() \
             or envs.VLLM_USE_V1 \
@@ -82,6 +81,20 @@ class LogitsProcessor(nn.Module):
 
         return logits
 
+    def _gather_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """gather/all-gather the logits tensor across model parallel group."""
+        if self.use_all_gather:
+            # Gather is not supported for some devices such as TPUs.
+            # Use all-gather instead.
+            # NOTE(woosuk): Here, the outputs of every device should not be None
+            # because XLA requires strict SPMD among all devices. Every device
+            # should execute the same operations after gathering the logits.
+            logits = tensor_model_parallel_all_gather(logits)
+        else:
+            # None may be returned for rank > 0
+            logits = tensor_model_parallel_gather(logits)
+        return logits
+
     def _get_logits(
         self,
         hidden_states: torch.Tensor,
@@ -93,16 +106,9 @@ class LogitsProcessor(nn.Module):
                                              hidden_states,
                                              bias=embedding_bias)
 
-        if self.use_all_gather:
-            # Gather is not supported for some devices such as TPUs.
-            # Use all-gather instead.
-            # NOTE(woosuk): Here, the outputs of every device should not be None
-            # because XLA requires strict SPMD among all devices. Every device
-            # should execute the same operations after gathering the logits.
-            logits = tensor_model_parallel_all_gather(logits)
-        else:
-            # None may be returned for rank > 0
-            logits = tensor_model_parallel_gather(logits)
+        # Gather logits for TP
+        logits = self._gather_logits(logits)
+
         # Remove paddings in vocab (if any).
         if logits is not None:
             logits = logits[..., :self.org_vocab_size]

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -232,7 +232,10 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def get_punica_wrapper(cls) -> str:
-        return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
+        if envs.VLLM_USE_V1:
+            return "vllm.lora.punica_wrapper.v1_gpu.V1LoRAGPU"
+        else:
+            return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
 
 
 # NVML utils

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2204,7 +2204,7 @@ def run_method(obj: Any, method: Union[str, bytes, Callable], args: Tuple[Any],
             func = getattr(obj, method)
         except AttributeError:
             raise NotImplementedError(f"Method {method!r} is not"
-                                      " implemented.") from None
+                                      f" implemented in object {obj}") from None
     else:
         func = partial(method, obj)  # type: ignore
     return func(*args, **kwargs)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -170,14 +170,28 @@ class FreeKVCacheBlockQueue:
         return ret
 
 
-def generate_block_hash_extra_keys(
-        request: Request, start_token_idx: int, end_token_idx: int,
-        start_mm_idx: int) -> Tuple[Optional[Tuple[Any, ...]], int]:
-    """Generate extra keys for the block hash. The extra keys can come from
-    the multi-modal inputs and request specific metadata (e.g., LoRA ID).
-    For multi-modal inputs, the extra keys are (mm_hash, start_offset) that
-    indicate a mm input contained in the block and its starting offset in
-    the block tokens.
+def need_extra_keys(request: Request) -> bool:
+    """Check whether the blocks allocated to this request need extra hash keys.
+
+    Args:
+        request (Request): The request. 
+
+    Returns:
+        bool: Whether blocks allocated to this request need extra hash keys. 
+    """
+
+    # Multimodal requests need to include the MM hash.
+    # LoRA requests need to include the LoRA ID.
+    return bool(request.mm_positions) or (request.lora_request is not None)
+
+
+def _gen_mm_extra_hash_keys(request: Request, start_token_idx: int,
+                            end_token_idx: int,
+                            start_mm_idx: int) -> Tuple[List[Any], int]:
+    """Generate extra keys related to MultiModal request for block hash
+    computation. For multi-modal inputs, the extra keys are
+    (mm_hash, start_offset) that indicate a mm input contained in the
+    block and its starting offset in the block tokens.
     
     Args:
         request: The request object.
@@ -188,10 +202,11 @@ def generate_block_hash_extra_keys(
     Returns:
         A tuple of extra keys and the next multi-modal index.
     """
+    extra_keys: List[Any] = []
 
     mm_positions, mm_hashes = request.mm_positions, request.mm_hashes
     if not mm_positions:
-        return None, start_mm_idx
+        return extra_keys, start_mm_idx
 
     if mm_positions and len(mm_positions) != len(mm_hashes):
         raise ValueError(
@@ -204,14 +219,13 @@ def generate_block_hash_extra_keys(
     # range. This usually happens in the late prefill phase and decoding phase.
     if mm_positions[-1]["offset"] + mm_positions[-1][
             "length"] < start_token_idx:
-        return None, start_mm_idx
+        return extra_keys, start_mm_idx
 
     # Support start_mm_idx == -1 to indicate the last mm input.
     if start_mm_idx < 0:
         assert -start_mm_idx <= len(mm_positions)
         start_mm_idx = len(mm_positions) + start_mm_idx
 
-    extra_keys = []
     curr_mm_idx = start_mm_idx
     while mm_positions and curr_mm_idx < len(mm_positions):
         assert mm_hashes[curr_mm_idx] is not None
@@ -237,7 +251,50 @@ def generate_block_hash_extra_keys(
         else:
             # This block has not reached the current mm input.
             break
-    return tuple(extra_keys), curr_mm_idx
+    return extra_keys, curr_mm_idx
+
+
+def _gen_lora_extra_hash_keys(request: Request) -> List[int]:
+    """Generate extra keys related to LoRA for block hash computation.
+    
+    Args:
+        request: The request object.
+    
+    Returns:
+        Return LoRA id of the request if it is a LoRA request. Return empty
+        list otherwise.
+    """
+    if not request.lora_request:
+        return []
+    return [request.lora_request.lora_int_id]
+
+
+def generate_block_hash_extra_keys(
+        request: Request, start_token_idx: int, end_token_idx: int,
+        start_mm_idx: int) -> Tuple[Optional[Tuple[Any, ...]], int]:
+    """Generate extra keys for the block hash. The extra keys can come from
+    the multi-modal inputs and request specific metadata (e.g., LoRA ID).
+    
+    Args:
+        request: The request object.
+        start_token_idx: The start token index of the block.
+        end_token_idx: The end token index of the block.
+        start_mm_idx: The start multi-modal index of the block.
+    
+    Returns:
+        A tuple of extra keys and the next multi-modal index.
+    """
+    mm_extra_keys: List[Any]
+    mm_extra_keys, new_start_mm_idx = _gen_mm_extra_hash_keys(
+        request, start_token_idx, end_token_idx, start_mm_idx)
+    lora_extra_keys: List[int] = _gen_lora_extra_hash_keys(request)
+
+    extra_keys: List[Any] = lora_extra_keys + mm_extra_keys
+
+    if not extra_keys:
+        return None, new_start_mm_idx
+
+    return tuple(extra_keys), new_start_mm_idx
 
 
 def hash_block_tokens(
@@ -248,9 +305,6 @@ def hash_block_tokens(
     the contents of the preceding block(s). The hash value is used for
     prefix caching. We use LRU cache for this function to avoid recomputing
     hash values for the same block contents.
-
-    TODO: Support arbitrary metadata so that we could support more
-    features such as LoRA adapter.
 
     Args:
         parent_block_hash: The hash of the parent block. None
@@ -291,14 +345,9 @@ def hash_request_tokens(block_size: int,
         The list of computed hash values.
     """
     token_ids = request.all_token_ids
-    mm_positions, mm_hashes = request.mm_positions, request.mm_hashes
-    if mm_positions and len(mm_positions) != len(mm_hashes):
-        raise ValueError(
-            "The number of multi-modal positions and hashes must match.")
 
-    # TODO: Extend this to support other features such as LoRA.
-    need_extra_keys = bool(mm_positions)
-    extra_keys = None
+    req_need_extra_keys = need_extra_keys(request)
+    req_extra_keys = None
     curr_mm_idx = 0
 
     ret = []
@@ -310,13 +359,13 @@ def hash_request_tokens(block_size: int,
         if len(block_token_ids) < block_size:
             break
 
-        # Add extra keys if the block is a multi-modal block.
-        if need_extra_keys:
-            extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
+        if req_need_extra_keys:
+            # MM and LoRA requests need extra keys for block-hash computation.
+            req_extra_keys, curr_mm_idx = generate_block_hash_extra_keys(
                 request, start, end, curr_mm_idx)
 
         block_hash = hash_block_tokens(parent_block_hash_value,
-                                       block_token_ids, extra_keys)
+                                       block_token_ids, req_extra_keys)
         ret.append(block_hash)
         parent_block_hash_value = block_hash.hash_value
     return ret

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -7,6 +7,7 @@ from typing import (TYPE_CHECKING, Deque, Dict, Iterable, List, Optional, Set,
 
 from vllm.config import CacheConfig, LoRAConfig, ModelConfig, SchedulerConfig
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
                                                 compute_encoder_budget)
@@ -35,8 +36,6 @@ class Scheduler:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
         self.lora_config = lora_config
-        # TODO: Support LoRA.
-        assert lora_config is None, "V1 does not support LoRA yet."
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
@@ -180,6 +179,14 @@ class Scheduler:
                     self.encoder_cache_manager.allocate(request, i)
                 encoder_budget = new_encoder_budget
 
+        # Record the LoRAs in scheduled_running_reqs
+        requested_loras: Set[int] = set()
+        if self.lora_config:
+            requested_loras = set(
+                req.lora_request.lora_int_id for req in scheduled_running_reqs
+                if req.lora_request and req.lora_request.lora_int_id > 0)
+            assert len(requested_loras) <= self.lora_config.max_loras
+
         # Next, schedule the WAITING requests.
         if not preempted_reqs:
             while self.waiting and token_budget > 0:
@@ -187,6 +194,17 @@ class Scheduler:
                     break
 
                 request = self.waiting[0]
+
+                # Check that adding the request still respects the max_loras
+                # constraint.
+                if self.lora_config and request.lora_request:
+                    req_lora_id = request.lora_request.lora_int_id
+                    if len(requested_loras) == self.lora_config.max_loras and (
+                            req_lora_id not in requested_loras):
+                        # cannot schedule
+                        break
+                    requested_loras.add(req_lora_id)
+
                 # Get already-cached tokens.
                 computed_blocks, num_computed_tokens = \
                     self.kv_cache_manager.get_computed_blocks(request)
@@ -568,6 +586,7 @@ class NewRequestData:
     sampling_params: SamplingParams
     block_ids: List[int]
     num_computed_tokens: int
+    lora_request: Optional[LoRARequest]
 
     @classmethod
     def from_request(
@@ -586,6 +605,7 @@ class NewRequestData:
             sampling_params=request.sampling_params,
             block_ids=block_ids,
             num_computed_tokens=num_computed_tokens,
+            lora_request=request.lora_request,
         )
 
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -72,6 +72,9 @@ class EngineCoreProfile:
 class EngineCoreResetPrefixCache:
     pass
 
+@dataclass
+class EngineCoreAddLora:
+    lora_request: "LoRARequest"
 
 class EngineCoreRequestType(enum.Enum):
     """
@@ -82,7 +85,9 @@ class EngineCoreRequestType(enum.Enum):
     ABORT = b'\x01'
     PROFILE = b'\x02'
     RESET_PREFIX_CACHE = b'\x03'
+    ADD_LORA = b'\x04'
 
 
 EngineCoreRequestUnion = Union[EngineCoreRequest, EngineCoreProfile,
-                               EngineCoreResetPrefixCache, List[str]]
+                               EngineCoreResetPrefixCache, EngineCoreAddLora,
+                               List[str]]

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -375,4 +375,4 @@ class AsyncLLM(EngineClient):
 
     async def add_lora(self, lora_request: LoRARequest) -> None:
         """Load a new LoRA adapter into the engine for future requests."""
-        raise NotImplementedError("LoRA not yet supported in V1")
+        await self.engine_core.add_lora_async(lora_request)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -3,11 +3,12 @@
 # Datastructures defining an input batch
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 import numpy as np
 import torch
 
+from vllm.lora.request import LoRARequest
 from vllm.multimodal import MultiModalKwargs
 from vllm.sampling_params import SamplingParams, SamplingType
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -34,6 +35,8 @@ class CachedRequestState:
 
     mrope_positions: Optional[torch.Tensor] = None
     mrope_position_delta: Optional[int] = None
+
+    lora_request: Optional[LoRARequest] = None
 
     @property
     def num_tokens(self) -> int:
@@ -161,6 +164,12 @@ class InputBatch:
         ]
         self.prompt_token_ids: Optional[torch.Tensor] = None
 
+        # lora related
+        self.request_lora_mapping = np.zeros((self.max_num_reqs, ),
+                                             dtype=np.int32)
+        self.lora_id_to_request_ids: Dict[int, Set[str]] = {}
+        self.lora_id_to_lora_request: Dict[int, LoRARequest] = {}
+
         # req_index -> generator
         # NOTE(woosuk): The indices of the requests that do not have their own
         # generator should not be included in the dictionary.
@@ -235,6 +244,19 @@ class InputBatch:
         if sampling_params.prompt_logprobs:
             self.prompt_logprob_reqs.add(req_id)
 
+        # Add request lora ID
+        if request.lora_request:
+            lora_id = request.lora_request.lora_int_id
+            if lora_id not in self.lora_id_to_request_ids:
+                self.lora_id_to_request_ids[lora_id] = set()
+
+            self.request_lora_mapping[req_index] = lora_id
+            self.lora_id_to_request_ids[lora_id].add(request.req_id)
+            self.lora_id_to_lora_request[lora_id] = request.lora_request
+        else:
+            # No LoRA
+            self.request_lora_mapping[req_index] = 0
+
     def remove_request(self, req_id: str) -> Optional[int]:
         req_index = self.req_id_to_index.pop(req_id, None)
         if req_index is None:
@@ -251,6 +273,16 @@ class InputBatch:
         self.generators.pop(req_index, None)
         self.num_logprobs.pop(req_id, None)
         self.prompt_logprob_reqs.discard(req_id)
+
+        # LoRA
+        lora_id = self.request_lora_mapping[req_index]
+        if lora_id != 0:
+            self.lora_id_to_request_ids[lora_id].discard(req_id)
+            if len(self.lora_id_to_request_ids[lora_id]) == 0:
+                self.lora_id_to_request_ids.pop(lora_id)
+                self.lora_id_to_lora_request.pop(lora_id)
+            self.request_lora_mapping[req_index] = 0
+
         return req_index
 
     def clear(self) -> None:
@@ -266,6 +298,9 @@ class InputBatch:
         self.generators.clear()
         self.num_logprobs.clear()
         self.prompt_logprob_reqs.clear()
+        self.request_lora_mapping.fill(0)
+        self.lora_id_to_lora_request.clear()
+        self.lora_id_to_request_ids.clear()
 
     def condense(self, empty_req_indices: List[int]) -> None:
         if self.num_reqs == 0:
@@ -317,6 +352,9 @@ class InputBatch:
             generator = self.generators.pop(last_req_index, None)
             if generator is not None:
                 self.generators[empty_index] = generator
+
+            self.request_lora_mapping[empty_index] = self.request_lora_mapping[
+                last_req_index]
 
             # Decrement last_req_index since it is now empty.
             last_req_index -= 1
@@ -400,6 +438,29 @@ class InputBatch:
             prompt_token_ids[i, self.num_prompt_tokens[i]:] = self.vocab_size
         return prompt_token_ids_cpu_tensor.to(device=self.device,
                                               non_blocking=True)
+
+    def make_lora_inputs(
+        self, num_scheduled_tokens: np.ndarray
+    ) -> Tuple[Tuple[int, ...], Tuple[int, ...], Set[LoRARequest]]:
+        """
+        Given the num_scheduled_tokens for each request in the batch, return
+        datastructures used to activate the current LoRAs.
+        Returns:
+            1. prompt_lora_mapping: A tuple of size self.num_reqs where,
+               prompt_lora_mapping[i] is the LoRA id to use for the ith prompt.
+            2. token_lora_mapping: A tuple of size np.sum(num_scheduled_tokens)
+               where, token_lora_mapping[i] is the LoRA id to use for ith token.
+            3. lora_requests: Set of relevant LoRA requests.
+        """
+
+        req_lora_mapping = self.request_lora_mapping[:self.num_reqs]
+        prompt_lora_mapping = tuple(req_lora_mapping)
+        token_lora_mapping = tuple(
+            req_lora_mapping.repeat(num_scheduled_tokens))
+        active_lora_requests: Set[LoRARequest] = set(
+            self.lora_id_to_lora_request.values())
+
+        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
 
     @property
     def num_reqs(self) -> int:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1062,10 +1062,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # can reuse the memory pool allocated for the large shapes.
         with graph_capture(device=self.device):
             for num_tokens in reversed(self.cudagraph_batch_sizes):
-                for _ in range(self.vllm_config.compilation_config.
-                               cudagraph_num_of_warmups):
+                print(f"running capture model for {num_tokens}...")
+                with self.maybe_capture_model_with_lora(
+                        self.lora_config, num_tokens):
+                    for _ in range(self.vllm_config.compilation_config.
+                                   cudagraph_num_of_warmups):
+                        self._dummy_run(num_tokens)
                     self._dummy_run(num_tokens)
-                self._dummy_run(num_tokens)
 
         end_time = time.perf_counter()
         end_free_gpu_memory = torch.cuda.mem_get_info()[0]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -15,6 +15,7 @@ from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment,
                               set_custom_all_reduce)
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.utils import GiB_bytes
@@ -247,6 +248,9 @@ class Worker:
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.
         return
+
+    def add_lora(self, lora_request: LoRARequest) -> None:
+        self.model_runner.add_lora(lora_request)
 
 
 def init_worker_distributed_environment(

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -1,0 +1,129 @@
+"""
+Define LoRA functionality mixin for model runners.
+"""
+
+from contextlib import contextmanager
+from typing import Set, Tuple
+
+import numpy as np
+import torch.nn as nn
+
+from vllm.config import LoRAConfig, ModelConfig, SchedulerConfig
+from vllm.logger import init_logger
+from vllm.lora.layers import LoRAMapping
+from vllm.lora.request import LoRARequest
+from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
+from vllm.model_executor.models import supports_lora, supports_multimodal
+from vllm.v1.worker.gpu_input_batch import InputBatch
+
+logger = init_logger(__name__)
+
+
+# Defined as a mixin for GPUModelRunner
+class LoRAModelRunnerMixin:
+
+    LORA_WARMUP_RANK = 8
+
+    def load_lora_model(self, model: nn.Module, model_config: ModelConfig,
+                        scheduler_config: SchedulerConfig,
+                        lora_config: LoRAConfig, device: str) -> nn.Module:
+
+        assert supports_lora(
+            model), f"{model.__class__.__name__} does not support LoRA yet."
+
+        if supports_multimodal(model):
+            logger.warning("Regarding multimodal models, vLLM currently "
+                           "only supports adding LoRA to language model.")
+
+        # It's necessary to distinguish between the max_position_embeddings
+        # of VLMs and LLMs.
+        if hasattr(model.config, "max_position_embeddings"):
+            max_pos_embeddings = model.config.max_position_embeddings
+        else:
+            max_pos_embeddings = (
+                model.config.text_config.max_position_embeddings)
+
+        # Add LoRA Manager to the Model Runner
+        self.lora_manager = LRUCacheWorkerLoRAManager(
+            scheduler_config.max_num_seqs,
+            scheduler_config.max_num_batched_tokens,
+            model_config.get_vocab_size(),
+            lora_config,
+            device,
+            model.embedding_modules,
+            model.embedding_padding_modules,
+            max_position_embeddings=max_pos_embeddings,
+        )
+        return self.lora_manager.create_lora_manager(model)
+
+    def _set_active_loras(self, prompt_lora_mapping: Tuple[int, ...],
+                          token_lora_mapping: Tuple[int, ...],
+                          lora_requests: Set[LoRARequest]) -> None:
+        if not self.lora_manager:
+            raise RuntimeError("LoRA is not enabled.")
+
+        # We dont make any distinction between prefills and decodes in the
+        # scheduler. To that effect, set is_prefill to True so we use the
+        # sgmv punica kernels always.
+        lora_mapping = LoRAMapping(token_lora_mapping,
+                                   prompt_lora_mapping,
+                                   is_prefill=True)
+        self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
+
+    def set_active_loras(self, input_batch: InputBatch,
+                         num_scheduled_tokens: np.ndarray) -> None:
+
+        prompt_lora_mapping: Tuple[int, ...]  # of size input_batch.num_reqs
+        token_lora_mapping: Tuple[int,
+                                  ...]  # of size np.sum(num_scheduled_tokens)
+        lora_requests: Set[LoRARequest]
+        prompt_lora_mapping, token_lora_mapping, lora_requests = \
+                            input_batch.make_lora_inputs(num_scheduled_tokens)
+        return self._set_active_loras(prompt_lora_mapping, token_lora_mapping,
+                                      lora_requests)
+
+    @contextmanager
+    def maybe_profile_with_lora(self, lora_config: LoRAConfig,
+                                num_scheduled_tokens: np.ndarray):
+        if lora_config is None:
+            yield
+        else:
+            # __enter__ code
+            assert self.lora_manager is not None, "LoRA is not enabled"
+
+            num_reqs = len(num_scheduled_tokens)
+            num_loras = lora_config.max_loras
+
+            # Make prompt lora mapping
+            # Assign LoRA IDs to requests arbitrarily
+            prompt_lora_mapping = np.random.randint(low=1,
+                                                    high=num_loras + 1,
+                                                    size=num_reqs,
+                                                    dtype=np.int32)
+            # Make token lora mapping
+            token_lora_mapping = np.repeat(prompt_lora_mapping,
+                                           num_scheduled_tokens)
+
+            # Make dummy lora requests
+            lora_requests: Set[LoRARequest] = {
+                LoRARequest(lora_name=f"warmup_{lora_id}",
+                            lora_int_id=lora_id,
+                            lora_path="/not/a/real/path")
+                for lora_id in range(1, num_loras + 1)
+            }
+
+            with self.lora_manager.dummy_lora_cache():
+                # Add the dummy LoRAs here so _set_active_loras doesn't try to
+                # load from disk.
+                for lr in lora_requests:
+                    self.lora_manager.add_dummy_lora(
+                        lr, rank=self.LORA_WARMUP_RANK)
+
+                self._set_active_loras(tuple(prompt_lora_mapping),
+                                       tuple(token_lora_mapping),
+                                       lora_requests)
+
+                yield
+
+            # __exit__ code
+            self.lora_manager.remove_all_adapters()


### PR DESCRIPTION
LoRA works end-to-end with this PR. However, this PR introduces a lot of changes that (some unnecessary) need to split up into smaller PRs. Putting up this PR as a reference for sub PRs.

Benchmarks: 
Machine - 1xA100

Command:

```
VLLM_USE_V1="1" python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000  --max-loras 4  --max-lora-rank 8 --enable-lora --lora-path "yard1/llama-2-7b-sql-lora-test" -O 3
```
Throughput: 10.96 requests/s, 5272.77 total tokens/s, 2577.68 output tokens/s


```
python3 benchmarks/benchmark_throughput.py --model  meta-llama/Llama-2-7b-hf --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 1000  --max-loras 4  --max-lora-rank 8 --enable-lora --lora-path "yard1/llama-2-7b-sql-lora-test" --num-scheduler-steps 8
```
Throughput: 9.60 requests/s, 4617.92 total tokens/s, 2257.54 output tokens/s


Plan for PR split:
 - Base PR (changes to gpu_model_runner.py, v1 scheduler, and prefix caching) - https://github.com/vllm-project/vllm/pull/10957
 - Changes to support torch.compile for LoRA - https://github.com/vllm-project/vllm/pull/14626
 - Add LoRA kernels for V1, Autotune LoRA kernels for V1 - https://github.com/vllm-project/vllm/pull/13096
 - Add and Test add_lora - https://github.com/vllm-project/vllm/pull/12883
 - Add and Test remove/pin LoRA functions - https://github.com/vllm-project/vllm/pull/13705
