### PR TITLE
[Bugfix] Fix k_proj's bias for whisper self attention

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -319,8 +319,11 @@ class ColumnParallelLinear(LinearBase):
                 self.weight_loader_v2 if self.quant_method.__class__.__name__
                 in WEIGHT_LOADER_V2_SUPPORTED else self.weight_loader))
         if bias:
+            # NOTE(Isotr0py): We intentionally use zeros to initialize the bias,
+            # so that it can be still compatible with the qkv_proj in model
+            # like whisper which has bias on q and v proj but not on k proj.
             self.bias = Parameter(
-                torch.empty(self.output_size_per_partition,
+                torch.zeros(self.output_size_per_partition,
                             dtype=params_dtype))
             set_weight_attrs(self.bias, {
                 "output_dim": 0,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -319,11 +319,8 @@ class ColumnParallelLinear(LinearBase):
                 self.weight_loader_v2 if self.quant_method.__class__.__name__
                 in WEIGHT_LOADER_V2_SUPPORTED else self.weight_loader))
         if bias:
-            # NOTE(Isotr0py): We intentionally use zeros to initialize the bias,
-            # so that it can be still compatible with the qkv_proj in model
-            # like whisper which has bias on q and v proj but not on k proj.
             self.bias = Parameter(
-                torch.zeros(self.output_size_per_partition,
+                torch.empty(self.output_size_per_partition,
                             dtype=params_dtype))
             set_weight_attrs(self.bias, {
                 "output_dim": 0,

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -728,13 +728,11 @@ class WhisperForConditionalGeneration(nn.Module, SupportsMultiModal):
 
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:
+        loader = AutoWeightsLoader(self, skip_prefixes=["proj_out."])
+        mapper = WeightsMapper({".fc1.": ".mlp.fc1.", ".fc2.": ".mlp.fc2."})
         # add fake zeros bias for k_proj to state_dict
         weights = _create_fake_bias_for_k_proj(weights)
-        loader = AutoWeightsLoader(self, skip_prefixes=["proj_out."])
-        loaded_weights = [(name, loaded_weight)
-                          for name, loaded_weight in weights]
-        mapper = WeightsMapper({".fc1.": ".mlp.fc1.", ".fc2.": ".mlp.fc2."})
-        return loader.load_weights(loaded_weights, mapper=mapper)
+        return loader.load_weights(weights, mapper=mapper)
 
 
 def _create_fake_bias_for_k_proj(

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -35,13 +35,6 @@ from .utils import AutoWeightsLoader, WeightsMapper, make_layers
 logger = init_logger(__name__)
 
 
-def _cast_overflow_values(x: torch.Tensor) -> torch.Tensor:
-    if x.isinf().any() or x.isnan().any():
-        clamp_value = torch.finfo(x.dtype).max - 1000
-        x = torch.clamp(x, min=-clamp_value, max=clamp_value)
-    return x
-
-
 class WhisperAudioInputs(TypedDict):
     input_features: NestedTensors
     """Shape: `(batch_size, 128, M)`"""
@@ -302,7 +295,12 @@ class WhisperEncoderLayer(nn.Module):
         hidden_states = self.final_layer_norm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
-        hidden_states = _cast_overflow_values(hidden_states)
+
+        if hidden_states.isinf().any() or hidden_states.isnan().any():
+            clamp_value = torch.finfo(hidden_states.dtype).max - 1000
+            hidden_states = torch.clamp(hidden_states,
+                                        min=-clamp_value,
+                                        max=clamp_value)
 
         return hidden_states
 

--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -728,8 +728,25 @@ class WhisperForConditionalGeneration(nn.Module, SupportsMultiModal):
 
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:
+        # add fake zeros bias for k_proj to state_dict
+        weights = _create_fake_bias_for_k_proj(weights)
         loader = AutoWeightsLoader(self, skip_prefixes=["proj_out."])
         loaded_weights = [(name, loaded_weight)
                           for name, loaded_weight in weights]
         mapper = WeightsMapper({".fc1.": ".mlp.fc1.", ".fc2.": ".mlp.fc2."})
         return loader.load_weights(loaded_weights, mapper=mapper)
+
+
+def _create_fake_bias_for_k_proj(
+    weights: Iterable[Tuple[str, torch.Tensor]]
+) -> Iterable[Tuple[str, torch.Tensor]]:
+    """
+    Create full zeros bias for k_proj weight in self-attention layers.
+    So that the bias for k_proj in qkv_proj can be initialized with zeros.
+    """
+    for name, weight in weights:
+        if ".self_attn.k_proj.weight" in name:
+            bias = torch.zeros(weight.size(0))
+            bias_name = name.replace("weight", "bias")
+            yield from [(name, weight), (bias_name, bias)]
+        yield name, weight


### PR DESCRIPTION
- Whisper has `bias=False` for `k_proj` in its self-attention, however, `torch.empty` will initialize the bias value randomly, and may cause overflow on key (this is very significant on CPU backend due to the device difference)
- Use `torch.zeros` instead of `torch.empty` to initialize bias in `ColumnParallelLinearLayer`

