### PR TITLE
[ci/build] add nightly torch for test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /workspace
 # after this step
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu124 "torch==2.6.0.dev20241210+cu124" "torchvision==0.22.0.dev20241215";  \
+        python3 -m pip install --index-url https://download.pytorch.org/whl/nightly/cu126 "torch==2.7.0.dev20250121+cu126" "torchvision==0.22.0.dev20250121";  \
     fi
 
 COPY requirements-common.txt requirements-common.txt


### PR DESCRIPTION
bump the version of nightly pytorch for testing.

pytorch cuda 12.4 does not release arm64 wheels anymore, so we need to use cuda 12.6 wheels. fortunately, that version of pytorch also works for cuda 12.4 runtime.

locally tested it works.