### PR TITLE
[V1] LoRA - Enable Serving Usecase

### DIFF
--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -69,7 +69,7 @@ async def requests_processing_time(
         if warmup_function:
             await warmup_function(llm, lora_requests)
             # Wait for the warmup functions complete
-            time.sleep(10)
+            time.sleep(30)
 
         generators = []
         start = time.perf_counter()

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -16,7 +16,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module #noqa
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 96
+DEFAULT_MAX_LORAS = 63
 
 
 def download_and_prepare_lora_module():

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -14,7 +14,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_PATH = "yard1/llama-2-7b-sql-lora-test"
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 4
+DEFAULT_MAX_LORAS = 64
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+import time
+from typing import Callable, List, Optional
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.openai.api_server import (
+    build_async_engine_client_from_engine_args)
+from vllm.inputs import TextPrompt
+from vllm.lora.request import LoRARequest
+from vllm.sampling_params import SamplingParams
+from vllm.utils import merge_async_iterators
+
+MODEL_PATH = "meta-llama/Llama-2-7b-hf"
+LORA_MODULE_PATH = "yard1/llama-2-7b-sql-lora-test"
+LORA_RANK = 8
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
+
+
+def add_lora_callable(llm: EngineClient, lora_requests=List[LoRARequest]):
+    for lr in lora_requests:
+        llm.add_lora(lr)
+
+
+async def requests_processing_time(
+    lora_requests=List[LoRARequest],
+    warmup_function: Optional[Callable[[EngineClient, List[LoRARequest]],
+                                       None]] = None
+) -> float:
+    """
+    Utility function to measure LoRA requests processing time. The primary
+    usecase is to test the difference between a cold start
+    (no warmup functions) vs a hot start.
+    """
+
+    max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
+    engine_args = EngineArgs(model=MODEL_PATH,
+                             enable_lora=True,
+                             max_loras=max_loras,
+                             max_lora_rank=LORA_RANK)
+    sampling_params = SamplingParams(n=1,
+                                     temperature=0.0,
+                                     top_p=1.0,
+                                     ignore_eos=True,
+                                     max_tokens=1)
+
+    async with build_async_engine_client_from_engine_args(engine_args) as llm:
+
+        if warmup_function:
+            warmup_function(llm, lora_requests)
+            # Wait for the warmup functions complete
+            time.sleep(10)
+
+        generators = []
+        start = time.perf_counter()
+
+        for idx, lora_request in enumerate(lora_requests):
+            generator = llm.generate(prompt=TextPrompt("hello"),
+                                     sampling_params=sampling_params,
+                                     lora_request=lora_request,
+                                     request_id=f"test{idx}")
+            generators.append(generator)
+
+        all_gens = merge_async_iterators(*generators)
+        async for i, res in all_gens:
+            pass
+        end = time.perf_counter()
+        return end - start
+
+
+DEFAULT_MAX_LORAS = 4
+
+
+def get_lora_requests() -> List[LoRARequest]:
+    lora_requests: List[LoRARequest] = [
+        LoRARequest(lora_name=f"{i}",
+                    lora_int_id=i,
+                    lora_path=LORA_MODULE_PATH)
+        for i in range(DEFAULT_MAX_LORAS)
+    ]
+    return lora_requests
+
+
+@pytest.mark.asyncio
+async def test_add_lora():
+    """ 
+    The add_lora function is used to pre-load some LoRA adapters into the
+    engine in anticipation of future requests using these adapters. To test
+    this functionality, we use the async engine to process some requests - We
+    do it twice, once with add_lora() pre-loading and once without.
+
+    We measure the request processing time in both cases and expect the time 
+    to be lesser in the case with add_lora() calls.
+    """
+
+    lora_requests: List[LoRARequest] = get_lora_requests()
+
+    # Dummy run - So any 1-time functionality like triton kernel compilation
+    # is complete here.
+    await requests_processing_time(lora_requests)
+
+    # Run with warmup
+    time_with_add_lora = await requests_processing_time(
+        lora_requests, warmup_function=add_lora_callable)
+
+    # Run without any warmup
+    time_cold_start = await requests_processing_time(lora_requests)
+
+    assert time_with_add_lora < time_cold_start, (
+        "The engine request processing time with LoRA pre-loading "
+        "must be less than the version that does on-demand LoRA loading")

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -16,7 +16,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module #noqa
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 192
+DEFAULT_MAX_LORAS = 96
 
 
 def download_and_prepare_lora_module():

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import time
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import pytest
 
@@ -26,7 +26,7 @@ def v1(run_with_both_engines_lora):
 
 
 async def add_lora_callable(llm: EngineClient,
-                            lora_requests=List[LoRARequest]):
+                            lora_requests: List[LoRARequest]):
     for lr in lora_requests:
         await llm.add_lora(lr)
 
