### PR TITLE
Do not run `suggestion` `pre-commit` hook multiple times

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,3 +90,4 @@ repos:
     entry: bash -c 'echo "To bypass pre-commit hooks, add --no-verify to git commit."'
     language: system
     verbose: true
+    pass_filenames: false


### PR DESCRIPTION
Prevents the message `To bypass pre-commit hooks, add --no-verify to git commit.` from being printed once for each changed file.
