### PR TITLE
[Build] update requirements of no-device

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -549,7 +549,7 @@ def get_requirements() -> List[str]:
         return resolved_requirements
 
     if _no_device():
-        requirements = _read_requirements("requirements-cuda.txt")
+        requirements = _read_requirements("requirements-cpu.txt")
     elif _is_cuda():
         requirements = _read_requirements("requirements-cuda.txt")
         cuda_major, cuda_minor = torch.version.cuda.split(".")


### PR DESCRIPTION
When we install vLLM with no-device, use `requirements-cpu.txt` instead of `requirements-cuda.txt` to avoid downloading a lot of nv-related packages required by torch with cuda.

cc @youkaichao 