### PR TITLE
[BugFix] add more `is not None` check in VllmConfig.__post_init__

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3172,7 +3172,8 @@ class VllmConfig:
 
         if self.compilation_config is None:
             self.compilation_config = CompilationConfig()
-        if envs.VLLM_USE_V1 and not self.model_config.enforce_eager:
+        if envs.VLLM_USE_V1 and self.model_config is not None and \
+            not self.model_config.enforce_eager:
             # NOTE(woosuk): Currently, we use inductor because the piecewise
             # CUDA graphs do not work properly with the custom CUDA kernels.
             # FIXME(woosuk): Disable inductor to reduce the compilation time


### PR DESCRIPTION
Add this check to allow v1 tests to use `VllmConfig` without specifying `model_config`

It can fix this CI failure.
https://buildkite.com/vllm/ci/builds/12063#01947022-e123-4675-9572-9f37e75c77ec/200-1479