### PR TITLE
[Documentation][AMD] Add information about prebuilt ROCm vLLM docker for perf validation purpose

### DIFF
--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -13,7 +13,7 @@ vLLM supports AMD GPUs with ROCm 6.2.
 
 Currently, there are no pre-built ROCm wheels.
 
-However, the [ROCm Hub for vLLM](https://hub.docker.com/r/rocm/vllm/tags) offers a prebuilt, optimized
+However, the [AMD Infinity hub for vLLM](https://hub.docker.com/r/rocm/vllm/tags) offers a prebuilt, optimized
 docker image designed for validating inference performance on the AMD Instinct™ MI300X accelerator.
 
 ```{tip}

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -13,6 +13,13 @@ vLLM supports AMD GPUs with ROCm 6.2.
 
 Currently, there are no pre-built ROCm wheels.
 
+However, the ROCm [ROCm Hub for vLLM](https://hub.docker.com/r/rocm/vllm/tags) offers a prebuilt, optimized environment
+designed for validating large language model (LLM) inference performance on the AMD Instinct™ MI300X accelerator.
+
+```{tip}
+Please check [LLM inference performance validation on AMD Instinct MI300X] (https://rocm.docs.amd.com/en/latest/how-to/performance-validation/mi300x/vllm-benchmark.html) for instructions on how to use this prebuilt docker image to validate inference performance on MI300x accelerator.
+```
+
 ### Build wheel from source
 
 0. Install prerequisites (skip if you are already in an environment/docker with the following installed):

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -13,11 +13,12 @@ vLLM supports AMD GPUs with ROCm 6.2.
 
 Currently, there are no pre-built ROCm wheels.
 
-However, the ROCm [ROCm Hub for vLLM](https://hub.docker.com/r/rocm/vllm/tags) offers a prebuilt, optimized environment
-designed for validating large language model (LLM) inference performance on the AMD Instinct™ MI300X accelerator.
+However, the [ROCm Hub for vLLM](https://hub.docker.com/r/rocm/vllm/tags) offers a prebuilt, optimized
+docker image designed for validating inference performance on the AMD Instinct™ MI300X accelerator.
 
 ```{tip}
-Please check [LLM inference performance validation on AMD Instinct MI300X] (https://rocm.docs.amd.com/en/latest/how-to/performance-validation/mi300x/vllm-benchmark.html) for instructions on how to use this prebuilt docker image to validate inference performance on MI300x accelerator.
+Please check [LLM inference performance validation on AMD Instinct MI300X](https://rocm.docs.amd.com/en/latest/how-to/performance-validation/mi300x/vllm-benchmark.html)
+for instructions on how to use this prebuilt docker image.
 ```
 
 ### Build wheel from source


### PR DESCRIPTION
Added information about prebuilt vLLM on ROCm docker for validation of performance on MI300x node.

This is to address the request from [PR](https://github.com/vllm-project/vllm/pull/11877). We will close/cancel that PR after this is merged.





