### PR TITLE
[Bugfix] add input embedding

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -732,7 +732,6 @@ class FlashAttentionImpl(AttentionImpl):
         prefill_output = output[:num_prefill_query_tokens]
         assert query.shape[0] == num_prefill_query_tokens
         assert decode_query.shape[0] == num_decode_query_tokens
-
         if prefill_meta := attn_metadata.prefill_metadata:
             # Prompt run.
             if (kv_cache.numel() == 0 or prefill_meta.block_tables is None

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -486,6 +486,13 @@ class _AsyncLLMEngine(LLMEngine):
         if arrival_time is None:
             arrival_time = time.time()
 
+        if isinstance(prompt, dict) and prompt.get("prompt_embeds",
+                                                   None) is not None:
+            if not prompt.get("prompt_token_ids", None):
+                prompt["prompt_token_ids"] = [
+                    0
+                ] * prompt["prompt_embeds"].shape[0]
+
         if self.tokenizer is not None:
             tokenizer = await self.get_tokenizer_async(lora_request)
             self._validate_token_prompt(prompt, tokenizer=tokenizer)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -753,6 +753,11 @@ class LLMEngine:
         if arrival_time is None:
             arrival_time = time.time()
 
+        if isinstance(prompt, dict) and prompt.get("prompt_embeds",
+                                                   None) is not None:
+            if not prompt.get("prompt_token_ids", None):
+                prompt["prompt_token_ids"] = [0] * len(prompt["prompt_embeds"])
+
         if self.tokenizer is not None:
             self._validate_token_prompt(
                 prompt,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -753,10 +753,9 @@ class LLMEngine:
         if arrival_time is None:
             arrival_time = time.time()
 
-        if isinstance(prompt, dict) and prompt.get("prompt_embeds",
-                                                   None) is not None:
+        if isinstance(prompt, dict) and prompt.get("prompt_embeds", None) is not None:
             if not prompt.get("prompt_token_ids", None):
-                prompt["prompt_token_ids"] = [0] * len(prompt["prompt_embeds"])
+                prompt["prompt_token_ids"] = [0] * prompt["prompt_embeds"].shape[0]
 
         if self.tokenizer is not None:
             self._validate_token_prompt(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -10,7 +10,7 @@ import cloudpickle
 import torch.nn as nn
 from tqdm import tqdm
 from typing_extensions import TypeVar, deprecated
-
+import torch
 from vllm import envs
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence, get_beam_search_score)
@@ -286,6 +286,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -302,6 +304,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -318,6 +322,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -335,6 +341,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -352,6 +360,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -367,6 +377,8 @@ class LLM:
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        priority: Optional[list[int]] = None,
     ) -> list[RequestOutput]:
         ...
 
@@ -381,7 +393,7 @@ class LLM:
                        Optional[Union[str, list[str]]]] = None,
         sampling_params: Optional[Union[SamplingParams,
                                         Sequence[SamplingParams]]] = None,
-        prompt_token_ids: Optional[Union[List[int], List[List[int]]]] = None,
+        prompt_token_ids: Optional[Union[list[int], list[list[int]]]] = None,
         prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
@@ -405,10 +417,15 @@ class LLM:
                 When it is a single value, it is applied to every prompt.
                 When it is a list, the list must have the same length as the
                 prompts and it is paired one by one with the prompt.
+            prompt_token_ids: DEPRECATED. Token IDs for the prompts. If provided,
+                the `prompts` will be ignored.
+            prompt_embeds: Optional tensor of prompt embeddings to use instead of
+                text prompts.
             use_tqdm: Whether to use tqdm to display the progress bar.
             lora_request: LoRA request to use for generation, if any.
             prompt_adapter_request: Prompt Adapter request to use for
                 generation, if any.
+            guided_options_request: Options for guided decoding, if any.
             priority: The priority of the requests, if any.
                 Only applicable when priority scheduling policy is enabled.
 
@@ -442,13 +459,13 @@ class LLM:
             parsed_prompts = self._convert_v1_inputs(
                 prompts=cast(Optional[Union[str, list[str]]], prompts),
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=prompt_embeds,
             )
         else:
             parsed_prompts = cast(Union[PromptType, Sequence[PromptType]],
                                   prompts)
