### PR TITLE
Remove the duplicate imports of MultiModalKwargs and PlaceholderRange…

### DIFF
--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -5,8 +5,6 @@ from typing import (TYPE_CHECKING, Deque, Dict, Iterable, List, Optional, Set,
 
 from vllm.config import CacheConfig, LoRAConfig, SchedulerConfig
 from vllm.logger import init_logger
-from vllm.multimodal import MultiModalKwargs
-from vllm.multimodal.base import PlaceholderRange
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
 from vllm.v1.core.kv_cache_manager import KVCacheManager


### PR DESCRIPTION
Remove the duplicate imports of MultiModalKwargs and PlaceholderRange in scheduler.py, as they are only used for type hints.