### PR TITLE
[core] allow callable in collective_rpc

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -107,7 +107,7 @@ steps:
   source_file_dependencies:
   - vllm/
   commands:
-  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py
+  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py --ignore=entrypoints/llm/test_collective_rpc.py
   - pytest -v -s entrypoints/llm/test_lazy_outlines.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
   - pytest -v -s entrypoints/llm/test_generate_multiple_loras.py # it needs a clean process
@@ -466,7 +466,9 @@ steps:
   - vllm/worker/worker_base.py
   - vllm/worker/worker.py
   - vllm/worker/model_runner.py
+  - entrypoints/llm/test_collective_rpc.py
   commands:
+  - pytest -v -s entrypoints/llm/test_collective_rpc.py
   - torchrun --nproc-per-node=2 distributed/test_torchrun_example.py
   - pytest -v -s ./compile/test_basic_correctness.py
   - pytest -v -s ./compile/test_wrapper.py

--- a/tests/engine/test_custom_executor.py
+++ b/tests/engine/test_custom_executor.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pytest
 
@@ -18,7 +18,7 @@ class Mock:
 class CustomUniExecutor(UniProcExecutor):
 
     def collective_rpc(self,
-                       method: str,
+                       method: Union[str, Callable],
                        timeout: Optional[float] = None,
                        args: Tuple = (),
                        kwargs: Optional[Dict] = None) -> List[Any]:

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -18,9 +18,8 @@ class MyWorker(Worker):
 
 @pytest.mark.parametrize("tp_size", [1, 2])
 @pytest.mark.parametrize("backend", ["mp", "ray"])
-@pytest.mark.parametrize("method", ["echo_rank", echo_rank])
 @fork_new_process_for_each_test
-def test_collective_rpc(tp_size, backend, method):
+def test_collective_rpc(tp_size, backend):
     if tp_size == 1 and backend == "ray":
         pytest.skip("Skip duplicate test case")
     if tp_size == 1:
@@ -30,4 +29,5 @@ def test_collective_rpc(tp_size, backend, method):
               tensor_parallel_size=tp_size,
               distributed_executor_backend=backend,
               worker_cls=MyWorker)
-    assert llm.collective_rpc(method) == list(range(tp_size))
+    for method in ["echo_rank", echo_rank]:
+        assert llm.collective_rpc(method) == list(range(tp_size))

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -1,0 +1,33 @@
+import pytest
+
+from vllm import LLM
+from vllm.worker.worker import Worker
+
+from ...utils import fork_new_process_for_each_test
+
+
+def echo_rank(self):
+    return self.rank
+
+
+class MyWorker(Worker):
+
+    def echo_rank(self):
+        return self.rank
+
+
+@pytest.mark.parametrize("tp_size", [1, 2])
+@pytest.mark.parametrize("backend", ["mp", "ray"])
+@pytest.mark.parametrize("method", ["echo_rank", echo_rank])
+@fork_new_process_for_each_test
+def test_collective_rpc(tp_size, backend, method):
+    if tp_size == 1 and backend == "ray":
+        pytest.skip("Skip duplicate test case")
+    if tp_size == 1:
+        backend = None
+    llm = LLM(model="meta-llama/Llama-3.2-1B-Instruct",
+              enforce_eager=True,
+              tensor_parallel_size=tp_size,
+              distributed_executor_backend=backend,
+              worker_cls=MyWorker)
+    assert llm.collective_rpc(method) == list(range(tp_size))

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -1,19 +1,12 @@
 import pytest
 
 from vllm import LLM
-from vllm.worker.worker import Worker
 
 from ...utils import fork_new_process_for_each_test
 
 
 def echo_rank(self):
     return self.rank
-
-
-class MyWorker(Worker):
-
-    def echo_rank(self):
-        return self.rank
 
 
 @pytest.mark.parametrize("tp_size", [1, 2])
@@ -24,6 +17,14 @@ def test_collective_rpc(tp_size, backend):
         pytest.skip("Skip duplicate test case")
     if tp_size == 1:
         backend = None
