### PR TITLE
[Misc] Update benchmark_prefix_caching.py fixed example usage

### DIFF
--- a/benchmarks/benchmark_prefix_caching.py
+++ b/benchmarks/benchmark_prefix_caching.py
@@ -10,7 +10,8 @@ Fixed example usage:
         --model meta-llama/Llama-2-7b-chat-hf \
         --enable-prefix-caching \
         --num-prompts 1 \
-        --repeat-count 100
+        --repeat-count 100 \
+        --input-length-range 128:256
 
 ShareGPT example usage:
     # This command samples 20 prompts with input lengths


### PR DESCRIPTION
PR #9929  change benchmark_prefix_caching.py "--input-length-range" from default value to "required=True".

Update  fixed example usage with "--input-length-range" option