### PR TITLE
benchmark_serving support --served-model-name param

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -44,8 +44,8 @@ class RequestFuncOutput:
 
 
 async def async_request_tgi(
-        request_func_input: RequestFuncInput,
-        pbar: Optional[tqdm] = None,
+    request_func_input: RequestFuncInput,
+    pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -116,8 +116,8 @@ async def async_request_tgi(
 
 
 async def async_request_trt_llm(
-        request_func_input: RequestFuncInput,
-        pbar: Optional[tqdm] = None,
+    request_func_input: RequestFuncInput,
+    pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -183,8 +183,8 @@ async def async_request_trt_llm(
 
 
 async def async_request_deepspeed_mii(
-        request_func_input: RequestFuncInput,
-        pbar: Optional[tqdm] = None,
+    request_func_input: RequestFuncInput,
+    pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert request_func_input.best_of == 1
@@ -226,8 +226,8 @@ async def async_request_deepspeed_mii(
 
 
 async def async_request_openai_completions(
-        request_func_input: RequestFuncInput,
-        pbar: Optional[tqdm] = None,
+    request_func_input: RequestFuncInput,
+    pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
@@ -317,8 +317,8 @@ async def async_request_openai_completions(
 
 
 async def async_request_openai_chat_completions(
-        request_func_input: RequestFuncInput,
-        pbar: Optional[tqdm] = None,
+    request_func_input: RequestFuncInput,
+    pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
@@ -420,10 +420,10 @@ def get_model(pretrained_model_name_or_path: str) -> str:
 
 
 def get_tokenizer(
-        pretrained_model_name_or_path: str,
-        tokenizer_mode: str = "auto",
-        trust_remote_code: bool = False,
-        **kwargs,
+    pretrained_model_name_or_path: str,
+    tokenizer_mode: str = "auto",
+    trust_remote_code: bool = False,
+    **kwargs,
 ) -> Union[PreTrainedTokenizer, PreTrainedTokenizerFast]:
     if pretrained_model_name_or_path is not None and not os.path.exists(
             pretrained_model_name_or_path):

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -22,7 +22,7 @@ class RequestFuncInput:
     prompt_len: int
     output_len: int
     model: str
-    model_name: str = None
+    model_name: Optional[str] = None
     best_of: int = 1
     logprobs: Optional[int] = None
     extra_body: Optional[dict] = None

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1228,13 +1228,12 @@ if __name__ == "__main__":
         'always use the slow tokenizer. \n* '
         '"mistral" will always use the `mistral_common` tokenizer.')
 
-    parser.add_argument(
-        "--served-model-name",
-        type=str,
-        default=None,
-        help="The model name used in the API. "
-             "If not specified, the model name will be the "
-             "same as the ``--model`` argument. ")
+    parser.add_argument("--served-model-name",
+                        type=str,
+                        default=None,
+                        help="The model name used in the API. "
+                        "If not specified, the model name will be the "
+                        "same as the ``--model`` argument. ")
 
     args = parser.parse_args()
     main(args)

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -525,6 +525,7 @@ async def benchmark(
     api_url: str,
     base_url: str,
     model_id: str,
+    model_name: str,
     tokenizer: PreTrainedTokenizerBase,
     input_requests: List[Tuple[str, int, int]],
     logprobs: Optional[int],
@@ -553,6 +554,7 @@ async def benchmark(
             "Multi-modal content is only supported on 'openai-chat' backend.")
     test_input = RequestFuncInput(
         model=model_id,
+        model_name=model_name,
         prompt=test_prompt,
         api_url=api_url,
         prompt_len=test_prompt_len,
@@ -573,6 +575,7 @@ async def benchmark(
     if profile:
         print("Starting profiler...")
         profile_input = RequestFuncInput(model=model_id,
+                                         model_name=model_name,
                                          prompt=test_prompt,
                                          api_url=base_url + "/start_profile",
                                          prompt_len=test_prompt_len,
@@ -616,6 +619,7 @@ async def benchmark(
     async for request in get_request(input_requests, request_rate, burstiness):
         prompt, prompt_len, output_len, mm_content = request
         request_func_input = RequestFuncInput(model=model_id,
+                                              model_name=model_name,
                                               prompt=prompt,
                                               api_url=api_url,
                                               prompt_len=prompt_len,
@@ -780,6 +784,7 @@ def main(args: argparse.Namespace):
 
     backend = args.backend
     model_id = args.model
+    model_name = args.served_model_name
     tokenizer_id = args.tokenizer if args.tokenizer is not None else args.model
     tokenizer_mode = args.tokenizer_mode
 
@@ -877,6 +882,7 @@ def main(args: argparse.Namespace):
             api_url=api_url,
             base_url=base_url,
             model_id=model_id,
+            model_name=model_name,
             tokenizer=tokenizer,
             input_requests=input_requests,
             logprobs=args.logprobs,
@@ -1221,6 +1227,14 @@ if __name__ == "__main__":
         'fast tokenizer if available.\n* "slow" will '
         'always use the slow tokenizer. \n* '
         '"mistral" will always use the `mistral_common` tokenizer.')
+
+    parser.add_argument(
+        "--served-model-name",
+        type=str,
+        default=None,
+        help="The model name used in the API. "
+             "If not specified, the model name will be the "
+             "same as the ``--model`` argument. ")
 
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
benchmark_serving.py  add `--served-model-name` param

Test Result:
```
python3 /root/vllm/benchmarks/benchmark_serving.py --backend vllm --model /mnt/models/ --served-model-name qwen --trust-remote-code --dataset-name sonnet --dataset-path /root/vllm/benchmarks/sonnet.txt --sonnet-input-len 1024 --sonnet-output-len 6 --sonnet-prefix-len 50 --num-prompts 200 --request-rate 2 --host vllm-serving.default --port 8000 --save-result --result-dir ./ --result-filename pd-disagg-qps-2.json
Namespace(backend='vllm', base_url=None, host='vllm-serving.default.svc.cluster.local', port=8000, endpoint='/v1/completions', dataset=None, dataset_name='sonnet', dataset_path='/root/vllm/benchmarks/sonnet.txt', max_concurrency=None, model='/mnt/models/', tokenizer=None, best_of=1, use_beam_search=False, num_prompts=200, logprobs=None, request_rate=2.0, burstiness=1.0, seed=0, trust_remote_code=True, disable_tqdm=False, profile=False, save_result=True, metadata=None, result_dir='./', result_filename='pd-disagg-qps-2.json', ignore_eos=False, percentile_metrics='ttft,tpot,itl', metric_percentiles='99', goodput=None, sonnet_input_len=1024, sonnet_output_len=6, sonnet_prefix_len=50, sharegpt_output_len=None, random_input_len=1024, random_output_len=128, random_range_ratio=1.0, random_prefix_len=0, hf_subset=None, hf_split=None, hf_output_len=None, tokenizer_mode='auto', served_model_name='qwen')
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
Traffic request rate: 2.0
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: None
100%|████████████████████████████████████████████████████████████████████████████████████████| 200/200 [01:39<00:00,  2.01it/s]
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  99.71
Total input tokens:                      203135
Total generated tokens:                  1200
Request throughput (req/s):              2.01
Output token throughput (tok/s):         12.03
Total Token throughput (tok/s):          2049.30
---------------Time to First Token----------------
Mean TTFT (ms):                          2273.31
Median TTFT (ms):                        1240.81
P99 TTFT (ms):                           9287.21
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          119.03
Median TPOT (ms):                        17.50
P99 TPOT (ms):                           724.67
---------------Inter-token Latency----------------
Mean ITL (ms):                           118.72
Median ITL (ms):                         13.08
P99 ITL (ms):                            2233.79
==================================================
```