### PR TITLE
[Doc] int4 w4a16 example

### DIFF
--- a/docs/source/features/quantization/index.md
+++ b/docs/source/features/quantization/index.md
@@ -12,6 +12,7 @@ supported_hardware
 auto_awq
 bnb
 gguf
+int4
 int8
 fp8
 quantized_kvcache

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -127,10 +127,10 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
 - Employ the chat template or instruction template that the model was trained with
 - If you've fine-tuned a model, consider using a sample of your training data for calibration
 - Tune key hyperparameters to the quantization algorithm:
-    - `dampening_frac` sets how much influence the GPTQ algorithm has. Lower values can improve accuracy, but can lead to numerical instabilities that cause the algorithm to fail.
-    - `actorder` sets the activation ordering. When compressing the weights of a layer weight, the order in which channels are quantized matters. Setting `actorder="weight"` can improve accuracy without added latency.
+  - `dampening_frac` sets how much influence the GPTQ algorithm has. Lower values can improve accuracy, but can lead to numerical instabilities that cause the algorithm to fail.
+  - `actorder` sets the activation ordering. When compressing the weights of a layer weight, the order in which channels are quantized matters. Setting `actorder="weight"` can improve accuracy without added latency.
 
-An example configuration for the recipe with non-default hyperparameters:
+The following is an example of an expanded quantization recipe you can tune to your own use case:
 
 ```python
 from compressed_tensors.quantization import (
@@ -145,7 +145,7 @@ recipe = GPTQModifier(
         "config_group": QuantizationScheme(
             targets=["Linear"],
             weights=QuantizationArgs(
-                num_bits=NUM_BITS,
+                num_bits=4,
                 type=QuantizationType.INT,
                 strategy=QuantizationStrategy.GROUP,
                 group_size=128,

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -76,11 +76,7 @@ from llmcompressor.modifiers.quantization import GPTQModifier
 from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
 
 # Configure the quantization algorithms
-recipe = [
-    # TODO (Brian/Kyle) SmoothQuant is only meant for W8A8, should this be something else?
-    SmoothQuantModifier(smoothing_strength=0.8),
-    GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"]),
-]
+recipe = GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"])
 
 # Apply quantization
 oneshot(
@@ -130,10 +126,11 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
 - Use a sequence length of 2048 as a starting point
 - Employ the chat template or instruction template that the model was trained with
 - If you've fine-tuned a model, consider using a sample of your training data for calibration
-<!-- TODO (Brian/Kyle) include description of activation ordering and dampening_frac hyperparameters -->
-<!-- TODO (Brian/Kyle) "choosing the correct quantization scheme/ compression technique" -->
-<!-- TODO (Brian/Kyle) include vision or audio calibration datasets as well -->
+- Tune key hyperparameters to the quantization algorithm:
+    - `dampening_frac` sets how much influence the GPTQ algorithm has. Lower values can improve accuracy, but can lead to numerical instabilities that cause the algorithm to fail.
+    - `actorder` sets the activation ordering. When compressing the weights of a layer weight, the order in which channels are quantized matters. Setting `actorder="weight"` can improve accuracy without added latency.
+
 
 ## Troubleshooting and Support
 
-If you encounter any issues or have feature requests, please open an issue on the [`vllm-project/llm-compressor`](https://github.com/vllm-project/llm-compressor) GitHub repository. The full INT4 quantization example is available in `llm-compressor` [here](https://github.com/vllm-project/llm-compressor/blob/main/examples/quantization_w4a16/llama3_example.py).
+If you encounter any issues or have feature requests, please open an issue on the [`vllm-project/llm-compressor`](https://github.com/vllm-project/llm-compressor) GitHub repository. The full INT4 quantization example in `llm-compressor` is available [here](https://github.com/vllm-project/llm-compressor/blob/main/examples/quantization_w4a16/llama3_example.py).

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -2,7 +2,7 @@
 
 # INT4 W4A16
 
-vLLM supports quantizing weights and activations to INT4 for memory savings and inference acceleration. This quantization method is particularly useful for reducing model size and maintaining low latency in workloads with low queries per second (QPS).
+vLLM supports quantizing weights to INT4 for memory savings and inference acceleration. This quantization method is particularly useful for reducing model size and maintaining low latency in workloads with low queries per second (QPS).
 
 Please visit the HF collection of [quantized INT4 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int4-llms-for-vllm-668ec34bf3c9fa45f857df2c).
 
@@ -43,7 +43,7 @@ tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
 
 ### 2. Preparing Calibration Data
 
-When quantizing activations to INT8, you need sample data to estimate the activation scales.
+When quantizing weights to INT4, you need sample data to estimate the weight updates and calibrated scales.
 It's best to use calibration data that closely matches your deployment data.
 For a general-purpose instruction-tuned model, you can use a dataset like `ultrachat`:
 
@@ -93,7 +93,7 @@ model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)
 ```
 
