### PR TITLE
[V1] Add notes on test_async_engine.py::test_abort

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -66,6 +66,8 @@ async def test_load(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_abort(monkeypatch):
+    # NOTE: this test fails on fast GPUs (e.g. H100) because some requests are
+    # finished before they are canceled.
 
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_V1", "1")


### PR DESCRIPTION
This test fails on fast GPUs (e.g. H100) because some requests are finished before they are canceled. Add a note to save time for people running this test in their local enviroment.
CC @robertgshaw2-redhat 