### PR TITLE
Revert "[Build/CI] Fix libcuda.so linkage"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,9 +446,6 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
 endif()
 
 message(STATUS "Enabling C extension.")
-if(VLLM_GPU_LANG STREQUAL "CUDA")
-  list(APPEND VLLM_C_LIBS cuda)
-endif()
 define_gpu_extension_target(
   _C
   DESTINATION vllm
@@ -457,7 +454,6 @@ define_gpu_extension_target(
   COMPILE_FLAGS ${VLLM_GPU_FLAGS}
   ARCHITECTURES ${VLLM_GPU_ARCHES}
   INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR};${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
-  LIBRARIES ${VLLM_C_LIBS}
   USE_SABI 3
   WITH_SOABI)
 


### PR DESCRIPTION
Looks like vllm-project/vllm#12424 is causing problems for some users that don't have libcuda.so on their LD_LIBRARY_PATH. See https://github.com/vllm-project/vllm/issues/12505.

I believe there are potential linkage issues for `_C.abi3.so`, but I haven't seen any concrete examples of users running into any issues with this so I think it makes sense to revert this for now, and look into following Pytorch's approach (https://github.com/pytorch/pytorch/blob/50f834f13417e4e4b930472c8cf237aa5a60f38e/c10/cuda/driver_api.cpp#L12)