### PR TITLE
[Bug] Fix usage of `.transpose()` and `.view()` consecutively.

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -222,7 +222,7 @@ class MultiHeadAttention(nn.Module):
                                                  key,
                                                  value,
                                                  scale=self.scale)
-            out = out.transpose(1, 2)
+            out = out.transpose(1, 2).contiguous()
         return out.view(bsz, q_len, -1)
 
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -222,8 +222,8 @@ class MultiHeadAttention(nn.Module):
                                                  key,
                                                  value,
                                                  scale=self.scale)
-            out = out.transpose(1, 2).contiguous()
-        return out.view(bsz, q_len, -1)
+            out = out.transpose(1, 2)
+        return out.reshape(bsz, q_len, -1)
 
 
 def unified_attention(

--- a/vllm/model_executor/models/intern_vit.py
+++ b/vllm/model_executor/models/intern_vit.py
@@ -271,7 +271,7 @@ class InternSdpaAttention(nn.Module):
         v = v.transpose(1, 2)
 
         x = F.scaled_dot_product_attention(q, k, v, scale=self.scale)
-        x = x.transpose(1, 2).contiguous().view(B, N, -1)
+        x = x.transpose(1, 2).reshape(B, N, -1)
 
         x = self.proj(x)
         return x

--- a/vllm/model_executor/models/intern_vit.py
+++ b/vllm/model_executor/models/intern_vit.py
@@ -271,7 +271,7 @@ class InternSdpaAttention(nn.Module):
         v = v.transpose(1, 2)
 
         x = F.scaled_dot_product_attention(q, k, v, scale=self.scale)
-        x = x.transpose(1, 2).view(B, N, -1)
+        x = x.transpose(1, 2).contiguous().view(B, N, -1)
 
         x = self.proj(x)
         return x


### PR DESCRIPTION
Cooperate with @Fryezsh-edu

FIX #8630
FIX #11978 

As I have said in the issue, this is a logic bug, which only occurs when `USE_XFORMERS_OPS = False`, so it is a little difficult to reproduce on common devices, but this bug really exists.
