### PR TITLE
[Doc] Docstring fix in `benchmark_long_document_qa_throughput.py`

### DIFF
--- a/benchmarks/benchmark_long_document_qa_throughput.py
+++ b/benchmarks/benchmark_long_document_qa_throughput.py
@@ -2,7 +2,6 @@
 Offline benchmark to test the long document QA throughput.
 
 Example usage:
-    # This command run the vllm with 50GB CPU memory for offloading
     # The workload samples 8 different prompts with a default input
     # length of 20000 tokens, then replicates each prompt 2 times 
     # in random order.

--- a/benchmarks/benchmark_long_document_qa_throughput.py
+++ b/benchmarks/benchmark_long_document_qa_throughput.py
@@ -2,7 +2,7 @@
 Offline benchmark to test the long document QA throughput.
 
 Example usage:
-    # The workload samples 8 different prompts with a default input
+    # This workload samples 8 different prompts with a default input
     # length of 20000 tokens, then replicates each prompt 2 times 
     # in random order.
     python benchmark_long_document_qa_throughput.py \


### PR DESCRIPTION
The command in the example does not use the CPU offloading feature and thus does not require 50GB CPU memory. Remove the incorrect description.

