### PR TITLE
Misc: allow to use proxy in `HTTPConnection`

### DIFF
--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -29,7 +29,7 @@ class HTTPConnection:
     # required, so that the client is only accessible inside async event loop
     async def get_async_client(self) -> aiohttp.ClientSession:
         if self._async_client is None or not self.reuse_client:
-            self._async_client = aiohttp.ClientSession()
+            self._async_client = aiohttp.ClientSession(trust_env=True)
 
         return self._async_client
 


### PR DESCRIPTION
This patch fixes the HTTPConnection to work with proxy 

Ref: https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support

