### PR TITLE
[Frontend][V1] Online serving performance improvements

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import gc
 import importlib
 import inspect
 import multiprocessing
@@ -104,6 +105,11 @@ async def lifespan(app: FastAPI):
             task.add_done_callback(_running_tasks.remove)
         else:
             task = None
+
+        # Mark the startup heap as static so that it's ignored by GC.
+        # Reduces pause times of oldest generation collections.
+        gc.collect()
+        gc.freeze()
         try:
             yield
         finally:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_V1_OUTPUT_PROC_CHUNK_SIZE: int = 128
 
 
 def get_default_cache_root():
@@ -467,6 +468,16 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
+
+    # Controls the maximum number of requests to handle in a
+    # single asyncio task when processing per-token outputs in the
+    # V1 AsyncLLM interface. It is applicable when handling a high
+    # concurrency of streaming requests.
+    # Setting this too high can result in a higher variance of
+    # inter-message latencies. Setting it too low can negatively impact
+    # TTFT and overall throughput.
+    "VLLM_V1_OUTPUT_PROC_CHUNK_SIZE":
+    lambda: int(os.getenv("VLLM_V1_OUTPUT_PROC_CHUNK_SIZE", "128")),
 }
 
 # end-env-vars-definition

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -244,9 +244,10 @@ class AsyncLLM(EngineClient):
                 # event loop for too long.
                 num_outputs = len(outputs.outputs)
                 if num_outputs <= OUTPUT_PROCESSING_CHUNK_SIZE:
-                    slices = (outputs.outputs,)
+                    slices = (outputs.outputs, )
                 else:
-                    slices = np.array_split(outputs.outputs,
+                    slices = np.array_split(
+                        outputs.outputs,
                         math.ceil(num_outputs / OUTPUT_PROCESSING_CHUNK_SIZE))
 
                 iteration_stats = None

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1,8 +1,9 @@
+import asyncio
 import os
 import signal
 import weakref
 from abc import ABC, abstractmethod
-from typing import List, Type
+from typing import List, Optional, Type
 
 import msgspec
 import zmq
@@ -242,10 +243,23 @@ class AsyncMPClient(MPClient):
             log_stats=True,
         )
 
-    async def get_output_async(self) -> EngineCoreOutputs:
+        self.outputs_queue: Optional[asyncio.Queue[bytes]] = None
+        self.queue_task: Optional[asyncio.Task] = None
 
-        frames = await self.output_socket.recv_multipart(copy=False)
-        return self.decoder.decode(frames[0].buffer)
+    async def get_output_async(self) -> EngineCoreOutputs:
+        if self.outputs_queue is None:
+            # Perform IO in separate task to parallelize as much as possible
+            self.outputs_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+            async def process_outputs_socket():
+                while True:
+                    (frame, ) = await self.output_socket.recv_multipart(
+                        copy=False)
+                    self.outputs_queue.put_nowait(frame.buffer)
+
+            self.queue_task = asyncio.create_task(process_outputs_socket())
+
+        return self.decoder.decode(await self.outputs_queue.get())
 
     async def _send_input(self, request_type: EngineCoreRequestType,
                           request: EngineCoreRequestUnion) -> None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -249,9 +249,10 @@ class AsyncMPClient(MPClient):
     async def get_output_async(self) -> EngineCoreOutputs:
         if self.outputs_queue is None:
             # Perform IO in separate task to parallelize as much as possible
-            self.outputs_queue: asyncio.Queue[bytes] = asyncio.Queue()
+            self.outputs_queue = asyncio.Queue()
 
             async def process_outputs_socket():
