### PR TITLE
[V1][Log] Add max request concurrency log to V1

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -393,6 +393,10 @@ def _get_kv_cache_config_uniform_type(vllm_config: VllmConfig,
         num_blocks = num_gpu_blocks_override
 
     logger.info("# GPU blocks: %d", num_blocks)
+    max_concurrency = (num_blocks * vllm_config.cache_config.block_size /
+                       vllm_config.model_config.max_model_len)
+    logger.info("Maximum concurrency for %s tokens per request: %.2fx",
+                vllm_config.model_config.max_model_len, max_concurrency)
 
     per_layer_size = page_size * num_blocks
 


### PR DESCRIPTION
Ports over the `Maximum concurrency for XXXX tokens per request: YYx` log from V0

```
VLLM_USE_V1=1 vllm serve neuralmagic/Meta-Llama-3.1-70B-Instruct-quantized.w8a8 --max-model-len 2048 --gpu-memory-utilization 0.98
...
INFO 01-30 03:18:12 gpu_model_runner.py:848] Loading model weights took 67.7229 GB
INFO 01-30 03:18:25 backends.py:577] Using cache directory: /home/mgoin/.cache/vllm/torch_compile_cache/2b70b500a6/rank_0 for vLLM's torch.compile
INFO 01-30 03:18:25 backends.py:585] Dynamo bytecode transform time: 12.88 s
INFO 01-30 03:18:28 backends.py:309] Cache the graph of shape None for later use
INFO 01-30 03:19:07 backends.py:321] Compiling a graph for general shape takes 41.86 s
INFO 01-30 03:19:13 monitor.py:31] torch.compile takes 54.73 s in total
INFO 01-30 03:19:14 kv_cache_utils.py:395] # GPU blocks: 1381
INFO 01-30 03:19:14 kv_cache_utils.py:398] Maximum concurrency for 2048 tokens per request: 10.79x
```