### PR TITLE
[Bugfix][Platform] Check whether selected backend is None in get_attn_backend_cls()

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -35,7 +35,7 @@ class CpuPlatform(Platform):
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
                              block_size: int, use_v1: bool,
                              use_mla: bool) -> str:
-        if selected_backend != _Backend.TORCH_SDPA:
+        if selected_backend is not None and selected_backend != _Backend.TORCH_SDPA:
             logger.info("Cannot use %s backend on CPU.", selected_backend)
         logger.info("Using Torch SDPA backend.")
         return "vllm.attention.backends.torch_sdpa.TorchSDPABackend"

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -35,7 +35,7 @@ class CpuPlatform(Platform):
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
                              block_size: int, use_v1: bool,
                              use_mla: bool) -> str:
-        if selected_backend is not None and selected_backend != _Backend.TORCH_SDPA:
+        if selected_backend and selected_backend != _Backend.TORCH_SDPA:
             logger.info("Cannot use %s backend on CPU.", selected_backend)
         logger.info("Using Torch SDPA backend.")
         return "vllm.attention.backends.torch_sdpa.TorchSDPABackend"


### PR DESCRIPTION
This avoids the misleading message "cannot use None backend" as seen below:

```
INFO 02-09 03:13:01 __init__.py:190] Automatically detected platform cpu.
INFO 02-09 03:13:05 cpu.py:39] Cannot use None backend on CPU.
INFO 02-09 03:13:05 cpu.py:40] Using Torch SDPA backend.
```