### PR TITLE
[V1] Avoid sending text prompt to core engine

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -19,8 +19,8 @@ class EngineCoreRequest:
     # due to circular imports and typing we have in data.py
 
     request_id: str
-    #NOTE(Nick): I don't think we need to pass prompt here since it should
-    # always be tokenized?
+    # NOTE(ywang96): original text prompt is needed when a request is added to 
+    # Detokenizer, but set to None when it is added to EngineCoreClient.
     prompt: Optional[str]
     prompt_token_ids: List[int]
     mm_inputs: Optional[List[Optional["MultiModalKwargs"]]]

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -19,7 +19,7 @@ class EngineCoreRequest:
     # due to circular imports and typing we have in data.py
 
     request_id: str
-    # NOTE(ywang96): original text prompt is needed when a request is added to 
+    # NOTE(ywang96): original text prompt is needed when a request is added to
     # Detokenizer, but set to None when it is added to EngineCoreClient.
     prompt: Optional[str]
     prompt_token_ids: List[int]

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -219,6 +219,9 @@ class SyncMPClient(MPClient):
         self.input_socket.send_multipart(msg, copy=False)
 
     def add_request(self, request: EngineCoreRequest) -> None:
+        # NOTE: text prompt is not needed in the core engine as it has been
+        # tokenized.
+        request.prompt = None
         self._send_input(EngineCoreRequestType.ADD, request)
 
     def abort_requests(self, request_ids: List[str]) -> None:
@@ -257,6 +260,9 @@ class AsyncMPClient(MPClient):
         await self.input_socket.send_multipart(msg, copy=False)
 
     async def add_request_async(self, request: EngineCoreRequest) -> None:
+        # NOTE: text prompt is not needed in the core engine as it has been
+        # tokenized.
+        request.prompt = None
         await self._send_input(EngineCoreRequestType.ADD, request)
 
     async def abort_requests_async(self, request_ids: List[str]) -> None:

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -181,7 +181,7 @@ class Processor:
 
         return EngineCoreRequest(
             request_id=request_id,
-            prompt=None,  # core engine does not need original text prompt
+            prompt=decoder_inputs.prompt,
             prompt_token_ids=decoder_inputs.prompt_token_ids,
             mm_inputs=sorted_mm_inputs,
             mm_hashes=sorted_mm_hashes,

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -181,7 +181,7 @@ class Processor:
 
         return EngineCoreRequest(
             request_id=request_id,
-            prompt=decoder_inputs.prompt,
+            prompt=None,  # core engine does not need original text prompt
             prompt_token_ids=decoder_inputs.prompt_token_ids,
             mm_inputs=sorted_mm_inputs,
             mm_hashes=sorted_mm_hashes,


### PR DESCRIPTION
The original text prompt is already tokenized in the processing process and thus should not be needed in the core engine (since everything is done with token IDs on the engine).

I ran a mini benchmark with an extreme case to see the perf impact:
```python
from vllm.v1.engine import EngineCoreRequest
from vllm import SamplingParams
import pickle
import time


prompt = "response" * 131072  # from llama 3 tokenizer, string "response" encodes to token id 2376
# prompt = None
prompt_token_ids = [2376] * 131072
params = SamplingParams()

core_request_list = [
        EngineCoreRequest(
            request_id=str(i),
            prompt=prompt,
            prompt_token_ids=prompt_token_ids,
            mm_inputs=None,
            mm_hashes=None,
            mm_placeholders=None,
            sampling_params=params,
            eos_token_id=None,
            arrival_time=i,
            lora_request=None
        )
        for i in range(100000)
]

st = time.perf_counter()
for request in core_request_list:
    res = pickle.dumps(request)

print(f"Pickling all requests took: {time.perf_counter() - st}")
```

- With `prompt = "response" * 131072`:
```
Pickling all requests took: 94.43566319113597
```
- With `prompt = None`
```
Pickling all requests took: 90.20890240790322
```

