### PR TITLE
[misc] Revert # 12833

### DIFF
--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -260,6 +260,9 @@ class InputPreprocessor:
         mm_processor = self.mm_registry.create_processor(
             self.model_config, tokenizer)
 
+        if isinstance(prompt, list):
+            prompt = tokenizer.decode(prompt)
+
         if mm_processor_kwargs is None:
             mm_processor_kwargs = {}
 


### PR DESCRIPTION
Entrypoints test started failing because the number of tokens mismatched after https://github.com/vllm-project/vllm/pull/12833 was merged: https://github.com/vllm-project/vllm/pull/12833#issuecomment-2641299260. This is to revert it to unblock CI.