### PR TITLE
PD Disagg Performance enhance & benchmark tool update

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -52,6 +52,9 @@ try:
     from vllm.utils import FlexibleArgumentParser
 except ImportError:
     from argparse import ArgumentParser as FlexibleArgumentParser
+import asyncio
+import pynvml
+import time
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
 
@@ -125,6 +128,68 @@ def sample_sharegpt_requests(
             # Prune too long sequences.
             continue
         filtered_dataset.append((prompt, prompt_len, output_len, None))
+
+    return filtered_dataset
+
+
+def sample_booksum_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: PreTrainedTokenizerBase,
+    fix_prompt_len: int = 100,
+    fixed_output_len: int = 1,
+) -> List[Tuple[str, int, int, None]]:
+
+    import csv
+    import sys  # To access sys.maxsize if needed
+
+    # Set the maximum field size limit to a reasonable value
+    MAX_FIELD_SIZE_LIMIT = 2_000_000  # Adjust this value as needed
+    csv.field_size_limit(MAX_FIELD_SIZE_LIMIT)
+
+    column_name = "chapter"
+
+    filtered_dataset: List[Tuple[str, int, int]] = []
+
+    with open(
+            dataset_path, newline=''
+    ) as csvfile:  #, open("/tmp/prompt_15k_to_50k.csv", 'w', newline='') as outfile:
+        csvreader = csv.DictReader(csvfile)
+        # fieldnames = csvreader.fieldnames
+        # writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        # writer.writeheader()
+
+        for row in csvreader:
+            if len(filtered_dataset) == num_requests:
+                break
+            prompt = row[column_name]
+            prompt_size = len(prompt.encode('utf-8'))
+            if prompt_size > MAX_FIELD_SIZE_LIMIT:
+                print(
+                    f"Skipping entry: field size {prompt_size} exceeds limit.")
+                continue
+
+            prompt_token_ids = tokenizer(prompt).input_ids
+
+            prompt_len = len(prompt_token_ids)
+
+            # if 15000 <= prompt_len <= 50000:
+            #     writer.writerow(row)
+
+            if prompt_len < fix_prompt_len:
+                continue
+
+            if prompt_len / fix_prompt_len > 1.1:
+                continue
+
+            filtered_dataset.append(
+                (prompt, prompt_len, fixed_output_len, None))
+
+    if len(filtered_dataset) < num_requests:
+        raise ValueError(
+            f"Only {len(filtered_dataset)} qualified entries found in the dataset. "
+            "Please consider decreasing the number of requests or using a different dataset."
+        )
 
     return filtered_dataset
 
@@ -545,6 +610,7 @@ async def benchmark(
         raise ValueError(f"Unknown backend: {backend}")
 
     print("Starting initial single prompt test run...")
+
     test_prompt, test_prompt_len, test_output_len, test_mm_content = (
         input_requests[0])
     if backend != "openai-chat" and test_mm_content is not None:
@@ -629,6 +695,23 @@ async def benchmark(
                 limited_request_func(request_func_input=request_func_input,
                                      pbar=pbar)))
     outputs: List[RequestFuncOutput] = await asyncio.gather(*tasks)
+
+    # outputs = []
+    # async for request in get_request(input_requests, request_rate):
+    #     prompt, prompt_len, output_len, mm_content = request
+    #     request_func_input = RequestFuncInput(
+    #         model=model_id,
+    #         prompt=prompt,
+    #         api_url=api_url,
+    #         prompt_len=prompt_len,
+    #         output_len=output_len,
+    #         logprobs=logprobs,
+    #         best_of=best_of,
+    #         multi_modal_content=mm_content,
+    #     )
+    #     # Await the request_func call directly to ensure each request completes before the next
+    #     output = await request_func(request_func_input=request_func_input, pbar=pbar)
+    #     outputs.append(output)  # Collect each result one by one
 
     if profile:
         print("Stopping profiler...")
@@ -773,6 +856,42 @@ def parse_goodput(slo_pairs):
     return gootput_config_dict
 
 
+async def collect_gpu_utilization(data_dict, stop_event, interval=1):
+    # Initialize NVML
+    pynvml.nvmlInit()
+    try:
+        # Parse CUDA_VISIBLE_DEVICES
+        visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
+        if visible_devices is None:
+            visible_indices = range(pynvml.nvmlDeviceGetCount(
+            ))  # Use all GPUs if the variable is not set
+        else:
+            visible_indices = [
+                int(index) for index in visible_devices.split(",")
+                if index.isdigit()
+            ]
+
+        # Initialize dictionary keys for each GPU
+        for i in visible_indices:
+            data_dict[f"GPU-{i} utilization"] = []
+
+        while not stop_event.is_set():
+            timestamp = time.time()
+            for i in visible_indices:
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                    util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+
+                    # Append gpu_utilization to the list for the respective GPU
+                    data_dict[f"GPU-{i} utilization"].append(util.gpu)
+                except pynvml.NVMLError as e:
+                    print(f"Failed to get data for GPU {i}: {e}")
+            await asyncio.sleep(interval)
+    finally:
+        # Shutdown NVML when done
+        pynvml.nvmlShutdown()
+
+
 def main(args: argparse.Namespace):
     print(args)
     random.seed(args.seed)
@@ -813,6 +932,15 @@ def main(args: argparse.Namespace):
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
             fixed_output_len=args.sharegpt_output_len,
+        )
+
+    elif args.dataset_name == "booksum":
+        input_requests = sample_booksum_requests(
+            dataset_path=args.dataset_path,
+            num_requests=args.num_prompts,
+            tokenizer=tokenizer,
+            fix_prompt_len=args.booksum_fix_prompt_len,
+            fixed_output_len=args.booksum_output_len,
         )
 
     elif args.dataset_name == "sonnet":