-
-        if prompt_embeds is not None:
-            parsed_prompts.prompt_embeds = prompt_embeds
+            if prompt_embeds is not None and hasattr(parsed_prompts, "prompt_embeds"):
+                parsed_prompts.prompt_embeds = prompt_embeds
 
         if isinstance(guided_options_request, dict):
             if len(guided_options_request) > 1:
@@ -1229,8 +1246,8 @@ class LLM:
     # LEGACY
     def _convert_v1_inputs(
         self,
-        prompts: Optional[Union[str, List[str]]],
-        prompt_token_ids: Optional[Union[List[int], List[List[int]]]],
+        prompts: Optional[Union[str, list[str]]],
+        prompt_token_ids: Optional[Union[list[int], list[list[int]]]],
         prompt_embeds: Optional[torch.Tensor] = None,
     ):
         # skip_tokenizer_init is now checked in engine
@@ -1268,6 +1285,13 @@ class LLM:
                 raise AssertionError
 
             parsed_prompts.append(item)
+
+        # Handle prompt_embeds if provided
+        if prompt_embeds is not None:
+            # Assuming prompt_embeds is a tensor that can be assigned to the first prompt
+            # This might need adjustment based on how prompt_embeds is actually used
+            if len(parsed_prompts) > 0 and hasattr(parsed_prompts[0], "prompt_embeds"):
+                parsed_prompts[0].prompt_embeds = prompt_embeds
 
         return parsed_prompts
 
@@ -1403,3 +1427,4 @@ class LLM:
         # This is necessary because some requests may be finished earlier than
         # its previous requests.
         return sorted(outputs, key=lambda x: int(x.request_id))
+

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -9,7 +9,12 @@ from typing import Any, Callable, ClassVar, Optional, Union, cast, overload
 import cloudpickle
 import torch.nn as nn
 from tqdm import tqdm
+<<<<<<< HEAD
 from typing_extensions import TypeVar, deprecated
+=======
+from typing_extensions import deprecated
+import torch
+>>>>>>> 0d69ec2f ((vllm) add input embedding)
 
 from vllm import envs
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
@@ -381,7 +386,12 @@ class LLM:
                        Optional[Union[str, list[str]]]] = None,
         sampling_params: Optional[Union[SamplingParams,
                                         Sequence[SamplingParams]]] = None,
+<<<<<<< HEAD
         prompt_token_ids: Optional[Union[list[int], list[list[int]]]] = None,
+=======
+        prompt_token_ids: Optional[Union[List[int], List[List[int]]]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+>>>>>>> 0d69ec2f ((vllm) add input embedding)
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -445,6 +455,9 @@ class LLM:
         else:
             parsed_prompts = cast(Union[PromptType, Sequence[PromptType]],
                                   prompts)
+
+        if prompt_embeds is not None:
+            parsed_prompts.prompt_embeds = prompt_embeds
 
         if isinstance(guided_options_request, dict):
             if len(guided_options_request) > 1:
@@ -1225,8 +1238,14 @@ class LLM:
     # LEGACY
     def _convert_v1_inputs(
         self,
+<<<<<<< HEAD
         prompts: Optional[Union[str, list[str]]],
         prompt_token_ids: Optional[Union[list[int], list[list[int]]]],
+=======
+        prompts: Optional[Union[str, List[str]]],
+        prompt_token_ids: Optional[Union[List[int], List[List[int]]]],
+        prompt_embeds: Optional[torch.Tensor] = None,
+>>>>>>> 0d69ec2f ((vllm) add input embedding)
     ):
         # skip_tokenizer_init is now checked in engine
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -9,12 +9,7 @@ from typing import Any, Callable, ClassVar, Optional, Union, cast, overload
 import cloudpickle
 import torch.nn as nn
 from tqdm import tqdm
-<<<<<<< HEAD
 from typing_extensions import TypeVar, deprecated
-=======
-from typing_extensions import deprecated
-import torch
->>>>>>> 0d69ec2f ((vllm) add input embedding)
 
 from vllm import envs
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
@@ -386,12 +381,8 @@ class LLM:
                        Optional[Union[str, list[str]]]] = None,
         sampling_params: Optional[Union[SamplingParams,
                                         Sequence[SamplingParams]]] = None,
