### PR TITLE
Add label if pre-commit passes

### DIFF
--- a/.github/workflows/add_label_precommit.yml
+++ b/.github/workflows/add_label_precommit.yml
@@ -1,0 +1,22 @@
+name: Add label on pre-commit success
+on:
+    workflow_run:
+        workflows: ["pre-commit"]
+        types: [completed]
+jobs:
+    add-label-on-pre-commit-success:
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        steps:
+            -   name: Add label
+                uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+                with:
+                    script: |
+                        github.rest.issues.addLabels({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            labels: ['pre-commit passed']
+                        })
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_label_precommit.yml
+++ b/.github/workflows/add_label_precommit.yml
@@ -16,7 +16,7 @@ jobs:
                             owner: context.repo.owner,
                             repo: context.repo.repo,
                             issue_number: context.issue.number,
-                            labels: ['pre-commit passed']
+                            labels: ['pre-commit-passed']
                         })
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/add_label_precommit.yml
+++ b/.github/workflows/add_label_precommit.yml
@@ -2,7 +2,7 @@ name: Add label on pre-commit success
 on:
     workflow_run:
         workflows: [pre-commit]
-        types: [completed]
+        types: [requested, completed]
 jobs:
     add-label-on-pre-commit-success:
         runs-on: ubuntu-latest
@@ -13,6 +13,22 @@ jobs:
                 with:
                     script: |
                         github.rest.issues.addLabels({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            issue_number: context.issue.number,
+                            labels: ['pre-commit passed']
+                        })
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    remove-label-on-pre-commit-failure:
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        steps:
+            -   name: Remove label
+                uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+                with:
+                    script: |
+                        github.rest.issues.removeLabels({
                             owner: context.repo.owner,
                             repo: context.repo.repo,
                             issue_number: context.issue.number,

--- a/.github/workflows/add_label_precommit.yml
+++ b/.github/workflows/add_label_precommit.yml
@@ -1,7 +1,7 @@
 name: Add label on pre-commit success
 on:
     workflow_run:
-        workflows: ["pre-commit"]
+        workflows: [pre-commit]
         types: [completed]
 jobs:
     add-label-on-pre-commit-success:

--- a/.github/workflows/add_label_precommit.yml
+++ b/.github/workflows/add_label_precommit.yml
@@ -20,7 +20,7 @@ jobs:
                         })
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    remove-label-on-pre-commit-failure:
+    remove-label-on-pre-commit-not-success:
         runs-on: ubuntu-latest
         if: ${{ github.event.workflow_run.conclusion != 'success' }}
         steps:


### PR DESCRIPTION
Allows Buildkite to not run CI until pre-commit is passing, saving CI cost. 

Originally discussed in https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1736691851928849