### PR TITLE
[Docs] Update spec decode + structured output in compat matrix

### DIFF
--- a/docs/source/features/compatibility_matrix.md
+++ b/docs/source/features/compatibility_matrix.md
@@ -307,7 +307,7 @@ Check the '✗' with links to see tracking issue for unsupported feature/hardwar
      - ✅
      - ?
      - ?
-     - ✅
+     - [✗](gh-issue:11484)
      - ✅
      - ✗
      - ?


### PR DESCRIPTION
Update the feature compatibility matrix to reflect that speculative
decoding and structured output do not currently work together.

Related to issue #11484

Signed-off-by: Russell Bryant <rbryant@redhat.com>
