### PR TITLE
[Bugfix] Update chat_utils.py to avoid issues when tool call is present but None

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -887,7 +887,7 @@ def _parse_chat_message_content(
         if role == 'assistant':
             parsed_msg = _AssistantParser(message)
 
-            if "tool_calls" in parsed_msg:
+            if "tool_calls" in parsed_msg and parsed_msg["tool_calls"] is not None:
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
         elif role == "tool":
             parsed_msg = _ToolParser(message)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -887,7 +887,8 @@ def _parse_chat_message_content(
         if role == 'assistant':
             parsed_msg = _AssistantParser(message)
 
-            if "tool_calls" in parsed_msg and parsed_msg["tool_calls"] is not None:
+            if ("tool_calls" in parsed_msg
+                    and parsed_msg["tool_calls"] is not None):
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
         elif role == "tool":
             parsed_msg = _ToolParser(message)


### PR DESCRIPTION
Using LiteLLM to call VLLM models can sometimes result in assistant messages having a `tool_calls` element that is `None`. This causes an internal server error on the VLLM server due to `list(None)` being invalid as `None` is not an iterable.
