### PR TITLE
[CI][UT] make device count general

### DIFF
--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 import pytest
 
 from vllm.config import CompilationLevel
-from vllm.utils import cuda_device_count_stateless
+from vllm.utils import device_count_stateless
 
 from ..utils import compare_all_settings
 
@@ -101,7 +101,7 @@ def test_compile_correctness(test_setting: TestSetting):
     attn_backend = test_setting.attn_backend
     method = test_setting.method
     fullgraph = test_setting.fullgraph
-    if cuda_device_count_stateless() != pp_size * tp_size:
+    if device_count_stateless() != pp_size * tp_size:
         pytest.skip("Not correct CUDA devices for the test.")
     import os
     os.environ["VLLM_ATTENTION_BACKEND"] = attn_backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ from vllm.inputs import (ExplicitEncoderDecoderPrompt, TextPrompt,
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams
-from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, cuda_device_count_stateless,
+from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, device_count_stateless,
                         identity, is_list_of)
 
 logger = init_logger(__name__)
@@ -257,7 +257,7 @@ class HfRunner:
             return x
 
         if device is None:
-            device = "cpu" if current_platform.is_cpu() else "cuda"
+            device = current_platform.device_type
 
         if isinstance(x, dict):
             return {k: self.wrap_device(v, device) for k, v in x.items()}
@@ -985,7 +985,7 @@ def num_gpus_available():
     """Get number of GPUs without initializing the CUDA context
     in current process."""
 
-    return cuda_device_count_stateless()
+    return device_count_stateless()
 
 
 temp_dir = tempfile.gettempdir()

--- a/tests/samplers/test_typical_acceptance_sampler.py
+++ b/tests/samplers/test_typical_acceptance_sampler.py
@@ -7,8 +7,9 @@ import torch
 from vllm.model_executor.layers.typical_acceptance_sampler import (
     TypicalAcceptanceSampler)
 from vllm.model_executor.utils import set_random_seed
+from vllm.platforms import current_platform
 
-CUDA_DEVICES = [f"cuda:{i}" for i in range(1)]
+CUDA_DEVICES = [f"{current_platform.device_type}:0"]
 
 
 def get_zero_temperature_prob_dist(batch_size, k, vocab_size):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -59,7 +59,7 @@ def test_model_from_modelscope(monkeypatch):
     MODELSCOPE_MODEL_NAME = "qwen/Qwen1.5-0.5B-Chat"
     monkeypatch.setenv("VLLM_USE_MODELSCOPE", "True")
     try:
