### PR TITLE
[perf] fix perf regression from #12253

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -476,7 +476,8 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                 finished_requests_ids: Optional[List[str]] = None) -> None:
         self.finished_requests_ids = finished_requests_ids
 
-        # if the current batch is decode-only
+        # if the current batch is decode-only.
+        # will be set to False if there is any non-decode request.
         self.decode_only = True
 
         # Intermediate data (data in CPU before going to GPU) for

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -455,7 +455,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         self.enable_prompt_adapter = (self.runner.prompt_adapter_config
                                       is not None)
         self.multi_modal_input_mapper = self.runner.multi_modal_input_mapper
-        self.decode_only = True
 
         # Attention metadata inputs.
         if self.attn_backend is not None:
@@ -476,6 +475,9 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
     def prepare(self,
                 finished_requests_ids: Optional[List[str]] = None) -> None:
         self.finished_requests_ids = finished_requests_ids
+
+        # if the current batch is decode-only
+        self.decode_only = True
 
         # Intermediate data (data in CPU before going to GPU) for
         # the current sequence group.


### PR DESCRIPTION
When I made the PR #12253 , I though `self.decode_only = True` is whether this model is decoder-only model, and therefore it is static.

However, it turns out this field means if the current batch is decode only batch (so that we can use cudagraph).

The bug makes every batch use previous batch's `self.decode_only` value, which is set to `False` when the batch contains prefill.

Moving this line into `prepare` function (which is executed for every batch) solves the perf regression.

test command: `python benchmarks/benchmark_latency.py --model meta-llama/Meta-Llama-3-8B --load-format dummy`

main branch:

```text
Avg latency: 1.1250504679279403 seconds
10% percentile latency: 1.1177026848774403 seconds
25% percentile latency: 1.1233553139027208 seconds
50% percentile latency: 1.1258818825008348 seconds
75% percentile latency: 1.127114001486916 seconds
90% percentile latency: 1.1292839918518438 seconds
99% percentile latency: 1.1434868656494654 seconds
```

after this PR:

```text
Avg latency: 1.0009459006755301 seconds
10% percentile latency: 1.0002478279871867 seconds
25% percentile latency: 1.0005546582397074 seconds
50% percentile latency: 1.001000543939881 seconds
75% percentile latency: 1.0012907102354802 seconds
90% percentile latency: 1.00162893619854 seconds
99% percentile latency: 1.0022530709696003 seconds
```