-<<<<<<< HEAD
-        prompt_token_ids: Optional[Union[list[int], list[list[int]]]] = None,
-=======
         prompt_token_ids: Optional[Union[List[int], List[List[int]]]] = None,
         prompt_embeds: Optional[torch.Tensor] = None,
->>>>>>> 0d69ec2f ((vllm) add input embedding)
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -1238,14 +1229,9 @@ class LLM:
     # LEGACY
     def _convert_v1_inputs(
         self,
-<<<<<<< HEAD
-        prompts: Optional[Union[str, list[str]]],
-        prompt_token_ids: Optional[Union[list[int], list[list[int]]]],
-=======
         prompts: Optional[Union[str, List[str]]],
         prompt_token_ids: Optional[Union[List[int], List[List[int]]]],
         prompt_embeds: Optional[torch.Tensor] = None,
->>>>>>> 0d69ec2f ((vllm) add input embedding)
     ):
         # skip_tokenizer_init is now checked in engine
 

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -145,9 +145,6 @@ class TokenInputs(TypedDict):
     prompt_token_ids: List[int]
     """The token IDs of the prompt."""
 
-    prompt_embeds: NotRequired[torch.Tensor]
-    """The embeddings of the prompt, if available."""
-
     token_type_ids: NotRequired[List[int]]
     """The token type IDs of the prompt."""
 
@@ -155,6 +152,9 @@ class TokenInputs(TypedDict):
     """
     The original prompt text corresponding to the token IDs, if available.
     """
+
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
 
     multi_modal_data: NotRequired["MultiModalDataDict"]
     """

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -20,6 +20,9 @@ class TextPrompt(TypedDict):
     prompt: str
     """The input text to be tokenized before passing to the model."""
 
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
+
     multi_modal_data: NotRequired["MultiModalDataDict"]
     """
     Optional multi-modal data to pass to the model,
@@ -40,6 +43,9 @@ class TokensPrompt(TypedDict):
 
     prompt_token_ids: List[int]
     """A list of token IDs to pass to the model."""
+
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
 
     token_type_ids: NotRequired[List[int]]
     """A list of token type IDs to pass to the cross encoder model."""
@@ -139,6 +145,9 @@ class TokenInputs(TypedDict):
     prompt_token_ids: List[int]
     """The token IDs of the prompt."""
 
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
+
     token_type_ids: NotRequired[List[int]]
     """The token type IDs of the prompt."""
 
