### PR TITLE
[misc] improve memory profiling

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -309,7 +309,7 @@ def test_memory_profiling():
 
     # this is an analytic value, it is exact,
     # we only have 256 MiB non-torch memory increase
-    measured_diff =monitored_values.values[-1] - monitored_values.values[0]
+    measured_diff = monitored_values.values[-1] - monitored_values.values[0]
     assert measured_diff == 256 * 1024 * 1024
 
     # Check that the memory usage is within 5% of the expected values

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,13 +5,13 @@ from typing import AsyncIterator, Tuple
 
 import pytest
 import torch
+from vllm_test_utils import monitor
 
 from vllm.utils import (FlexibleArgumentParser, StoreBoolean, deprecate_kwargs,
                         get_open_port, memory_profiling, merge_async_iterators,
                         supports_kw)
 
 from .utils import error_on_warning, fork_new_process_for_each_test
-from vllm_test_utils import monitor
 
 
 @pytest.mark.asyncio
@@ -307,12 +307,15 @@ def test_memory_profiling():
         # Add some extra non-torch memory 256 MiB (simulate NCCL)
         handle2 = lib.cudaMalloc(256 * 1024 * 1024)
 
-    for value, stack in zip(monitored_values.values, \
-        monitored_values.trace_stacks):
-        print(f"non_torch memory changed to {value / 1024 / 1024} MiB in")
-        print(stack)
+    # this is an analytic value, it is exact,
+    # we only have 256 MiB non-torch memory increase
+    measured_diff =monitored_values.values[-1] - monitored_values.values[0]
+    assert measured_diff == 256 * 1024 * 1024
 
     # Check that the memory usage is within 5% of the expected values
+    # 5% tolerance is caused by PyTorch caching allocator,
+    # we cannot control PyTorch's behavior of its internal buffers,
+    # which causes a small error (<10 MiB in practice)
     non_torch_ratio = result.non_torch_increase_in_bytes / (256 * 1024 * 1024) # noqa
     torch_peak_ratio = result.torch_peak_increase_in_bytes / (1024 * 1024 * 1024) # noqa
     assert abs(non_torch_ratio - 1) <= 0.05

--- a/tests/vllm_test_utils/vllm_test_utils/__init__.py
+++ b/tests/vllm_test_utils/vllm_test_utils/__init__.py
@@ -4,5 +4,6 @@ It does not import any vLLM modules.
 """
 
 from .blame import BlameResult, blame
+from .monitor import MonitoredValues, monitor
 
-__all__ = ["blame", "BlameResult"]
+__all__ = ["blame", "BlameResult", "monitor", "MonitoredValues"]

--- a/tests/vllm_test_utils/vllm_test_utils/monitor.py
+++ b/tests/vllm_test_utils/vllm_test_utils/monitor.py
@@ -2,9 +2,10 @@ import contextlib
 import dataclasses
 import sys
 import traceback
-from typing import Any, Callable, Generator, Generic, TypeVar
+from typing import Callable, Generator, Generic, TypeVar
 
 _T = TypeVar("_T")
+
 
 @dataclasses.dataclass
 class MonitoredValues(Generic[_T]):
@@ -14,8 +15,8 @@ class MonitoredValues(Generic[_T]):
 
 @contextlib.contextmanager
 def monitor(
-        measure_func: Callable[[],
-                               _T]) -> Generator[MonitoredValues[_T], None, None]:
+    measure_func: Callable[[],
+                           _T]) -> Generator[MonitoredValues[_T], None, None]:
     """
     Trace the function calls to continuously monitor the change of
     a value.

--- a/tests/vllm_test_utils/vllm_test_utils/monitor.py
+++ b/tests/vllm_test_utils/vllm_test_utils/monitor.py
@@ -2,19 +2,20 @@ import contextlib
 import dataclasses
 import sys
 import traceback
-from typing import Any, Callable, Generator, List
+from typing import Any, Callable, Generator, Generic, TypeVar
 
