### PR TITLE
[Bugfix][Kernel] FA3 Fix - RuntimeError: This flash attention build only supports pack_gqa (for build size reasons).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 0aff05f577e8a10086066a00618609199b25231d
+          GIT_TAG 9732b0ce005d1e6216864788502d5570004678f5
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
Based off of https://github.com/vllm-project/vllm/pull/12375 that should be merged first

We thought we could get away with only packed-gqa (is the default for varlen gqa) for build time and size reasons, but fails for true MHA, this turns back on the non packed-gqa kernels.

Tested with `facebook/opt-125m`