### PR TITLE
[V1][Metrics] Add TTFT and TPOT histograms

### DIFF
--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -208,6 +208,12 @@ EXPECTED_METRICS_V1 = [
     "vllm:request_generation_tokens_sum",
     "vllm:request_generation_tokens_bucket",
     "vllm:request_generation_tokens_count",
+    "vllm:time_to_first_token_seconds_sum",
+    "vllm:time_to_first_token_seconds_bucket",
+    "vllm:time_to_first_token_seconds_count",
+    "vllm:time_per_output_token_seconds_sum",
+    "vllm:time_per_output_token_seconds_bucket",
+    "vllm:time_per_output_token_seconds_count",
 ]
 
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -27,6 +27,7 @@ class RequestState:
         prompt: Optional[str],
         prompt_token_ids: List[int],
         detokenizer: IncrementalDetokenizer,
+        arrival_time: float,
         queue: Optional[asyncio.Queue[RequestOutput]],
     ):
         self.request_id = request_id
@@ -37,7 +38,7 @@ class RequestState:
         self.is_prefilling = True
         self.queue = queue
 
-        self.stats = RequestStateStats()
+        self.stats = RequestStateStats(last_token_time=arrival_time)
 
     @classmethod
     def from_new_request(
@@ -54,6 +55,7 @@ class RequestState:
                 tokenizer=tokenizer,
                 request=request,
             ),
+            arrival_time=request.arrival_time,
             queue=queue,
         )
 

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List
 
@@ -22,6 +23,7 @@ class RequestStateStats:
     """Stats that need to be tracked across delta updates."""
 
     num_generation_tokens: int = 0
+    last_token_time: float = 0.0
 
 
 @dataclass
@@ -40,6 +42,8 @@ class IterationStats:
         self.num_generation_tokens = 0
         self.num_prompt_tokens = 0
         self.finished_requests: List[FinishedRequestStats] = []
+        self.time_to_first_tokens_iter: List[float] = []
+        self.time_per_output_tokens_iter: List[float] = []
 
     def update_from_output(self, output: "EngineCoreOutput",
                            is_prefilling: bool, prompt_len: int,
@@ -48,6 +52,8 @@ class IterationStats:
             return
 
         num_new_generation_tokens = len(output.new_token_ids)
+        now = time.time()
+        last_token_latency = now - request_state_stats.last_token_time
 
         self.num_generation_tokens += num_new_generation_tokens
         if is_prefilling:
@@ -58,7 +64,12 @@ class IterationStats:
             assert (num_new_generation_tokens > 0)
             self.num_prompt_tokens += prompt_len
 
+            self.time_to_first_tokens_iter.append(last_token_latency)
+        else:
+            self.time_per_output_tokens_iter.append(last_token_latency)
+
         request_state_stats.num_generation_tokens += num_new_generation_tokens
+        request_state_stats.last_token_time = now
 
     def update_from_finished_request(self, request_output: "RequestOutput",
                                      request_state_stats: RequestStateStats):


### PR DESCRIPTION
Follow on from #12516, part of #10582

Compute these intervals on the API server side as EngineCoreOutputs are processed.

The OutputProcessor needs to track per-request arrival times and the generation timestamp of the most recent token generation.

Prefill intervals are calculated when the first EngineCoreOutput is received, indicating prefill completion.

The histogram buckets match the v0 implementation, but they should probably be improved in future.