### PR TITLE
[Bugfix] Fix broken internvl2 inference with v1

### DIFF
--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -503,8 +503,13 @@ def group_mm_inputs_by_modality(
         if len(mm_input.modalities) > 1:
             return id(mm_input)
 
-        # Otherwise return the modality string
-        return list(mm_input.modalities)[0]
+        elif len(mm_input.modalities) == 1:
+            return list(mm_input.modalities)[0]
+
+        # FIXME(Isotr0py): Modality of mm_input from legacy pipeline is empty,
+        # this is used to make InternVL with legacy pipeline still work with v1.
+        else:
+            return ""
 
     return [
         list(group) for _, group in groupby(mm_inputs, key=modality_group_func)


### PR DESCRIPTION


- Fix broken InternVL2 inference on v1

InternVL2 inference on v1 is broken due to `modality_group_func`:

<details>
<summary> Logs </summary>

```text
ERROR 01-23 21:30:09 core.py:208] EngineCore hit an exception: Traceback (most recent call last):
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 201, in run_engine_core
ERROR 01-23 21:30:09 core.py:208]     engine_core.run_busy_loop()
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 241, in run_busy_loop
ERROR 01-23 21:30:09 core.py:208]     outputs = self.step()
ERROR 01-23 21:30:09 core.py:208]               ^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/engine/core.py", line 127, in step
ERROR 01-23 21:30:09 core.py:208]     output = self.model_executor.execute_model(scheduler_output)
ERROR 01-23 21:30:09 core.py:208]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/executor/abstract.py", line 75, in execute_model
ERROR 01-23 21:30:09 core.py:208]     output = self.collective_rpc("execute_model",
ERROR 01-23 21:30:09 core.py:208]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/executor/uniproc_executor.py", line 49, in collective_rpc
ERROR 01-23 21:30:09 core.py:208]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 01-23 21:30:09 core.py:208]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/utils.py", line 2208, in run_method
ERROR 01-23 21:30:09 core.py:208]     return func(*args, **kwargs)
ERROR 01-23 21:30:09 core.py:208]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 01-23 21:30:09 core.py:208]     return func(*args, **kwargs)
ERROR 01-23 21:30:09 core.py:208]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/worker/gpu_worker.py", line 223, in execute_model
ERROR 01-23 21:30:09 core.py:208]     output = self.model_runner.execute_model(scheduler_output)
ERROR 01-23 21:30:09 core.py:208]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/miniconda3/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 01-23 21:30:09 core.py:208]     return func(*args, **kwargs)
ERROR 01-23 21:30:09 core.py:208]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 720, in execute_model
ERROR 01-23 21:30:09 core.py:208]     self._execute_encoder(scheduler_output)
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/v1/worker/gpu_model_runner.py", line 641, in _execute_encoder
ERROR 01-23 21:30:09 core.py:208]     grouped_mm_inputs_list = group_mm_inputs_by_modality(mm_inputs)
ERROR 01-23 21:30:09 core.py:208]                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/multimodal/utils.py", line 510, in group_mm_inputs_by_modality
ERROR 01-23 21:30:09 core.py:208]     return [
ERROR 01-23 21:30:09 core.py:208]            ^
ERROR 01-23 21:30:09 core.py:208]   File "/root/autodl-tmp/vllm/vllm/multimodal/utils.py", line 508, in modality_group_func
ERROR 01-23 21:30:09 core.py:208]     return list(mm_input.modalities)[0]
ERROR 01-23 21:30:09 core.py:208]            ~~~~~~~~~~~~~~~~~~~~~~~~~^^^
ERROR 01-23 21:30:09 core.py:208] IndexError: list index out of range
ERROR 01-23 21:30:09 core.py:208] 
CRITICAL 01-23 21:30:09 core_client.py:156] Got fatal signal from worker processes, shutting down. See stack trace above for root cause issue.
``` 

</details>

