### PR TITLE
Disable chunked prefill and/or prefix caching when MLA is enabled

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3225,6 +3225,15 @@ class VllmConfig:
 
         current_platform.check_and_update_config(self)
 
+        # Disable chunked prefill and prefix caching when MLA is enabled.
+        if self.model_config.use_mla:
+            if self.scheduler_config.enable_chunked_prefill:
+                logger.warning("MLA is enabled; disabling chunked prefill.")
+                self.scheduler_config.enable_chunked_prefill = False
+            if self.cache_config.enable_prefix_caching:
+                logger.warning("MLA is enabled; disabling prefix caching.")
+                self.cache_config.enable_prefix_caching = False
+
         if not self.instance_id:
             self.instance_id = random_uuid()[:5]
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3225,13 +3225,14 @@ class VllmConfig:
 
         current_platform.check_and_update_config(self)
 
-        # Disable chunked prefill and prefix caching when MLA is enabled.
+        # If MLA is enabled, force disable chunked prefill and prefix caching
         if self.model_config.use_mla:
-            if self.scheduler_config.enable_chunked_prefill:
-                logger.warning("MLA is enabled; disabling chunked prefill.")
-                self.scheduler_config.enable_chunked_prefill = False
-            if self.cache_config.enable_prefix_caching:
-                logger.warning("MLA is enabled; disabling prefix caching.")
+            logger.info("MLA is enabled; forcing chunked prefill and prefix "
+                        "caching to be disabled.")
+            self.scheduler_config.enable_chunked_prefill = False
+            self.scheduler_config.chunked_prefill_enabled = False
+
+            if self.cache_config is not None:
                 self.cache_config.enable_prefix_caching = False
 
         if not self.instance_id:


### PR DESCRIPTION
Requires https://github.com/vllm-project/vllm/pull/12601 to land first

```
lm_eval --model vllm --model_args pretrained=deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct,enable_chunked_prefill=True,enable_prefix_caching=True --trust_remote_code --tasks gsm8k --num_fewshot 5 --batch_size auto
...
INFO 02-01 03:51:32 config.py:1537] Chunked prefill is enabled with max_num_batched_tokens=2048.
INFO 02-01 04:11:04 config.py:3230] MLA is enabled; forcing chunked prefill and prefix caching to be disabled.
INFO 02-01 04:11:04 llm_engine.py:232] Initializing a V0 LLM engine (v0.7.1.dev100+g7ac6f525d) with config: model='deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=163840, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar'), observability_config=ObservabilityConfig(otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=1234, served_model_name=deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=False, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=False, 
...
INFO 02-01 03:51:34 cuda.py:166] Using Triton MLA backend.
...
vllm (pretrained=deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct,enable_chunked_prefill=True,enable_prefix_caching=True,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: 5, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.7635|±  |0.0117|
|     |       |strict-match    |     5|exact_match|↑  |0.7453|±  |0.0120|
```
