### PR TITLE
[Misc] Add helpers to get pipeline rank & world size

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1147,6 +1147,16 @@ def get_tensor_model_parallel_rank():
     return get_tp_group().rank_in_group
 
 
+def get_pipeline_model_parallel_world_size():
+    """Return world size for the pipeline model parallel group."""
+    return get_pp_group().world_size
+
+
+def get_pipeline_model_parallel_rank():
+    """Return my rank for the pipeline model parallel group."""
+    return get_pp_group().rank_in_group
+
+
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
     global _TP


### PR DESCRIPTION
- Add two helper functions to `vllm.distributed` for getting the pipeline parallel rank and world size values.
- The equivalent helpers for tensor parallel are already defined, but not for pipeline parallel, so it would be appropriate to add them as well.