@@ -871,28 +999,77 @@ def main(args: argparse.Namespace):
 
     gootput_config_dict = check_goodput_args(args)
 
-    benchmark_result = asyncio.run(
-        benchmark(
-            backend=backend,
-            api_url=api_url,
-            base_url=base_url,
-            model_id=model_id,
-            tokenizer=tokenizer,
-            input_requests=input_requests,
-            logprobs=args.logprobs,
-            best_of=args.best_of,
-            request_rate=args.request_rate,
-            burstiness=args.burstiness,
-            disable_tqdm=args.disable_tqdm,
-            profile=args.profile,
-            selected_percentile_metrics=args.percentile_metrics.split(","),
-            selected_percentiles=[
-                float(p) for p in args.metric_percentiles.split(",")
-            ],
-            ignore_eos=args.ignore_eos,
-            gootput_config_dict=gootput_config_dict,
-            max_concurrency=args.max_concurrency,
-        ))
+    # benchmark_result = asyncio.run(
+    #     benchmark(
+    #         backend=backend,
+    #         api_url=api_url,
+    #         base_url=base_url,
+    #         model_id=model_id,
+    #         tokenizer=tokenizer,
+    #         input_requests=input_requests,
+    #         logprobs=args.logprobs,
+    #         best_of=args.best_of,
+    #         request_rate=args.request_rate,
+    #         burstiness=args.burstiness,
+    #         disable_tqdm=args.disable_tqdm,
+    #         profile=args.profile,
+    #         selected_percentile_metrics=args.percentile_metrics.split(","),
+    #         selected_percentiles=[
+    #             float(p) for p in args.metric_percentiles.split(",")
+    #         ],
+    #         ignore_eos=args.ignore_eos,
+    #         gootput_config_dict=gootput_config_dict,
+    #         max_concurrency=args.max_concurrency,
+    #     ))
+    async def run_benchmark_and_collect_gpu():
+        # Initialize the list to hold GPU utilization data
+        gpu_utilization_data = {}
+
+        # Create an asyncio Event for stopping the GPU collection task
+        stop_event = asyncio.Event()
+
+        # Start the GPU utilization collection task
+        gpu_task = asyncio.create_task(
+            collect_gpu_utilization(gpu_utilization_data, stop_event,
+                                    args.gpu_metric_interval))
+
+        try:
+            # Run the benchmark
+            benchmark_result = await benchmark(
+                backend=backend,
+                api_url=api_url,
+                base_url=base_url,
+                model_id=model_id,
+                tokenizer=tokenizer,
+                input_requests=input_requests,
+                logprobs=args.logprobs,
+                best_of=args.best_of,
+                request_rate=args.request_rate,
+                burstiness=args.burstiness,
+                disable_tqdm=args.disable_tqdm,
+                profile=args.profile,
+                selected_percentile_metrics=args.percentile_metrics.split(","),
+                selected_percentiles=[
+                    float(p) for p in args.metric_percentiles.split(",")
+                ],
+                ignore_eos=args.ignore_eos,
+                gootput_config_dict=gootput_config_dict,
+                max_concurrency=args.max_concurrency,
+            )
+        finally:
+            # Stop the GPU collection task
+            stop_event.set()
+            await gpu_task
+
+        # Now, gpu_utilization_data contains the collected data
+        # You can process or save it as needed
+        # For example:
+        print("Collected GPU Utilization Data:")
+        for gpu, data in gpu_utilization_data.items():
+            print(f"{gpu}: {data}")
+
+    # Run the asynchronous function
+    asyncio.run(run_benchmark_and_collect_gpu())
 
     # Save config and results to json
     if args.save_result:
@@ -974,7 +1151,7 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "sonnet", "random", "hf"],
+        choices=["sharegpt", "sonnet", "random", "hf", "booksum"],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument("--dataset-path",
@@ -1131,6 +1308,25 @@ if __name__ == "__main__":
         "\"ttft\", \"tpot\", \"e2el\". For more context on the definition of "
         "goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 "
         "and the blog: https://hao-ai-lab.github.io/blogs/distserve")
+
+    parser.add_argument(
+        "--gpu-metric-interval",
+        type=float,
+        default=1,
+        help="Interval in seconds to collect GPU utilization data.",
+    )
+
+    booksum_group = parser.add_argument_group("booksum dataset options")
+    booksum_group.add_argument(
+        "--booksum-fix-prompt-len",
+        type=int,
+        default=100,
+        help="Number of prompt tokens.",
+    )
+    booksum_group.add_argument("--booksum-output-len",
+                               type=int,
+                               default=None,
+                               help="Output length for each request..")
 
     # group for dataset specific arguments
     sonnet_group = parser.add_argument_group("sonnet dataset options")

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -124,6 +124,8 @@ class AttentionMetadata:
     multi_modal_placeholder_index_maps: Optional[Dict[
         str, MultiModalPlaceholderMap.IndexMap]]
 
+    token_hashes: List[str]
+
     @property
     @abstractmethod
     def prefill_metadata(self) -> Optional["AttentionMetadata"]:

--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -276,6 +276,7 @@ class CommonMetadataBuilder(AttentionMetadataBuilder[TAttentionMetadata]):
             context_lens_tensor=context_lens_tensor,
             block_tables=block_tables,
             use_cuda_graph=use_captured_graph,
+            token_hashes=[],
         )
 
 

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -229,7 +229,8 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
             max_encoder_seq_len=self.max_encoder_seq_len,
             cross_slot_mapping=self.cross_slot_mapping,
