### PR TITLE
[Model][Speculative Decoding] Add EAGLE-style MTP module reference code for DeepSeek-R1

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,21 @@
+# Run config for DeepSeek-R1 on a single 8xH200 node
+# Using one MTP module for speculative execution,
+# Called recursively for k=2 speculative tokens.
+# Expected draft acceptance rate is ~70%
+# (~80% for token 1, ~60% for token 2 due to accuracy decay)
+python3 \
+  -m vllm.entrypoints.openai.api_server \
+  --disable-log-requests \
+  --gpu-memory-utilization 0.85 \
+  --quantization fp8 \
+  --max-model-len 65536 \
+  --max-num-seqs 128 \
+  --seed 0 \
+  --tensor-parallel-size 8 \
+  --swap-space 0 \
+  --block-size 32 \
+  --model deepseek-ai/DeepSeek-R1 \
+  --distributed-executor-backend=mp \
+  --trust-remote-code \
+  --num-speculative-tokens 2 \
+  --speculative-model DeepSeekV3MTP

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -313,8 +313,7 @@ class ModelConfig:
 
         self.hf_text_config = get_hf_text_config(self.hf_config)
         self.encoder_config = self._get_encoder_config()
-        self.hf_image_processor_config = get_hf_image_processor_config(
-            self.model, revision)
+        self.hf_image_processor_config = {}# get_hf_image_processor_config(self.model, revision)
         self.dtype = _get_and_verify_dtype(self.hf_text_config, dtype)
         self.use_async_output_proc = use_async_output_proc
         self.mm_processor_kwargs = mm_processor_kwargs
@@ -420,6 +419,8 @@ class ModelConfig:
     def _init_multimodal_config(
         self, limit_mm_per_prompt: Optional[Mapping[str, int]]
     ) -> Optional["MultiModalConfig"]:
+        return None
+    
         architectures = getattr(self.hf_config, "architectures", [])
         if ModelRegistry.is_multimodal_model(architectures):
             return MultiModalConfig(limit_per_prompt=limit_mm_per_prompt or {})
@@ -756,7 +757,7 @@ class ModelConfig:
     def is_deepseek_mla(self) -> bool:
         return (hasattr(self.hf_text_config, "model_type")) \
                 and (self.hf_text_config.model_type in \
-                    ('deepseek_v2', 'deepseek_v3'))\
+                    ('deepseek_v2', 'deepseek_v3', 'eagle'))\
                 and (self.hf_text_config.kv_lora_rank is not None)
 
     def get_head_size(self) -> int:

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -383,6 +383,8 @@ class DefaultModelLoader(BaseModelLoader):
                 model = _initialize_model(vllm_config=vllm_config)
 
             weights_to_load = {name for name, _ in model.named_parameters()}
+            if hasattr(model_config.hf_config, 'model_type') and model_config.hf_config.model_type == 'eagle':
+                model_config.model = 'deepseek-ai/DeepSeek-R1'
             loaded_weights = model.load_weights(
                 self._get_all_weights(model_config, model))
             # We only enable strict check for non-quantized models

