### PR TITLE
[Bugfix] Fix _get_lora_device for HQQ marlin

### DIFF
--- a/vllm/lora/layers.py
+++ b/vllm/lora/layers.py
@@ -51,6 +51,9 @@ def _get_lora_device(base_layer: nn.Module) -> torch.device:
     # marlin
     elif hasattr(base_layer, "B"):
         return base_layer.B.device
+    # HQQ marlin
+    elif hasattr(base_layer, "W_q"):
+        return base_layer.W_q.device
     else:
         raise ValueError(f"Unsupported base layer: {base_layer}")
 


### PR DESCRIPTION
Account for HQQ Marlin in _get_lora_device()

Bug: HQQ models with LoRA will raise ValueError(f"Unsupported base layer: {base_layer}") from [here](https://github.com/vllm-project/vllm/blob/main/vllm/lora/layers.py#L55).

Fix:
 hqq_marlin.py, registers the weights under the name "W_q". Look for attribute name "W_q" in  _get_lora_device() for HQQ marlin.

Testing: 
```
#!/bin/bash
num_prompts=100
lora_path="Taiwar/llama-3.2-1b-instruct-lora_model-1epoch" # grabbed a random adapter from HF 
model="nm-testing/Llama-3.2-1B-Instruct-HQQ" 

python3 benchmarks/benchmark_throughput.py --model  ${model} --backend vllm   --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts ${num_prompts} --max-loras 2 --max-lora-rank 16  --enable-lora --lora-path ${lora_path}
```


