### PR TITLE
[Bugfix] support to run partially 2:4 model with CompressedTensors24 scheme

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -381,6 +381,8 @@ class CompressedTensorsConfig(QuantizationConfig):
             weight_quant = None
             input_quant = None
 
+        # For models with sparsity, assumes that the sparse layers are also
+        # quantized for cutlass 2:4 support
         sparsity_scheme: Optional[SparsityCompressionConfig] = None
         if self.sparsity_scheme_map:
             matched_target = find_matched_target(
@@ -388,12 +390,6 @@ class CompressedTensorsConfig(QuantizationConfig):
                 module=layer,
                 targets=self.sparsity_scheme_map.keys())
             sparsity_scheme = self.sparsity_scheme_map.get(matched_target)
-
-        # For models with sparsity, assumes that the sparse layers are also
-        # quantized for cutlass 2:4 support
-        sparsity_scheme: Optional[
-            SparsityCompressionConfig] = self.sparsity_scheme_map.get(
-                matched_target)
 
         if self.supports_cutlass_24(weight_quant=weight_quant,
                                     input_quant=input_quant,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -377,13 +377,18 @@ class CompressedTensorsConfig(QuantizationConfig):
             scheme_dict = self.target_scheme_map[matched_target]
             weight_quant = scheme_dict.get("weights")
             input_quant = scheme_dict.get("input_activations")
-        elif self.sparsity_scheme_map:
+        else:
+            weight_quant = None
+            input_quant = None
+
+        sparsity_scheme: Optional[SparsityCompressionConfig] = None
+        if self.sparsity_scheme_map:
             matched_target = find_matched_target(
                 layer_name=layer_name,
                 module=layer,
                 targets=self.sparsity_scheme_map.keys())
-            weight_quant = None
-            input_quant = None
+            sparsity_scheme = self.sparsity_scheme_map.get(
+                    matched_target)
 
         # For models with sparsity, assumes that the sparse layers are also
         # quantized for cutlass 2:4 support

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -387,8 +387,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                 layer_name=layer_name,
                 module=layer,
                 targets=self.sparsity_scheme_map.keys())
-            sparsity_scheme = self.sparsity_scheme_map.get(
-                    matched_target)
+            sparsity_scheme = self.sparsity_scheme_map.get(matched_target)
 
         # For models with sparsity, assumes that the sparse layers are also
         # quantized for cutlass 2:4 support

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -101,13 +101,38 @@ def find_matched_target(layer_name: Optional[str], module: Module,
     if layer_name is None:
         layer_name = ""
 
-    matched_target = (_find_first_match(layer_name, targets)
-                      or _find_first_match(module.__class__.__name__, targets,
-                                           True))
+    # match layer_name with targets
+    matched_target = _find_first_match(layer_name, targets)
 
+    # Fused layers like gate_up_proj or qkv_proj will not be fused
+    # in the safetensors checkpoint. So, they will not be matched 
+    # in the first match process. Here, we convert the name
+    # from the fused version to unfused + check to make sure that
+    # each shard of the fused layer has the same scheme.
     if matched_target is None:
-        raise ValueError(f"Unable to find matching target for {module} in the "
-                         "compressed-tensors config.")
+        proj_name = layer_name.split(".")[-1]
+        if proj_name in FUSED_LAYER_NAME_MAPPING:
+            shard_proj_names = FUSED_LAYER_NAME_MAPPING[proj_name]
+
+            # Convert fused_name --> [shard_names]
+            shard_names = [
+                layer_name.replace(proj_name, shard_proj_name)
+                for shard_proj_name in shard_proj_names
+            ]
+            # Layer should be matched if all shards are matched.
+            matched_target = _find_first_match(shard_names[0], targets)
+            for i in range(1, len(shard_names)):
+                shard_name = shard_names[i]
+                matched_target_shard = _find_first_match(shard_name, targets)
+                if matched_target_shard is None != matched_target is None:
+                    raise ValueError(f"Found a different quantization schemes for "
+                                     f"{shard_proj_names} in {layer_name}. vLLM "
+                                     "requires all to use the same scheme.")
+
+    # if layer_name is not matched, then match the class name with targets.
+    if matched_target is None:
+        matched_target = _find_first_match(module.__class__.__name__, targets,
+                                           True)
 
     return matched_target
 

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -105,7 +105,7 @@ def find_matched_target(layer_name: Optional[str], module: Module,
     matched_target = _find_first_match(layer_name, targets)
 
     # Fused layers like gate_up_proj or qkv_proj will not be fused
-    # in the safetensors checkpoint. So, they will not be matched 
+    # in the safetensors checkpoint. So, they will not be matched
     # in the first match process. Here, we convert the name
     # from the fused version to unfused + check to make sure that
     # each shard of the fused layer has the same scheme.
@@ -125,9 +125,10 @@ def find_matched_target(layer_name: Optional[str], module: Module,
                 shard_name = shard_names[i]
                 matched_target_shard = _find_first_match(shard_name, targets)
                 if matched_target_shard is None != matched_target is None:
-                    raise ValueError(f"Found a different quantization schemes for "
-                                     f"{shard_proj_names} in {layer_name}. vLLM "
-                                     "requires all to use the same scheme.")
+                    raise ValueError(
+                        f"Found a different quantization schemes for "
+                        f"{shard_proj_names} in {layer_name}. vLLM "
+                        "requires all to use the same scheme.")
 
     # if layer_name is not matched, then match the class name with targets.
     if matched_target is None:


### PR DESCRIPTION
After using llmcompressor to create a partially 2:4 sparse FP8 quantized model (where the MLP layers are sparse, but the attention layers are not), I tested its speed and found that the inference speed of this model did not differ from that of a regular FP8 quantized model. Further investigation revealed that although the MLP layers are 2:4 sparse, the `get_scheme` function in the `CompressedTensorsConfig` of the code repository does not handle this partially sparse model appropriately, causing the MLP layers to not utilize the CompressedTensors24 scheme.
Before:
![image](https://github.com/user-attachments/assets/5a5962d9-d1f5-428b-bdee-f254e279bb86)
Fixed:
![image](https://github.com/user-attachments/assets/40e6bc2d-2826-47f2-af7b-95c5a7c4dc92)

FIX https://github.com/vllm-project/llm-compressor/issues/1037

Tested_model:
- original qwen2.5-3B
- fp8 quantized qwen2.5-3B
- fully 2:4 sparse fp8 quantized qwen2.5-3B
- partially 2:4 sparse fp8 quantized qwen2.5-3B
