### PR TITLE
[Misc][Docs] Raise error when flashinfer is not installed and `VLLM_ATTENTION_BACKEND` is set

### DIFF
--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -184,3 +184,7 @@ chat_response = client.chat.completions.create(
 )
 print("Chat response:", chat_response)
 ```
+
+## On Attention Backends
+
+Currently, vLLM supports multiple backends for efficient Attention computation, depending on target platform and accelerator architecture.   

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -187,4 +187,10 @@ print("Chat response:", chat_response)
 
 ## On Attention Backends
 
-Currently, vLLM supports multiple backends for efficient Attention computation, depending on target platform and accelerator architecture.   
+Currently, vLLM supports multiple backends for efficient Attention computation across different platforms and accelerator architectures. It automatically selects the most performant backend compatible with your system and model specifications.
+
+If desired, you can also manually set the backend of your choice by configuring the environment variable `VLLM_ATTENTION_BACKEND` to one of the following options: `FLASH_ATTN`, `FLASHINFER` or `XFORMERS`.
+
+```{attention}
+There are no pre-built vllm wheels containing Flash Infer, so you must install it in your environment first. Refer to the [Flash Infer official docs](https://docs.flashinfer.ai/) or see [Dockerfile](https://github.com/vllm-project/vllm/blob/main/Dockerfile) for instructions on how to install it.
+```

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
+from importlib.util import find_spec
 from pathlib import Path
 from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Counter, Dict,
                     Final, List, Literal, Mapping, Optional, Protocol, Set,
@@ -261,6 +262,14 @@ class ModelConfig:
             warnings.warn(DeprecationWarning(msg), stacklevel=2)
 
         self.maybe_pull_model_tokenizer_for_s3(model, tokenizer)
+
+        if (backend := envs.VLLM_ATTENTION_BACKEND
+            ) and backend == "FLASHINFER" and find_spec("flashinfer") is None:
+            raise ValueError(
+                "VLLM_ATTENTION_BACKEND is set to FLASHINFER, but flashinfer "
+                "module was not found."
+                "See https://github.com/vllm-project/vllm/blob/main/Dockerfile"
+                "for instructions on how to install it.")
 
         # The tokenizer version is consistent with the model version by default.
         if tokenizer_revision is None:


### PR DESCRIPTION
FlashAttn is currently not resolved when installing through a package manager, as it still resorting to manual installation (see https://github.com/vllm-project/vllm/blob/main/Dockerfile#L210).
If the user manually sets the backend to `flashinfer` and `flashinfer` is not installed in the system, the resulting error message is not super informative:
```
Traceback (most recent call last):
  File "/opt/dlami/nvme/vllm/vllm/worker/model_runner_base.py", line 116, in _wrapper
    return func(*args, **kwargs)
  File "/opt/dlami/nvme/vllm/vllm/worker/model_runner.py", line 1670, in execute_model
    self.attn_state.begin_forward(model_input)
  File "/opt/dlami/nvme/vllm/vllm/attention/backends/flashinfer.py", line 269, in begin_forward
    model_input.attn_metadata.prefill_wrapper = state._get_prefill_wrapper(
  File "/opt/dlami/nvme/vllm/vllm/attention/backends/flashinfer.py", line 121, in _get_prefill_wrapper
    self._prefill_wrapper = BatchPrefillWithPagedKVCacheWrapper(
TypeError: 'NoneType' object is not callable
```

We could instead simply check whether the backend is *specifically* set to `flashinfer` and verify the package can be found, raising an error if that's not the case.

When VLLM_ATTENTION_BACKEND is not set, I think it's fine to default to one of the other backends. However, if the environment variable is set, I believe it is best practice not to overwrite it. 