### PR TITLE
[Bugfix] use_existing_torch.py: filter out comments

### DIFF
--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -6,6 +6,8 @@ for file in requires_files:
     print(f">>> cleaning {file}")
     with open(file) as f:
         lines = f.readlines()
+    # filter out comments
+    lines = [ line.split(" #")[0] for line in lines ]
     if "torch" in "".join(lines).lower():
         print("removed:")
         with open(file, 'w') as f:

--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -7,7 +7,7 @@ for file in requires_files:
     with open(file) as f:
         lines = f.readlines()
     # filter out comments
-    lines = [ line.split(" #")[0] for line in lines ]
+    lines = [line.split(" #")[0] for line in lines]
     if "torch" in "".join(lines).lower():
         print("removed:")
         with open(file, 'w') as f:


### PR DESCRIPTION
The current `use_existing_torch.py` filters out any line that contains the word `torch`, but right now in `requirements-commont.txt` we have these lines:
```
outlines == 0.1.11 # Requires pytorch
compressed-tensors == 0.8.1 # required for compressed-tensors, requires pytorch
```
and this is causing the lines to get removed:
```
>>> cleaning requirements-common.txt
removed:
outlines == 0.1.11 # Requires pytorch
compressed-tensors == 0.8.1 # required for compressed-tensors, requires pytorch
<<< done cleaning requirements-common.txt
```
This is breaking some of our images that use custom pytorch version, because these dependencies end up not getting installed. 