--- a/vllm/model_executor/models/deepseek_mtp.py
+++ b/vllm/model_executor/models/deepseek_mtp.py
@@ -1,0 +1,188 @@
+from typing import Iterable, List, Optional, Set, Tuple
+
+import torch
+from torch import nn
+
+from vllm.attention import AttentionMetadata
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead, VocabParallelEmbedding)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.layers.fused_moe import FusedMoE
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.sequence import IntermediateTensors
+
+from .utils import is_pp_missing_parameter
+from .deepseek_v2 import DeepseekV2DecoderLayer
+
+class DeepseekV3MTPSpeculator(nn.Module):
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "", mtp_layer_index: int = 0):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        config.first_k_dense_replace = 0
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.quant_config = vllm_config.quant_config
+
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+        )
+
+        self.shared_head = nn.ModuleDict({
+            "head": ParallelLMHead(config.vocab_size, config.hidden_size, quant_config=self.quant_config),
+            "norm": RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        })
+
+        layer_index = 61
+
+        self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.eh_proj = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
+        self.transformer = DeepseekV2DecoderLayer(config, f"{prefix}.layers.{layer_index}", quant_config=self.quant_config, cache_config=self.cache_config, model_config=self.model_config)
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.sampler = get_sampler()
+    
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        kv_caches: List[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+        previous_hidden_states: Optional[torch.Tensor] = None,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> List[torch.Tensor]:        
+        if inputs_embeds is not None:
+            embedding = inputs_embeds
+        else:
+            embedding = self.embed_tokens(input_ids)
+
+        h_normed = self.hnorm(previous_hidden_states)
+        e_normed = self.enorm(embedding)
+
+        cat_in = torch.cat([e_normed, h_normed], dim=-1) # swapped from the paper
+        proj_out = self.eh_proj(cat_in)
+
+        (mtp_hidden, mtp_residual) = self.transformer(
+            positions,
+            proj_out,
+            kv_cache=kv_caches[0],
+            attn_metadata=attn_metadata,
+            residual=None
+        )
+
+        return mtp_hidden + mtp_residual
+        # hidden_states = mtp_hidden
+        # hidden_states, _ = self.shared_head["norm"](hidden_states, mtp_residual)
+        # return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor, sampling_metadata: SamplingMetadata) -> torch.Tensor:
+        logits = self.logits_processor(self.shared_head["head"], self.shared_head["norm"](hidden_states), sampling_metadata)
+        return logits
+
+    def sample(self, logits: torch.Tensor, sampling_metadata: SamplingMetadata) -> SamplerOutput:
+        next_tokens = self.sampler(logits, sampling_metadata)
+        return next_tokens
+    
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("gate_up_proj", "gate_proj", 0),
+            ("gate_up_proj", "up_proj", 1),
+        ]
+
+        # Params for weights, fp8 weight scales, fp8 activation scales
+        # (param_name, weight_name, expert_id, shard_id)
+        expert_params_mapping = FusedMoE.make_expert_params_mapping(
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.n_routed_experts)
+
+        params_dict = dict(self.named_parameters())
+        loaded_params: Set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            assert self.config.num_nextn_predict_layers == 1
+            layer_idx = 61
+            if name.startswith(f"model.layers.{layer_idx}"):
+                name = name.replace(f"model.layers.{layer_idx}.", "")
+                if name.startswith("input_layernorm") or name.startswith("post_attention_layernorm") or name.startswith("mlp") or name.startswith("self_attn"):
+                    name = "transformer." + name
+            else:
+                continue
+            
+            for (param_name, weight_name, shard_id) in stacked_params_mapping:
+                # Skip non-stacked layers and experts (experts handled below).
+                if weight_name not in name:
+                    continue
+                # We have mlp.experts[0].gate_proj in the checkpoint.
+                # Since we handle the experts below in expert_params_mapping,
+                # we need to skip here BEFORE we update the name, otherwise
+                # name will be updated to mlp.experts[0].gate_up_proj, which
+                # will then be updated below in expert_params_mapping
+                # for mlp.experts[0].gate_gate_up_proj, which breaks load.
+                if (("mlp.experts." in name) and name not in params_dict):
+                    continue
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+
+                if is_pp_missing_parameter(name, self):
+                    continue
+
+                if name not in params_dict:
+                    breakpoint()
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                for mapping in expert_params_mapping:
+                    param_name, weight_name, expert_id, shard_id = mapping
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+
+                    if is_pp_missing_parameter(name, self):
+                        continue
+                    
+                    if name not in params_dict:
+                        breakpoint()
+                    param = params_dict[name]
+                    weight_loader = param.weight_loader
+                    weight_loader(param,
+                                  loaded_weight,
+                                  name,
+                                  shard_id=shard_id,
+                                  expert_id=expert_id)
+                    break
+                else:
+                    # Skip loading extra bias for GPTQ models.
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+
+                    if is_pp_missing_parameter(name, self):
+                        continue
+
+                    if name not in params_dict:
+                        breakpoint()
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader",
+                                            default_weight_loader)
+                    weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -640,8 +640,8 @@ class DeepseekV2Model(nn.Module):
                 "residual": residual
             })
 
-        hidden_states, _ = self.norm(hidden_states, residual)
-        return hidden_states
+        # hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states + residual
 
 
 class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
@@ -684,7 +684,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         hidden_states: torch.Tensor,
         sampling_metadata: SamplingMetadata,
     ) -> Optional[torch.Tensor]:
