### PR TITLE
add support for AMD MI25/50/60

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -108,12 +108,14 @@ def use_rocm_custom_paged_attention(qtype: torch.dtype, head_size: int,
 
     GPU_ARCH = torch.cuda.get_device_properties("cuda").gcnArchName
     ON_GFX9 = any(arch in GPU_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
+    ON_GCN5 = any(arch in GPU_ARCH for arch in ["gfx900", "gfx902", "gfx906"])
 
     # rocm custom page attention not support on gfx1*
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
     return (ON_GFX9 and (not envs.VLLM_USE_V1 or sliding_window == 0
                          or sliding_window == (-1, -1))
+            and not ON_GCN5
             and (qtype == torch.half or qtype == torch.bfloat16)
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -114,8 +114,7 @@ def use_rocm_custom_paged_attention(qtype: torch.dtype, head_size: int,
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
     return (ON_GFX9 and (not envs.VLLM_USE_V1 or sliding_window == 0
-                         or sliding_window == (-1, -1))
-            and not ON_GCN5
+                         or sliding_window == (-1, -1)) and not ON_GCN5
             and (qtype == torch.half or qtype == torch.bfloat16)
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)


### PR DESCRIPTION
This two line change adds much needed support for older AMD GCN5 arch cards: AMD MI25/50/60. I tested these changes locally and vllm is working with my AMD MI60 cards.