### PR TITLE
[ci/build] detect and auto use cxx abi

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -431,7 +431,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
   # dependencies that are not necessary and may not be installed.
   if (GPU_LANGUAGE STREQUAL "CUDA")
-    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver libtorch_cpu libtorch_cuda libc10_cuda libc10)
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver torch_cpu torch_cuda c10_cuda c10)
   else()
     target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES})
   endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -431,7 +431,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
   # dependencies that are not necessary and may not be installed.
   if (GPU_LANGUAGE STREQUAL "CUDA")
-    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver)
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver libtorch_cpu libtorch_cuda libc10_cuda libc10)
   else()
     target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES})
   endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -413,6 +413,13 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   target_compile_options(${GPU_MOD_NAME} PRIVATE
     $<$<COMPILE_LANGUAGE:${GPU_LANGUAGE}>:${GPU_COMPILE_FLAGS}>)
 
+  if (TORCH_CXX_FLAGS)
+      # keep the same flags as torch, especially for flags like
+      # GLIBCXX_USE_CXX11_ABI
+      message(STATUS "Find and use torch CXX flags: ${TORCH_CXX_FLAGS}")
+      target_compile_options(${GPU_MOD_NAME} PRIVATE ${TORCH_CXX_FLAGS})
+  endif()
+
   target_compile_definitions(${GPU_MOD_NAME} PRIVATE
     "-DTORCH_EXTENSION_NAME=${GPU_MOD_NAME}")
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -431,7 +431,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
   # dependencies that are not necessary and may not be installed.
   if (GPU_LANGUAGE STREQUAL "CUDA")
-    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver torch_cpu torch_cuda c10_cuda c10)
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver)
   else()
     target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES})
   endif()


### PR DESCRIPTION
PyTorch 2.6 has a complicated scheme of using cxx abi or not, see https://dev-discuss.pytorch.org/t/pytorch-linux-wheels-switching-to-new-wheel-build-platform-manylinux-2-28-on-november-12-2024/2581 .

When adapting vllm to work for pytorch nightly, I find this fix is necessary on x86 machines.