### PR TITLE
[Misc] sort torch profiler table by kernel timing

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -52,7 +52,7 @@ def main(args: argparse.Namespace):
                 llm.generate(dummy_prompts,
                              sampling_params=sampling_params,
                              use_tqdm=False)
-            print(p.key_averages())
+            print(p.key_averages().table(sort_by="self_cuda_time_total"))
         else:
             start_time = time.perf_counter()
             llm.generate(dummy_prompts,


### PR DESCRIPTION
This commits sorts torch profiler print table by total kernel timings for easier profiling.
