### PR TITLE
[Bugfix] fix beam search input errors and latency benchmark script

### DIFF
--- a/benchmarks/benchmark_latency.py
+++ b/benchmarks/benchmark_latency.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from vllm import LLM, SamplingParams
 from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
+from vllm.sampling_params import BeamSearchParams
 from vllm.utils import FlexibleArgumentParser
 
 
@@ -40,6 +41,20 @@ def main(args: argparse.Namespace):
         "prompt_token_ids": batch
     } for batch in dummy_prompt_token_ids.tolist()]
 
+    def llm_generate():
+        if not args.use_beam_search:
+            llm.generate(dummy_prompts,
+                         sampling_params=sampling_params,
+                         use_tqdm=False)
+        else:
+            llm.beam_search(
+                dummy_prompts,
+                BeamSearchParams(
+                    beam_width=args.n,
+                    max_tokens=args.output_len,
+                    ignore_eos=True,
+                ))
+
     def run_to_completion(profile_dir: Optional[str] = None):
         if profile_dir:
             with torch.profiler.profile(
@@ -49,15 +64,11 @@ def main(args: argparse.Namespace):
                     ],
                     on_trace_ready=torch.profiler.tensorboard_trace_handler(
                         str(profile_dir))) as p:
-                llm.generate(dummy_prompts,
-                             sampling_params=sampling_params,
-                             use_tqdm=False)
+                llm_generate()
             print(p.key_averages().table(sort_by="self_cuda_time_total"))
         else:
             start_time = time.perf_counter()
-            llm.generate(dummy_prompts,
-                         sampling_params=sampling_params,
-                         use_tqdm=False)
+            llm_generate()
             end_time = time.perf_counter()
             latency = end_time - start_time
             return latency


### PR DESCRIPTION
# Summary

Support latency benchmarking for beam search, which was not added in #9087.

Ran into follow type errors so fixed them too.
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/data/users/yeq/gitrepos/vllm/benchmarks/benchmark_latency.py", line 158, in <module>
[rank0]:     main(args)
[rank0]:   File "/data/users/yeq/gitrepos/vllm/benchmarks/benchmark_latency.py", line 80, in main
[rank0]:     run_to_completion(profile_dir=None)
[rank0]:   File "/data/users/yeq/gitrepos/vllm/benchmarks/benchmark_latency.py", line 73, in run_to_completion
[rank0]:     llm_generate()
[rank0]:   File "/data/users/yeq/gitrepos/vllm/benchmarks/benchmark_latency.py", line 49, in llm_generate
[rank0]:     llm.beam_search(
[rank0]:   File "/data/users/yeq/gitrepos/vllm/vllm/entrypoints/llm.py", line 497, in beam_search
[rank0]:     prompt, list) else tokenizer.encode(prompt)
[rank0]:                        ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/yeq/venv/p312env/lib64/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2627, in encode
[rank0]:     encoded_inputs = self.encode_plus(
[rank0]:                      ^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/yeq/venv/p312env/lib64/python3.12/site-packages/transformers/tokenization_utils_base.py", line 3046, in encode_plus
[rank0]:     return self._encode_plus(
[rank0]:            ^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/yeq/venv/p312env/lib64/python3.12/site-packages/transformers/tokenization_utils_fast.py", line 600, in _encode_plus
[rank0]:     batched_output = self._batch_encode_plus(
[rank0]:                      ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/data/users/yeq/venv/p312env/lib64/python3.12/site-packages/transformers/tokenization_utils_fast.py", line 526, in _batch_encode_plus
[rank0]:     encodings = self._tokenizer.encode_batch(
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]
[rank0]:[W108 17:27:59.587486578 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
```

# Test Plan
mypy
```
python benchmarks/benchmark_latency.py --model "meta-llama/Meta-Llama-3.1-8B" --input-len 128 --output-len 32 --n 2 --use-beam-search
...
Avg latency: 2.738890287039491 seconds
10% percentile latency: 2.7096714439219793 seconds
25% percentile latency: 2.7163948111992795 seconds
50% percentile latency: 2.723542522522621 seconds
75% percentile latency: 2.7382597793184686 seconds
90% percentile latency: 2.7676841208711265 seconds
99% percentile latency: 2.931331386717502 second
```
