### PR TITLE
[CI/Build] Update OpenVINO Dockerfile to Ubuntu 24.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+/Dockerfile
+/Dockerfile.*

--- a/Dockerfile.openvino
+++ b/Dockerfile.openvino
@@ -1,7 +1,7 @@
 # The vLLM Dockerfile is used to construct vLLM image that can be directly used
 # to run the OpenAI compatible server.
 
-FROM ubuntu:22.04 AS dev
+FROM ubuntu:24.04 AS dev
 
 RUN apt-get update -y && \
     apt-get install -y \
@@ -15,14 +15,14 @@ RUN --mount=type=bind,source=.git,target=.git \
     if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh ; fi
 
 # install build requirements
-RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install -r /workspace/requirements-build.txt
+RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install --break-system-packages -r /workspace/requirements-build.txt
 # build vLLM with OpenVINO backend
-RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" VLLM_TARGET_DEVICE="openvino" python3 -m pip install /workspace
+RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" VLLM_TARGET_DEVICE="openvino" python3 -m pip install --break-system-packages /workspace
 
 COPY examples/ /workspace/examples
 COPY benchmarks/ /workspace/benchmarks
 
 # install development dependencies (for testing)
-RUN python3 -m pip install -e tests/vllm_test_utils
+RUN python3 -m pip install --break-system-packages -e tests/vllm_test_utils
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
I tried to build the OpenVINO Docker container last week and it failed. I updated to Ubuntu 24.04, and it works again