+_T = TypeVar("_T")
 
 @dataclasses.dataclass
-class MonitoredValues:
-    values: List[Any] = dataclasses.field(default_factory=list)
-    trace_stacks: List[str] = dataclasses.field(default_factory=list)
+class MonitoredValues(Generic[_T]):
+    values: list[_T] = dataclasses.field(default_factory=list)
+    trace_stacks: list[str] = dataclasses.field(default_factory=list)
 
 
 @contextlib.contextmanager
 def monitor(
         measure_func: Callable[[],
-                               Any]) -> Generator[MonitoredValues, None, None]:
+                               _T]) -> Generator[MonitoredValues[_T], None, None]:
     """
     Trace the function calls to continuously monitor the change of
     a value.
@@ -30,10 +31,11 @@ def monitor(
     with monitor(measure_func) as monitored_values:
         # do something
     
-    monitored_values.values # all changes of the values
-    monitored_values.trace_stacks # trace stacks of every change
+        monitored_values.values # all changes of the values
+        monitored_values.trace_stacks # trace stacks of every change
+    ```
     """
-    monitored_values = MonitoredValues()
+    monitored_values = MonitoredValues[_T]()
 
     def _trace_calls(frame, event, arg=None):
         nonlocal monitored_values

--- a/tests/vllm_test_utils/vllm_test_utils/monitor.py
+++ b/tests/vllm_test_utils/vllm_test_utils/monitor.py
@@ -1,0 +1,63 @@
+import contextlib
+import dataclasses
+import sys
+import traceback
+from typing import Any, Callable, Generator, List
+
+
+@dataclasses.dataclass
+class MonitoredValues:
+    values: List[Any] = dataclasses.field(default_factory=list)
+    trace_stacks: List[str] = dataclasses.field(default_factory=list)
+
+
+@contextlib.contextmanager
+def monitor(
+        measure_func: Callable[[],
+                               Any]) -> Generator[MonitoredValues, None, None]:
+    """
+    Trace the function calls to continuously monitor the change of
+    a value.
+
+    Usage:
+
+    ```python
+
+    def measure_func():
+        ... # measure the current value
+        return current_value
+
+    with monitor(measure_func) as monitored_values:
+        # do something
+    
+    monitored_values.values # all changes of the values
+    monitored_values.trace_stacks # trace stacks of every change
+    """
+    monitored_values = MonitoredValues()
+
+    def _trace_calls(frame, event, arg=None):
+        nonlocal monitored_values
+        if event in ['call', 'return']:
+            # for every function call or return
+            try:
+                # Temporarily disable the trace function
+                sys.settrace(None)
+                # do a measurement
+                current_value = measure_func()
+                if len(monitored_values.values
+                       ) == 0 or current_value != monitored_values.values[-1]:
+                    monitored_values.values.append(current_value)
+                    monitored_values.trace_stacks.append("".join(
+                        traceback.format_stack()))
+                # Re-enable the trace function
+                sys.settrace(_trace_calls)
+            except NameError:
+                # modules are deleted during shutdown
+                pass
+        return _trace_calls
+
+    try:
+        sys.settrace(_trace_calls)
+        yield monitored_values
+    finally:
+        sys.settrace(None)

