### PR TITLE
[Bugfix] Gracefully handle huggingface hub http error

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -296,7 +296,7 @@ def get_hf_file_to_dict(file_name: str,
                              e)
                 return None
             except HfHubHTTPError as e:
-                logger.debug(
+                logger.warning(
                     "Cannot connect to Hugging Face Hub. Skipping ,"
                     "file download for '%s':",
                     file_name,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -297,8 +297,8 @@ def get_hf_file_to_dict(file_name: str,
                 return None
             except HfHubHTTPError as e:
                 logger.warning(
-                    "Cannot connect to Hugging Face Hub. Skipping ,"
-                    "file download for '%s':",
+                    "Cannot connect to Hugging Face Hub. Skipping file "
+                    "download for '%s':",
                     file_name,
                     exc_info=e)
                 return None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -301,6 +301,7 @@ def get_hf_file_to_dict(file_name: str,
                     "file download for '%s':",
                     file_name,
                     exc_info=e)
+                return None
             file_path = Path(hf_hub_file)
 
         with open(file_path) as file:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, Optional, Type, Union
 import huggingface_hub
 from huggingface_hub import (file_exists, hf_hub_download,
                              try_to_load_from_cache)
-from huggingface_hub.utils import (EntryNotFoundError, LocalEntryNotFoundError,
+from huggingface_hub.utils import (EntryNotFoundError, HfHubHTTPError,
+                                   LocalEntryNotFoundError,
                                    RepositoryNotFoundError,
                                    RevisionNotFoundError)
 from torch import nn
@@ -294,6 +295,12 @@ def get_hf_file_to_dict(file_name: str,
                 logger.debug("File or repository not found in hf_hub_download",
                              e)
                 return None
+            except HfHubHTTPError as e:
+                logger.debug(
+                    "Cannot connect to Hugging Face Hub. Skipping ,"
+                    "file download for '%s':",
+                    file_name,
+                    exc_info=e)
             file_path = Path(hf_hub_file)
 
         with open(file_path) as file:


### PR DESCRIPTION
Currently if huggingface hub is down, users cannot start the engine because of the following code that always checks against the hub if the specified model has a encoder config, even though the users have all the other files available locally.
https://github.com/vllm-project/vllm/blob/f17f1d46086692a2973fad94860a95799fbd8582/vllm/config.py#L299
https://github.com/vllm-project/vllm/blob/f17f1d46086692a2973fad94860a95799fbd8582/vllm/config.py#L417-L419


This PR gracefully handles the http error from huggingface hub and gives warnings if there's indeed connection issue.

IMO a proper fix for this issue should be optionally calling `_get_encoder_config` to check against the hub (though I'm not sure there's a good way to do so) cc @flaviabeo @maxdebayser 