### PR TITLE
Update docker.md

### DIFF
--- a/docs/source/deployment/docker.md
+++ b/docs/source/deployment/docker.md
@@ -10,7 +10,7 @@ vLLM offers an official Docker image for deployment.
 The image can be used to run OpenAI compatible server and is available on Docker Hub as [vllm/vllm-openai](https://hub.docker.com/r/vllm/vllm-openai/tags).
 
 ```console
-$ docker run --runtime nvidia --gpus all \
+$ docker run --runtime=nvidia --gpus all \
     -v ~/.cache/huggingface:/root/.cache/huggingface \
     --env "HUGGING_FACE_HUB_TOKEN=<secret>" \
     -p 8000:8000 \


### PR DESCRIPTION
update the command of running the vllm using docker  it currently miss '=' when assigning the runtime to nvidia



<!--- pyml disable-next-line no-emphasis-as-heading -->
