### PR TITLE
Bugfix for whisper quantization due to fake k_proj bias

### DIFF
--- a/vllm/model_executor/models/whisper.py
+++ b/vllm/model_executor/models/whisper.py
@@ -743,7 +743,7 @@ def _create_fake_bias_for_k_proj(
     So that the bias for k_proj in qkv_proj can be initialized with zeros.
     """
     for name, weight in weights:
-        if ".self_attn.k_proj.weight" in name:
+        if name.endswith(".self_attn.k_proj.weight"):
             bias = torch.zeros(weight.size(0))
             bias_name = name.replace("weight", "bias")
             yield from [(name, weight), (bias_name, bias)]


### PR DESCRIPTION
Without this change, running a quantized whisper like https://huggingface.co/nm-testing/whisper-large-v2-FP8-dynamic results in a complaint about a non-existent `bias_scale`

```
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/whisper.py", line 735, in load_weights
[rank0]:     return loader.load_weights(weights, mapper=mapper)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/utils.py", line 233, in load_weights
[rank0]:     autoloaded_weights = set(self._load_module("", self.module, weights))
[rank0]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/utils.py", line 194, in _load_module
[rank0]:     yield from self._load_module(prefix,
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/utils.py", line 171, in _load_module
[rank0]:     loaded_params = module_load_weights(weights)
[rank0]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/mgoin/code/vllm/vllm/model_executor/models/whisper.py", line 555, in load_weights
[rank0]:     param = params_dict[name]
[rank0]:             ~~~~~~~~~~~^^^^^^
[rank0]: KeyError: 'decoder.layers.0.self_attn.qkv_proj.bias_scale'
```