### PR TITLE
[Bugfix] [Core] Fix zero temperature case (#5404 and part of #5898)

### DIFF
--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -275,12 +275,13 @@ class Sampler(nn.Module):
         # Positive temperature path.
         # Need to adjust denominator to avoid division by zero causing problems.
         # Any zero temperature entries are multiplied by False (0).
-        # This effectively means denominator adjustment never messes with things.
+        # This means denominator adjustment never messes with things.
         logits_p = (~is_zero) * logits / (temperature + is_zero)
 
         # Zero temperature path.
-        # Any positive temperature entries are multipled by False (0).
-        logits_z = is_zero * 1e9 * (logits == logits.max(dim=1, keepdim=True)[0])
+        # Any positive temperature entries are multiplied by False (0).
+        logits_z = is_zero * 1e9 * (logits == logits.max(dim=1,
+                                                         keepdim=True)[0])
 
         # Final logits is sum of both cases.
         # Always one of them is zero since mutually exclusive.

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -266,10 +266,25 @@ class Sampler(nn.Module):
                                      sampling_tensors.frequency_penalties,
                                      sampling_tensors.repetition_penalties)
 
-        # Use float32 to apply temperature scaling.
-        # Use in-place division to avoid creating a new tensor.
+        # Apply temperature scaling, special handling for zero-temperature case.
+        # Use float32 to apply temperature scaling in all cases.
         logits = logits.to(torch.float)
-        logits.div_(sampling_tensors.temperatures.unsqueeze(dim=1))
+        temperature = sampling_tensors.temperatures.unsqueeze(dim=1)
+        is_zero = (temperature == 0)
+
+        # Positive temperature path.
+        # Need to adjust denominator to avoid division by zero causing problems.
+        # Any zero temperature entries are multiplied by False (0).
+        # This effectively means denominator adjustment never messes with things.
+        logits_p = (~is_zero) * logits / (temperature + is_zero)
+
+        # Zero temperature path.
+        # Any positive temperature entries are multipled by False (0).
+        logits_z = is_zero * 1e9 * (logits == logits.max(dim=1, keepdim=True)[0])
+
+        # Final logits is sum of both cases.
+        # Always one of them is zero since mutually exclusive.
+        logits = logits_p + logits_z
 
         if do_top_p_top_k and flashinfer_top_k_top_p_sampling is None:
             logits = _apply_top_k_top_p(logits, sampling_tensors.top_ps,

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -417,11 +417,6 @@ class SamplingTensors:
             # k should not be greater than the vocab size.
             top_k = min(sampling_params.top_k, vocab_size)
             top_k = vocab_size if top_k == -1 else top_k
-            if temperature < _SAMPLING_EPS:
-                # NOTE: Zero temperature means deterministic sampling
-                # (i.e., greedy sampling or beam search).
-                # Set the temperature to 1 to avoid division by zero.
-                temperature = 1.0
             if not do_top_p_top_k and (top_p < 1.0 - _SAMPLING_EPS
                                        or top_k != vocab_size):
                 do_top_p_top_k = True


### PR DESCRIPTION
Fixes nondeterminism from the sampler that occurs even at zero temperature. The patch supports both zero and nonzero temperatures for different entries in the same batch, using the correct operation in each case. It does this by multiplying by an is-zero indicator for the zero temperature calculation and is-nonzero indicator for positive temperature case. These two are then summed. For any entry, only one term in the sum is nonzero as the two cases are mutually exclusive.

I created this patch and discussed it in https://github.com/vllm-project/vllm/issues/5404#issuecomment-2628860618. I used this patch internally and it greatly reduced variation in answers at zero temperature (remaining nondeterminism I think is due to CUDA nondeterminacy in the steps leading up to calculation of the logits).

Please feel free to make any improvements to this patch you can think of.

FIX #5404 (patch discussed there).

FIX #5898 (part from sampler, nondeterminism from the computation of the logits themselves not covered here).