### PR TITLE
[Kernel] Use self.kv_cache and forward_context.attn_metadata in Attention.forward

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -187,9 +187,8 @@ class Attention(nn.Module):
                 forward_context: ForwardContext = get_forward_context()
                 ctx_attn_metadata = forward_context.attn_metadata
                 self_kv_cache = self.kv_cache[forward_context.virtual_engine]
-                return self.impl.forward(query, key, value, self_kv_cache,
-                                         ctx_attn_metadata, self._k_scale,
-                                         self._v_scale)
+                return self.impl.forward(self, query, key, value,
+                                         self_kv_cache, ctx_attn_metadata)
             else:
                 return torch.ops.vllm.unified_attention(
                     query, key, value, self.layer_name)

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -150,10 +150,9 @@ class Attention(nn.Module):
     ) -> torch.Tensor:
         # NOTE: please avoid accessing `kv_cache` and `attn_metadata` arguments
         # directly. Instead, please use the `self.kv_cache` and
-        # `forward_context.attn_metadata` to access them.
+        # `get_forward_context().attn_metadata` to access them.
         if self.calculate_kv_scales:
-            forward_context: ForwardContext = get_forward_context()
-            ctx_attn_metadata = forward_context.attn_metadata
+            ctx_attn_metadata = get_forward_context().attn_metadata
             if ctx_attn_metadata.enable_kv_scales_calculation:
                 self.calc_kv_scales(key, value)
         if self.use_output:

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -148,9 +148,14 @@ class Attention(nn.Module):
         kv_cache: torch.Tensor,
         attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
-        if self.calculate_kv_scales and \
-            attn_metadata.enable_kv_scales_calculation:
-            self.calc_kv_scales(key, value)
+        # NOTE: please avoid accessing `kv_cache` and `attn_metadata` arguments
+        # directly. Instead, please use the `self.kv_cache` and
+        # `forward_context.attn_metadata` to access them.
+        if self.calculate_kv_scales:
+            forward_context: ForwardContext = get_forward_context()
+            ctx_attn_metadata = forward_context.attn_metadata
+            if ctx_attn_metadata.enable_kv_scales_calculation:
+                self.calc_kv_scales(key, value)
         if self.use_output:
             output = torch.empty_like(query)
             hidden_size = query.size(-1)
@@ -164,15 +169,28 @@ class Attention(nn.Module):
             if value is not None:
                 value = value.view(-1, self.num_kv_heads, self.head_size)
             if self.use_direct_call:
-                unified_attention_with_output(query, key, value, output,
-                                              self.layer_name)
+                forward_context: ForwardContext = get_forward_context()
+                ctx_attn_metadata = forward_context.attn_metadata
+                self_kv_cache = self.kv_cache[forward_context.virtual_engine]
+                self.impl.forward(self,
+                                  query,
+                                  key,
+                                  value,
+                                  self_kv_cache,
+                                  ctx_attn_metadata,
+                                  output=output)
             else:
                 torch.ops.vllm.unified_attention_with_output(
                     query, key, value, output, self.layer_name)
             return output.view(-1, hidden_size)
         else:
             if self.use_direct_call:
-                return unified_attention(query, key, value, self.layer_name)
+                forward_context: ForwardContext = get_forward_context()
+                ctx_attn_metadata = forward_context.attn_metadata
+                self_kv_cache = self.kv_cache[forward_context.virtual_engine]
+                return self.impl.forward(query, key, value, self_kv_cache,
+                                         ctx_attn_metadata, self._k_scale,
+                                         self._v_scale)
             else:
                 return torch.ops.vllm.unified_attention(
                     query, key, value, self.layer_name)

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -184,7 +184,7 @@ class Attention(nn.Module):
             return output.view(-1, hidden_size)
         else:
             if self.use_direct_call:
-                forward_context: ForwardContext = get_forward_context()
+                forward_context = get_forward_context()
                 ctx_attn_metadata = forward_context.attn_metadata
                 self_kv_cache = self.kv_cache[forward_context.virtual_engine]
                 return self.impl.forward(self, query, key, value,

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -149,8 +149,8 @@ class Attention(nn.Module):
         attn_metadata: AttentionMetadata,
     ) -> torch.Tensor:
         # NOTE: please avoid accessing `kv_cache` and `attn_metadata` arguments
-        # directly. Instead, please use the `self.kv_cache` and
-        # `get_forward_context().attn_metadata` to access them.
+        # directly, use `self.kv_cache` and
+        # `get_forward_context().attn_metadata` instead.
         if self.calculate_kv_scales:
             ctx_attn_metadata = get_forward_context().attn_metadata
             if ctx_attn_metadata.enable_kv_scales_calculation:


### PR DESCRIPTION
This PR does the following things:
1. Use self.kv_cache instead of getting attn object from forward_context and access attn object's kv_cache attribute . This can avoid unnecessary torch.compile guards as mentioned in #12410
2. Remove the direct access of attn_metadata in dynamic kv cache scale.
3. Add notes about how to use kv_cache and attn_metadata in this function

@anko-intel does this PR fix your problem?

fix #12410 
CC @youkaichao 
