### PR TITLE
[BugFix] decode b-str device name in fused moe config reading

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -339,7 +339,10 @@ def invoke_fused_moe_kernel(A: torch.Tensor,
 
 
 def get_config_file_name(E: int, N: int, dtype: Optional[str]) -> str:
-    device_name = current_platform.get_device_name().replace(" ", "_")
+    device_name = current_platform.get_device_name()
+    if isinstance(device_name, bytes):
+        device_name = device_name.decode("utf-8")
+    device_name = device_name.replace(" ", "_")
     dtype_selector = "" if not dtype else f",dtype={dtype}"
     return f"E={E},N={N},device_name={device_name}{dtype_selector}.json"
 


### PR DESCRIPTION
# Summary

Seeing following errors locally on NvmlCudaPlatform`:
```
[rank0]:   File "/data/users/yeq/fbsource/buck-out/v2/gen/fbcode/06e8b956b67eee3d/vllm/__benchmark_latency__/benchmark_latency#link-tree/vllm/model_executor/layers/fused_moe/fused_moe.py", line 347, in get_config_file_name
[rank0]:     device_name = device_name.replace(" ", "_")
[rank0]: TypeError: a bytes-like object is required, not 'str'
```

# Test Plan

Ran a random moe model e2e:
```
python benchmarks/benchmark_latency.py --model "deepseek-ai/DeepSeek-V2-Lite" --trust-remote-code -tp 8
```