### PR TITLE
[Hardware][Gaudi][Doc] Add missing step in setup instructions

### DIFF
--- a/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
+++ b/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
@@ -59,6 +59,7 @@ To build and install vLLM from source, run:
 ```console
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
+pip install -r requirements-hpu.txt
 python setup.py develop
 ```
 
@@ -68,6 +69,7 @@ Currently, the latest features and performance optimizations are developed in Ga
 git clone https://github.com/HabanaAI/vllm-fork.git
 cd vllm-fork
 git checkout habana_main
+pip install -r requirements-hpu.txt
 python setup.py develop
 ```
 


### PR DESCRIPTION
This PR adds the missing step to install requirements-hpu.txt without which the setup currently fails with the following message:
```
Traceback (most recent call last):
  File "/vllm/setup.py", line 16, in <module>
    from setuptools_scm import get_version
ModuleNotFoundError: No module named 'setuptools_scm'
```