### PR TITLE
[CI/Build] add python-json-logger to requirements-common

### DIFF
--- a/examples/other/logging_configuration.md
+++ b/examples/other/logging_configuration.md
@@ -49,7 +49,8 @@ disabled, an error will occur while starting vLLM.
 ### Example 1: Customize vLLM root logger
 
 For this example, we will customize the vLLM root logger to use
-[`python-json-logger`](https://github.com/madzak/python-json-logger) to log to
+[`python-json-logger`](https://github.com/nhairs/python-json-logger)
+(which is part of the container image) to log to
 STDOUT of the console in JSON format with a log level of `INFO`.
 
 To begin, first, create an appropriate JSON logging configuration file:
@@ -80,12 +81,6 @@ To begin, first, create an appropriate JSON logging configuration file:
   },
   "version": 1
 }
-```
-
-Next, install the `python-json-logger` package if it's not already installed:
-
-```bash
-pip install python-json-logger
 ```
 
 Finally, run vLLM with the `VLLM_LOGGING_CONFIG_PATH` environment variable set

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -38,3 +38,4 @@ compressed-tensors == 0.9.2 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files
+python-json-logger # Used by logging as per examples/other/logging_configuration.md


### PR DESCRIPTION
* the maintainer of python-json-logger changed, updated the URL
* adding python-json-logger to requirements-common.txt
  * simplifies usage of examples/other/logging_configuration.md
  * no extra build step for people to use logging
  * wheel file is just 14.9 kB so no big impact on container size

⚒️ with ❤️ by @siemens