### PR TITLE
Use `RMSNorm` in `TransformersModel`

### DIFF
--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -87,9 +87,10 @@ def replace_rms_norm_class(rms_norm: nn.Module) -> RMSNorm:
     parameters = dict(rms_norm.named_parameters())
     if len(parameters) != 1:
         class_name = rms_norm.__class__.__name__
-        raise ValueError(
-            f"Expected {class_name} to have exactly one parameter, "
-            f"but got: {parameters}.")
+        logger.warning(
+            "Unable to determine `hidden_size` of %s. "
+            "This layer will not benefit from vLLM's custom ops.", class_name)
+        return rms_norm
     hidden_size = next(iter(parameters.values())).numel()
 
     # Get eps
@@ -98,9 +99,10 @@ def replace_rms_norm_class(rms_norm: nn.Module) -> RMSNorm:
     attrs = {k: v for k, v in attrs.items() if isinstance(v, float)}
     if len(attrs) != 1:
         class_name = rms_norm.__class__.__name__
-        raise ValueError(
-            f"Expected {class_name} to have exactly one float attribute, "
-            f"but got: {attrs}.")
+        logger.warning(
+            "Unable to determine `eps` of %s. "
+            "This layer will not benefit from vLLM's custom ops.", class_name)
+        return rms_norm
     eps = next(iter(attrs.values()))
 
     return RMSNorm(

--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -95,8 +95,8 @@ def replace_rms_norm_class(rms_norm: nn.Module) -> RMSNorm:
 
     # Get eps
     attrs = vars(rms_norm)
-    attrs = {k: v for k, v in attrs.items() if not k.startswith("_")}
-    attrs = {k: v for k, v in attrs.items() if isinstance(v, float)}
+    condition = lambda k, v: not k.startswith("_") and isinstance(v, float)
+    attrs = {k: v for k, v in attrs.items() if condition(k, v)}
     if len(attrs) != 1:
         class_name = rms_norm.__class__.__name__
         logger.warning(


### PR DESCRIPTION
Changes:
- Improve performance by using vLLM's `RMSNorm` class in `TransformersModel`
- Improve user experience by warning instead of raising when `Linear` layer cannot be tensor parallelised

Before and after benchmarks using the following command:
```console
python benchmarks/benchmark_throughput.py \
  --backend vllm \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --dataset ShareGPT_V3_unfiltered_cleaned_split.json \
  --model-impl transformers # forces TransformersModel
```
Results:
|             | Result |
|--------|--------|
| `LlamaForCausalLM` | 13.07 requests/s, 5403.27 total tokens/s, 2591.54 output tokens/s |
| `TransformersModel` before | 11.78 requests/s, 4872.95 total tokens/s, 2337.18 output tokens/s |
| `TransformersModel` after | 12.11 requests/s, 5009.63 total tokens/s, 2402.73 output tokens/s |

This corresponds to a +2.8% performance boost for this model.