### PR TITLE
[Misc] Fix improper placement of SPDX header in scripts

### DIFF
--- a/cmake/hipify.py
+++ b/cmake/hipify.py
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
-
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
 
 #
 # A command line tool for running pytorch's hipify preprocessor on CUDA

--- a/tests/models/test_transformers.py
+++ b/tests/models/test_transformers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Test the functionality of the Transformers backend.
 
 Run `pytest tests/models/test_transformers.py`.

--- a/tools/check_spdx_header.py
+++ b/tools/check_spdx_header.py
@@ -10,18 +10,25 @@ def check_spdx_header(file_path):
     with open(file_path, encoding='UTF-8') as file:
         lines = file.readlines()
         if not lines:
-            # not necessary for an empty file like __init__.py
+            # Empty file like __init__.py
             return True
-        if not lines[0].strip().startswith(SPDX_HEADER_PREFIX):
-            return False
-    return True
+        for line in lines:
+            if line.strip().startswith(SPDX_HEADER_PREFIX):
+                return True
+    return False
 
 
 def add_header(file_path):
     with open(file_path, 'r+', encoding='UTF-8') as file:
         lines = file.readlines()
         file.seek(0, 0)
-        file.write(SPDX_HEADER + '\n\n' + ''.join(lines))
+        if lines and lines[0].startswith("#!"):
+            file.write(lines[0])
+            file.write(SPDX_HEADER + '\n')
+            file.writelines(lines[1:])
+        else:
+            file.write(SPDX_HEADER + '\n')
+            file.writelines(lines)
 
 
 def main():

--- a/tools/report_build_time_ninja.py
+++ b/tools/report_build_time_ninja.py
@@ -1,6 +1,6 @@
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 
-#!/usr/bin/env python3
 # Copyright (c) 2018 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -1,6 +1,5 @@
-# SPDX-License-Identifier: Apache-2.0
-
 #!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
 """
 Fused Attention
 ===============

--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # Copyright 2024 The vLLM team.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
When a file starts with '#!', the SPDX header needs to go after that.

When looking for the SPDX header, find it on any line, not just the
first.

Finally, don't add an extra newline when injecting the header into a
file.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
