### PR TITLE
[Bugfix] Guided decoding falls back to outlines when fails to import xgrammar

### DIFF
--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -55,7 +55,7 @@ def maybe_backend_fallback(
                 guided_params.backend = "outlines"
 
             # xgrammar doesn't support regex or choice, fallback to outlines
-            if guided_params.regex is not None or guided_params.choice is not None:
+            if guided_params.regex is not None or guided_params.choice is not None:  # noqa
                 logger.warning(
                     "xgrammar only supports json or grammar guided decoding. "
                     "Falling back to use outlines instead.")
@@ -65,7 +65,7 @@ def maybe_backend_fallback(
             elif (guided_params.json is not None and
                   has_xgrammar_unsupported_json_features(guided_params.json)):
                 logger.warning(
-                    "xgrammar does not support advanced JSON schema features like "
+                    "xgrammar does not support advanced JSON schema features like "  # noqa
                     "patterns or numeric ranges. "
                     "Falling back to use outlines instead.")
                 guided_params.backend = "outlines"

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -40,42 +40,49 @@ def maybe_backend_fallback(
             guided_params.backend = "outlines"
 
     if guided_params.backend == "xgrammar":
-        # xgrammar only has x86 wheels for linux, fallback to outlines
-        from vllm.platforms import current_platform
-        if current_platform.get_cpu_architecture() is not CpuArchEnum.X86:
-            logger.warning("xgrammar is only supported on x86 CPUs. "
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
+            xgr_installed)
+        if not xgr_installed:
+            logger.warning("xgrammar module cannot be imported successfully. "
                            "Falling back to use outlines instead.")
             guided_params.backend = "outlines"
+        else:
+            # xgrammar only has x86 wheels for linux, fallback to outlines
+            from vllm.platforms import current_platform
+            if current_platform.get_cpu_architecture() is not CpuArchEnum.X86:
+                logger.warning("xgrammar is only supported on x86 CPUs. "
+                               "Falling back to use outlines instead.")
+                guided_params.backend = "outlines"
 
-        # xgrammar doesn't support regex or choice, fallback to outlines
-        if guided_params.regex is not None or guided_params.choice is not None:
-            logger.warning(
-                "xgrammar only supports json or grammar guided decoding. "
-                "Falling back to use outlines instead.")
-            guided_params.backend = "outlines"
-
-        # xgrammar doesn't support some JSON schema features
-        elif (guided_params.json is not None
-              and has_xgrammar_unsupported_json_features(guided_params.json)):
-            logger.warning(
-                "xgrammar does not support advanced JSON schema features like "
-                "patterns or numeric ranges. "
-                "Falling back to use outlines instead.")
-            guided_params.backend = "outlines"
-
-        # xgrammar only supports GBNF grammars, so we must convert Lark.
-        # We must check if the grammar is likely Lark and if that
-        # grammar is convertible to GBNF
-        elif (guided_params.grammar is not None
-              and grammar_is_likely_lark(guided_params.grammar)):
-            try:
-                convert_lark_to_gbnf(guided_params.grammar)
-            except Exception:
+            # xgrammar doesn't support regex or choice, fallback to outlines
+            if guided_params.regex is not None or guided_params.choice is not None:
                 logger.warning(
-                    "xgrammar does not support Lark grammars and the "
-                    "grammar failed to convert to GBNF. "
+                    "xgrammar only supports json or grammar guided decoding. "
                     "Falling back to use outlines instead.")
                 guided_params.backend = "outlines"
+
+            # xgrammar doesn't support some JSON schema features
+            elif (guided_params.json is not None
+                  and has_xgrammar_unsupported_json_features(guided_params.json)):
+                logger.warning(
+                    "xgrammar does not support advanced JSON schema features like "
+                    "patterns or numeric ranges. "
+                    "Falling back to use outlines instead.")
+                guided_params.backend = "outlines"
+
+            # xgrammar only supports GBNF grammars, so we must convert Lark.
+            # We must check if the grammar is likely Lark and if that
+            # grammar is convertible to GBNF
+            elif (guided_params.grammar is not None
+                  and grammar_is_likely_lark(guided_params.grammar)):
+                try:
+                    convert_lark_to_gbnf(guided_params.grammar)
+                except Exception:
+                    logger.warning(
+                        "xgrammar does not support Lark grammars and the "
+                        "grammar failed to convert to GBNF. "
+                        "Falling back to use outlines instead.")
+                    guided_params.backend = "outlines"
 
     if (guided_params.backend == "outlines"
             and guided_params.json_object is not None):

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -79,7 +79,7 @@ def maybe_backend_fallback(
                     "Falling back to use outlines instead.")
                 guided_params.backend = "outlines"
 
-        # If the xgrammar module cannot be imported successfully for some reason,
+        # If the xgrammar module cannot be imported successfully,
         # we should still allow users to use guided decoding with a fallback.
         elif not xgr_installed:
             logger.warning("xgrammar module cannot be imported successfully. "

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -62,8 +62,8 @@ def maybe_backend_fallback(
                 guided_params.backend = "outlines"
 
             # xgrammar doesn't support some JSON schema features
-            elif (guided_params.json is not None
-                  and has_xgrammar_unsupported_json_features(guided_params.json)):
+            elif (guided_params.json is not None and
+                  has_xgrammar_unsupported_json_features(guided_params.json)):
                 logger.warning(
                     "xgrammar does not support advanced JSON schema features like "
                     "patterns or numeric ranges. "

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -57,8 +57,8 @@ def maybe_backend_fallback(
             guided_params.backend = "outlines"
 
         # xgrammar doesn't support some JSON schema features
-        elif (guided_params.json is not None and
-              has_xgrammar_unsupported_json_features(guided_params.json)):
+        elif (guided_params.json is not None
+              and has_xgrammar_unsupported_json_features(guided_params.json)):
             logger.warning(
                 "xgrammar does not support advanced JSON schema features like "
                 "patterns or numeric ranges. "

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -40,7 +40,7 @@ def maybe_backend_fallback(
             guided_params.backend = "outlines"
 
     if guided_params.backend == "xgrammar":
-        from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
+        from vllm.model_executor.guided_decoding.xgrammar_decoding import (
             xgr_installed)
         # xgrammar only has x86 wheels for linux, fallback to outlines
         from vllm.platforms import current_platform
@@ -50,7 +50,7 @@ def maybe_backend_fallback(
             guided_params.backend = "outlines"
 
         # xgrammar doesn't support regex or choice, fallback to outlines
-        if guided_params.regex is not None or guided_params.choice is not None:  # noqa
+        if guided_params.regex is not None or guided_params.choice is not None:
             logger.warning(
                 "xgrammar only supports json or grammar guided decoding. "
                 "Falling back to use outlines instead.")
@@ -60,7 +60,7 @@ def maybe_backend_fallback(
         elif (guided_params.json is not None and
               has_xgrammar_unsupported_json_features(guided_params.json)):
             logger.warning(
-                "xgrammar does not support advanced JSON schema features like "  # noqa
+                "xgrammar does not support advanced JSON schema features like "
                 "patterns or numeric ranges. "
                 "Falling back to use outlines instead.")
             guided_params.backend = "outlines"

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -14,7 +14,9 @@ from transformers import PreTrainedTokenizerFast
 try:
     import xgrammar as xgr
     from xgrammar.base import _core as xgr_core
+    xgr_installed = True
 except ImportError:
+    xgr_installed = False
     pass
 
 from vllm.model_executor.guided_decoding.utils import (convert_lark_to_gbnf,


### PR DESCRIPTION
This fixes the issue when xgrammar module cannot be imported successfully for some reason, e.g. triton is not available. This fallback allows users to still use guided decoding when xgrammar cannot be used.

```
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/multiprocessing/client.py", line 606, in _process_request
    params = await \
  File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 553, in build_guided_decoding_logits_processor_async
    processor = await get_guided_decoding_logits_processor(
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/guided_decoding/__init__.py", line 109, in get_guided_decoding_logits_processor
    return get_local_xgrammar_guided_decoding_logits_processor(
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 38, in get_local_xgrammar_guided_decoding_logits_processor
    config = GrammarConfig.from_guided_params(guided_params=guided_params,
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 174, in from_guided_params
    tokenizer_data = TokenizerDataCache.get_tokenizer_data(tokenizer)
  File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 87, in get_tokenizer_data
    vocab_type = xgr.VocabType.RAW
NameError: name 'xgr' is not defined

```