### PR TITLE
[core] add wake_up doc and some sanity check

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1157,6 +1157,9 @@ class LLM:
         self.llm_engine.sleep(level=level)
 
     def wake_up(self):
+        """
+        Wake up the engine from sleep mode. See the :meth:`sleep` method
+        for more details."""
         self.llm_engine.wake_up()
 
     # LEGACY

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -47,6 +47,7 @@ class ExecutorBase(ABC):
         self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
         self._init_executor()
+        self.is_sleeping = False
 
     @abstractmethod
     def _init_executor(self) -> None:
@@ -194,10 +195,18 @@ class ExecutorBase(ABC):
         self.collective_rpc("stop_profile")
 
     def sleep(self, level: int = 1):
+        if self.is_sleeping:
+            logger.warning("Executor is already sleeping.")
+            return
         self.collective_rpc("sleep", kwargs=dict(level=level))
+        self.is_sleeping = True
 
     def wake_up(self):
+        if not self.is_sleeping:
+            logger.warning("Executor is not sleeping.")
+            return
         self.collective_rpc("wake_up")
+        self.is_sleeping = False
 
     def save_sharded_state(
         self,


### PR DESCRIPTION
`wake_up` does not appear in the api doc https://docs.vllm.ai/en/latest/api/offline_inference/llm.html . fix it by adding doc string.

also added some checks to make sure `sleep` and `wake_up` calls are in order. incorrect calls will be ignored with a warning.