+
+    from vllm.worker.worker import Worker
+
+    class MyWorker(Worker):
+
+        def echo_rank(self):
+            return self.rank
+
     llm = LLM(model="meta-llama/Llama-3.2-1B-Instruct",
               enforce_eager=True,
               load_format="dummy",

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -5,10 +5,6 @@ from vllm import LLM
 from ...utils import fork_new_process_for_each_test
 
 
-def echo_rank(self):
-    return self.rank
-
-
 @pytest.mark.parametrize("tp_size", [1, 2])
 @pytest.mark.parametrize("backend", ["mp", "ray"])
 @fork_new_process_for_each_test
@@ -17,6 +13,9 @@ def test_collective_rpc(tp_size, backend):
         pytest.skip("Skip duplicate test case")
     if tp_size == 1:
         backend = None
+
+    def echo_rank(self):
+        return self.rank
 
     from vllm.worker.worker import Worker
 

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -26,6 +26,7 @@ def test_collective_rpc(tp_size, backend):
         backend = None
     llm = LLM(model="meta-llama/Llama-3.2-1B-Instruct",
               enforce_eager=True,
+              load_format="dummy",
               tensor_parallel_size=tp_size,
               distributed_executor_backend=backend,
               worker_cls=MyWorker)

--- a/tests/entrypoints/llm/test_collective_rpc.py
+++ b/tests/entrypoints/llm/test_collective_rpc.py
@@ -14,6 +14,8 @@ def test_collective_rpc(tp_size, backend):
     if tp_size == 1:
         backend = None
 
+    # intentionally define the method and class in the test function,
+    # to test if they can be serialized and sent to the workers
     def echo_rank(self):
         return self.rank
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -5,10 +5,10 @@ from collections import deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
-from typing import (TYPE_CHECKING, Callable, ClassVar, Deque, Dict, Iterable,
-                    List, Mapping, NamedTuple, Optional)
+from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Deque, Dict,
+                    Iterable, List, Mapping, NamedTuple, Optional)
 from typing import Sequence as GenericSequence
-from typing import Set, Type, Union, cast, overload
+from typing import Set, Tuple, Type, Union, cast, overload
 
 import torch
 from typing_extensions import TypeVar, deprecated
@@ -1815,6 +1815,17 @@ class LLMEngine:
 
     def stop_profile(self) -> None:
         self.model_executor.stop_profile()
+
+    def collective_rpc(self,
+                       method: Union[str, Callable],
+                       timeout: Optional[float] = None,
+                       args: Tuple = (),
+                       kwargs: Optional[Dict] = None) -> List[Any]:
+        """
+        See LLM.collective_rpc for more details.
+        """
+        return self.model_executor.collective_rpc(method, timeout, args,
+                                                  kwargs)
 
     def check_health(self) -> None:
         if self.tokenizer:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,8 +1,8 @@
 import itertools
 import warnings
 from contextlib import contextmanager
-from typing import (Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Type,
-                    Union, cast, overload)
+from typing import (Any, Callable, ClassVar, Dict, List, Optional, Sequence,
+                    Tuple, Type, Union, cast, overload)
 
 import cloudpickle
 from tqdm import tqdm
@@ -464,7 +464,7 @@ class LLM:
         return self.engine_class.validate_outputs(outputs, RequestOutput)
 
     def collective_rpc(self,
-                       method: str,
+                       method: Union[str, Callable],
                        timeout: Optional[float] = None,
                        args: Tuple = (),
                        kwargs: Optional[Dict] = None) -> List[Any]:
@@ -476,9 +476,13 @@ class LLM:
         Then, users can call the new methods through this API.
         It is recommended to use this API to only pass control messages,
         and set up data-plane communication to pass data.
+        The method can also be a callable, which will be serialized
+        and sent to all workers to execute.
+        If the method is a callable, it should accept an additional
+        `self` argument, in addition to the arguments passed in `args`
+        and `kwargs`. The `self` argument will be the worker object.
         """
-        return self.llm_engine.model_executor.collective_rpc(
-            method, timeout, args, kwargs)
+        return self.llm_engine.collective_rpc(method, timeout, args, kwargs)
 
     def beam_search(
         self,

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -1,6 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, Dict, List, Optional, Set, Tuple, Union
+from typing import (Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple,
+                    Union)
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -47,7 +48,7 @@ class ExecutorBase(ABC):
 
     @abstractmethod
     def collective_rpc(self,
-                       method: str,
+                       method: Union[str, Callable],
                        timeout: Optional[float] = None,
                        args: Tuple = (),
                        kwargs: Optional[Dict] = None) -> List[Any]:
@@ -260,7 +261,7 @@ class DistributedExecutorBase(ExecutorBase):
         raise NotImplementedError
 
     def collective_rpc(self,
-                       method: str,
+                       method: Union[str, Callable],
                        timeout: Optional[float] = None,
                        args: Tuple = (),
                        kwargs: Optional[Dict] = None) -> List[Any]:
@@ -269,7 +270,7 @@ class DistributedExecutorBase(ExecutorBase):
     @abstractmethod
     def _run_workers(
         self,
-        method: str,
+        method: Union[str, Callable],
         *args,
         async_run_tensor_parallel_workers_only: bool = False,
         max_concurrent_workers: Optional[int] = None,

--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -126,8 +126,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
         if isinstance(method, str):
             sent_method = method
         else:
-            sent_method = cloudpickle.dumps(
-                method, protocol=cloudpickle.HIGHEST_PROTOCOL)
+            sent_method = cloudpickle.dumps(method)
         del method
 
         if max_concurrent_workers:

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -430,8 +430,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         if isinstance(method, str):
             sent_method = method
         else:
-            sent_method = cloudpickle.dumps(
-                method, protocol=cloudpickle.HIGHEST_PROTOCOL)
+            sent_method = cloudpickle.dumps(method)
         del method
         if self.use_ray_spmd_worker:
             assert not async_run_tensor_parallel_workers_only, (

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -2,8 +2,9 @@ import asyncio
 import os
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
+import cloudpickle
 import msgspec
 
 import vllm.envs as envs
@@ -410,7 +411,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
     def _run_workers(
         self,
-        method: str,
+        method: Union[str, Callable],
         *args,
         async_run_tensor_parallel_workers_only: bool = False,
         max_concurrent_workers: Optional[int] = None,
@@ -426,6 +427,12 @@ class RayDistributedExecutor(DistributedExecutorBase):
           rather than blocking on the results.
         - args/kwargs: All workers share the same args/kwargs
         """