-            cross_block_tables=self.cross_block_tables)
+            cross_block_tables=self.cross_block_tables,
+            token_hashes=self.token_hashes)
         return self._cached_prefill_metadata
 
     @property
@@ -269,7 +270,9 @@ class XFormersMetadata(AttentionMetadata, PagedAttentionMetadata):
             encoder_seq_lens_tensor=self.encoder_seq_lens_tensor,
             max_encoder_seq_len=self.max_encoder_seq_len,
             cross_slot_mapping=self.cross_slot_mapping,
-            cross_block_tables=self.cross_block_tables)
+            cross_block_tables=self.cross_block_tables,
+            token_hashes=[],
+        )
 
         # Batch may be composed of prefill|decodes, adjust query start indices
         # to refer to the start of decodes when the two are split apart.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -907,6 +907,8 @@ class CacheConfig:
         self.num_gpu_blocks: Optional[int] = None
         self.num_cpu_blocks: Optional[int] = None
 
+        self.kv_cache_transporter = None
+
     def metrics_info(self):
         # convert cache_config to dict(key: str, value: str) for prometheus
         # metrics info

--- a/vllm/distributed/kv_transfer/base.py
+++ b/vllm/distributed/kv_transfer/base.py
@@ -14,16 +14,16 @@ class KVCacheTransporterBase(ABC):
 
     @abstractmethod
     def read_kv_cache(self, prompt_token_page_hashes: List[str],
-                      prompt_seq_lengths: List[int],
-                      offsets: List[Tuple[int, int]], layer_idx: int,
-                      kv_cache: torch.Tensor) -> None:
+                      prompt_seq_lengths: List[int], offsets: List[Tuple[int,
+                                                                         int]],
+                      layer_idx: int, kv_cache: torch.Tensor) -> None:
 
         raise NotImplementedError
 
     @abstractmethod
     def save_hidden_states(self, prompt_token_page_hashes: List[str],
                            prompt_seq_lengths: List[int],
-                           hidden_states: torch.Tensor) ->None:
+                           hidden_states: torch.Tensor) -> None:
 
         raise NotImplementedError
 
@@ -33,13 +33,14 @@ class KVCacheTransporterBase(ABC):
                            hidden_states: torch.Tensor):
 
         raise NotImplementedError
-    
+
     def get_hidden_states_cache_key(self, page_hash: str) -> str:
         raise NotImplementedError
-    
-    def get_kv_cache_key(self, page_hash: str, layer_idx: int) -> Tuple[str, str]:
+
+    def get_kv_cache_key(self, page_hash: str,
+                         layer_idx: int) -> Tuple[str, str]:
         raise NotImplementedError
-    
+
     @abstractmethod
     def key_exists(self, key: str) -> bool:
         raise NotImplementedError
@@ -52,7 +53,13 @@ class KVCacheTransporterBase(ABC):
     def synchronize(self):
 
         raise NotImplementedError
-    
+
     @abstractmethod
-    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str], seq_lens: List[int], layer_idx: int) -> None:
+    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str],
+                                      seq_lens: List[int],
+                                      layer_idx: int) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def check_kv_cache_ready(self, hash: str) -> bool:
         raise NotImplementedError

--- a/vllm/distributed/kv_transfer/base.py
+++ b/vllm/distributed/kv_transfer/base.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+import torch
+from typing import List, Tuple
+
+
+class KVCacheTransporterBase(ABC):
+
+    @abstractmethod
+    def save_kv_cache(self, prompt_token_page_hashes: List[str],
+                      offsets: List[Tuple[int, int]], layer_idx: int,
+                      kv_cache: torch.Tensor) -> None:
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_kv_cache(self, prompt_token_page_hashes: List[str],
+                      prompt_seq_lengths: List[int],
+                      offsets: List[Tuple[int, int]], layer_idx: int,
+                      kv_cache: torch.Tensor) -> None:
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def save_hidden_states(self, prompt_token_page_hashes: List[str],
+                           prompt_seq_lengths: List[int],
+                           hidden_states: torch.Tensor) ->None:
+
+        raise NotImplementedError
+
+    @abstractmethod
+    def read_hidden_states(self, prompt_token_page_hashes: List[str],
+                           prompt_seq_lengths: List[int],
+                           hidden_states: torch.Tensor):
+
+        raise NotImplementedError
+    
+    def get_hidden_states_cache_key(self, page_hash: str) -> str:
+        raise NotImplementedError
+    
+    def get_kv_cache_key(self, page_hash: str, layer_idx: int) -> Tuple[str, str]:
+        raise NotImplementedError
+    
+    @abstractmethod
+    def key_exists(self, key: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_match_last_index(self, keys: List[str]) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def synchronize(self):
+
+        raise NotImplementedError
+    
+    @abstractmethod
+    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str], seq_lens: List[int], layer_idx: int) -> None:
+        raise NotImplementedError

