### PR TITLE
[Misc] fix typo: add missing space in lora adapter error message

### DIFF
--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -203,7 +203,7 @@ class OpenAIServingModels:
                for lora_request in self.lora_requests):
             return create_error_response(
                 message=
-                f"The lora adapter '{request.lora_name}' has already been"
+                f"The lora adapter '{request.lora_name}' has already been "
                 "loaded.",
                 err_type="InvalidUserInput",
                 status_code=HTTPStatus.BAD_REQUEST)


### PR DESCRIPTION
This PR fixes a minor typo in the error message for when a LoRA adapter has already been loaded. 
