### PR TITLE
[ci] fix broken distributed-tests-4-gpus

### DIFF
--- a/tests/spec_decode/e2e/test_integration_dist_tp4.py
+++ b/tests/spec_decode/e2e/test_integration_dist_tp4.py
@@ -108,7 +108,8 @@ def test_skip_speculation(common_llm_kwargs, per_test_common_llm_kwargs,
 
     TODO: fix it to pass without raising Error. (#5814)
     """
-    with pytest.raises(openai.APIConnectionError):
+    with pytest.raises(
+        (openai.APIConnectionError, openai.InternalServerError)):
         run_equality_correctness_test_tp(MAIN_MODEL,
                                          common_llm_kwargs,
                                          per_test_common_llm_kwargs,


### PR DESCRIPTION
Lots of ci failures for this test, and I can locally reproduce.

The test expects to fail, since it has `with pytest.raises` .

However, it only expects `openai.APIConnectionError`, while we see in the ci that it actually raises `openai.InternalServerError`

cc @robertgshaw2-neuralmagic how we differentiate these two errors. I'm taking the conservative approach of taking care of both errors.