### PR TITLE
Change clone files mechanism

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -388,7 +388,7 @@ class ModelConfig:
             if is_s3(tokenizer):
                 s3_tokenizer = S3Model()
                 s3_tokenizer.pull_files(
-                    model, ignore_pattern=["*.pt", "*.safetensors", "*.bin"])
+                    model, allow_pattern=["*.json"])
                 self.tokenizer = s3_tokenizer.dir
 
     def _init_multimodal_config(


### PR DESCRIPTION
For S3 Model loading, we clone all files except weights files to a local, temporary, directory.

We do it using ignore pattern of `["*.pt", "*.safetensors", "*.bin"]`.
This raise a problem, users may upload large files to the S3 (For example, like in this issue: https://github.com/run-ai/runai-model-streamer/issues/25#issuecomment-2576314295)
The case is very valid, downloading all model repo from HF and directly upload it to S3 (Including `.git` which is a large dir)
Most of them are not needed.

One option is to still pull all files, but it can take time if the files are large (like the `.git` dir)
Option 2 - pull only relevant files, tokenizer files, however there is no clear list of which file names are relevant and may change in the future.
Option 3 - Pull only json files, from the assumption that if the filenames will change in the future most likely all the tokenizer metadata file will still be jsons.
Option 4 - ignore `.git` dir only
