### PR TITLE
[V1][WIP] Hybrid allocator for full attention & sliding window attention interleaved models (Reference PR, do not merge)

### DIFF
--- a/examples/offline_sliding.py
+++ b/examples/offline_sliding.py
@@ -1,0 +1,64 @@
+import random
+from typing import List
+from vllm import LLM, SamplingParams
+
+
+def prep_prompts(batch_size: int):
+    """
+    Generate prompts which a bunch of assignments,
+    then asking for the value of one of them.
+    The prompt is just under 10k tokens; sliding window is 4k
+    so the answer is outside sliding window, but should still be correct.
+    """
+    prompts: List[str] = []
+    answer: List[int] = []
+    indices: List[int] = []
+    random.seed(1)
+    for _ in range(batch_size):
+        idx = random.randint(30, 90)
+        indices.append(idx)
+        prompt = "```python\n# We set a number of variables, " + \
+                 f"x{idx} will be important later\n"
+        ln = random.randint(600, 800)
+        for k in range(30, ln):
+            v = random.randint(10, 99)
+            if k == idx:
+                answer.append(v)
+            prompt += f"x{k} = {v}\n"
+        prompt += f"# Now, we check the value of x{idx}:\n"
+        prompt += f"assert x{idx} == "
+        prompts.append(prompt)
+    return prompts, answer, indices
+
+
+def check_answers(indices: List[int], answer: List[int], outputs: List[str]):
+    answer2 = [int(text[0:2].strip()) for text in outputs]
+    print(list(zip(indices, zip(answer, answer2))))
+    numok = 0
+    for a1, a2 in zip(answer, answer2):
+        if a1 == a2:
+            numok += 1
+    frac_ok = numok / len(answer)
+    print(f"Num OK: {numok}/{len(answer)} {frac_ok}")
+    assert frac_ok > 0.7
+
+
+# Sample prompts.
+prompts, answer, indices = prep_prompts(1)
+
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.0, max_tokens=100)
+
+# Create an LLM.
+llm = LLM(model="google/gemma-2-9b-it", enforce_eager=True)
+# llm = LLM(model="meta-llama/Llama-3.1-8B-Instruct")
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Generated text: {generated_text!r}")
+check_answers(indices, answer,
+              [response.outputs[0].text for response in outputs])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,14 +1,14 @@
 import asyncio
 import os
 import socket
-from typing import TYPE_CHECKING, AsyncIterator, Tuple
+from typing import AsyncIterator, Tuple
 
 import pytest
 import torch
 
 from vllm.utils import (FlexibleArgumentParser, StoreBoolean, deprecate_kwargs,
                         get_open_port, memory_profiling, merge_async_iterators,
-                        supports_kw, register_kv_cache)
+                        register_kv_cache, supports_kw)
 
 from .utils import error_on_warning, fork_new_process_for_each_test
 
@@ -309,8 +309,8 @@ def test_memory_profiling():
 
 
 def test_register_gpu_kv_cache():
-    from vllm.config import LayerForwardContext
     from vllm.attention import Attention
+    from vllm.config import LayerForwardContext
 
     # example from Jamba PP=2
     ctx = {

--- a/tests/v1/e2e/test_correctness_sliding_window.py
+++ b/tests/v1/e2e/test_correctness_sliding_window.py
@@ -14,12 +14,10 @@ def test_sliding_window_retrival(monkeypatch, model, batch_size, seed):
     If we tell it upfront which we are going to be looking for, then
     it answers correctly (mostly).
     """
-    prompt = "\n<User>: Implement fibonacci sequence in Python.\n<Claude>:"
-
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")
 
-        llm = LLM(model="Qwen/Qwen2-1.5B-Instruct")
+        llm = LLM(model=model)
         sampling_params = SamplingParams(temperature=0.0, max_tokens=100)
 
         prompts, answer, indices = prep_prompts(batch_size)

--- a/tests/v1/e2e/test_correctness_sliding_window.py
+++ b/tests/v1/e2e/test_correctness_sliding_window.py
@@ -1,0 +1,81 @@
+import random
+from typing import List
+from vllm import LLM, SamplingParams
+import pytest
+
+
+@pytest.mark.parametrize("model", ["bigcode/starcoder2-3b"])
+@pytest.mark.parametrize("batch_size", [5])
+@pytest.mark.parametrize("seed", [1])
+def test_sliding_window_retrival(monkeypatch, model, batch_size, seed):
+    """
+    The test does a bunch of assignments "x1 = 10\nx2 = 33\n..." and then
+    asks for value of one of them (which is outside the sliding window).
+    If we tell it upfront which we are going to be looking for, then
+    it answers correctly (mostly).
+    """
+    prompt = "\n<User>: Implement fibonacci sequence in Python.\n<Claude>:"
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+
+        llm = LLM(model="Qwen/Qwen2-1.5B-Instruct")
+        sampling_params = SamplingParams(temperature=0.0, max_tokens=100)
+
+        prompts, answer, indices = prep_prompts(batch_size)
+
+        responses = llm.generate(prompts, sampling_params)
+        check_answers(indices, answer,
+                      [response.outputs[0].text for response in responses])
+
+
+def prep_prompts(batch_size: int):
+    """
+    Generate prompts which a bunch of assignments,
+    then asking for the value of one of them.
+    The prompt is just under 10k tokens; sliding window is 4k
+    so the answer is outside sliding window, but should still be correct.
+    """
+    prompts: List[str] = []
+    answer: List[int] = []
+    indices: List[int] = []
+    random.seed(1)
+    for _ in range(batch_size):
+        idx = random.randint(30, 90)
+        indices.append(idx)
+        prompt = "```python\n# We set a number of variables, " + \
+                 f"x{idx} will be important later\n"
+        ln = random.randint(800, 1100)
+        for k in range(30, ln):
+            v = random.randint(10, 99)
+            if k == idx:
+                answer.append(v)
+            prompt += f"x{k} = {v}\n"
+        prompt += f"# Now, we check the value of x{idx}:\n"
+        prompt += f"assert x{idx} == "
+        prompts.append(prompt)
+    return prompts, answer, indices
+
+
+def check_answers(indices: List[int], answer: List[int], outputs: List[str]):
+    answer2 = [int(text[0:2].strip()) for text in outputs]
+    print(list(zip(indices, zip(answer, answer2))))
+    numok = 0
+    for a1, a2 in zip(answer, answer2):
+        if a1 == a2:
+            numok += 1
+    frac_ok = numok / len(answer)
+    print(f"Num OK: {numok}/{len(answer)} {frac_ok}")
+    assert frac_ok > 0.7
+
+
+def check_window(prompts: List[str]):
+
+    def inner(llm: LLM):
+        sliding_window = llm.llm_engine.model_config.get_sliding_window()
+        assert sliding_window and sliding_window > 0
+        assert any(
+            len(llm.get_tokenizer().tokenize(prompt)) > sliding_window
+            for prompt in prompts)
+
+    return inner

--- a/vllm/attention/backends/blocksparse_attn.py
+++ b/vllm/attention/backends/blocksparse_attn.py
@@ -300,6 +300,7 @@ class BlocksparseFlashAttentionImpl(AttentionImpl):
         kv_cache_dtype: str,
         blocksparse_params: Optional[Dict[str, Any]] = None,
         logits_soft_cap: Optional[float] = None,
+        layer_name: str = "",
     ) -> None:
         assert blocksparse_params is not None
         assert alibi_slopes is None, ValueError(

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -102,6 +102,7 @@ class Attention(nn.Module):
         self.head_size = head_size
         self.num_kv_heads = num_kv_heads
         self.sliding_window = sliding_window
+        print("sliding_window", sliding_window)
         self.backend = backend_name_to_enum(attn_backend.get_name())
         self.dtype = dtype
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -102,7 +102,6 @@ class Attention(nn.Module):
         self.head_size = head_size
         self.num_kv_heads = num_kv_heads
         self.sliding_window = sliding_window
-        print("sliding_window", sliding_window)
         self.backend = backend_name_to_enum(attn_backend.get_name())
         self.dtype = dtype
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -244,6 +244,8 @@ def unified_attention(
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.dynamic_forward_context
     self = forward_context.static_forward_context[layer_name]
+    if isinstance(attn_metadata, dict):
+        attn_metadata = attn_metadata[layer_name]
     return self.impl.forward(query,
                              key,
                              value,
@@ -286,6 +288,8 @@ def unified_attention_with_output(
     forward_context: ForwardContext = get_forward_context()
     attn_metadata = forward_context.dynamic_forward_context
     self = forward_context.static_forward_context[layer_name]
+    if isinstance(attn_metadata, dict):
+        attn_metadata = attn_metadata[layer_name]
     self.impl.forward(query,
                       key,
                       value,

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -7,7 +7,8 @@ import torch.nn.functional as F
 
 from vllm.attention import AttentionMetadata, AttentionType
 from vllm.attention.selector import backend_name_to_enum, get_attn_backend
-from vllm.config import CacheConfig, get_current_vllm_config
+from vllm.config import (CacheConfig, LayerForwardContext,
+                         get_current_vllm_config)
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
@@ -119,7 +120,10 @@ class Attention(nn.Module):
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
-        compilation_config.static_forward_context[prefix] = self
+        # use a placeholder kv cache tensor during init, which will be replaced
+        # after kv cache initialization
+        compilation_config.static_forward_context[
+            prefix] = LayerForwardContext(self, torch.tensor([]))
         self.layer_name = prefix
 
     def forward(
@@ -154,13 +158,11 @@ class Attention(nn.Module):
             if value is not None:
                 value = value.view(-1, self.num_kv_heads, self.head_size)
             torch.ops.vllm.unified_attention_with_output(
-                query, key, value, output, kv_cache, attn_type,
-                self.layer_name)
+                query, key, value, output, attn_type, self.layer_name)
             return output.view(-1, hidden_size)
         else:
             return torch.ops.vllm.unified_attention(query, key, value,
-                                                    kv_cache, attn_type,
-                                                    self.layer_name)
+                                                    attn_type, self.layer_name)
 
     def extra_repr(self) -> str:
         s = f"head_size={self.impl.head_size}"  # type: ignore
@@ -237,19 +239,19 @@ def unified_attention(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    kv_cache: torch.Tensor,
     attn_type: str,
     layer_name: str,
 ) -> torch.Tensor:
     forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.dynamic_forward_context
-    self = forward_context.static_forward_context[layer_name]
+    attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
         attn_metadata = attn_metadata[layer_name]
+    ctx = forward_context.layers[layer_name]
+    self = ctx.attn_module
     return self.impl.forward(query,
                              key,
                              value,
-                             kv_cache,
+                             ctx.kv_cache,
                              attn_metadata,
                              self._k_scale,
                              self._v_scale,
@@ -260,7 +262,6 @@ def unified_attention_fake(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    kv_cache: torch.Tensor,
     attn_type: str,
     layer_name: str,
 ) -> torch.Tensor:
@@ -270,7 +271,7 @@ def unified_attention_fake(
 direct_register_custom_op(
     op_name="unified_attention",
     op_func=unified_attention,
-    mutates_args=["kv_cache"],
+    mutates_args=[],
     fake_impl=unified_attention_fake,
     dispatch_key=current_platform.dispatch_key,
 )
@@ -281,19 +282,19 @@ def unified_attention_with_output(
     key: torch.Tensor,
     value: torch.Tensor,
     output: torch.Tensor,
-    kv_cache: torch.Tensor,
     attn_type: str,
     layer_name: str,
 ) -> None:
     forward_context: ForwardContext = get_forward_context()
-    attn_metadata = forward_context.dynamic_forward_context
-    self = forward_context.static_forward_context[layer_name]
+    attn_metadata = forward_context.attn_metadata
     if isinstance(attn_metadata, dict):
         attn_metadata = attn_metadata[layer_name]
+    ctx = forward_context.layers[layer_name]
+    self = ctx.attn_module
     self.impl.forward(query,
                       key,
                       value,
-                      kv_cache,
+                      ctx.kv_cache,
                       attn_metadata,
                       self._k_scale,
                       self._v_scale,
@@ -306,7 +307,6 @@ def unified_attention_with_output_fake(
     key: torch.Tensor,
     value: torch.Tensor,
     output: torch.Tensor,
-    kv_cache: torch.Tensor,
     attn_type: str,
     layer_name: str,
 ) -> None:
@@ -316,7 +316,7 @@ def unified_attention_with_output_fake(
 direct_register_custom_op(
     op_name="unified_attention_with_output",
     op_func=unified_attention_with_output,
-    mutates_args=["kv_cache", "output"],
+    mutates_args=["output"],
     fake_impl=unified_attention_with_output_fake,
     dispatch_key=current_platform.dispatch_key,
 )

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -100,7 +100,9 @@ class Attention(nn.Module):
         self.num_heads = num_heads
         self.head_size = head_size
         self.num_kv_heads = num_kv_heads
+        self.sliding_window = sliding_window
         self.backend = backend_name_to_enum(attn_backend.get_name())
+        self.dtype = dtype
 
         # For cuda-alike (CUDA and ROCM) and cpu platforms, we control how
         # torch.compile works by registering the attention as one giant

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -992,7 +992,7 @@ class CacheConfig:
         if not self.enable_prefix_caching:
             return
 
-        if self.sliding_window is not None:
+        if not envs.VLLM_USE_V1 and self.sliding_window is not None:
             raise NotImplementedError(
                 "Prefix caching is not supported with sliding window. "
                 "Run with --disable-sliding-window to use prefix caching.")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2564,6 +2564,12 @@ class CompilationLevel:
     PIECEWISE = 3
 
 
+@dataclass
+class LayerForwardContext:
+    attn_module: Any  # vllm.attention.layer.Attention
+    kv_cache: Any  # torch.Tensor
+
+
 class CompilationConfig(BaseModel):
     """
     Configuration for compilation.
@@ -2717,9 +2723,9 @@ class CompilationConfig(BaseModel):
     inductor_hash_cache: Any = PrivateAttr
 
     # Per-model forward context
-    # Mainly used to store attention cls
-    # Map from layer name to the attention cls
-    static_forward_context: Dict[str, Any] = PrivateAttr
+    # Map from layer name to the layer's forward context, which stores
+    # attention cls and kv_cache
+    static_forward_context: Dict[str, LayerForwardContext] = PrivateAttr
 
     def compute_hash(self) -> str:
         """

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -2,13 +2,16 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import torch
 
 import vllm.envs as envs
-from vllm.config import VllmConfig
+from vllm.config import LayerForwardContext, VllmConfig
 from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.attention.backends.abstract import AttentionMetadata
 
 logger = init_logger(__name__)
 
@@ -21,9 +24,10 @@ batchsize_forward_time: defaultdict = defaultdict(list)
 
 @dataclass
 class ForwardContext:
-    static_forward_context: Dict[str, Any]
+    # copy from vllm_config.compilation_config.static_forward_context
+    layers: Dict[str, LayerForwardContext]
     # TODO: extend to support per-layer dynamic forward context
-    dynamic_forward_context: Any
+    attn_metadata: "AttentionMetadata"  # set dynamically for each forward pass
 
 
 _forward_context: Optional[ForwardContext] = None
@@ -38,34 +42,32 @@ def get_forward_context() -> ForwardContext:
 
 
 @contextmanager
-def set_forward_context(context: Any, vllm_config: VllmConfig):
+def set_forward_context(attn_metadata: Any, vllm_config: VllmConfig):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
     Here we can inject common logic for every model forward pass.
     """
     global forward_start_time
-    need_to_track_batchsize = track_batchsize and context is not None
+    need_to_track_batchsize = track_batchsize and attn_metadata is not None
     if need_to_track_batchsize:
         forward_start_time = time.perf_counter()
     global _forward_context
     prev_context = _forward_context
     _forward_context = ForwardContext(
-        static_forward_context=vllm_config.compilation_config.
-        static_forward_context,
-        dynamic_forward_context=context)
+        layers=vllm_config.compilation_config.static_forward_context,
+        attn_metadata=attn_metadata)
     try:
         yield
     finally:
