### PR TITLE
[Bugfix] Fix Qwen2_5_VLForConditionalGeneration packed_modules_mapping

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -760,9 +760,12 @@ class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
             "q_proj",
             "k_proj",
             "v_proj",
-        ]
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
     }
-
     # LoRA specific attributes, TODO: double check
     supported_lora_modules = [
         "qkv_proj",


### PR DESCRIPTION
There are issues with packed_modules_mapping, which is causing problems with BNB.
FIX https://github.com/vllm-project/vllm/issues/12900
FIX https://github.com/vllm-project/vllm/issues/12902

