### PR TITLE
[Bugfix] fix vocab size assertion

### DIFF
--- a/vllm/entrypoints/openai/logits_processors.py
+++ b/vllm/entrypoints/openai/logits_processors.py
@@ -30,11 +30,12 @@ class AllowedTokenIdsLogitsProcessor:
 @lru_cache(maxsize=32)
 def _get_allowed_token_ids_logits_processor(
     allowed_token_ids: FrozenSet[int],
-    vocab_size: int,
+    tokenizer: AnyTokenizer,
 ) -> LogitsProcessor:
     if not allowed_token_ids:
         raise ValueError("Empty allowed_token_ids provided")
-    if not all(0 <= tid < vocab_size for tid in allowed_token_ids):
+    token_ids = set(tokenizer.get_vocab().values())
+    if not all(tid in token_ids for tid in allowed_token_ids):
         raise ValueError("allowed_token_ids contains "
                          "out-of-vocab token id")
     return AllowedTokenIdsLogitsProcessor(allowed_token_ids)
@@ -81,6 +82,6 @@ def get_logits_processors(
     if allowed_token_ids is not None:
         logits_processors.append(
             _get_allowed_token_ids_logits_processor(
-                frozenset(allowed_token_ids), len(tokenizer)))
+                frozenset(allowed_token_ids), tokenizer))
 
     return logits_processors


### PR DESCRIPTION
This PR fixes a bug that I encountered when using a modified tokenizer.

**Details**: I have a Huggingface tokenizer (for [Mistral-Nemo-Instruct-2407](https://huggingface.co/mistralai/Mistral-Nemo-Instruct-2407)) that I've modified with the [Tokenizer-Changer](https://github.com/1kkiRen/Tokenizer-Changer) library (i.e. I've removed some of the tokens). When I first tried to run, the assertion gave an error `"allowed_token_ids contains out-of-vocab token id"`. So instead of checking if the `allowed_token_ids` are correct by checking if they satisfy `0 <= tid < vocab_size` I suggest to first get the all token IDs from the tokenizer and then check if each token ID in `allowed_token_ids` is in that set.

This code was tested by running inference with Mistral-Nemo-Instruct-2407.