-This process creates a W4A16 model with weights and activations quantized to 4-bit integers.
+This process creates a W4A16 model with weights quantized to 4-bit integers.
 
 ### 4. Evaluating Accuracy
 

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -133,6 +133,12 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
 An example configuration for the recipe with non-default hyperparameters:
 
 ```python
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+    QuantizationType,
+) 
 recipe = GPTQModifier(
     targets="Linear",
     config_groups={

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -1,19 +1,19 @@
-(int8)=
+(int4)=
 
-# INT8 W8A8
+# INT4 W4A16
 
-vLLM supports quantizing weights and activations to INT8 for memory savings and inference acceleration.
-This quantization method is particularly useful for reducing model size while maintaining good performance.
+vLLM supports quantizing weights and activations to INT4 for memory savings and inference acceleration.
+<!-- #TODO (Brian/Kyle) This quantization method is particularly useful for reducing model size while maintaining good performance. -->
 
-Please visit the HF collection of [quantized INT8 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int8-llms-for-vllm-668ec32c049dca0369816415).
+Please visit the HF collection of [quantized INT4 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int4-llms-for-vllm-668ec34bf3c9fa45f857df2c).
 
 :::{note}
-INT8 computation is supported on NVIDIA GPUs with compute capability > 7.5 (Turing, Ampere, Ada Lovelace, Hopper).
+INT4 computation is supported on NVIDIA GPUs with compute capability > 8.0 (Ampere, Ada Lovelace, Hopper).
 :::
 
 ## Prerequisites
 
-To use INT8 quantization with vLLM, you'll need to install the [llm-compressor](https://github.com/vllm-project/llm-compressor/) library:
+To use INT4 quantization with vLLM, you'll need to install the [llm-compressor](https://github.com/vllm-project/llm-compressor/) library:
 
 ```console
 pip install llmcompressor
@@ -78,8 +78,9 @@ from llmcompressor.modifiers.smoothquant import SmoothQuantModifier
 
 # Configure the quantization algorithms
 recipe = [
+    # TODO (Brian/Kyle) SmoothQuant is only meant for W8A8, should this be something else?
     SmoothQuantModifier(smoothing_strength=0.8),
-    GPTQModifier(targets="Linear", scheme="W8A8", ignore=["lm_head"]),
+    GPTQModifier(targets="Linear", scheme="W4A16", ignore=["lm_head"]),
 ]
 
 # Apply quantization
@@ -92,12 +93,12 @@ oneshot(
 )
 
 # Save the compressed model
-SAVE_DIR = MODEL_ID.split("/")[1] + "-W8A8-Dynamic-Per-Token"
+SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16-Dynamic-Per-Token"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)
 ```
 
-This process creates a W8A8 model with weights and activations quantized to 8-bit integers.
+This process creates a W4A16 model with weights and activations quantized to 4-bit integers.
 
 ### 4. Evaluating Accuracy
 
@@ -105,14 +106,14 @@ After quantization, you can load and run the model in vLLM:
 
 ```python
 from vllm import LLM
-model = LLM("./Meta-Llama-3-8B-Instruct-W8A8-Dynamic-Per-Token")
+model = LLM("./Meta-Llama-3-8B-Instruct-W4A16-Dynamic-Per-Token")
 ```
 
 To evaluate accuracy, you can use `lm_eval`:
 
 ```console
 $ lm_eval --model vllm \
-  --model_args pretrained="./Meta-Llama-3-8B-Instruct-W8A8-Dynamic-Per-Token",add_bos_token=true \
+  --model_args pretrained="./Meta-Llama-3-8B-Instruct-W4A16-Dynamic-Per-Token",add_bos_token=true \
   --tasks gsm8k \
   --num_fewshot 5 \
   --limit 250 \
@@ -125,10 +126,12 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
 
 ## Best Practices
 
+<!-- #TODO (Brian/Kyle)
+
 - Start with 512 samples for calibration data (increase if accuracy drops)
 - Use a sequence length of 2048 as a starting point
 - Employ the chat template or instruction template that the model was trained with
-- If you've fine-tuned a model, consider using a sample of your training data for calibration
+- If you've fine-tuned a model, consider using a sample of your training data for calibration -->
 
 ## Troubleshooting and Support
 

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -7,7 +7,7 @@ vLLM supports quantizing weights and activations to INT4 for memory savings and 
 Please visit the HF collection of [quantized INT4 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int4-llms-for-vllm-668ec34bf3c9fa45f857df2c).
 
 :::{note}
-INT4 computation is supported on NVIDIA GPUs with compute capability > 8.0 (Ampere, Ada Lovelace, Hopper).
+INT4 computation is supported on NVIDIA GPUs with compute capability > 8.0 (Ampere, Ada Lovelace, Hopper, Blackwell).
 :::
 
 ## Prerequisites

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -2,8 +2,7 @@
 
 # INT4 W4A16
 
-vLLM supports quantizing weights and activations to INT4 for memory savings and inference acceleration.
-<!-- #TODO (Brian/Kyle) This quantization method is particularly useful for reducing model size while maintaining good performance. -->
+vLLM supports quantizing weights and activations to INT4 for memory savings and inference acceleration. This quantization method is particularly useful for reducing model size and maintaining low latency in workloads with low queries per second (QPS).
 
 Please visit the HF collection of [quantized INT4 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int4-llms-for-vllm-668ec34bf3c9fa45f857df2c).
 
