### PR TITLE
[platform] allow the out-of-tree device to set executor class

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -283,6 +283,13 @@ class Platform:
         """
         raise NotImplementedError
 
+    @classmethod
+    def get_executor_cls(cls,
+                         distributed_executor_backend: Optional[str] = None,
+                         is_async: Optional[bool] = None) -> str:
+        """Get the executor class of the out-of-tree device."""
+        return ""
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED


### PR DESCRIPTION
Allow the out-of-tree device to set executor class

**How to use**:

In an out-of-tree plugin repo (for example, the `npu` device):

```python
class NPUPlatform(Platform):
    # implementation
    ...

    @classmethod
    def get_executor_cls(cls,
                         distributed_executor_backend: Optional[str] = None,
                         is_async: Optional[bool] = None) -> str:
        if distributed_executor_backend == "ray":
            ...
        if distributed_executor_backend == "mp":
            ...
        if is_async:
            return "vllm_npu.executor.NPUExecutorAsync"
        else:
            return "vllm_npu.executor.NPUExecutor"
```