### PR TITLE
[DOC] Add link to vLLM blog

### DIFF
--- a/docs/source/community/blog.md
+++ b/docs/source/community/blog.md
@@ -1,0 +1,3 @@
+# vLLM Blog
+
+vLLM blog posts are published [here](https://blog.vllm.ai/).

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -184,6 +184,7 @@ api/model/index
 :caption: Community
 :maxdepth: 1
 
+community/blog
 community/meetups
 community/sponsors
 ```


### PR DESCRIPTION
This gives more visibility to https://blog.vllm.ai/.