### PR TITLE
[Build] Make pypi install work on CPU platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ elif not (sys.platform.startswith("linux")
         "Building on %s, "
         "so vLLM may not be able to run correctly", sys.platform)
     VLLM_TARGET_DEVICE = "empty"
+elif (sys.platform.startswith("linux") and torch.version.cuda is None
+      and os.getenv("VLLM_TARGET_DEVICE") is None):
+    # if cuda is not available and VLLM_TARGET_DEVICE is not set,
+    # fallback to cpu
+    VLLM_TARGET_DEVICE = "cpu"
 
 MAIN_CUDA_VERSION = "12.1"
 
@@ -482,7 +487,6 @@ def get_vllm_version() -> str:
     version = get_version(
         write_to="vllm/_version.py",  # TODO: move this to pyproject.toml
     )
-
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
     if _no_device():
@@ -520,7 +524,8 @@ def get_vllm_version() -> str:
     elif _is_tpu():
         version += f"{sep}tpu"
     elif _is_cpu():
-        version += f"{sep}cpu"
+        if envs.VLLM_TARGET_DEVICE == "cpu":
+            version += f"{sep}cpu"
     elif _is_xpu():
         version += f"{sep}xpu"
     else:


### PR DESCRIPTION
when use `pip install vllm` on mac os, 0.7.x version can't be installed and will fallback to 0.6.6post1. The log is 
```
Collecting vllm
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/69/1a/58ef1f5278d2039cdec4453c522c52f39b29b0ccbf7b8177d5766a99f8ec/vllm-0.7.2.tar.gz (5.4 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Discarding https://pypi.tuna.tsinghua.edu.cn/packages/69/1a/58ef1f5278d2039cdec4453c522c52f39b29b0ccbf7b8177d5766a99f8ec/vllm-0.7.2.tar.gz (from https://pypi.tuna.tsinghua.edu.cn/simple/vllm/) (requires-python:>=3.9): Requested vllm from https://pypi.tuna.tsinghua.edu.cn/packages/69/1a/58ef1f5278d2039cdec4453c522c52f39b29b0ccbf7b8177d5766a99f8ec/vllm-0.7.2.tar.gz has inconsistent version: expected '0.7.2', but metadata has '0.7.2+cpu'
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/c1/9d/151eba20b6959913d05df917cb53d5adb5d2e3dd8a19fea365d48b2b2bf3/vllm-0.7.1.tar.gz (5.3 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Discarding https://pypi.tuna.tsinghua.edu.cn/packages/c1/9d/151eba20b6959913d05df917cb53d5adb5d2e3dd8a19fea365d48b2b2bf3/vllm-0.7.1.tar.gz (from https://pypi.tuna.tsinghua.edu.cn/simple/vllm/) (requires-python:>=3.9): Requested vllm from https://pypi.tuna.tsinghua.edu.cn/packages/c1/9d/151eba20b6959913d05df917cb53d5adb5d2e3dd8a19fea365d48b2b2bf3/vllm-0.7.1.tar.gz has inconsistent version: expected '0.7.1', but metadata has '0.7.1+cpu'
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/fd/1c/602eafc32a1f6ddf66f4700f30fd4039e20c04a9ef9334e32fb18270cda2/vllm-0.7.0.tar.gz (5.0 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Discarding https://pypi.tuna.tsinghua.edu.cn/packages/fd/1c/602eafc32a1f6ddf66f4700f30fd4039e20c04a9ef9334e32fb18270cda2/vllm-0.7.0.tar.gz (from https://pypi.tuna.tsinghua.edu.cn/simple/vllm/) (requires-python:>=3.9): Requested vllm from https://pypi.tuna.tsinghua.edu.cn/packages/fd/1c/602eafc32a1f6ddf66f4700f30fd4039e20c04a9ef9334e32fb18270cda2/vllm-0.7.0.tar.gz has inconsistent version: expected '0.7.0', but metadata has '0.7.0+cpu'
  Using cached vllm-0.6.6.post1-py3-none-any.whl
```
Another case is try `pip install vllm` on Linux with arm64 arch, the error log is 
```
Collecting vllm
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/69/1a/58ef1f5278d2039cdec4453c522c52f39b29b0ccbf7b8177d5766a99f8ec/vllm-0.7.2.tar.gz (5.4 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      /tmp/pip-build-env-wyrqtb06/overlay/lib/python3.9/site-packages/torch/_subclasses/functional_tensor.py:295: UserWarning: Failed to initialize NumPy: No module named 'numpy' (Triggered internally at /pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
        cpu = _conversion_method_template(device=torch.device("cpu"))
      Traceback (most recent call last):
        File "/usr/local/python3.9/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/python3.9/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/python3.9/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-wyrqtb06/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-wyrqtb06/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-wyrqtb06/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 633, in <module>
        File "<string>", line 527, in get_vllm_version
      RuntimeError: Unknown runtime environment
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
```
This PR fix both issue to make sure `pip install vllm` works well on CPU platform.