@@ -93,7 +92,7 @@ oneshot(
 )
 
 # Save the compressed model
-SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16-Dynamic-Per-Token"
+SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16-G128"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)
 ```
@@ -106,14 +105,14 @@ After quantization, you can load and run the model in vLLM:
 
 ```python
 from vllm import LLM
-model = LLM("./Meta-Llama-3-8B-Instruct-W4A16-Dynamic-Per-Token")
+model = LLM("./Meta-Llama-3-8B-Instruct-W4A16-G128")
 ```
 
 To evaluate accuracy, you can use `lm_eval`:
 
 ```console
 $ lm_eval --model vllm \
-  --model_args pretrained="./Meta-Llama-3-8B-Instruct-W4A16-Dynamic-Per-Token",add_bos_token=true \
+  --model_args pretrained="./Meta-Llama-3-8B-Instruct-W4A16-G128",add_bos_token=true \
   --tasks gsm8k \
   --num_fewshot 5 \
   --limit 250 \
@@ -126,13 +125,15 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
 
 ## Best Practices
 
-<!-- #TODO (Brian/Kyle)
-
-- Start with 512 samples for calibration data (increase if accuracy drops)
+- Start with 512 samples for calibration data, and increase if accuracy drops
+- Ensure the calibration data contains a high variety of samples to prevent overfitting towards a specific use case
 - Use a sequence length of 2048 as a starting point
 - Employ the chat template or instruction template that the model was trained with
-- If you've fine-tuned a model, consider using a sample of your training data for calibration -->
+- If you've fine-tuned a model, consider using a sample of your training data for calibration
+<!-- TODO (Brian/Kyle) include description of activation ordering and dampening_frac hyperparameters -->
+<!-- TODO (Brian/Kyle) "choosing the correct quantization scheme/ compression technique" -->
+<!-- TODO (Brian/Kyle) include vision or audio calibration datasets as well -->
 
 ## Troubleshooting and Support
 
-If you encounter any issues or have feature requests, please open an issue on the [`vllm-project/llm-compressor`](https://github.com/vllm-project/llm-compressor) GitHub repository.
+If you encounter any issues or have feature requests, please open an issue on the [`vllm-project/llm-compressor`](https://github.com/vllm-project/llm-compressor) GitHub repository. The full INT4 quantization example is available in `llm-compressor` [here](https://github.com/vllm-project/llm-compressor/blob/main/examples/quantization_w4a16/llama3_example.py).

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -130,6 +130,30 @@ Quantized models can be sensitive to the presence of the `bos` token. Make sure 
     - `dampening_frac` sets how much influence the GPTQ algorithm has. Lower values can improve accuracy, but can lead to numerical instabilities that cause the algorithm to fail.
     - `actorder` sets the activation ordering. When compressing the weights of a layer weight, the order in which channels are quantized matters. Setting `actorder="weight"` can improve accuracy without added latency.
 
+An example configuration for the recipe with non-default hyperparameters:
+
+```python
+recipe = GPTQModifier(
+    targets="Linear",
+    config_groups={
+        "config_group": QuantizationScheme(
+            targets=["Linear"],
+            weights=QuantizationArgs(
+                num_bits=NUM_BITS,
+                type=QuantizationType.INT,
+                strategy=QuantizationStrategy.GROUP,
+                group_size=128,
+                symmetric=True,
+                dynamic=False,
+                actorder="weight",
+            ),
+        ),
+    },
+    ignore=["lm_head"],
+    update_size=NUM_CALIBRATION_SAMPLES,
+    dampening_frac=0.01
+)
+```
 
 ## Troubleshooting and Support
 

--- a/docs/source/features/quantization/int8.md
+++ b/docs/source/features/quantization/int8.md
@@ -8,7 +8,7 @@ This quantization method is particularly useful for reducing model size while ma
 Please visit the HF collection of [quantized INT8 checkpoints of popular LLMs ready to use with vLLM](https://huggingface.co/collections/neuralmagic/int8-llms-for-vllm-668ec32c049dca0369816415).
 
 :::{note}
-INT8 computation is supported on NVIDIA GPUs with compute capability > 7.5 (Turing, Ampere, Ada Lovelace, Hopper).
+INT8 computation is supported on NVIDIA GPUs with compute capability > 7.5 (Turing, Ampere, Ada Lovelace, Hopper, Blackwell).
 :::
 
 ## Prerequisites


### PR DESCRIPTION
Based on a request by @mgoin , with @kylesayrs we have added an example doc for int4 w4a16 quantization, following the pre-existing int8 w8a8 quantization example and the example available in [`llm-compressor`](https://github.com/vllm-project/llm-compressor/blob/main/examples/quantization_w4a16/llama3_example.py)

FIX #n/a (no issue created)

@kylesayrs and I have discussed a couple additional improvements for the quantization docs. We will revisit at a later date, possibly including:
- A section for "choosing the correct quantization scheme/ compression technique"
- Additional vision or audio calibration datasets

