### PR TITLE
[Build] Do not add cmake/ninja dependencies when they are installed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 # Should be mirrored in requirements/build.txt
+# Please do not add cmake or ninja here, they are handled in setup.py
 requires = [
-    "cmake>=3.26.1",
-    "ninja",
     "packaging>=24.2",
     "setuptools>=77.0.3,<81.0.0",
     "setuptools-scm>=8.0",

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,10 @@ def is_freethreaded():
     return bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
 
 
+def is_cmake_available() -> bool:
+    return which("cmake") is not None
+
+
 class CMakeExtension(Extension):
     def __init__(self, name: str, cmake_lists_dir: str = ".", **kwa) -> None:
         super().__init__(name, sources=[], py_limited_api=not is_freethreaded(), **kwa)
@@ -788,11 +792,18 @@ else:
         else cmake_build_ext
     }
 
+setup_requires = []
+if not is_cmake_available():
+    setup_requires += ["cmake>=3.26.1"]
+if not is_ninja_available():
+    setup_requires += ["ninja"]
+
 setup(
     # static metadata should rather go in pyproject.toml
     version=get_vllm_version(),
     ext_modules=ext_modules,
     install_requires=get_requirements(),
+    setup_requires=setup_requires,
     extras_require={
         "bench": ["pandas", "matplotlib", "seaborn", "datasets"],
         "tensorizer": ["tensorizer==2.10.1"],


### PR DESCRIPTION
Add the build dependencies on `cmake` and `ninja` only if the relevant tools are not found installed.  This avoids unnecessary dependencies, and ensures that system tools are preferred over the PyPI builds.  This improves portability, as CMake frequently carries downstream patches.