### PR TITLE
fix: [doc] fix typo

### DIFF
--- a/vllm/core/block/block_table.py
+++ b/vllm/core/block/block_table.py
@@ -23,7 +23,7 @@ class BlockTable:
             blocks to initialize the BlockTable with. If not provided, an empty
             BlockTable is created.
         max_block_sliding_window (Optional[int], optional): The number of
-            blocks to keep around for each sequance. If None, all blocks
+            blocks to keep around for each sequence. If None, all blocks
             are kept (eg., when sliding window is not used).
             It should at least fit the sliding window size of the model.
 


### PR DESCRIPTION
I corrected the spell of **sequance**,the message as follows;
`sequance` -> `sequence`

