### PR TITLE
[CI] Fix flaky CI test 

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -488,9 +488,7 @@ steps:
   - pytest models/encoder_decoder/language/test_bart.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/encoder_decoder/vision_language/test_broadcast.py -v -s -m 'distributed(num_gpus=2)'
   - pytest models/decoder_only/vision_language/test_models.py -v -s -m 'distributed(num_gpus=2)'
-  # this test fails consistently.
-  # TODO: investigate and fix
-  # - pytest -v -s spec_decode/e2e/test_integration_dist_tp2.py
+  - pytest -v -s spec_decode/e2e/test_integration_dist_tp2.py
   - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s test_sharded_state_loader.py
   - CUDA_VISIBLE_DEVICES=0,1 pytest -v -s kv_transfer/disagg_test.py
 

--- a/tests/spec_decode/e2e/test_integration_dist_tp2.py
+++ b/tests/spec_decode/e2e/test_integration_dist_tp2.py
@@ -78,7 +78,7 @@ def test_target_model_tp_gt_1(common_llm_kwargs, per_test_common_llm_kwargs,
 
         # precision
         "--dtype",
-        "bfloat16",
+        "float16",
     ]])
 @pytest.mark.parametrize("per_test_common_llm_kwargs", [[]])
 @pytest.mark.parametrize("baseline_llm_kwargs", [[]])


### PR DESCRIPTION
There's a test suite that's currently disabled https://github.com/vllm-project/vllm/pull/12240 due to a flaky test, in which the output tokens end up being slightly different wrt the baseline (here's the test https://github.com/vllm-project/vllm/blob/main/tests/spec_decode/e2e/test_integration_dist_tp2.py#L104).
Issue is only reproducible with tp>1.

Due to it being a slight change of phrasing in the output sentence, I suspect it might be a numerical issue (as also noted in the original PR that introduced it https://github.com/vllm-project/vllm/pull/6050#issuecomment-2203352390). Tests are now passing both with fp32 and fp16 accuracy, but I'll be on the lookout in case it errors out again.
 
 