### PR TITLE
[Core] Silence unnecessary deprecation warnings

### DIFF
--- a/vllm/lora/request.py
+++ b/vllm/lora/request.py
@@ -31,7 +31,7 @@ class LoRARequest(
     base_model_name: Optional[str] = msgspec.field(default=None)
 
     def __post_init__(self):
-        if 'lora_local_path' in self.__struct_fields__:
+        if self.lora_local_path:
             warnings.warn(
                 "The 'lora_local_path' attribute is deprecated "
                 "and will be removed in a future version. "


### PR DESCRIPTION
I noticed during testing that I was getting a lot of these deprecation
warnings about `local_lora_path`:

```
DeprecationWarning: The 'lora_local_path' attribute is deprecated
     and will be removed in a future version.
     Please use 'lora_path' instead.
```

The check used for emitting this warning was always True, even when the
parameter was not actually specified. It will always be in
`__struct_fields__`. We should be checking for a non-None value,
instead.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
