### PR TITLE
[Core][Frontend] Fix : Adding Control Vector Support

### DIFF
--- a/tests/control_vectors/test_control_vector.py
+++ b/tests/control_vectors/test_control_vector.py
@@ -1,28 +1,96 @@
 # SPDX-License-Identifier: Apache-2.0
-from vllm import EngineArgs, LLMEngine, SamplingParams
+import pytest
+
+from vllm import LLM, EngineArgs, LLMEngine, SamplingParams
 from vllm.control_vectors.request import ControlVectorRequest
 
-MODEL_PATH = "mistralai/Mistral-7B-v0.1"
-cv_path = "raywanb/mistral-cv-example/mistral-7b-v0.1-control-vector.gguf"
+MODEL_PATH = "Qwen/Qwen2.5-1.5B-Instruct"
+cv_path_happy = "yuu-biz/qwen-cv-example/happy_vector_qwen.gguf"
+cv_path_spanish = "yuu-biz/qwen-cv-example/english_spanish_vector_qwen.gguf"
 
 
-def do_sample(engine):
+@pytest.fixture
+def requests():
+    prompt_text = "Write a story about a dog:"  # noqa: E501
 
-    prompt_text = "Finish the sentence. Life is good because:"  # noqa: E501
+    return [
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("spanish", 1, cv_path_spanish, 2.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("spanish", 2, cv_path_spanish, 1.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            None,
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("spanish", 3, cv_path_spanish, -1.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("spanish", 4, cv_path_spanish, -2.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("happy", 5, cv_path_happy, 2.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("happy", 6, cv_path_happy, 1.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            None,
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("happy", 7, cv_path_happy, -1.0),
+        ),
+        (
+            prompt_text,
+            SamplingParams(temperature=0.0,
+                           max_tokens=100,
+                           stop=["[/assistant]"]),
+            ControlVectorRequest("happy", 8, cv_path_happy, -2.0),
+        ),
+    ]
 
-    # first prompt with a control vector and second without.
-    prompts = [(prompt_text,
-                SamplingParams(temperature=0.0,
-                               max_tokens=100,
-                               stop=["[/assistant]"]),
-                ControlVectorRequest("chaotic", 1, cv_path, 1.0)),
-               (prompt_text,
-                SamplingParams(temperature=0.0,
-                               max_tokens=100,
-                               stop=["[/assistant]"]), None)]
 
+def do_sample(engine, prompts):
     request_id = 0
     results = set()
+    list_results = []
     while prompts or engine.has_unfinished_requests():
         if prompts:
             prompt, sampling_params, cv_request = prompts.pop(0)
@@ -37,11 +105,53 @@ def do_sample(engine):
         for request_output in request_outputs:
             if request_output.finished:
                 results.add(request_output.outputs[0].text)
-    return results
+    list_results = [{
+        "request_id": request_output.request_id,
+        "generation": request_output.outputs[0].text,
+    } for request_output in request_outputs]
+    return results, list_results
 
 
-def test_cv_adapter():
-    engine_args = EngineArgs(model=MODEL_PATH, enable_control_vector=True)
+def test_cv_adapter(requests):
+    engine_args = EngineArgs(
+        model=MODEL_PATH,
+        enable_control_vector=True,
+        max_control_vectors=10,
+        max_num_seqs=20,
+        gpu_memory_utilization=0.4,
+    )
     engine = LLMEngine.from_engine_args(engine_args)
-    result = do_sample(engine)
-    assert len(result) == 2
+    result, list_result = do_sample(engine, requests)
+    assert len(result) == 9
+
+
+def test_offline_inferance(requests):
+    llm = LLM(
+        model=MODEL_PATH,
+        enable_control_vector=True,
+        max_control_vectors=10,
+        max_num_seqs=20,
+        gpu_memory_utilization=0.4,
+    )
+
+    results = []
+    for request in requests:
+        prompt, sampling_param, cv_request = request
+        result = llm.generate(prompt,
+                              sampling_param,
+                              control_vector_request=cv_request)
+        results.append({
+            "prompt":
+            prompt,
+            "generation":
+            result[0].outputs[0].text,
+            "cv_name":
+            cv_request.control_vector_name if cv_request else None,
+            "scale":
+            cv_request.scale_factor if cv_request else None
+        })
+    assert len(results) == 10
+
+
+if __name__ == "__main__":
+    test_cv_adapter(requests())

--- a/tests/control_vectors/test_control_vector.py
+++ b/tests/control_vectors/test_control_vector.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+from vllm import EngineArgs, LLMEngine, SamplingParams
+from vllm.control_vectors.request import ControlVectorRequest
+
+MODEL_PATH = "mistralai/Mistral-7B-v0.1"
+cv_path = "raywanb/mistral-cv-example/mistral-7b-v0.1-control-vector.gguf"
+
+
+def do_sample(engine):
+
+    prompt_text = "Finish the sentence. Life is good because:"  # noqa: E501
+
+    # first prompt with a control vector and second without.
+    prompts = [(prompt_text,
+                SamplingParams(temperature=0.0,
+                               max_tokens=100,
+                               stop=["[/assistant]"]),
+                ControlVectorRequest("chaotic", 1, cv_path, 1.0)),
+               (prompt_text,
+                SamplingParams(temperature=0.0,
+                               max_tokens=100,
+                               stop=["[/assistant]"]), None)]
+
+    request_id = 0
+    results = set()
+    while prompts or engine.has_unfinished_requests():
+        if prompts:
+            prompt, sampling_params, cv_request = prompts.pop(0)
+            engine.add_request(str(request_id),
+                               prompt,
+                               sampling_params,
+                               control_vector_request=cv_request)
+            request_id += 1
+
+        request_outputs = engine.step()
+
+        for request_output in request_outputs:
+            if request_output.finished:
+                results.add(request_output.outputs[0].text)
+    return results
+
+
+def test_cv_adapter():
+    engine_args = EngineArgs(model=MODEL_PATH, enable_control_vector=True)
+    engine = LLMEngine.from_engine_args(engine_args)
+    result = do_sample(engine)
+    assert len(result) == 2

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2506,6 +2506,17 @@ class PromptAdapterConfig:
 
 
 @dataclass
+class ControlVectorConfig:
+    max_control_vectors: int
+    adapter_dtype: Optional[torch.dtype] = torch.float16
+    normalize: bool = False
+
+    def __post_init__(self):
+        if self.max_control_vectors < 1:
+            raise ValueError("max_control_vectors must be >= 1")
+
+
+@dataclass
 class MultiModalConfig:
     """Controls the behavior of multimodal models."""
 
@@ -3392,6 +3403,7 @@ class VllmConfig:
     decoding_config: Optional[DecodingConfig] = None
     observability_config: Optional[ObservabilityConfig] = None
     prompt_adapter_config: Optional[PromptAdapterConfig] = None
+    control_vector_config: Optional[ControlVectorConfig] = None
     quant_config: Optional[QuantizationConfig] = None
     compilation_config: CompilationConfig = field(default=None,
                                                   init=True)  # type: ignore

--- a/vllm/control_vectors/layers.py
+++ b/vllm/control_vectors/layers.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+@dataclass
+class ControlVectorMapping:
+    layer_mapping: dict[int, torch.Tensor]
+
+
+class BaseLayerWithControlVector(nn.Module):
+    pass
+
+
+class MLPWithControlVector(BaseLayerWithControlVector):
+
+    def __init__(self, base_layer) -> None:
+        super().__init__()
+        self.base_layer = base_layer
+        self.normalize = True
+        self.control_vectors = {}
+        self.active_vector: torch.Tensor = None
+
+    def set_normalization(self, normalize: bool) -> None:
+        self.normalize = normalize
+
+    def set_layer_id(self, layer_id: int) -> None:
+        """assign the layer id of this MLP layer"""
+        self.layer_id = layer_id
+
+    def set_control_vector(self, index: int, cv_vector: torch.Tensor):
+        """Set a control vector at a specific index."""
+        self.control_vectors[index] = cv_vector
+
+    def get_control_vector(self, index: int) -> Optional[torch.Tensor]:
+        """Get a control vector by index."""
+        return self.control_vectors.get(index)
+
+    def reset_control_vector(self, index: int):
+        """Reset a control vector to zero at a specific index."""
+        if index in self.control_vectors:
+            self.control_vectors[index] = 0
+
+    def set_active_tensor(self, index: int):
+        """Sets the active vector"""
+        if index is not None and index in self.control_vectors:
+            self.active_vector = self.control_vectors[index]
+        else:
+            self.active_vector = None
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Forward pass with optional application of control vectors."""
+        hidden_states = self.base_layer(hidden_states)
+
+        norm_pre = torch.norm(hidden_states, dim=-1, keepdim=True)
+
+        cv = self.active_vector
+
+        if cv is not None and cv.numel() > 0:
+            hidden_states += cv
+
+            if self.normalize:
+                norm_post = torch.norm(hidden_states, dim=-1, keepdim=True)
+                hidden_states = hidden_states * norm_pre / norm_post
+
+        return hidden_states

--- a/vllm/control_vectors/layers.py
+++ b/vllm/control_vectors/layers.py
@@ -21,8 +21,8 @@ class MLPWithControlVector(BaseLayerWithControlVector):
         super().__init__()
         self.base_layer = base_layer
         self.normalize = True
-        self.control_vectors = {}
-        self.active_vector: torch.Tensor = None
+        self.control_vectors: dict[int, torch.Tensor | int] = {}
+        self.active_vector: Optional[torch.Tensor] = None
 
     def set_normalization(self, normalize: bool) -> None:
         self.normalize = normalize

--- a/vllm/control_vectors/models.py
+++ b/vllm/control_vectors/models.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import gguf
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from torch import nn
+
+from vllm.adapter_commons.models import (AdapterLRUCache, AdapterModel,
+                                         AdapterModelManager)
+from vllm.adapter_commons.utils import (add_adapter, deactivate_adapter,
+                                        get_adapter, list_adapters,
+                                        remove_adapter, set_adapter_mapping)
+from vllm.config import ControlVectorConfig
+from vllm.control_vectors.layers import (ControlVectorMapping,
+                                         MLPWithControlVector)
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_CONTROL_VECTOR_ID = 0
+
+
+def get_control_vector_id():
+    global _GLOBAL_CONTROL_VECTOR_ID
+    _GLOBAL_CONTROL_VECTOR_ID += 1
+    return _GLOBAL_CONTROL_VECTOR_ID
+
+
+_all_cv_classes = {"mlp": MLPWithControlVector}
+
+
+def parse_number_from_string(s: str) -> int:
+    parts = s.split('.')
+    for part in parts:
+        if part.isdigit():
+            return int(part)
+    return None
+
+
+def load_control_vector_file(file_path, revision="main"):
+    try:
+        if Path(file_path).exists():
+            return str(Path(file_path).resolve())
+        parts = file_path.split("/")
+        repo_id = "/".join(parts[:2])
+        file_name = "/".join(parts[2:])
+
+        return hf_hub_download(repo_id=repo_id,
+                               filename=file_name,
+                               revision=revision)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"File not found: {file_path}") from e
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred: {e}") from e
+
+
+class ControlVectorModel(AdapterModel):
+
+    def __init__(self,
+                 control_vector_id=None,
+                 control_vector_weights=None,
+                 scale_factor=1.0) -> None:
+        self.id = control_vector_id
+        self.control_vector_weights = control_vector_weights
+        self.scale_factor = scale_factor
+
+    @classmethod
+    def from_local_checkpoint(
+        cls,
+        control_vector_model_path: str,
+        control_vector_id: int,
+        config: ControlVectorConfig,
+        device: str = "cuda",
+        scale_factor: float = 1.0,
+    ) -> "ControlVectorModel":
+
+        try:
+            file_path = load_control_vector_file(control_vector_model_path)
+            reader = gguf.GGUFReader(file_path)
+            archf = reader.get_field("general.architecture")
+
+            if not archf or not len(archf.parts):
+                logger.error(".gguf file missing architecture field")
+            else:
+                arch = str(bytes(archf.parts[-1]),
+                           encoding="utf-8",
+                           errors="replace")
+                if arch != "controlvector":
+                    logger.error(
+                        ".gguf file with arch %s is not a control vector",
+                        arch)
+            modelf = reader.get_field('controlvector.model_hint')
+
+            if not modelf or not len(modelf.parts):
+                raise ValueError(
+                    ".gguf file missing controlvector.model_hint field")
+
+            model_hint = str(bytes(modelf.parts[-1]), encoding="utf-8")
+            logger.info("Control Vector for %s loaded.", model_hint)
+            cv_weights = {}
+            for tensor in reader.tensors:
+                if not tensor.name.startswith("direction."):
+                    continue
+                try:
+                    layer = int(tensor.name.split(".")[1])
+                except ValueError as e:
+                    raise ValueError(
+                        ".gguf file has invalid direction field name: %s",
+                        tensor.name) from e
+                np_copy = np.array(tensor.data, copy=True)
+                cv_weights[layer] = torch.from_numpy(np_copy).to(device).to(
+                    config.adapter_dtype)
+
+            return cls(control_vector_id, cv_weights, scale_factor)
+
+        except Exception as e:
+            raise e
+
+
+class ControlVectorModelManager(AdapterModelManager):
+
+    def __init__(self, model: nn.Module,
+                 control_vector_config: ControlVectorConfig):
+        self.model = model
+        self._registered_adapters = {}
+        self._active_adapters = {}
+        self.control_vector_config = control_vector_config
+        self._last_mapping = None
+        self.model.control_vector_manager = self
+        self.control_vector_index_to_id: list[
+            Optional[int]] = [None] * self.adapter_slots
+        self.modules: dict[str, nn.Module] = {}
+        self._create_cv_modules()
+
+    @property
+    def adapter_slots(self) -> int:
+        return self.capacity
+
+    @property
+    def capacity(self) -> int:
+        return self.control_vector_config.max_control_vectors
+
+    def activate_adapter(
+        self,
+        control_vector_id: int,
+    ) -> bool:
+        if control_vector_id in self._active_adapters:
+            return False
+        first_free_slot = next(
+            ((i, control_vector_id) for i, control_vector_id in enumerate(
+                self.control_vector_index_to_id) if control_vector_id is None),
+            None)
+        if first_free_slot is None:
+            raise ValueError("No free control vector slots")
+        index, _ = first_free_slot
+        self._active_adapters[control_vector_id] = None
+        control_vector_model = (self._registered_adapters[control_vector_id])
+        logger.debug("Activating control vector. int id: %d, slot index: %d",
+                     control_vector_model.id, index)
+        self.control_vector_index_to_id[index] = control_vector_model.id
+        for k, v in self.modules.items():
+            layer_index = parse_number_from_string(k)
+            if layer_index in control_vector_model.control_vector_weights:
+                v.set_control_vector(
+                    index,
+                    control_vector_model.control_vector_weights[layer_index] *
+                    control_vector_model.scale_factor)
+        return True
+
+    def _deactivate_adapter(self, control_vector_id: int):
+        try:
+            index = self.control_vector_index_to_id.index(control_vector_id)
+            self.control_vector_index_to_id[index] = None
+            for _, module in self.modules.items():
+                module.reset_control_vector(index)
+        except ValueError:
+            pass
+
+    def _add_adapter(self, control_vector: ControlVectorModel):
+        self._registered_adapters[control_vector.id] = control_vector
+
+    def get_index_from_id(self, id):
+        for i in range(len(self.control_vector_index_to_id)):
+            if self.control_vector_index_to_id[i] == id:
+                return i
+        return None
+
+    def _set_adapter_mapping(self, id: int) -> None:
+        index = self.get_index_from_id(id)
+
+        for k, v in self.modules.items():
+            v.set_active_tensor(index)
+
+    def _create_cv_modules(self):
+        for module_name, module in self.model.named_modules():
+            for key in _all_cv_classes:
+                if not module_name.endswith(key):
+                    continue
+                if isinstance(module, _all_cv_classes[key]):
+                    continue
+                new_module = self.replace_submodule(
+                    self.model, module_name, _all_cv_classes[key](module))
+                new_module.set_layer_id(parse_number_from_string(module_name))
+                self.register_module(module_name, new_module)
+                new_module.set_normalization(
+                    self.control_vector_config.normalize)
+
+    def replace_submodule(self, model: nn.Module, module_name: str,
+                          new_module: nn.Module) -> nn.Module:
+        """Replace a submodule in a model with a new module."""
+        parent = model.get_submodule(".".join(module_name.split(".")[:-1]))
+        target_name = module_name.split(".")[-1]
+        setattr(parent, target_name, new_module)
+        return new_module
+
+    def register_module(self, module_name: str, module: nn.Module):
+        self.modules[module_name] = module
+
+    def remove_all_adapters(self):
+        """Remove all PromptAdapterModel from the manager."""
+        self._registered_adapters.clear()
+        self.control_vector_index_to_id = [None] * self.adapter_slots
+        self._active_adapters.clear()
+
+    def deactivate_adapter(self, adapter_id: int) -> bool:
+        return deactivate_adapter(adapter_id, self._active_adapters,
+                                  self._deactivate_adapter)
+
+    def add_adapter(self, adapter: ControlVectorModel) -> bool:
+        return add_adapter(adapter, self._registered_adapters, self.capacity,
+                           self._add_adapter)
+
+    def set_adapter_mapping(self, mapping: ControlVectorMapping) -> None:
+        self._last_mapping = set_adapter_mapping(mapping, self._last_mapping,
+                                                 self._set_adapter_mapping)
+
+    def remove_adapter(self, adapter_id: int) -> bool:
+        return remove_adapter(adapter_id, self._registered_adapters,
+                              self.deactivate_adapter)
+
+    def list_adapters(self) -> dict[int, Any]:
+        return list_adapters(self._registered_adapters)
+
+    def get_adapter(self, adapter_id: int) -> Optional[Any]:
+        return get_adapter(adapter_id, self._registered_adapters)
+
+    def pin_adapter(self, adapter_id: int) -> bool:
+        raise NotImplementedError
+
+
+class ControlVectorLRUCache(AdapterLRUCache[ControlVectorModel]):
+
+    def __init__(self, capacity: int, deactivate_cv_fn: Callable[[int], bool]):
+        super().__init__(capacity, deactivate_cv_fn)
+
+
+class LRUCacheControlVectorModelManager(ControlVectorModelManager):
+
+    def __init__(self, model: nn.Module,
+                 control_vector_config: ControlVectorConfig):
+        self.control_vector_config = control_vector_config
+        super().__init__(model, control_vector_config)
+        self._registered_adapters = ControlVectorLRUCache(
+            self.capacity, self.deactivate_adapter)
+        self._active_adapters = ControlVectorLRUCache(self.adapter_slots,
+                                                      self._deactivate_adapter)
+
+    def list_adapters(self) -> dict[int, ControlVectorModel]:
+        """List all registered ControlVectorModel."""
+        return dict(self._registered_adapters.cache)
+
+    def activate_adapter(
+        self,
+        control_vector_id: int,
+    ) -> bool:
+        if control_vector_id not in self._active_adapters and len(
+                self._active_adapters) >= self.adapter_slots:
+            self._active_adapters.remove_oldest()
+        result = super().activate_adapter(control_vector_id)
+        # We always touch to update the LRU cache order
+        self._active_adapters.touch(control_vector_id)
+        return result
+
+    def remove_oldest_adapter(self) -> bool:
+        if len(self._registered_adapters) > 0:
+            self._registered_adapters.remove_oldest()
+            return True
+        return False
+
+
+def create_cv_manager(
+    model: nn.Module,
+    control_vector_config: ControlVectorConfig,
+    control_vector_manager_cls: type[
+        ControlVectorModelManager] = ControlVectorModelManager,
+) -> ControlVectorModelManager:
+    control_vector_manager = control_vector_manager_cls(
+        model=model, control_vector_config=control_vector_config)
+
+    return control_vector_manager

--- a/vllm/control_vectors/request.py
+++ b/vllm/control_vectors/request.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+
+from vllm.adapter_commons.request import AdapterRequest
+
+
+@dataclass
+class ControlVectorRequest(AdapterRequest):
+    """
+    Request for a Prompt adapter.
+    """
+
+    control_vector_name: str
+    control_vector_id: int
+    control_vector_local_path: str
+    scale: float = 1.0
+
+    def __hash__(self):
+        return super().__hash__()
+
+    @property
+    def adapter_id(self):
+        return self.control_vector_id
+
+    @property
+    def name(self):
+        return self.control_vector_name
+
+    @property
+    def local_path(self):
+        return self.control_vector_local_path
+
+    @property
+    def scale_factor(self):
+        return self.scale

--- a/vllm/control_vectors/worker_manager.py
+++ b/vllm/control_vectors/worker_manager.py
@@ -82,7 +82,6 @@ class WorkerControlVectorManager(AbstractWorkerManager):
         return self._adapter_manager.pin_adapter(adapter_id)
 
     def set_active_adapters(self, requests: set[Any]) -> None:
-        assert len(requests) <= 1, "No more than 1 control vector at a time"
         mapping = next((request.adapter_id for request in requests), None)
         set_active_adapters_worker(requests, mapping, self._apply_adapters,
                                    self._adapter_manager.set_adapter_mapping)

--- a/vllm/control_vectors/worker_manager.py
+++ b/vllm/control_vectors/worker_manager.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import Any
+
+import torch
+
+from vllm.adapter_commons.utils import (add_adapter_worker,
+                                        apply_adapters_worker,
+                                        list_adapters_worker,
+                                        set_active_adapters_worker)
+from vllm.adapter_commons.worker_manager import AbstractWorkerManager
+from vllm.config import ControlVectorConfig
+from vllm.control_vectors.models import (ControlVectorModel,
+                                         ControlVectorModelManager,
+                                         LRUCacheControlVectorModelManager,
+                                         create_cv_manager)
+from vllm.control_vectors.request import ControlVectorRequest
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerControlVectorManager(AbstractWorkerManager):
+    """WorkerControlVectorManager that manages 
+    control vector models on the worker side.
+
+    Every request, the requested control vectors will be 
+    loaded (unless they are already loaded), 
+    and every other control vector will be unloaded."""
+
+    _manager_cls: type[ControlVectorModelManager] = ControlVectorModelManager
+
+    def __init__(
+        self,
+        device: torch.device,
+        control_vector_config: ControlVectorConfig,
+        control_vector_model_cls: type[ControlVectorModel] = ControlVectorModel
+    ):
+        self._adapter_manager: ControlVectorModelManager
+        self._control_vector_model_cls = control_vector_model_cls
+        self.control_vector_config = control_vector_config
+        super().__init__(device)
+
+    @property
+    def is_enabled(self) -> bool:
+        return True
+
+    def create_control_vector_manager(
+        self,
+        model: torch.nn.Module,
+    ) -> Any:
+        control_vector_manager = create_cv_manager(
+            model,
+            control_vector_config=self.control_vector_config,
+            control_vector_manager_cls=self._manager_cls,
+        )
+        self._adapter_manager = control_vector_manager
+        return control_vector_manager.model
+
+    def _load_adapter(
+            self, control_vector_request: ControlVectorRequest
+    ) -> ControlVectorModel:
+        try:
+            control_vector = (
+                self._control_vector_model_cls.from_local_checkpoint(
+                    control_vector_request.control_vector_local_path,
+                    control_vector_id=control_vector_request.control_vector_id,
+                    config=self.control_vector_config,
+                    device=str(self.device),
+                    scale_factor=control_vector_request.scale_factor))
+        except Exception as e:
+            raise RuntimeError(
+                f"Loading control vector "
+                f"{control_vector_request.control_vector_local_path}"
+                f" failed") from e
+        return control_vector
+
+    def add_dummy_control_vector(
+            self, control_vector_request: ControlVectorRequest) -> bool:
+        return True
+
+    def pin_adapter(self, adapter_id: int) -> bool:
+        return self._adapter_manager.pin_adapter(adapter_id)
+
+    def set_active_adapters(self, requests: set[Any]) -> None:
+        assert len(requests) <= 1, "No more than 1 control vector at a time"
+        mapping = next((request.adapter_id for request in requests), None)
+        set_active_adapters_worker(requests, mapping, self._apply_adapters,
+                                   self._adapter_manager.set_adapter_mapping)
+
+    def add_adapter(self, adapter_request: Any) -> bool:
+        return add_adapter_worker(adapter_request, self.list_adapters,
+                                  self._load_adapter,
+                                  self._adapter_manager.add_adapter,
+                                  self._adapter_manager.activate_adapter)
+
+    def _apply_adapters(self, adapter_requests: set[Any]) -> None:
+        apply_adapters_worker(adapter_requests, self.list_adapters,
+                              self._adapter_manager.adapter_slots,
+                              self.remove_adapter, self.add_adapter)
+
+    def remove_adapter(self, adapter_id: int) -> bool:
+        return self._adapter_manager.remove_adapter(adapter_id)
+
+    def remove_all_adapters(self):
+        self._adapter_manager.remove_all_adapters()
+
+    def list_adapters(self) -> set[int]:
+        return list_adapters_worker(self._adapter_manager.list_adapters)
+
+
+class LRUCacheWorkerControlVectorManager(WorkerControlVectorManager):
+    """WorkerControlVectorManager that manages 
+    control vector models on the worker side.
+
+    Uses an LRU Cache. Every request, the requested 
+    control vectors will be loaded (unless they are already loaded) 
+    and least recently used control vectors will
+    be unloaded if the cache is above capacity."""
+
+    _control_vector_manager_cls: type[
+        LRUCacheControlVectorModelManager] = LRUCacheControlVectorModelManager
+
+    def create_control_vector_manager(
+        self,
+        model: torch.nn.Module,
+    ) -> Any:
+        control_vector_manager = create_cv_manager(
+            model,
+            control_vector_config=self.control_vector_config,
+            control_vector_manager_cls=self._control_vector_manager_cls)
+        self._adapter_manager: LRUCacheControlVectorModelManager = (
+            control_vector_manager)
+        return control_vector_manager.model
+
+    def _apply_adapters(
+            self, control_vector_requests: set[ControlVectorRequest]) -> None:
+        control_vectors_map = {
+            control_vector_request.control_vector_id: control_vector_request
+            for control_vector_request in control_vector_requests
+            if control_vector_request
+        }
+        if len(control_vectors_map) > self._adapter_manager.adapter_slots:
+            raise RuntimeError(f"Number of requested control vectors "
+                               f"({len(control_vectors_map)}) is greater "
+                               "than the number of GPU control vector slots "
+                               f"({self._adapter_manager.adapter_slots}).")
+        for control_vector in control_vectors_map.values():
+            self.add_adapter(control_vector)
+
+    def add_adapter(self,
+                    control_vector_request: ControlVectorRequest) -> bool:
+        if control_vector_request.control_vector_id not in self.list_adapters(
+        ):
+            # Remove before we load the new control vector to save memory
+            if len(self._adapter_manager) + 1 > self._adapter_manager.capacity:
+                self._adapter_manager.remove_oldest_adapter()
+            control_vector = self._load_adapter(control_vector_request)
+            loaded = self._adapter_manager.add_adapter(control_vector)
+        else:
+            loaded = self._adapter_manager.get_adapter(
+                control_vector_request.adapter_id)
+        self._adapter_manager.activate_adapter(
+            control_vector_request.control_vector_id)
+        return loaded

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1598,6 +1598,7 @@ class Scheduler:
                         if scheduler_outputs.num_prefill_groups > 0 else None),
                     mm_processor_kwargs=seq_group.mm_processor_kwargs,
                     prompt_adapter_request=seq_group.prompt_adapter_request,
+                    control_vector_request=seq_group.control_vector_request,
                 )
             else:
                 # When SPMD mode is enabled, we only send delta data except for

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -441,6 +441,7 @@ class _AsyncLLMEngine(LLMEngine):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> None:
         ...
@@ -455,6 +456,7 @@ class _AsyncLLMEngine(LLMEngine):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> None:
         ...
@@ -485,6 +487,10 @@ class _AsyncLLMEngine(LLMEngine):
         if lora_request is not None and not self.lora_config:
             raise ValueError(f"Got lora_request {lora_request} but LoRA is "
                              "not enabled!")
+        if (control_vector_request is not None
+                and not self.control_vector_config):
+            raise ValueError(f"Got cv_request {lora_request} but "
+                             "control vector is not enabled!")
         if priority != 0 and not self.scheduler_config.policy == "priority":
             raise ValueError(f"Got priority {priority} but "
                              "Priority scheduling is not enabled.")
@@ -893,6 +899,7 @@ class AsyncLLMEngine(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> Coroutine[None, None, AsyncGenerator[Union[
             RequestOutput, PoolingRequestOutput], None]]:
@@ -908,6 +915,7 @@ class AsyncLLMEngine(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> Coroutine[None, None, AsyncGenerator[Union[
             RequestOutput, PoolingRequestOutput], None]]:
@@ -926,6 +934,7 @@ class AsyncLLMEngine(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
         *,
         inputs: Optional[PromptType] = None,  # DEPRECATED
@@ -958,6 +967,7 @@ class AsyncLLMEngine(EngineClient):
             lora_request=lora_request,
             trace_headers=trace_headers,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             priority=priority,
         )
 
@@ -971,6 +981,7 @@ class AsyncLLMEngine(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> AsyncGenerator[RequestOutput, None]:
         """Generate outputs for a request.
@@ -1047,6 +1058,7 @@ class AsyncLLMEngine(EngineClient):
                     lora_request=lora_request,
                     trace_headers=trace_headers,
                     prompt_adapter_request=prompt_adapter_request,
+                    control_vector_request=control_vector_request,
                     priority=priority,
             ):
                 yield LLMEngine.validate_output(output, RequestOutput)
@@ -1236,6 +1248,10 @@ class AsyncLLMEngine(EngineClient):
 
     async def add_lora(self, lora_request: LoRARequest) -> None:
         self.engine.add_lora(lora_request)
+
+    async def add_control_vector(self,
+                                 cv_request: ControlVectorRequest) -> None:
+        self.engine.add_control_vector(cv_request)
 
 
 # TODO(v1): Remove this class proxy when V1 goes default.

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -14,6 +14,7 @@ from typing_extensions import deprecated
 import vllm.envs as envs
 from vllm.config import (DecodingConfig, LoRAConfig, ModelConfig,
                          ParallelConfig, SchedulerConfig, VllmConfig)
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_timeout import asyncio_timeout
@@ -471,6 +472,7 @@ class _AsyncLLMEngine(LLMEngine):
             lora_request: Optional[LoRARequest] = None,
             trace_headers: Optional[Mapping[str, str]] = None,
             prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+            control_vector_request: Optional[ControlVectorRequest] = None,
             priority: int = 0,
             *,
             inputs: Optional[PromptType] = None,  # DEPRECATED
@@ -521,6 +523,7 @@ class _AsyncLLMEngine(LLMEngine):
             arrival_time=arrival_time,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             trace_headers=trace_headers,
             priority=priority,
         )

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -19,6 +19,7 @@ import vllm.envs as envs
 from vllm.config import (DecodingConfig, LoRAConfig, ModelConfig,
                          ObservabilityConfig, ParallelConfig, SchedulerConfig,
                          VllmConfig)
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.core.scheduler import ScheduledSequenceGroup, SchedulerOutputs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.metrics_types import StatLoggerBase, Stats
@@ -236,6 +237,7 @@ class LLMEngine:
         self.decoding_config = vllm_config.decoding_config or DecodingConfig(  # noqa
         )
         self.prompt_adapter_config = vllm_config.prompt_adapter_config  # noqa
+        self.control_vector_config = vllm_config.control_vector_config
         self.observability_config = vllm_config.observability_config or ObservabilityConfig(  # noqa
         )
 
@@ -584,6 +586,7 @@ class LLMEngine:
         arrival_time: float,
         lora_request: Optional[LoRARequest],
         prompt_adapter_request: Optional[PromptAdapterRequest],
+        control_vector_request: Optional[ControlVectorRequest],
         trace_headers: Optional[Mapping[str, str]] = None,
         priority: int = 0,
     ) -> Optional[SequenceGroup]:
@@ -600,6 +603,7 @@ class LLMEngine:
                 lora_request=lora_request,
                 trace_headers=trace_headers,
                 prompt_adapter_request=prompt_adapter_request,
+                control_vector_request=control_vector_request,
                 priority=priority,
             )
             return None
@@ -629,6 +633,7 @@ class LLMEngine:
                 lora_request=lora_request,
                 trace_headers=trace_headers,
                 prompt_adapter_request=prompt_adapter_request,
+                control_vector_request=control_vector_request,
                 encoder_seq=encoder_seq,
                 priority=priority)
         elif isinstance(params, PoolingParams):
