### PR TITLE
Allow Unsloth Dynamic 4bit BnB quants to work

### DIFF
--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -133,15 +133,14 @@ def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
     components = prefix.split('.')
 
     # Check if any of the skip modules exactly matches any component
-    substr_check = any(
-        module_name in components
-        for module_name in llm_int8_skip_modules
-    )
+    substr_check = any(module_name in components
+                       for module_name in llm_int8_skip_modules)
 
     # Allow certain layers to not be quantized
-    components = set(".".join(components[:i+1]) for i in range(len(components)))
+    components = set(".".join(components[:i + 1])
+                     for i in range(len(components)))
     prefix_check = len(set(llm_int8_skip_modules) & components) != 0
-    
+
     return substr_check or prefix_check
 
 

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -133,8 +133,16 @@ def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
     components = prefix.split('.')
 
     # Check if any of the skip modules exactly matches any component
-    return any(module_name in components
-               for module_name in llm_int8_skip_modules)
+    vllm_check = any(
+        module_name in components
+        for module_name in llm_int8_skip_modules
+    )
+
+    # Allow certain layers to not be quantized
+    components = set(".".join(components[:i+1]) for i in range(len(components)))
+    unsloth_check = len(set(llm_int8_skip_modules) & components) != 0
+    
+    return vllm_check or unsloth_check
 
 
 class BitsAndBytesLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -133,16 +133,16 @@ def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
     components = prefix.split('.')
 
     # Check if any of the skip modules exactly matches any component
-    vllm_check = any(
+    substr_check = any(
         module_name in components
         for module_name in llm_int8_skip_modules
     )
 
     # Allow certain layers to not be quantized
     components = set(".".join(components[:i+1]) for i in range(len(components)))
-    unsloth_check = len(set(llm_int8_skip_modules) & components) != 0
+    prefix_check = len(set(llm_int8_skip_modules) & components) != 0
     
-    return vllm_check or unsloth_check
+    return substr_check or prefix_check
 
 
 class BitsAndBytesLinearMethod(LinearMethodBase):

--- a/vllm/model_executor/layers/quantization/bitsandbytes.py
+++ b/vllm/model_executor/layers/quantization/bitsandbytes.py
@@ -137,9 +137,10 @@ def is_layer_skipped_bnb(prefix: str, llm_int8_skip_modules: List[str]):
                        for module_name in llm_int8_skip_modules)
 
     # Allow certain layers to not be quantized
-    components = set(".".join(components[:i + 1])
-                     for i in range(len(components)))
-    prefix_check = len(set(llm_int8_skip_modules) & components) != 0
+    set_components = set(".".join(components[:i + 1])
+                         for i in range(len(components)))
+    set_llm_int8_skip_modules = set(llm_int8_skip_modules)
+    prefix_check = len(set_llm_int8_skip_modules & set_components) != 0
 
     return substr_check or prefix_check
 


### PR DESCRIPTION
This PR allows vLLM to skip applying bitsandbytes quantization to certain layers, and leave them in 16bit. This will for now work only on skipped modules specified inside of `llm_int8_skip_modules`

For example https://huggingface.co/unsloth/DeepSeek-R1-Distill-Llama-8B-unsloth-bnb-4bit/blob/main/config.json has
```python
"llm_int8_skip_modules": [
      "lm_head",
      "multi_modal_projector",
      "merger",
      "modality_projection",
      "model.layers.1.mlp"
],
```
will skip quantizing `model.layers.1.mlp`. Tagging @mgoin ! :)