### PR TITLE
[CI/Build]: bump gguf to 0.11

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -27,7 +27,7 @@ filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/31
 partial-json-parser # used for parsing partial JSON outputs
 pyzmq
 msgspec
-gguf == 0.10.0
+gguf == 0.11.0
 importlib_metadata
 mistral_common[opencv] >= 1.5.0
 pyyaml


### PR DESCRIPTION
gguf 0.11 has support for Granite 3.0 models. If any project wants vllm as a dependency and tries to use a GGUF library version > 0.10, build fails. Bump at least to 0.11 here to support Granite 3.0