@@ -639,6 +644,7 @@ class LLMEngine:
                 arrival_time=arrival_time,
                 lora_request=lora_request,
                 prompt_adapter_request=prompt_adapter_request,
+                control_vector_request=control_vector_request,
                 encoder_seq=encoder_seq,
                 priority=priority)
         else:
@@ -668,6 +674,7 @@ class LLMEngine:
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> None:
         ...
@@ -684,6 +691,7 @@ class LLMEngine:
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> None:
         ...
@@ -701,6 +709,7 @@ class LLMEngine:
             lora_request: Optional[LoRARequest] = None,
             trace_headers: Optional[Mapping[str, str]] = None,
             prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+            control_vector_request: Optional[ControlVectorRequest] = None,
             priority: int = 0,
             *,
             inputs: Optional[PromptType] = None,  # DEPRECATED
@@ -791,6 +800,7 @@ class LLMEngine:
             arrival_time=arrival_time,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             trace_headers=trace_headers,
             priority=priority,
         )
@@ -825,6 +835,7 @@ class LLMEngine:
         lora_request: Optional[LoRARequest],
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         encoder_seq: Optional[Sequence] = None,
         priority: int = 0,
     ) -> SequenceGroup:
@@ -860,6 +871,7 @@ class LLMEngine:
             lora_request=lora_request,
             trace_headers=trace_headers,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             encoder_seq=encoder_seq,
             priority=priority,
             draft_size=draft_size)
