### PR TITLE
[Core] Prefill Only Tokens Without KV Cache in Batch Requests (Disagg Prefill)

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/base.py
@@ -87,7 +87,7 @@ class KVConnectorBase(ABC):
         self, model_executable: torch.nn.Module,
         model_input: "ModelInputForGPUWithSamplingMetadata",
         kv_caches: List[torch.Tensor]
-    ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
+    ) -> Tuple[Union[torch.Tensor, IntermediateTensors], List[bool],
                "ModelInputForGPUWithSamplingMetadata"]:
         """
         Receive KV caches and hidden states from the connector.
@@ -110,7 +110,7 @@ class KVConnectorBase(ABC):
             IntermediateTensors): 
                 Concatenated hidden states if all required data is retrieved, 
                 otherwise `None`.
-            - bypass_model_exec (bool): 
+            - bypass_model_exec (List[bool]): 
                 Indicates whether the model execution can be skipped (True) or 
                 needs to be redone (False).
             - model_input (ModelInputForGPUWithSamplingMetadata): 

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -298,7 +298,6 @@ class SimpleConnector(KVConnectorBase):
                 # Some of the KV cache of this request is not retrieved
                 # Here we will fall back to normal model forwarding
                 logger.debug(
-<<<<<<< HEAD
                     "[rank%d]: Failed to receive request %d's"
                     " KVs and hidden states, "
                     "redo model forwarding.", torch.distributed.get_rank(),
@@ -306,10 +305,6 @@ class SimpleConnector(KVConnectorBase):
 
                 hidden_or_intermediate_states = torch.cat(
                     hidden_or_intermediate_states_for_one_req, dim=0)
-=======
-                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {idx}'s KVs and hidden states, redo model forwarding.")
-                hidden_or_intermediate_states = torch.cat(hidden_or_intermediate_states_for_one_req, dim=0)
->>>>>>> 4d9d7f8d (Fix request id typo)
                 all_bypass_flag = False
         if all_bypass_flag:
             logger.debug(

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -298,6 +298,7 @@ class SimpleConnector(KVConnectorBase):
                 # Some of the KV cache of this request is not retrieved
                 # Here we will fall back to normal model forwarding
                 logger.debug(
+<<<<<<< HEAD
                     "[rank%d]: Failed to receive request %d's"
                     " KVs and hidden states, "
                     "redo model forwarding.", torch.distributed.get_rank(),
@@ -305,6 +306,10 @@ class SimpleConnector(KVConnectorBase):
 
                 hidden_or_intermediate_states = torch.cat(
                     hidden_or_intermediate_states_for_one_req, dim=0)
+=======
+                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {idx}'s KVs and hidden states, redo model forwarding.")
+                hidden_or_intermediate_states = torch.cat(hidden_or_intermediate_states_for_one_req, dim=0)
+>>>>>>> 4d9d7f8d (Fix request id typo)
                 all_bypass_flag = False
         if all_bypass_flag:
             logger.debug(

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -296,7 +296,7 @@ class SimpleConnector(KVConnectorBase):
                 # Some of the KV cache of this request is not retrieved
                 # Here we will fall back to normal model forwarding
                 logger.debug(
-                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {idx}'s KVs and hidden states, redo model forwarding.")
+                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {i}'s KVs and hidden states, redo model forwarding.")
                 hidden_or_intermediate_states = torch.cat(hidden_or_intermediate_states_for_one_req, dim=0)
                 all_bypass_flag = False
         if all_bypass_flag:

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -390,8 +390,7 @@ class SimpleConnector(KVConnectorBase):
             rebuilt_slot_mapping.append(new_slot_mapping)
             rebuilt_max_query_len = max(q_len, rebuilt_max_query_len)
             last_query_start_loc += q_len
-            rebuilt_query_start_loc.append(
-                last_query_start_loc)  # start with 0
+            rebuilt_query_start_loc.append(last_query_start_loc)
             rebuilt_context_lens_tensor.append(num_computed_token)
 
             # recover `block_table`

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -296,7 +296,7 @@ class SimpleConnector(KVConnectorBase):
                 # Some of the KV cache of this request is not retrieved
                 # Here we will fall back to normal model forwarding
                 logger.debug(
-                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {i}'s KVs and hidden states, redo model forwarding.")
+                    f"[rank{torch.distributed.get_rank()}]: Failed to receive request {idx}'s KVs and hidden states, redo model forwarding.")
                 hidden_or_intermediate_states = torch.cat(hidden_or_intermediate_states_for_one_req, dim=0)
                 all_bypass_flag = False
         if all_bypass_flag:

--- a/vllm/distributed/kv_transfer/kv_transfer_agent.py
+++ b/vllm/distributed/kv_transfer/kv_transfer_agent.py
@@ -68,7 +68,7 @@ class KVTransferAgent:
         self, model_executable: torch.nn.Module,
         model_input: "ModelInputForGPUWithSamplingMetadata",
         kv_caches: List[torch.Tensor]
-    ) -> Tuple[Union[torch.Tensor, IntermediateTensors], bool,
+    ) -> Tuple[Union[torch.Tensor, IntermediateTensors], List[bool],
                "ModelInputForGPUWithSamplingMetadata"]:
 
         return self.connector.recv_kv_caches_and_hidden_states(

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1693,11 +1693,11 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                         model_input,
                         kv_caches=kv_caches
                     )
-            logger.info("Received states shape: %s",
-                        recv_hidden_or_intermediate_states.shape)
+            logger.debug("Received states shape: %s",
+                         recv_hidden_or_intermediate_states.shape)
             for i in range(recv_hidden_or_intermediate_states.shape[0]):
-                logger.info("Received states[%d]'s mean value: %s", i,
-                            recv_hidden_or_intermediate_states[i].mean())
+                logger.debug("Received states[%d]'s mean value: %s", i,
+                             recv_hidden_or_intermediate_states[i].mean())
             bypass_model_exec = all(bypass_model_exec_per_request)
             need_rebuild_states = not all(
                 not value for value in bypass_model_exec_per_request)
@@ -1742,11 +1742,11 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                     **seqlen_agnostic_kwargs)
 
                 if need_recv_kv_flag:
-                    logger.info("Computed states shape: %s",
-                                hidden_or_intermediate_states.shape)
+                    logger.debug("Computed states shape: %s",
+                                 hidden_or_intermediate_states.shape)
                     for i in range(hidden_or_intermediate_states.shape[0]):
-                        logger.info("Computed states[%d]'s mean value: %s", i,
-                                    hidden_or_intermediate_states[i].mean())
+                        logger.debug("Computed states[%d]'s mean value: %s", i,
+                                     hidden_or_intermediate_states[i].mean())
 
                 # Since we use the original sampling metadata,
                 # we need to combine
@@ -1787,11 +1787,11 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
                     hidden_or_intermediate_states = torch.cat(rebuilt_states,
                                                               dim=0)
 
-                    logger.info("Rebuilt states shape: %s",
-                                hidden_or_intermediate_states.shape)
+                    logger.debug("Rebuilt states shape: %s",
+                                 hidden_or_intermediate_states.shape)
                     for i in range(hidden_or_intermediate_states.shape[0]):
-                        logger.info("Rebuilt states[%d]'s mean value: %s", i,
-                                    hidden_or_intermediate_states[i].mean())
+                        logger.debug("Rebuilt states[%d]'s mean value: %s", i,
+                                     hidden_or_intermediate_states[i].mean())
 
         else:
             hidden_or_intermediate_states = recv_hidden_or_intermediate_states


### PR DESCRIPTION
This ticket is part of [[RFC]: Disaggregated Prefilling and KV Cache Transfer Roadmap #10818](https://github.com/vllm-project/vllm/issues/10818), with the following issue: "Adaptivity and Fault Tolerance: [Perf] If not all KV caches in the batch are received, only perform prefilling on those tokens without KV cache."

When there are multiple requests in a batch, the decode node may only receive the KV cache for some of them from the prefill node. Previously, in such cases, the decode node would perform prefilling for all requests in the batch, even if it had already received the KV cache for some requests.

This PR rebuilds the model input when the KV cache for some requests in the batch is missing, thereby preventing prefilling on those requests.
