### PR TITLE
[Kernel][Triton][AMD] Use block size heuristic for avg 2.8x speedup for int8 models

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
@@ -128,7 +128,8 @@ def triton_scaled_mm(input: torch.Tensor,
                      bias: Optional[torch.Tensor] = None,
                      block_size_m: int = 32,
                      block_size_n: int = 32,
-                     block_size_k: int = 32) -> torch.Tensor:
+                     block_size_k: int = 32,
+                     use_heuristic=True) -> torch.Tensor:
     M, K = input.shape
     N = weight.shape[1]
 
@@ -152,21 +153,19 @@ def triton_scaled_mm(input: torch.Tensor,
 
     has_scalar = lambda x: x.shape[0] == 1 and x.shape[1] == 1
 
-    is_small_N = N < 8192
-    next_power_of_2_M = max(32, triton.next_power_of_2(M))
-    if next_power_of_2_M <= 32:
-        if is_small_N:
-            shape = (64, 64, 256)
+    if use_heuristic:
+        is_small_N = N < 8192
+        next_power_of_2_M = max(32, triton.next_power_of_2(M))
+        if next_power_of_2_M <= 32:
+            tile_shape = (64, 64, 256) if is_small_N else (64, 128, 256)
+        elif next_power_of_2_M <= 64:
+            tile_shape = (64, 64, 256)
+        elif next_power_of_2_M <= 128:
+            tile_shape = (64, 128, 128)
         else:
-            shape = (64, 128, 256)
-    elif next_power_of_2_M <= 64:
-        shape = (64, 64, 256)
-    elif next_power_of_2_M <= 128:
-        shape = (64, 128, 128)
-    else:
-        shape = (128, 128, 128)
+            tile_shape = (128, 128, 128)
 
-    block_size_m, block_size_n, block_size_k = shape
+    block_size_m, block_size_n, block_size_k = tile_shape
 
     block_size_sa = 1 if has_scalar(scale_a) else block_size_m
     block_size_sb = 1 if has_scalar(scale_b) else block_size_n

--- a/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
@@ -126,9 +126,9 @@ def triton_scaled_mm(input: torch.Tensor,
                      scale_b: torch.Tensor,
                      out_dtype: Type[torch.dtype],
                      bias: Optional[torch.Tensor] = None,
-                     block_size_m: int = 32,
-                     block_size_n: int = 32,
-                     block_size_k: int = 32) -> torch.Tensor:
+                     block_size_m: int = 128,
+                     block_size_n: int = 128,
+                     block_size_k: int = 128) -> torch.Tensor:
     M, K = input.shape
     N = weight.shape[1]
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/triton_scaled_mm.py
@@ -126,9 +126,9 @@ def triton_scaled_mm(input: torch.Tensor,
                      scale_b: torch.Tensor,
                      out_dtype: Type[torch.dtype],
                      bias: Optional[torch.Tensor] = None,
-                     block_size_m: int = 128,
-                     block_size_n: int = 128,
-                     block_size_k: int = 128) -> torch.Tensor:
+                     block_size_m: int = 32,
+                     block_size_n: int = 32,
+                     block_size_k: int = 32) -> torch.Tensor:
     M, K = input.shape
     N = weight.shape[1]
 
@@ -151,6 +151,22 @@ def triton_scaled_mm(input: torch.Tensor,
     result = torch.empty((M, N), dtype=out_dtype, device=input.device)
 
     has_scalar = lambda x: x.shape[0] == 1 and x.shape[1] == 1
+
+    is_small_N = N < 8192
+    next_power_of_2_M = max(32, triton.next_power_of_2(M))
+    if next_power_of_2_M <= 32:
+        if is_small_N:
+            shape = (64, 64, 256)
+        else:
+            shape = (64, 128, 256)
+    elif next_power_of_2_M <= 64:
+        shape = (64, 64, 256)
+    elif next_power_of_2_M <= 128:
+        shape = (64, 128, 128)
+    else:
+        shape = (128, 128, 128)
+
+    block_size_m, block_size_n, block_size_k = shape
 
     block_size_sa = 1 if has_scalar(scale_a) else block_size_m
     block_size_sb = 1 if has_scalar(scale_b) else block_size_n


### PR DESCRIPTION
Use the heuristic from scaled_mm_c3x_sm90_int8_dispatch.cuh:116 to choose block-size for triton_scaled_mm instead of always using 32x32x32 for better performance.  This results in average 2.8x speedup.

I ran: 
python benchmarks/benchmark_latency.py --dtype bfloat16 --enable-chunked-prefill False --load-format dummy --batch-size BS --num-iters-warmup 2 --num-iters 5 --input-len INPUT_LEN --output-len OUTPUT_LEN --model MODEL

where
```python
BS in [1, 16, 64]
INPUT_LEN in [128, 1024, 2048]
OUTPUT_LEN in [1, 128, 1024]
MODEL in ["Qwen2-7B-Instruct-quantized.w8a8", "Phi-3-medium-128k-instruct-quantized.w8a8", 
                  "Meta-Llama-3.1-8B-Instruct-quantized.w8a8", "Mistral-7B-Instruct-v0.3-quantized.w8a8"]
```
to get this number.

Here are a few samples for Qwen2-7B-Instruct-quantized.w8a8 with dtype = bfloat16

| batch_size | input_len | output_len | avg_latency_old | avg_latency_new | speedup |
|------------|-----------|------------|-----------------|-----------------|---------|
| 1          | 128       | 128        | 1.4206          | 0.9828          | 1.4453  |
| 1          | 1024      | 1024       | 11.4586         | 7.8414          | 1.4612  |
| 64         | 2048      | 128        | 14.2707         | 4.7842          | 2.9828  |

I uploaded the full CSV file for all of the models and configs.

[heuristic_speedups.csv](https://github.com/user-attachments/files/18339277/heuristic_speedups.csv)
