### PR TITLE
fix: update platform detection for M-series arm based MacBook processors

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -101,6 +101,10 @@ def cpu_platform_plugin() -> Optional[str]:
     try:
         from importlib.metadata import version
         is_cpu = "cpu" in version("vllm")
+        if is_cpu == False:
+            import platform
+            is_cpu = platform.machine().lower().startswith("arm")
+
     except Exception:
         pass
 


### PR DESCRIPTION
Error log without this change:
```
    model = vllm.LLM(
            ^^^^^^^^^
  File "/Users/p1/miniconda3/lib/python3.12/site-packages/vllm/utils.py", line 986, in inner
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/miniconda3/lib/python3.12/site-packages/vllm/entrypoints/llm.py", line 230, in __init__
    self.llm_engine = self.engine_class.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/miniconda3/lib/python3.12/site-packages/vllm/engine/llm_engine.py", line 514, in from_engine_args
    engine_config = engine_args.create_engine_config(usage_context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/miniconda3/lib/python3.12/site-packages/vllm/engine/arg_utils.py", line 1043, in create_engine_config
    device_config = DeviceConfig(device=self.device)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/p1/miniconda3/lib/python3.12/site-packages/vllm/config.py", line 1528, in __init__
    raise RuntimeError("Failed to infer device type")
RuntimeError: Failed to infer device type
```