### PR TITLE
[Misc] Improve error message for incorrect pynvml

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -41,7 +41,11 @@ def cuda_platform_plugin() -> Optional[str]:
                 is_cuda = True
         finally:
             pynvml.nvmlShutdown()
-    except Exception:
+    except Exception as e:
+        if "nvml" not in e.__class__.__name__.lower():
+            # If the error is not related to NVML, re-raise it.
+            raise e
+
         # CUDA is supported on Jetson, but NVML may not be.
         import os
 


### PR DESCRIPTION
after https://github.com/vllm-project/vllm/pull/12679 , incorrect `pynvml` will lead to runtime error. right now this error will be suppressed. we need to let it speak out so that users know what's happening, otherwise they will get a confusing error saying that `No platform detected, vLLM is running on UnspecifiedPlatform`.