### PR TITLE
[Bugfix] update the prefix for qwen2

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -298,7 +298,7 @@ class Qwen2Model(nn.Module):
             lambda prefix: Qwen2DecoderLayer(config=config,
                                              cache_config=cache_config,
                                              quant_config=quant_config,
-                                             prefix=f"{prefix}.layers"),
+                                             prefix=prefix),
             prefix=f"{prefix}.layers",
         )
 


### PR DESCRIPTION
There exists a `KeyError: 'layers.0.self_attn.qkv_proj.weight'` when loading a partially quantized qwen2 model, where the MLP layers are quantized but the attention layers are not. The problem lies in the incorrect prefix within the qwen2 model. According to the current code, the prefix for each layer in the model is structured as follows: `model.layers.{idx}.layers.*`. However, the keys for the actual tensors in the model should be `model.layers.{idx}.*`.

FIX https://github.com/vllm-project/vllm/issues/11790
