### PR TITLE
[CI/Build] Add label automation for structured-output, speculative-decoding, v1

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -35,6 +35,32 @@ pull_request_rules:
       add:
         - frontend
 
+- name: label-structured-output
+  description: Automatically apply structured-output label
+  conditions:
+    - or:
+      - files~=^vllm/model_executor/guided_decoding/
+      - files=tests/model_executor/test_guided_processors.py
+      - files=tests/entrypoints/llm/test_guided_generate.py
+      - files=benchmarks/benchmark_serving_guided.py
+      - files=benchmarks/benchmark_guided.py
+  actions:
+    label:
+      add:
+        - structured-output
+
+- name: label-speculative-decoding
+  description: Automatically apply speculative-decoding label
+  conditions:
+    - or:
+      - files~=^vllm/spec_decode/
+      - files=vllm/model_executor/layers/spec_decode_base_sampler.py
+      - files~=^tests/spec_decode/
+  actions:
+    label:
+      add:
+        - structured-output
+
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
       - conflict

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -59,7 +59,7 @@ pull_request_rules:
   actions:
     label:
       add:
-        - structured-output
+        - speculative-decoding
 
 - name: label-v1
   description: Automatically apply v1 label

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -61,6 +61,17 @@ pull_request_rules:
       add:
         - structured-output
 
+- name: label-v1
+  description: Automatically apply v1 label
+  conditions:
+    - or:
+      - files~=^vllm/v1/
+      - files~=^tests/v1/
+  actions:
+    label:
+      add:
+        - v1
+
 - name: ping author on conflicts and add 'needs-rebase' label
   conditions:
       - conflict


### PR DESCRIPTION
We have `v1`, `structured-output`, and `speculative-decoding` labels on
github. This adds automation for applying these labels based on the
files touched by a PR.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
