### PR TITLE
Add flag for enabling finer-grained cuda graph capture

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3312,8 +3312,12 @@ class VllmConfig:
 
                 possible_sizes = [1, 2, 4] + [8 * i for i in range(1, 1025)]
                 if envs.VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS:
-                    logger.info("Capturing additional cuda graphs. This will significantly increase the GPU memory utilization")
-                    possible_sizes = sorted(set(possible_sizes + list(range(1, 8)) + list(range(8, 16, 2)) + list(range(16, 32, 4))))
+                    logger.info(
+                        "Capturing additional cuda graphs. This will significantly increase the GPU memory utilization"
+                    )
+                    possible_sizes = sorted(
+                        set(possible_sizes + list(range(1, 8)) +
+                            list(range(8, 16, 2)) + list(range(16, 32, 4))))
                 # find the minimum size that is larger than max_num_seqs,
                 # which then becomes the max_batchsize_to_capture
                 larger_sizes = [

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3311,6 +3311,9 @@ class VllmConfig:
                     not self.model_config.enforce_eager:
 
                 possible_sizes = [1, 2, 4] + [8 * i for i in range(1, 1025)]
+                if envs.VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS:
+                    logger.info("Capturing additional cuda graphs. This will significantly increase the GPU memory utilization")
+                    possible_sizes = sorted(set(possible_sizes + list(range(1, 8)) + list(range(8, 16, 2)) + list(range(16, 32, 4))))
                 # find the minimum size that is larger than max_num_seqs,
                 # which then becomes the max_batchsize_to_capture
                 larger_sizes = [

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3315,7 +3315,7 @@ class VllmConfig:
                         envs.VLLM_EXTRA_CUDA_GRAPH_SIZES) > 0:
                     logger.info(
                         "Capturing additional cuda graphs. "
-                        "This may lead to an increase in GPU memory usage")
+                        "This may lead to an increase in GPU memory usage.")
                     possible_sizes = sorted(
                         set(possible_sizes + envs.VLLM_EXTRA_CUDA_GRAPH_SIZES))
                 # find the minimum size that is larger than max_num_seqs,

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3311,13 +3311,13 @@ class VllmConfig:
                     not self.model_config.enforce_eager:
 
                 possible_sizes = [1, 2, 4] + [8 * i for i in range(1, 1025)]
-                if envs.VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS:
+                if envs.VLLM_EXTRA_CUDA_GRAPH_SIZES and len(
+                        envs.VLLM_EXTRA_CUDA_GRAPH_SIZES) > 0:
                     logger.info(
-                        "Capturing additional cuda graphs. This will significantly increase the GPU memory utilization"
-                    )
+                        "Capturing additional cuda graphs. "
+                        "This may lead to an increase in GPU memory usage")
                     possible_sizes = sorted(
-                        set(possible_sizes + list(range(1, 8)) +
-                            list(range(8, 16, 2)) + list(range(16, 32, 4))))
+                        set(possible_sizes + envs.VLLM_EXTRA_CUDA_GRAPH_SIZES))
                 # find the minimum size that is larger than max_num_seqs,
                 # which then becomes the max_batchsize_to_capture
                 larger_sizes = [

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -577,11 +577,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # in addition to the default set of sizes. The sizes are specified
     # as a comma-separated sequence of integers.
     "VLLM_EXTRA_CUDA_GRAPH_SIZES":
-    lambda: list(
-        map(
-            int,
-            filter(None,
-                   os.getenv("VLLM_EXTRA_CUDA_GRAPH_SIZES", "").split(',')))),
+    lambda: [
+        int(s.strip())
+        for s in os.getenv("VLLM_EXTRA_CUDA_GRAPH_SIZES", "").split(',')
+        if s != ""
+    ]
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -572,6 +572,9 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # models the alignment is already naturally aligned to 256 bytes.
     "VLLM_CUDA_MEM_ALIGN_KV_CACHE":
     lambda: bool(int(os.getenv("VLLM_CUDA_MEM_ALIGN_KV_CACHE", "1"))),
+
+    "VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS":
+    lambda: bool(int(os.getenv("VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -572,8 +572,16 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # models the alignment is already naturally aligned to 256 bytes.
     "VLLM_CUDA_MEM_ALIGN_KV_CACHE":
     lambda: bool(int(os.getenv("VLLM_CUDA_MEM_ALIGN_KV_CACHE", "1"))),
-    "VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS":
-    lambda: bool(int(os.getenv("VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS", "0"))),
+
+    # If set, vllm will capture a cuda graph of each specified size
+    # in addition to the default set of sizes. The sizes are specified
+    # as a comma-separated sequence of integers.
+    "VLLM_EXTRA_CUDA_GRAPH_SIZES":
+    lambda: list(
+        map(
+            int,
+            filter(None,
+                   os.getenv("VLLM_EXTRA_CUDA_GRAPH_SIZES", "").split(',')))),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -572,7 +572,6 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # models the alignment is already naturally aligned to 256 bytes.
     "VLLM_CUDA_MEM_ALIGN_KV_CACHE":
     lambda: bool(int(os.getenv("VLLM_CUDA_MEM_ALIGN_KV_CACHE", "1"))),
-
     "VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS":
     lambda: bool(int(os.getenv("VLLM_CAPTURE_ADDITIONAL_SMALL_GRAPHS", "0"))),
 }


### PR DESCRIPTION
For certain batch sizes, the rounding effect of cuda graph padding can be severe. Consider for instance a batch of size 9, rounded up to the nearest multiple of 8 (16), can lead to a noticeable worsening in performance around batch sizes, especially at batch_size=5 (rounded up to 8) and batch_size=9 (rounded up to 16).

This PR adds an opt-in flag to capture additional CUDA graphs at small batch sizes to offset this problem.

I benchmarked using a deployment of DeepSeek-R1 on 8xH200, with `max-concurrent==9` and `num-requests==100`. 

Without this PR, I measured **TPOT 55ms, Output Token Throughput 154 tok/s**
With the flag enabled, I measured **TPOT 44ms, Output Token Throughput 192 tok/s**, for an improvement of **~25%**.