@@ -34,7 +34,7 @@ async def add_lora_callable(llm: EngineClient,
 async def requests_processing_time(
     lora_requests=List[LoRARequest],
     warmup_function: Optional[Callable[[EngineClient, List[LoRARequest]],
-                                       None]] = None
+                                       Any]] = None
 ) -> float:
     """
     Utility function to measure LoRA requests processing time. The primary
@@ -75,11 +75,12 @@ async def requests_processing_time(
         start = time.perf_counter()
 
         for idx, lora_request in enumerate(lora_requests):
-            generator = llm.generate(prompt=TextPrompt(prompt=f"hello {idx}",
-                                                       multi_modal_data=None),
-                                     sampling_params=sampling_params,
-                                     lora_request=lora_request,
-                                     request_id=f"test{idx}")
+            generator = llm.generate(
+                prompt=TextPrompt(prompt=f"hello {idx}",
+                                  multi_modal_data=None),  # type: ignore 
+                sampling_params=sampling_params,
+                lora_request=lora_request,
+                request_id=f"test{idx}")
             generators.append(generator)
 
         all_gens = merge_async_iterators(*generators)

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -4,10 +4,8 @@ from typing import Callable, List, Optional
 
 import pytest
 
-from vllm.engine.arg_utils import EngineArgs
+from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.protocol import EngineClient
-from vllm.entrypoints.openai.api_server import (
-    build_async_engine_client_from_engine_args)
 from vllm.inputs import TextPrompt
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
@@ -16,6 +14,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_PATH = "yard1/llama-2-7b-sql-lora-test"
 LORA_RANK = 8
+DEFAULT_MAX_LORAS = 4
 
 
 @pytest.fixture(autouse=True)
@@ -26,9 +25,10 @@ def v1(run_with_both_engines_lora):
     pass
 
 
-def add_lora_callable(llm: EngineClient, lora_requests=List[LoRARequest]):
+async def add_lora_callable(llm: EngineClient,
+                            lora_requests=List[LoRARequest]):
     for lr in lora_requests:
-        llm.add_lora(lr)
+        await llm.add_lora(lr)
 
 
 async def requests_processing_time(
@@ -43,20 +43,31 @@ async def requests_processing_time(
     """
 
     max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
-    engine_args = EngineArgs(model=MODEL_PATH,
-                             enable_lora=True,
-                             max_loras=max_loras,
-                             max_lora_rank=LORA_RANK)
+    engine_args = AsyncEngineArgs(model=MODEL_PATH,
+                                  enable_lora=True,
+                                  max_loras=max_loras,
+                                  max_lora_rank=LORA_RANK)
     sampling_params = SamplingParams(n=1,
                                      temperature=0.0,
                                      top_p=1.0,
                                      ignore_eos=True,
                                      max_tokens=1)
 
+    # The run_with_both_engines_lora fixture sets up the `VLLM_USE_V1`
+    # environment variable. reload vllm.enging.async_llm_engine as
+    # vllm.engine.async_llm_engine.AsyncLLMEgnine changes depending on the
+    # env var
+    import importlib
+
+    import vllm.engine.async_llm_engine
+    importlib.reload(vllm.engine.async_llm_engine)
+    from vllm.entrypoints.openai.api_server import (
+        build_async_engine_client_from_engine_args)
+
     async with build_async_engine_client_from_engine_args(engine_args) as llm:
 
         if warmup_function:
-            warmup_function(llm, lora_requests)
+            await warmup_function(llm, lora_requests)
             # Wait for the warmup functions complete
             time.sleep(10)
 
