### PR TITLE
Fix Max Token ID for Qwen-VL-Chat

### DIFF
--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -74,8 +74,9 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
     # are added and included in the implementation of the vocab_size
     # property, but not in get_vocab(); if there is an implementation
     # of vocab size, we should take the greater value.
-    with contextlib.suppress(NotImplementedError):
-        max_token_id = max(max_token_id, tokenizer.vocab_size)
+    if hasattr(tokenizer, "vocab_size"):
+        with contextlib.suppress(NotImplementedError):
+            max_token_id = max(max_token_id, tokenizer.vocab_size)
 
     class CachedTokenizer(tokenizer.__class__):  # type: ignore
 

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import warnings
 from pathlib import Path
@@ -67,7 +68,14 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
         tokenizer.all_special_tokens_extended)
     tokenizer_all_special_tokens = set(tokenizer.all_special_tokens)
     tokenizer_len = len(tokenizer)
+
     max_token_id = max(tokenizer.get_vocab().values())
+    # Some tokenizers (e.g., QwenTokenizer) have special tokens that
+    # are added and included in the implementation of the vocab_size
+    # property, but not in get_vocab(); if there is an implementation
+    # of vocab size, we should take the greater value.
+    with contextlib.suppress(NotImplementedError):
+        max_token_id = max(max_token_id, tokenizer.vocab_size)
 
     class CachedTokenizer(tokenizer.__class__):  # type: ignore
 


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/11832

LLMEngine has validation (`_validate_token_prompt`) to check for out of vocabulary tokens if token prompts are provided, e.g., when calling a model running online. This relies on the value of the tokenizer's vocab size being correct.

The Transformers `PreTrainedTokenizer` class has an unimplemented property `vocab_size` ([ref](https://github.com/huggingface/transformers/blob/main/src/transformers/tokenization_utils.py#L451)) - in the case of `QwenTokenizer`, `max(tokenizer.get_vocab().values())` returns the size of the mergable ranks, but `num_vocab` includes special tokens, i.e.,

```python
from transformers import AutoTokenizer

MODEL="Qwen/Qwen-VL-Chat"
tokenizer = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)

print(f"Max in vocab: {max(tokenizer.get_vocab().values())}")
print(f"Tokenizer vocab size property: {tokenizer.vocab_size}")
```
Produces:
Max in vocab: 151642
Tokenizer vocab size property: 151860


This PR fixes models using the QwenTokenizer, e.g., Qwen-VL, by taking the max token ID as the max of the max value in `get_vocab()`'s values and the `vocab_size` if the model has it implemented.