### PR TITLE
[Docs] Fix docstring in `get_ip` function

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -446,7 +446,7 @@ def get_ip() -> str:
         logger.warning(
             "The environment variable HOST_IP is deprecated and ignored, as"
             " it is often used by Docker and other software to"
-            "interact with the container's network stack. Please"
+            "interact with the container's network stack. Please "
             "use VLLM_HOST_IP instead to set the IP address for vLLM processes"
             " to communicate with each other.")
     if host_ip:


### PR DESCRIPTION
A space is missing in the docstring of `get_ip` function in `utils.py`.

