### PR TITLE
[Bugfix] Check that number of images matches number of <|image|> tokens with mllama

### DIFF
--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1500,6 +1500,8 @@ def convert_sparse_cross_attention_mask_to_dense(
             dense_mask[seq_start + start:seq_start + end,
                        tile_start:tile_start + tile] = 1
             tile_start += tile
+        assert ts != -1
+        assert td != 0
         tile_range_for_decode.append((ts, ts + td))
         seq_start += length
 

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -123,6 +123,13 @@ def input_processor_for_mllama(
 
     assert is_list_of(image_data, Image.Image)
 
+    num_image_tokens = dec_inputs['prompt_token_ids'].count(
+        MLLAMA_IMAGE_TOKEN_ID)
+    if num_image_tokens != len(image_data):
+        raise ValueError(
+            f"The number of image tokens ({num_image_tokens}) must be"
+            f" the same as the number of images ({len(image_data)})")
+
     # Since only the last group of consecutive images
     # are attended by the decoded tokens, we only need to
     # get the number of tiles for those images.


### PR DESCRIPTION
The OpenAI server can be crashed when serving the Llama Vision Instruct models if the request contains more `<|image|>` tokens than images. This can be triggered if the user message includes the `<|image|>` special token that is non-adjacent to the image message, eg.:
```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "meta-llama/Llama-3.2-11B-Vision",
    "messages": [
      {
        "role": "user",
        "content": [
          {"type": "text", "text": " <|image|> "},
          {"type": "image_url", "image_url": {"url": "https://upload.wikimedia.org/wikipedia/commons/d/da/2015_Kaczka_krzy%C5%BCowka_w_wodzie_%28samiec%29.jpg"}}
        ]
      }
    ]
  }'
```

This PR adds a check similar to [this one in Transformers](https://github.com/huggingface/transformers/blob/8de7b1ba8d126a6fc9f9bcc3173a71b46f0c3601/src/transformers/models/mllama/processing_mllama.py#L309-L311) to ensure the number of images and number of tokens matches.

Potential fix for https://github.com/vllm-project/vllm/issues/10648