--- a/vllm/distributed/kv_transfer/infinite.py
+++ b/vllm/distributed/kv_transfer/infinite.py
@@ -1,0 +1,252 @@
+import math
+import logging
+from typing import Dict, List, Tuple
+import torch
+import os
+import time
+import infinistore
+
+from vllm.distributed.kv_transfer.base import KVCacheTransporterBase
+from vllm.distributed import (get_tensor_model_parallel_rank,
+                              get_tensor_model_parallel_world_size)
+
+
+logger = logging.getLogger(__name__)
+
+Default_Infinite_Server = "127.0.0.1"
+interval = 0.01
+count = 0
+shared_signal_folder = "/tmp/infinistore"
+
+class InfiniStoreKVCacheTransporter(KVCacheTransporterBase):
+    #Class-level singleton connection instance
+    _singleton_conn = None
+    _singleton_rdma_conn = None
+
+    def __init__(self, model: str, kv_cache_list: List[torch.Tensor], tokens_per_page: int =16) -> None:
+        if not model:
+            raise ValueError("model cannot be empty.")
+        if tokens_per_page <= 0:
+            raise ValueError("tokens_per_page must be greater than 0.")
+
+        # escape the slash in the model name
+        self.model = model.replace("/", "_")
+        self.kv_cache_list = kv_cache_list
+        self.tokens_per_page = tokens_per_page
+        self.page_size = kv_cache_list[0][0][0].numel() 
+        self.k_or_v_total_size = kv_cache_list[0][0].numel()
+
+        # TODO: when server is local, use connection_type=infinistore.TYPE_LOCAL_GPU,
+        # otherwise RDMA
+        # TODO: grab the config values dynamically instead of hardcoding
+        infinite_server = os.environ.get("INFINITE_STORE_SERVER",
+                                         Default_Infinite_Server)
+        infinite_server = infinite_server.strip('"')
+        if InfiniStoreKVCacheTransporter._singleton_conn is None:
+            infinte_config = infinistore.ClientConfig(
+                host_addr=infinite_server,
+                service_port=22345,
+                log_level="info",
+                connection_type=infinistore.TYPE_LOCAL_GPU,
+                ib_port=1,
+                link_type="Ethernet",
+                dev_name="mlx5_0",
+            )
+            InfiniStoreKVCacheTransporter._singleton_conn = infinistore.InfinityConnection(
+                infinte_config)
+            logger.info("Connecting to infinite store server: %s",
+                        infinite_server)
+
+            InfiniStoreKVCacheTransporter._singleton_conn.connect()
+
+        # Assign the singleton connection to the instance attribute
+        self.conn = InfiniStoreKVCacheTransporter._singleton_conn
+
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+
+        self.hs_key_initial = f"hs_{self.model}_tp_{self.tp_rank}_{self.tp_size}_"
+        self.kv_key_initial = f"{self.model}_tp_{self.tp_rank}_{self.tp_size}_"
+
+
+    def get_hidden_states_cache_key(self, page_hash: str) -> str:
+        return self.hs_key_initial + page_hash
+  
+    def get_kv_cache_key(self, page_hash: str, layer_idx: int) -> Tuple[str, str]:
+        k_cache_key = self.kv_key_initial + f"{layer_idx}_{page_hash}_k"
+        v_cache_key = self.kv_key_initial + f"{layer_idx}_{page_hash}_v"
+        return k_cache_key, v_cache_key
+
+    def _compute_kv_cache_block_offsets(
+            self, prompt_token_page_hashes: List[str], offsets: List[Tuple[int, int]],
+            layer_idx: int) -> List[Tuple[str, int]]:
+        
+        block_offsets: List[Tuple[str, int]] = []
+
+        for current_hash, offset in zip(prompt_token_page_hashes, offsets):
+            k_cache_key, v_cache_key = self.get_kv_cache_key(current_hash, layer_idx)
+            block_offsets.append((k_cache_key, offset[0]))
+            block_offsets.append((v_cache_key, offset[1]))
+
+        return block_offsets
+
+    def _compute_hidden_states_block_offsets(
+            self, prompt_token_page_hashes: List[str], seq_lens: List[int],
+            hidden_states: torch.Tensor) -> Dict[int, List[Tuple[str, int]]]:
+
+        block_offsets: Dict[int, List[Tuple[str, int]]] = {}
+        hidden_size = hidden_states.size(-1)
+
+        seq_start_index = 0
+        page_start_index = 0
+        for seq_length in seq_lens:
+            num_pages = math.ceil(seq_length / self.tokens_per_page)
+
+            for page_num in range(num_pages):
+                start_token_idx = page_num * self.tokens_per_page
+                end_token_idx = min((page_num + 1) * self.tokens_per_page,
+                                    seq_length)
+                current_hash = prompt_token_page_hashes[page_start_index +
+                                                        page_num]
+
+                cache_key = self.get_hidden_states_cache_key(current_hash)
+
+                cache_size = hidden_size * (end_token_idx - start_token_idx)
+                offset = (seq_start_index + start_token_idx) * hidden_size
+
+                if cache_size not in block_offsets:
+                    block_offsets[cache_size] = []
+                block_offsets[cache_size].append((cache_key, offset))
+
+            seq_start_index += seq_length
+            page_start_index += num_pages
+
+        return block_offsets
+    
+    def _publish_write_completion(self, key: str) -> None:
+        open(os.path.join(shared_signal_folder, key), mode="w").close()
+
+    def publish_kv_cache_prefill_done(self, input_token_hashes: List[str], seq_lens: List[int], layer_idx: int) -> None:
+
+        covered_pages = 0
+        for seq_len in seq_lens:
+            covered_pages += math.ceil(seq_len / self.tokens_per_page)
+            current_hash = input_token_hashes[covered_pages-1]
+            _, v_cache_key = self.get_kv_cache_key(
+                    current_hash, layer_idx)
+            
+            # only need to publish V cache key, as V cache is always written after K cache
+            self._publish_write_completion(v_cache_key)
+
+    def verify_kv_cache_prefill_done(self, input_token_hashes: List[str], seq_lens: List[int], layer_idx: int) :
+        covered_pages = 0
+        for seq_len in seq_lens:
+            covered_pages += math.ceil(seq_len / self.tokens_per_page)
+            current_hash = input_token_hashes[covered_pages-1]
+            _, v_cache_key = self.get_kv_cache_key(
+                    current_hash, layer_idx)
+            if os.path.exists(os.path.join(shared_signal_folder, v_cache_key)):
+                continue
+            
+            wt = 0
+            while not os.path.exists(os.path.join(shared_signal_folder, v_cache_key)):
+                time.sleep(interval)
+                wt += 1
+                if wt % 100 == 0:
+                    logger.warning(f"Wait for kv cache key {v_cache_key} for {wt} times")
+
+    def save_kv_cache(self, prompt_token_page_hashes: List[str],
+                      offsets: List[Tuple[int, int]], layer_idx: int,
+                      kv_cache: torch.Tensor) -> None:
+
+        block_offsets = self._compute_kv_cache_block_offsets(
+            prompt_token_page_hashes, offsets, layer_idx)
+        
+        try:            
+            if self.conn.rdma_connected:
+                self.conn.rdma_write_cache(kv_cache, block_offsets, self.page_size)
+            else:
+                self.conn.local_gpu_write_cache(kv_cache, block_offsets, self.page_size)
+
+        except Exception as e:
+            logger.error("Failed to write kv_cache: %s", e)
+            raise
+
+        logger.debug("Saved kv_cache for layer %s", layer_idx)
+
+    def read_kv_cache(self, prompt_token_page_hashes: List[str],
+                      prompt_seq_lengths: List[int],
+                      offsets: List[Tuple[int, int]], layer_idx: int,
+                      kv_cache: torch.Tensor) -> None:
+        
+        self.verify_kv_cache_prefill_done(prompt_token_page_hashes, prompt_seq_lengths, layer_idx)
+
+        block_offsets = self._compute_kv_cache_block_offsets(
+            prompt_token_page_hashes, offsets, layer_idx)
+
+        try:
+            self.conn.read_cache(kv_cache, block_offsets, self.page_size)
+        except Exception as e:
+            logger.error("Failed to read kv_cache: %s", e)
+
+        logger.debug("Loaded kv_cache for layer %s", layer_idx)
+
+    def save_hidden_states(self, prompt_token_page_hashes: List[str],
+                           prompt_seq_lengths: List[int],
+                           hidden_states: torch.Tensor) -> None:
+
+        if self.conn.rdma_connected:
+            self.conn.register_mr(hidden_states)
+        block_offsets = self._compute_hidden_states_block_offsets(
+            prompt_token_page_hashes, prompt_seq_lengths, hidden_states)
+
+        try:
+            for cache_size, offsets in block_offsets.items():
+                if self.conn.rdma_connected:
+                    self.conn.rdma_write_cache(hidden_states, offsets, cache_size)
+                else:
+                    self.conn.local_gpu_write_cache(hidden_states, offsets, cache_size)
+        except Exception as e:
+            logger.error("Failed to read hidden_states: %s", e)
+            raise
+
+        logger.debug("Saved hidden_states")
+
+    def read_hidden_states(self, prompt_token_page_hashes: List[str],
+                           prompt_seq_lengths: List[int],
+                           hidden_states: torch.Tensor) -> None:
+
+        hs_cache_key = self.get_hidden_states_cache_key(prompt_token_page_hashes[-1])
+        wt = 0
+        while not self.conn.check_exist(hs_cache_key):
+            time.sleep(interval)
+            wt += 1
+            if wt % 100 == 0:
+                logger.warning(f"Wait for hidden states cache key {hs_cache_key} for {wt} times")
+
+        if self.conn.rdma_connected:
+            self.conn.register_mr(hidden_states)
+        block_offsets = self._compute_hidden_states_block_offsets(
+            prompt_token_page_hashes, prompt_seq_lengths, hidden_states)
+
+        try:
+            for cache_size, offsets in block_offsets.items():
+                self.conn.read_cache(hidden_states, offsets, cache_size)
+        except Exception as e:
+            logger.error("Failed to read hidden_states: %s", e)
+            raise
+
+        logger.debug("Loaded hidden_states")
+
+    def key_exists(self, key: str) -> bool:
+        return self.conn.check_exist(key)
+
+    def get_match_last_index(self, keys: List[str]) -> int:
+        return self.conn.get_match_last_index(keys)
+
+    def synchronize(self) -> None:
+        try:
+            self.conn.sync()
+        except Exception as e:
+            logger.error("Failed to synchronize: %s", e)
+            raise

