### PR TITLE
[Delete]

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -239,11 +239,10 @@ class DefaultModelLoader(BaseModelLoader):
             allow_patterns = ["*.safetensors"]
         elif load_format == LoadFormat.MISTRAL:
             use_safetensors = True
-            allow_patterns = ["model*.safetensors",
-                              "consolidated*.safetensors"]
-            possible_index_files.append(
-                "consolidated.safetensors.index.json"
-            )
+            allow_patterns = [
+                "model*.safetensors", "consolidated*.safetensors"
+            ]
+            possible_index_files.append("consolidated.safetensors.index.json")
         elif load_format == LoadFormat.PT:
             allow_patterns = ["*.pt"]
         elif load_format == LoadFormat.NPCACHE:
@@ -277,8 +276,8 @@ class DefaultModelLoader(BaseModelLoader):
             # For models like Mistral-7B-Instruct-v0.3
             # there are both sharded safetensors files and a consolidated
             # safetensors file. Using both breaks.
-            # Here, we download the `(model|consolidated).safetensors.index.json` 
-            # and filter any files not found in the index.
+            # Here, we download `(model|consolidated).safetensors.index.json`
+            # index file and filter any files not found in the index.
             if not is_local:
                 download_safetensors_index_file_from_hf(
                     model_name_or_path,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -268,7 +268,7 @@ def download_weights_from_hf(
 
 def download_safetensors_index_file_from_hf(
     model_name_or_path: str,
-    possible_index_files: str | List[str],
+    possible_index_files: Union[str, List[str]],
     cache_dir: Optional[str],
     revision: Optional[str] = None,
 ) -> None:
@@ -311,9 +311,9 @@ def download_safetensors_index_file_from_hf(
 # Passing both of these to the weight loader functionality breaks.
 # So, we use the first index_file found from `possible_index_files` to
 # look up which safetensors files should be used.
-def filter_duplicate_safetensors_files(hf_weights_files: List[str],
-                                       hf_folder: str,
-                                       possible_index_files: str | List[str]) -> List[str]:
+def filter_duplicate_safetensors_files(
+        hf_weights_files: List[str], hf_folder: str,
+        possible_index_files: Union[str, List[str]]) -> List[str]:
     # index file (like `model.safetensors.index.json`) is a mapping from
     # keys in the torch state_dict to safetensors file holding that weight.
     index_file_name = None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -493,13 +493,19 @@ def load_params_config(model: Union[str, Path], revision: Optional[str],
         "hidden_dim": "intermediate_size",
     }
 
+    def pretrained_or_mixtral_config(elem: dict, **config_dict):
+        if elem.get("moe") is not None:
+            from transformers import MixtralConfig
+            return MixtralConfig(**config_dict)
+        return PretrainedConfig(**config_dict)
+
     def recurse_elems(elem: Any):
         if isinstance(elem, dict):
             config_dict = {}
             for key, value in elem.items():
                 key = config_mapping.get(key, key)
                 config_dict[key] = recurse_elems(value)
-            return PretrainedConfig(**config_dict)
+            return pretrained_or_mixtral_config(elem, **config_dict)
         else:
             return elem
 


### PR DESCRIPTION
This PR fixes the potential errors when downloading the HF weights for multiple Mistral models. Before, the loader would search for weight files with naming pattern `consolidated*.safetensors`, although the patten `model*.safetensors` is also used. See examples respectively [here](https://huggingface.co/mistralai/Mistral-Large-Instruct-2411/tree/main) and [here](https://huggingface.co/mistralai/Mixtral-8x22B-Instruct-v0.1/tree/main).

This is the same for the index file naming (example [here](https://huggingface.co/mistralai/Pixtral-Large-Instruct-2411/tree/main) vs [here](https://huggingface.co/mistralai/Mixtral-8x22B-v0.1/tree/main)).

Finally, this PR fixes loading of Mistral MoEs such that the model config (`params.json`) matches the [MixtralConfig](https://github.com/huggingface/transformers/blob/main/src/transformers/models/mixtral/configuration_mixtral.py#L24).