### PR TITLE
[Bugfix] Path join when building local path for S3 clone

### DIFF
--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -145,7 +145,8 @@ class S3Model:
             return
 
         for file in files:
-            destination_file = self.dir + file.removeprefix(base_dir)
+            destination_file = os.path.join(self.dir,
+                                            file.removeprefix(base_dir))
             local_dir = Path(destination_file).parent
             os.makedirs(local_dir, exist_ok=True)
             self.s3.download_file(bucket_name, file, destination_file)


### PR DESCRIPTION
As arsed in issue https://github.com/vllm-project/vllm/issues/12311, 
When running vLLM with S3 path, it clones the meta files locally. 

Current state has a bug when building the destination path for every file:
When the S3 path ends with "/" it does not clone the files, due to bug in the building path algorithm.

The solution is to use `os.path.join`

A workaround for now is to have the path without "/" at the end

FIX #12311