### PR TITLE
[Doc] Update Quantization Hardware Support Documentation

### DIFF
--- a/docs/source/features/quantization/supported_hardware.md
+++ b/docs/source/features/quantization/supported_hardware.md
@@ -113,7 +113,7 @@ The table below shows the compatibility of various quantization implementations 
   - ✅︎
   - ✅︎
   - ✅︎
-  - ✗
+  - ✅︎
   - ✗
   - ✗
   - ✗


### PR DESCRIPTION
Update the Quantization Hardware Support Documentation.

GGUF had been enabled on AMD platform in this PR https://github.com/vllm-project/vllm/pull/10254

