### PR TITLE
[V1] Simpify vision block hash for prefix caching by removing offset from hash

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -470,8 +470,8 @@ def test_mm_prefix_caching():
     assert not computed_blocks
     assert len(req0.kv_block_hashes) == 3
     assert req0.kv_block_hashes[0].extra_keys == ("aaa", )
-    assert req0.kv_block_hashes[1].extra_keys == ("bbb", )
-    assert req0.kv_block_hashes[2].extra_keys == tuple()
+    assert req0.kv_block_hashes[1].extra_keys == ("aaa", "bbb")
+    assert req0.kv_block_hashes[2].extra_keys == ("bbb", )
 
     blocks = manager.allocate_slots(req0, 59, computed_blocks)
     assert [b.block_id for b in blocks] == [0, 1, 2, 3, 4]

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -469,9 +469,9 @@ def test_mm_prefix_caching():
     # Completed block should have hashes with extra keys.
     assert not computed_blocks
     assert len(req0.kv_block_hashes) == 3
-    assert req0.kv_block_hashes[0].extra_keys == (("aaa", 0), )
-    assert req0.kv_block_hashes[1].extra_keys == (("aaa", 5), ("bbb", 0))
-    assert req0.kv_block_hashes[2].extra_keys == (("bbb", 2), )
+    assert req0.kv_block_hashes[0].extra_keys == ("aaa", )
+    assert req0.kv_block_hashes[1].extra_keys == ("bbb", )
+    assert req0.kv_block_hashes[2].extra_keys == tuple()
 
     blocks = manager.allocate_slots(req0, 59, computed_blocks)
     assert [b.block_id for b in blocks] == [0, 1, 2, 3, 4]
@@ -485,7 +485,7 @@ def test_mm_prefix_caching():
 
     # The just completed block should have hashes with extra keys.
     assert len(req0.kv_block_hashes) == 4
-    assert req0.kv_block_hashes[3].extra_keys == (("ccc", 0), )
+    assert req0.kv_block_hashes[3].extra_keys == ("ccc", )
 
     # Cache hit.
     unique_token_ids = [-1] * 7 + [200] * 5

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -217,9 +217,10 @@ def generate_block_hash_extra_keys(
                 curr_mm_idx += 1
                 continue
 
-            # The block contains the current mm input.
-            mm_start = max(0, start_token_idx - offset)
-            extra_keys.append((mm_hashes[curr_mm_idx], mm_start))
+            if start_token_idx <= offset:
+                # This block contains the start of the current mm input.
+                extra_keys.append(mm_hashes[curr_mm_idx])
+
             if end_token_idx >= offset + length:
                 # If this block contains the end of the current mm input,
                 # move to the next mm input as this block may also contain

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -217,9 +217,8 @@ def generate_block_hash_extra_keys(
                 curr_mm_idx += 1
                 continue
 
-            if start_token_idx <= offset:
-                # This block contains the start of the current mm input.
-                extra_keys.append(mm_hashes[curr_mm_idx])
+            # The block contains the current mm input.
+            extra_keys.append(mm_hashes[curr_mm_idx])
 
             if end_token_idx >= offset + length:
                 # If this block contains the end of the current mm input,


### PR DESCRIPTION
Reuse the example in https://github.com/vllm-project/vllm/pull/11187

Taking a series of 3 blocks as an example: T0,T1,P00,P01 | P02,P03,P04,T2 | T3,P10,P11,P12, where Ti is i-th text token and Pxy is the y-th placeholder token of the x-th image, so this prompt has 2 images (P0 and P1). Assuming the image hash of P0 and P1 is aaa and bbb, respectively, and mm_positions=[(offset=2, length=5), (offset=9, length=3)], the hash of 3 blocks in https://github.com/vllm-project/vllm/pull/11187 is as follows
```
# (Parent hash,
#  token ID w. placeholders,
#  image hash, start)
hash0 = hash(None, T0,T1,P00,P01, (aaa,0))
hash1 = hash(hash0, P02,P03,P04,T2, (aaa,2))
hash2 = hash(hash1, T3,P10,P11,P12, (bbb,0))
```

But offset is redundant and the following hash format is enough:
```
# (Parent hash,
#  token ID w. placeholders,
#  image hash)
hash0 = hash(None, T0,T1,P00,P01, aaa)
hash1 = hash(hash0, P02,P03,P04,T2, aaa)
hash2 = hash(hash1, T3,P10,P11,P12, bbb)
```

Simple proof:
We need to distinguish the above example with the following cases:
1. The same image but different offset, e.g., T0,T1,T2,P00 | P01,P02,P03,P04 | T3,P10,P11,P12. The hash0 becomes hash(None, T0,T1, **T2,P00**, aaa), which is different
2. The same offset but different image, e.g.,  T0,T1,P20,P21 | P22,P23,P24,T2 | T3,P10,P11,P12. The hash0 becomes hash(None, T0,T1,P20,P21, **ccc**), which is different

This hash format has almost the same speed as previous one, but can avoid the confusion about why we need to add offset to the hash.

Benchmark result on H100 with the script in https://github.com/vllm-project/vllm/pull/11187: https://gist.github.com/comaniac/ea26df17fdffa533cf53d53b8455bc31 I ran 3 times for each commit
```
VLLM_USE_V1=1 VLLM_ENABLE_V1_MULTIPROCESSING=1 python3 mmmu_bench.py --model llava-hf/llava-v1.6-mistral-7b-hf --num-prompts 500  --image-hit-rate 0.3
Without this pr:
Throughput: 15.84 req/s
Throughput: 16.09 req/s
Throughput: 16.00 req/s

With this pr:
Throughput: 16.11 req/s
Throughput: 15.94 req/s
Throughput: 15.84 req/s
```

Note that the following format that only adds the image hash to the first block of this image is also correct, but is a little slower (15.50 reqs/s). The code is here https://github.com/vllm-project/vllm/commit/539e84c58f8ac08d8764573f402057e58ca6d7d2
```
# (Parent hash,
#  token ID w. placeholders,
#  image hash)
hash0 = hash(None, T0,T1,P00,P01, aaa)
hash1 = hash(hash0, P02,P03,P04,T2, )
hash2 = hash(hash1, T3,P10,P11,P12, bbb)
```