### PR TITLE
[BUILD] Add VLLM_BUILD_EXT to control custom op build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 envs = load_module_from_path('envs', os.path.join(ROOT_DIR, 'vllm', 'envs.py'))
 
 VLLM_TARGET_DEVICE = envs.VLLM_TARGET_DEVICE
+VLLM_BUILD_EXT = envs.VLLM_BUILD_EXT
 
 if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
     logger.warning(
@@ -387,7 +388,11 @@ def _is_xpu() -> bool:
 
 
 def _build_custom_ops() -> bool:
-    return _is_cuda() or _is_hip() or _is_cpu()
+    if not VLLM_BUILD_EXT:
+        logger.warning("Building of custom op is disabled,"
+                       "this is only used in a out-of-tree device situation."
+                       "Set VLLM_BUILD_EXT as true if this is unexpected.")
+    return VLLM_BUILD_EXT and (_is_cuda() or _is_hip() or _is_cpu())
 
 
 def get_rocm_version():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
     VLLM_TARGET_DEVICE: str = "cuda"
+    VLLM_BUILD_EXT: bool = True
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None
     VLLM_USE_PRECOMPILED: bool = False
@@ -101,6 +102,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # rocm, neuron, cpu, openvino]
     "VLLM_TARGET_DEVICE":
     lambda: os.getenv("VLLM_TARGET_DEVICE", "cuda"),
+
+    # Whether to build custom op, disable me if building an oot vllm
+    # It only makes sense when the device is cuda, cpu or hip(rocm)
+    "VLLM_BUILD_EXT":
+    lambda: os.environ.get("VLLM_BUILD_EXT", "True").lower() == "true",
 
     # Maximum number of compilation jobs to run in parallel.
     # By default this is the number of CPUs


### PR DESCRIPTION
Add `VLLM_BUILD_EXT` to control custom op build, this is used to avoid building cpu custom op when we just need a base vLLM on  a out-of-tree device.