### PR TITLE
[Platform] improve platforms getattr

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -217,8 +217,11 @@ def __getattr__(name: str):
             global _init_trace
             _init_trace = "".join(traceback.format_stack())
         return _current_platform
-    else:
+    elif name in globals():
         return globals()[name]
+    else:
+        raise AttributeError(
+            f"No attribute named '{name}' exists in {__name__}.")
 
 
 __all__ = [


### PR DESCRIPTION
Improve platforms `__getattr__` func, raise `AttributeError` instead of reporting `KeyError` when there is no attribute named `name`