+                assert self.outputs_queue is not None
                 while True:
                     (frame, ) = await self.output_socket.recv_multipart(
                         copy=False)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -101,6 +101,7 @@ class OutputProcessor:
     def process_outputs(
         self,
         engine_core_outputs: List[EngineCoreOutput],
+        iteration_stats: Optional[IterationStats] = None,
     ) -> OutputProcessorOutput:
         """
         Process the EngineCoreOutputs:
@@ -133,7 +134,8 @@ class OutputProcessor:
 
         request_outputs: List[RequestOutput] = []
         reqs_to_abort: List[str] = []
-        iteration_stats = IterationStats(self.log_stats)
+        if not iteration_stats:
+            iteration_stats = IterationStats(self.log_stats)
         for engine_core_output in engine_core_outputs:
             req_id = engine_core_output.request_id
             req_state = self.request_states.get(req_id)
@@ -175,8 +177,8 @@ class OutputProcessor:
             iteration_stats=iteration_stats,
         )
 
+    @staticmethod
     def _make_request_output(
-        self,
         request_state: RequestState,
         detokenizer_output: Optional[DetokenizerOutput],
     ) -> Optional[RequestOutput]:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -64,6 +64,12 @@ class Request:
         # recomputing.
         self._kv_block_hashes: List[BlockHashType] = []
 
+        # Read-only views
+        # Prevent directly appending to the these lists since
+        # they should also be updated simultaneously.
+        self.output_token_ids = ConstantList(self._output_token_ids)
+        self.all_token_ids = ConstantList(self._all_token_ids)
+
     @classmethod
     def from_engine_core_request(cls, request: EngineCoreRequest) -> "Request":
         return cls(
@@ -78,18 +84,6 @@ class Request:
             arrival_time=request.arrival_time,
             lora_request=request.lora_request,
         )
-
-    @property
-    def output_token_ids(self) -> ConstantList[int]:
-        # Prevent directly appending to the output_token_ids since
-        # all_token_ids should also be updated simultaneously.
-        return ConstantList(self._output_token_ids)
-
-    @property
-    def all_token_ids(self) -> ConstantList[int]:
-        # Prevent directly appending to the all_token_ids since
-        # output_token_ids should also be updated simultaneously
-        return ConstantList(self._all_token_ids)
 
     def append_output_token_ids(
         self,


### PR DESCRIPTION
These help in particular with TTFT, ITL variance, and overall throughput.

- Break up output processing (detokenization) to avoid blocking the event loop for too long
- Freeze the heap after startup to reduce GC overhead/pauses
- Optimize a couple of CPU hotspots seen during profiling

Benchmark on A100:
```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.2-1B-Instruct --disable-log-requests --port 8001 --max-num-batched-tokens 8192 --no-enable-prefix-caching --uvicorn-log-level=error
```
```
python benchmarks/benchmark_serving.py \
    --backend vllm \
    --model meta-llama/Llama-3.2-1B-Instruct \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --ignore-eos \
    --port 8001 \
    --save-result \
    --result-dir results \
    --result-filename test.json \
    --num-prompts 6000 \
    --request-rate inf \
    --max-concurrency=400
```

### Before:
```
============ Serving Benchmark Result ============
Successful requests:                     6000      
Benchmark duration (s):                  94.31     
Total input tokens:                      1350511   
Total generated tokens:                  1211959   
Request throughput (req/s):              63.62     
Output token throughput (tok/s):         12850.45  
Total Token throughput (tok/s):          27169.98  
---------------Time to First Token----------------
Mean TTFT (ms):                          229.23    
Median TTFT (ms):                        158.08    
P99 TTFT (ms):                           1050.70   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          30.02     
Median TPOT (ms):                        29.64     
P99 TPOT (ms):                           68.90     
---------------Inter-token Latency----------------
Mean ITL (ms):                           28.77     
Median ITL (ms):                         23.19     
P99 ITL (ms):                            386.30    
==================================================
```

### After:
```
============ Serving Benchmark Result ============
Successful requests:                     6000      
Benchmark duration (s):                  88.60     
Total input tokens:                      1350511   
Total generated tokens:                  1211959   
Request throughput (req/s):              67.72     
Output token throughput (tok/s):         13679.34  
Total Token throughput (tok/s):          28922.50  
---------------Time to First Token----------------
Mean TTFT (ms):                          197.34    
Median TTFT (ms):                        168.03    
P99 TTFT (ms):                           1059.55   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          28.30     
Median TPOT (ms):                        27.75     
P99 TPOT (ms):                           47.38     
---------------Inter-token Latency----------------
Mean ITL (ms):                           26.64     
Median ITL (ms):                         24.38     
P99 ITL (ms):                            65.19     
==================================================
```
