### PR TITLE
[Core] Fix an isort error from pre-commit

### DIFF
--- a/tests/async_engine/api_server_async_engine.py
+++ b/tests/async_engine/api_server_async_engine.py
@@ -1,9 +1,9 @@
 """vllm.entrypoints.api_server with some extra logging for testing."""
 from typing import Any, Dict, Iterable
 
-import uvicorn
 from fastapi.responses import JSONResponse, Response
 
+import uvicorn
 import vllm.entrypoints.api_server
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine

--- a/vllm/entrypoints/launcher.py
+++ b/vllm/entrypoints/launcher.py
@@ -3,9 +3,9 @@ import signal
 from http import HTTPStatus
 from typing import Any
 
-import uvicorn
 from fastapi import FastAPI, Request, Response
 
+import uvicorn
 from vllm import envs
 from vllm.engine.async_llm_engine import AsyncEngineDeadError
 from vllm.engine.multiprocessing import MQEngineDeadError


### PR DESCRIPTION
pre-commit does not currently run cleanly against `main` because of
this `isort` error. Apply the change it wants.

You can run `pre-commit run -a` to validate that it runs cleanly
against your current code.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
