### PR TITLE
[Frontend] Add segments to OpenAI Requests

### DIFF
--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -209,6 +209,23 @@ The following extra parameters are supported:
 :end-before: end-completion-extra-params
 ```
 
+In addition, the format of the `prompt` has been extended: You can pass a list of segments, each specifying if
+special tokens should be included or split:
+
+```ts
+{
+  ...
+  prompt: [
+        { text: "<|fim_prefix|>", split_special_tokens: false },
+        { text: prefix, split_special_tokens: true },
+        { text: "<|fim_suffix|>", split_special_tokens: false },
+        { text: suffix, split_special_tokens: true },
+        { text: "<|fim_middle|>", split_special_tokens: false },
+      ]
+  ...
+}
+```
+
 (chat-api)=
 ### Chat API
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -614,11 +614,17 @@ class ChatCompletionRequest(OpenAIBaseModel):
         return data
 
 
+class OpenAIPromptSegment(OpenAIBaseModel):
+    text: str
+    split_special_tokens: bool
+
+
 class CompletionRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/completions/create
     model: str
-    prompt: Union[List[int], List[List[int]], str, List[str]]
+    prompt: Union[List[int], List[List[int]], str, List[str],
+                  List[OpenAIPromptSegment]]
     best_of: Optional[int] = None
     echo: Optional[bool] = False
     frequency_penalty: Optional[float] = 0.0

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -225,6 +225,7 @@ class MistralTokenizer:
         self,
         prompt: str,
         add_special_tokens: bool = False,
+        split_special_tokens: bool = True,
         truncation: bool = False,
         max_length: Optional[int] = None,
     ):


### PR DESCRIPTION
I extended the format of the completions prompt:
```ts
{
  ...
  prompt: [
        { text: "<|fim_prefix|>", split_special_tokens: false },
        { text: prefix, split_special_tokens: true },
        { text: "<|fim_suffix|>", split_special_tokens: false },
        { text: suffix, split_special_tokens: true },
        { text: "<|fim_middle|>", split_special_tokens: false },
      ]
  ...
}
```
This allows fine control over the generated tokens, protection against prompt injection, and low latency since all of this can be achieved with a single request.

Sample Usage using the javascript openai client:

```ts
const response = await openai.completions.create({
      model: config.model,
      prompt: [
        { text: "<|fim_prefix|>", split_special_tokens: false },
        { text: prefix, split_special_tokens: true },
        { text: "<|fim_suffix|>", split_special_tokens: false },
        { text: suffix, split_special_tokens: true },
        { text: "<|fim_middle|>", split_special_tokens: false },
      ] as {
        text: string;
        split_special_tokens: boolean;
      }[] as any,
      stream: true,
      max_tokens: 25,
      temperature: 0,
    });
``1`