### PR TITLE
[Frontend] Add split_special_tokens to the Tokenize Endpoint

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1251,8 +1251,14 @@ class TokenizeCompletionRequest(OpenAIBaseModel):
         default=True,
         description=(
             "If true (the default), special tokens (e.g. BOS) will be added to "
-            "the prompt."),
-    )
+            "the prompt."))
+    split_special_tokens: bool = Field(
+        default=False,
+        description=(
+            "If set to true, special tokens in the prompt will be split. "
+            "For example for Qwen2.5, |fim_prefix|> is a special token "
+            "and is by default tokenized to a single token [151661]. With "
+            "this flag set to true, it becomes [27,91,69,318,37151,91,29]"))
 
 
 class TokenizeChatRequest(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -159,12 +159,16 @@ class OpenAIServing:
         prompt: str,
         truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]],
         add_special_tokens: bool,
+        split_special_tokens: bool = False,
     ) -> TextTokensPrompt:
         if truncate_prompt_tokens is None:
-            encoded = tokenizer(prompt, add_special_tokens=add_special_tokens)
+            encoded = tokenizer(prompt,
+                                add_special_tokens=add_special_tokens,
+                                split_special_tokens=split_special_tokens)
         else:
             encoded = tokenizer(prompt,
                                 add_special_tokens=add_special_tokens,
+                                split_special_tokens=split_special_tokens,
                                 truncation=True,
                                 max_length=truncate_prompt_tokens)
 
@@ -298,6 +302,7 @@ class OpenAIServing:
         input_or_inputs: Union[str, List[str], List[int], List[List[int]]],
         truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None,
         add_special_tokens: bool = True,
+        split_special_tokens: bool = False,
     ) -> List[TextTokensPrompt]:
         """
         Tokenize/detokenize depending on the input format.
@@ -316,8 +321,9 @@ class OpenAIServing:
                 tokenizer,
                 prompt=prompt_input["content"],
                 truncate_prompt_tokens=truncate_prompt_tokens,
-                add_special_tokens=add_special_tokens)
-            if prompt_input["is_tokens"] is False else
+                add_special_tokens=add_special_tokens,
+                split_special_tokens=split_special_tokens,
+            ) if prompt_input["is_tokens"] is False else
             self._normalize_prompt_tokens_to_input(
                 request,
                 tokenizer,
@@ -333,6 +339,7 @@ class OpenAIServing:
         input_or_inputs: Union[str, List[str], List[int], List[List[int]]],
         truncate_prompt_tokens: Optional[Annotated[int, Field(ge=1)]] = None,
         add_special_tokens: bool = True,
+        split_special_tokens: bool = False,
     ) -> Tuple[List[TextTokensPrompt], List[TokensPrompt]]:
         request_prompts = await self._tokenize_prompt_input_or_inputs_async(
             request,
@@ -340,6 +347,7 @@ class OpenAIServing:
             input_or_inputs,
             truncate_prompt_tokens=truncate_prompt_tokens,
             add_special_tokens=add_special_tokens,
+            split_special_tokens=split_special_tokens,
         )
 
         engine_prompts = [

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -85,6 +85,7 @@ class OpenAIServingTokenization(OpenAIServing):
                      tokenizer,
                      request.prompt,
                      add_special_tokens=request.add_special_tokens,
+                     split_special_tokens=request.split_special_tokens,
                  )
         except ValueError as e:
             logger.exception("Error in preprocessing prompt inputs")

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -225,6 +225,7 @@ class MistralTokenizer:
         self,
         prompt: str,
         add_special_tokens: bool = False,
+        split_special_tokens: bool = False,
         truncation: bool = False,
         max_length: Optional[int] = None,
     ):


### PR DESCRIPTION
I would like to have more control over the tokenization to avoid prompt injections. Therefore, I added a split_special_tokens parameter to the `/tokenize` endpoint.

