### PR TITLE
[Doc] Correct the spelling of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ If you use vLLM for your research, please cite our [paper](https://arxiv.org/abs
 
 ## Contact Us
 
-* For technical questions and feature requests, please use Github issues or discussions.
+* For technical questions and feature requests, please use GitHub issues or discussions.
 * For discussing with fellow users, please use Discord.
 * For coordinating contributions and development, please use Slack.
-* For security disclosures, please use Github's security advisory feature.
+* For security disclosures, please use GitHub's security advisory feature.
 * For collaborations and partnerships, please contact us at vllm-questions AT lists.berkeley.edu.
 
 ## Media Kit


### PR DESCRIPTION
GitHub is spelled with a capitalized H.