--- a/vllm/distributed/kv_transfer/utils.py
+++ b/vllm/distributed/kv_transfer/utils.py
@@ -1,0 +1,120 @@
+from enum import Enum
+import math
+import os
+import torch
+from typing import List
+import hashlib
+
+from vllm.attention import AttentionMetadata
+
+PAGE_SIZE = 16
+
+class pd_separate_stage(Enum):
+    PREFILL = "prefill"
+    DECODE = "decode"
+
+
+class ForwardPassType(Enum):
+    PREFILL = "prefill_pass"
+    FIRST_DECODE = "first_decode_pass"
+    REGULAR = "regular_pass"
+
+
+def get_forward_pass_type(input_ids: torch.Tensor, attn_metadata: AttentionMetadata):
+    pd_stage = os.environ.get("PD_SEPARATE_STAGE", "").lower()
+    is_profile_run = torch.any(input_ids == 0).item()
+    if pd_stage not in pd_separate_stage._value2member_map_ or is_profile_run:
+        return ForwardPassType.REGULAR
+
+    if pd_stage == "prefill":
+        return ForwardPassType.PREFILL
+    else:
+        if (attn_metadata.prefill_metadata is not None
+            and attn_metadata.decode_metadata is None):
+            return ForwardPassType.FIRST_DECODE
+
+    return ForwardPassType.REGULAR
+
+
+def prepare_kv_cache_transport(input_ids, attn_metadata, cache_config):
+
+    fp_type = get_forward_pass_type(input_ids, attn_metadata)
+
+    input_token_hashes = []
+    offsets = []
+    kv_cache_transporter = cache_config.kv_cache_transporter
+    if fp_type in (ForwardPassType.PREFILL, ForwardPassType.FIRST_DECODE):
+        input_token_hashes = compute_token_page_hashes(input_ids,
+                                                       attn_metadata.seq_lens,
+                                                       kv_cache_transporter.tokens_per_page)
+
+        # Compute block ids for each page in the input sequence
+        assert kv_cache_transporter is not None
+        seq_start_index = 0
+        page_start_index = 0
+        tokens_per_page = kv_cache_transporter.tokens_per_page
+        page_size = kv_cache_transporter.page_size
+        k_or_v_total_size = kv_cache_transporter.k_or_v_total_size
+        for seq_length in attn_metadata.seq_lens:
+            num_pages = math.ceil(seq_length / tokens_per_page)
+
+            for page_num in range(num_pages):
+                start_token_idx = page_num * tokens_per_page
+
+                slot_mapping_value = attn_metadata.slot_mapping[seq_start_index +
+                                                      start_token_idx].item()
+
+                block_id = slot_mapping_value //tokens_per_page
+                k_offset = block_id * page_size
+                offsets.append((k_offset, k_offset + k_or_v_total_size))
+
+            seq_start_index += seq_length
+            page_start_index += num_pages
+
+        assert len(offsets) == len(input_token_hashes)
+
+    return fp_type, kv_cache_transporter, input_token_hashes, offsets
+
+
+def finalize_kv_cache_transport(fp_type, kv_cache_transporter,
+                                input_token_hashes, attn_metadata,
+                                hidden_states):
+    if fp_type == ForwardPassType.PREFILL:
+        kv_cache_transporter.save_hidden_states(input_token_hashes,
+                                                attn_metadata.seq_lens,
+                                                hidden_states)
+
+        kv_cache_transporter.synchronize()
+
+    return
+
+def compute_token_page_hashes(prompt_token_ids: torch.Tensor,
+                              prompt_seq_lengths: List[int],
+                              tokens_per_page=PAGE_SIZE) -> List[str]:
+
+    hashes = []
+    seq_index = 0
+
+    prompt_ids = prompt_token_ids.cpu().numpy()
+
+    for seq_len in prompt_seq_lengths:
+        seq_tokens = prompt_ids[seq_index:seq_index + seq_len]
+        num_pages = math.ceil(seq_len / tokens_per_page)
+        prev_hash = ""
+
+        # Loop over each page within the current sequence
+        for page_num in range(num_pages):
+            start_token = page_num * tokens_per_page
+            end_token = min((page_num + 1) * tokens_per_page, seq_len)
+            tokens_in_page = seq_tokens[start_token:end_token]
+
+            # Compute hash for the current page
+            tokens_bytes = tokens_in_page.tobytes()
+            hash_input = prev_hash.encode('utf-8') + tokens_bytes
+            current_hash = hashlib.sha256(hash_input).hexdigest()
+
+            hashes.append(current_hash)
+
+        seq_index += seq_len
+
+    return hashes

