### PR TITLE
[Kernel] Revert the API change of Attention.forward

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -134,8 +134,8 @@ class Attention(nn.Module):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        _kv_cache: torch.Tensor,
-        _attn_metadata: AttentionMetadata,
+        kv_cache: torch.Tensor,
+        attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
         if self.use_output:
             output = torch.empty_like(query)


### PR DESCRIPTION
The changing of `kv_cache` -> `_kv_cache` and `attn_metadata` -> `_attn_metadata` in `Attention.forward` by https://github.com/vllm-project/vllm/pull/11967 breaks models that pass these two arguments with kwargs, e.g., phi3_small:
```
attn_output = self.attn(q, k, v, kv_cache, attn_metadata=attn_metadata)
```
And this script is crashed
```
from vllm import LLM, SamplingParams

# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

# Create an LLM.
llm = LLM(model="microsoft/Phi-3-small-8k-instruct", trust_remote_code=True)
# Generate texts from the prompts. The output is a list of RequestOutput objects
# that contain the prompt, generated text, and other information.
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
```
This pr reverts the API change to fix this problem.
CC @youkaichao 
**NOTE: the above script is still crashed due to other problems. I'm investigating and fixing it.**