### PR TITLE
Fix: cases with empty sparsity config

### DIFF
--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -113,7 +113,7 @@ class CompressedTensorsConfig(QuantizationConfig):
         :return: A dictionary mapping target layer names to their corresponding
             sparsity compression configurations
         """
-        if (sparsity_config := config.get(SPARSITY_CONFIG_NAME)) is None:
+        if not (sparsity_config := config.get(SPARSITY_CONFIG_NAME)):
             return dict()
 
         sparsity_config = SparsityCompressionConfig.model_validate(


### PR DESCRIPTION
FIX #12044

This PR fixes a bug where the `sparsity_config` in the `CompressedTensorsConfig` class would not handle empty configurations correctly. The issue, tracked in #12044, arose due to the explicit check for `None` values instead of evaluating the truthiness of `sparsity_config`. The fix ensures that empty configurations are now handled gracefully by directly checking the truthiness of `sparsity_config`.

### Changes
- Updated the conditional check in `CompressedTensorsConfig.get_sparsity_config` to evaluate the truthiness of `sparsity_config` instead of explicitly comparing against `None`.

### Testing
The fix was tested by running the following:
- `nm-testing/llama2.c-stories42M-quantized-fp8-Dynamic`
  - This ncludes an empty `sparsity_config` and confirmed the correctness of the fix.

### Resolves
- Fixes #12044
