### PR TITLE
force quit when get pynvml version issue

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2252,11 +2252,13 @@ def import_pynvml():
         import pynvml
         if pynvml.__file__.endswith("__init__.py"):
             # this is pynvml < 12.0
-            raise RuntimeError(
-                "You are using a deprecated `pynvml` package. "
-                "Please uninstall `pynvml` or upgrade to at least"
-                " version 12.0. See https://pypi.org/project/pynvml "
-                "for more information.")
+            print(
+                "ERROR: You are using a deprecated `pynvml` package. "
+                "Please uninstall `pynvml` or upgrade to at least version 12.0. "
+                "See https://pypi.org/project/pynvml for more information.",
+                file=sys.stderr,
+            )
+            sys.exit(1)  # Forcefully terminate the script
         return sys.modules["pynvml"]
     import importlib.util
     import os


### PR DESCRIPTION
This PR fixes an issue where CUDA detection fails silently when an outdated
version of `pynvml` (<12.0) is installed. The previous implementation
swallowed the `RuntimeError`, leading to `is_cuda=False` even when CUDA 
devices were available, leading to UnspecifiedPlatform --> NotImplementedError

- To avoid overwriting higher-level's RuntimeError catches, decided to forcefully 
terminate when found version error.