### PR TITLE
[Bugfix] Remove unused seq_group_metadata_list from ModelInputForGPU

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -98,7 +98,6 @@ class ModelInputForGPU(ModelRunnerInputBase):
     finished_requests_ids: Optional[List[str]] = None
     virtual_engine: int = 0
     async_callback: Optional[Callable] = None
-    seq_group_metadata_list: Optional[List[SequenceGroupMetadata]] = None
     scheduler_outputs: Optional[SchedulerOutputs] = None
 
     def as_broadcastable_tensor_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
While implementing the XpYd disaggregated prefilling feature, I found that the `model_input.seq_group_metadata_list` of model_input passed to the `execute_model` function in _model_runner.py_ is always None.

Turn out the `seq_group_metadata_list` variable in class `ModelInputForGPU` is never initialized and used.
The CI results confirmed that removing this unused parameter has zero impact on the correctness, so I think it can be removed. The only failed test (distributed-tests-4-gpus) is caused by ray initialization, it should be irrelevant.