### PR TITLE
[Bugfix][Kernel] Fix perf regression caused by PR #12405

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,7 +576,7 @@ else()
   FetchContent_Declare(
           vllm-flash-attn
           GIT_REPOSITORY https://github.com/vllm-project/flash-attention.git
-          GIT_TAG 9732b0ce005d1e6216864788502d5570004678f5
+          GIT_TAG d4e09037abf588af1ec47d0e966b237ee376876c
           GIT_PROGRESS TRUE
           # Don't share the vllm-flash-attn build between build types
           BINARY_DIR ${CMAKE_BINARY_DIR}/vllm-flash-attn


### PR DESCRIPTION
Fix perf regression caused by https://github.com/vllm-project/vllm/pull/12405 (resulted in falling back on FA2)

Tested using:
```
VLLM_FLASH_ATTN_VERSION=3 python -m vllm.scripts serve meta-llama/Meta-Llama-3-8B
```