### PR TITLE
[Bugfix] Support missing tool parameters in mistral tokenizer

### DIFF
--- a/tests/tokenization/test_mistral_tokenizer.py
+++ b/tests/tokenization/test_mistral_tokenizer.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from mistral_common.protocol.instruct.messages import UserMessage
+from mistral_common.protocol.instruct.request import ChatCompletionRequest
+from mistral_common.protocol.instruct.tool_calls import Function, Tool
+
+from vllm.transformers_utils.tokenizers.mistral import (
+    make_mistral_chat_completion_request)
+
+
+# yapf: enable
+@pytest.mark.parametrize(
+    "openai_request,expected_mistral_request",
+    [(
+        {
+            "messages": [{
+                "role": "user",
+                "content": "What is the current local date and time?",
+            }],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "description": "Fetch the current local date and time.",
+                    "name": "get_current_time",
+                },
+            }],
+        },
+        ChatCompletionRequest(
+            messages=[
+                UserMessage(content="What is the current local date and time?")
+            ],
+            tools=[
+                Tool(
+                    type="function",
+                    function=Function(
+                        name="get_current_time",
+                        description="Fetch the current local date and time.",
+                        parameters={},
+                    ),
+                )
+            ],
+        ),
+    )],
+)
+def test_make_mistral_chat_completion_request(openai_request,
+                                              expected_mistral_request):
+    assert (make_mistral_chat_completion_request(
+        openai_request["messages"],
+        openai_request["tools"]) == expected_mistral_request)


### PR DESCRIPTION
The Mistral schema is a bit more restrictive and does not accept
functions without parameter dictionary. This is no problem with the
OpenAI schema though, so the Mistral tokenizer should adapt the request
before passing it on.

This is how it's currently failing:

```
INFO:     172.18.0.8:60210 - "POST /v1/chat/completions HTTP/1.0" 400 Bad Request
ERROR 02-04 06:22:47 serving_chat.py:191] Error in preprocessing prompt inputs
ERROR 02-04 06:22:47 serving_chat.py:191] Traceback (most recent call last):
ERROR 02-04 06:22:47 serving_chat.py:191]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_chat.py", line 175, in create_chat_completion
ERROR 02-04 06:22:47 serving_chat.py:191]     ) = await self._preprocess_chat(
ERROR 02-04 06:22:47 serving_chat.py:191]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-04 06:22:47 serving_chat.py:191]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_engine.py", line 403, in _preprocess_chat
ERROR 02-04 06:22:47 serving_chat.py:191]     request_prompt = apply_mistral_chat_template(
ERROR 02-04 06:22:47 serving_chat.py:191]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-04 06:22:47 serving_chat.py:191]   File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/chat_utils.py", line 1002, in apply_mistral_chat_template
ERROR 02-04 06:22:47 serving_chat.py:191]     return tokenizer.apply_chat_template(
ERROR 02-04 06:22:47 serving_chat.py:191]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-04 06:22:47 serving_chat.py:191]   File "/usr/local/lib/python3.12/dist-packages/vllm/transformers_utils/tokenizers/mistral.py", line 285, in apply_chat_template
ERROR 02-04 06:22:47 serving_chat.py:191]     request = ChatCompletionRequest(messages=messages,
ERROR 02-04 06:22:47 serving_chat.py:191]               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-04 06:22:47 serving_chat.py:191]   File "/usr/local/lib/python3.12/dist-packages/pydantic/main.py", line 214, in __init__
ERROR 02-04 06:22:47 serving_chat.py:191]     validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
ERROR 02-04 06:22:47 serving_chat.py:191]                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-04 06:22:47 serving_chat.py:191] pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatCompletionRequest
ERROR 02-04 06:22:47 serving_chat.py:191] tools.0.function.parameters
ERROR 02-04 06:22:47 serving_chat.py:191]   Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
ERROR 02-04 06:22:47 serving_chat.py:191]     For further information visit https://errors.pydantic.dev/2.10/v/dict_type
```

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/) 