+        if isinstance(method, str):
+            sent_method = method
+        else:
+            sent_method = cloudpickle.dumps(
+                method, protocol=cloudpickle.HIGHEST_PROTOCOL)
+        del method
         if self.use_ray_spmd_worker:
             assert not async_run_tensor_parallel_workers_only, (
                 "async_run_tensor_parallel_workers_only is not supported for "
@@ -440,7 +447,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         if async_run_tensor_parallel_workers_only:
             ray_workers = self.non_driver_workers
         ray_worker_outputs = [
-            worker.execute_method.remote(method, *args, **kwargs)
+            worker.execute_method.remote(sent_method, *args, **kwargs)
             for worker in ray_workers
         ]
 
@@ -455,7 +462,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         if not self.use_ray_spmd_worker:
             # Start the driver worker after all the ray workers.
             driver_worker_output = [
-                self.driver_worker.execute_method(method, *args, **kwargs)
+                self.driver_worker.execute_method(sent_method, *args, **kwargs)
             ]
 
         # Get the results of the ray workers.

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -46,11 +46,7 @@ class UniProcExecutor(ExecutorBase):
                        kwargs: Optional[Dict] = None) -> List[Any]:
         if kwargs is None:
             kwargs = {}
-        try:
-            answer = run_method(self.driver_worker, method, args, kwargs)
-        except AttributeError:
-            raise NotImplementedError(f"Method {method!r} is not"
-                                      " implemented.") from None
+        answer = run_method(self.driver_worker, method, args, kwargs)
         return [answer]
 
     def check_health(self) -> None:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2169,16 +2169,19 @@ def bind_kv_cache(
             forward_ctx.kv_cache[ve] = ve_kv_cache[kv_cache_idx]
 
 
-def run_method(obj: Any, method: Union[str, bytes], args: Tuple[Any],
+def run_method(obj: Any, method: Union[str, bytes, Callable], args: Tuple[Any],
                kwargs: Dict[str, Any]) -> Any:
     """
     Run a method of an object with the given arguments and keyword arguments.
     If the method is string, it will be converted to a method using getattr.
-    Else, the method should be serialized bytes and will be deserialized using
+    If the method is serialized bytes and will be deserialized using
     cloudpickle.
+    If the method is a callable, it will be called directly.
     """
     if isinstance(method, bytes):
         func = partial(cloudpickle.loads(method), obj)
-    else:
+    elif isinstance(method, str):
         func = getattr(obj, method)
+    else:
+        func = method # type: ignore
     return func(*args, **kwargs)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2183,5 +2183,5 @@ def run_method(obj: Any, method: Union[str, bytes, Callable], args: Tuple[Any],
     elif isinstance(method, str):
         func = getattr(obj, method)
     else:
-        func = method # type: ignore
+        func = method  # type: ignore
     return func(*args, **kwargs)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2181,7 +2181,11 @@ def run_method(obj: Any, method: Union[str, bytes, Callable], args: Tuple[Any],
     if isinstance(method, bytes):
         func = partial(cloudpickle.loads(method), obj)
     elif isinstance(method, str):
-        func = getattr(obj, method)
+        try:
+            func = getattr(obj, method)
+        except AttributeError:
+            raise NotImplementedError(f"Method {method!r} is not"
+                                      " implemented.") from None
     else:
         func = method  # type: ignore
     return func(*args, **kwargs)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2187,5 +2187,5 @@ def run_method(obj: Any, method: Union[str, bytes, Callable], args: Tuple[Any],
             raise NotImplementedError(f"Method {method!r} is not"
                                       " implemented.") from None
     else:
-        func = method  # type: ignore
+        func = partial(method, obj)  # type: ignore
     return func(*args, **kwargs)


### PR DESCRIPTION
Users find it annoying if they just want to execute a simple function but they need to inherit the worker class. This PR makes it possible to directly pass a function (callable).