### PR TITLE
[ci]try to fix flaky multi-step tests

### DIFF
--- a/tests/multi_step/test_correctness_async_llm.py
+++ b/tests/multi_step/test_correctness_async_llm.py
@@ -16,7 +16,6 @@ NUM_SCHEDULER_STEPS = [8]  # Multi-step decoding steps
 NUM_PROMPTS = [10]
 
 DEFAULT_SERVER_ARGS: List[str] = [
-    "--disable-log-requests",
     "--worker-use-ray",
     "--gpu-memory-utilization",
     "0.85",
@@ -110,7 +109,7 @@ async def test_multi_step(
 
     # Spin up client/server & issue completion API requests.
     # Default `max_wait_seconds` is 240 but was empirically
-    # was raised 3x to 720 *just for this test* due to
+    # was raised 5x to 1200 *just for this test* due to
     # observed timeouts in GHA CI
     ref_completions = await completions_with_server_args(
         prompts,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -780,7 +780,6 @@ async def completions_with_server_args(
     assert len(max_tokens) == len(prompts)
 
     outputs = None
-    max_wait_seconds = 240 * 3  # 240 is default
     with RemoteOpenAIServer(model_name,
                             server_cli_args,
                             max_wait_seconds=max_wait_seconds) as server:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -159,7 +159,7 @@ class RemoteOpenAIServer:
 
     def get_client(self, **kwargs):
         if "timeout" not in kwargs:
-            kwargs["timeout"] = 60
+            kwargs["timeout"] = 600
         return openai.OpenAI(
             base_url=self.url_for("v1"),
             api_key=self.DUMMY_API_KEY,
@@ -169,7 +169,7 @@ class RemoteOpenAIServer:
 
     def get_async_client(self, **kwargs):
         if "timeout" not in kwargs:
-            kwargs["timeout"] = 60
+            kwargs["timeout"] = 600
         return openai.AsyncOpenAI(base_url=self.url_for("v1"),
                                   api_key=self.DUMMY_API_KEY,
                                   max_retries=0,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,13 +157,19 @@ class RemoteOpenAIServer:
     def url_for(self, *parts: str) -> str:
         return self.url_root + "/" + "/".join(parts)
 
-    def get_client(self):
+    def get_client(self, **kwargs):
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 60
         return openai.OpenAI(
             base_url=self.url_for("v1"),
             api_key=self.DUMMY_API_KEY,
+            max_retries=0,
+            **kwargs,
         )
 
     def get_async_client(self, **kwargs):
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 60
         return openai.AsyncOpenAI(base_url=self.url_for("v1"),
                                   api_key=self.DUMMY_API_KEY,
                                   max_retries=0,


### PR DESCRIPTION
The test `Multi-step Tests (4 GPUs)` is found to be quite flaky, e.g. https://buildkite.com/vllm/ci/builds/11759#01944a43-2101-4b44-9e06-3c6dc1259452

After investigation, I find the `max_wait_seconds=5 * 240` is not respected in the function, `max_wait_seconds = 240 * 3 ` overrides the argument.

In addition, I find that the failed test only get 9 requests while we expect 10 requests:

<img width="773" alt="image" src="https://github.com/user-attachments/assets/48edca09-3671-4ef2-89c9-7fad1ae84162" />

therefore I deleted `--disable-log-requests` to see if we can collect more information in the future.