### PR TITLE
[ROCM][AMD][TRITON] Halving warps number for fw_prefill to reduce spilling

### DIFF
--- a/vllm/attention/ops/prefix_prefill.py
+++ b/vllm/attention/ops/prefix_prefill.py
@@ -11,7 +11,7 @@ from vllm.platforms import current_platform
 
 # Static kernels parameters
 BASE_BLOCK = 128 if current_platform.has_device_capability(80) else 64
-NUM_WARPS = 8
+NUM_WARPS = 4 if current_platform.is_rocm() else 8
 
 # To check compatibility
 IS_TURING = current_platform.get_device_capability() == (7, 5)


### PR DESCRIPTION
in general this gives 2-3x perf gain over default and about 1.5x slower than H100

for model run llama3.1 70B fp16

HIP_VISIBLE_DEVICES=1 python /root/workspace/vllm/benchmarks/profiling/benchmark_throughput.py --model /data/models/Llama-3.1-70B-Instruct --input-len 1024 --output-len 1024 --num-prompts 256 --max-model-len 32768 --disable-log-stats --enable-chunked-prefill

8 warps
Throughput: 0.65 requests/s, 1327.15 total tokens/s, 663.57 output tokens/s
Throughput: 0.64 requests/s, 1318.79 total tokens/s, 659.40 output tokens/s
Throughput: 0.65 requests/s, 1323.83 total tokens/s, 661.91 output tokens/s


4 warps
Throughput: 0.68 requests/s, 1396.40 total tokens/s, 698.20 output tokens/s
Throughput: 0.68 requests/s, 1394.23 total tokens/s, 697.12 output tokens/s
Throughput: 0.68 requests/s, 1393.89 total tokens/s, 696.94 output tokens/s

kernel time reduced from 5% to 3% of total execution time
