### PR TITLE
k8s-config: Update the secret to use stringData

### DIFF
--- a/docs/source/serving/deploying_with_k8s.md
+++ b/docs/source/serving/deploying_with_k8s.md
@@ -43,7 +43,7 @@ metadata:
   name: hf-token-secret
   namespace: default
 type: Opaque
-data:
+stringData:
   token: "REPLACE_WITH_TOKEN"
 ```
 


### PR DESCRIPTION
Right now the secret config documentation uses
`data` which expects the `value` (from the key
vaue pair) to be base64 encoded. Instead, we can
use `stringData` which expects the `value` to be
plain text. This way we don't need to make the
documentation overly complicated.
