### PR TITLE
[Bugfix] Fix num_heads value for simple connector when tp enabled

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -35,6 +35,7 @@ class SimpleConnector(KVConnectorBase):
     ):
 
         self.config = config.kv_transfer_config
+        self.tp_size = config.parallel_config.tensor_parallel_size
 
         if self.config.kv_connector == "PyNcclConnector":
             from vllm.distributed.kv_transfer.kv_pipe.pynccl_pipe import (
@@ -161,7 +162,7 @@ class SimpleConnector(KVConnectorBase):
         end_layer = model_executable.model.end_layer
 
         model_config = model_executable.model.config
-        num_heads = model_config.num_key_value_heads
+        num_heads = int(model_config.num_key_value_heads / self.tp_size)
         hidden_size = model_config.hidden_size
         num_attention_heads = model_config.num_attention_heads
         head_size = int(hidden_size / num_attention_heads)


### PR DESCRIPTION
This is a bug fix for #11058. The former fix did not handle the head_size properly when tp is enabled.

Let say, if `-tp 2` is enabled, we will send the key/value cache with its shape equal to "`[num_layer, prompt_token_length, num_key_value_heads, head_size]`" in the implementation of #11058. And the "`[num_layer, prompt_token_length, num_key_value_heads/2:num_key_value_heads, head_size]`" will all be zeros. 
<img width="819" alt="image" src="https://github.com/user-attachments/assets/66532cc3-3f8b-40ce-8081-a8ede872f198" />
Currently, the recv side will discard these zeros when calling `ops.reshape_and_cache_flash`, so it somehow works in the previous version, but we should not send these zeros in the first place.

cc @KuntaiDu 