### PR TITLE
Fix device return is bytecode instead of str

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1289,7 +1289,7 @@ class EngineArgs:
         # context.
         # Use different default values for different hardware.
         from vllm.platforms import current_platform
-        device_name = current_platform.get_device_name().lower()
+        device_name = str(current_platform.get_device_name().lower())
         if "h100" in device_name or "h200" in device_name:
             # For H100 and H200, we use larger default values.
             default_max_num_batched_tokens = {


### PR DESCRIPTION


 File "/host/vllm/vllm/engine/arg_utils.py", line 1293, in _override_v1_engine_args
    if "h100" in device_name or "h200" in device_name:
TypeError: a bytes-like object is required, not 'str'

