### PR TITLE
[DOC] Add missing docstring for additional args in LLMEngine.add_request()

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -694,8 +694,6 @@ class LLMEngine:
             prompt_adapter_request: The prompt adapter request to add.
             priority: The priority of the request.
                 Only applicable with priority scheduling.
-            inputs: The prompt to the LLM. See :class:`~vllm.inputs.PromptType`
-                for more details about the format of each input.
 
         Details:
             - Set arrival_time to the current time if it is None.

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -689,9 +689,13 @@ class LLMEngine:
                 :class:`~vllm.PoolingParams` for pooling.
             arrival_time: The arrival time of the request. If None, we use
                 the current monotonic time.
+            lora_request: The LoRA request to add.
             trace_headers: OpenTelemetry trace headers.
+            prompt_adapter_request: The prompt adapter request to add.
             priority: The priority of the request.
                 Only applicable with priority scheduling.
+            inputs: The prompt to the LLM. See :class:`~vllm.inputs.PromptType`
+                for more details about the format of each input.
 
         Details:
             - Set arrival_time to the current time if it is None.


### PR DESCRIPTION
These are public methods so adding docstring would be helpful.