### PR TITLE
[Bugfix][Spec Decode][V0] fix: update logits processor for MQA scoring

### DIFF
--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -2,6 +2,7 @@
 """A layer that compute logits from hidden_stats."""
 import inspect
 from concurrent.futures import ThreadPoolExecutor
+from itertools import zip_longest
 from typing import Optional
 
 import torch
@@ -152,10 +153,17 @@ def _apply_logits_processors(
         if logits_processors:
             found_logits_processors = True
 
-            for seq_id, logits_row_idx in zip(seq_ids,
-                                              seq_group.sample_indices):
+            for i, (seq_id, logits_row_idx) in enumerate(
+                    zip_longest(seq_ids,
+                                seq_group.sample_indices,
+                                fillvalue=seq_ids[-1])):
                 logits_row = logits[logits_row_idx]
-                past_tokens_ids = seq_group.seq_data[seq_id].output_token_ids
+                max_output_len = len(
+                    seq_group.seq_data[seq_id].output_token_ids)
+                num_samples = len(seq_group.sample_indices)
+                past_tokens_ids = seq_group.seq_data[
+                    seq_id].output_token_ids[:max_output_len - num_samples +
+                                             i + 1]
                 prompt_tokens_ids = seq_group.seq_data[seq_id].prompt_token_ids
 
                 if _logits_processor_threadpool is not None:

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -334,6 +334,8 @@ def _prepare_seq_groups(
                 range(logit_idx, logit_idx + prompt_logprob_len))
             logit_idx += prompt_logprob_len
         if do_sample:
+            # Note: sample_indices is expected to be contiguous
+            # as required by LogitsProcessor.
             sample_indices.extend(range(logit_idx, logit_idx + sample_len))
             categorized_sample_indices[sampling_params.sampling_type].extend(
                 list(range(logit_idx, logit_idx + sample_len)))


### PR DESCRIPTION
FIX #9423 

## Summary
- In issue #9423, the MQA scorer sampled different tokens than the BatchExpansion scorer, even when using the greedy option.
- The model itself produced the same hidden states, but differences in `model_input.sampling_metadata` led to discrepancies.
- The sampling metadata generated by the MQA scorer is not compatible with the operation of [LogitsProcessor](https://github.com/vllm-project/vllm/blob/5f671cb4c3145194e94ffb393ee459432f7fa2b8/vllm/model_executor/layers/logits_processor.py#L78-L80).
- Therefore, this PR aims to make the LogitsProcessor work correctly with the MQA scorer. I updated the LogitsProcessor because handling the sampling metadata from the MQA scorer is not straightforward.

https://github.com/vllm-project/vllm/blob/2079e43beecc486a607c9d79ab691e0e4563aa11/vllm/worker/model_runner.py#L1762-L1763

<model_input.sampling_metadata from MQA Scorer>
```
SamplingMetadata(seq_groups=[

SequenceGroupToSample(seq_ids=[1], sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), seq_data={1: SequenceData(prompt_token_ids=array('l', [1, 3087, 8970, 338, 263]), output_token_ids=(29912, 29871, 29908, 29874, 1115, 29871, 29908, 29874, 1115), cumulative_logprob=0.0, get_num_computed_tokens=10},seq_len=None, query_len=4, generator=None, is_prompt=False, prompt_logprob_indices=[], sample_indices=[0, 1, 2, 3])],

selected_token_indices=tensor([0, 1, 2, 3], device='cuda:0'), categorized_sample_indices={<SamplingType.GREEDY: 0>: tensor([], device='cuda:0', dtype=torch.int32), <SamplingType.RANDOM: 1>: tensor([0, 1, 2, 3], device='cuda:0', dtype=torch.int32), <SamplingType.RANDOM_SEED: 2>: tensor([], device='cuda:0', dtype=torch.int32)})
```

<model_input.sampling_metadata from BatchExpansion Scorer>
```
SamplingMetadata(seq_groups=[

SequenceGroupToSample(seq_ids=[1], sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), seq_data={1: SequenceData(prompt_token_ids=array('l', [1, 3087, 8970, 338, 263]), output_token_ids=(29912, 29871, 29908, 29874, 1115, 29871), cumulative_logprob=0.0, get_num_computed_tokens=10}, seq_len=None, query_len=1, generator=None, is_prompt=False, prompt_logprob_indices=[], sample_indices=[0]), 
SequenceGroupToSample(seq_ids=[2], sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), seq_data={2: SequenceData(prompt_token_ids=array('l', [1, 3087, 8970, 338, 263]), output_token_ids=(29912, 29871, 29908, 29874, 1115, 29871, 29908), cumulative_logprob=0.0, get_num_computed_tokens=11}, seq_len=None, query_len=1, generator=None, is_prompt=False, prompt_logprob_indices=[], sample_indices=[1]), 
SequenceGroupToSample(seq_ids=[3], sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), seq_data={3: SequenceData(prompt_token_ids=array('l', [1, 3087, 8970, 338, 263]), output_token_ids=(29912, 29871, 29908, 29874, 1115, 29871, 29908, 29874), cumulative_logprob=0.0, get_num_computed_tokens=12}, seq_len=None, query_len=1, generator=None, is_prompt=False, prompt_logprob_indices=[], sample_indices=[2]),
SequenceGroupToSample(seq_ids=[4], sampling_params=SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=1.0, top_p=1.0, top_k=1, min_p=0.0, seed=None, stop=[], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=32, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None), seq_data={4: SequenceData(prompt_token_ids=array('l', [1, 3087, 8970, 338, 263]), output_token_ids=(29912, 29871, 29908, 29874, 1115, 29871, 29908, 29874, 1115), cumulative_logprob=0.0, get_num_computed_tokens=13}, seq_len=None, query_len=1, generator=None, is_prompt=False, prompt_logprob_indices=[], sample_indices=[3])], 

selected_token_indices=tensor([0, 1, 2, 3], device='cuda:0'), categorized_sample_indices={<SamplingType.GREEDY: 0>: tensor([], device='cuda:0', dtype=torch.int32), <SamplingType.RANDOM: 1>: tensor([0, 1, 2, 3], device='cuda:0', dtype=torch.int32), <SamplingType.RANDOM_SEED: 2>: tensor([], device='cuda:0', dtype=torch.int32)}), 
```

## Results
### Run Server
```
python -m vllm.entrypoints.openai.api_server \
     --model meta-llama/Llama-2-7b-hf \
     --port 8087 \
     --disable-custom-all-reduce \
     --swap-space 0 \
     --gpu-memory-utilization 0.8 \
     --speculative_model "[ngram]" \
     --ngram_prompt_lookup_max 2 \
     --num_speculative_tokens 3 \
     --guided-decoding-backend "outlines" \
     --enforce-eager \
```

### Request
```
curl http://localhost:8087/v1/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "meta-llama/Llama-2-7b-hf",
        "prompt": "San Francisco is a",
                "max_tokens": 32,
                "top_k": 1,
                "top_p": 1.0,
        "temperature": 1.0,
                "guided_decoding_backend": "outlines",
                "guided_json": {"properties": {"a": {"title": "A", "type": "integer"}}, "required": ["a"], "title": "A", "type": "object"}
    }' | jq
```

### Logits
- as-is
```
tensor([[    -inf,     -inf,   3.6250,  ...,     -inf,     -inf,     -inf],
        [-10.6406, -11.0078,   1.7412,  ...,  -0.7197,  -6.2422,  -2.6250],
        [-11.1641,  -9.0703,   1.0527,  ...,  -4.8320,  -8.4844,  -7.2109],
        [ -9.1719,  -6.3828,   4.4492,  ...,  -3.3496,  -3.8672,  -2.7852]],
       device='cuda:0', dtype=torch.float16)
```

- to-be
```
tensor([[  -inf,   -inf,   -inf,  ...,   -inf,   -inf,   -inf],
        [  -inf,   -inf, 1.7412,  ...,   -inf,   -inf,   -inf],
        [  -inf,   -inf, 1.0527,  ...,   -inf,   -inf,   -inf],
        [  -inf,   -inf, 4.4492,  ...,   -inf,   -inf,   -inf]],
       device='cuda:0', dtype=torch.float16)
```

### Response
- as-is
```
{"a": 1
```
- to-be
```
{ \"a\": 1 }
```