@@ -182,6 +191,7 @@ def token_inputs(
     prompt_token_ids: List[int],
     token_type_ids: Optional[List[int]] = None,
     prompt: Optional[str] = None,
+    prompt_embeds: Optional[torch.Tensor] = None,
     multi_modal_data: Optional["MultiModalDataDict"] = None,
     multi_modal_inputs: Optional["MultiModalKwargs"] = None,
     multi_modal_hashes: Optional[List[str]] = None,
@@ -195,6 +205,8 @@ def token_inputs(
         inputs["prompt"] = prompt
     if token_type_ids is not None:
         inputs["token_type_ids"] = token_type_ids
+    if prompt_embeds is not None:
+        inputs["prompt_embeds"] = prompt_embeds
     if multi_modal_data is not None:
         inputs["multi_modal_data"] = multi_modal_data
     if multi_modal_inputs is not None:
@@ -277,7 +289,7 @@ class SingletonInputsAdapter:
         inputs = self.inputs
 
         if inputs["type"] == "token" or inputs["type"] == "multimodal":
-            return None
+            return inputs.get("prompt_embeds")
 
         assert_never(inputs)  # type: ignore[arg-type]
 

--- a/vllm/inputs/parse.py
+++ b/vllm/inputs/parse.py
@@ -97,6 +97,9 @@ def parse_singleton_prompt(
         elif "prompt" in prompt:
             return ParsedTextPrompt(type="text", content=prompt)
 
+        elif "prompt_embeds" in prompt:
+            return ParsedTokensPrompt(type="tokens", content=prompt)
+
     raise TypeError("inputs must be a string, TextPrompt, or TokensPrompt")
 
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -360,6 +360,7 @@ class InputPreprocessor:
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=tokens_content.get('prompt_embeds'),
                 token_type_ids=token_type_ids,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
@@ -389,6 +390,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=text_content.get('prompt_embeds'),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )
@@ -434,6 +436,7 @@ class InputPreprocessor:
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=tokens_content.get('prompt_embeds'),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )
@@ -462,6 +465,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=text_content.get('prompt_embeds'),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -360,7 +360,7 @@ class InputPreprocessor:
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
-                prompt_embeds=tokens_content.get('prompt_embeds'),
+                prompt_embeds=tokens_content.get("prompt_embeds"),
                 token_type_ids=token_type_ids,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
@@ -390,7 +390,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
-                prompt_embeds=text_content.get('prompt_embeds'),
+                prompt_embeds=text_content.get("prompt_embeds"),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )
@@ -436,7 +436,7 @@ class InputPreprocessor:
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
-                prompt_embeds=tokens_content.get('prompt_embeds'),
+                prompt_embeds=tokens_content.get("prompt_embeds"),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )
@@ -465,7 +465,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
-                prompt_embeds=text_content.get('prompt_embeds'),
+                prompt_embeds=tokens_content.get("prompt_embeds"),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -460,14 +460,10 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         intermediate_tensors: Optional[IntermediateTensors] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
-<<<<<<< HEAD
-        hidden_states = self.model(input_ids, positions, intermediate_tensors,
-                                   inputs_embeds)
-=======
+
         hidden_states = self.model(input_ids, positions, kv_caches,
                                    attn_metadata, intermediate_tensors,
                                    inputs_embeds, self.lm_head.bias)