-        logits = self.logits_processor(self.lm_head, hidden_states,
+        logits = self.logits_processor(self.lm_head, self.model.norm(hidden_states),
                                        sampling_metadata)
         return logits
 

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -184,6 +184,7 @@ _MULTIMODAL_MODELS = {
 _SPECULATIVE_DECODING_MODELS = {
     "EAGLEModel": ("eagle", "EAGLE"),
     "MedusaModel": ("medusa", "Medusa"),
+    "DeepseekV3MTPModel": ("deepseek_mtp", "DeepseekV3MTPSpeculator"),
     "MLPSpeculatorPreTrainedModel": ("mlp_speculator", "MLPSpeculator"),
 }
 

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -178,13 +178,13 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
                 proposer_worker = MedusaWorker(**draft_worker_kwargs)
             else:
                 if draft_tp == 1:
-                    if current_platform.is_cuda_alike():
+                    if current_platform.is_cuda_alike() and not draft_model_config.use_mla:
                         draft_worker_kwargs[
                             "model_runner_cls"] = TP1DraftModelRunner
                 else:
-                    if draft_model_config.hf_config.model_type == "eagle":
-                        raise NotImplementedError(
-                            "EAGLE does not support TP > 1 yet")
+                    # if draft_model_config.hf_config.model_type == "eagle":
+                    #     raise NotImplementedError(
+                    #         "EAGLE does not support TP > 1 yet")
 
                     allow_zero_draft_token_step = False
                 proposer_worker = MultiStepWorker(**draft_worker_kwargs)

--- a/vllm/transformers_utils/configs/eagle.py
+++ b/vllm/transformers_utils/configs/eagle.py
@@ -8,37 +8,104 @@ from transformers import AutoConfig, PretrainedConfig
 
 class EAGLEConfig(PretrainedConfig):
     model_type = "eagle"
+    # model_type = "deepseek_v3"
+    
+    keys_to_ignore_at_inference = ["past_key_values"]
 
-    def __init__(self,
-                 model: Union[PretrainedConfig, dict, None] = None,
-                 truncated_vocab_size: Optional[int] = None,
-                 **kwargs):
+    def __init__(
+        self,
+        vocab_size=129280,
+        hidden_size=7168,
+        intermediate_size=18432,
+        moe_intermediate_size = 2048,
+        num_hidden_layers=-1,
+        num_nextn_predict_layers=1,
+        num_attention_heads=128,
+        num_key_value_heads=128,
+        n_shared_experts = 1,
+        n_routed_experts = 256,
+        ep_size = 1,
+        routed_scaling_factor = 2.5,
+        kv_lora_rank = 512,
+        q_lora_rank = 1536,
+        qk_rope_head_dim = 64,
+        v_head_dim = 128,
+        qk_nope_head_dim = 128,
+        topk_method = 'noaux_tc',
+        n_group = 8,
+        topk_group = 4,
+        num_experts_per_tok = 8,
+        moe_layer_freq = 1,
+        first_k_dense_replace = 3,
+        norm_topk_prob = True,
+        scoring_func = 'sigmoid',
+        aux_loss_alpha = 0.001,
+        seq_aux = True,
+        hidden_act="silu",
+        max_position_embeddings=4096,
+        initializer_range=0.02,
+        rms_norm_eps=1e-6,
+        use_cache=True,
+        pad_token_id=None,
+        bos_token_id=0,
+        eos_token_id=1,
+        pretraining_tp=1,
+        tie_word_embeddings=False,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        attention_bias=False,
+        attention_dropout=0.0,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_hidden_layers = 1
+        self.num_nextn_predict_layers = num_nextn_predict_layers
+        self.num_attention_heads = num_attention_heads
+        self.n_shared_experts = n_shared_experts
+        self.n_routed_experts = n_routed_experts
+        self.ep_size = ep_size
+        self.routed_scaling_factor = routed_scaling_factor
+        self.kv_lora_rank = kv_lora_rank
+        self.q_lora_rank = q_lora_rank
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.topk_method = topk_method
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_layer_freq = moe_layer_freq
+        self.first_k_dense_replace = first_k_dense_replace
+        self.norm_topk_prob = norm_topk_prob
+        self.scoring_func = scoring_func
+        self.aux_loss_alpha = aux_loss_alpha
+        self.seq_aux = seq_aux
+        # for backward compatibility
+        if num_key_value_heads is None:
+            num_key_value_heads = num_attention_heads
 
-        model_config = None if model is None else (AutoConfig.for_model(
-            **model) if isinstance(model, dict) else model)
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.pretraining_tp = pretraining_tp
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
 
-        for k, v in kwargs.items():
-            if k != "architectures" and k != "model_type" and hasattr(
-                    model_config, k):
-                setattr(model_config, k, v)
-
-        self.model = model_config
-
-        if self.model is None:
-            self.truncated_vocab_size = None
-        else:
-            self.truncated_vocab_size = self.model.vocab_size if \
-                truncated_vocab_size is None else truncated_vocab_size
-
-        if "architectures" not in kwargs:
-            kwargs["architectures"] = ["EAGLEModel"]
-
-        super().__init__(**kwargs)
-
-        if self.model is not None:
-            for k, v in self.model.to_dict().items():
-                if not hasattr(self, k):
-                    setattr(self, k, v)
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
 
     @classmethod
     def from_pretrained(
@@ -46,6 +113,11 @@ class EAGLEConfig(PretrainedConfig):
         pretrained_model_name_or_path: Union[str, os.PathLike],
         **kwargs,
     ) -> "EAGLEConfig":
-        config_dict, kwargs = cls.get_config_dict(
-            pretrained_model_name_or_path, **kwargs)
-        return cls.from_dict(config_dict, **kwargs)
+        if pretrained_model_name_or_path == "DeepSeekV3MTP":
+            pretrained_model_name_or_path = "deepseek-ai/DeepSeek-R1"
+        config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
+        config_dict["model_type"] = "eagle"
+        config_dict["num_hidden_layers"] = 1
+        config_dict["architectures"] = ["DeepseekV3MTPModel"]
+        res = cls.from_dict(config_dict, **kwargs)
+        return res

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -316,11 +316,13 @@ class LocalOrDistributedWorkerBase(WorkerBase):
             return None
 
         worker_input = WorkerInput.from_broadcasted_tensor_dict(broadcast_data)
+        
+        kwargs = extract_previous_hidden_states(broadcast_data)
+        broadcast_data.pop("previous_hidden_states", None)
+
         model_input = (
             self.model_runner.make_model_input_from_broadcasted_tensor_dict(
                 broadcast_data))
-
-        kwargs = extract_previous_hidden_states(broadcast_data)
 
         return model_input, worker_input, kwargs
 


### PR DESCRIPTION
This is @CentML's implementation of DeepSeek MTP modules that enable speculative decoding for DeepSeek-R1.

The changes in this branch enable `--speculative-model DeepSeekV3MTP` to register itself as an alternate implementation of DeepSeek-R1, that loads only the MTP weights and have modified model code to invoke only the MTP layer. This model code resides in `deepseek_mtp.py`.

An additional change moves the RMSNorm application of the final hidden states into the `compute_logits` function, such that the `previous_hidden_states` which are taken from the output of `model(...)` are un-normalized. Our experimental results show a small increase in predictive accuracy by making this change. This makes sense intuitively because the hidden states are treated as they would be for an additional layer of the transformer model and the output norm is treated separately as a part of the output head.

This code also enables the EAGLE code path for reusing `previous_hidden_states` across TP workers in the base model runner code, enabling (single-step) multi-GPU draft model execution.

While it is possible that the hidden states can be reused from each worker and do not need to be broadcasted to the TP workers between iterations, we choose to follow the EAGLE syntax and respect the abstraction boundary of draft worker / target worker for speculative decoding.

Notably, this implementation does not mask the zero-th position of the input embeddings into the MTP module, though the existing EAGLE models do. This is because of an unknown issue with CUDA graphs and MLA attention that causes accuracy issues when this is performed. Our testing shows much improved acceptance rates by omitting this problematic masking. 

Note that this is not the first vLLM PR to implement MTP module support for DeepSeekV3 models, and serves primarily as a reference implementation for validation purposes. See [vllm#12755](https://github.com/vllm-project/vllm/pull/12755)