### PR TITLE
[Model][Bugfix]: correct Aria model output

### DIFF
--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -28,9 +28,10 @@ def run_aria(question: str, modality: str):
     llm = LLM(model=model_name,
               max_model_len=4096,
               max_num_seqs=2,
+              dtype="bfloat16",
               disable_mm_preprocessor_cache=args.disable_mm_preprocessor_cache)
 
-    prompt = (f"<|im_start|>user\n<fim_prefix><|img|><fim_suffix>\n{question}"
+    prompt = (f"<|im_start|>user\n<fim_prefix><|img|><fim_suffix>{question}"
               "<|im_end|>\n<|im_start|>assistant\n")
 
     stop_token_ids = [93532, 93653, 944, 93421, 1019, 93653, 93519]

--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -60,6 +60,9 @@ class AriaVisionTransformer(Idefics3VisionTransformer):
         prefix: str = "",
     ) -> None:
         super().__init__(config, quant_config, prefix)
+        # Unlike Idefics3VisionTransformer which uses LayerNorm after the
+        # final layer, Aria omits this normalization, so we replace it with an
+        # Identity layer
         self.post_layernorm = nn.Identity()
 
     def load_weights(self, weights: Iterable[Tuple[str,

--- a/vllm/model_executor/models/aria.py
+++ b/vllm/model_executor/models/aria.py
@@ -30,6 +30,7 @@ from vllm.multimodal.profiling import BaseDummyInputsBuilder, ProcessorInputs
 from vllm.sequence import IntermediateTensors
 
 # yapf: disable
+from .idefics2_vision_model import Idefics2VisionConfig
 from .idefics2_vision_model import (
     Idefics2VisionTransformer as Idefics3VisionTransformer)
 # yapf: enable
@@ -48,6 +49,50 @@ class AriaImagePixelInputs(TypedDict):
         pixel_values: `(batch_size * num_images, num_channels, height, width)`
         pixel_mask: `(batch_size * num_images, height, width)`
     """
+
+
+class AriaVisionTransformer(Idefics3VisionTransformer):
+
+    def __init__(
+        self,
+        config: Idefics2VisionConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(config, quant_config, prefix)
+        self.post_layernorm = nn.Identity()
+
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("qkv_proj", "q_proj", "q"),
+            ("qkv_proj", "k_proj", "k"),
+            ("qkv_proj", "v_proj", "v"),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: Set[str] = set()
+        for name, loaded_weight in weights:
+
+            # NOTE: post_layernorm is not used in Aria
+            if "post_layernorm" in name:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
 
 
 class AriaProjectorMLP(nn.Module):
@@ -228,8 +273,10 @@ class AriaTextMoELayer(nn.Module):
         router_output = torch.nn.functional.linear(hidden_states,
                                                    self.router_weight)
 
+        hidden_states_copy = hidden_states.clone()
+        # NOTE: hidden_states will be modified inplace by `FusedMoE`
         sparse_expert_output = self.experts(hidden_states, router_output)
-        shared_expert_output = self.shared_experts(hidden_states)
+        shared_expert_output = self.shared_experts(hidden_states_copy)
 
         return sparse_expert_output + shared_expert_output
 
@@ -445,7 +492,7 @@ class AriaForConditionalGeneration(nn.Module, SupportsMultiModal):
         quant_config = vllm_config.quant_config
 
         self.config = config
-        self.vision_tower = Idefics3VisionTransformer(
+        self.vision_tower = AriaVisionTransformer(
             config.vision_config,
             quant_config,
             prefix=f"{prefix}.vision_tower",


### PR DESCRIPTION
fix #12241 


The output of `python examples/offline_inference/vision_language.py -m aria` in my local env is correct
```
> The image shows a beautiful scene with cherry blossoms in full bloom. The blossoms are in the foreground, framing the view. In the background, there is a tall tower, which appears to be the Tokyo Skytree, a well-known landmark in Japan. The sky is clear and
> The image shows a beautiful scene with cherry blossoms in full bloom. The blossoms are pink and frame the view of a tall structure in the background, which appears to be the Tokyo Skytree, a famous landmark in Japan. The sky is clear and blue, adding to the serene and picturesque
> The image shows a beautiful scene with cherry blossoms in full bloom in the foreground. Behind the blossoms, the Tokyo Skytree, a tall broadcasting and observation tower, is visible against a clear blue sky. The cherry blossoms frame the tower, creating a picturesque and serene
> The image shows a scenic view of the Tokyo Skytree, a famous broadcasting and observation tower in Tokyo, Japan. The tower is partially visible through a frame of cherry blossom trees in full bloom, with pink flowers creating a beautiful contrast against the clear blue sky. The composition highlights the blend of modern
```

