### PR TITLE
[Bugfix] make moe_align_block_size compliable with cuda graph

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -8,7 +8,7 @@
 #include "../cuda_compat.h"
 #include "../dispatch_utils.h"
 
-#define CEILDIV(x, y) (((x) + (y) - 1) / (y))
+#define CEILDIV(x, y) (((x) + (y)-1) / (y))
 
 namespace vllm {
 namespace moe {
@@ -237,8 +237,9 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
           // tensors
           const int32_t num_thread = max((int32_t)num_experts, WARP_SIZE);
 
-          auto options_int =
-              torch::TensorOptions().dtype(torch::kInt).device(topk_ids.device());
+          auto options_int = torch::TensorOptions()
+                                 .dtype(torch::kInt)
+                                 .device(topk_ids.device());
           torch::Tensor token_cnts_buffer =
               torch::empty({(num_experts + 1) * num_experts}, options_int);
           torch::Tensor cumsum_buffer =

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -245,8 +245,7 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
               sorted_token_ids.data_ptr<int32_t>(),
               experts_ids.data_ptr<int32_t>(),
               num_tokens_post_pad.data_ptr<int32_t>(), num_experts, block_size,
-              topk_ids.numel(),
-              token_cnts_buffer.data_ptr<int32_t>(),
+              topk_ids.numel(), token_cnts_buffer.data_ptr<int32_t>(),
               cumsum_buffer.data_ptr<int32_t>());
         });
   } else {

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -11,4 +11,6 @@ void moe_sum(torch::Tensor& input, torch::Tensor& output);
 void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
                           int64_t block_size, torch::Tensor sorted_token_ids,
                           torch::Tensor experts_ids,
-                          torch::Tensor num_tokens_post_pad);
+                          torch::Tensor num_tokens_post_pad,
+                          torch::Tensor token_cnts_buffer,
+                          torch::Tensor cumsum_buffer);

--- a/csrc/moe/moe_ops.h
+++ b/csrc/moe/moe_ops.h
@@ -12,5 +12,4 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
                           int64_t block_size, torch::Tensor sorted_token_ids,
                           torch::Tensor experts_ids,
                           torch::Tensor num_tokens_post_pad,
-                          torch::Tensor token_cnts_buffer,
-                          torch::Tensor cumsum_buffer);
+                          bool use_global_memory);

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -20,8 +20,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "                     int block_size, Tensor! sorted_token_ids,"
       "                     Tensor! experts_ids,"
       "                     Tensor! num_tokens_post_pad,"
-      "                     Tensor! token_cnts_buffer,"
-      "                     Tensor! cumsum_buffer) -> ()");
+      "                     bool use_global_memory) -> ()");
   m.impl("moe_align_block_size", torch::kCUDA, &moe_align_block_size);
 
 #ifndef USE_ROCM