-        llm = LLM(model=MODELSCOPE_MODEL_NAME)
+        llm = LLM(model=MODELSCOPE_MODEL_NAME, dtype=torch.float16)
 
         prompts = [
             "Hello, my name is",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -391,7 +391,7 @@ def test_bind_kv_cache_encoder_decoder():
 
 
 def test_bind_kv_cache_pp():
-    with patch("vllm.utils.cuda_device_count_stateless", lambda: 2):
+    with patch("vllm.utils.device_count_stateless", lambda: 2):
         # this test runs with 1 GPU, but we simulate 2 GPUs
         cfg = VllmConfig(
             parallel_config=ParallelConfig(pipeline_parallel_size=2))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,7 @@ from vllm.model_executor.model_loader.loader import get_model_loader
 from vllm.platforms import current_platform
 from vllm.transformers_utils.tokenizer import get_tokenizer
 from vllm.utils import (FlexibleArgumentParser, GB_bytes,
-                        cuda_device_count_stateless, get_open_port)
+                        device_count_stateless, get_open_port)
 
 if current_platform.is_rocm():
     from amdsmi import (amdsmi_get_gpu_vram_usage,
@@ -733,7 +733,7 @@ def multi_gpu_marks(*, num_gpus: int):
     """Get a collection of pytest marks to apply for `@multi_gpu_test`."""
     test_selector = pytest.mark.distributed(num_gpus=num_gpus)
     test_skipif = pytest.mark.skipif(
-        cuda_device_count_stateless() < num_gpus,
+        device_count_stateless() < num_gpus,
         reason=f"Need at least {num_gpus} GPUs to run the test.",
     )
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -33,7 +33,7 @@ from vllm.transformers_utils.config import (
     try_get_generation_config, uses_mrope)
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3
-from vllm.utils import (GiB_bytes, LayerBlockType, cuda_device_count_stateless,
+from vllm.utils import (GiB_bytes, LayerBlockType, device_count_stateless,
                         get_cpu_memory, random_uuid, resolve_obj_by_qualname)
 
 if TYPE_CHECKING:
@@ -1382,7 +1382,7 @@ class ParallelConfig:
                 # neuron uses single process to control multiple devices
                 backend = "uni"
             elif (current_platform.is_cuda()
-                  and cuda_device_count_stateless() < self.world_size):
+                  and device_count_stateless() < self.world_size):
                 if not ray_found:
                     raise ValueError("Unable to load Ray which is "
                                      "required for multi-node inference, "

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -16,7 +16,7 @@ from vllm.distributed.device_communicators.custom_all_reduce_utils import (
 from vllm.distributed.parallel_state import in_the_same_node_as
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
-from vllm.utils import cuda_device_count_stateless
+from vllm.utils import device_count_stateless
 
 try:
     ops.meta_size()
@@ -112,7 +112,7 @@ class CustomAllreduce:
         if cuda_visible_devices:
             device_ids = list(map(int, cuda_visible_devices.split(",")))
         else:
-            device_ids = list(range(cuda_device_count_stateless()))
+            device_ids = list(range(device_count_stateless()))
 
         physical_device_id = device_ids[device.index]
         tensor = torch.tensor([physical_device_id],

--- a/vllm/distributed/device_communicators/custom_all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce_utils.py
@@ -16,8 +16,7 @@ import torch.multiprocessing as mp
 import vllm.envs as envs
 from vllm.distributed.device_communicators.cuda_wrapper import CudaRTLibrary
 from vllm.logger import init_logger
-from vllm.utils import (cuda_device_count_stateless,
-                        update_environment_variables)
+from vllm.utils import device_count_stateless, update_environment_variables
 
 logger = init_logger(__name__)
 
@@ -189,7 +188,7 @@ def gpu_p2p_access_check(src: int, tgt: int) -> bool:
 
     is_distributed = dist.is_initialized()
 
-    num_dev = cuda_device_count_stateless()
+    num_dev = device_count_stateless()
     cuda_visible_devices = envs.CUDA_VISIBLE_DEVICES
     if cuda_visible_devices is None:
         cuda_visible_devices = ",".join(str(i) for i in range(num_dev))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -577,6 +577,35 @@ environment_variables: Dict[str, Callable[[], Any]] = {
 # end-env-vars-definition
 
 
+def overwrite_env_vars(name: str,
+                       default_value: Optional[Any],
+                       getter: Optional[Callable[[], Any]]):
+    """Overwrite the existed environment variance in `environment_variables`.
+
+    Args:
+        name: name of env var
+        default_value: default value of env var, will be used when env var
+            is not set
+        getter: Optional function to get the value. If not provided, os.getenv
+            is used by default
+    """
+    from vllm.logger import init_logger
+    logger = init_logger(__name__)
+
+    if name in environment_variables:
+        logger.warning(
+            "Environment variable %s is already exists."
+            "This operation will overwrite it.", name)
+    else:
+        raise ValueError(
+            "No environment variable named %s found."
+            "Use `overwrite_env_vars` if attempt to create one.", name)
+    if getter is None:
+        getter = lambda: os.getenv(name, default_value)
+
+    environment_variables[name] = getter
+
+
 def __getattr__(name: str):
     # lazy evaluation of environment variables
     if name in environment_variables:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -577,8 +577,7 @@ environment_variables: Dict[str, Callable[[], Any]] = {
 # end-env-vars-definition
 
 
-def overwrite_env_vars(name: str,
-                       default_value: Optional[Any],
+def overwrite_env_vars(name: str, default_value: Optional[Any],
                        getter: Optional[Callable[[], Any]]):
     """Overwrite the existed environment variance in `environment_variables`.
 

--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -13,7 +13,7 @@ from vllm.executor.multiproc_worker_utils import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import ExecuteModelRequest
-from vllm.utils import (_run_task_with_lock, cuda_device_count_stateless,
+from vllm.utils import (_run_task_with_lock, device_count_stateless,
                         get_distributed_init_method, get_ip, get_open_port,
                         make_async, run_method, update_environment_variables)
 from vllm.worker.worker_base import WorkerWrapperBase
@@ -35,7 +35,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
         world_size = parallel_config.world_size
         tensor_parallel_size = parallel_config.tensor_parallel_size
 
-        cuda_device_count = cuda_device_count_stateless()
+        cuda_device_count = device_count_stateless()
         # Use confusing message for more common TP-only case.
         if tensor_parallel_size > cuda_device_count:
             raise RuntimeError(

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -179,6 +179,12 @@ class Platform:
         return current_capability.to_int() >= capability
 
     @classmethod
+    def get_device_count_stateless(cls,
+                                   visible_devices: Optional[str] = None
+                                   ) -> int:
+        raise NotImplementedError
+
+    @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         """Get the name of a device."""
         raise NotImplementedError

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -31,7 +31,7 @@ from asyncio import FIRST_COMPLETED, AbstractEventLoop, Task
 from collections import OrderedDict, UserDict, defaultdict
 from collections.abc import Hashable, Iterable, Mapping
 from dataclasses import dataclass, field
-from functools import cache, lru_cache, partial, wraps
+from functools import cache, partial, wraps
 from typing import (TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable,
                     Dict, Generator, Generic, Iterator, List, Literal,
                     NamedTuple, Optional, Tuple, Type, TypeVar, Union,

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1090,44 +1090,16 @@ def deprecate_kwargs(
     return wrapper
 
 
-@lru_cache(maxsize=8)
-def _cuda_device_count_stateless(
-        cuda_visible_devices: Optional[str] = None) -> int:
-    # Note: cuda_visible_devices is not used, but we keep it as an argument for
-    # LRU Cache purposes.
-
-    # Code below is based on
-    # https://github.com/pytorch/pytorch/blob/
-    # c1cd946818442aca8c7f812b16d187ce1586c3bc/
-    # torch/cuda/__init__.py#L831C1-L831C17
-    import torch.cuda
-    import torch.version
-
-    from vllm.platforms import current_platform
-    if not torch.cuda._is_compiled():
-        return 0
-    if current_platform.is_rocm():
-        # ROCm uses amdsmi instead of nvml for stateless device count
-        # This requires a sufficiently modern version of Torch 2.4.0
-        raw_count = torch.cuda._device_count_amdsmi() if (hasattr(
-            torch.cuda, "_device_count_amdsmi")) else -1
-    else:
-        raw_count = torch.cuda._device_count_nvml()
-    r = torch._C._cuda_getDeviceCount() if raw_count < 0 else raw_count
-    return r
-
-
-def cuda_device_count_stateless() -> int:
-    """Get number of CUDA devices, caching based on the value of
-    CUDA_VISIBLE_DEVICES at the time of call.
+def device_count_stateless() -> int:
+    """Get number of accelerators, caching based on the value of
+    envs.CUDA_VISIBLE_DEVICES at the time of call.
 
     This should be used instead of torch.cuda.device_count()
     unless CUDA_VISIBLE_DEVICES has already been set to the desired
     value."""
-
-    # This can be removed and simply replaced with torch.cuda.get_device_count
-    # after https://github.com/pytorch/pytorch/pull/122815 is released.
-    return _cuda_device_count_stateless(envs.CUDA_VISIBLE_DEVICES)
+    from vllm.platforms import current_platform
+    return current_platform.get_device_count_stateless(
+        envs.CUDA_VISIBLE_DEVICES)
 
 
 def cuda_is_initialized() -> bool:


### PR DESCRIPTION
While establishing integration tests for the plugin backend, in order to reuse vLLM's native UTs to the greatest extent, it is necessary to generalize the cuda hard-coded and related functions in vLLM's existing UTs.

This PR is the first in the UT rectification series of PRs.
Mainly changes:
1. Move the `cuda_device_count_stateless` method to platform so that out-of-tree devices can implement the corresponding method.
2. Provide a method to overwrite the `envs.CUDA_VISIBLE_DEVICES` environment variable so that vLLM can still obtain the out-of-tree device count through it.