### PR TITLE
[Bugfix] Fix test_long_context.py and activation kernels

### DIFF
--- a/tests/lora/test_long_context.py
+++ b/tests/lora/test_long_context.py
@@ -1,4 +1,5 @@
 import ast
+import os
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -113,7 +114,10 @@ def lora_llm(long_context_infos):
         context_len_to_scaling_factor[info["context_length"]]
         for info in long_context_infos.values()
     ]
-
+    # Since dist_init sets CUDA_VISIBLE_DEVICES and affects LLM initialization,
+    # remove this env if it exists.
+    if "CUDA_VISIBLE_DEVICES" in os.environ:
+        del os.environ["CUDA_VISIBLE_DEVICES"]
     llm = vllm.LLM(
         "meta-llama/Llama-2-13b-chat-hf",
         enable_lora=True,

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -30,7 +30,7 @@ class FatreluAndMul(CustomOp):
     def __init__(self, threshold: float = 0.):
         super().__init__()
         self.threshold = threshold
-        if current_platform.is_cuda_alike() or current_platform.is_cpu():
+        if current_platform.is_cuda_alike():
             self.op = torch.ops._C.fatrelu_and_mul
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
@@ -100,7 +100,7 @@ class MulAndSilu(CustomOp):
 
     def __init__(self):
         super().__init__()
-        if current_platform.is_cuda_alike() or current_platform.is_cpu():
+        if current_platform.is_cuda_alike():
             self.op = torch.ops._C.mul_and_silu
         elif current_platform.is_xpu():
             from vllm._ipex_ops import ipex_ops


### PR DESCRIPTION
## test_long_context.py Failure
The `test_long_context.py`  is currently failing (see failure details at: [test_long_context failure](https://buildkite.com/vllm/ci/builds/12025#01946b8d-cc0b-4af1-bb73-5093f0c45f8d/145-438)). The issue can be reproduced using the following code:
```python

from vllm import LLM, SamplingParams
from vllm.distributed import cleanup_dist_env_and_memory


# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.0, top_p=0.95)

model_name="model_path"
llm = LLM(
    model=model_name,
    trust_remote_code=True,
    max_model_len=128,
    max_num_seqs=16,
    enforce_eager=True,
    tensor_parallel_size=1,
)
del llm
cleanup_dist_env_and_memory()
llm = LLM(
    model=model_name,
    trust_remote_code=True,
    max_model_len=128,
    max_num_seqs=16,
    enforce_eager=True,
    tensor_parallel_size=2,
)

outputs = llm.generate(prompts, sampling_params)
```
The error occurs because during the [platform check](https://github.com/vllm-project/vllm/blob/main/vllm/platforms/cuda.py#L149), `CUDA_VISIBLE_DEVICES` is written to environment variables, and  the env var are not properly cleaned up in `cleanup_dist_env_and_memory`, resulting in the error mentioned above. @youkaichao  Since I'm not sure if this is the expected behavior, I'm only deleting it in `test_lora_context.py`

**Also fixed the activation kernel  bug**
