### PR TITLE
Fix broken cmake on AMD platform

### DIFF
--- a/cmake/hipify.py
+++ b/cmake/hipify.py
@@ -1,6 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
-
 #!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
 
 #
 # A command line tool for running pytorch's hipify preprocessor on CUDA


### PR DESCRIPTION
The commit https://github.com/vllm-project/vllm/commit/e489ad7a210f4234db696d1f2749d5f3662fa65b breaks hipify.py causes error when build on AMD platform. This PR will fix that issue.