### PR TITLE
[core] LLM.collective_rpc interface and RLHF example

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -126,7 +126,9 @@ steps:
   - tests/distributed
   - tests/spec_decode/e2e/test_integration_dist_tp4
   - tests/compile
+  - examples/offline_inference/rlhf.py
   commands:
+  - pytest -v -s ../examples/offline_inference/rlhf.py
   - pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -128,7 +128,7 @@ steps:
   - tests/compile
   - examples/offline_inference/rlhf.py
   commands:
-  - pytest -v -s ../examples/offline_inference/rlhf.py
+  - python ../examples/offline_inference/rlhf.py
   - pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -128,11 +128,13 @@ steps:
   - tests/compile
   - examples/offline_inference/rlhf.py
   commands:
-  - python3 ../examples/offline_inference/rlhf.py
   - pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py
   - pytest -v -s spec_decode/e2e/test_integration_dist_tp4.py
+  # TODO: create a dedicated test section for multi-GPU example tests
+  # when we have multiple distributed example tests
+  - python3 ../examples/offline_inference/rlhf.py
 
 - label: Metrics, Tracing Test # 10min
   num_gpus: 2 

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -128,7 +128,7 @@ steps:
   - tests/compile
   - examples/offline_inference/rlhf.py
   commands:
-  - python ../examples/offline_inference/rlhf.py
+  - python3 ../examples/offline_inference/rlhf.py
   - pytest -v -s distributed/test_utils.py
   - pytest -v -s compile/test_basic_correctness.py
   - pytest -v -s distributed/test_pynccl.py

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -1,5 +1,6 @@
 # a simple demonstration of RLHF with VLLM.
 import os
+
 import ray
 import torch
 from ray.util.placement_group import placement_group
@@ -27,6 +28,7 @@ def stateless_init_process_group(master_address, master_port, rank, world_size,
 
 # inference code, inherit from Worker to provide custom functions
 class MyWorker(Worker):
+
     def init_weight_update_group(self, master_address, master_port,
                                  rank_offset, world_size):
         from vllm.distributed.parallel_state import get_world_group
@@ -55,12 +57,15 @@ class MyWorker(Worker):
             sum_value += p.square().sum().item()
         return sum_value
 
+
 class MyLLM(LLM):
+
     def __init__(self, *args, **kwargs):
         # stop ray from manipulating CUDA_VISIBLE_DEVICES
         # at the top-level
         del os.environ["CUDA_VISIBLE_DEVICES"]
         super().__init__(*args, **kwargs)
+
 
 # current process is a training process, and it takes 1 GPU.
 # important: set some common environment variables the same as vLLM workers.
@@ -78,7 +83,8 @@ ray.get(pg_inference.ready())
 scheduling_inference = PlacementGroupSchedulingStrategy(
     placement_group=pg_inference,
     placement_group_capture_child_tasks=True,
-    placement_group_bundle_index=0,)
+    placement_group_bundle_index=0,
+)
 
 # inferencing engine, it takes 2 GPUs.
 # for simplicity, we define the MyWorker class in this self-contained script.

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -65,7 +65,7 @@ train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
 
 ray.init()
 
