### PR TITLE
[Misc] Move find_loaded_library to platform_aware_utils.py

### DIFF
--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 import torch  # noqa
 
 from vllm.logger import init_logger
+from vllm.platform_aware_utils import find_loaded_library
 
 logger = init_logger(__name__)
 
@@ -31,32 +32,6 @@ class Function:
     name: str
     restype: Any
     argtypes: List[Any]
-
-
-def find_loaded_library(lib_name) -> Optional[str]:
-    """
-    According to according to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
-    the file `/proc/self/maps` contains the memory maps of the process, which includes the
-    shared libraries loaded by the process. We can use this file to find the path of the
-    a loaded library.
-    """ # noqa
-    found = False
-    with open("/proc/self/maps") as f:
-        for line in f:
-            if lib_name in line:
-                found = True
-                break
-    if not found:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = line.index("/")
-    path = line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), \
-        f"Unexpected filename: {filename} for library {lib_name}"
-    return path
 
 
 class CudaRTLibrary:

--- a/vllm/platform_aware_utils.py
+++ b/vllm/platform_aware_utils.py
@@ -1,0 +1,31 @@
+"""This file contains all the platform related utility functions.
+Please ensure we only add new functions to this file when necessary.
+"""
+from typing import Optional
+import subprocess
+
+
+def find_loaded_library(lib_name) -> Optional[str]:
+    """
+    According to according to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
+    the file `/proc/self/maps` contains the memory maps of the process, which includes the
+    shared libraries loaded by the process. We can use this file to find the path of the
+    a loaded library.
+    """ # noqa
+    found = False
+    with open("/proc/self/maps") as f:
+        for line in f:
+            if lib_name in line:
+                found = True
+                break
+    if not found:
+        # the library is not loaded in the current process
+        return None
+    # if lib_name is libcudart, we need to match a line with:
+    # address /path/to/libcudart-hash.so.11.0
+    start = line.index("/")
+    path = line[start:].strip()
+    filename = path.split("/")[-1]
+    assert filename.rpartition(".so")[0].startswith(lib_name), \
+        f"Unexpected filename: {filename} for library {lib_name}"
+    return path


### PR DESCRIPTION
find_loaded_library is a platform specific implementation, so create "platform_aware_utils.py". For different platform (such as using PAR to pack the binary), we can create our own version of "platform_aware_utils.py" to override such platform aware utility functions.