### PR TITLE
[Bugfix] Fix multi-round chat error when mistral tokenizer is used

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -291,6 +291,16 @@ class MistralTokenizer:
 
         from mistral_common.protocol.instruct.request import (
             ChatCompletionRequest)
+
+        # mistral-common requires AssistantMessage content to be string [1].
+        #
+        # [1]: https://github.com/mistralai/mistral-common/blob/f4a06998b75ed78bbf5aaf569590b772ea26c9f6/src/mistral_common/protocol/instruct/messages.py#L80
+        for message in messages:
+            if message.get("role") == "assistant":
+                content = message.get("content")
+                if isinstance(content, list):
+                    content = "\n".join(chunk.get("text") for chunk in content)
+                    message["content"] = content
         request = ChatCompletionRequest(messages=messages,
                                         tools=tools)  # type: ignore[type-var]
         encoded = self.mistral.encode_chat_completion(request)


### PR DESCRIPTION
mistral-common [requires](https://github.com/mistralai/mistral-common/blob/f4a06998b75ed78bbf5aaf569590b772ea26c9f6/src/mistral_common/protocol/instruct/messages.py#L80) AssistantMessage content to be string, which is [different](https://github.com/openai/openai-python/blob/7193688e364bd726594fe369032e813ced1bdfe2/src/openai/types/chat/chat_completion_assistant_message_param.py#L46) from OpenAI.

As a result, valid OpenAI multi-round chat messages can trigger error like the following when mistral tokenizer is used:

```
2025-02-06 15:21:19.903	INFO:     10.92.12.39:57034 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     For further information visit https://errors.pydantic.dev/2.10/v/string_type
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   Input should be a valid string [type=string_type, input_value=[{'text': "Sure, here are...face!", 'type': 'text'}], input_type=list]
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193] messages.1.assistant.content
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193] pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatCompletionRequest
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   File "/usr/local/lib/python3.12/dist-packages/pydantic/main.py", line 214, in __init__
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     request = ChatCompletionRequest(messages=messages,
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   File "/usr/local/lib/python3.12/dist-packages/vllm/transformers_utils/tokenizers/mistral.py", line 294, in apply_chat_template
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     return tokenizer.apply_chat_template(
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/chat_utils.py", line 1004, in apply_mistral_chat_template
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     request_prompt = apply_mistral_chat_template(
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_engine.py", line 405, in _preprocess_chat
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]     ) = await self._preprocess_chat(
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_chat.py", line 177, in create_chat_completion
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193] Traceback (most recent call last):
2025-02-06 15:21:19.902	ERROR 02-06 15:21:19 serving_chat.py:193] Error in preprocessing prompt inputs
```

This PR fixes the the issue by converting list of message chunks into a single string. Tested with mistralai/Pixtral-12B-2409.

