### PR TITLE
[Quant] Fix use_mla TypeError and support loading pure-sparsity Compressed Tensors configs

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1000,8 +1000,9 @@ class ModelConfig:
         # have fp8 for both weights and activations.
         if self.quantization == "compressed-tensors":
             quant_config = self._parse_quant_hf_config()
-            for group_name, cfg in quant_config.get("config_groups",
-                                                    ("", {})).items():
+            for group_name, cfg in quant_config.get("config_groups", {
+                    "": {}
+            }).items():
                 act_cfg = cfg.get("input_activations", {})
                 act_type = None if act_cfg is None else act_cfg.get("type", "")
                 w_cfg = cfg.get("weights", {})

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -989,7 +989,8 @@ class ModelConfig:
         if not self.is_deepseek_mla or envs.VLLM_MLA_DISABLE:
             return False
 
-        if self.quantization not in ("fp8", "compressed-tensors"):
+        if self.quantization is not None and self.quantization not in [\
+            "fp8", "compressed-tensors"]:
             logger.warning(
                 "MLA is not supported with %s quantization. "
                 "Disabling MLA.", self.quantization)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -989,8 +989,7 @@ class ModelConfig:
         if not self.is_deepseek_mla or envs.VLLM_MLA_DISABLE:
             return False
 
-        if self.quantization is not None and self.quantization not in [\
-            "fp8", "compressed-tensors"]:
+        if self.quantization not in ("fp8", "compressed-tensors"):
             logger.warning(
                 "MLA is not supported with %s quantization. "
                 "Disabling MLA.", self.quantization)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -424,6 +424,11 @@ class CompressedTensorsConfig(QuantizationConfig):
                                          or input_quant is not None,
                                          weight_quant=weight_quant,
                                          input_quant=input_quant)
+        elif weight_quant is None:
+            logger.warning_once("Acceleration for non-quantized schemes is "
+                                "not supported by Compressed Tensors. "
+                                "Falling back to UnquantizedLinearMethod")
+            return None
         else:
             # Find the quant_scheme
             scheme = self._get_scheme_from_parts(  # type: ignore


### PR DESCRIPTION
## Purpose ##
* Fix type error in `use_mla` which was causing models with quantization and without `config_groups` to fail
* Support loading models which do not have `config_groups` in the compressed tensors config. While these models aren't accelerated, they can still be generated from valid recipes in LLM Compressor and are useful for testing.

## Changes ##
* Fix type error in `use_mla`
* Add warning and return no scheme if the model is attempted to load without quantization

## Testing ##
* Tested `nm-testing/Qwen2-VL-2B-Instruct-Sparse-0.6`
  * Confirmed that MLA is indeed disabled in the fallback case
```
WARNING 02-03 16:37:36 config.py:1008] compressed-tensors MLA support requires fp8 activations and weights in group 'group_0', but got activations type 'None' and weights type 'int'.
```
* Tested `neuralmagic/Sparse-Llama-3.1-8B-ultrachat_200k-2of4-quantized.w4a16`