### PR TITLE
[ci] Fix AMD build error

### DIFF
--- a/cmake/hipify.py
+++ b/cmake/hipify.py
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
-
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 #
 # A command line tool for running pytorch's hipify preprocessor on CUDA


### PR DESCRIPTION
#12628 added license header which overrides the shebang line in `hipify.py`, thus Python syntax is [no longer recognized by the AMD build machine](https://buildkite.com/vllm/ci/builds/12803#0194ca59-0c19-4e56-9f3d-cbc01572503a/55-2840): https://github.com/russellb/vllm/blob/850f4e566c3a8fd56002f8568b320deeabdd8bf0/cmake/hipify.py#L3 