### PR TITLE
[Misc] Fix the error in the tip for the --lora-modules parameter

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -117,7 +117,7 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         "or JSON format. "
         "Example (old format): ``'name=path'`` "
         "Example (new format): "
-        "``{\"name\": \"name\", \"local_path\": \"path\", "
+        "``{\"name\": \"name\", \"path\": \"lora_path\", "
         "\"base_model_name\": \"id\"}``")
     parser.add_argument(
         "--prompt-adapters",


### PR DESCRIPTION
Since LoRAModulePath only contains three fields ('name', 'path', and 'base_model_name') and does not include a 'local_path' field, attempting to use 'local_path' caused an error as indicated by the usage tip. Therefore,  update the tip error message to reflect this.