### PR TITLE
[core] improve error handling when wake up from sleep mode

### DIFF
--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -233,7 +233,7 @@ void my_free(void* ptr, ssize_t size, int device, CUstream stream) {
   // free address and the handle
   CUDA_CHECK(cuMemAddressFree(d_mem, size));
   if (error_code != 0) {
-    return nullptr;
+    return;
   }
   free(p_memHandle);
 }

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -26,6 +26,7 @@ CUresult error_code = no_error;  // store error code
       snprintf(error_msg, sizeof(error_msg), "CUDA Error: %s at %s:%d", \
                error_string, __FILE__, __LINE__);                       \
       std::cerr << error_msg << std::endl;                              \
+      return;                                                           \
     }                                                                   \
   } while (0)
 

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -12,8 +12,9 @@ extern "C" {
 #include <cuda_runtime_api.h>
 #include <cuda.h>
 
-char error_msg[10240];    // 10KB buffer to store error messages
-CUresult error_code = 0;  // store error code
+char error_msg[10240];  // 10KB buffer to store error messages
+CUresult no_error = CUresult(0);
+CUresult error_code = no_error;  // store error code
 
 #define CUDA_CHECK(condition)                                           \
   do {                                                                  \
@@ -264,7 +265,7 @@ static PyObject* python_unmap_and_release(PyObject* self, PyObject* args) {
   unmap_and_release(recv_device, recv_size, d_mem_ptr, p_memHandle);
 
   if (error_code != 0) {
-    error_code = 0;
+    error_code = no_error;
     PyErr_SetString(PyExc_RuntimeError, error_msg);
     return nullptr;
   }
@@ -294,7 +295,7 @@ static PyObject* python_create_and_map(PyObject* self, PyObject* args) {
   create_and_map(recv_device, recv_size, d_mem_ptr, p_memHandle);
 
   if (error_code != 0) {
-    error_code = 0;
+    error_code = no_error;
     PyErr_SetString(PyExc_RuntimeError, error_msg);
     return nullptr;
   }


### PR DESCRIPTION
Feedback from RLHF user: when vLLM wakes up from sleep mode, and there's not enough memory, there will be an error from C++ side, with error messages:

```text
CUDA Error: out of memory at /workspace/csrc/cumem_allocator.cpp:56
CUDA Error: invalid argument at /workspace/csrc/cumem_allocator.cpp:57
CUDA Error: invalid argument at /workspace/csrc/cumem_allocator.cpp:64
```

However, the python function still returns, and later the `memcpy` function gets invalid memory address, causing a segment fault.

This PR improves the error handling, so that we can raise proper python exception without crashing the process.