### PR TITLE
[Hardware][Gaudi][BugFix] Fix dataclass error due to triton package update

### DIFF
--- a/requirements-hpu.txt
+++ b/requirements-hpu.txt
@@ -3,7 +3,7 @@
 
 # Dependencies for HPU code
 ray
-triton
+triton==3.1.0
 pandas
 tabulate
 setuptools>=61


### PR DESCRIPTION
Fix dataclass error caused by Triton package update by pinning Triton to v3.1.0 as a temporary workaround..

Error logs:
```
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/__init__.py", line 100, in wrapper
    ret = original_fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/debug.py", line 26, in <module>
    from . import config, ir  # noqa: F811, this is needed
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/__init__.py", line 100, in wrapper
    ret = original_fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/ir.py", line 77, in <module>
    from .runtime.hints import ReductionHint
  File "/usr/local/lib/python3.10/dist-packages/habana_frameworks/torch/core/__init__.py", line 100, in wrapper
    ret = original_fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/runtime/hints.py", line 36, in <module>
    attr_desc_fields = {f.name for f in fields(AttrsDescriptor)}
  File "/usr/lib/python3.10/dataclasses.py", line 1198, in fields                                                                                                                           raise TypeError('must be called with a dataclass type or instance') from None
TypeError: must be called with a dataclass type or instance
```

cherry-pick from vllm-fork:
https://github.com/HabanaAI/vllm-fork/pull/729