### PR TITLE
Avoid unnecessary multi-modal input data copy when len(batch) == 1

### DIFF
--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -211,6 +211,8 @@ class MultiModalBatchedField(BaseMultiModalField):
 
     def _reduce_data(self, batch: list[NestedTensors]) -> NestedTensors:
         if len(batch) > 0 and is_list_of(batch, torch.Tensor, check="all"):
+            if len(batch) == 1:
+                return batch[0].unsqueeze(0).contiguous()
             first_shape = batch[0].shape
             if all(elem.shape == first_shape for elem in batch):
                 return torch.stack(batch)
@@ -234,6 +236,8 @@ class MultiModalFlatField(BaseMultiModalField):
 
     def _reduce_data(self, batch: list[NestedTensors]) -> NestedTensors:
         if len(batch) > 0 and is_list_of(batch, torch.Tensor, check="all"):
+            if len(batch) == 1:
+                return batch[0].contiguous()
             first_shape = batch[0].shape
             if all(elem.shape[1:] == first_shape[1:] for elem in batch):
                 return torch.concat(batch)
@@ -396,6 +400,9 @@ class MultiModalKwargs(UserDict[str, NestedTensors]):
             return stacked
 
         tensors_ = cast(list[torch.Tensor], stacked)
+        if len(tensors_) == 1:
+            return tensors_[0].unsqueeze(0).contiguous()
+
         if any(t.shape != tensors_[0].shape for t in tensors_):
             # The tensors have incompatible shapes and can't be stacked.
             return tensors_


### PR DESCRIPTION
A len=1 multi-modal data batch (`List[torch.Tensor]`) can avoid a copy operation by creating view of original tensor data if possible.

- if `len(batch) == 1` then
  - `torch.stack(batch)` -> `batch[0].unsqueeze(0).contiguous()`
  - `torch.concat(batch)` -> `batch[0].contiguous()`
- NOTE: ensure contiguous to achieve consistent behaviour

Example code:

```python
import torch

src_tensor = torch.rand((2, 3, 4))
batch = [src_tensor]

assert len(batch) == 1
# only works when batch size = 1

copied_batched_tensor = torch.stack(batch)
print(src_tensor.storage().data_ptr() == copied_batched_tensor.storage().data_ptr())
# False

no_copy_batched_tensor = src_tensor.unsqueeze(0).contiguous()
print(src_tensor.storage().data_ptr() == no_copy_batched_tensor.storage().data_ptr())
# True

print(torch.equal(copied_batched_tensor, no_copy_batched_tensor))
# True
```