### PR TITLE
[V1][Bugfix] Fix assertion when mm hashing is turned off

### DIFF
--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -58,7 +58,8 @@ class Request:
 
         # Sanity check
         assert len(self.mm_inputs) == len(self.mm_positions)
-        assert len(self.mm_inputs) == len(self.mm_hashes)
+        if self.mm_hashes:
+            assert len(self.mm_inputs) == len(self.mm_hashes)
 
         # Cache the computed kv block hashes of the request to avoid
         # recomputing.


### PR DESCRIPTION
Hashing multimodal data is turned on by default, and we want to skip this sanity check if the user explicitly wants to turn it off via `--disable-mm-preprocessor-cache --no-enable-prefix-caching`