### PR TITLE
[V1] Add prefix caching hit rate

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1,7 +1,7 @@
 """KV-Cache Utilities."""
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, List, NamedTuple, Optional, Tuple
+from typing import Any, List, NamedTuple, Optional, Tuple, TypedDict
 
 from vllm.logger import init_logger
 from vllm.v1.request import Request
@@ -22,6 +22,16 @@ class BlockHashType(NamedTuple):
     token_ids: Tuple[int, ...]
     # Extra keys for the block.
     extra_keys: Optional[Any] = None
+
+
+class PrefixCachingMetrics(TypedDict):
+    """Metrics for prefix caching."""
+
+    query_total: int
+    """The total number of queries."""
+
+    query_hit: int
+    """The number of queries that hit the prefix cache."""
 
 
 @dataclass

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -244,10 +244,17 @@ class EngineCoreProc(EngineCore):
         now = time.time()
 
         if now - self._last_logging_time > LOGGING_TIME_S:
+            prefix_caching_hit_rate = ""
+            if (hit_rate := self.scheduler.kv_cache_manager.
+                    get_prefix_caching_hit_rate()) > 0:
+                prefix_caching_hit_rate = (
+                    f" | PrefixCachingHitRate: {hit_rate:.2f}")
+
             logger.info(
-                "RUNNING: %s | WAITING: %s",
+                "RUNNING: %s | WAITING: %s%s",
                 len(self.scheduler.running),
                 len(self.scheduler.waiting),
+                prefix_caching_hit_rate,
             )
 
             self._last_logging_time = now


### PR DESCRIPTION
While the metric system in V1 is not ready yet, this PR adds prefix caching hit rate to the current lightweight logging in v1.

cc @robertgshaw2-neuralmagic @WoosukKwon 