### PR TITLE
[Platform] add pre_register_and_update function

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3057,7 +3057,8 @@ class VllmConfig:
     kv_transfer_config: KVTransferConfig = field(default=None,
                                                  init=True)  # type: ignore
     # some opaque config, only used to provide additional information
-    # for the hash computation, mainly used for testing and debugging.
+    # for the hash computation, mainly used for testing, debugging or out of
+    # tree config registration.
     additional_config: SupportsHash = field(default=None,
                                             init=True)  # type: ignore
     instance_id: str = ""

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -13,8 +13,10 @@ from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.utils import FlexibleArgumentParser
 else:
     VllmConfig = None
+    FlexibleArgumentParser = None
 
 logger = init_logger(__name__)
 
@@ -221,6 +223,22 @@ class Platform:
         random.seed(seed)
         np.random.seed(seed)
         torch.manual_seed(seed)
+
+    @classmethod
+    def pre_register_and_update(cls,
+                                parser: Optional[FlexibleArgumentParser] = None
+                                ) -> None:
+        """
+        Do some pre-registeration or update action for the current platform.
+
+        This function is called before global VllmConfig is initialized or cli
+        arguments are parsed. It's used for out-of-tree platforms to register or
+        update the configuration.
+
+        For example, the out-of-tree quantization config can be imported and
+        registered here dynamically.
+        """
+        pass
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:


### PR DESCRIPTION
When a quantization method is implemented out-of-tree in platform plugin, there comes a problem that no place to load the register method in vLLM.

For example:
```
# In plugin repo:
@register_quantization_config("new_method")
def NewQuantConfig:
    ...

# in vLLM:
from vllm import LLM
LLM(model="./opt-125m", quantization='new_method')
```
It'll raise ValueError since there is no place in vLLM to call `register_quantization_config`.

Another case is using command-line:
```
vllm-server xxx --quantization=new_method --device=new_device
```
This will raise error as well since the `new_method` and `new_device` is not registered to cli.

---
This PR add the new function called `pre_register_and_update` to platform. It's called before engine config and cli command initialized, platform can use this function register/update config content there.

This PR also exposed `additional_config` parameter so that the platform specified configs can be passed and used then.

After this PR. The use case will be like:

```
# Case1
# in plugin repo:
class NewPlatform:
    @classmethod
    def pre_register_and_update():
        import plugin_repo.quantization

# Then it will work:
LLM(model="./opt-125m", quantization='new_method', device="new_device") or
vllm-server xxx --quantization=new_method
```
```
# Case2
# pass additional_config to vLLM, then used by platform
LLM(model="./opt-125m", additional_config={"config_key": "config_value"}) or 
vllm-server xxx --additional-config='{"config_key":"config_value"}'
```

