### PR TITLE
[MISC] Always import version library first in the vllm package

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """vLLM: a high-throughput and memory-efficient inference engine for LLMs"""
+# The version.py should be independent library, and we always import the
+# version library first.  Such assumption is critical for some customization.
+from .version import __version__, __version_tuple__  # isort:skip
+
 import os
 
 import torch
@@ -18,8 +22,6 @@ from vllm.outputs import (ClassificationOutput, ClassificationRequestOutput,
                           ScoringRequestOutput)
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
-
-from .version import __version__, __version_tuple__
 
 # set some common config/environment variables that should be set
 # for all processes created by vllm and all processes


### PR DESCRIPTION
We insert some customization logic into the generated _version.py. We need to ensure that the "version" library is always the first one to import in the vllm package.