-        global batchsize_counter
         global last_logging_time, batchsize_logging_interval
         if need_to_track_batchsize:
-            if hasattr(context, "num_prefill_tokens"):
+            if hasattr(attn_metadata, "num_prefill_tokens"):
                 # for v0 attention backends
-                batchsize = context.num_prefill_tokens + \
-                    context.num_decode_tokens
+                batchsize = attn_metadata.num_prefill_tokens + \
+                    attn_metadata.num_decode_tokens
             else:
                 # for v1 attention backends
-                batchsize = context.num_input_tokens
+                batchsize = attn_metadata.num_input_tokens
             # we use synchronous scheduling right now,
             # adding a sync point here should not affect
             # scheduling of the next batch

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -156,7 +156,8 @@ class FlashAttentionImpl(AttentionImpl):
         # not padded. However, we don't need to do key[:num_actual_tokens] and
         # value[:num_actual_tokens] because the reshape_and_cache_flash op uses
         # the slot_mapping's shape to determine the number of actual tokens.
-        key_cache, value_cache = kv_cache.unbind(0)
+        key_cache = kv_cache[0]
+        value_cache = kv_cache[1]
         torch.ops._C_cache_ops.reshape_and_cache_flash(
             key,
             value,

--- a/vllm/v1/core/custom_manager.py
+++ b/vllm/v1/core/custom_manager.py
@@ -81,7 +81,7 @@ class FullAttentionManager(CustomManager):
         return []
 
 
-class SlidingWindowManager(CustomManager):
+class SlidingWindowManager(FullAttentionManager):
 
     def __init__(self, layer_spec: SlidingWindowSpec,
                  memory_pool_operations: MemoryPoolOperations):
@@ -119,20 +119,6 @@ class SlidingWindowManager(CustomManager):
                     self.memory_pool_operations.get_null_block())
                 start = i + 1
         return ranges, computed_blocks
-
-    def get_num_new_blocks(self, num_computed_tokens: int,
-                           num_append_tokens: int,
-                           num_allocated_blocks: int) -> int:
-        # TODO: need test on we can get the correct number
-        # TODO: need test on the assumption that freeing blocks outside sliding
-        # window before allocating new blocks
-        # NOTE: may be 1 more block than required
-        num_computed_blocks = min(cdiv(num_computed_tokens, self.block_size),
-                                  self.num_block_sliding_window)
-        num_append_blocks = cdiv(num_append_tokens, self.block_size)
-        num_required_blocks = num_computed_blocks + num_append_blocks
-        num_new_blocks = num_required_blocks - num_allocated_blocks
-        return num_new_blocks
 
     def remove_useless_blocks(self, block_table: List[KVCacheBlock],
                               num_computed_tokens: int) -> List[KVCacheBlock]:

--- a/vllm/v1/core/custom_manager.py
+++ b/vllm/v1/core/custom_manager.py
@@ -1,0 +1,103 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple, TypedDict
+from vllm.utils import cdiv
+from vllm.v1.core.kv_cache_interface import FullAttentionSpec, KVCacheConfig, KVCacheSpecBase, SlidingWindowSpec
+from vllm.v1.core.kv_cache_utils import BlockHashType, ComputedTokenRange, KVCacheBlock, ComputedTokens
+from vllm.v1.utils import ConstantList
+
+
+@dataclass
+class MemoryPoolOperations:
+    get_cached_block: Callable[[BlockHashType], Optional[KVCacheBlock]]
+
+
+class CustomManager(ABC):
+    block_size: int
+    max_num_blocks_per_req: int
+
+    def __init__(
+        self,
+        layer_spec: KVCacheSpecBase,
+        memory_pool_operations: MemoryPoolOperations,
+    ) -> None:
+        self.block_size = layer_spec.block_size
+        self.memory_pool_operations = memory_pool_operations
+
+    @abstractmethod
+    def get_computed_tokens(
+        self, block_hashes: ConstantList[BlockHashType]
+    ) -> Tuple[ComputedTokens, List[KVCacheBlock]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_num_new_blocks(self, num_computed_tokens: int,
+                           num_append_tokens: int,
+                           num_allocated_blocks: int) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove_useless_blocks(self, block_table: List[KVCacheBlock],
+                              num_computed_tokens: int, call_free: bool):
+        # update block_table inplace
+        raise NotImplementedError
+
+
+class FullAttentionManager(CustomManager):
+
+    def get_computed_tokens(
+        self, block_hashes: ConstantList[BlockHashType]
+    ) -> Tuple[ComputedTokens, List[KVCacheBlock]]:
+        computed_blocks: List[KVCacheBlock] = []
+        for block_hash in block_hashes:
+            # block_hashes is a chain of block hashes. If a block hash is not
+            # in the cached_block_hash_to_id, the following block hashes are
+            # not computed yet for sure.
+            if cached_block := self.memory_pool_operations.get_cached_block(
+                    block_hash):
+                computed_blocks.append(cached_block)
+            else:
+                break
+        if len(computed_blocks) == 0:
+            return [], []
+        else:
+            return [
+                ComputedTokenRange(0,
+                                   len(computed_blocks) * self.block_size)
+            ], computed_blocks
+
+    def get_num_new_blocks(self, num_computed_tokens: int,
+                           num_append_tokens: int,
+                           num_allocated_blocks: int) -> int:
+        num_required_blocks = cdiv(num_computed_tokens + num_append_tokens,
+                                   self.block_size)
+        num_new_blocks = num_required_blocks - num_allocated_blocks
+        return num_new_blocks
+
+    def remove_useless_blocks(self, block_table: List[KVCacheBlock],
+                              num_computed_tokens: int, call_free: bool):
+        pass
+
+
+class SlidingWindowManager(FullAttentionManager):
+    # TODO: implement the sliding window manager
+    pass
+
+
+spec_manager_map = {
+    FullAttentionSpec: FullAttentionManager,
+    SlidingWindowSpec: SlidingWindowManager
+}
+
+
+def get_managers(
+    kv_cache_config: KVCacheConfig,
+    cached_block_hash_to_block: Dict[BlockHashType, Dict[int, KVCacheBlock]]
+) -> Dict[str, CustomManager]:
+    managers: Dict[str, CustomManager] = {}
+    for group_id, layer_ids in kv_cache_config.groups.items():
+        group_spec = kv_cache_config.kv_cache_spec[layer_ids[0]]
+        manager_class = spec_manager_map[type(group_spec)]
+        managers[group_id] = manager_class(group_spec,
+                                           cached_block_hash_to_block)
+    return managers

--- a/vllm/v1/core/custom_manager.py
+++ b/vllm/v1/core/custom_manager.py
@@ -91,13 +91,13 @@ spec_manager_map = {
 
 
 def get_managers(
-    kv_cache_config: KVCacheConfig,
-    cached_block_hash_to_block: Dict[BlockHashType, Dict[int, KVCacheBlock]]
-) -> Dict[str, CustomManager]:
-    managers: Dict[str, CustomManager] = {}
-    for group_id, layer_ids in kv_cache_config.groups.items():
+        kv_cache_config: KVCacheConfig,
+        memory_pool_operations: MemoryPoolOperations) -> List[CustomManager]:
+    managers: List[CustomManager] = []
+    for layer_ids in kv_cache_config.groups:
+        # All layers in the same group have the same spec, choose arbitrary one
         group_spec = kv_cache_config.kv_cache_spec[layer_ids[0]]
         manager_class = spec_manager_map[type(group_spec)]
-        managers[group_id] = manager_class(group_spec,
-                                           cached_block_hash_to_block)
+        manager = manager_class(group_spec, memory_pool_operations)
+        managers.append(manager)
     return managers

--- a/vllm/v1/core/hybrid_allocator_compiler.py
+++ b/vllm/v1/core/hybrid_allocator_compiler.py
@@ -32,6 +32,8 @@ def _get_kv_cache_config_same_type(
     num_gpu_blocks = int(available_memory // page_size // len(kv_cache_spec))
     num_gpu_blocks = max(num_gpu_blocks, 0)
 
+    logger.info("num_gpu_blocks=%d", num_gpu_blocks)
+
     if vllm_config.cache_config.num_gpu_blocks_override is not None:
         num_gpu_blocks_override = \
             vllm_config.cache_config.num_gpu_blocks_override
@@ -86,6 +88,8 @@ def _get_kv_cache_config_same_size(
             "num_gpu_blocks_override=%d", num_pages, num_gpu_blocks_override)
         # TODO(Chen): num_page and num_block has different meaning
         num_pages = num_gpu_blocks_override
+
+    logger.info("num_gpu_blocks=%d", num_pages)
 
     groups = []
     tensors: Dict[int, KVCacheTensor] = {}

--- a/vllm/v1/core/hybrid_allocator_compiler.py
+++ b/vllm/v1/core/hybrid_allocator_compiler.py
@@ -1,0 +1,90 @@
+from typing import Tuple
+from vllm.config import VllmConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheTensorSeperate, LayerConfig, SelfAttentionCache, SlidingWindowCache
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def get_kv_cache_config(vllm_config: VllmConfig, layer_config: LayerConfig,
+                        available_memory: int) -> Tuple[KVCacheConfig, int]:
+    check_enough_memory(vllm_config, layer_config, available_memory)
+    if is_same_type(layer_config):
+        return _get_kv_cache_config_same_type(vllm_config, layer_config,
+                                              available_memory)
+    elif is_same_hidden_size(layer_config):
+        raise NotImplementedError
+    else:
+        raise NotImplementedError
+
+
+def _get_kv_cache_config_same_type(
+        vllm_config: VllmConfig, layer_config: LayerConfig,
+        available_memory: int) -> Tuple[KVCacheConfig, int]:
+    page_sizes = {lc.page_size for lc in layer_config.layers.values()}
+    assert len(page_sizes) == 1
+    page_size = page_sizes.pop()
+
+    num_gpu_blocks = int(available_memory // page_size //
+                         len(layer_config.layers))
+    num_gpu_blocks = max(num_gpu_blocks, 0)
+
+    if vllm_config.cache_config.num_gpu_blocks_override is not None:
+        num_gpu_blocks_override = \
+            vllm_config.cache_config.num_gpu_blocks_override
+        logger.info(
+            "Overriding num_gpu_blocks=%d with "
+            "num_gpu_blocks_override=%d", num_gpu_blocks,
+            num_gpu_blocks_override)
+        num_gpu_blocks = num_gpu_blocks_override
+
+    per_layer_size = page_size * num_gpu_blocks
+
+    kv_cache_config = KVCacheConfig(
+        buffer_size=-1,
+        tensors={
+            layer_cnt: KVCacheTensorSeperate(size=per_layer_size)
+            for layer_cnt in layer_config.layer_id_mapping.keys()
+        },
+        block_table_sharing={
+            "default":
+            [layer_id for layer_id in layer_config.layer_id_mapping.values()]
+        },
+        layer_config=layer_config)
+    # TODO (Chen): KVCacheTensorSeperate can be removed
+    print("kv_cache_config", kv_cache_config)
+    return kv_cache_config, num_gpu_blocks
+
+
+def is_same_type(layer_config: LayerConfig) -> bool:
+    layer_keys = set(lc.key for lc in layer_config.layers.values())
+    return len(layer_keys) == 1
+
+
+def is_same_hidden_size(layer_config: LayerConfig):
+    return all(
+        isinstance(lc, (SelfAttentionCache, SlidingWindowCache))
+        for lc in layer_config.layers.values())
+
+
+def check_enough_memory(vllm_config: VllmConfig, layer_config: LayerConfig,
+                        available_memory: int):
+    if available_memory <= 0:
+        raise ValueError("No available memory for the cache blocks. "
+                         "Try increasing `gpu_memory_utilization` when "
+                         "initializing the engine.")
+
+    max_model_len = vllm_config.model_config.max_model_len
+    needed_memory = 0
+    for lc in layer_config.layers.values():
+        needed_memory += lc.memory_size(max_model_len)
+
+    if needed_memory > available_memory:
+        # TODO (Chen): need unit test
+        raise ValueError(
+            f"The model's KV cache needed ({needed_memory/1024/1024/1024} "
+            f"GB) to store one request with the models's max seq len "
+            f"({max_model_len}) is larger than the available KV Cache memory "
+            f"({available_memory/1024/1024/1024} GB). Try increasing "
+            f"`gpu_memory_utilization` or decreasing `max_model_len` when "
+            f"initializing the engine.")

--- a/vllm/v1/core/hybrid_allocator_compiler.py
+++ b/vllm/v1/core/hybrid_allocator_compiler.py
@@ -1,35 +1,35 @@
+from collections import defaultdict
 import math
 from typing import Dict, List, Tuple
 from vllm.config import VllmConfig
-from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheTensor, KVCacheTensorSeperate, KVCacheTensorShareBuffer, LayerCache, LayerConfig, SelfAttentionCache, SlidingWindowCache
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheTensor, KVCacheTensorSeperate, KVCacheTensorShareBuffer, KVCacheSpec, KVCacheSpec, FullAttentionSpec, SlidingWindowSpec
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
 
-def get_kv_cache_config(vllm_config: VllmConfig, layer_config: LayerConfig,
+def get_kv_cache_config(vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
                         available_memory: int) -> Tuple[KVCacheConfig, int]:
-    check_enough_memory(vllm_config, layer_config, available_memory)
-    if is_same_type(layer_config):
+    check_enough_memory(vllm_config, kv_cache_spec, available_memory)
+    if is_same_type(kv_cache_spec):
         # TODO (Chen): improve the readability of default path (self attn only models)
-        return _get_kv_cache_config_same_type(vllm_config, layer_config,
+        return _get_kv_cache_config_same_type(vllm_config, kv_cache_spec,
                                               available_memory)
-    elif is_same_hidden_size(layer_config):
-        return _get_kv_cache_config_same_size(vllm_config, layer_config,
+    elif is_same_hidden_size(kv_cache_spec):
+        return _get_kv_cache_config_same_size(vllm_config, kv_cache_spec,
                                               available_memory)
     else:
         raise NotImplementedError
 
 
 def _get_kv_cache_config_same_type(
-        vllm_config: VllmConfig, layer_config: LayerConfig,
+        vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
         available_memory: int) -> Tuple[KVCacheConfig, int]:
-    page_sizes = {lc.page_size for lc in layer_config.layers.values()}
+    page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     assert len(page_sizes) == 1
     page_size = page_sizes.pop()
 
-    num_gpu_blocks = int(available_memory // page_size //
-                         len(layer_config.layers))
+    num_gpu_blocks = int(available_memory // page_size // len(kv_cache_spec))
     num_gpu_blocks = max(num_gpu_blocks, 0)
 
     if vllm_config.cache_config.num_gpu_blocks_override is not None:
@@ -46,40 +46,37 @@ def _get_kv_cache_config_same_type(
     kv_cache_config = KVCacheConfig(
         buffer_size=-1,
         tensors={
-            layer_cnt: KVCacheTensorSeperate(size=per_layer_size)
-            for layer_cnt in layer_config.layer_id_mapping.keys()
+            layer_name: KVCacheTensorSeperate(size=per_layer_size)
+            for layer_name in kv_cache_spec.keys()
         },
-        block_table_sharing={
-            "default":
-            [layer_id for layer_id in layer_config.layer_id_mapping.values()]
+        groups={
+            "default": [layer_name for layer_name in kv_cache_spec.keys()]
         },
-        layer_config=layer_config)
+        kv_cache_spec=kv_cache_spec)
     # TODO (Chen): KVCacheTensorSeperate can be removed
     print("kv_cache_config", kv_cache_config)
     return kv_cache_config, num_gpu_blocks
 
 
 def _get_kv_cache_config_same_size(
-        vllm_config: VllmConfig, layer_config: LayerConfig,
+        vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
         available_memory: int) -> Tuple[KVCacheConfig, int]:
     # Grouped allocation
     # TODO (Chen): explain it, need test
 
-    page_sizes = {lc.page_size for lc in layer_config.layers.values()}
+    page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     assert len(page_sizes) == 1
     page_size = page_sizes.pop()
 
-    grouped_layers: Dict[str, List[str]] = {}  # key -> List[layer_id]
-    for layer_id, lc in layer_config.layers.items():
-        if lc.key not in grouped_layers:
-            grouped_layers[lc.key] = []
-        grouped_layers[lc.key].append(layer_id)
+    grouped_layers: Dict[str, List[str]] = defaultdict(
+        list)  # key -> List[layer_name]
+    for layer_name, layer_spec in kv_cache_spec.items():
+        grouped_layers[layer_spec.key].append(layer_name)
 
     group_size_gcd = math.gcd(
         *[len(layers) for layers in grouped_layers.values()])
 
     allocator_page_size = page_size * group_size_gcd
-    # TODO (Chen): remove -1 and avoid overflow
     num_pages = available_memory // allocator_page_size
     buffer_size = num_pages * allocator_page_size
 
@@ -92,50 +89,45 @@ def _get_kv_cache_config_same_size(
         # TODO (Chen): num_page and num_block has different meaning
         num_pages = num_gpu_blocks_override
 
-    block_table_sharing = {}
+    groups = {}
     tensors: Dict[int, KVCacheTensor] = {}
-    layer_id_mapping_reverse = {
-        layer_id: layer_cnt
-        for layer_cnt, layer_id in layer_config.layer_id_mapping.items()
-    }
 
     for group_key, layers in grouped_layers.items():
         for i in range(0, len(layers), group_size_gcd):
             group_id = f"{group_key}_{i // group_size_gcd}"
-            block_table_sharing[group_id] = []
-            for idx_in_group, layer_id in enumerate(layers[i:i +
-                                                           group_size_gcd]):
-                block_table_sharing[group_id].append(layer_id)
-                tensors[layer_id_mapping_reverse[
-                    layer_id]] = KVCacheTensorShareBuffer(
-                        size=buffer_size - idx_in_group * page_size,
-                        start_bias=idx_in_group * page_size,
-                    )
+            groups[group_id] = []
+            for idx_in_group, layer_name in enumerate(layers[i:i +
+                                                             group_size_gcd]):
+                groups[group_id].append(layer_name)
+                tensors[layer_name] = KVCacheTensorShareBuffer(
+                    size=buffer_size - idx_in_group * page_size,
+                    start_bias=idx_in_group * page_size,
+                )
 
     kv_cache_config = KVCacheConfig(
         buffer_size=num_pages * allocator_page_size,
         tensors=tensors,
-        block_table_sharing=block_table_sharing,
-        layer_config=layer_config,
+        groups=groups,
+        kv_cache_spec=kv_cache_spec,
     )
 
     print("kv_cache_config", kv_cache_config)
     return kv_cache_config, num_pages
 
 
-def is_same_type(layer_config: LayerConfig) -> bool:
-    layer_keys = set(lc.key for lc in layer_config.layers.values())
+def is_same_type(kv_cache_spec: KVCacheSpec) -> bool:
+    layer_keys = set(layer.key for layer in kv_cache_spec.values())
     return len(layer_keys) == 1
 
 
-def is_same_hidden_size(layer_config: LayerConfig):
+def is_same_hidden_size(kv_cache_spec: KVCacheSpec):
     # TODO (Chen): needs more accurate check
     return all(
-        isinstance(lc, (SelfAttentionCache, SlidingWindowCache))
-        for lc in layer_config.layers.values())
+        isinstance(layer, (FullAttentionSpec, SlidingWindowSpec))
+        for layer in kv_cache_spec.values())
 
 
-def check_enough_memory(vllm_config: VllmConfig, layer_config: LayerConfig,
+def check_enough_memory(vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
                         available_memory: int):
     if available_memory <= 0:
         raise ValueError("No available memory for the cache blocks. "
@@ -144,15 +136,15 @@ def check_enough_memory(vllm_config: VllmConfig, layer_config: LayerConfig,
 
     max_model_len = vllm_config.model_config.max_model_len
     needed_memory = 0
-    for lc in layer_config.layers.values():
-        needed_memory += lc.memory_size(max_model_len)
+    for layer_spec in kv_cache_spec.values():
+        needed_memory += layer_spec.bytes_for_tokens(max_model_len)
 
     if needed_memory > available_memory:
         # TODO (Chen): need unit test
         raise ValueError(
-            f"The model's KV cache needed ({needed_memory/1024/1024/1024} "
-            f"GB) to store one request with the models's max seq len "
-            f"({max_model_len}) is larger than the available KV Cache memory "
+            f"To serve at least one request with the models's max seq len "
+            f"({max_model_len}), ({needed_memory/1024/1024/1024} GB KV cache is"
+            f"needed, which is larger than the available KV Cache memory "
             f"({available_memory/1024/1024/1024} GB). Try increasing "
             f"`gpu_memory_utilization` or decreasing `max_model_len` when "
             f"initializing the engine.")

--- a/vllm/v1/core/hybrid_allocator_compiler.py
+++ b/vllm/v1/core/hybrid_allocator_compiler.py
@@ -12,7 +12,7 @@ def get_kv_cache_config(vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
                         available_memory: int) -> Tuple[KVCacheConfig, int]:
     check_enough_memory(vllm_config, kv_cache_spec, available_memory)
     if is_same_type(kv_cache_spec):
-        # TODO (Chen): improve the readability of default path (self attn only models)
+        # TODO(Chen): improve the readability of default path (self attn only models)
         return _get_kv_cache_config_same_type(vllm_config, kv_cache_spec,
                                               available_memory)
     elif is_same_hidden_size(kv_cache_spec):
@@ -53,7 +53,7 @@ def _get_kv_cache_config_same_type(
             "default": [layer_name for layer_name in kv_cache_spec.keys()]
         },
         kv_cache_spec=kv_cache_spec)
-    # TODO (Chen): KVCacheTensorSeperate can be removed
+    # TODO(Chen): KVCacheTensorSeperate can be removed
     print("kv_cache_config", kv_cache_config)
     return kv_cache_config, num_gpu_blocks
 
@@ -62,7 +62,7 @@ def _get_kv_cache_config_same_size(
         vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
         available_memory: int) -> Tuple[KVCacheConfig, int]:
     # Grouped allocation
-    # TODO (Chen): explain it, need test
+    # TODO(Chen): explain it, need test
 
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     assert len(page_sizes) == 1
@@ -86,7 +86,7 @@ def _get_kv_cache_config_same_size(
         logger.info(
             "Overriding num_gpu_blocks=%d with "
             "num_gpu_blocks_override=%d", num_pages, num_gpu_blocks_override)
-        # TODO (Chen): num_page and num_block has different meaning
+        # TODO(Chen): num_page and num_block has different meaning
         num_pages = num_gpu_blocks_override
 
     groups = {}
@@ -121,7 +121,7 @@ def is_same_type(kv_cache_spec: KVCacheSpec) -> bool:
 
 
 def is_same_hidden_size(kv_cache_spec: KVCacheSpec):
-    # TODO (Chen): needs more accurate check
+    # TODO(Chen): needs more accurate check
     return all(
         isinstance(layer, (FullAttentionSpec, SlidingWindowSpec))
         for layer in kv_cache_spec.values())
@@ -140,7 +140,7 @@ def check_enough_memory(vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec,
         needed_memory += layer_spec.bytes_for_tokens(max_model_len)
 
     if needed_memory > available_memory:
-        # TODO (Chen): need unit test
+        # TODO(Chen): need unit test
         raise ValueError(
             f"To serve at least one request with the models's max seq len "
             f"({max_model_len}), ({needed_memory/1024/1024/1024} GB KV cache is"

--- a/vllm/v1/core/kv_cache_interface.py
+++ b/vllm/v1/core/kv_cache_interface.py
@@ -93,5 +93,5 @@ class KVCacheTensorSeperate(KVCacheTensor):
 class KVCacheConfig:
     buffer_size: int  # -1 if do not need a global buffer
     tensors: Dict[str, KVCacheTensor]  # layer_name -> KVCacheTensor
-    groups: Dict[str, List[str]]  # group_id -> List[layer_name]
+    groups: List[List[str]]  # group_id -> [layer_name in the group]
     kv_cache_spec: KVCacheSpec

--- a/vllm/v1/core/kv_cache_interface.py
+++ b/vllm/v1/core/kv_cache_interface.py
@@ -58,7 +58,7 @@ class SlidingWindowSpec(KVCacheSpecBase):
 
     @property
     def key(self) -> str:
-        return f"sliding_window_{self.sliding_window}_{self.bytes_for_tokens(1)}"
+        return f"sliding_window_{self.sliding_window}_{self.block_size}_{self.bytes_for_tokens(1)}"
 
     @property
     def page_size_bytes(self) -> int:

--- a/vllm/v1/core/kv_cache_interface.py
+++ b/vllm/v1/core/kv_cache_interface.py
@@ -16,6 +16,7 @@ from vllm.utils import get_dtype_size
 # TODO(Chen): find a better name
 @dataclass
 class KVCacheSpecBase:
+    block_size: int
 
     @property
     def key(self) -> str:
@@ -31,7 +32,6 @@ class KVCacheSpecBase:
 
 @dataclass
 class FullAttentionSpec(KVCacheSpecBase):
-    block_size: int
     num_kv_heads: int
     head_size: int
     dtype: torch.dtype
@@ -51,7 +51,6 @@ class FullAttentionSpec(KVCacheSpecBase):
 
 @dataclass
 class SlidingWindowSpec(KVCacheSpecBase):
-    block_size: int
     num_kv_heads: int
     head_size: int
     dtype: torch.dtype

--- a/vllm/v1/core/kv_cache_interface.py
+++ b/vllm/v1/core/kv_cache_interface.py
@@ -38,7 +38,7 @@ class SelfAttentionCache(LayerCache):
 
     @property
     def key(self) -> str:
-        return "self_attention"
+        return f"self_attention_{self.block_size}_{self.memory_size(1)}"
 
     @property
     def page_size(self) -> int:
@@ -59,7 +59,7 @@ class SlidingWindowCache(LayerCache):
 
     @property
     def key(self) -> str:
-        return f"sliding_window_{self.sliding_window}"
+        return f"sliding_window_{self.sliding_window}_{self.memory_size(1)}"
 
     @property
     def page_size(self) -> int:

--- a/vllm/v1/core/kv_cache_interface.py
+++ b/vllm/v1/core/kv_cache_interface.py
@@ -1,0 +1,102 @@
+from dataclasses import dataclass
+import math
+from typing import Dict, List, Protocol, runtime_checkable
+import torch
+
+from vllm.config import ModelConfig, VllmConfig
+from vllm.utils import get_dtype_size
+
+# TODO: add comment for
+# layer_id:
+# layer_cnt:
+# group_id:
+
+
+# worker -> scheduler about the model architecture
+# TODO(Chen): find a better name
+@dataclass
+class LayerCache:
+
+    @property
+    def key(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def page_size(self) -> int:
+        raise NotImplementedError
+
+    def memory_size(self, num_tokens: int) -> int:
+        raise NotImplementedError
+
+
+@dataclass
+class SelfAttentionCache(LayerCache):
+    block_size: int
+    num_kv_heads: int
+    head_size: int
+    dtype: torch.dtype
+
+    @property
+    def key(self) -> str:
+        return "self_attention"
+
+    @property
+    def page_size(self) -> int:
+        return  2 * self.block_size * self.num_kv_heads * self.head_size \
+                * get_dtype_size(self.dtype)
+
+    def memory_size(self, num_tokens: int) -> int:
+        return math.ceil(num_tokens / self.block_size) * self.page_size
+
+
+@dataclass
+class SlidingWindowCache(LayerCache):
+    block_size: int
+    num_kv_heads: int
+    head_size: int
+    dtype: torch.dtype
+    sliding_window: int
+
+    @property
+    def key(self) -> str:
+        return f"sliding_window_{self.sliding_window}"
+
+    @property
+    def page_size(self) -> int:
+        return  2 * self.block_size * self.num_kv_heads * self.head_size \
+                * get_dtype_size(self.dtype)
+
+    def memory_size(self, num_tokens: int) -> int:
+        num_tokens = min(num_tokens, self.sliding_window)
+        return math.ceil(num_tokens / self.block_size) * self.page_size
+
+
+@dataclass
+class LayerConfig:
+    # TODO (Chen): remove layer_cnt and use layer_id to index kv_cache in models
+    layer_id_mapping: Dict[str, int]  # layer_cnt -> layer_id
+    layers: Dict[str, LayerCache]
+
+
+# scheduler -> worker about the kv cache configuration
+@dataclass
+class KVCacheTensor:
+    size: int  # in bytes
+
+
+@dataclass
+class KVCacheTensorShareBuffer(KVCacheTensor):
+    start_bias: int
+
+
+@dataclass
+class KVCacheTensorSeperate(KVCacheTensor):
+    pass
+
+
+@dataclass
+class KVCacheConfig:
+    buffer_size: int  # -1 if do not need a global buffer
+    tensors: Dict[int, KVCacheTensor]  # layer_cnt -> KVCacheTensor
+    block_table_sharing: Dict[str, List[str]]  # group_id -> List[layer_id]
+    layer_config: LayerConfig

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -1,35 +1,46 @@
 from collections import defaultdict
-from typing import Dict, Iterable, List, Optional
+import math
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from vllm.logger import init_logger
 from vllm.utils import cdiv
+from vllm.v1.core.custom_manager import MemoryPoolOperations, get_managers
+from vllm.v1.core.kv_cache_interface import KVCacheConfig
 from vllm.v1.core.kv_cache_utils import (BlockHashType, FreeKVCacheBlockQueue,
                                          KVCacheBlock,
                                          generate_block_hash_extra_keys,
                                          hash_block_tokens,
-                                         hash_request_tokens)
+                                         hash_request_tokens, ComputedTokens,
+                                         intersect_ranges)
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+KVCacheBlocks = Dict[str, List[KVCacheBlock]]  # group_name -> blocks
 
 
 class KVCacheManager:
 
     def __init__(
         self,
-        block_size: int,
         num_gpu_blocks: int,
         max_model_len: int,
-        sliding_window: Optional[int] = None,
+        kv_cache_config: KVCacheConfig,
         enable_caching: bool = True,
         num_preallocate_tokens: int = 64,
     ) -> None:
-        self.block_size = block_size
+        # self.block_size = block_size
         self.num_gpu_blocks = num_gpu_blocks
         self.max_model_len = max_model_len
-        self.max_num_blocks_per_req = cdiv(max_model_len, block_size)
-        self.sliding_window = sliding_window
+        # self.max_num_blocks_per_req = cdiv(max_model_len, block_size)
         self.enable_caching = enable_caching
+
+        # TODO(Chen): add comments
+        self.managers = get_managers(
+            kv_cache_config,
+            MemoryPoolOperations(get_cached_block=self._get_cached_block
+                                 ))  # group_name -> manager
+
         # NOTE(woosuk): To avoid frequent block allocation, we preallocate some
         # blocks for each request. For example, when a request reaches the end
         # of its block table, we preallocate N blocks in advance. This way, we
@@ -41,7 +52,10 @@ class KVCacheManager:
         # further allocation. When it uses up all the N empty blocks, it gets
         # N new empty blocks.
         self.num_preallocate_tokens = num_preallocate_tokens
-        self.num_preallocate_blocks = cdiv(num_preallocate_tokens, block_size)
+        # TODO(Chen): add comments
+        self.num_preallocate_blocks = cdiv(
+            num_preallocate_tokens,
+            max(manager.block_size for manager in self.managers.values()))
 
         # A Block pool of all kv-cache blocks.
         self.block_pool: List[KVCacheBlock] = [
@@ -67,9 +81,12 @@ class KVCacheManager:
         # Mapping from request ID to blocks to track the blocks allocated
         # for each request, so that we can free the blocks when the request
         # is finished.
-        self.req_to_blocks: Dict[str, List[KVCacheBlock]] = {}
+        self.req_to_blocks: Dict[str, KVCacheBlocks] = {}
 
-    def get_computed_blocks(self, request: Request) -> List[KVCacheBlock]:
+        self.null_block: Optional[KVCacheBlock] = None
+
+    def get_computed_tokens(self,
+                            request: Request) -> Tuple[int, KVCacheBlocks]:
         """Get the computed (cached) blocks for the request.
         Note that the computed blocks must be full.
 
@@ -81,33 +98,56 @@ class KVCacheManager:
         """
         if not self.enable_caching:
             # Prefix caching is disabled.
-            return []
-
-        computed_blocks = []
+            return 0, {group_name: [] for group_name in self.managers}
 
         # The block hashes for the request may already be computed
         # if the request was preempted and resumed.
         if not request.kv_block_hashes:
-            request.set_kv_block_hashes(
-                hash_request_tokens(self.block_size, request))
-        block_hashes = request.kv_block_hashes
+            request.set_kv_block_hashes({
+                group_name: hash_request_tokens(manager.block_size, request,
+                                                group_name)
+                for group_name, manager in self.managers.items()
+            })
+        request.kv_block_hashes
+        block_hashes = {}
 
-        for block_hash in block_hashes:
-            # block_hashes is a chain of block hashes. If a block hash is not
-            # in the cached_block_hash_to_id, the following block hashes are
-            # not computed yet for sure.
-            if cached_block := self._get_cached_block(block_hash):
-                computed_blocks.append(cached_block)
+        for group_name in self.managers:
+            if request.num_tokens % self.managers[group_name].block_size == 0:
+                # When prompt length is divisible by the block size and all
+                # blocks are cached, we need to force the recomputation of
+                # the last block. We remove the hash of the last block so that
+                # get_computed_tokens will skip the last block. Note that we
+                # have to re-compute an entire block because allocate_slots()
+                # assumes num_computed_tokens is always a multiple of the block
+                # size. This limitation can potentially be removed in the future
+                # to slightly improve the performance.
+                block_hashes[group_name] = request.kv_block_hashes[
+                    group_name][:-1]
             else:
-                break
+                block_hashes[group_name] = request.kv_block_hashes[group_name]
 
-        return computed_blocks
+        computed_blocks: KVCacheBlocks = {}
+        computed_tokens: Dict[str, ComputedTokens] = {}
+        for group_name, manager in self.managers.items():
+            computed_tokens[group_name], computed_blocks[group_name] = (
+                manager.get_computed_tokens(block_hashes[group_name]))
+
+        # find the common cached prefix of all groups
+        num_computed_tokens = self.get_common_computed_tokens(computed_tokens)
+
+        for group_name, blocks in computed_blocks.items():
+            blocks = blocks[:num_computed_tokens //
+                            self.managers[group_name].block_size]
+            self.managers[group_name].remove_useless_blocks(
+                blocks, num_computed_tokens, call_free=True)
+
+        return num_computed_tokens, computed_blocks
 
     def append_slots(
         self,
         request: Request,
         num_tokens: int,
-    ) -> Optional[List[KVCacheBlock]]:
+    ) -> Optional[KVCacheBlocks]:
         """Append slots to the block table of the request.
         We first append slots to already allocated blocks. If the allocated
         blocks are not enough, we allocate new blocks.
@@ -120,62 +160,84 @@ class KVCacheManager:
             A list of new blocks if new blocks are allocated, or None
             if new blocks are required but cannot be allocated.
         """
-        num_required_blocks = cdiv(request.num_computed_tokens + num_tokens,
-                                   self.block_size)
         req_blocks = self.req_to_blocks[request.request_id]
+        num_new_blocks_of_group = {
+            group_name: manager.get_num_new_blocks(request.num_computed_tokens,
+                                                   num_tokens,
+                                                   len(req_blocks[group_name]))
+            for group_name, manager in self.managers.items()
+        }
 
-        num_new_blocks = num_required_blocks - len(req_blocks)
+        num_new_blocks = sum(
+            max(x, 0) for x in num_new_blocks_of_group.values())
         if num_new_blocks > self.free_block_queue.num_free_blocks:
             # Need to allocate new blocks due to insufficient pre-allocated
             # slots, but we cannot allocate new blocks due to the limit.
             return None
 
-        if num_new_blocks <= 0:
-            # No new block is needed.
-            new_blocks = []
-        else:
-            # Get new blocks from the free block pool considering
-            # preallocated blocks.
-            num_new_blocks = min(
-                num_new_blocks + self.num_preallocate_blocks,
-                self.free_block_queue.num_free_blocks,
-                # Should not exceed the maximum number of blocks per request.
-                # This is especially because the block table has the shape
-                # [..., max_num_blocks_per_req].
-                # TODO(woosuk): Check and reject requests if
-                # num_prompt_tokens + max_tokens > max_model_len.
-                self.max_num_blocks_per_req - len(req_blocks),
-            )
-            assert num_new_blocks > 0
+        # TODO(Chen): add comments
+        num_preallocate_blocks = min(
+            self.num_preallocate_blocks,
+            (self.free_block_queue.num_free_blocks - num_new_blocks) //
+            len(self.managers))
 
-            new_blocks = self._get_new_blocks(num_new_blocks)
-            req_blocks.extend(new_blocks)
+        for group_name, manager in self.managers.items():
+            # NOTE(Chen): do all free before allocation to make less eviction
+            manager.remove_useless_blocks(request.num_computed_tokens,
+                                          req_blocks[group_name],
+                                          call_free=True)
+        new_blocks = {}
+
+        for group_name in self.managers:
+            if num_new_blocks[group_name] <= 0:
+                # No new block is needed.
+                new_blocks[group_name] = []
+            else:
+                # Get new blocks from the free block pool considering
+                # preallocated blocks.
+                num_block_to_allocate = min(
+                    num_new_blocks[group_name] + num_preallocate_blocks,
+                    # Should not exceed the maximum number of blocks per request.
+                    # This is especially because the block table has the shape
+                    # [..., max_num_blocks_per_req].
+                    # TODO(woosuk): Check and reject requests if
+                    # num_prompt_tokens + max_tokens > max_model_len.
+                    # TODO(Chen): update comments about max_num_blocks_per_req
+                    cdiv(self.max_model_len, manager.block_size) -
+                    len(req_blocks[group_name]),
+                )
+                assert num_new_blocks > 0
+
+                new_blocks[group_name] = self._get_new_blocks(
+                    num_block_to_allocate)
+                req_blocks[group_name].extend(new_blocks[group_name])
 
         if not self.enable_caching:
             return new_blocks
 
-        num_computed_full_blocks = (request.num_computed_tokens //
-                                    self.block_size)
+        for group_name, manager in self.managers.items():
+            num_computed_full_blocks = (request.num_computed_tokens //
+                                        manager.block_size)
 
-        # NOTE(rickyx): We are assuming the `num_tokens` are actual
-        # tokens rather than lookahead slots (e.g. for speculative decoding).
-        # TODO(rickyx): When supporting speculative decoding, we will need to
-        # differentiate between them so that we can know how many blocks are
-        # full after appending the actual tokens.
-        num_full_blocks_after_append = (request.num_computed_tokens +
-                                        num_tokens) // self.block_size
-        assert num_full_blocks_after_append <= len(req_blocks)
+            # NOTE(rickyx): We are assuming the `num_tokens` are actual
+            # tokens rather than lookahead slots (e.g. for speculative decoding).
+            # TODO(rickyx): When supporting speculative decoding, we will need to
+            # differentiate between them so that we can know how many blocks are
+            # full after appending the actual tokens.
+            num_full_blocks_after_append = (request.num_computed_tokens +
+                                            num_tokens) // manager.block_size
+            assert num_full_blocks_after_append <= len(req_blocks)
 
-        new_full_blocks = req_blocks[
-            num_computed_full_blocks:num_full_blocks_after_append]
-        if new_full_blocks:
-            self._cache_full_blocks(
-                request=request,
-                blk_start_idx=num_computed_full_blocks,
-                full_blocks=new_full_blocks,
-                prev_block=req_blocks[num_computed_full_blocks - 1]
-                if num_computed_full_blocks >= 1 else None,
-            )
+            new_full_blocks = req_blocks[
+                num_computed_full_blocks:num_full_blocks_after_append]
+            if new_full_blocks:
+                self._cache_full_blocks(
+                    request=request,
+                    blk_start_idx=num_computed_full_blocks,
+                    full_blocks=new_full_blocks,
+                    prev_block=req_blocks[num_computed_full_blocks - 1]
+                    if num_computed_full_blocks >= 1 else None,
+                    group_name=group_name)
 
         return new_blocks
 
@@ -183,8 +245,8 @@ class KVCacheManager:
         self,
         request: Request,
         num_tokens: int,
-        computed_blocks: List[KVCacheBlock],
-    ) -> Optional[List[KVCacheBlock]]:
+        computed_blocks: KVCacheBlocks,
+    ) -> Optional[KVCacheBlocks]:
         """Allocate slots for a new request.
 
         Args:
@@ -208,45 +270,72 @@ class KVCacheManager:
                 "Computed blocks should be empty when "
                 "prefix caching is disabled")
 
-        num_required_blocks = cdiv(num_tokens, self.block_size)
-        if (num_required_blocks > self.free_block_queue.num_free_blocks):
+        num_new_blocks_of_group = {
+            group_name:
+            manager.get_num_new_blocks(request.num_computed_tokens, num_tokens,
+                                       len(computed_blocks[group_name]))
+            for group_name, manager in self.managers.items()
+        }
+
+        num_new_blocks = sum(
+            max(x, 0) for x in num_new_blocks_of_group.values())
+        if num_new_blocks > self.free_block_queue.num_free_blocks:
             # Cannot allocate new blocks.
             return None
 
-        # Determine the number of new blocks to allocate considering
-        # preallocated blocks.
-        num_new_blocks = min(
-            num_required_blocks + self.num_preallocate_blocks,
-            self.free_block_queue.num_free_blocks,
-            # Should not exceed the maximum number of blocks per request.
-            # This is especially because the block table has the shape
-            # [..., max_num_blocks_per_req].
-            # TODO(woosuk): Check and reject requests if
-            # num_prompt_tokens + max_tokens > max_model_len.
-            self.max_num_blocks_per_req - len(computed_blocks),
-        )
-        assert num_new_blocks > 0
+        # TODO(Chen): add comments
+        num_preallocate_blocks = min(
+            self.num_preallocate_blocks,
+            (self.free_block_queue.num_free_blocks - num_new_blocks) //
+            len(self.managers))
 
-        # Concatenate the computed block IDs and the new block IDs.
-        new_blocks = self._get_new_blocks(num_new_blocks)
-        self.req_to_blocks[request.request_id] = computed_blocks + new_blocks
+        new_blocks = {}
+        req_to_blocks = {}
+
+        for group_name, manager in self.managers.items():
+            # Determine the number of new blocks to allocate considering
+            # preallocated blocks.
+            num_block_to_allocate = min(
+                num_new_blocks_of_group[group_name] + num_preallocate_blocks,
+                # Should not exceed the maximum number of blocks per request.
+                # This is especially because the block table has the shape
+                # [..., max_num_blocks_per_req].
+                # TODO(woosuk): Check and reject requests if
+                # num_prompt_tokens + max_tokens > max_model_len.
+                # TODO(Chen): update comments about max_num_blocks_per_req
+                cdiv(self.max_model_len, manager.block_size) -
+                len(computed_blocks[group_name]),
+            )
+            assert num_block_to_allocate > 0
+
+            # Concatenate the computed block IDs and the new block IDs.
+            new_blocks[group_name] = self._get_new_blocks(
+                num_block_to_allocate)
+            req_to_blocks[group_name] = \
+                computed_blocks[group_name] + new_blocks[group_name]
+
+        self.req_to_blocks[request.request_id] = req_to_blocks
 
         if not self.enable_caching:
             return new_blocks
 
-        num_computed_tokens = len(computed_blocks) * self.block_size
-        num_full_blocks = (num_computed_tokens + num_tokens) // self.block_size
+        for group_name, manager in self.managers.items():
+            num_computed_tokens = len(
+                computed_blocks[group_name]) * manager.block_size
+            num_full_blocks = (num_computed_tokens +
+                               num_tokens) // manager.block_size
 
-        new_full_blocks = self.req_to_blocks[
-            request.request_id][len(computed_blocks):num_full_blocks]
-        if new_full_blocks:
-            self._cache_full_blocks(
-                request=request,
-                blk_start_idx=len(computed_blocks),
-                # The new full blocks are the full blocks that are not computed.
-                full_blocks=new_full_blocks,
-                prev_block=computed_blocks[-1] if computed_blocks else None,
-            )
+            new_full_blocks = self.req_to_blocks[request.request_id][
+                group_name][len(computed_blocks):num_full_blocks]
+            if new_full_blocks:
+                self._cache_full_blocks(
+                    request=request,
+                    blk_start_idx=len(computed_blocks),
+                    # The new full blocks are the full blocks that are not computed.
+                    full_blocks=new_full_blocks,
+                    prev_block=computed_blocks[group_name][-1]
+                    if computed_blocks else None,
+                )
 
         return new_blocks
 
@@ -258,17 +347,32 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
-        # Default to [] in case a request is freed (aborted) before alloc.
-        blocks = self.req_to_blocks.pop(request.request_id, [])
-        ordered_blocks: Iterable[KVCacheBlock] = blocks
-        if self.enable_caching:
-            # Free blocks in reverse order so that the tail blocks are
-            # freed first.
-            ordered_blocks = reversed(blocks)
+        # Default to {} in case a request is freed (aborted) before alloc.
+        blocks = self.req_to_blocks.pop(request.request_id, {})
+        if len(blocks) == 0:
+            # This request is freed before alloc. just return
+            return
+        elif len(blocks) == 1:
+            ordered_blocks: Iterable[KVCacheBlock] = iter(
+                blocks.values()).__next__()
+            if self.enable_caching:
+                # Free blocks in reverse order so that the tail blocks are
+                # freed first.
+                ordered_blocks = reversed(blocks)
+        else:
+            if self.enable_caching:
+                # TODO(Chen): add comments
+                ordered_blocks = self._merge_blocks_by_length_reversed(blocks)
+            else:
+                ordered_blocks = []
+                for block_list in blocks.values():
+                    ordered_blocks.extend(block_list)
 
         for block in ordered_blocks:
             block.decr_ref()
-            if block.ref_cnt == 0:
+            # TODO(Chen): add comments: never free the null_block, so do not
+            # need to track its ref_cnt carefully.
+            if block.ref_cnt == 0 and block != self.null_block:
                 self.free_block_queue.append(block)
 
     def _get_new_blocks(self, num_blocks: int) -> List[KVCacheBlock]:
@@ -336,7 +440,7 @@ class KVCacheManager:
             return self.cached_block_hash_to_block[block_hash][first_block_id]
         return None
 
-    def _touch(self, blocks: List[KVCacheBlock]) -> None:
+    def _touch(self, blocks: KVCacheBlocks) -> None:
         """Touch a block increases its reference count by 1, and may remove
         the block from the free queue. This is used when a block is hit by
         another request with the same prefix.
@@ -344,20 +448,18 @@ class KVCacheManager:
         Args:
             blocks: A list of blocks to touch.
         """
-        for block in blocks:
-            # ref_cnt=0 means this block is in the free list (i.e. eviction
-            # candidate), so remove it.
-            if block.ref_cnt == 0:
-                self.free_block_queue.remove(block)
-            block.incr_ref()
+        for block_list in blocks.values():
+            for block in block_list:
+                # ref_cnt=0 means this block is in the free list (i.e. eviction
+                # candidate), so remove it.
+                if block.ref_cnt == 0 and block != self.null_block:
+                    self.free_block_queue.remove(block)
+                block.incr_ref()
 
-    def _cache_full_blocks(
-        self,
-        request: Request,
-        blk_start_idx: int,
-        full_blocks: List[KVCacheBlock],
-        prev_block: Optional[KVCacheBlock],
-    ) -> None:
+    def _cache_full_blocks(self, request: Request, blk_start_idx: int,
+                           full_blocks: List[KVCacheBlock],
+                           prev_block: Optional[KVCacheBlock],
+                           group_name: str) -> None:
         """Cache a list of full blocks for prefix caching.
 
         This function takes a list of blocks that will have their block hash
@@ -372,8 +474,11 @@ class KVCacheManager:
                 to cache.
             full_blocks: The list of blocks to update hash metadata.
             prev_block: The previous block in the chain.
+            group_name: TODO(Chen): add comments
         """
-        num_cached_block_hashes = len(request.kv_block_hashes)
+        kv_block_hashes = request.kv_block_hashes[group_name]
+        num_cached_block_hashes = len(kv_block_hashes)
+        block_size = self.managers[group_name].block_size
 
         # Update the new blocks with the block hashes through the chain.
         prev_block_hash_value = None
@@ -392,24 +497,28 @@ class KVCacheManager:
                 # this request (either the prompt tokens or the previously
                 # generated tokens with preemption). In this case we simply
                 # reuse the block hash.
-                block_hash = request.kv_block_hashes[blk_idx]
+                block_hash = kv_block_hashes[blk_idx]
             else:
                 # Otherwise compute the block hash and cache it in the request
                 # in case it will be preempted in the future.
-                start_token_idx = blk_idx * self.block_size
-                end_token_idx = (blk_idx + 1) * self.block_size
+                start_token_idx = blk_idx * block_size
+                end_token_idx = (blk_idx + 1) * block_size
                 block_tokens = request.all_token_ids[
                     start_token_idx:end_token_idx]
-                assert len(block_tokens) == self.block_size, (
-                    f"Expected {self.block_size} tokens, got "
+                assert len(block_tokens) == block_size, (
+                    f"Expected {block_size} tokens, got "
                     f"{len(block_tokens)} at {blk_idx}th block for request "
                     f"{request.request_id}({request})")
+
+                extra_keys = [group_name]
 
                 # Generate extra keys for multi-modal inputs. Note that since
                 # we reach to this branch only when the block is completed with
                 # generated tokens, we only need to consider the last mm input.
-                extra_keys, _ = generate_block_hash_extra_keys(
+                extra_mm_keys, _ = generate_block_hash_extra_keys(
                     request, start_token_idx, end_token_idx, -1)
+                if extra_mm_keys is not None:
+                    extra_keys.extend(extra_mm_keys)
 
                 # Compute the hash of the current block.
                 block_hash = hash_block_tokens(prev_block_hash_value,
@@ -420,3 +529,50 @@ class KVCacheManager:
             blk.block_hash = block_hash
             self.cached_block_hash_to_block[block_hash][blk.block_id] = blk
             prev_block_hash_value = block_hash.hash_value
+
+    def _merge_blocks_by_length_reversed(
+            self, blocks: KVCacheBlocks) -> List[KVCacheBlock]:
+        # merge blocks from different groups based on the block size
+        block_size_set = set(manager.block_size
+                             for manager in self.managers.values())
+        if len(block_size_set) == 1:
+            # O(n) time complexity if all block sizes are the same
+            ordered_blocks = []
+            group_name = iter(self.managers).next()
+            for i in range(len(blocks[group_name]) - 1, -1, -1):
+                for block_list in blocks.values():
+                    ordered_blocks.append(block_list[i])
+        else:
+            # O(n * log(n)) time complexity
+            # TODO: optimize it to O(n*len(self.managers)) time complexity
+            ordered_blocks_with_key = []
+
+            for group_name, block_list in blocks.items():
+                block_size = self.managers[group_name].block_size
+                for i, block in enumerate(block_list):
+                    ordered_blocks_with_key.append((block_size * i, block))
+
+            ordered_blocks_with_key.sort(reverse=True)
+            ordered_blocks = [block for _, block in ordered_blocks_with_key]
+
+        return ordered_blocks
+
+    def get_common_computed_tokens(self,
+                                   computed_tokens: KVCacheBlocks) -> int:
+        # TODO: add comments: the largest in the intersection, and alignment
+        intersection = intersect_ranges(list(computed_tokens.values()))
+
+        # Since incomplete blocks are not eligible for sharing,
+        # `num_computed_tokens` should be a multiple of `block_size` of
+        # all managers, so we take the least common multiple (LCM) of them
+        alignment = math.lcm(
+            *[manager.block_size for manager in self.managers.values()])
+
+        num_computed_tokens = 0
+        for range_ in intersection:
+            aligned_end = cdiv(range_.end, alignment) * alignment
+            if aligned_end > range_.start:
+                num_computed_tokens = aligned_end
+                break
+
+        return num_computed_tokens

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -259,7 +259,7 @@ def hash_block_tokens(
         The entire tuple is used as the hash key of the block.
     """
     return BlockHashType(hash((parent_block_hash, *curr_block_token_ids)),
-                         tuple(curr_block_token_ids), extra_keys)
+                         tuple(curr_block_token_ids), tuple(extra_keys))
 
 
 def hash_request_tokens(block_size: int, request: Request,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -25,7 +25,8 @@ class BlockHashType(NamedTuple):
 @dataclass
 class KVCacheBlock:
     """KV-cache block metadata."""
-    # Block ID, ranging from 0 to num_gpu_blocks - 1.
+    # Block ID, ranging from 0 to num_gpu_blocks - 1, and a special block_id -1
+    # for the null block.
     block_id: int
     # Reference count.
     ref_cnt: int = 0

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -262,7 +262,7 @@ def hash_block_tokens(
 
 
 def hash_request_tokens(block_size: int, request: Request,
-                        group_name: str) -> List[BlockHashType]:
+                        group_id: int) -> List[BlockHashType]:
     """Computes hash values of a chain of blocks given a sequence of
     token IDs. The hash value is used for prefix caching.
 
@@ -290,7 +290,7 @@ def hash_request_tokens(block_size: int, request: Request,
         if len(block_token_ids) < block_size:
             break
 
-        extra_keys = [group_name]
+        extra_keys = [group_id]
         # Add extra keys if the block is a multi-modal block.
         extra_keys_mm, curr_mm_idx = generate_block_hash_extra_keys(
             request, start, end, curr_mm_idx)

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -9,6 +9,7 @@ from vllm.multimodal import MultiModalKwargs
 from vllm.multimodal.base import PlaceholderRange
 from vllm.sampling_params import SamplingParams
 from vllm.v1.core.encoder_cache_manager import EncoderCacheManager
+from vllm.v1.core.kv_cache_interface import KVCacheConfig
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.engine import EngineCoreOutput
 from vllm.v1.outputs import ModelRunnerOutput
@@ -28,6 +29,7 @@ class Scheduler:
         scheduler_config: SchedulerConfig,
         cache_config: CacheConfig,
         lora_config: Optional[LoRAConfig],
+        kv_cache_config: KVCacheConfig,
     ) -> None:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
@@ -197,6 +199,7 @@ class Scheduler:
                 # which have output tokens.
                 num_new_tokens = request.num_tokens - num_computed_tokens
                 if num_new_tokens == 0:
+                    # TODO (Chen): remove this constraint inside num_computed_blocks?
                     # The happens when prompt length is divisible by the block
                     # size and all blocks are cached. Now we force to recompute
                     # the last block. Note that we have to re-compute an entire

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -17,6 +17,7 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.usage.usage_lib import UsageContext
+from vllm.v1.core.hybrid_allocator_compiler import get_kv_cache_config
 from vllm.v1.core.scheduler import Scheduler
 from vllm.v1.engine import (EngineCoreOutput, EngineCoreOutputs,
                             EngineCoreProfile, EngineCoreRequest,
@@ -54,7 +55,7 @@ class EngineCore:
 
         # Setup KV Caches and update CacheConfig after profiling.
         num_gpu_blocks, num_cpu_blocks = self._initialize_kv_caches(
-            vllm_config.cache_config)
+            vllm_config)
         vllm_config.cache_config.num_gpu_blocks = num_gpu_blocks
         vllm_config.cache_config.num_cpu_blocks = num_cpu_blocks
 
@@ -69,21 +70,16 @@ class EngineCore:
             vllm_config.model_config)
 
     def _initialize_kv_caches(self,
-                              cache_config: CacheConfig) -> Tuple[int, int]:
+                              vllm_config: VllmConfig) -> Tuple[int, int]:
         start = time.time()
-        num_gpu_blocks, _ = self.model_executor.determine_num_available_blocks(
-        )
-
-        if cache_config.num_gpu_blocks_override is not None:
-            num_gpu_blocks_override = cache_config.num_gpu_blocks_override
-            logger.info(
-                "Overriding num_gpu_blocks=%d with "
-                "num_gpu_blocks_override=%d", num_gpu_blocks,
-                num_gpu_blocks_override)
-            num_gpu_blocks = num_gpu_blocks_override
+        layer_config = self.model_executor.get_layer_config()
+        availble_gpu_memory = self.model_executor.get_available_memory()
+        print("layer_config", layer_config)
+        kv_cache_config, num_gpu_blocks = get_kv_cache_config(
+            vllm_config, layer_config, availble_gpu_memory)
 
         num_cpu_blocks = 0
-        self.model_executor.initialize(num_gpu_blocks)
+        self.model_executor.initialize(kv_cache_config)
         elapsed = time.time() - start
         logger.info(("init engine (profile, create kv cache, "
                      "warmup model) took %.2f seconds"), elapsed)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 from vllm.config import VllmConfig
-from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import ModelRunnerOutput
 
 
@@ -23,7 +23,7 @@ class Executor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_layer_config(self) -> LayerConfig:
+    def get_kv_cache_spec(self) -> KVCacheSpec:
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Tuple
 
 from vllm.config import VllmConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
 from vllm.v1.outputs import ModelRunnerOutput
 
 
@@ -13,11 +14,16 @@ class Executor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def initialize(self, num_gpu_blocks: int) -> None:
+    def initialize(self, kv_cache_config: KVCacheConfig) -> None:
         raise NotImplementedError
 
     @abstractmethod
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def get_available_memory(self) -> int:
+        # in bytes
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_layer_config(self) -> LayerConfig:
         raise NotImplementedError
 
     @abstractmethod

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -9,7 +9,7 @@ from enum import Enum, auto
 from multiprocessing.process import BaseProcess
 from typing import Any, Dict, List, Optional, Tuple
 
-from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheSpec
 import zmq
 
 from vllm.config import VllmConfig
@@ -94,10 +94,10 @@ class MultiprocExecutor(Executor):
         # operators can be applied to all workers.
         return min(memory_sizes)
 
-    def get_layer_config(self) -> LayerConfig:
-        layer_configs = self.collective_rpc("get_layer_config")
-        assert all(lc == layer_configs[0] for lc in layer_configs)
-        return layer_configs[0]
+    def get_kv_cache_spec(self) -> KVCacheSpec:
+        kv_cache_specs = self.collective_rpc("get_kv_cache_spec")
+        assert all(lc == kv_cache_specs[0] for lc in kv_cache_specs)
+        return kv_cache_specs[0]
 
     def collective_rpc(self,
                        method: str,

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.utils import get_distributed_init_method, get_ip, get_open_port
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.gpu_worker import Worker
@@ -49,20 +50,24 @@ class UniprocExecutor(Executor):
             distributed_init_method=distributed_init_method,
         )
 
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
-        """Determine the number of available KV blocks by invoking the
+    def get_available_memory(self) -> int:
+        """Determine the available memory for KV cache by invoking the
         underlying worker.
         """
-        return self.worker.determine_num_available_blocks()
+        return self.worker.get_available_memory()
 
-    def initialize(self, num_gpu_blocks: int) -> None:
+    def get_layer_config(self) -> LayerConfig:
+        return self.worker.get_layer_config()
+
+    def initialize(self, kv_cache_config: KVCacheConfig) -> None:
         """Initialize the KV cache by invoking the underlying worker.
         """
+        # TODO (Chen): why do we need this log?
         # NOTE: This is logged in the executor because there can be >1 worker
         # with other executors. We could log in the engine level, but work
         # remains to abstract away the device for non-GPU configurations.
-        logger.info("# GPU blocks: %d", num_gpu_blocks)
-        self.worker.initialize_cache(num_gpu_blocks)
+        # logger.info("# GPU blocks: %d", num_gpu_blocks)
+        self.worker.initialize_cache(kv_cache_config)
         self.worker.compile_or_warm_up_model()
 
     def execute_model(

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.utils import get_distributed_init_method, get_ip, get_open_port
-from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.executor.abstract import Executor
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.gpu_worker import Worker
@@ -56,8 +56,8 @@ class UniprocExecutor(Executor):
         """
         return self.worker.get_available_memory()
 
-    def get_layer_config(self) -> LayerConfig:
-        return self.worker.get_layer_config()
+    def get_kv_cache_spec(self) -> KVCacheSpec:
+        return self.worker.get_kv_cache_spec()
 
     def initialize(self, kv_cache_config: KVCacheConfig) -> None:
         """Initialize the KV cache by invoking the underlying worker.

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -62,7 +62,7 @@ class UniprocExecutor(Executor):
     def initialize(self, kv_cache_config: KVCacheConfig) -> None:
         """Initialize the KV cache by invoking the underlying worker.
         """
-        # TODO (Chen): why do we need this log?
+        # TODO(Chen): why do we need this log?
         # NOTE: This is logged in the executor because there can be >1 worker
         # with other executors. We could log in the engine level, but work
         # remains to abstract away the device for non-GPU configurations.

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -65,8 +65,7 @@ class Request:
 
         # Cache the computed kv block hashes of the request to avoid
         # recomputing.
-        self._kv_block_hashes: Dict[str,
-                                    List[BlockHashType]] = defaultdict(list)
+        self._kv_block_hashes: List[List[BlockHashType]] = []
 
     @classmethod
     def from_engine_core_request(cls, request: EngineCoreRequest) -> "Request":
@@ -135,20 +134,20 @@ class Request:
         return num_tokens
 
     @property
-    def kv_block_hashes(self) -> Dict[str, ConstantList["BlockHashType"]]:
+    def kv_block_hashes(self) -> List[ConstantList["BlockHashType"]]:
         # Prevent directly appending to the kv_block_hashes.
-        return {
-            group_name: ConstantList(block_hashes)
-            for group_name, block_hashes in self._kv_block_hashes.items()
-        }
+        return [
+            ConstantList(block_hashes_of_group)
+            for block_hashes_of_group in self._kv_block_hashes
+        ]
 
     def set_kv_block_hashes(self, value: Dict[str,
                                               List["BlockHashType"]]) -> None:
         self._kv_block_hashes = value
 
-    def append_kv_block_hashes(self, group_name: str,
+    def append_kv_block_hashes(self, group_id: int,
                                block_hash: "BlockHashType") -> None:
-        self._kv_block_hashes[group_name].append(block_hash)
+        self._kv_block_hashes[group_id].append(block_hash)
 
 
 class RequestStatus(enum.IntEnum):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -208,7 +208,7 @@ class GPUModelRunner:
                 num_new_blocks = len(new_block_ids)
                 if num_new_blocks == 0:
                     continue
-                start_index = len(req_state.block_ids)
+                start_index = len(req_state.block_ids[group_id])
                 end_index = start_index + num_new_blocks
                 req_state.block_ids[group_id].extend(new_block_ids)
                 self.input_batch.block_table_cpu[

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -162,7 +162,7 @@ class Worker:
         print("available kv cache memory", available_kv_cache_memory, "bytes",
               available_kv_cache_memory / 1024 / 1024 / 1024, "GB")
 
-        return available_kv_cache_memory
+        return int(available_kv_cache_memory)
 
     def get_layer_config(self) -> LayerConfig:
         return self.model_runner.get_layer_config()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -15,7 +15,7 @@ from vllm.logger import init_logger
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, LayerBlockType, get_dtype_size
-from vllm.v1.core.kv_cache_interface import KVCacheConfig, LayerConfig
+from vllm.v1.core.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.core.scheduler import SchedulerOutput
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
@@ -164,8 +164,8 @@ class Worker:
 
         return int(available_kv_cache_memory)
 
-    def get_layer_config(self) -> LayerConfig:
-        return self.model_runner.get_layer_config()
+    def get_kv_cache_spec(self) -> KVCacheSpec:
+        return self.model_runner.get_kv_cache_spec()
 
     def initialize_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate GPU and CPU KV cache with the specified number of blocks."""

--- a/vllm/worker/cache_engine.py
+++ b/vllm/worker/cache_engine.py
@@ -1,11 +1,13 @@
 """CacheEngine class for managing the KV cache."""
-from typing import List
+from typing import Dict, List
 
 import torch
 
 from vllm.attention import get_attn_backend
-from vllm.config import CacheConfig, DeviceConfig, ModelConfig, ParallelConfig
+from vllm.config import (CacheConfig, CompilationConfig, DeviceConfig,
+                         LayerForwardContext, ModelConfig, ParallelConfig)
 from vllm.logger import init_logger
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, LayerBlockType,
                         get_dtype_size, is_pin_memory_available)
 
@@ -26,6 +28,7 @@ class CacheEngine:
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
         device_config: DeviceConfig,
+        compilation_config: CompilationConfig,
     ) -> None:
         self.cache_config = cache_config
         self.model_config = model_config
@@ -62,6 +65,7 @@ class CacheEngine:
         self.gpu_cache = self._allocate_kv_cache(
             self.num_gpu_blocks, self.device_config.device_type)
         self.cpu_cache = self._allocate_kv_cache(self.num_cpu_blocks, "cpu")
+        self._register_gpu_kv_cache(compilation_config.static_forward_context)
 
     def _allocate_kv_cache(
         self,
@@ -83,6 +87,14 @@ class CacheEngine:
                             pin_memory=pin_memory,
                             device=device))
         return kv_cache
+
+    def _register_gpu_kv_cache(self, ctx: Dict[str,
+                                               LayerForwardContext]) -> None:
+        if self.parallel_config.pipeline_parallel_size > 1:
+            raise NotImplementedError
+        for layer_name, forward_ctx in ctx.items():
+            layer_id = extract_layer_index(layer_name)
+            forward_ctx.kv_cache = self.gpu_cache[layer_id]
 
     def swap_in(self, src_to_dst: torch.Tensor) -> None:
         for i in range(self.num_attention_layers):

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -208,7 +208,8 @@ class HPUWorker(LocalOrDistributedWorkerBase):
         assert self.cache_config.num_gpu_blocks is not None
         self.cache_engine = [
             HPUCacheEngine(self.cache_config, self.model_config,
-                           self.parallel_config, self.device_config)
+                           self.parallel_config, self.device_config,
+                           self.compilation_config)
             for _ in range(self.parallel_config.pipeline_parallel_size)
         ]
         self.hpu_cache = [

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -278,7 +278,8 @@ class Worker(LocalOrDistributedWorkerBase):
         assert self.cache_config.num_gpu_blocks is not None
         self.cache_engine = [
             CacheEngine(self.cache_config, self.model_config,
-                        self.parallel_config, self.device_config)
+                        self.parallel_config, self.device_config,
+                        self.compilation_config)
             for _ in range(self.parallel_config.pipeline_parallel_size)
         ]
         self.gpu_cache = [

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -44,6 +44,9 @@ class WorkerBase(ABC):
         self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
         self.kv_transfer_config = vllm_config.kv_transfer_config
+        self.compilation_config = vllm_config.compilation_config
+        from vllm.platforms import current_platform
+        self.current_platform = current_platform
 
     @abstractmethod
     def init_device(self) -> None:


### PR DESCRIPTION
This pr implements step 1 of https://github.com/vllm-project/vllm/issues/11382 , so that 
1. we won't waste memory on sliding window & full attention interleaved models
2. support prefix caching of sliding window attention, where the cache hit only requires the tokens inside sliding window not evicted

Benchmark result (accelerate hybrid model & very little overhead on standard full attention models)
* this pr: 
```
VLLM_USE_V1=1 python3 benchmark_throughput.py --model google/gemma-2-27b-it --input-len 6144 --output-len 1024 --num-prompts 50
Throughput: 0.17 requests/s, 1239.96 total tokens/s, 177.14 output tokens/s
VLLM_USE_V1=1 python3 benchmark_throughput.py --model meta-llama/Llama-3.1-8B-Instruct --input-len 6144 --output-len 1024 --num-prompts 50
Throughput: 1.48 requests/s, 10609.31 total tokens/s, 1515.62 output tokens/s
```
* main branch (d53575a5f0e5c0f9003b4ec6e33c8bf761e93cef)
```
VLLM_USE_V1=1 python3 benchmark_throughput.py --model google/gemma-2-27b-it --input-len 6144 --output-len 1024 --num-prompts 50
Throughput: 0.15 requests/s, 1077.11 total tokens/s, 153.87 output tokens/s
VLLM_USE_V1=1 python3 benchmark_throughput.py --model meta-llama/Llama-3.1-8B-Instruct --input-len 6144 --output-len 1024 --num-prompts 50
Throughput: 1.49 requests/s, 10682.79 total tokens/s, 1526.11 output tokens/s
```

Key modifications
1. kv cache initialization: 
  * original workflow:
     1. `num_gpu_blocks, _ = self.model_executor.determine_num_available_blocks()` 
     2. `self.model_executor.initialize(num_gpu_blocks)` (allocate kv cache)
  * modified workflow
    ```python
     # Get all kv cache tensor needed via parsing the model
     kv_cache_spec = self.model_executor.get_kv_cache_spec()
     # Get availble_gpu_memory (instead of determine num_blocks based on that) by profile_run
     availble_gpu_memory = self.model_executor.get_available_memory()
     # EngineCore determines the page size & how to create each kv cache tensor
     kv_cache_config, num_gpu_blocks = get_kv_cache_config(
         vllm_config, kv_cache_spec, availble_gpu_memory)
     # Executor initialize the kv_cache based on that decision
     self.model_executor.initialize(kv_cache_config)
     ```
2. grouped allocation 
   * original: one KVCacheManager that allocate memory for all layers
   * modified: 
      * multiple KVCacheManagers, one for each group of layer (see "group the layers" for detail). All KVCacheManagers have the same page size and allocate memory from the same pool. 
      * add group_id to kv_block_hash
      * block_table in worker: add a new dimension for groups
      * two KVCacheManager implementation, for full attention & sliding window attention respectively

I plan to split it into the following prs:
1. kv cache initialization, as discussed above.
2. add a new "group" dimension to the block_table, to represent the different memory allocated for different types of kv cache.
3. change AttentionMetadata to dict[layer_name, AttentionMetadata]
4. a very large pr implementing `HybridKVCacheManager`, which is a pluggable alternative with `KVCacheManager`, and won't touch the code path for standard models with only full attention layers.