### PR TITLE
[Bugfix] Fix Granite 3.0 MoE model loading

### DIFF
--- a/vllm/model_executor/models/granitemoe.py
+++ b/vllm/model_executor/models/granitemoe.py
@@ -348,6 +348,7 @@ class GraniteMoeForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
 
         self.config = config
         self.lora_config = lora_config
+        self.quant_config = quant_config  # Required by MixtralForCausalLM
 
         self.model = GraniteMoeModel(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "model"))


### PR DESCRIPTION
This fixes the failure in Granite model tests (https://buildkite.com/vllm/ci/builds/12467#0194a0fc-112d-48fd-a0d4-099edd508fef). The problem was introduced by https://github.com/vllm-project/vllm/pull/10765 which updated Mixtral model loading to require `self.quant_config`. Granite MoE indirectly uses the same loading logic but wasn't updated to also store the `quant_config` attribute.