### PR TITLE
[Core] tokens in queue metric

### DIFF
--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -40,6 +40,7 @@ class Stats:
     # Iteration stats (should have _iter suffix)
     num_prompt_tokens_iter: int
     num_generation_tokens_iter: int
+    num_queue_tokens_iter: int
     num_tokens_iter: int
     time_to_first_tokens_iter: List[float]
     time_per_output_tokens_iter: List[float]
@@ -82,6 +83,7 @@ class StatLoggerBase(ABC):
         # Tracked stats over current local logging interval.
         self.num_prompt_tokens: List[int] = []
         self.num_generation_tokens: List[int] = []
+        self.num_queue_tokens: List[int] = []
         self.last_local_log = time.time()
         self.local_interval = local_interval
         self.spec_decode_metrics: Optional[SpecDecodeWorkerMetrics] = None


### PR DESCRIPTION
Metric for total tokens waiting in the queue

Goal is to measure how many tokens are waiting in the queue. Ideally this would avoid double counting when prefix caching is enabled.

Motivation to add this metric is I am currently prototyping an autoscaling strategy that takes sum of (total tokens in the kv cache + total tokens in the queue) into account.

Seeking feedback on if I've implemented this tokens in the queue metric appropriately, I attempted to duplicate logic related to the scheduler's decision to turn status from WAITING -> RUNNING

cc @robertgshaw2-redhat who has experience with tokens in the batch metric
cc @apatke who implemented priority scheduling logic for which part of tokens in queue is based on
cc @rkooo567 who implemented refactor for chunked prefill which changed part of scheduler decision to remove requests from the queue
cc @youkaichao who simplified scheduler code