### PR TITLE
[CI] Pass local python version explicitly to pre-commit mypy.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   hooks:
   - id: mypy-local
     name: Run mypy for local Python installation
-    entry: tools/mypy.sh 1 "local"
+    entry: tools/mypy.sh 0 "local"
     language: python
     types: [python]
     additional_dependencies: &mypy_deps [mypy==1.11.1, types-setuptools, types-PyYAML, types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   hooks:
   - id: mypy-local
     name: Run mypy for local Python installation
-    entry: tools/mypy.sh
+    entry: tools/mypy.sh 1 "local"
     language: python
     types: [python]
     additional_dependencies: &mypy_deps [mypy==1.11.1, types-setuptools, types-PyYAML, types-requests]

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -7,6 +7,10 @@ if [ "$CI" -eq 1 ]; then
     set -e
 fi
 
+if [ $PYTHON_VERSION == "local" ]; then
+    PYTHON_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+fi
+
 run_mypy() {
     echo "Running mypy on $1"
     if [ "$CI" -eq 1 ] && [ -z "$1" ]; then

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CI=${1:-0}
-PYTHON_VERSION=${2:-3.9}
+PYTHON_VERSION=${2:-local}
 
 if [ "$CI" -eq 1 ]; then
     set -e


### PR DESCRIPTION
pre-commit passes all modified fills to `mypy.sh`, and `$1` `$2` will be filled by the path to modified filenames and I get the following errors:
```
tools/mypy.sh: line 12: [: vllm/v1/attention/backends/flash_attn.py: integer expression expected
usage: mypy [-h] [-v] [-V] [more options; see below]
            [-m MODULE] [-p PACKAGE] [-c PROGRAM_TEXT] [files ...]
mypy: error: argument --python-version: Invalid python version 'vllm/v1/worker/gpu_model_runner.py' (expected format: 'x.y')
```
This pr fixes the error by passing "local" explicitly.