### PR TITLE
[V1] Bugfix: Validate Model Input Length

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -206,6 +206,11 @@ class Processor:
         if prompt_ids is None or len(prompt_ids) == 0:
             raise ValueError("Prompt cannot be empty")
 
+        if len(prompt_ids) >= self.model_config.max_model_len:
+            raise ValueError(
+                f"Prompt length of {len(prompt_ids)} is longer than the "
+                f"maximum model length of {self.model_config.max_model_len}.")
+
         if self.model_config.is_multimodal_model:
             max_prompt_len = self.model_config.max_model_len
 


### PR DESCRIPTION
SUMMARY:
* avoid crashing the engine when we get an input longer than max_model_len

FIX #12567(*link existing issues this PR will resolve*)

