### PR TITLE
[Bugfix] Fix unsupported FA version check for Turing GPU

### DIFF
--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -612,5 +612,5 @@ try:
         return fa_version
 
     VLLM_FLASH_ATTN_VERSION = flash_attn_version()
-except ImportError:
+except (ImportError, AssertionError):
     VLLM_FLASH_ATTN_VERSION = None


### PR DESCRIPTION
#12807 broke xformers fallback because `AssertionError` from `assert is_fa_version_supported(fa_version)` is not included in the exception:
https://github.com/vllm-project/vllm/blob/c786e757fae4519256e4ef88a7d4f56c3339d14d/vllm/attention/backends/utils.py#L611-L616
```
ERROR 02-06 12:53:27 utils.py:608] Cannot use FA version 2 is not supported due to FA3 is only supported on devices with compute capability >= 8 excluding 8.6 and 8.9
Traceback (most recent call last):
  File "/kaggle/working/vllm/examples/offline_inference/basic.py", line 16, in <module>
    llm = LLM(model="facebook/opt-125m")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ...

  File "/kaggle/working/vllm/vllm/worker/worker.py", line 29, in <module>
    from vllm.worker.enc_dec_model_runner import EncoderDecoderModelRunner
  File "/kaggle/working/vllm/vllm/worker/enc_dec_model_runner.py", line 12, in <module>
    from vllm.attention.backends.utils import PAD_SLOT_ID
  File "/kaggle/working/vllm/vllm/attention/backends/utils.py", line 614, in <module>
    VLLM_FLASH_ATTN_VERSION = flash_attn_version()
                              ^^^^^^^^^^^^^^^^^^^^
  File "/kaggle/working/vllm/vllm/attention/backends/utils.py", line 611, in flash_attn_version
    assert is_fa_version_supported(fa_version)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

cc @LucasWilkinson 

