### PR TITLE
[Doc] ROCM instructions for Triton may have wrong instructions

### DIFF
--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -39,9 +39,9 @@ for instructions on how to use this prebuilt docker image.
     ```console
     python3 -m pip install ninja cmake wheel pybind11
     pip uninstall -y triton
-    git clone https://github.com/OpenAI/triton.git
+    git clone git://github.com/ROCm/triton.git
     cd triton
-    git checkout e192dba
+    git checkout triton-mlir
     cd python
     pip3 install .
     cd ../..


### PR DESCRIPTION
I think the ROCM instructions at https://docs.vllm.ai/en/stable/getting_started/installation/gpu/index.html#build-wheel-from-source can't be right -- even though it's talking about the triton-mlir branch it's linking to the openai github repo, and it also doesn't match the instructions at https://github.com/ROCm/triton/tree/triton-mlir?tab=readme-ov-file#install-from-source.

Added to that, it explicitly calls out the `triton-mlir` branch:

> Install ROCm’s Triton flash attention (the default triton-mlir branch) following the instructions from [ROCm/triton](https://github.com/ROCm/triton/blob/triton-mlir/README.md)

If this is intended to be followed as original, can you provide context explaining that the specific git rev and path are important?
