### PR TITLE
[Misc] Revert FA on ViT #12355 and #12435

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -210,9 +210,6 @@ class MultiHeadAttention(nn.Module):
         self.scale = scale
         self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
 
-        assert self.num_heads % self.num_kv_heads == 0
-        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
-
         dtype = torch.get_default_dtype()
         attn_backend = get_attn_backend(head_size,
                                         dtype,


### PR DESCRIPTION
Unfortunately FA3 support on ViT isn't at a reliable state to be used so revert the related PRs to always use xformers or SDPA.

Related error logs when running llava-one-vision
```
ERROR 01-26 09:57:39 core.py:208]   File "/home/jovyan/vllm/vllm/model_executor/models/siglip.py", line 329, in forward
ERROR 01-26 09:57:39 core.py:208]     out = self.attn(query_states, key_states, value_states)
ERROR 01-26 09:57:39 core.py:208]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
ERROR 01-26 09:57:39 core.py:208]     return self._call_impl(*args, **kwargs)
ERROR 01-26 09:57:39 core.py:208]   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
ERROR 01-26 09:57:39 core.py:208]     return forward_call(*args, **kwargs)
ERROR 01-26 09:57:39 core.py:208]   File "/home/jovyan/vllm/vllm/attention/layer.py", line 265, in forward
ERROR 01-26 09:57:39 core.py:208]     out = flash_attn_varlen_func(
ERROR 01-26 09:57:39 core.py:208]   File "/home/jovyan/vllm/vllm/vllm_flash_attn/flash_attn_interface.py", line 172, in flash_attn_varlen_func
ERROR 01-26 09:57:39 core.py:208]     out, softmax_lse = torch.ops._vllm_fa2_C.varlen_fwd(
ERROR 01-26 09:57:39 core.py:208]   File "/usr/local/lib/python3.10/dist-packages/torch/_ops.py", line 1116, in __call__
ERROR 01-26 09:57:39 core.py:208]     return self._op(*args, **(kwargs or {}))
ERROR 01-26 09:57:39 core.py:208] RuntimeError: This flash attention build does not support headdim not being a multiple of 32.
```
