### PR TITLE
[AMD][CI/Build][Bugfix] updated pytorch stale wheel path by using stable wheel

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -51,10 +51,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         *"rocm-6.2"*) \
             python3 -m pip uninstall -y torch torchvision \
             && python3 -m pip install --pre \
-                torch==2.6.0.dev20241113+rocm6.2 \
+                torch \
                 'setuptools-scm>=8' \
-                torchvision==0.20.0.dev20241113+rocm6.2 \
-                --extra-index-url https://download.pytorch.org/whl/nightly/rocm6.2;; \
+                torchvision \
+                --extra-index-url https://download.pytorch.org/whl/rocm6.2;; \
         *) ;; esac
 
 ENV LLVM_SYMBOLIZER_PATH=/opt/rocm/llvm/bin/llvm-symbolizer

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -70,7 +70,7 @@ Currently, there are no pre-built ROCm wheels.
 
     # Install PyTorch
     $ pip uninstall torch -y
-    $ pip install --no-cache-dir --pre torch==2.6.0.dev20241024 --index-url https://download.pytorch.org/whl/nightly/rocm6.2
+    $ pip install --no-cache-dir --pre torch --index-url https://download.pytorch.org/whl/rocm6.2
 
     # Build & install AMD SMI
     $ pip install /opt/rocm/share/amd_smi


### PR DESCRIPTION
FIX [#12066](https://github.com/vllm-project/vllm/issues/12066)

This PR is to replace the stale nightly wheel path for ROCm 6.2 pytorch with the stable pytorch wheel.
When the Dockerfile.rocm was previously upgraded to ROCm 6.2, the stable wheel does not exist yet for ROCm 6.2 in pytorch,  therefore a nightly wheel path was used.
Since the current stable wheel is available, we replace it with the stable wheel path.

The  [reporter of the issue](https://github.com/vllm-project/vllm/issues/12066) has confirmed it worked.

