### PR TITLE
[Bugfix] Fix cpu image tagging

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -66,7 +66,7 @@ steps:
       queue: cpu_queue_postmerge
     commands:
       - "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/q9t5s3a7"
-      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$RELEASE_VERSION --progress plain -f Dockerfile.cpu ."
-      - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$RELEASE_VERSION"
+      - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --tag public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_COMMIT --progress plain -f Dockerfile.cpu ."
+      - "docker push public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:$BUILDKITE_COMMIT"
     env:
       DOCKER_BUILDKIT: "1"


### PR DESCRIPTION
Related to https://github.com/vllm-project/vllm/pull/11261

I see that for 0.7.0 the cpu image release failed: https://buildkite.com/vllm/release/builds/2787#0194a650-3f4b-489e-bb99-f04c46c06147

It looks like the `$RELEASE_VERSION` variable is empty or unset, and the other image release jobs use `$BUILDKITE_COMMIT` for the tag instead. This just changes the cpu job to match the other image pushes.

FIX (None)

