### PR TITLE
[Bugfix] Multi-sequence broken

### DIFF
--- a/tests/samplers/test_seeded_generate.py
+++ b/tests/samplers/test_seeded_generate.py
@@ -31,7 +31,7 @@ def test_random_sample_with_seed(
 
     sampling_params = SamplingParams(
         # Parameters to ensure sufficient randomness
-        temperature=2.0,
+        temperature=3.0,
         top_p=min(random.random() + 0.3, 1),
         top_k=random.randint(5, 20),
         n=random.randint(1, 10),
@@ -75,3 +75,8 @@ def test_random_sample_with_seed(
         # verify requests with the same seed match
         assert outputs[1] == outputs[4]
         assert outputs[2] == outputs[5]
+
+        # verify generations within the same parallel sampling group differ
+        for output in outputs:
+            for sub_output_a, sub_output_b in combinations(output, 2):
+                assert sub_output_a != sub_output_b

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -172,9 +172,9 @@ class RequestOutput:
         if seq_group.request_id in seq_id_to_seq_group:
             group: SequenceGroupBase = seq_id_to_seq_group[
                 seq_group.request_id]
+            assembled_seq_group = group.maybe_assemble_group(seq_group)
             if finished:
                 group.finish_seq(seq_group)
-            assembled_seq_group = group.maybe_assemble_group(seq_group)
             if assembled_seq_group is None:
                 return None
             return cls.from_seq_group(assembled_seq_group, use_cache,

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1457,11 +1457,9 @@ class ParallelSampleSequenceGroup(SequenceGroupBase):
         # in the non-streaming mode, we will return the assembled sequence
         # when the last sequences finishes, and then return None for the
         # rest of the time
-        if (
-            len(self.to_be_finished) == 1
-            and seq_group.request_id in self.to_be_finished
-            and seq_group.is_finished()
-        ):
+        if (len(self.to_be_finished) == 1
+                and seq_group.request_id in self.to_be_finished
+                and seq_group.is_finished()):
             assert self.assembled_seq_group is not None
             params = self.assembled_seq_group.sampling_params
             assert isinstance(params, SamplingParams)


### PR DESCRIPTION
Fixes the bugs introduced in #9569 
- `SequenceGroup` does not necessarily contain only one sequence (e.g. when `n` > 1), so many of the optimisations don't make sense.
- Currently the seed is duplicated across all completions, so when we have `n` > 1 with seed set, all completions give the same output.
- Currently only the first sequence in a ParallelSampleSequenceGroup yields responses. But once the first sequence finishes it won't receive new chunks. This means responses from other sequences are not sent when the first sequence terminates first.

Andy@MistralAI