### PR TITLE
[misc] print a message to suggest how to bypass commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
   hooks:
   - id: pymarkdown
     files: docs/.*
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.6
+  hooks:
+  - id: actionlint
 - repo: local
   hooks:
   - id: mypy-local
@@ -81,7 +85,7 @@ repos:
     entry: tools/png-lint.sh
     language: script
     types: [png]
-- repo: https://github.com/rhysd/actionlint
-  rev: v1.7.6
-  hooks:
-  - id: actionlint
+  - id: suggestion
+    name: Suggestion
+    entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit."'
+    language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,5 +87,5 @@ repos:
     types: [png]
   - id: suggestion
     name: Suggestion
-    entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit."'
+    entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit." 1>&2'
     language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,5 +87,6 @@ repos:
     types: [png]
   - id: suggestion
     name: Suggestion
-    entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit." 1>&2'
+    entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit."'
     language: system
+    verbose: true


### PR DESCRIPTION
developers find it annoying if they need to pass linters for temporary commits.

not everyone knows the `--no-verify` falg.

I added this dummy hook to always print a message to tell users how to bypass hooks.