### PR TITLE
[build][misc] allow to use recent numpy

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,6 +1,6 @@
 psutil
 sentencepiece  # Required for LLaMA tokenizer.
-numpy < 2.0.0
+numpy
 requests >= 2.26.0
 tqdm
 blake3

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -36,6 +36,7 @@ buildkite-test-collector==0.1.9
 genai_perf==0.0.8
 tritonclient==2.51.0
 
-numpy < 2.0.0
+numpy
 runai-model-streamer==0.11.0
 runai-model-streamer-s3==0.11.0
+


### PR DESCRIPTION
This patch removed the limitation on `numpy < 2.0.0 `
outlines already did a workaround for running with recent numpy
https://github.com/dottxt-ai/outlines/pull/1265

Fixes https://github.com/vllm-project/vllm/issues/6570