--- a/tests/vllm_test_utils/vllm_test_utils/monitor.py
+++ b/tests/vllm_test_utils/vllm_test_utils/monitor.py
@@ -37,8 +37,10 @@ def monitor(
 
     def _trace_calls(frame, event, arg=None):
         nonlocal monitored_values
-        if event in ['call', 'return']:
-            # for every function call or return
+        if event in ['line']:
+            # triggered by every line of Python code.
+            # only Python functions will trigger it,
+            # c/cpp functions will not trigger it.
             try:
                 # Temporarily disable the trace function
                 sys.settrace(None)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1742,10 +1742,8 @@ class MemorySnapshot:
     timestamp: float = 0.0
 
     def measure(self):
-        self.torch_peak_in_bytes = torch.cuda.memory_stats(
-        )["allocated_bytes.all.peak"]
-        self.torch_memory_in_bytes = torch.cuda.memory_stats(
-        )["allocated_bytes.all.current"]
+        self.torch_peak_in_bytes = torch.cuda.max_memory_reserved()
+        self.torch_memory_in_bytes = torch.cuda.memory_reserved()
         self.timestamp = time.time()
 
     def __sub__(self, other: "MemorySnapshot") -> "MemorySnapshot":
@@ -1827,6 +1825,8 @@ def memory_profiling(
     (c.) is tricky. We measure the total memory used in this GPU (`torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]`),
     subtract the baseline memory, the memory used by the model weights, and diff of `torch.cuda.memory_stats()["allocated_bytes.all.current"]`.
     """ # noqa
+    gc.collect()
+    torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
 
     result = MemoryProfilingResult()

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1827,8 +1827,6 @@ def memory_profiling(
     (c.) is tricky. We measure the total memory used in this GPU (`torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]`),
     subtract the baseline memory, the memory used by the model weights, and diff of `torch.cuda.memory_reserved()`.
     """ # noqa
-    gc.collect()
-    torch.cuda.empty_cache()
     torch.cuda.reset_peak_memory_stats()
 
     result = MemoryProfilingResult()

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1743,6 +1743,8 @@ class MemorySnapshot:
 
     def measure(self):
         self.torch_peak_in_bytes = torch.cuda.max_memory_reserved()
+        # torch.cuda.memory_reserved() is how many bytes
+        # PyTorch gets from cuda (by calling cudaMalloc, etc.)
         self.torch_memory_in_bytes = torch.cuda.memory_reserved()
         self.timestamp = time.time()
 
@@ -1820,10 +1822,10 @@ def memory_profiling(
 
     The memory used for loading weights (a.) is directly given from the argument `weights_memory_in_bytes`.
 
-    The increase of ``torch.cuda.memory_stats()["allocated_bytes.all.peak"]` after profiling gives (b.).
+    The increase of `torch.cuda.memory_stats()["allocated_bytes.all.peak"]` after profiling gives (b.).
 
     (c.) is tricky. We measure the total memory used in this GPU (`torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]`),
-    subtract the baseline memory, the memory used by the model weights, and diff of `torch.cuda.memory_stats()["allocated_bytes.all.current"]`.
+    subtract the baseline memory, the memory used by the model weights, and diff of `torch.cuda.memory_reserved()`.
     """ # noqa
     gc.collect()
     torch.cuda.empty_cache()


### PR DESCRIPTION
Previous, we use `torch.cuda.memory_stats()["allocated_bytes.all.current"]` as the memory taken by PyTorch, and `torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]` as the memory cost reported by cuda. The diff is treated as  non-torch memory.

However, I find this is incorrect:

```python
import torch

def incorrect_measure_non_torch_memory():
    cuda_report_memory = torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]
    torch_report_memory = torch.cuda.memory_stats()["allocated_bytes.all.current"]
    return cuda_report_memory - torch_report_memory

def correct_measure_non_torch_memory():
    cuda_report_memory = torch.cuda.mem_get_info()[1] - torch.cuda.mem_get_info()[0]
    torch_report_memory = torch.cuda.memory_reserved()
    return cuda_report_memory - torch_report_memory

# func = incorrect_measure_non_torch_memory # will error
func = correct_measure_non_torch_memory

init_non_torch_memory = func() # cuda context memory

data = torch.randn(5).cuda()

after_non_torch_memory = func() # should not change, we don't have any non-torch memory cost

assert after_non_torch_memory == init_non_torch_memory
```

`torch.cuda.memory_stats()["allocated_bytes.all.current"]` does not include the memory allocated from `cudaMalloc` but cannot be released (partially used).

This PR uses `torch.cuda.memory_reserved()`, which is the correct value of total memory cost by pytorch.

I also added a monitor utility function to monitor non-torch memory to make sure we are measuring the correct value. 