### PR TITLE
[TPU] Update TPU CI to use torchxla nightly on 20250122

### DIFF
--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,4 +1,4 @@
-ARG NIGHTLY_DATE="20241017"
+ARG NIGHTLY_DATE="20250122"
 ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"
 
 FROM $BASE_IMAGE


### PR DESCRIPTION
Update TPU CI to use torchxla nightly on 20250122. It was on 20241017 which is very outdated.

To run the TPU CI script offline, in `.buildkite/run-tpu-test.sh` add `export HF_TOKEN=$(cat ~/.cache/huggingface/token)` for the HF token. And then run the test script to verify the updated nightly whl works.