@@ -64,7 +75,8 @@ async def requests_processing_time(
         start = time.perf_counter()
 
         for idx, lora_request in enumerate(lora_requests):
-            generator = llm.generate(prompt=TextPrompt("hello"),
+            generator = llm.generate(prompt=TextPrompt(prompt=f"hello {idx}",
+                                                       multi_modal_data=None),
                                      sampling_params=sampling_params,
                                      lora_request=lora_request,
                                      request_id=f"test{idx}")
@@ -73,11 +85,9 @@ async def requests_processing_time(
         all_gens = merge_async_iterators(*generators)
         async for i, res in all_gens:
             pass
+
         end = time.perf_counter()
         return end - start
-
-
-DEFAULT_MAX_LORAS = 4
 
 
 def get_lora_requests() -> List[LoRARequest]:
@@ -85,7 +95,7 @@ def get_lora_requests() -> List[LoRARequest]:
         LoRARequest(lora_name=f"{i}",
                     lora_int_id=i,
                     lora_path=LORA_MODULE_PATH)
-        for i in range(DEFAULT_MAX_LORAS)
+        for i in range(1, DEFAULT_MAX_LORAS + 1)
     ]
     return lora_requests
 
@@ -101,7 +111,6 @@ async def test_add_lora():
     We measure the request processing time in both cases and expect the time 
     to be lesser in the case with add_lora() calls.
     """
-
     lora_requests: List[LoRARequest] = get_lora_requests()
 
     # Dummy run - So any 1-time functionality like triton kernel compilation
@@ -115,6 +124,12 @@ async def test_add_lora():
     # Run without any warmup
     time_cold_start = await requests_processing_time(lora_requests)
 
+    print(f"time hot-start {time_with_add_lora} vs "
+          f"time cold-start {time_cold_start} ")
+
     assert time_with_add_lora < time_cold_start, (
+        f"time_with_add_lora={time_with_add_lora}, "
+        f"time_cold_start={time_cold_start}"
         "The engine request processing time with LoRA pre-loading "
-        "must be less than the version that does on-demand LoRA loading")
+        "must be less than the version that does on-demand LoRA loading."
+        f"time with add_lora ={time}")

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -43,10 +43,13 @@ async def requests_processing_time(
     """
 
     max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
+    # Create engine in eager-mode. Due to high max_loras, the CI can
+    # OOM during cuda-graph capture.
     engine_args = AsyncEngineArgs(model=MODEL_PATH,
                                   enable_lora=True,
                                   max_loras=max_loras,
-                                  max_lora_rank=LORA_RANK)
+                                  max_lora_rank=LORA_RANK,
+                                  enforce_eager=True)
     sampling_params = SamplingParams(n=1,
                                      temperature=0.0,
                                      top_p=1.0,

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -2,13 +2,12 @@
 import asyncio
 import time
 from pathlib import Path
-from typing import Any, Callable, List, Optional
+from typing import List
 
 import pytest
 from huggingface_hub import snapshot_download
 
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.engine.protocol import EngineClient
 from vllm.inputs import TextPrompt
 from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
@@ -17,7 +16,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module #noqa
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 64
+DEFAULT_MAX_LORAS = 192
 
 
 def download_and_prepare_lora_module():
@@ -53,78 +52,6 @@ def v1(run_with_both_engines_lora):
     pass
 
 
-async def add_lora_callable(llm: EngineClient,
-                            lora_requests: List[LoRARequest]):
-    for lr in lora_requests:
-        await llm.add_lora(lr)
-
-
-async def requests_processing_time(
-    lora_requests=List[LoRARequest],
-    warmup_function: Optional[Callable[[EngineClient, List[LoRARequest]],
-                                       Any]] = None
-) -> float:
-    """
-    Utility function to measure LoRA requests processing time. The primary
-    usecase is to test the difference between a cold start
-    (no warmup functions) vs a hot start.
-    """
-
-    max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
-    # Create engine in eager-mode. Due to high max_loras, the CI can
-    # OOM during cuda-graph capture.
-    engine_args = AsyncEngineArgs(
-        model=MODEL_PATH,
-        enable_lora=True,
-        max_loras=max_loras,
-        max_lora_rank=LORA_RANK,
-        max_model_len=128,
-        gpu_memory_utilization=0.8,  #avoid OOM
-        enforce_eager=True)
-    sampling_params = SamplingParams(n=1,
-                                     temperature=0.0,
-                                     top_p=1.0,
-                                     ignore_eos=True,
-                                     max_tokens=1)
-
-    # The run_with_both_engines_lora fixture sets up the `VLLM_USE_V1`
-    # environment variable. reload vllm.enging.async_llm_engine as
-    # vllm.engine.async_llm_engine.AsyncLLMEgnine changes depending on the
-    # env var
-    import importlib
-
-    import vllm.engine.async_llm_engine
-    importlib.reload(vllm.engine.async_llm_engine)
-    from vllm.entrypoints.openai.api_server import (
-        build_async_engine_client_from_engine_args)
-
-    async with build_async_engine_client_from_engine_args(engine_args) as llm:
-
-        if warmup_function:
-            await warmup_function(llm, lora_requests)
-            # Wait for the warmup functions complete
-            await asyncio.sleep(30)
-
-        generators = []
-        start = time.perf_counter()
-
-        for idx, lora_request in enumerate(lora_requests):
-            generator = llm.generate(
-                prompt=TextPrompt(prompt=f"hello {idx}",
-                                  multi_modal_data=None),  # type: ignore 
-                sampling_params=sampling_params,
-                lora_request=lora_request,
-                request_id=f"test{idx}")
-            generators.append(generator)
-
-        all_gens = merge_async_iterators(*generators)
-        async for i, res in all_gens:
-            pass
-
-        end = time.perf_counter()
-        return end - start
-
-
 def get_lora_requests() -> List[LoRARequest]:
     lora_requests: List[LoRARequest] = [
         LoRARequest(lora_name=f"{i}",
@@ -132,8 +59,37 @@ def get_lora_requests() -> List[LoRARequest]:
                     lora_path=LORA_MODULE_DOWNLOAD_PATH)
         for i in range(1, DEFAULT_MAX_LORAS + 1)
     ]
-
     return lora_requests
+
+
+async def requests_processing_time(llm,
+                                   lora_requests: List[LoRARequest]) -> float:
+
+    sampling_params = SamplingParams(n=1,
+                                     temperature=0.0,
+                                     top_p=1.0,
+                                     ignore_eos=True,
+                                     max_tokens=1)
+
+    generators = []
+    start = time.perf_counter()
+
+    for lora_request in lora_requests:
+        lora_int_id = lora_request.lora_int_id
+        generator = llm.generate(
+            prompt=TextPrompt(prompt=f"hello {lora_int_id}",
+                              multi_modal_data=None),  # type: ignore 
+            sampling_params=sampling_params,
+            lora_request=lora_request,
+            request_id=f"test{lora_int_id}")
+        generators.append(generator)
+
+    all_gens = merge_async_iterators(*generators)
+    async for i, res in all_gens:
+        pass
+
+    end = time.perf_counter()
+    return end - start
 
 
 @pytest.mark.asyncio
@@ -152,16 +108,52 @@ async def test_add_lora():
 
     lora_requests: List[LoRARequest] = get_lora_requests()
 
-    # Dummy run - So any 1-time functionality like triton kernel compilation
-    # is complete here.
-    await requests_processing_time(lora_requests)
+    max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
+    # Create engine in eager-mode. Due to high max_loras, the CI can
+    # OOM during cuda-graph capture.
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enable_lora=True,
+        max_loras=max_loras,
+        max_lora_rank=LORA_RANK,
+        max_model_len=128,
+        gpu_memory_utilization=0.8,  #avoid OOM
+        enforce_eager=True)
 
-    # Run with warmup
-    time_with_add_lora = await requests_processing_time(
-        lora_requests, warmup_function=add_lora_callable)
+    # The run_with_both_engines_lora fixture sets up the `VLLM_USE_V1`
+    # environment variable. reload vllm.enging.async_llm_engine as
+    # vllm.engine.async_llm_engine.AsyncLLMEgnine changes depending on the
+    # env var.
+    import importlib
 
-    # Run without any warmup
-    time_cold_start = await requests_processing_time(lora_requests)
+    import vllm.engine.async_llm_engine
+    importlib.reload(vllm.engine.async_llm_engine)
+    from vllm.entrypoints.openai.api_server import (
+        build_async_engine_client_from_engine_args)
+
+    # split lora_requests into 3 parts
+    part_size = len(lora_requests) // 3
+    dummy_run_requests = lora_requests[:part_size]
+    warmup_run_requests = lora_requests[part_size:part_size * 2]
+    cold_run_requests = lora_requests[part_size * 2:]
+
+    async with build_async_engine_client_from_engine_args(engine_args) as llm:
+
+        # Dummy run - So any 1-time functionality like triton kernel compilation
+        # is complete here.
+        await requests_processing_time(llm, dummy_run_requests)
+
+        # Run with warmup
+        for lr in warmup_run_requests:
+            await llm.add_lora(lr)
+        # Wait for the add_lora function to complete on the server side.
+        await asyncio.sleep(30)
+        time_with_add_lora = await requests_processing_time(
+            llm, warmup_run_requests)
+
+        # Run without any warmup
+        time_cold_start = await requests_processing_time(
+            llm, cold_run_requests)
 
     print(f"time hot-start {time_with_add_lora} vs "
           f"time cold-start {time_cold_start} ")
@@ -170,5 +162,4 @@ async def test_add_lora():
         f"time_with_add_lora={time_with_add_lora}, "
         f"time_cold_start={time_cold_start}"
         "The engine request processing time with LoRA pre-loading "
-        "must be less than the version that does on-demand LoRA loading."
-        f"time with add_lora ={time}")
+        "must be less than the version that does on-demand LoRA loading.")

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -14,7 +14,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_PATH = "yard1/llama-2-7b-sql-lora-test"
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 64
+DEFAULT_MAX_LORAS = 32
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -16,7 +16,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module #noqa
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 63
+DEFAULT_MAX_LORAS = 16 * 3
 
 
 def download_and_prepare_lora_module():

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -14,7 +14,7 @@ from vllm.utils import merge_async_iterators
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
 LORA_MODULE_PATH = "yard1/llama-2-7b-sql-lora-test"
 LORA_RANK = 8
