### PR TITLE
fix init error for MessageQueue when n_local_reader is zero

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -247,7 +247,8 @@ class MessageQueue:
         self.handle = Handle(
             connect_ip=connect_ip,
             local_reader_ranks=local_reader_ranks,
-            buffer_handle=self.buffer.handle(),
+            buffer_handle=self.buffer.handle()
+            if self.buffer is not None else None,
             local_subscribe_port=local_subscribe_port,
             remote_subscribe_port=remote_subscribe_port,
         )


### PR DESCRIPTION
This pull request includes a small but important change to the `vllm/distributed/device_communicators/shm_broadcast.py` file. The change ensures that the `buffer_handle` parameter is correctly set to `None` if `self.buffer` is not initialized, preventing potential errors.

* [`vllm/distributed/device_communicators/shm_broadcast.py`](diffhunk://#diff-75b8ca6d854db6a47e75db6507afd20c15624f35229e2fd0d71642bffd70b11cL250-R250): Modified the `__init__` method to handle cases where `self.buffer` is `None` by setting `buffer_handle` to `None` in such cases.