@@ -874,6 +886,7 @@ class LLMEngine:
         arrival_time: float,
         lora_request: Optional[LoRARequest],
         prompt_adapter_request: Optional[PromptAdapterRequest],
+        control_vector_request: Optional[ControlVectorRequest],
         encoder_seq: Optional[Sequence] = None,
         priority: int = 0,
     ) -> SequenceGroup:
@@ -888,6 +901,7 @@ class LLMEngine:
             lora_request=lora_request,
             pooling_params=pooling_params,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             encoder_seq=encoder_seq,
             priority=priority)
         return seq_group

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1941,6 +1941,12 @@ class LLMEngine:
     def list_prompt_adapters(self) -> List[int]:
         return self.model_executor.list_prompt_adapters()
 
+    def add_control_vector(self, cv_request: ControlVectorRequest) -> bool:
+        return self.model_executor.add_control_vector(cv_request)
+
+    def remove_control_vector(self, cv_id: int) -> bool:
+        return self.model_executor.remove_control_vector(cv_id)
+
     def start_profile(self) -> None:
         self.model_executor.start_profile()
 

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -17,6 +17,7 @@ from zmq.asyncio import Socket
 
 from vllm import PoolingParams
 from vllm.config import DecodingConfig, ModelConfig, VllmConfig
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.core.scheduler import SchedulerOutputs
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -446,6 +447,7 @@ class MQLLMEngineClient(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> AsyncGenerator[RequestOutput, None]:
         ...
@@ -461,6 +463,7 @@ class MQLLMEngineClient(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> AsyncGenerator[RequestOutput, None]:
         ...
@@ -477,6 +480,7 @@ class MQLLMEngineClient(EngineClient):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
         *,
         inputs: Optional[PromptType] = None  # DEPRECATED
@@ -740,3 +744,8 @@ class MQLLMEngineClient(EngineClient):
         # Raise on error, otherwise happily return None
         if isinstance(request_output, BaseException):
             raise request_output
+
+    async def add_control_vector(self,
+                                 cv_request: ControlVectorRequest) -> None:
+        """Load a new control vector into the engine for future requests."""
+        pass

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator, List, Mapping, Optional
 
 from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
 from vllm.config import DecodingConfig, ModelConfig
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.inputs.data import PromptType, TokensPrompt
 from vllm.inputs.parse import is_explicit_encoder_decoder_prompt
@@ -55,6 +56,7 @@ class EngineClient(ABC):
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> AsyncGenerator[RequestOutput, None]:
         """Generate outputs for a request."""
@@ -293,5 +295,11 @@ class EngineClient(ABC):
 
     @abstractmethod
     async def add_lora(self, lora_request: LoRARequest) -> None:
+        """Load a new LoRA adapter into the engine for future requests."""
+        ...
+
+    @abstractmethod
+    async def add_control_vector(self,
+                                 cv_request: ControlVectorRequest) -> None:
         """Load a new LoRA adapter into the engine for future requests."""
         ...

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1086,7 +1086,7 @@ class LLM:
             params=pooling_params,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
-        )
+            control_vector_request=None)
 
         outputs = self._run_engine(use_tqdm=use_tqdm)
         items = self.engine_class.validate_outputs(outputs,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -14,6 +14,7 @@ from typing_extensions import TypeVar, deprecated
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence, get_beam_search_score)
 from vllm.config import CompilationConfig
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.engine.arg_utils import (EngineArgs, HfOverrides, PoolerConfig,
                                    TaskOption)
 from vllm.engine.llm_engine import LLMEngine
