### PR TITLE
[API_SERVER] Add maximum concurrency limit for API interface

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -17,7 +17,7 @@ from http import HTTPStatus
 from typing import AsyncIterator, Dict, Optional, Set, Tuple, Union
 
 import uvloop
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -86,6 +86,22 @@ prometheus_multiproc_dir: tempfile.TemporaryDirectory
 logger = init_logger('vllm.entrypoints.openai.api_server')
 
 _running_tasks: Set[asyncio.Task] = set()
+
+# Global request semaphore for concurrency control
+_request_semaphore: Optional[asyncio.Semaphore] = None
+
+# Dependency function to limit concurrency
+async def limit_concurrency():
+    if _request_semaphore is not None:
+        if _request_semaphore.locked():
+            raise HTTPException(
+                status_code=503,
+                detail="Server is at maximum capacity. Please try again later."
+            )
+        async with _request_semaphore:
+            yield
+    else:
+        yield
 
 
 @asynccontextmanager
@@ -365,7 +381,7 @@ async def show_version():
     return JSONResponse(content=ver)
 
 
-@router.post("/v1/chat/completions")
+@router.post("/v1/chat/completions", dependencies=[Depends(limit_concurrency)])
 @with_cancellation
 async def create_chat_completion(request: ChatCompletionRequest,
                                  raw_request: Request):
@@ -386,7 +402,7 @@ async def create_chat_completion(request: ChatCompletionRequest,
     return StreamingResponse(content=generator, media_type="text/event-stream")
 
 
-@router.post("/v1/completions")
+@router.post("/v1/completions", dependencies=[Depends(limit_concurrency)])
 @with_cancellation
 async def create_completion(request: CompletionRequest, raw_request: Request):
     handler = completion(raw_request)
@@ -750,6 +766,14 @@ async def init_app_state(
         chat_template_content_format=args.chat_template_content_format,
     )
     state.task = model_config.task
+
+    # Initialize request semaphore
+    global _request_semaphore
+    if envs.VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS > 0:
+        _request_semaphore = asyncio.Semaphore(
+            envs.VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS)
+        logger.info("Request concurrency limited to %d",
+                    envs.VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS)
 
 
 def create_server_socket(addr: Tuple[str, int]) -> socket.socket:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS: int = 0
 
 
 def get_default_cache_root():
@@ -447,6 +448,10 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # and trust the driver's peer-to-peer capability report.
     "VLLM_SKIP_P2P_CHECK":
     lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "0") == "1",
+
+    # Maximum number of concurrent requests to the API server
+    "VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS":
+    lambda: int(os.getenv("VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS", "0")),
 
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel


### PR DESCRIPTION
The larger the concurrent API requests, the longer the response time. In order to improve user experience, the maximum concurrent request limit is increased to ensure that the response time of the service is within a controllable range
