### PR TITLE
Support for registering custom ops on third-party devices

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1876,6 +1876,10 @@ def direct_register_custom_op(
             "the required dependencies.")
         return
 
+    import torch
+    if dispatch_key == torch._C._get_privateuse1_backend_name().upper():
+        dispatch_key = "PrivateUse1"
+
     import torch.library
     if hasattr(torch.library, "infer_schema"):
         schema_str = torch.library.infer_schema(op_func,


### PR DESCRIPTION
For third-party accelerators like Ascend NPU, they are registered in PyTorch by `PrivateUse1`, see: https://pytorch.org/tutorials/advanced/privateuseone.html#rename-privateuse1-to-a-custom-name-for-the-new-backend 

In out-of-tree plugin repositories (e.g. `torch_npu`), we can use `torch.rename_privateuse1_backend("npu")` to map the privateuse1 field to npu, but when actually specifying the dispatch key, we need to reuse the dispatch key that pytorch can recognize, i.e. `PrivateUse1` instead of `NPU`.


cc @youkaichao 