@@ -381,6 +382,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
         priority: Optional[list[int]] = None,
@@ -459,6 +461,7 @@ class LLM:
             params=sampling_params,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             guided_options=guided_options_request,
             priority=priority)
 
@@ -851,6 +854,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
     ) -> list[PoolingRequestOutput]:
         """Apply pooling to the hidden states corresponding to the input
         prompts.
@@ -912,7 +916,7 @@ class LLM:
             params=pooling_params,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
-        )
+            control_vector_request=control_vector_request)
 
         outputs = self._run_engine(use_tqdm=use_tqdm)
         return self.engine_class.validate_outputs(outputs,
@@ -1094,6 +1098,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
     ) -> list[ScoringRequestOutput]:
         """Generate similarity scores for all pairs ``<text,text_pair>``.
 
@@ -1281,6 +1286,7 @@ class LLM:
                       Sequence[PoolingParams]],
         lora_request: Optional[Union[Sequence[LoRARequest], LoRARequest]],
         prompt_adapter_request: Optional[PromptAdapterRequest],
+        control_vector_request: Optional[ControlVectorRequest],
         guided_options: Optional[GuidedDecodingRequest] = None,
         priority: Optional[list[int]] = None,
     ) -> None:
@@ -1329,6 +1335,7 @@ class LLM:
         params: Union[SamplingParams, PoolingParams],
         lora_request: Optional[LoRARequest] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         priority: int = 0,
     ) -> None:
         request_id = str(next(self.request_counter))