-DEFAULT_MAX_LORAS = 32
+DEFAULT_MAX_LORAS = 64
 
 
 @pytest.fixture(autouse=True)
@@ -45,11 +45,13 @@ async def requests_processing_time(
     max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
     # Create engine in eager-mode. Due to high max_loras, the CI can
     # OOM during cuda-graph capture.
-    engine_args = AsyncEngineArgs(model=MODEL_PATH,
-                                  enable_lora=True,
-                                  max_loras=max_loras,
-                                  max_lora_rank=LORA_RANK,
-                                  enforce_eager=True)
+    engine_args = AsyncEngineArgs(
+        model=MODEL_PATH,
+        enable_lora=True,
+        max_loras=max_loras,
+        max_lora_rank=LORA_RANK,
+        gpu_memory_utilization=0.8,  #avoid OOM
+        enforce_eager=True)
     sampling_params = SamplingParams(n=1,
                                      temperature=0.0,
                                      top_p=1.0,

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -14,7 +14,7 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils import merge_async_iterators
 
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
-LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module #noqa
+LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module() #noqa
 LORA_RANK = 8
 DEFAULT_MAX_LORAS = 16 * 3
 

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -50,6 +50,7 @@ async def requests_processing_time(
         enable_lora=True,
         max_loras=max_loras,
         max_lora_rank=LORA_RANK,
+        max_model_len=128,
         gpu_memory_utilization=0.8,  #avoid OOM
         enforce_eager=True)
     sampling_params = SamplingParams(n=1,

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -134,3 +134,4 @@ class EngineCoreRequestType(enum.Enum):
     ABORT = b'\x01'
     PROFILE = b'\x02'
     RESET_PREFIX_CACHE = b'\x03'
+    ADD_LORA = b'\x04'

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -361,6 +361,10 @@ class AsyncLLM(EngineClient):
     async def reset_prefix_cache(self) -> None:
         await self.engine_core.reset_prefix_cache_async()
 
+    async def add_lora(self, lora_request: LoRARequest) -> None:
+        """Load a new LoRA adapter into the engine for future requests."""
+        await self.engine_core.add_lora_async(lora_request)
+
     @property
     def is_running(self) -> bool:
         return True
@@ -376,7 +380,3 @@ class AsyncLLM(EngineClient):
     @property
     def dead_error(self) -> BaseException:
         return Exception()  # TODO: implement
-
-    async def add_lora(self, lora_request: LoRARequest) -> None:
-        """Load a new LoRA adapter into the engine for future requests."""
-        await self.engine_core.add_lora_async(lora_request)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -379,4 +379,4 @@ class AsyncLLM(EngineClient):
 
     async def add_lora(self, lora_request: LoRARequest) -> None:
         """Load a new LoRA adapter into the engine for future requests."""
-        raise NotImplementedError("LoRA not yet supported in V1")
+        await self.engine_core.add_lora_async(lora_request)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -269,6 +269,7 @@ class EngineCoreProc(EngineCore):
 
         # Msgpack serialization decoding.
         add_request_decoder = MsgpackDecoder(EngineCoreRequest)
+        add_lora_decoder = MsgpackDecoder(LoRARequest)
         generic_decoder = MsgpackDecoder()
 
         with zmq_socket_ctx(input_path, zmq.constants.PULL) as socket:
@@ -278,9 +279,14 @@ class EngineCoreProc(EngineCore):
                 request_type = EngineCoreRequestType(bytes(type_frame.buffer))
 
                 # Deserialize the request data.
-                decoder = add_request_decoder if (
-                    request_type
-                    == EngineCoreRequestType.ADD) else generic_decoder
+                decoder = None
+                if request_type == EngineCoreRequestType.ADD:
+                    decoder = add_request_decoder
+                elif request_type == EngineCoreRequestType.ADD_LORA:
+                    decoder = add_lora_decoder
+                else:
+                    decoder = generic_decoder
+
                 request = decoder.decode(data_frame.buffer)
 
                 # Push to input queue for core busy loop.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -13,6 +13,7 @@ import zmq.asyncio
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.utils import get_exception_traceback, zmq_socket_ctx
@@ -141,6 +142,9 @@ class EngineCore:
     def reset_prefix_cache(self):
         self.scheduler.reset_prefix_cache()
 
+    def add_lora(self, lora_request: LoRARequest) -> None:
+        self.model_executor.add_lora(lora_request)
+
 
 class EngineCoreProc(EngineCore):
     """ZMQ-wrapper for running EngineCore in background process."""
@@ -257,6 +261,8 @@ class EngineCoreProc(EngineCore):
             self.reset_prefix_cache()
         elif request_type == EngineCoreRequestType.PROFILE:
             self.model_executor.profile(request)
+        elif request_type == EngineCoreRequestType.ADD_LORA:
+            self.model_executor.add_lora(request)
 
     def process_input_socket(self, input_path: str):
         """Input socket IO thread."""

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -244,7 +244,7 @@ class Worker:
         else:
             self.profiler.stop()
 
-    def add_lora(self, lora_request: LoRARequest) -> None:
+    def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_runner.add_lora(lora_request)
 
     def check_health(self) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -15,6 +15,7 @@ from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment,
                               set_custom_all_reduce)
 from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.utils import GiB_bytes
@@ -242,6 +243,9 @@ class Worker:
             self.profiler.start()
         else:
             self.profiler.stop()
+
+    def add_lora(self, lora_request: LoRARequest) -> None:
+        return self.model_runner.add_lora(lora_request)
 
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -127,3 +127,8 @@ class LoRAModelRunnerMixin:
 
             # __exit__ code
             self.lora_manager.remove_all_adapters()
+
+    def add_lora(self, lora_request: LoRARequest) -> None:
+        if not self.lora_manager:
+            raise RuntimeError("LoRA is not enabled.")
+        return self.lora_manager.add_adapter(lora_request)

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -128,7 +128,7 @@ class LoRAModelRunnerMixin:
             # __exit__ code
             self.lora_manager.remove_all_adapters()
 
-    def add_lora(self, lora_request: LoRARequest) -> None:
+    def add_lora(self, lora_request: LoRARequest) -> bool:
         if not self.lora_manager:
             raise RuntimeError("LoRA is not enabled.")
         return self.lora_manager.add_adapter(lora_request)


### PR DESCRIPTION
Enable LoRA serving for V1 :- 
  Specifically, this PR plumbs the `add_lora` function from `async_llm.py` to `lora_model_runner_mixin.py`. The `add_lora` function is essential for the serving usecase.

Tested locally for correctness.

Note: The other LoRA specific serving functionality, like `remove_lora`, `pin_lora` and `list_loras` are yet to be implemented. 