### PR TITLE
[Docs] Add Modal to deployment frameworks

### DIFF
--- a/docs/source/deployment/frameworks/bentoml.md
+++ b/docs/source/deployment/frameworks/bentoml.md
@@ -2,6 +2,6 @@
 
 # BentoML
 
-[BentoML](https://github.com/bentoml/BentoML) allows you to deploy a large language model (LLM) server with vLLM as the backend, which exposes OpenAI-compatible endpoints. You can serve the model locally or containerize it as an OCI-complicant image and deploy it on Kubernetes.
+[BentoML](https://github.com/bentoml/BentoML) allows you to deploy a large language model (LLM) server with vLLM as the backend, which exposes OpenAI-compatible endpoints. You can serve the model locally or containerize it as an OCI-compliant image and deploy it on Kubernetes.
 
 For details, see the tutorial [vLLM inference in the BentoML documentation](https://docs.bentoml.com/en/latest/use-cases/large-language-models/vllm.html).

--- a/docs/source/deployment/frameworks/index.md
+++ b/docs/source/deployment/frameworks/index.md
@@ -8,6 +8,7 @@ cerebrium
 dstack
 helm
 lws
+modal
 skypilot
 triton
 ```

--- a/docs/source/deployment/frameworks/modal.md
+++ b/docs/source/deployment/frameworks/modal.md
@@ -1,0 +1,7 @@
+(deployment-modal)=
+
+# Modal
+
+vLLM can be run on cloud GPUs with [Modal](https://modal.com), a serverless computing platform designed for fast auto-scaling.
+
+For details on how to deploy vLLM on Modal, see [this tutorial in the Modal documentation](https://modal.com/docs/examples/vllm_inference).


### PR DESCRIPTION
This PR adds Modal to the list of deployment frameworks, as discussed in Slack DMs with @mgoin.

The documentation page essentially just links to a page on our docs that explains how to use vLLM on our platform -- so we're the ones on the hook for maintaining the example.

I copied the style of the other deployment options. Happy to change the text!

Also, this PR fixes a small typo in the BentoML -- "OCI-complicant" -> "OCI-compliant".

FYI You can preview the updated docs [here](https://charlesfrye--vllm-docs-serve-dev.modal.run/deployment/frameworks/modal.html). I set up a preview server for the docs -- naturally, running on Modal ;)

![Screenshot 2025-01-09 at 12 31 20 PM](https://github.com/user-attachments/assets/609cd91e-fdfb-40b9-9142-0c2eb5666cb7)