@@ -1338,6 +1345,7 @@ class LLM:
             params,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=control_vector_request,
             priority=priority,
         )
 

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -281,6 +281,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -297,6 +298,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -313,6 +315,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -330,6 +333,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -347,6 +351,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -362,6 +367,7 @@ class LLM:
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        control_vector_request: Optional[ControlVectorRequest] = None,
         guided_options_request: Optional[Union[LLMGuidedOptions,
                                                GuidedDecodingRequest]] = None,
     ) -> list[RequestOutput]:
@@ -1326,6 +1332,7 @@ class LLM:
                 lora_request=lora_request[i] if isinstance(
                     lora_request, Sequence) else lora_request,
                 prompt_adapter_request=prompt_adapter_request,
+                control_vector_request=control_vector_request,
                 priority=priority[i] if priority else 0,
             )
 

--- a/vllm/entrypoints/logger.py
+++ b/vllm/entrypoints/logger.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Union
 
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.pooling_params import PoolingParams
@@ -27,6 +28,7 @@ class RequestLogger:
                                BeamSearchParams]],
         lora_request: Optional[LoRARequest],
         prompt_adapter_request: Optional[PromptAdapterRequest],
+        control_vector_request: Optional[ControlVectorRequest],
     ) -> None:
         max_log_len = self.max_log_len
         if max_log_len is not None:
@@ -39,6 +41,7 @@ class RequestLogger:
         logger.info(
             "Received request %s: prompt: %r, "
             "params: %s, prompt_token_ids: %s, "
-            "lora_request: %s, prompt_adapter_request: %s.", request_id,
-            prompt, params, prompt_token_ids, lora_request,
-            prompt_adapter_request)
+            "lora_request: %s, prompt_adapter_request: %s, "
+            "control_vector_request: %s.", request_id, prompt, params,
+            prompt_token_ids, lora_request, prompt_adapter_request,
+            control_vector_request)

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -489,6 +489,7 @@ class OpenAIServing:
             params=params,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
+            control_vector_request=None,
         )
 
     async def _get_trace_headers(

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -194,6 +194,20 @@ class ExecutorBase(ABC):
                     ), "All workers should have the same prompt adapters."
         return sets[0]
 
+    def add_control_vector(
+            self, control_vector_request: ControlVectorRequest) -> bool:
+        assert control_vector_request.adapter_id > 0, \
+            "control vector's adapter_id must be greater than 0."
+        return all(
+            self.collective_rpc("add_control_vector",
+                                args=(control_vector_request, )))
+
+    def remove_control_vector(self, control_vector_id: int) -> bool:
+        assert control_vector_id > 0, "cv_id must be greater than 0."
+        return all(
+            self.collective_rpc("remove_control_vector",
+                                args=(control_vector_id, )))
+
     def start_profile(self) -> None:
         self.collective_rpc("start_profile")
 
