### PR TITLE
[Build] update requirements of no-device for plugin usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -554,7 +554,7 @@ def get_requirements() -> List[str]:
         return resolved_requirements
 
     if _no_device():
-        requirements = _read_requirements("requirements-cpu.txt")
+        requirements = _read_requirements("requirements-common.txt")
     elif _is_cuda():
         requirements = _read_requirements("requirements-cuda.txt")
         cuda_major, cuda_minor = torch.version.cuda.split(".")


### PR DESCRIPTION
For a lot of backend devices, the requirements consists of `requirements-common.txt` + some other python packages. Therefore, when installing a plugin we first want to install vllm with `requirements-common.txt` in a first step, and then install `requirements-{plugin}.txt` through the plugin. 

When doing this, `VLLM_TARGET_DEVICE` cannot be directly set as the name of the target device (e.g. "spyre" would raise an "Unknown runtime environment" error), therefore setting `VLLM_TARGET_DEVICE` as `empty` is the best solution so far, but it downloads some unnecessary packages unrelated to the target device.

Note: another possibility could be to add "oot" as additional accepted value for `VLLM_TARGET_DEVICE`, which would install `requirements-common.txt` only.

@MengqingCao tagging you because you are the last one that modified that line.
cc @youkaichao 