--- a/csrc/moe/torch_bindings.cpp
+++ b/csrc/moe/torch_bindings.cpp
@@ -19,7 +19,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, m) {
       "moe_align_block_size(Tensor topk_ids, int num_experts,"
       "                     int block_size, Tensor! sorted_token_ids,"
       "                     Tensor! experts_ids,"
-      "                     Tensor! num_tokens_post_pad) -> ()");
+      "                     Tensor! num_tokens_post_pad,"
+      "                     Tensor! token_cnts_buffer,"
+      "                     Tensor! cumsum_buffer) -> ()");
   m.impl("moe_align_block_size", torch::kCUDA, &moe_align_block_size);
 
 #ifndef USE_ROCM

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -918,17 +918,11 @@ def moe_align_block_size(topk_ids: torch.Tensor, num_experts: int,
                          block_size: int, sorted_token_ids: torch.Tensor,
                          experts_ids: torch.Tensor,
                          num_tokens_post_pad: torch.Tensor,
-                         token_cnts_buffer: Optional[torch.Tensor] = None,
-                         cumsum_buffer: Optional[torch.Tensor] = None,
-                         ) -> None:
-    if token_cnts_buffer is None:
-        token_cnts_buffer = torch.empty((0,), device=topk_ids.device)
-    if cumsum_buffer is None:
-        cumsum_buffer = torch.empty((0,), device=topk_ids.device)
+                         use_global_memory: bool = False) -> None:
     torch.ops._moe_C.moe_align_block_size(topk_ids, num_experts, block_size,
                                           sorted_token_ids, experts_ids,
                                           num_tokens_post_pad,
-                                          token_cnts_buffer, cumsum_buffer)
+                                          use_global_memory)
 
 
 def topk_softmax(topk_weights: torch.Tensor, topk_ids: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -914,8 +914,10 @@ def moe_sum(input: torch.Tensor, output: torch.Tensor):
     torch.ops._moe_C.moe_sum(input, output)
 
 
-def moe_align_block_size(topk_ids: torch.Tensor, num_experts: int,
-                         block_size: int, sorted_token_ids: torch.Tensor,
+def moe_align_block_size(topk_ids: torch.Tensor,
+                         num_experts: int,
+                         block_size: int,
+                         sorted_token_ids: torch.Tensor,
                          experts_ids: torch.Tensor,
                          num_tokens_post_pad: torch.Tensor,
                          use_global_memory: bool = False) -> None:

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -917,10 +917,13 @@ def moe_sum(input: torch.Tensor, output: torch.Tensor):
 def moe_align_block_size(topk_ids: torch.Tensor, num_experts: int,
                          block_size: int, sorted_token_ids: torch.Tensor,
                          experts_ids: torch.Tensor,
-                         num_tokens_post_pad: torch.Tensor) -> None:
+                         num_tokens_post_pad: torch.Tensor,
+                         token_cnts_buffer: torch.Tensor,
+                         cumsum_buffer: torch.Tensor) -> None:
     torch.ops._moe_C.moe_align_block_size(topk_ids, num_experts, block_size,
                                           sorted_token_ids, experts_ids,
-                                          num_tokens_post_pad)
+                                          num_tokens_post_pad,
+                                          token_cnts_buffer, cumsum_buffer)
 
 
 def topk_softmax(topk_weights: torch.Tensor, topk_ids: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -918,8 +918,13 @@ def moe_align_block_size(topk_ids: torch.Tensor, num_experts: int,
                          block_size: int, sorted_token_ids: torch.Tensor,
                          experts_ids: torch.Tensor,
                          num_tokens_post_pad: torch.Tensor,
-                         token_cnts_buffer: torch.Tensor,
-                         cumsum_buffer: torch.Tensor) -> None:
+                         token_cnts_buffer: Optional[torch.Tensor] = None,
+                         cumsum_buffer: Optional[torch.Tensor] = None,
+                         ) -> None:
+    if token_cnts_buffer is None:
+        token_cnts_buffer = torch.empty((0,), device=topk_ids.device)
+    if cumsum_buffer is None:
+        cumsum_buffer = torch.empty((0,), device=topk_ids.device)
     torch.ops._moe_C.moe_align_block_size(topk_ids, num_experts, block_size,
                                           sorted_token_ids, experts_ids,
                                           num_tokens_post_pad,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -604,6 +604,7 @@ class ModelConfig:
                                           self.max_model_len)
 
         if (self.hf_config.model_type == 'deepseek_v3'
+                and self.quantization == "fp8"
                 and not self.enforce_eager):
             logger.warning("CUDA graph is not supported for Deepseek V3 yet, "
                            "fallback to the eager mode.")

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -604,8 +604,7 @@ class ModelConfig:
                                           self.max_model_len)
 
         if (self.hf_config.model_type == 'deepseek_v3'
-                and self.quantization == "fp8"
-                and not self.enforce_eager):
+                and self.quantization == "fp8" and not self.enforce_eager):
             logger.warning("CUDA graph is not supported for Deepseek V3 yet, "
                            "fallback to the eager mode.")
             self.enforce_eager = True

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -256,8 +256,21 @@ def moe_align_block_size(
     num_tokens_post_pad = torch.empty((1),
                                       dtype=torch.int32,
                                       device=topk_ids.device)
+    if num_experts >= 256:
+        # For DeepSeek-V3
+        token_cnts_buffer = torch.empty(
+            (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
+        )
+        cumsum_buffer = torch.empty(
+            num_experts + 1, dtype=torch.int32, device=topk_ids.device
+        )
+    else:
+        token_cnts_buffer = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
+        cumsum_buffer = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
+
     ops.moe_align_block_size(topk_ids, num_experts, block_size, sorted_ids,
-                             expert_ids, num_tokens_post_pad)
+                             expert_ids, num_tokens_post_pad,
+                             token_cnts_buffer, cumsum_buffer)
     return sorted_ids, expert_ids, num_tokens_post_pad
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -256,25 +256,10 @@ def moe_align_block_size(
     num_tokens_post_pad = torch.empty((1),
                                       dtype=torch.int32,
                                       device=topk_ids.device)
-    if num_experts >= 256:
-        # For DeepSeek-V3
-        token_cnts_buffer = torch.empty((num_experts + 1) * num_experts,
-                                        dtype=torch.int32,
-                                        device=topk_ids.device)
-        cumsum_buffer = torch.empty(num_experts + 1,
-                                    dtype=torch.int32,
-                                    device=topk_ids.device)
-    else:
-        token_cnts_buffer = torch.empty((0, ),
-                                        dtype=torch.int32,
-                                        device=topk_ids.device)
-        cumsum_buffer = torch.empty((0, ),
-                                    dtype=torch.int32,
-                                    device=topk_ids.device)
-
+    use_global_memory = num_experts >= 256  # for deepseek-v3
     ops.moe_align_block_size(topk_ids, num_experts, block_size, sorted_ids,
                              expert_ids, num_tokens_post_pad,
-                             token_cnts_buffer, cumsum_buffer)
+                             use_global_memory)
     return sorted_ids, expert_ids, num_tokens_post_pad
 
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -258,28 +258,20 @@ def moe_align_block_size(
                                       device=topk_ids.device)
     if num_experts >= 256:
         # For DeepSeek-V3
-        token_cnts_buffer = torch.empty(
-            (num_experts + 1) * num_experts,
-            dtype=torch.int32,
-            device=topk_ids.device
-        )
-        cumsum_buffer = torch.empty(
-            num_experts + 1,
-            dtype=torch.int32,
-            device=topk_ids.device
-        )
+        token_cnts_buffer = torch.empty((num_experts + 1) * num_experts,
+                                        dtype=torch.int32,
+                                        device=topk_ids.device)
+        cumsum_buffer = torch.empty(num_experts + 1,
+                                    dtype=torch.int32,
+                                    device=topk_ids.device)
     else:
-        token_cnts_buffer = torch.empty(
-            (0,),
-            dtype=torch.int32,
-            device=topk_ids.device
-        )
-        cumsum_buffer = torch.empty(
-            (0,),
-            dtype=torch.int32,
-            device=topk_ids.device
-        )
-
+        token_cnts_buffer = torch.empty((0, ),
+                                        dtype=torch.int32,
+                                        device=topk_ids.device)
+        cumsum_buffer = torch.empty((0, ),
+                                    dtype=torch.int32,
+                                    device=topk_ids.device)
+ 
     ops.moe_align_block_size(topk_ids, num_experts, block_size, sorted_ids,
                              expert_ids, num_tokens_post_pad,
                              token_cnts_buffer, cumsum_buffer)

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -259,14 +259,26 @@ def moe_align_block_size(
     if num_experts >= 256:
         # For DeepSeek-V3
         token_cnts_buffer = torch.empty(
-            (num_experts + 1) * num_experts, dtype=torch.int32, device=topk_ids.device
+            (num_experts + 1) * num_experts,
+            dtype=torch.int32,
+            device=topk_ids.device
         )
         cumsum_buffer = torch.empty(
-            num_experts + 1, dtype=torch.int32, device=topk_ids.device
+            num_experts + 1,
+            dtype=torch.int32,
+            device=topk_ids.device
         )
     else:
-        token_cnts_buffer = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
-        cumsum_buffer = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)
+        token_cnts_buffer = torch.empty(
+            (0,),
+            dtype=torch.int32,
+            device=topk_ids.device
+        )
+        cumsum_buffer = torch.empty(
+            (0,),
+            dtype=torch.int32,
+            device=topk_ids.device
+        )
 
     ops.moe_align_block_size(topk_ids, num_experts, block_size, sorted_ids,
                              expert_ids, num_tokens_post_pad,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -271,7 +271,7 @@ def moe_align_block_size(
         cumsum_buffer = torch.empty((0, ),
                                     dtype=torch.int32,
                                     device=topk_ids.device)
- 
+
     ops.moe_align_block_size(topk_ids, num_experts, block_size, sorted_ids,
                              expert_ids, num_tokens_post_pad,
                              token_cnts_buffer, cumsum_buffer)


### PR DESCRIPTION
The `moe_align_block_size` is used by many moe models (e.g. DeepSeek-V3) but it is not compliable with cuda graph now. This PR fix it.

Reference: https://github.com/sgl-project/sglang/commit/77d1210b3610eda49fee06bc8b7400e2af4dd5e5 https://github.com/sgl-project/sglang/commit/6e5305158cded4aa7523c28435339905adb2f610