### PR TITLE
[Bugfix] Fix quark fp8 format loading on AMD GPUs

### DIFF
--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -10,6 +10,8 @@ from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
     QuarkLinearMethod, QuarkW8A8Fp8, QuarkW8A8Int8)
 from vllm.platforms import current_platform
 
+import torch
+
 
 @pytest.fixture(scope="function", autouse=True)
 def use_v0_only(monkeypatch):
@@ -63,3 +65,28 @@ def test_quark_int8_w_per_tensor_a_per_tensor(vllm_runner, tp):
 
         output = llm.generate_greedy("Hello my name is", max_tokens=20)
         assert output
+
+
+def test_quark_fp8_parity(vllm_runner):
+    quark_model_id = "amd-quark/llama-tiny-fp8-quark-quant-method"
+    fp8_model_id = "amd-quark/llama-tiny-fp8-quant-method"
+
+    llm_kwargs = {
+        "tensor_parallel_size": 1,
+        "enforce_eager": True,
+        "gpu_memory_utilization": 0.1
+    }
+    with (vllm_runner(quark_model_id, **llm_kwargs) as
+          quark_handle, vllm_runner(fp8_model_id, **llm_kwargs) as fp8_handle):
+        quark_model = (quark_handle.model.llm_engine.model_executor.
+                       driver_worker.model_runner.model)
+        quark_state_dict = quark_model.state_dict()
+
+        fp8_model = (fp8_handle.model.llm_engine.model_executor.driver_worker.
+                     model_runner.model)
+        fp8_state_dict = fp8_model.state_dict()
+
+    assert fp8_state_dict.keys() == quark_state_dict.keys()
+
+    for key in fp8_state_dict:
+        assert torch.equal(fp8_state_dict[key], quark_state_dict[key])

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -5,12 +5,11 @@ Run `pytest tests/quantization/test_quark.py`.
 """
 
 import pytest
+import torch
 
 from vllm.model_executor.layers.quantization.quark.quark import (  # noqa: E501
     QuarkLinearMethod, QuarkW8A8Fp8, QuarkW8A8Int8)
 from vllm.platforms import current_platform
-
-import torch
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -41,7 +41,8 @@ class QuarkW8A8Fp8(QuarkScheme):
                     weight_scale=layer.weight_scale,
                     input_scale=input_scale)
                 if input_scale is not None:
-                    layer.input_scale = Parameter(input_scale, requires_grad=False)
+                    layer.input_scale = Parameter(input_scale,
+                                                  requires_grad=False)
             else:
                 max_w_scale = layer.weight_scale
                 weight = layer.weight

--- a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py
@@ -34,24 +34,26 @@ class QuarkW8A8Fp8(QuarkScheme):
         # tensor scales (thus N scales being passed to the kernel),
         # requantize so we can always run per tensor
         if self.qscheme == "per_tensor":
+            if current_platform.is_rocm():
+                weight, max_w_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
+                    weight=layer.weight,
+                    weight_scale=layer.weight_scale,
+                    input_scale=layer.input_scale)
+            else:
+                max_w_scale = layer.weight_scale
+                weight = layer.weight
+                input_scale = layer.input_scale
+
             max_w_scale, weight = requantize_with_max_scale(
-                weight=layer.weight,
-                weight_scale=layer.weight_scale,
+                weight=weight,
+                weight_scale=max_w_scale,
                 logical_widths=layer.logical_widths,
             )
 
-            if current_platform.is_fp8_fnuz():
-                input_scale = getattr(layer, 'input_scale', None)
-                weight, max_w_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
-                    weight=weight,
-                    weight_scale=max_w_scale,
-                    input_scale=input_scale)
-                if input_scale is not None:
-                    layer.input_scale = Parameter(input_scale,
-                                                  requires_grad=False)
-
             layer.weight = Parameter(weight.t(), requires_grad=False)
             layer.weight_scale = Parameter(max_w_scale, requires_grad=False)
+            if input_scale is not None:
+                layer.input_scale = Parameter(input_scale, requires_grad=False)
 
         # If channelwise, scales are already lined up, so just transpose.
         elif self.qscheme == "per_channel":


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/10765 was merged into vllm to support Quark quantized models. Unfortunately, tests are somewhat limited and the issue fixed in this PR was not catched by the tests. Namely, if you compare

https://github.com/vllm-project/vllm/blob/7a8987dac5f0ed0c798a73e8b4ec8f5e640bc63a/vllm/model_executor/layers/quantization/fp8.py#L303-L317
and
https://github.com/vllm-project/vllm/blob/7a8987dac5f0ed0c798a73e8b4ec8f5e640bc63a/vllm/model_executor/layers/quantization/quark/schemes/quark_w8a8_fp8.py#L34-L51

We see that the call order of `normalize_e4m3fn_to_e4m3fnuz` and `requantize_with_max_scale` is swapped for quark. This eventually loads in weights being different in case a checkpoint uses `"quant_method": "quark"` and is loaded in vllm.

We might want to add more tests or extend https://github.com/vllm-project/vllm/blob/main/tests/quantization/test_quark.py in this PR or in a later PR.