### PR TITLE
Implement chunked prefill for Triton MLA attention backend

### DIFF
--- a/vllm/attention/backends/mla/utils.py
+++ b/vllm/attention/backends/mla/utils.py
@@ -442,10 +442,6 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         is_decode = attn_metadata.decode_metadata is not None
         is_prefill = attn_metadata.prefill_metadata is not None
 
-        if (is_decode and is_prefill):
-            raise NotImplementedError(
-                "chunked prefill is not supported for MLAImplBase")
-
         # Restore head dim (for rotary embedding)
         k_pe = k_pe.unsqueeze(1)
         assert hasattr(attn_metadata, "input_positions")
@@ -479,7 +475,8 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
             )
 
         if attn_metadata.prefill_metadata is not None:
-            return self._forward_prefill(q, k_c_normed, k_pe, attn_metadata)
+            return self._forward_prefill(q, k_c_normed, k_pe, kv_cache,
+                                         attn_metadata)
 
         if attn_metadata.decode_metadata is not None:
             return self._forward_decode(q_nope, q_pe, kv_cache, attn_metadata)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3264,16 +3264,6 @@ class VllmConfig:
 
         current_platform.check_and_update_config(self)
 
-        # If MLA is enabled, force disable chunked prefill and prefix caching
-        if self.model_config and self.model_config.use_mla:
-            logger.info("MLA is enabled; forcing chunked prefill and prefix "
-                        "caching to be disabled.")
-            self.scheduler_config.enable_chunked_prefill = False
-            self.scheduler_config.chunked_prefill_enabled = False
-
-            if self.cache_config is not None:
-                self.cache_config.enable_prefix_caching = False
-
         if not self.instance_id:
             self.instance_id = random_uuid()[:5]
 


### PR DESCRIPTION
Finishes the rest of @LucasWilkinson's PR #12639

Implement chunked prefill for Triton MLA backend (DeepSeek v2/v3)

I have been testing with DeepSeek-Coder-v2-Lite-Instruct, both short and long-context responses seem correct.

My prompt is:
`{"model": "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct", "max_tokens": 100, "seed": 6, "messages": [{"role": "user", "content": "Yes or no, will the following code compile:\n\n.... some long python script ..."}`

I think I fixed the issue with one block not being copied.