### PR TITLE
[Bugfix] Check chain_speculative_sampling before calling it

### DIFF
--- a/vllm/model_executor/layers/rejection_sampler.py
+++ b/vllm/model_executor/layers/rejection_sampler.py
@@ -118,7 +118,7 @@ class RejectionSampler(SpecDecodeStochasticBaseSampler):
 
         # If use Flashinfer chain_speculative_sampling kernel
         # for rejection sampling
-        if self.use_flashinfer:
+        if self.use_flashinfer and chain_speculative_sampling is not None:
             batch_size, k, _ = draft_probs.shape
             uniform_samples = self._create_uniform_samples(
                 seeded_seqs, batch_size, k, draft_probs.device)


### PR DESCRIPTION
The error is reported by type checker, and it's legit.

Since we can have the chain_speculative_sampling as None meanwhile user still set use_flashinfer=True.