--- a/vllm/distributed/kv_transfer_proxy/flask_proxy.py
+++ b/vllm/distributed/kv_transfer_proxy/flask_proxy.py
@@ -1,0 +1,61 @@
+from flask import Flask, request, Response
+import httpx
+import time
+from datetime import datetime
+
+app = Flask(__name__)
+
+# URLs for the two vLLM processes
+VLLM_1_URL = "http://localhost:8100/v1/completions"
+VLLM_2_URL = "http://localhost:8200/v1/completions"
+
+
+def send_request_to_vllm(vllm_url, req_data):
+    """Send request to a vLLM process and return the response."""
+    with httpx.Client(timeout=None) as client:
+        response = client.post(vllm_url, json=req_data)
+        response.raise_for_status()
+
+
+def stream_vllm_response(vllm_url, req_data):
+    """Stream response from a vLLM process."""
+    with httpx.Client(timeout=None) as client:
+        with client.stream("POST", vllm_url, json=req_data) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes():
+                yield chunk
+
+
+@app.route("/v1/completions", methods=["POST"])
+def proxy_request():
+    req_data = request.get_json()
+
+    # Log initial request data
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----received request :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Send request to vLLM-1
+    send_request_to_vllm(VLLM_1_URL, req_data)
+
+    # Log after first response
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----response 1 :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Stream response from vLLM-2 back to the client
+    def generate_stream():
+        for chunk in stream_vllm_response(VLLM_2_URL, req_data):
+            yield chunk
+
+    # Log before sending final response
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----response 2 :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Return streaming response using Flask's Response object
+    return Response(generate_stream(), content_type="application/json")
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/vllm/distributed/kv_transfer_proxy/kv_proxy.py
+++ b/vllm/distributed/kv_transfer_proxy/kv_proxy.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+import httpx
+import asyncio
+
+app = FastAPI()
+
+# URLs for the two vLLM processes
+# VLLM_1_URL = "http://10.192.18.145:8000/v1/completions"
+# VLLM_2_URL = "http://10.192.24.218:8000/v1/completions"
+
+VLLM_1_URL = "http://localhost:8000/v1/completions"
+VLLM_2_URL = "http://localhost:8001/v1/completions"
+
+
+async def send_request_to_vllm(vllm_url, req_data):
+    """Send request to a vLLM process and return the response."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        response = await client.post(vllm_url, json=req_data)
+        response.raise_for_status()
+        return
+
+
+async def stream_vllm_response(vllm_url, req_data):
+    """Asynchronously streams the response from a vLLM process."""
+    async with httpx.AsyncClient(timeout=None) as client:
+        async with client.stream("POST", vllm_url, json=req_data) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+
+                # print("streaming chunk", chunk)
+                yield chunk
+
+
+@app.post("/v1/completions")
+async def proxy_request(request: Request):
+    # Extract the incoming request JSON data
+    import time
+    from datetime import datetime
+    req_data = await request.json()
+
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----received request :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Send request to vLLM-1 and wait for its response
+    # Response from vLLM-1 is not sent back to the user
+    response1 = await send_request_to_vllm(VLLM_1_URL, req_data)
+
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----response 1 :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Optionally, you can process response1 and modify req_data if needed
+    # For now, we'll proceed with the original req_data
+
+    # Stream response from vLLM-2 back to the client
+    async def generate_stream():
+        chunk_count = 0
+        async for chunk in stream_vllm_response(VLLM_2_URL, req_data):
+            if chunk_count == 0:
+                print(
+                    len(req_data['prompt']), req_data['prompt'][0:10],
+                    "----First chunk sent at:",
+                    datetime.fromtimestamp(
+                        time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+            chunk_count += 1
+            yield chunk
+
+        print(
+            len(req_data['prompt']), req_data['prompt'][0:10],
+            "----Last chunk sent at:",
+            datetime.fromtimestamp(
+                time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+        print(len(req_data['prompt']), req_data['prompt'][0:10],
+              f"Total chunks sent: {chunk_count}")
+
+    print(len(req_data['prompt']), req_data['prompt'][0:10],
+          "----response 2 :",
+          datetime.fromtimestamp(time.time()).strftime('%Y-%m-%d %H:%M:%S.%f'))
+
+    # Use StreamingResponse to stream the response back to the client
+    return StreamingResponse(generate_stream(), media_type="application/json")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/vllm/distributed/kv_transfer_proxy/kv_proxy_with_tracing.py
+++ b/vllm/distributed/kv_transfer_proxy/kv_proxy_with_tracing.py
@@ -1,0 +1,145 @@
+import asyncio
+from fastapi import FastAPI, Request
+from fastapi.responses import StreamingResponse
+import httpx
+
+# OpenTelemetry imports
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.semconv.resource import ResourceAttributes
+from opentelemetry.trace import Status, StatusCode
+
+# Initialize the tracer provider with a resource containing the service name
+resource = Resource(attributes={ResourceAttributes.SERVICE_NAME: "pd-sep-vllm_proxy"})
+
+trace.set_tracer_provider(TracerProvider(resource=resource))
+
+# Configure the OTLP exporter to send data to Jaeger
+otlp_exporter = OTLPSpanExporter(endpoint="localhost:4317", insecure=True)
+
+# Add the BatchSpanProcessor to the tracer provider
+trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(otlp_exporter))
+
+# Set the global propagator to TraceContext
+set_global_textmap(TraceContextTextMapPropagator())
+
+# Initialize the FastAPI app
+app = FastAPI()
+
+# Instrument the FastAPI app to automatically create spans for incoming HTTP requests
+FastAPIInstrumentor.instrument_app(app)
+
+# Obtain a tracer instance
+tracer = trace.get_tracer(__name__)
+
+# Base URLs for the two vLLM processes (set to the root of the API)
+VLLM_1_BASE_URL = "http://localhost:8000/v1"
+VLLM_2_BASE_URL = "http://localhost:8001/v1"
+
+# Initialize variables to hold the persistent clients
+app.state.vllm1_client = None
+app.state.vllm2_client = None
+
+
+@app.on_event("startup")
+async def startup_event():
+    """
+    Initialize persistent HTTPX clients for vLLM services on startup.
+    """
+    HTTPXClientInstrumentor().instrument()
+    app.state.vllm2_client = httpx.AsyncClient(timeout=None, base_url=VLLM_2_BASE_URL)
+    app.state.vllm1_client = httpx.AsyncClient(timeout=None, base_url=VLLM_1_BASE_URL)
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """
+    Close the persistent HTTPX clients on shutdown.
+    """
+    await app.state.vllm1_client.aclose()
+    await app.state.vllm2_client.aclose()
+
+
+async def send_request_to_vllm(client: httpx.AsyncClient, req_data: dict):
+    """
+    Send a request to a vLLM process using a persistent client.
+    """
+    response = await client.post("/completions", json=req_data)  # Correct endpoint path
+    response.raise_for_status()
+    return response
+
+
+async def stream_vllm_response(client: httpx.AsyncClient, req_data: dict):
+    """
+    Asynchronously stream the response from a vLLM process using a persistent client.
+
+    Args:
+        client (httpx.AsyncClient): The persistent HTTPX client.
+        req_data (dict): The JSON payload to send.
+
+    Yields:
+        bytes: Chunks of the response data.
+    """
+    async with client.stream("POST", "/completions", json=req_data) as response:  # Correct endpoint path
+        response.raise_for_status()
+        async for chunk in response.aiter_bytes():
+            yield chunk
+
+
+@app.post("/v1/completions")
+async def proxy_request(request: Request):
+    """
+    Proxy endpoint that forwards requests to two vLLM services.
+
+    Args:
+        request (Request): The incoming HTTP request.
+
+    Returns:
+        StreamingResponse: The streamed response from the second vLLM service.
+    """
+    req_data = await request.json()
+
+    with tracer.start_as_current_span("proxy-request-span") as proxy_span:
+        proxy_span.set_attribute("http.method", request.method)
+        proxy_span.set_attribute("http.url", str(request.url))
+        proxy_span.set_attribute("client.ip", request.client.host)
+
+        # Fire-and-forget request to vLLM-1
+        with tracer.start_as_current_span("send-to-prefill-vllm") as send_vllm1_span:
+            send_vllm1_span.set_attribute("vllm.url", VLLM_1_BASE_URL + "/completions")
+            try:
+                # Use asyncio.create_task to avoid waiting for the response
+                asyncio.create_task(send_request_to_vllm(app.state.vllm1_client, req_data))
+                send_vllm1_span.set_status(Status(StatusCode.OK))
+            except Exception as e:
+                send_vllm1_span.record_exception(e)
+                send_vllm1_span.set_status(Status(StatusCode.ERROR, str(e)))
+
+        # Proceed to vLLM-2 immediately
+        with tracer.start_as_current_span("send-to-decode-vllm") as send_vllm2_span:
+            send_vllm2_span.set_attribute("vllm.url", VLLM_2_BASE_URL + "/completions")
+            try:
+                async def generate_stream():
+                    with tracer.start_as_current_span("stream-vllm2-response") as stream_span:
+                        async for chunk in stream_vllm_response(app.state.vllm2_client, req_data):
+                            stream_span.add_event("Streaming chunk")
+                            yield chunk
+
+                return StreamingResponse(generate_stream(), media_type="application/json")
+            except Exception as e:
+                send_vllm2_span.record_exception(e)
+                send_vllm2_span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,6 +1,5 @@
 """Sampling parameters for text generation."""
 import copy
-import os
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -407,7 +406,10 @@ class SamplingParams(
                 RequestOutputKind.DELTA):
             raise ValueError("best_of must equal n to use output_kind=DELTA")
 
-        if os.environ.get("PD_SEPARATE_STAGE", "").lower() == "prefill":
+        # use local imports to avoid circular imports
+        from vllm.distributed.kv_transfer.utils import (PDDisaggStage,
+                                                        get_pd_stage)
+        if get_pd_stage() == PDDisaggStage.PREFILL:
             if self.max_tokens is None or self.max_tokens != 1:
                 logger.warning("Prefill run only generates one token. "
                                "max_tokens is set to 1.")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -1,5 +1,6 @@
 """Sampling parameters for text generation."""
 import copy
+import os
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -405,6 +406,13 @@ class SamplingParams(
         if self.best_of != self._real_n and self.output_kind == (
                 RequestOutputKind.DELTA):
             raise ValueError("best_of must equal n to use output_kind=DELTA")
+
+        if os.environ.get("PD_SEPARATE_STAGE", "").lower() == "prefill":
+            if self.max_tokens is None or self.max_tokens != 1:
+                logger.warning("Prefill run only generates one token. "
+                               "max_tokens is set to 1.")
+
+            self.max_tokens = 1
 
     def _verify_greedy_sampling(self) -> None:
         if self.n > 1:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -433,6 +433,14 @@ class Sequence:
         # Input + output tokens
         self.tokens: Optional[List[str]] = None
 
+        # using local import to aoivd circular import
+        from vllm.distributed.kv_transfer.utils import (
+            PDDisaggStage, get_pd_stage, compute_token_page_hashes)
+
+        if get_pd_stage() != PDDisaggStage.NONE:
+            self.prompt_token_hashes = compute_token_page_hashes(
+                self.prompt_token_ids, [len(self.prompt_token_ids)])
+
     @property
     def n_blocks(self) -> int:
         return (self.get_len() + self.block_size - 1) // self.block_size
@@ -473,6 +481,10 @@ class Sequence:
     def prompt_adapter_id(self) -> int:
         return self.prompt_adapter_request.prompt_adapter_id \
                         if self.prompt_adapter_request else 0
+
+    @property
+    def last_prompt_hash(self) -> str:
+        return self.prompt_token_hashes[-1] if self.prompt_token_hashes else ""
 
     def get_output_text_to_return(self, buffer_length: int,
                                   delta: bool) -> str:

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -2,7 +2,6 @@
 from typing import List
 
 import torch
-import os
 
 from vllm.attention import get_attn_backend
 from vllm.config import CacheConfig, DeviceConfig, ModelConfig, ParallelConfig
@@ -66,7 +65,10 @@ class CacheEngine:
             self.num_gpu_blocks, self.device_config.device_type)
         self.cpu_cache = self._allocate_kv_cache(self.num_cpu_blocks, "cpu")
 
-        if os.environ.get("PD_SEPARATE_STAGE", "") != "":
+        # use local imports to avoid circular imports
+        from vllm.distributed.kv_transfer.utils import (PDDisaggStage,
+                                                        get_pd_stage)
+        if get_pd_stage() != PDDisaggStage.NONE:
             self.set_kv_cache_transporter()
 
     def set_kv_cache_transporter(self):


### PR DESCRIPTION
This PR includes some updates to help improve prefill latency:
1. Skip the sampling in prefill side as the first token is returned by the decode side.
2. In decode side, download the KV cache before a request is scheduled, thus avoiding the waiting in model forward pass.
3.  only write the hidden_states in TP where rank == 0, as the hidden states are the same across all the ranks.
4. compute the token hashes BEFORE the input_ids are turned into tensors in GPU. Tests show that computing hashes based on GPU tensors are detrimental to prefill latencies.  Now the hashes are computed and attached to AttentionMetadata.
5. handle the case of request preemption in the decode side.

This PR also update the benchmark tool to have a better control of the prompts when using booksum datasets. It makes sure that every sequence is unique if the users wants it. User can also control the repitition rate of the prompts being tested now.