@@ -246,15 +260,6 @@ class ExecutorBase(ABC):
                             kwargs=dict(path=path,
                                         pattern=pattern,
                                         max_size=max_size))
-
-    @abstractmethod
-    def add_control_vector(
-            self, control_vector_request: ControlVectorRequest) -> bool:
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_control_vector(self, cv_id: int) -> bool:
-        raise NotImplementedError
 
     @abstractmethod
     def check_health(self) -> None:

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -11,6 +11,7 @@ from typing_extensions import TypeVar
 
 import vllm.platforms
 from vllm.config import VllmConfig
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.sampler import SamplerOutput
@@ -49,6 +50,7 @@ class ExecutorBase(ABC):
         self.speculative_config = vllm_config.speculative_config
         self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
+        self.control_vector_config = vllm_config.control_vector_config
         self._init_executor()
         self.is_sleeping = False
         self.sleeping_tags: set[str] = set()
@@ -244,6 +246,15 @@ class ExecutorBase(ABC):
                             kwargs=dict(path=path,
                                         pattern=pattern,
                                         max_size=max_size))
+
+    @abstractmethod
+    def add_control_vector(
+            self, control_vector_request: ControlVectorRequest) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def remove_control_vector(self, cv_id: int) -> bool:
+        raise NotImplementedError
 
     @abstractmethod
     def check_health(self) -> None:

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as dist
 
 import vllm.envs as envs
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.utils import (get_distributed_init_method, get_ip, get_open_port,
@@ -60,6 +61,14 @@ class UniProcExecutor(ExecutorBase):
         # UniProcExecutor will always be healthy as long as
         # it's running.
         return
+
+    def add_control_vector(
+            self, control_vector_request: ControlVectorRequest) -> bool:
+        assert control_vector_request.adapter_id > 0
+        return self.driver_worker.add_control_vector(control_vector_request)
+
+    def remove_control_vector(self, cv_id: int) -> bool:
+        return self.driver_worker.remove_control_vector(cv_id)
 
 
 UniProcExecutorAsync = UniProcExecutor

--- a/vllm/executor/uniproc_executor.py
+++ b/vllm/executor/uniproc_executor.py
@@ -7,7 +7,6 @@ import torch
 import torch.distributed as dist
 
 import vllm.envs as envs
-from vllm.control_vectors.request import ControlVectorRequest
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.utils import (get_distributed_init_method, get_ip, get_open_port,
@@ -61,14 +60,6 @@ class UniProcExecutor(ExecutorBase):
         # UniProcExecutor will always be healthy as long as
         # it's running.
         return
-
-    def add_control_vector(
-            self, control_vector_request: ControlVectorRequest) -> bool:
-        assert control_vector_request.adapter_id > 0
-        return self.driver_worker.add_control_vector(control_vector_request)
-
-    def remove_control_vector(self, cv_id: int) -> bool:
-        return self.driver_worker.remove_control_vector(cv_id)
 
 
 UniProcExecutorAsync = UniProcExecutor

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -116,6 +116,8 @@ class ModelInputForGPU(ModelRunnerInputBase):
             "multi_modal_kwargs": self.multi_modal_kwargs,
             "prompt_adapter_mapping": self.prompt_adapter_mapping,
             "prompt_adapter_requests": self.prompt_adapter_requests,
+            "control_vector_mapping": self.control_vector_mapping,
+            "control_vector_requests": self.control_vector_requests,
             "virtual_engine": self.virtual_engine,
             "request_ids_to_seq_ids": self.request_ids_to_seq_ids,
             "finished_requests_ids": self.finished_requests_ids,
@@ -166,6 +168,8 @@ class ModelInputForGPUWithSamplingMetadata(ModelInputForGPU):
             "multi_modal_kwargs": self.multi_modal_kwargs,
             "prompt_adapter_mapping": self.prompt_adapter_mapping,
             "prompt_adapter_requests": self.prompt_adapter_requests,
+            "control_vector_mapping": self.control_vector_mapping,
+            "control_vector_requests": self.control_vector_requests,
             "virtual_engine": self.virtual_engine,
             "request_ids_to_seq_ids": self.request_ids_to_seq_ids,
             "finished_requests_ids": self.finished_requests_ids,
@@ -360,7 +364,6 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                             prompt_adapter_prompt_mapping
                     else:
                         self.prompt_adapter_prompt_mapping.clear()
-
             else:
                 self.input_tokens = input_tokens or []
                 self.input_positions = input_positions or []
@@ -383,10 +386,10 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                     prompt_adapter_prompt_mapping or [])
 
             self.prompt_adapter_request = prompt_adapter_request
+            self.control_vector_request = control_vector_request
+
             self.multi_modal_kwargs = multi_modal_kwargs
             self.multi_modal_placeholder_maps = multi_modal_placeholder_maps
-
-            self.control_vector_request = control_vector_request
 
             self.prefix_cache_hit = prefix_cache_hit
 
@@ -689,8 +692,11 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
         inter_data: InterDataForSeqGroup,
         seq_group_metadata: SequenceGroupMetadata,
     ):
