### PR TITLE
[Bugfix] Fix max image feature size for Llava-one-vision

### DIFF
--- a/tests/models/multimodal/processing/test_llava_next.py
+++ b/tests/models/multimodal/processing/test_llava_next.py
@@ -27,7 +27,7 @@ def _validate_image_max_tokens_one(
         assert feature_size <= max_tokens, f"{feature_size} <= {max_tokens}"
     except Exception as exc:
         failed_size_excs.append((image_size, exc))
-    
+
 
 @pytest.mark.skip("This test takes around 5 minutes to run. "
                   "Comment this out to run it manually.")
@@ -56,7 +56,7 @@ def test_processor_max_tokens(model_id):
         if 1 <= aspect_ratio <= 2 and aspect_ratio not in seen_aspect_ratios:
             image_sizes.append(ImageSize(w, h))
             seen_aspect_ratios.add(aspect_ratio)
-    
+
     failed_size_excs = list[tuple[ImageSize, Exception]]()
 
     validate_one = partial(

--- a/tests/models/multimodal/processing/test_llava_next.py
+++ b/tests/models/multimodal/processing/test_llava_next.py
@@ -13,6 +13,67 @@ from vllm.multimodal.utils import cached_get_tokenizer
 from ...utils import build_model_context
 
 
+def _validate_image_max_tokens_one(
+    processor: BaseMultiModalProcessor,
+    max_tokens: int,
+    failed_size_excs: list[tuple[ImageSize, Exception]],
+    image_size: ImageSize,
+) -> None:
+    info = processor.info
+    feature_size = info.get_num_image_tokens(image_width=image_size.width,
+                                             image_height=image_size.height)
+
+    try:
+        assert feature_size <= max_tokens, f"{feature_size} <= {max_tokens}"
+    except Exception as exc:
+        failed_size_excs.append((image_size, exc))
+    
+
+@pytest.mark.skip("This test takes around 5 minutes to run. "
+                  "Comment this out to run it manually.")
+@pytest.mark.parametrize("model_id", ["llava-hf/llava-v1.6-mistral-7b-hf"])
+def test_processor_max_tokens(model_id):
+    ctx = build_model_context(
+        model_name=model_id,
+        tokenizer_name=model_id,
+        mm_processor_kwargs=None,
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config,
+        tokenizer=cached_get_tokenizer(ctx.model_config.tokenizer),
+    )
+    info = processor.info
+
+    seen_aspect_ratios = set[float]()
+    image_sizes = list[ImageSize]()
+
+    # The aspect ratio of the grid layout is between 1 and 2
+    # NOTE: Assumes that feature size calculation is the same if we
+    # swap the width and height of the image
+    for w, h in itertools.product(range(32, 4096), repeat=2):
+        aspect_ratio = w / h
+        if 1 <= aspect_ratio <= 2 and aspect_ratio not in seen_aspect_ratios:
+            image_sizes.append(ImageSize(w, h))
+            seen_aspect_ratios.add(aspect_ratio)
+    
+    failed_size_excs = list[tuple[ImageSize, Exception]]()
+
+    validate_one = partial(
+        _validate_image_max_tokens_one,
+        processor,
+        info.get_max_image_tokens(),  # type: ignore
+        failed_size_excs,
+    )
+    pqdm(image_sizes, validate_one, n_jobs=8, desc="Validating image sizes")
+
+    if failed_size_excs:
+        msg = "Found failing image sizes:" \
+            + "\n========\n".join(f"[{size}]\n{exc}"
+                                  for size, exc in failed_size_excs)
+        raise AssertionError(msg)
+
+
 def _validate_image_prompt_replacements_one(
     processor: BaseMultiModalProcessor,
     num_imgs: int,

--- a/tests/models/multimodal/processing/test_llava_onevision.py
+++ b/tests/models/multimodal/processing/test_llava_onevision.py
@@ -27,7 +27,7 @@ def _validate_image_max_tokens_one(
         assert feature_size <= max_tokens, f"{feature_size} <= {max_tokens}"
     except Exception as exc:
         failed_size_excs.append((image_size, exc))
-    
+
 
 @pytest.mark.skip("This test takes around 5 minutes to run. "
                   "Comment this out to run it manually.")
@@ -57,7 +57,7 @@ def test_processor_max_tokens(model_id):
         if 1 <= aspect_ratio <= 6 and aspect_ratio not in seen_aspect_ratios:
             image_sizes.append(ImageSize(w, h))
             seen_aspect_ratios.add(aspect_ratio)
-    
+
     failed_size_excs = list[tuple[ImageSize, Exception]]()
 
     validate_one = partial(

--- a/tests/models/multimodal/processing/test_llava_onevision.py
+++ b/tests/models/multimodal/processing/test_llava_onevision.py
@@ -13,6 +13,68 @@ from vllm.multimodal.utils import cached_get_tokenizer
 from ...utils import build_model_context
 
 
+def _validate_image_max_tokens_one(
+    processor: BaseMultiModalProcessor,
+    max_tokens: int,
+    failed_size_excs: list[tuple[ImageSize, Exception]],
+    image_size: ImageSize,
+) -> None:
+    info = processor.info
+    feature_size = info.get_num_image_tokens(image_width=image_size.width,
+                                             image_height=image_size.height)
+
+    try:
+        assert feature_size <= max_tokens, f"{feature_size} <= {max_tokens}"
+    except Exception as exc:
+        failed_size_excs.append((image_size, exc))
+    
+
+@pytest.mark.skip("This test takes around 5 minutes to run. "
+                  "Comment this out to run it manually.")
+@pytest.mark.parametrize("model_id",
+                         ["llava-hf/llava-onevision-qwen2-0.5b-ov-hf"])
+def test_processor_max_tokens(model_id):
+    ctx = build_model_context(
+        model_name=model_id,
+        tokenizer_name=model_id,
+        mm_processor_kwargs=None,
+        limit_mm_per_prompt={"image": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(
+        ctx.model_config,
+        tokenizer=cached_get_tokenizer(ctx.model_config.tokenizer),
+    )
+    info = processor.info
+
+    seen_aspect_ratios = set[float]()
+    image_sizes = list[ImageSize]()
+
+    # The aspect ratio of the grid layout is between 1 and 6
+    # NOTE: Assumes that feature size calculation is the same if we
+    # swap the width and height of the image
+    for w, h in itertools.product(range(32, 4096), repeat=2):
+        aspect_ratio = w / h
+        if 1 <= aspect_ratio <= 6 and aspect_ratio not in seen_aspect_ratios:
+            image_sizes.append(ImageSize(w, h))
+            seen_aspect_ratios.add(aspect_ratio)
+    
+    failed_size_excs = list[tuple[ImageSize, Exception]]()
+
+    validate_one = partial(
+        _validate_image_max_tokens_one,
+        processor,
+        info.get_max_image_tokens(),  # type: ignore
+        failed_size_excs,
+    )
+    pqdm(image_sizes, validate_one, n_jobs=8, desc="Validating image sizes")
+
+    if failed_size_excs:
+        msg = "Found failing image sizes:" \
+            + "\n========\n".join(f"[{size}]\n{exc}"
+                                  for size, exc in failed_size_excs)
+        raise AssertionError(msg)
+
+
 def _validate_image_prompt_replacements_one(
     processor: BaseMultiModalProcessor,
     num_imgs: int,

--- a/vllm/model_executor/models/llava_onevision.py
+++ b/vllm/model_executor/models/llava_onevision.py
@@ -37,7 +37,7 @@ from .utils import (AutoWeightsLoader, flatten_bn, init_vllm_registered_model,
 
 # For profile run
 _MAX_FRAMES_PER_VIDEO = 16
-_MAX_IMAGE_SIZE = 8686
+_MAX_IMAGE_SIZE_PLACEHOLDER = 12288
 
 
 class LlavaOnevisionVideoPixelInputs(TypedDict):
@@ -106,13 +106,12 @@ class LlavaOnevisionProcessingInfo(LlavaNextProcessingInfo):
 
         target_width, target_height = self.get_image_size_with_most_features()
 
-        # FIXME: This is in fact not accurate and we compare with a known
-        # max image size.
+        # FIXME: This is in fact not accurate and we compare with a placeholder.
         return max(
             self.get_num_image_tokens(
                 image_width=target_width,
                 image_height=target_height,
-            ), _MAX_IMAGE_SIZE)
+            ), _MAX_IMAGE_SIZE_PLACEHOLDER)
 
     def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
         return {

--- a/vllm/model_executor/models/llava_onevision.py
+++ b/vllm/model_executor/models/llava_onevision.py
@@ -37,6 +37,7 @@ from .utils import (AutoWeightsLoader, flatten_bn, init_vllm_registered_model,
 
 # For profile run
 _MAX_FRAMES_PER_VIDEO = 16
+_MAX_IMAGE_SIZE = 8686
 
 
 class LlavaOnevisionVideoPixelInputs(TypedDict):
@@ -100,6 +101,18 @@ class LlavaOnevisionProcessingInfo(LlavaNextProcessingInfo):
 
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
         return {"image": None, "video": None}
+
+    def get_max_image_tokens(self) -> int:
+
+        target_width, target_height = self.get_image_size_with_most_features()
+
+        # FIXME: This is in fact not accurate and we compare with a known
+        # max image size.
+        return max(
+            self.get_num_image_tokens(
+                image_width=target_width,
+                image_height=target_height,
+            ), _MAX_IMAGE_SIZE)
 
     def get_mm_max_tokens_per_item(self, seq_len: int) -> Mapping[str, int]:
         return {

--- a/vllm/model_executor/models/llava_onevision.py
+++ b/vllm/model_executor/models/llava_onevision.py
@@ -146,6 +146,7 @@ class LlavaOnevisionProcessingInfo(LlavaNextProcessingInfo):
         return (unpadded_features, newline_features)
 
     def get_image_size_with_most_features(self) -> ImageSize:
+        # NOTE: This hardcoded value is found via processor tests
         return ImageSize(width=1153, height=944)
 
     def _get_num_frame_tokens(


### PR DESCRIPTION
It was discovered that some images may generate embeddings with size bigger than the assumed max feature size, and therefore crash the server since these requests will never get scheduled because of #11895. This PR adds a temporary placeholder until the processor fixes this issue completely.
