### PR TITLE
[Docs] Drop duplicate [source] links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,6 @@ author = 'the vLLM Team'
 # ones.
 extensions = [
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
     "sphinx.ext.linkcode",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",


### PR DESCRIPTION
A prior change, #10672, added new `[source]` links for github. The old
links were left in place to ensure that that new github links were
working well before we removed them.

The github links seem to be working well, so we can now remove the
links to custom HTML pages of source code.

To do this, we just drop the `sphinx.ext.viewcode` extension. We will
now rely only on `sphinx.ext.linkcode`, which uses code in `conf.py`
to generate source code links.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