+        """If control vector is enabled, compute index and prompt mapping.
+        """
         if not self.enable_control_vector:
             return
+
         inter_data.control_vector_request = (
             seq_group_metadata.control_vector_request)
 
@@ -994,6 +1000,7 @@ class ModelInputForGPUBuilder(ModelRunnerInputBuilderBase[ModelInputForGPU]):
                 prompt_adapter_prompt_mapping,
             )
 
+        # Control vector data.
         control_vector_requests: Set[ControlVectorRequest] = set()
         if self.enable_control_vector:
             control_vector_requests = set(data.control_vector_request
@@ -1596,6 +1603,10 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                         )
                         self.set_active_prompt_adapters(
                             set(), prompt_adapter_mapping)
+
+                    if self.control_vector_config:
+                        self.set_active_control_vectors(set())
+
                     graph_runner = CUDAGraphRunner(
                         self.model, self.attn_backend.get_name(),
                         self.attn_state.graph_clone(batch_size),

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -188,6 +188,7 @@ class ModelRunnerBase(ABC, Generic[T]):
         self.device_config = vllm_config.device_config
         self.speculative_config = vllm_config.speculative_config
         self.prompt_adapter_config = vllm_config.prompt_adapter_config
+        self.control_vector_config = vllm_config.control_vector_config
         self.observability_config = vllm_config.observability_config
 
     # Map of request_id -> generator used for seeded random sampling

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -9,6 +9,7 @@ import torch.distributed
 
 import vllm.envs as envs
 from vllm.config import VllmConfig
+from vllm.control_vectors.request import ControlVectorRequest
 from vllm.device_allocator.cumem import CuMemAllocator
 from vllm.distributed import (ensure_kv_transfer_initialized,
                               ensure_model_parallel_initialized,
@@ -475,6 +476,13 @@ class Worker(LocalOrDistributedWorkerBase):
 
     def list_prompt_adapters(self) -> Set[int]:
         return self.model_runner.list_prompt_adapters()
+
+    def add_control_vector(
+            self, control_vector_request: ControlVectorRequest) -> bool:
+        return self.model_runner.add_control_vector(control_vector_request)
+
+    def remove_control_vector(self, cv_id: int) -> bool:
+        return self.model_runner.remove_control_vector(cv_id)
 
     @property
     def max_model_len(self) -> int:


### PR DESCRIPTION
## Introduction

This pull request rebases and fixes the feature requested in #3451 (which is already closed) and implemented by @raywanb in #7906 to the latest code.
(Thanks to @raywanb for the implementation!)

I have already implemented the [OpenAI compatible API](https://github.com/yuu-biz/vllm/tree/add-api-support-for-cv), but including this would make the pull request too large.
I am creating this pull request to enable the basic functionality of Control Vector in vllm.

If this feature is accepted into vllm, I am considering submitting a pull request for the Frontend implementation as well.

## Added Features

The same as implemented in #7906. I have merged that pull request and modified it to match the latest codebase.

> Control Vectors are a list of vectors per layer that can be added to a model during inference to change the model's activation. This allows users to change the model behavior without additional prompting. Furthermore, control vectors can be set to various magnitudes that can vary the level of model behavior steering.

## Example

It can be used by directly utilizing the LLM class or Engine.
If this feature is not enabled, it will not interfere with other processes.

```python
from vllm import LLM
from vllm.control_vectors.request import ControlVectorRequest

llm = LLM(model="Model Name", enable_control_vector=True, normalize_control_vector=True)
cv_request = ControlVectorRequest("vector name", 1, "path/to/control_vector.gguf", scale=1.0) 
output = llm.generate(some_prompt, control_vector_request=cv_request)
```