->>>>>>> 0d69ec2f ((vllm) add input embedding)
         return hidden_states
 
     def compute_logits(

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -437,6 +437,7 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
             else:
                 self.lm_head = ParallelLMHead(config.vocab_size,
                                               config.hidden_size,
+                                              True,
                                               quant_config=quant_config,
                                               prefix=maybe_prefix(
                                                   prefix, "lm_head"))
@@ -459,8 +460,14 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         intermediate_tensors: Optional[IntermediateTensors] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
+<<<<<<< HEAD
         hidden_states = self.model(input_ids, positions, intermediate_tensors,
                                    inputs_embeds)
+=======
+        hidden_states = self.model(input_ids, positions, kv_caches,
+                                   attn_metadata, intermediate_tensors,
+                                   inputs_embeds, self.lm_head.bias)
+>>>>>>> 0d69ec2f ((vllm) add input embedding)
         return hidden_states
 
     def compute_logits(

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -461,9 +461,7 @@ class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
 
-        hidden_states = self.model(input_ids, positions, kv_caches,
-                                   attn_metadata, intermediate_tensors,
-                                   inputs_embeds, self.lm_head.bias)
+        hidden_states = self.model(input_ids, positions,intermediate_tensors, inputs_embeds, self.lm_head.bias)
         return hidden_states
 
     def compute_logits(

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -158,6 +158,8 @@ class SequenceData(msgspec.Struct,
     _output_token_ids: array = msgspec.field(
         default_factory=lambda: array(VLLM_TOKEN_ID_ARRAY_TYPE, []))
 
+    _prompt_embeds: Optional[torch.Tensor] = None
+
     ### The below fields should not be passed as an argument ###
     _cumulative_logprob: float = 0.0
     _prompt_token_ids_tuple: tuple[int,
@@ -254,13 +256,21 @@ class SequenceData(msgspec.Struct,
     @property
     def output_token_ids(self) -> tuple[int, ...]:
         return tuple(self._output_token_ids)
-
+    
     @output_token_ids.setter
     def output_token_ids(self,
                          new_output_token_ids: GenericSequence[int]) -> None:
         self._output_token_ids = array(VLLM_TOKEN_ID_ARRAY_TYPE,
                                        new_output_token_ids)
         self._update_cached_all_tokens()
+
+    @property
+    def prompt_embeds(self) -> Optional[torch.Tensor]:
+        return self._prompt_embeds
+
+    @prompt_embeds.setter
+    def prompt_embeds(self, prompt_embeds: Optional[torch.Tensor]) -> None:
+        self._prompt_embeds = prompt_embeds
 
     @property
     def output_token_ids_array(self) -> array:
@@ -380,6 +390,7 @@ class SequenceData(msgspec.Struct,
         return (f"SequenceData("
                 f"prompt_token_ids={self._prompt_token_ids}, "
                 f"output_token_ids={self.output_token_ids}, "
+                f"prompt_embeds={getattr(self.prompt_embeds, 'shape', None)}, "
                 f"cumulative_logprob={self.cumulative_logprob}, "
                 f"get_num_computed_tokens={self.get_num_computed_tokens()})")
 
@@ -418,6 +429,7 @@ class Sequence:
         self.prompt_adapter_request = prompt_adapter_request
 
         self.data = SequenceData.from_seqs(self.prompt_token_ids)
+        self.data.prompt_embeds = self.inputs.prompt_embeds
         self.output_logprobs: SampleLogprobs = []
         self.output_text = ""
 

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -265,14 +265,6 @@ class SequenceData(msgspec.Struct,
         self._update_cached_all_tokens()
 
     @property
-    def prompt_embeds(self) -> Optional[torch.Tensor]:
-        return self._prompt_embeds
-
-    @prompt_embeds.setter
-    def prompt_embeds(self, prompt_embeds: Optional[torch.Tensor]) -> None:
-        self._prompt_embeds = prompt_embeds
-
-    @property
     def output_token_ids_array(self) -> array:
         """Return the prompt token ids in array type.
 
@@ -281,6 +273,14 @@ class SequenceData(msgspec.Struct,
         """
         assert isinstance(self._output_token_ids, array)
         return self._output_token_ids
+    
+    @property
+    def prompt_embeds(self) -> Optional[torch.Tensor]:
+        return self._prompt_embeds
+    
+    @prompt_embeds.setter
+    def prompt_embeds(self, prompt_embeds: torch.Tensor) -> None:
+        self._prompt_embeds = prompt_embeds
 
     @property
     def mrope_position_delta(self) -> Optional[int]:
@@ -389,8 +389,8 @@ class SequenceData(msgspec.Struct,
     def __repr__(self) -> str:
         return (f"SequenceData("
                 f"prompt_token_ids={self._prompt_token_ids}, "
+                f"prompt_embeds={getattr(self._prompt_embeds, 'shape', None)}, "
                 f"output_token_ids={self.output_token_ids}, "
-                f"prompt_embeds={getattr(self.prompt_embeds, 'shape', None)}, "
                 f"cumulative_logprob={self.cumulative_logprob}, "
                 f"get_num_computed_tokens={self.get_num_computed_tokens()})")
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -365,8 +365,9 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
             else:
                 self.input_tokens = input_tokens or []
-                self.inputs_embeds = (inputs_embeds
-                                      if inputs_embeds is not None else None)
+                self.inputs_embeds = (
+                    inputs_embeds if inputs_embeds is not None else None
+                )
                 self.input_positions = input_positions or []
                 self.token_types = token_types or []
                 self.mrope_input_positions = mrope_input_positions or None
@@ -544,12 +545,12 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         # Compute tokens.
         tokens = seq_data.get_token_ids()[context_len:seq_len]
-        if seq_data.prompt_embeds is not None and seq_data.get_output_len(
-        ) == 0:
-            prompt_embeds = seq_data.prompt_embeds[context_len:seq_len]
+        if seq_data.prompt_embeds is not None and seq_data.get_output_len() == 0:
+                prompt_embeds = seq_data.prompt_embeds[context_len:seq_len]
         else:
-            seq_data.prompt_embeds = None
+            seq_data.prompt_embeds = None  # release memory
             prompt_embeds = None
+
         token_types = seq_group_metadata.token_type_ids
 
         inter_data.seq_lens[seq_idx] = seq_len
@@ -870,9 +871,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
             for cur_token_types in inter_data.token_types:
                 token_types.extend(cur_token_types)
             if inter_data.inputs_embeds is not None:
-                inputs_embeds.append(
-                    inter_data.inputs_embeds.to(self.runner.device))
-
+                inputs_embeds.append(inter_data.inputs_embeds.to(self.runner.device))
         if len(inputs_embeds) == 0:
             inputs_embeds = None
         elif len(inputs_embeds) == 1:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -84,6 +84,7 @@ class ModelInputForGPU(ModelRunnerInputBase):
     additional fields.
     """
     input_tokens: Optional[torch.Tensor] = None
+    inputs_embeds: Optional[torch.Tensor] = None
     input_positions: Optional[torch.Tensor] = None
     token_types: Optional[torch.Tensor] = None
     seq_lens: Optional[List[int]] = None
@@ -104,6 +105,7 @@ class ModelInputForGPU(ModelRunnerInputBase):
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
+            "inputs_embeds": self.inputs_embeds,
             "input_positions": self.input_positions,
             "lora_requests": self.lora_requests,
             "lora_mapping": self.lora_mapping,
@@ -154,6 +156,7 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:
         tensor_dict = {
             "input_tokens": self.input_tokens,
+            "inputs_embeds": self.inputs_embeds,
             "input_positions": self.input_positions,
             "lora_requests": self.lora_requests,
             "lora_mapping": self.lora_mapping,
@@ -193,6 +196,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         def simple_reinit(self):
             self.input_tokens[0].clear()  # type: ignore
+            self.inputs_embeds = None  # type: ignore
             self.input_positions[0].clear()  # type: ignore
             self.token_types[0].clear()  # type: ignore
             self.mrope_input_positions = None  # type: ignore
@@ -220,6 +224,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
             # Input tokens and positions.
             input_tokens: Optional[List[List[int]]] = None,
+            inputs_embeds: Optional[torch.Tensor] = None,
             input_positions: Optional[List[List[int]]] = None,
             token_types: Optional[List[List[int]]] = None,
             mrope_input_positions: Optional[List[List[List[int]]]] = None,
@@ -280,6 +285,11 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                     else:
                         for seq_id in range(len(self.seq_ids)):
                             self.input_tokens[seq_id].clear()
+
+                    if inputs_embeds is not None:
+                        self.inputs_embeds = inputs_embeds
+                    else:
+                        self.inputs_embeds = None
 
                     if input_positions:
                         self.input_positions = input_positions
@@ -355,6 +365,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
             else:
                 self.input_tokens = input_tokens or []
+                self.inputs_embeds = (inputs_embeds
+                                      if inputs_embeds is not None else None)
                 self.input_positions = input_positions or []
                 self.token_types = token_types or []
                 self.mrope_input_positions = mrope_input_positions or None
@@ -399,6 +411,26 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
             self.lora_index_mapping = []
             self.lora_prompt_mapping = []
+
+        def __repr__(self) -> str:
+            return (
+                f"InterDataForSeqGroup("
+                f"request_id={self.request_id}, "
+                f"seq_ids={self.seq_ids}, "
+                f"is_prompt={self.is_prompt}, "
+                f"block_tables={self.block_tables}, "
+                f"computed_block_nums={self.computed_block_nums}, "
+                f"n_seqs={self.n_seqs}, "
+                f"input_tokens={self.input_tokens}, "
+                f"inputs_embeds={getattr(self.inputs_embeds, 'shape', None)}, "
+                f"input_positions={self.input_positions}, "
+                f"token_types={self.token_types}, "
+                f"mrope_input_positions={self.mrope_input_positions}, "
+                f"seq_lens={self.seq_lens}, "
+                f"orig_seq_lens={self.orig_seq_lens}, "
+                f"query_lens={self.query_lens}, "
+                f"context_lens={self.context_lens}, "
+                f"multi_modal_kwargs={self.multi_modal_kwargs}")
 
     def gen_inter_data_builder(self, num_seqs: int):
         return lambda: ModelInputForGPUBuilder.InterDataForSeqGroup(
@@ -512,12 +544,19 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         # Compute tokens.
         tokens = seq_data.get_token_ids()[context_len:seq_len]
+        if seq_data.prompt_embeds is not None and seq_data.get_output_len(
+        ) == 0:
+            prompt_embeds = seq_data.prompt_embeds[context_len:seq_len]
+        else:
+            seq_data.prompt_embeds = None
+            prompt_embeds = None
         token_types = seq_group_metadata.token_type_ids
 
         inter_data.seq_lens[seq_idx] = seq_len
         inter_data.orig_seq_lens[seq_idx] = seq_len
         inter_data.context_lens[seq_idx] = context_len
         inter_data.input_tokens[seq_idx].extend(tokens)
+        inter_data.inputs_embeds = prompt_embeds
         inter_data.input_positions[seq_idx].extend(range(context_len, seq_len))
         inter_data.token_types[seq_idx].extend(
             token_types if token_types else [])
@@ -823,12 +862,23 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         """
         # Combine and flatten intermediate data.
         input_tokens = []
+        inputs_embeds = []
         token_types = []
         for inter_data in self.inter_data_list:
             for cur_input_tokens in inter_data.input_tokens:
                 input_tokens.extend(cur_input_tokens)
             for cur_token_types in inter_data.token_types:
                 token_types.extend(cur_token_types)
+            if inter_data.inputs_embeds is not None:
+                inputs_embeds.append(
+                    inter_data.inputs_embeds.to(self.runner.device))
+
+        if len(inputs_embeds) == 0:
+            inputs_embeds = None
+        elif len(inputs_embeds) == 1:
+            inputs_embeds = inputs_embeds[0]
+        else:
+            inputs_embeds = torch.cat(inputs_embeds, dim=0)
 
         if not input_tokens:
             # This may happen when all prefill requests hit
@@ -980,6 +1030,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
 
         return self.model_input_cls(
             input_tokens=input_tokens_tensor,
+            inputs_embeds=inputs_embeds,
             input_positions=input_positions_tensor,
             token_types=token_types_tensor,
             attn_metadata=attn_metadata,
@@ -1741,6 +1792,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                                      self.vllm_config, virtual_engine):
                 hidden_or_intermediate_states = model_executable(
                     input_ids=model_input.input_tokens,
+                    **{
+                        "inputs_embeds": model_input.inputs_embeds,
+                    } if model_input.inputs_embeds is not None else {},
                     positions=model_input.input_positions,
                     intermediate_tensors=intermediate_tensors,
                     **MultiModalKwargs.as_kwargs(multi_modal_kwargs,
@@ -1855,6 +1909,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         # check if the current run is prefill
         is_prefill_run = prefill_meta is not None
 
+        if self.vllm_config.kv_transfer_config is None:
+            return False
+
         return self.vllm_config.kv_transfer_config.is_kv_consumer and (
             not is_profile_run) and is_prefill_run
 
@@ -1879,6 +1936,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         is_profile_run = (kv_caches[0].numel() == 0)
         # check if the current run is prefill
         is_prefill_run = prefill_meta is not None
+
+        if self.vllm_config.kv_transfer_config is None:
+            return False
 
         return self.vllm_config.kv_transfer_config.is_kv_producer and (
             not is_profile_run) and is_prefill_run


### PR DESCRIPTION
adds support for passing prompt_embeds to LLM.generate as
```python
llm.generate({"prompt_embeds": input_embeds}, sampling_params)
```
or
```python
llm.generate(
    [{"prompt_embeds": input_embeds} for input_embeds in inputs_embeds], sampling_params
)
```
this enables use cases when only the embedding layer is finetuned, and have the same model backend support multiple custom tuned embedding layers


FIX  https://github.com/vllm-project/vllm/issues/416
FIX https://github.com/vllm-project/vllm/issues/8323
FIX #14621
