### PR TITLE
Squelch MLA warning for Compressed-Tensors Models

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -986,6 +986,9 @@ class ModelConfig:
 
     @property
     def use_mla(self) -> bool:
+        if not self.is_deepseek_mla or envs.VLLM_MLA_DISABLE:
+            return False
+
         if self.quantization is not None and self.quantization not in [\
             "fp8", "compressed-tensors"]:
             logger.warning(
@@ -1012,8 +1015,7 @@ class ModelConfig:
                         quant_config)
                     return False
 
-        use_mla = (self.is_deepseek_mla and not envs.VLLM_MLA_DISABLE)
-        return use_mla
+        return True
 
     @property
     def supported_runner_types(self) -> Set[RunnerType]:


### PR DESCRIPTION
## Purpose ##
* Squelch MLA warning when loading compressed-tensors models

```
WARNING 02-03 14:14:32 config.py:1007] compressed-tensors MLA support requires fp8 activations and weights in group 'group
_0', but got activations type 'None' and weights type 'int'.
WARNING 02-03 14:14:32 config.py:1007]  Full config: {'config_groups': {'group_0': {'input_activations': None, 'output_act
ivations': None, 'targets': ['Linear'], 'weights': {'actorder': None, 'block_structure': None, 'dynamic': False, 'group_si
ze': 128, 'num_bits': 4, 'observer': 'mse', 'observer_kwargs': {}, 'strategy': 'group', 'symmetric': True, 'type': 'int'}}
}, 'format': 'marlin-24', 'global_compression_ratio': 1.8917232374233346, 'ignore': ['lm_head'], 'kv_cache_scheme': None, 
'quant_method': 'compressed-tensors', 'quantization_status': 'compressed', 'sparsity_config': {'format': 'dense', 'global_
sparsity': 0.4561021413812781, 'ignore': ['lm_head'], 'registry_requires_subclass': False, 'sparsity_structure': '2:4', 't
argets': ['Linear']}}
```

## Changes ##
* Use demorgans to invert final condition and place at the beginning to act as a guard before warnings

## Testing ##
```python3
from vllm import llm
llm = LLM("neuralmagic/Sparse-Llama-3.1-8B-ultrachat_200k-2of4-quantized.w4a16")
```