### PR TITLE
[Bugfix] Add `error` field for compatibility with OpenAI response format (#12886)

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -78,7 +78,13 @@ class ErrorResponse(OpenAIBaseModel):
     message: str
     type: str
     param: Optional[str] = None
-    code: int
+    code: int       
+    # In case of error OpenAI sends message in error field
+    error: Optional[dict] = Field(default_factory=lambda: {"message": ""})
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.error["message"] = self.message  # In case of error OpenAI sends message in error field
 
 
 class ModelPermission(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -87,6 +87,7 @@ class ErrorResponse(OpenAIBaseModel):
         # In case of error OpenAI sends message in error field
         self.error = {"message": self.message}
 
+
 class ModelPermission(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"modelperm-{random_uuid()}")
     object: str = "model_permission"

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -80,13 +80,12 @@ class ErrorResponse(OpenAIBaseModel):
     param: Optional[str] = None
     code: int
     # In case of error OpenAI sends message in error field
-    error: Optional[dict] = Field(default_factory=lambda: {"message": ""})
+    error: Optional[dict] = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # In case of error OpenAI sends message in error field
-        self.error["message"] = self.message
-
+        self.error = {"message": self.message}
 
 class ModelPermission(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"modelperm-{random_uuid()}")

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -78,13 +78,14 @@ class ErrorResponse(OpenAIBaseModel):
     message: str
     type: str
     param: Optional[str] = None
-    code: int       
+    code: int
     # In case of error OpenAI sends message in error field
     error: Optional[dict] = Field(default_factory=lambda: {"message": ""})
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.error["message"] = self.message  # In case of error OpenAI sends message in error field
+        # In case of error OpenAI sends message in error field
+        self.error["message"] = self.message
 
 
 class ModelPermission(OpenAIBaseModel):


### PR DESCRIPTION
In the `ErrorResponse` class, added an optional `error` field that contains a dictionary with the error message. Additionally, an initializer was added to set the `error` field's message to match the `message` field. This is done to align with the response format used by OpenAI, where the error message is sent via the `error` field.

This change ensures better compatibility with the OpenAI API and improves the handling of error responses.

FIX #12886

