### PR TITLE
[Kernel] fix moe_align_block_size error condition

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -233,15 +233,17 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
       (num_experts + 1) * sizeof(int32_t);
 
   bool use_global_memory = false;
-  bool use_i16 = false; // Use uint16_t for shared memory token counts
-  if (shared_mem_i16 > device_max_shared_mem) {
-    use_global_memory = true;
-  } else if (shared_mem_i32 > device_max_shared_mem &&
+  bool use_i16 = false;  // Use uint16_t for shared memory token counts
+  if (shared_mem_i32 < device_max_shared_mem) {
+    // use_global_memory = false, use_i16 = false
+  } else if (shared_mem_i16 < device_max_shared_mem &&
              topk_ids.numel() <= 65535) {
     // when nelements of topk_ids is smaller than 65535 (max value of uint16),
     // element value of token_cnts would also smaller than 65535,
     // so we can use uint16 as dtype of token_cnts
     use_i16 = true;
+  } else {
+    use_global_memory = true;
   }
 
   if (use_global_memory) {

--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -235,7 +235,7 @@ void moe_align_block_size(torch::Tensor topk_ids, int64_t num_experts,
   bool use_global_memory = false;
   bool use_i16 = false;  // Use uint16_t for shared memory token counts
   if (shared_mem_i32 < device_max_shared_mem) {
-    // use_global_memory = false, use_i16 = false
+    // Do nothing in this case. We're all set to use int32_t token counts
   } else if (shared_mem_i16 < device_max_shared_mem &&
              topk_ids.numel() <= 65535) {
     // when nelements of topk_ids is smaller than 65535 (max value of uint16),


### PR DESCRIPTION
@mgoin @tlrmchlsmth @houseroad 
Sorry, I made a mistake at https://github.com/vllm-project/vllm/pull/12222 .

```cpp
  bool use_global_memory = false;
  bool use_i16 = false; // Use uint16_t for shared memory token counts
  if (shared_mem_i16 > device_max_shared_mem) {
    use_global_memory = true;
  } else if (shared_mem_i32 > device_max_shared_mem &&
             topk_ids.numel() <= 65535) {
    // when nelements of topk_ids is smaller than 65535 (max value of uint16),
    // element value of token_cnts would also smaller than 65535,
    // so we can use uint16 as dtype of token_cnts
    use_i16 = true;
  }
```

When `shared_mem_i16 > device_max_shared_mem && shared_mem_i32 < device_max_shared_mem && topk_ids.numel() > 65535`, the setting would be `use_global_memory = false` and `use_i16 = false`, so we would use i32 shared memory kernel even when `num_experts` is large, this causes a `CUDA error: invalid argument`.

I fix this error and make the condition tree more clear in this PR.

