### PR TITLE
[misc] Reduce number of config file requests to HuggingFace

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Type, Union
 
 import huggingface_hub
 from huggingface_hub import (file_exists, hf_hub_download,
-                             try_to_load_from_cache)
+                             try_to_load_from_cache, list_repo_files)
 from huggingface_hub.utils import (EntryNotFoundError, HfHubHTTPError,
                                    LocalEntryNotFoundError,
                                    RepositoryNotFoundError,
@@ -395,18 +395,24 @@ def get_sentence_transformer_tokenizer_config(model: str,
     - dict: A dictionary containing the configuration parameters 
     for the Sentence Transformer BERT model.
     """
-    for config_name in [
-            "sentence_bert_config.json",
-            "sentence_roberta_config.json",
-            "sentence_distilbert_config.json",
-            "sentence_camembert_config.json",
-            "sentence_albert_config.json",
-            "sentence_xlm-roberta_config.json",
-            "sentence_xlnet_config.json",
-    ]:
-        encoder_dict = get_hf_file_to_dict(config_name, model, revision)
-        if encoder_dict:
-            break
+    sentence_transformer_config_files = [
+        "sentence_bert_config.json",
+        "sentence_roberta_config.json",
+        "sentence_distilbert_config.json",
+        "sentence_camembert_config.json",
+        "sentence_albert_config.json",
+        "sentence_xlm-roberta_config.json",
+        "sentence_xlnet_config.json",
+    ]
+    repo_files = list_repo_files(model, revision=revision, token=HF_TOKEN)
+    if not any(config_name in repo_files for config_name in sentence_transformer_config_files):
+        return None
+
+    for config_name in sentence_transformer_config_files:
+        if config_name in repo_files:
+            encoder_dict = get_hf_file_to_dict(config_name, model, revision)
+            if encoder_dict:
+                break
 
     if not encoder_dict:
         return None

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -405,8 +405,6 @@ def get_sentence_transformer_tokenizer_config(model: str,
         "sentence_xlnet_config.json",
     ]
     repo_files = list_repo_files(model, revision=revision, token=HF_TOKEN)
-    if not any(config_name in repo_files for config_name in sentence_transformer_config_files):
-        return None
 
     for config_name in sentence_transformer_config_files:
         if config_name in repo_files:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -404,11 +404,16 @@ def get_sentence_transformer_tokenizer_config(model: str,
         "sentence_xlm-roberta_config.json",
         "sentence_xlnet_config.json",
     ]
-    repo_files = list_repo_files(model, revision=revision, token=HF_TOKEN)
+    try:
+        # If model is on HuggingfaceHub, get the repo files
+        repo_files = list_repo_files(model, revision=revision, token=HF_TOKEN)
+    except Exception as e:
+        logger.debug("Error getting repo files", e)
+        repo_files = []
 
     encoder_dict = None
     for config_name in sentence_transformer_config_files:
-        if config_name in repo_files:
+        if config_name in repo_files or Path(model).exists():
             encoder_dict = get_hf_file_to_dict(config_name, model, revision)
             if encoder_dict:
                 break

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Type, Union
 
 import huggingface_hub
-from huggingface_hub import (file_exists, hf_hub_download,
-                             try_to_load_from_cache, list_repo_files)
+from huggingface_hub import (file_exists, hf_hub_download, list_repo_files,
+                             try_to_load_from_cache)
 from huggingface_hub.utils import (EntryNotFoundError, HfHubHTTPError,
                                    LocalEntryNotFoundError,
                                    RepositoryNotFoundError,
@@ -406,6 +406,7 @@ def get_sentence_transformer_tokenizer_config(model: str,
     ]
     repo_files = list_repo_files(model, revision=revision, token=HF_TOKEN)
 
+    encoder_dict = None
     for config_name in sentence_transformer_config_files:
         if config_name in repo_files:
             encoder_dict = get_hf_file_to_dict(config_name, model, revision)


### PR DESCRIPTION
Every time `_get_encoder_config` is called, `get_sentence_transformer_tokenizer_config` also gets called and that triggers 7 different calls to HF to check whether any sentence transformer config file exists in the repo. This is more calls than needed and sometimes lead to timeout/connection issue in CI. This PR is a temporary fix to list files in the repo and use it once instead of checking each file. There should be another fix to only call this if the model is a `sentence-transformers` one.