### PR TITLE
[Core] Handle conflicting features more gracefully

### DIFF
--- a/tests/entrypoints/openai/test_prompt_validation.py
+++ b/tests/entrypoints/openai/test_prompt_validation.py
@@ -44,9 +44,8 @@ async def test_reject_multistep_with_guided_decoding():
     with RemoteOpenAIServer(model_name, server_args) as remote_server:
         client = remote_server.get_async_client()
 
-        with pytest.raises(openai.BadRequestError,
-                           match=re.compile(
-                               '.*Guided decoding .* multi-step decoding.*')):
+        with pytest.raises(openai.ConflictError,
+                           match=re.compile('.*Conflicting features:.*')):
             await client.completions.create(
                 model=model_name,
                 prompt="Hello",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,4 +1,5 @@
-from vllm.features import *
+from vllm.features import (FEATURE_BEST_OF, FEATURE_SPEC_DECODE,
+                           FEATURE_STRUCTURED_OUTPUT, FeatureUsage)
 
 
 def test_incompatible_features():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,29 @@
+from vllm.features import *
+
+
+def test_incompatible_features():
+    usage = FeatureUsage()
+    # no features
+    assert usage.compatible() is True
+
+    # one feature
+    usage.add(FEATURE_STRUCTURED_OUTPUT)
+    assert usage.compatible() is True
+
+    # a second compatible feature
+    usage.add(FEATURE_BEST_OF)
+    assert usage.compatible() is True
+
+    # two features are incompatible with each other
+    usage.add(FEATURE_SPEC_DECODE)
+    assert usage.compatible() is False
+
+
+def test_incompatible_features_with_base():
+    base = FeatureUsage()
+    base.add(FEATURE_STRUCTURED_OUTPUT)
+    base.add(FEATURE_BEST_OF)
+
+    usage = FeatureUsage(base)
+    usage.add(FEATURE_SPEC_DECODE)
+    assert usage.compatible() is False

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,5 +1,4 @@
-from vllm.features import (FEATURE_BEST_OF, FEATURE_SPEC_DECODE,
-                           FEATURE_STRUCTURED_OUTPUT, FeatureUsage)
+from vllm.features import FEATURES, INCOMPATIBILITY_MATRIX, FeatureUsage
 
 
 def test_incompatible_features():
@@ -8,23 +7,38 @@ def test_incompatible_features():
     assert usage.compatible() is True
 
     # one feature
-    usage.add(FEATURE_STRUCTURED_OUTPUT)
+    usage.add(FEATURES.STRUCTURED_OUTPUT)
     assert usage.compatible() is True
 
     # a second compatible feature
-    usage.add(FEATURE_BEST_OF)
+    usage.add(FEATURES.BEST_OF)
     assert usage.compatible() is True
 
     # two features are incompatible with each other
-    usage.add(FEATURE_SPEC_DECODE)
+    usage.add(FEATURES.SPEC_DECODE)
     assert usage.compatible() is False
 
 
 def test_incompatible_features_with_base():
     base = FeatureUsage()
-    base.add(FEATURE_STRUCTURED_OUTPUT)
-    base.add(FEATURE_BEST_OF)
+    base.add(FEATURES.STRUCTURED_OUTPUT)
+    base.add(FEATURES.BEST_OF)
 
     usage = FeatureUsage(base)
-    usage.add(FEATURE_SPEC_DECODE)
+    usage.add(FEATURES.SPEC_DECODE)
     assert usage.compatible() is False
+
+
+def test_incompat_matrix_consistency():
+    # Features can not be incompatible with themselves
+    for feature, incompatible in INCOMPATIBILITY_MATRIX.items():
+        assert (feature & incompatible) == 0
+
+    # Features listed as incompatible should also be listed as incompatible
+    # the other way around
+    for feature, incompatible in INCOMPATIBILITY_MATRIX.items():
+        for other_feature in INCOMPATIBILITY_MATRIX:
+            if feature == other_feature:
+                continue
+            if incompatible & other_feature:
+                assert INCOMPATIBILITY_MATRIX[other_feature] & feature

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -29,7 +29,7 @@ from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+from vllm.sampling_params import SamplingParams
 from vllm.sequence import ExecuteModelRequest
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.usage.usage_lib import UsageContext
@@ -559,11 +559,9 @@ async def build_guided_decoding_logits_processor_async(
         sampling_params.logits_processors.append(processor)
 
     # Unset guided decoding params after constructing the lp from them
-    # but keep a mostly-empty GuidedDeodingParams object in the sampling params
-    # so we can detect elsewhere that guided decoding is use for this request.
-    # We can just keep which backend is in use so it's not empty.
-    sampling_params.guided_decoding = GuidedDecodingParams(
-        backend=guided_decoding.backend)
+    sampling_params.guided_decoding = None
+    # and leave behind an easy way to detect that guided decoding is in use
+    sampling_params.guided_decoding_in_use = True
 
     return sampling_params
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -29,7 +29,7 @@ from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.outputs import PoolingRequestOutput, RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 from vllm.sequence import ExecuteModelRequest
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.usage.usage_lib import UsageContext
@@ -559,7 +559,11 @@ async def build_guided_decoding_logits_processor_async(
         sampling_params.logits_processors.append(processor)
 
     # Unset guided decoding params after constructing the lp from them
-    sampling_params.guided_decoding = None
+    # but keep a mostly-empty GuidedDeodingParams object in the sampling params
+    # so we can detect elsewhere that guided decoding is use for this request.
+    # We can just keep which backend is in use so it's not empty.
+    sampling_params.guided_decoding = GuidedDecodingParams(
+        backend=guided_decoding.backend)
 
     return sampling_params
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -14,9 +14,9 @@ import torch
 from typing_extensions import TypeVar, deprecated
 
 import vllm.envs as envs
-from vllm.config import (DecodingConfig, LoRAConfig, ModelConfig,
-                         ObservabilityConfig, ParallelConfig, SchedulerConfig,
-                         VllmConfig)
+from vllm.config import (CompilationLevel, DecodingConfig, LoRAConfig,
+                         ModelConfig, ObservabilityConfig, ParallelConfig,
+                         SchedulerConfig, VllmConfig)
 from vllm.core.scheduler import (ScheduledSequenceGroup, Scheduler,
                                  SchedulerOutputs)
 from vllm.engine.arg_utils import EngineArgs
@@ -411,6 +411,10 @@ class LLMEngine:
             self._base_features.add(FEATURES.SPEC_DECODE)
         if self.scheduler_config.num_scheduler_steps > 1:
             self._base_features.add(FEATURES.MULTI_STEP)
+        if (self.vllm_config.compilation_config
+                and self.vllm_config.compilation_config.level
+                == CompilationLevel.PIECEWISE):
+            self._base_features.add(FEATURES.TORCH_COMPILE)
 
     def _initialize_kv_caches(self) -> None:
         """Initialize the KV cache in the worker(s).

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -28,7 +28,9 @@ from vllm.engine.output_processor.util import create_output_by_sequence_group
 from vllm.entrypoints.openai.logits_processors import (
     get_logits_processors as get_openai_logits_processors)
 from vllm.executor.executor_base import ExecutorBase
-from vllm.features import *
+from vllm.features import (FEATURE_BEST_OF, FEATURE_SPEC_DECODE,
+                           FEATURE_STRUCTURED_OUTPUT, FeaturesIncompatible,
+                           FeatureUsage)
 from vllm.inputs import (INPUT_REGISTRY, InputRegistry, ProcessorInputs,
                          PromptType, SingletonInputsAdapter)
 from vllm.inputs.parse import is_encoder_decoder_inputs, is_token_prompt

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -744,7 +744,7 @@ class LLMEngine:
         features = FeatureUsage(self._base_features)
         # Add any additional features enabled at the request level
         if isinstance(params, SamplingParams):
-            if params.guided_decoding:
+            if params.using_guided_decoding():
                 features.add(FEATURES.STRUCTURED_OUTPUT)
             if params.logits_processors:
                 features.add(FEATURES.LOGITS_PROCESSORS)
@@ -1995,6 +1995,8 @@ class LLMEngine:
 
             # Unset so this doesn't get passed down to the model
             sampling_params.guided_decoding = None
+            # and leave behind a hint that guided decoding is in use
+            sampling_params.guided_decoding_in_use = True
 
         if (sampling_params.logit_bias or sampling_params.allowed_token_ids):
             tokenizer = self.get_tokenizer(lora_request=lora_request)

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -20,6 +20,7 @@ from vllm.engine.multiprocessing import (ENGINE_DEAD_ERROR, IPC_DATA_EXT,
                                          RPCResetPrefixCacheRequest,
                                          RPCStartupRequest, RPCStartupResponse,
                                          RPCUProfileRequest)
+from vllm.features import FeaturesIncompatible
 # yapf: enable
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
@@ -382,6 +383,10 @@ def run_mp_engine(engine_args: AsyncEngineArgs, usage_context: UsageContext,
         signal.signal(signal.SIGTERM, signal_handler)
 
         engine.start()
+
+    except FeaturesIncompatible:
+        # A normal case where we can exit cleanly. It will be logged elsewhere.
+        engine_alive.value = False
 
     except BaseException as e:
         logger.exception(e)

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -294,7 +294,7 @@ class MQLLMEngine:
         try:
             self.engine.add_lora(request.lora_request)
         except BaseException as e:
-            # Send back an error if the adater fails to load
+            # Send back an error if the adapter fails to load
             rpc_err = RPCError(request_id=request.request_id,
                                is_engine_errored=False,
                                exception=e)

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import time
+from http import HTTPStatus
 from typing import AsyncGenerator, Final, List, Literal, Optional, Union, cast
 
 import numpy as np
@@ -18,6 +19,7 @@ from vllm.entrypoints.openai.protocol import (EmbeddingChatRequest,
                                               ErrorResponse, UsageInfo)
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
+from vllm.features import FeaturesIncompatible
 from vllm.logger import init_logger
 from vllm.outputs import (EmbeddingOutput, EmbeddingRequestOutput,
                           PoolingRequestOutput)
@@ -167,6 +169,10 @@ class OpenAIServingEmbedding(OpenAIServing):
                 )
 
                 generators.append(generator)
+        except FeaturesIncompatible as e:
+            return self.create_error_response(message=str(e),
+                                              err_type="Conflict",
+                                              status_code=HTTPStatus.CONFLICT)
         except ValueError as e:
             # TODO: Use a vllm-specific Validation Error
             return self.create_error_response(str(e))

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import time
+from http import HTTPStatus
 from typing import AsyncGenerator, Final, List, Literal, Optional, Union, cast
 
 import numpy as np
@@ -17,6 +18,7 @@ from vllm.entrypoints.openai.protocol import (ErrorResponse,
                                               PoolingResponseData, UsageInfo)
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
+from vllm.features import FeaturesIncompatible
 from vllm.logger import init_logger
 from vllm.outputs import PoolingOutput, PoolingRequestOutput
 from vllm.utils import merge_async_iterators
@@ -163,6 +165,10 @@ class OpenAIServingPooling(OpenAIServing):
                 )
 
                 generators.append(generator)
+        except FeaturesIncompatible as e:
+            return self.create_error_response(message=str(e),
+                                              err_type="Conflict",
+                                              status_code=HTTPStatus.CONFLICT)
         except ValueError as e:
             # TODO: Use a vllm-specific Validation Error
             return self.create_error_response(str(e))

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from http import HTTPStatus
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union, cast
 
 from fastapi import Request
@@ -12,6 +13,7 @@ from vllm.entrypoints.openai.protocol import (ErrorResponse, ScoreRequest,
                                               UsageInfo)
 from vllm.entrypoints.openai.serving_engine import OpenAIServing
 from vllm.entrypoints.openai.serving_models import OpenAIServingModels
+from vllm.features import FeaturesIncompatible
 from vllm.inputs.data import TokensPrompt
 from vllm.logger import init_logger
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
@@ -165,6 +167,10 @@ class OpenAIServingScores(OpenAIServing):
                 )
 
                 generators.append(generator)
+        except FeaturesIncompatible as e:
+            return self.create_error_response(message=str(e),
+                                              err_type="Conflict",
+                                              status_code=HTTPStatus.CONFLICT)
         except ValueError as e:
             # TODO: Use a vllm-specific Validation Error
             return self.create_error_response(str(e))

--- a/vllm/features.py
+++ b/vllm/features.py
@@ -1,5 +1,27 @@
 from typing import Dict, Optional
 
+#
+# Instructions:
+#
+# To add a new feature:
+#
+# 1) Reserve a bit by defining a new constant, FEATURE_<NAME>, with a value of
+#    1 << n, where n is the next available bit in the range 0-63.
+#
+# 2) Add a string representation of the feature to FEATURE_STR.
+#
+# 3) Add the feature to INCOMPATIBILITY_MATRIX. The key should be the feature
+#    and the value should be a bit mask of all the features that are
+#    incompatible with it. The feature should be added to the value of any other
+#    feature that it is incompatible with, as well.
+#
+# To change the compatibility matrix for existing features,
+# update INCOMPATIBILITY_MATRIX.
+#
+# This should match what in the feature compatibility matrix in the docs:
+# https://docs.vllm.ai/en/latest/features/compatibility_matrix.html
+#
+
 # This range must not go above 63 as they represent the bits in the feature
 # usage bit field. The implementation will have to change if we need to
 # calculate compatibility between more than 64 features.

--- a/vllm/features.py
+++ b/vllm/features.py
@@ -1,0 +1,77 @@
+from typing import Dict, Optional
+
+# This range must not go above 63 as they represent the bits in the feature
+# usage bit field. The implementation will have to change if we need to
+# calculate compatibility between more than 64 features.
+FEATURE_SPEC_DECODE: int = 1 << 0
+FEATURE_STRUCTURED_OUTPUT: int = 1 << 1
+FEATURE_BEST_OF: int = 1 << 2
+
+FEATURE_STR: Dict[int, str] = {
+    FEATURE_SPEC_DECODE: 'SPEC_DECODE',
+    FEATURE_STRUCTURED_OUTPUT: 'STRUCTURED_OUTPUT',
+    FEATURE_BEST_OF: 'BEST_OF',
+}
+
+INCOMPATIBILITY_MATRIX: Dict[int, int] = {
+    FEATURE_SPEC_DECODE: FEATURE_STRUCTURED_OUTPUT | FEATURE_BEST_OF,
+    FEATURE_STRUCTURED_OUTPUT: FEATURE_SPEC_DECODE,
+    FEATURE_BEST_OF: FEATURE_SPEC_DECODE,
+}
+
+
+class FeatureUsage:
+    '''A class to manage the usage of features and check for compatibility.
+
+    This class is used to manage the usage of features and check for
+    compatibility between them. It uses a bit field to store the features in use
+    and checks for compatibility in O(n) time.
+    '''
+
+    _features: int
+
+    def __init__(self, base: Optional['FeatureUsage'] = None):
+        self._features = base._features if base else 0
+
+    def add(self, feature: int):
+        '''Add a feature to the current usage.
+
+        Args:
+            feature (int): The feature to add to the current usage.
+        '''
+        self._features |= feature
+
+    def compatible(self) -> bool:
+        '''Check if the current feature usage is compatible.
+
+        Given a set of features in use (stored as bits in self._features),
+        do a check in O(n) time to see if any of the features are incompatible
+        with each other.
+
+        Returns:
+            bool: True if the features are compatible, False otherwise.
+        '''
+        for feature, incompatible in INCOMPATIBILITY_MATRIX.items():
+            # If `feature` is in use and something in its incompatibility mask
+            # is also in use
+            if self._features & feature and self._features & incompatible:
+                return False
+        return True
+
+    def conflicts(self) -> str:
+        '''Return a string representation of the incompatible features.'''
+        conflicts = []
+        for feature, incompatible in INCOMPATIBILITY_MATRIX.items():
+            if self._features & feature and self._features & incompatible:
+                conflicts.append(FEATURE_STR[feature])
+        return 'Conflicting features: ' + ', '.join(conflicts)
+
+
+class FeaturesIncompatible(ValueError):
+    '''An exception to raise when incompatible features are used.
+
+    Inherit from ValueError because ValueError is used throughout vllm
+    as a more generic exception that will get converted to a 400 HTTP
+    response in the API. This way, if a code path doesn't explicitly
+    handle FeaturesIncompatible, it can still handle it as a ValueError.
+    '''

--- a/vllm/features.py
+++ b/vllm/features.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional
 #
 # To add a new feature:
 #
-# 1) Reserve a bit by defining a new constant, FEATURE_<NAME>, with a value of
+# 1) Reserve a bit by defining a new constant in FEATURES with a value of
 #    1 << n, where n is the next available bit in the range 0-63.
 #
 # 2) Add a string representation of the feature to FEATURE_STR.
@@ -22,23 +22,42 @@ from typing import Dict, Optional
 # https://docs.vllm.ai/en/latest/features/compatibility_matrix.html
 #
 
+
 # This range must not go above 63 as they represent the bits in the feature
 # usage bit field. The implementation will have to change if we need to
 # calculate compatibility between more than 64 features.
-FEATURE_SPEC_DECODE: int = 1 << 0
-FEATURE_STRUCTURED_OUTPUT: int = 1 << 1
-FEATURE_BEST_OF: int = 1 << 2
+class FEATURES:
+    """Feature bitfield definitions"""
+    SPEC_DECODE: int = 1 << 0
+    STRUCTURED_OUTPUT: int = 1 << 1
+    BEST_OF: int = 1 << 2
+    LOGITS_PROCESSORS: int = 1 << 3
+    MULTI_STEP: int = 1 << 4
+
 
 FEATURE_STR: Dict[int, str] = {
-    FEATURE_SPEC_DECODE: 'SPEC_DECODE',
-    FEATURE_STRUCTURED_OUTPUT: 'STRUCTURED_OUTPUT',
-    FEATURE_BEST_OF: 'BEST_OF',
+    FEATURES.SPEC_DECODE: 'SPEC_DECODE',
+    FEATURES.STRUCTURED_OUTPUT: 'STRUCTURED_OUTPUT',
+    FEATURES.BEST_OF: 'BEST_OF',
+    FEATURES.LOGITS_PROCESSORS: 'LOGITS_PROCESSORS',
+    FEATURES.MULTI_STEP: 'MULTI_STEP',
 }
 
 INCOMPATIBILITY_MATRIX: Dict[int, int] = {
-    FEATURE_SPEC_DECODE: FEATURE_STRUCTURED_OUTPUT | FEATURE_BEST_OF,
-    FEATURE_STRUCTURED_OUTPUT: FEATURE_SPEC_DECODE,
-    FEATURE_BEST_OF: FEATURE_SPEC_DECODE,
+    FEATURES.SPEC_DECODE: (FEATURES.STRUCTURED_OUTPUT
+                           | FEATURES.BEST_OF
+                           | FEATURES.MULTI_STEP
+                           | FEATURES.LOGITS_PROCESSORS),
+    FEATURES.STRUCTURED_OUTPUT: (FEATURES.SPEC_DECODE
+                                 | FEATURES.MULTI_STEP),
+    FEATURES.BEST_OF: (FEATURES.SPEC_DECODE
+                       | FEATURES.MULTI_STEP),
+    FEATURES.LOGITS_PROCESSORS: (FEATURES.SPEC_DECODE
+                                 | FEATURES.MULTI_STEP),
+    FEATURES.MULTI_STEP: (FEATURES.SPEC_DECODE
+                          | FEATURES.BEST_OF
+                          | FEATURES.STRUCTURED_OUTPUT
+                          | FEATURES.LOGITS_PROCESSORS),
 }
 
 

--- a/vllm/features.py
+++ b/vllm/features.py
@@ -33,6 +33,7 @@ class FEATURES:
     BEST_OF: int = 1 << 2
     LOGITS_PROCESSORS: int = 1 << 3
     MULTI_STEP: int = 1 << 4
+    TORCH_COMPILE: int = 1 << 5
 
 
 FEATURE_STR: Dict[int, str] = {
@@ -41,13 +42,15 @@ FEATURE_STR: Dict[int, str] = {
     FEATURES.BEST_OF: 'BEST_OF',
     FEATURES.LOGITS_PROCESSORS: 'LOGITS_PROCESSORS',
     FEATURES.MULTI_STEP: 'MULTI_STEP',
+    FEATURES.TORCH_COMPILE: 'TORCH_COMPILE',
 }
 
 INCOMPATIBILITY_MATRIX: Dict[int, int] = {
     FEATURES.SPEC_DECODE: (FEATURES.STRUCTURED_OUTPUT
                            | FEATURES.BEST_OF
                            | FEATURES.MULTI_STEP
-                           | FEATURES.LOGITS_PROCESSORS),
+                           | FEATURES.LOGITS_PROCESSORS
+                           | FEATURES.TORCH_COMPILE),
     FEATURES.STRUCTURED_OUTPUT: (FEATURES.SPEC_DECODE
                                  | FEATURES.MULTI_STEP),
     FEATURES.BEST_OF: (FEATURES.SPEC_DECODE
@@ -58,6 +61,7 @@ INCOMPATIBILITY_MATRIX: Dict[int, int] = {
                           | FEATURES.BEST_OF
                           | FEATURES.STRUCTURED_OUTPUT
                           | FEATURES.LOGITS_PROCESSORS),
+    FEATURES.TORCH_COMPILE: (FEATURES.SPEC_DECODE),
 }
 
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -209,6 +209,9 @@ class SamplingParams(
     logit_bias: Optional[Dict[int, float]] = None
     allowed_token_ids: Optional[List[int]] = None
 
+    # guided decoding config has already been converted to a logits processor
+    guided_decoding_in_use: bool = False
+
     @staticmethod
     def from_optional(
         n: Optional[int] = 1,
@@ -448,6 +451,9 @@ class SamplingParams(
     @property
     def all_stop_token_ids(self) -> Set[int]:
         return self._all_stop_token_ids
+
+    def using_guided_decoding(self) -> bool:
+        return self.guided_decoding is not None or self.guided_decoding_in_use
 
     def clone(self) -> "SamplingParams":
         """Deep copy, but maybe not the LogitsProcessor objects.


### PR DESCRIPTION
Prior to this change, if you attempted to use speculative decoding and
structured output (guided decoding) at the same time, vllm would crash.

First, this change introduces a new interface in `vllm.features` for declaring
a set of features in use and determining whether there are any conflicts
between them. This check is done when a request is added to the engine. If
there is a conflict, a `FeaturesIncompatible` exception will be raised.

Next, the openai-compatible API server has been updated to handle the
`FeaturesIncompatible` exception explicitly. When this occurs, it will respond
with a `409 Conflict` HTTP response.

For example, from my local testing, I now get this:

```
openai.ConflictError: Error code: 409 - {'object': 'error',
                                         'message': 'Conflicting features: SPEC_DECODE, STRUCTURED_OUTPUT',
					 'type': 'Conflict', 'param': None, 'code': 409}
```

Follow-up work here should include:

- expand the feature set expressed in
`vllm.features` to capture all or most of the items in the vllm feature
compatibility matrix in the docs:
https://docs.vllm.ai/en/latest/features/compatibility_matrix.html

- add `vllm.features` usage to the V1 engine

Related to issue #11484.

- **[Core] Add a feature compatibility checking interface**
- **[Frontend] Handle FeaturesIncompatible exception**

commit 5ad8bfc48b46cd863b11f64ae3ca08533e0423ae
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Jan 24 13:48:06 2025 -0500

    [Core] Add a feature compatibility checking interface
    
    This change introduces an interface for checking for compatibility
    between a set of features that are in use. It uses bitwise math for
    checking to be able to perform the check in fewer operations than other
    potential approaches.
    
    This changle also makes use of the interface in the v0 engine to detect
    the conflict between speculative decoding and structured output (guided
    decoding). Without this in place, vllm will crash later on when trying
    to process the request.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit f7e3f82e03a61b52acdee9558fc6ce0f8c7c10a3
Author: Russell Bryant <rbryant@redhat.com>
Date:   Mon Jan 27 13:07:43 2025 -0500

    [Frontend] Handle FeaturesIncompatible exception
    
    When the engine detects that the requested features in a request include
    a conflict, it will raise this exception. Catch the exception and
    respond with a `409 Conflict` HTTP response.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