-pg_train = placement_group([{"GPU": 1, "CPU": 0}] * 1)
+pg_train = placement_group([{"GPU": 1, "CPU": 0}])
 ray.get(pg_train.ready())
 
 scheduling_train = PlacementGroupSchedulingStrategy(
@@ -73,7 +73,7 @@ scheduling_train = PlacementGroupSchedulingStrategy(
     placement_group_capture_child_tasks=True,
     placement_group_bundle_index=0)
 
-pg_inference = placement_group([{"GPU": 1, "CPU": 0}] * 2)
+pg_inference = placement_group([{"GPU": 2, "CPU": 0}])
 ray.get(pg_inference.ready())
 scheduling_inference = PlacementGroupSchedulingStrategy(
     placement_group=pg_inference,

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -1,31 +1,131 @@
-from vllm import LLM, SamplingParams
+# a simple demonstration of RLHF with VLLM.
 import cloudpickle
+import ray
+import torch
+from transformers import AutoModelForCausalLM
+
+from vllm import LLM, SamplingParams, configure_as_vllm_process
+from vllm.utils import get_ip, get_open_port
 from vllm.worker.worker import Worker
 
-class MyWorker(Worker):
-    def echo_rank(self):
-        from vllm.distributed.parallel_state import get_world_group
-        return get_world_group().rank
 
-# Sample prompts.
+# recommended way to create data-plane communication
+# between external (train processes) and VLLM workers.
+def stateless_init_process_group(master_address, master_port, rank, world_size,
+                                 device):
+    from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+    from vllm.distributed.utils import StatelessProcessGroup
+    pg = StatelessProcessGroup.create(host=master_address,
+                                      port=master_port,
+                                      rank=rank,
+                                      world_size=world_size)
+    pynccl = PyNcclCommunicator(pg, device=device)
+    return pynccl
+
+
+# inference code, inherit from Worker to provide custom functions
+class MyWorker(Worker):
+
+    def init_weight_update_group(self, master_address, master_port,
+                                 rank_offset, world_size):
+        from vllm.distributed.parallel_state import get_world_group
+        rank = get_world_group().rank + rank_offset
+        self.model_update_group = stateless_init_process_group(
+            master_address,
+            master_port,
+            rank,
+            world_size,
+            self.device,
+        )
+
+    def update_weight(self, name, dtype, shape):
+        weight = torch.empty(shape, dtype=dtype, device="cuda")
+        self.model_update_group.broadcast(weight,
+                                          src=0,
+                                          stream=torch.cuda.current_stream())
+
+        self.model_runner.model.load_weights(weights=[(name, weight)])
+
+        del weight
+
+    def get_weight_square_sum(self):
+        sum_value = 0.0
+        for name, p in self.model_runner.model.named_parameters():
+            sum_value += p.square().sum().item()
+        return sum_value
+
+
+# current process is a training process, and it takes 1 GPU.
+# important: set some common environment variables the same as vLLM workers.
+configure_as_vllm_process()
+
+train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+
+ray.init()
+
+
+class PlaceHolder:
+    pass
+
+
+# a place holder to reserve 1 GPU for the training process.
+place_holder = ray.remote(num_gpus=1)(PlaceHolder).remote()
+
+# inferencing engine, and it takes 2 GPUs.
+# for simplicity, we define the MyWorker class in this self-contained script,
+# and the MyWorker class does not have qualified name in the global scope,
+# so we need to pass the worker_cls through `cloudpickle.dumps(MyWorker)`.
+# normally, we should define the MyWorker class in a separate file and pass
+# the qualified name of the class to the worker_cls parameter.
+llm = ray.remote(num_gpus=2)(LLM).remote(
+    model="facebook/opt-125m",
+    enforce_eager=True,
+    worker_cls=cloudpickle.dumps(MyWorker),
+    tensor_parallel_size=2)
+
+# Generate texts from the prompts.
 prompts = [
     "Hello, my name is",
     "The president of the United States is",
     "The capital of France is",
     "The future of AI is",
 ]
-# Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
 
-# Create an LLM.
-llm = LLM(model="facebook/opt-125m", enforce_eager=True, worker_cls=cloudpickle.dumps(MyWorker), tensor_parallel_size=2)
-# Generate texts from the prompts. The output is a list of RequestOutput objects
-# that contain the prompt, generated text, and other information.
-outputs = llm.generate(prompts, sampling_params)
-# Print the outputs.
-for output in outputs:
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+sampling_params = SamplingParams(temperature=0)
 
-print(llm.collective_rpc("echo_rank"))
+outputs_original = ray.get(llm.generate.remote(prompts, sampling_params))
+
+master_address = get_ip()
+master_port = get_open_port()
+
+# set up the connection between the training process and the inference engine.
+handle = llm.collective_rpc.remote("init_process_group", master_address,
+                                   master_port, 1, 3)
+model_update_group = stateless_init_process_group(master_address, master_port,
+                                                  0, 3, torch.device("cuda:0"))
+ray.get(handle)
+
+# simulate training, modify the weights of the model.
+for name, p in train_model.named_parameters():
+    p.zero_()
+
+# sync weight from the training process to the inference engine.
+for name, p in train_model.named_parameters():
+    handle = llm.collective_rpc.remote("update_weight", name, p.dtype, p.shape)
+    model_update_group.broadcast(p, src=0, stream=torch.cuda.current_stream())
+    ray.get(handle)
+
+# check if the weights are updated.
+weight_square_sum_values = ray.get(
+    llm.collective_rpc.remote("get_weight_square_sum"))
+for x in weight_square_sum_values:
+    assert x == 0.0
+
+# use the updated model to generate texts.
+outputs_updated = ray.get(llm.generate.remote(prompts, sampling_params))
+
+# they should be different.
+for output_original, output_updated in zip(outputs_original, outputs_updated):
+    generated_text_original = output_original.outputs[0].text
+    generated_text_updated = output_updated.outputs[0].text
+    assert generated_text_original != generated_text_updated

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -77,6 +77,7 @@ place_holder = ray.remote(num_gpus=1)(PlaceHolder).remote()
 # so we need to pass the worker_cls through `cloudpickle.dumps(MyWorker)`.
 # normally, we should define the MyWorker class in a separate file and pass
 # the qualified name of the class to the worker_cls parameter.
+# here we use `enforce_eager` to reduce test time.
 llm = ray.remote(num_gpus=2)(LLM).remote(
     model="facebook/opt-125m",
     enforce_eager=True,
@@ -99,7 +100,7 @@ master_address = get_ip()
 master_port = get_open_port()
 
 # set up the connection between the training process and the inference engine.
-handle = llm.collective_rpc.remote("init_process_group",
+handle = llm.collective_rpc.remote("init_weight_update_group",
                                    args=(master_address, master_port, 1, 3))
 model_update_group = stateless_init_process_group(master_address, master_port,
                                                   0, 3, torch.device("cuda:0"))

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -176,3 +176,12 @@ for name, p in train_model.named_parameters():
 # check if the weights are updated.
 assert all(ray.get(
     llm.collective_rpc.remote("check_weights_changed")))
+
+# use the updated model to generate texts, they will be nonsense
+# because the weights are all zeros.
+outputs_updated = ray.get(llm.generate.remote(prompts, sampling_params))
+for output in outputs_updated:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, "
+          f"Generated text: {generated_text!r}")

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -78,7 +78,7 @@ class MyWorker(Worker):
         """
         Check if the weights are updated to 0.
         """
-        weights_updated = False
+        weights_updated = True
         for name, p in self.model_runner.model.named_parameters():
             weights_updated = weights_updated and torch.allclose(
                 p, torch.zeros_like(p))

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -1,0 +1,31 @@
+from vllm import LLM, SamplingParams
+import cloudpickle
+from vllm.worker.worker import Worker
+
+class MyWorker(Worker):
+    def echo_rank(self):
+        from vllm.distributed.parallel_state import get_world_group
+        return get_world_group().rank
+
+# Sample prompts.
+prompts = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+# Create a sampling params object.
+sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+
+# Create an LLM.
+llm = LLM(model="facebook/opt-125m", enforce_eager=True, worker_cls=cloudpickle.dumps(MyWorker), tensor_parallel_size=2)
+# Generate texts from the prompts. The output is a list of RequestOutput objects
+# that contain the prompt, generated text, and other information.
+outputs = llm.generate(prompts, sampling_params)
+# Print the outputs.
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+
+print(llm.collective_rpc("echo_rank"))

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -73,7 +73,7 @@ scheduling_train = PlacementGroupSchedulingStrategy(
     placement_group_capture_child_tasks=True,
     placement_group_bundle_index=0)
 
-pg_inference = placement_group([{"GPU": 2, "CPU": 0}] * 2)
+pg_inference = placement_group([{"GPU": 1, "CPU": 0}] * 2)
 ray.get(pg_inference.ready())
 scheduling_inference = PlacementGroupSchedulingStrategy(
     placement_group=pg_inference,

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -61,15 +61,9 @@ configure_as_vllm_process()
 
 train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
 
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "1,2"
 ray.init()
-
-
-class PlaceHolder:
-    pass
-
-
-# a place holder to reserve 1 GPU for the training process.
-place_holder = ray.remote(num_cpus=0, num_gpus=1)(PlaceHolder).remote()
 
 # inferencing engine, and it takes 2 GPUs.
 # for simplicity, we define the MyWorker class in this self-contained script,

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -69,7 +69,7 @@ class PlaceHolder:
 
 
 # a place holder to reserve 1 GPU for the training process.
-place_holder = ray.remote(num_gpus=1)(PlaceHolder).remote()
+place_holder = ray.remote(num_cpus=0, num_gpus=1)(PlaceHolder).remote()
 
 # inferencing engine, and it takes 2 GPUs.
 # for simplicity, we define the MyWorker class in this self-contained script,
@@ -78,12 +78,13 @@ place_holder = ray.remote(num_gpus=1)(PlaceHolder).remote()
 # normally, we should define the MyWorker class in a separate file and pass
 # the qualified name of the class to the worker_cls parameter.
 # here we use `enforce_eager` to reduce test time.
-llm = ray.remote(num_gpus=2)(LLM).remote(
+llm = ray.remote(num_cpus=0, num_gpus=2)(LLM).remote(
     model="facebook/opt-125m",
     enforce_eager=True,
     worker_cls=cloudpickle.dumps(MyWorker),
     tensor_parallel_size=2,
-    distributed_executor_backend="ray",)
+    distributed_executor_backend="ray",
+)
 
 # Generate texts from the prompts.
 prompts = [

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -99,8 +99,8 @@ master_address = get_ip()
 master_port = get_open_port()
 
 # set up the connection between the training process and the inference engine.
-handle = llm.collective_rpc.remote("init_process_group", master_address,
-                                   master_port, 1, 3)
+handle = llm.collective_rpc.remote("init_process_group",
+                                   args=(master_address, master_port, 1, 3))
 model_update_group = stateless_init_process_group(master_address, master_port,
                                                   0, 3, torch.device("cuda:0"))
 ray.get(handle)
@@ -111,7 +111,8 @@ for name, p in train_model.named_parameters():
 
 # sync weight from the training process to the inference engine.
 for name, p in train_model.named_parameters():
-    handle = llm.collective_rpc.remote("update_weight", name, p.dtype, p.shape)
+    handle = llm.collective_rpc.remote("update_weight",
+                                       args=(name, p.dtype, p.shape))
     model_update_group.broadcast(p, src=0, stream=torch.cuda.current_stream())
     ray.get(handle)
 

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -70,15 +70,13 @@ ray.get(pg_train.ready())
 
 scheduling_train = PlacementGroupSchedulingStrategy(
     placement_group=pg_train,
-    placement_group_capture_child_tasks=True,
-    placement_group_bundle_index=0)
+    placement_group_capture_child_tasks=True)
 
 pg_inference = placement_group([{"GPU": 2, "CPU": 0}])
 ray.get(pg_inference.ready())
 scheduling_inference = PlacementGroupSchedulingStrategy(
     placement_group=pg_inference,
-    placement_group_capture_child_tasks=True,
-    placement_group_bundle_index=1)
+    placement_group_capture_child_tasks=True)
 
 
 class PlaceHolder:

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -66,7 +66,8 @@ class MyLLM(LLM):
 # important: set some common environment variables the same as vLLM workers.
 configure_as_vllm_process()
 
-train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m").to("cuda:0")
+train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
+train_model.to("cuda:0")
 
 # start ray with 2 GPUs
 os.environ["CUDA_VISIBLE_DEVICES"] = "1,2"

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -82,7 +82,8 @@ llm = ray.remote(num_gpus=2)(LLM).remote(
     model="facebook/opt-125m",
     enforce_eager=True,
     worker_cls=cloudpickle.dumps(MyWorker),
-    tensor_parallel_size=2)
+    tensor_parallel_size=2,
+    distributed_executor_backend="ray",)
 
 # Generate texts from the prompts.
 prompts = [

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -46,9 +46,10 @@ def stateless_init_process_group(master_address, master_port, rank, world_size,
 class MyWorker(Worker):
     """
     The `MyWorker` class inherits from `Worker` to provide custom functions.
-    For simplicity, we define the `MyWorker` class in this self-contained script.
-    Normally, we should define the `MyWorker` class in a separate file and pass
-    the qualified name of the class to the `worker_cls` parameter.
+    For simplicity, we define the `MyWorker` class in this self-contained 
+    script. Normally, we should define the `MyWorker` class in a separate 
+    file and pass the qualified name of the class to the `worker_cls` 
+    parameter.
     """
 
     def init_weight_update_group(self, master_address, master_port,
@@ -107,9 +108,9 @@ configure_as_vllm_process()
 train_model = AutoModelForCausalLM.from_pretrained("facebook/opt-125m")
 train_model.to("cuda:0")
 """
-Start the inference process, here we use vLLM to hold a model on GPU 1 and GPU 2.
-For the details on how to use ray, please refer to the ray documentation
-https://docs.ray.io/en/latest/ .
+Start the inference process, here we use vLLM to hold a model on GPU 1 and 
+GPU 2. For the details on how to use ray, please refer to the ray 
+documentation https://docs.ray.io/en/latest/ .
 """
 os.environ["CUDA_VISIBLE_DEVICES"] = "1,2"
 ray.init()
@@ -155,7 +156,8 @@ for output in outputs:
     print(f"Prompt: {prompt!r}, "
           f"Generated text: {generated_text!r}")
 
-# set up the communication between the training process and the inference engine.
+# set up the communication between the training process
+# and the inference engine.
 master_address = get_ip()
 master_port = get_open_port()
 

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -41,7 +41,7 @@ def configure_as_vllm_process():
     if current_platform.is_xpu():
         # see https://github.com/pytorch/pytorch/blob/43c5f59/torch/_dynamo/config.py#L158
         torch._dynamo.config.disable = True
-    if current_platform.is_hpu():
+    elif current_platform.is_hpu():
         # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
         # does not support torch.compile
         # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -19,10 +19,11 @@ from .version import __version__, __version_tuple__
 
 
 def configure_as_vllm_process():
-
-    # some common environment variables
-    # for all processes created by vllm
-
+    """
+    set some common config/environment variables that should be set
+    for all processes created by vllm and all processes
+    that interact with vllm workers.
+    """
     import os
 
     import torch

--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -17,6 +17,43 @@ from vllm.sampling_params import SamplingParams
 
 from .version import __version__, __version_tuple__
 
+
+def configure_as_vllm_process():
+
+    # some common environment variables
+    # for all processes created by vllm
+
+    import os
+
+    import torch
+
+    # see https://github.com/NVIDIA/nccl/issues/1234
+    os.environ['NCCL_CUMEM_ENABLE'] = '0'
+
+    # see https://github.com/vllm-project/vllm/issues/10480
+    os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
+    # see https://github.com/vllm-project/vllm/issues/10619
+    torch._inductor.config.compile_threads = 1
+
+    from vllm.platforms import current_platform
+
+    if current_platform.is_xpu():
+        # see https://github.com/pytorch/pytorch/blob/43c5f59/torch/_dynamo/config.py#L158
+        torch._dynamo.config.disable = True
+    if current_platform.is_hpu():
+        # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
+        # does not support torch.compile
+        # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
+        # torch.compile support
+        is_lazy = os.environ.get('PT_HPU_LAZY_MODE', '1') == '1'
+        if is_lazy:
+            torch._dynamo.config.disable = True
+            # NOTE(kzawora) multi-HPU inference with HPUGraphs (lazy-only)
+            # requires enabling lazy collectives
+            # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html # noqa: E501
+            os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
+
+
 __all__ = [
     "__version__",
     "__version_tuple__",
@@ -42,4 +79,5 @@ __all__ = [
     "AsyncEngineArgs",
     "initialize_ray_cluster",
     "PoolingParams",
+    "configure_as_vllm_process",
 ]

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -455,6 +455,22 @@ class LLM:
         outputs = self._run_engine(use_tqdm=use_tqdm)
         return self.engine_class.validate_outputs(outputs, RequestOutput)
 
+    def collective_rpc(self,
+                       method: str,
+                       timeout: Optional[float] = None,
+                       args: Tuple = (),
+                       kwargs: Optional[Dict] = None) -> List[Any]:
+        """
+        Run a method on all workers, with homogeneous arguments.
+        The main extension point for the LLM entrypoint.
+        Users can provide custom worker class through `worker_cls`
+        argument, and implement new methods in the worker class.
+        Then, users can call the new methods through this API.
+        It is recommended to use this API to only pass control messages,
+        and set up data-plane communication to pass data.
+        """
+        return self.llm_engine.model_executor.collective_rpc(method, timeout, args, kwargs)
+
     def beam_search(
         self,
         prompts: List[Union[TokensPrompt, TextPrompt]],

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,10 +1,10 @@
 import itertools
 import warnings
 from contextlib import contextmanager
-import cloudpickle
 from typing import (Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type,
                     Union, cast, overload)
 
+import cloudpickle
 from tqdm import tqdm
 from typing_extensions import deprecated
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -469,7 +469,8 @@ class LLM:
         It is recommended to use this API to only pass control messages,
         and set up data-plane communication to pass data.
         """
-        return self.llm_engine.model_executor.collective_rpc(method, timeout, args, kwargs)
+        return self.llm_engine.model_executor.collective_rpc(
+            method, timeout, args, kwargs)
 
     def beam_search(
         self,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,6 +1,7 @@
 import itertools
 import warnings
 from contextlib import contextmanager
+import cloudpickle
 from typing import (Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type,
                     Union, cast, overload)
 
@@ -185,6 +186,13 @@ class LLM:
 
         if "disable_log_stats" not in kwargs:
             kwargs["disable_log_stats"] = True
+
+        if "worker_cls" in kwargs:
+            worker_cls = kwargs["worker_cls"]
+            # if the worker_cls is not qualified string name,
+            # we serialize it using cloudpickle to avoid pickling issues
+            if isinstance(worker_cls, type):
+                kwargs["worker_cls"] = cloudpickle.dumps(worker_cls)
 
         if compilation_config is not None:
             if isinstance(compilation_config, (int, dict)):

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -1,8 +1,5 @@
 import logging
-import os
 from typing import Callable, Dict
-
-import torch
 
 import vllm.envs as envs
 
@@ -50,34 +47,6 @@ def load_general_plugins():
     processes. They should be designed in a way that they can be loaded
     multiple times without causing issues.
     """
-
-    # all processes created by vllm will load plugins,
-    # and here we can inject some common environment variables
-    # for all processes.
-
-    # see https://github.com/vllm-project/vllm/issues/10480
-    os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
-    # see https://github.com/vllm-project/vllm/issues/10619
-    torch._inductor.config.compile_threads = 1
-
-    from vllm.platforms import current_platform
-
-    if current_platform.is_xpu():
-        # see https://github.com/pytorch/pytorch/blob/43c5f59/torch/_dynamo/config.py#L158
-        torch._dynamo.config.disable = True
-    if current_platform.is_hpu():
-        # NOTE(kzawora): PT HPU lazy backend (PT_HPU_LAZY_MODE = 1)
-        # does not support torch.compile
-        # Eager backend (PT_HPU_LAZY_MODE = 0) must be selected for
-        # torch.compile support
-        is_lazy = os.environ.get('PT_HPU_LAZY_MODE', '1') == '1'
-        if is_lazy:
-            torch._dynamo.config.disable = True
-            # NOTE(kzawora) multi-HPU inference with HPUGraphs (lazy-only)
-            # requires enabling lazy collectives
-            # see https://docs.habana.ai/en/latest/PyTorch/Inference_on_PyTorch/Inference_Using_HPU_Graphs.html # noqa: E501
-            os.environ['PT_HPU_ENABLE_LAZY_COLLECTIVES'] = 'true'
-
     global plugins_loaded
     if plugins_loaded:
         return

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -510,8 +510,8 @@ class WorkerWrapperBase:
         kwargs = all_kwargs[self.rank]
         enable_trace_function_call_for_thread(self.vllm_config)
 
-        # see https://github.com/NVIDIA/nccl/issues/1234
-        os.environ['NCCL_CUMEM_ENABLE'] = '0'
+        from vllm import configure_as_vllm_process
+        configure_as_vllm_process()
 
         from vllm.plugins import load_general_plugins
         load_general_plugins()
@@ -520,9 +520,11 @@ class WorkerWrapperBase:
             worker_class = resolve_obj_by_qualname(
                 self.vllm_config.parallel_config.worker_cls)
         else:
-            assert isinstance(self.vllm_config.parallel_config.worker_cls, bytes)
+            assert isinstance(self.vllm_config.parallel_config.worker_cls,
+                              bytes)
             import cloudpickle
-            worker_class = cloudpickle.loads(self.vllm_config.parallel_config.worker_cls)
+            worker_class = cloudpickle.loads(
+                self.vllm_config.parallel_config.worker_cls)
         self.worker = worker_class(**kwargs)
         assert self.worker is not None
 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -516,8 +516,13 @@ class WorkerWrapperBase:
         from vllm.plugins import load_general_plugins
         load_general_plugins()
 
-        worker_class = resolve_obj_by_qualname(
-            self.vllm_config.parallel_config.worker_cls)
+        if isinstance(self.vllm_config.parallel_config.worker_cls, str):
+            worker_class = resolve_obj_by_qualname(
+                self.vllm_config.parallel_config.worker_cls)
+        else:
+            assert issubclass(self.vllm_config.parallel_config.worker_cls, bytes)
+            import cloudpickle
+            worker_class = cloudpickle.loads(self.vllm_config.parallel_config.worker_cls)
         self.worker = worker_class(**kwargs)
         assert self.worker is not None
 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -1,3 +1,4 @@
+import cloudpickle
 import dataclasses
 import os
 import time
@@ -522,7 +523,6 @@ class WorkerWrapperBase:
         else:
             assert isinstance(self.vllm_config.parallel_config.worker_cls,
                               bytes)
-            import cloudpickle
             worker_class = cloudpickle.loads(
                 self.vllm_config.parallel_config.worker_cls)
         self.worker = worker_class(**kwargs)

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -1,10 +1,10 @@
-import cloudpickle
 import dataclasses
 import os
 import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
+import cloudpickle
 import torch
 
 from vllm.config import ObservabilityConfig, VllmConfig

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -520,7 +520,7 @@ class WorkerWrapperBase:
             worker_class = resolve_obj_by_qualname(
                 self.vllm_config.parallel_config.worker_cls)
         else:
-            assert issubclass(self.vllm_config.parallel_config.worker_cls, bytes)
+            assert isinstance(self.vllm_config.parallel_config.worker_cls, bytes)
             import cloudpickle
             worker_class = cloudpickle.loads(self.vllm_config.parallel_config.worker_cls)
         self.worker = worker_class(**kwargs)


### PR DESCRIPTION
This PR introduces a user-facing API `LLM.collective_rpc` so that users can easily extend the functionality of vLLM.

The workflow is:

- Users inherit vLLM's worker to add new functions. These functions have access to internal states of the workers.
- Users call `LLM.collective_rpc` on their newly defined functions, and get the returned results

I added a script to demonstrate the usage via RLHF integration, and also showcase how to inspect the internal state of a worker's model.

It should also solve the use cases mentioned in https://github.com/vllm-project/vllm/pull/10353#discussion_r1853652726 .