### PR TITLE
[Feature] Support user-specified "trigger" token before starting structured decoding

### DIFF
--- a/tests/entrypoints/llm/test_guided_generate.py
+++ b/tests/entrypoints/llm/test_guided_generate.py
@@ -12,7 +12,7 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 
-MODEL_NAME = "Qwen/Qwen2.5-7B-Instruct"
+MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
 MODEL_FOR_REASONING_NAME = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 GUIDED_DECODING_BACKENDS = ["outlines", "lm-format-enforcer", "xgrammar"]
 
@@ -21,7 +21,7 @@ GUIDED_DECODING_BACKENDS = ["outlines", "lm-format-enforcer", "xgrammar"]
 def llm():
     # pytest caches the fixture so we use weakref.proxy to
     # enable garbage collection
-    llm = LLM(model=MODEL_NAME, max_model_len=1024)
+    llm = LLM(model=MODEL_NAME, max_model_len=1024, gpu_memory_utilization=0.3)
 
     with llm.deprecate_legacy_api():
         yield weakref.proxy(llm)
@@ -33,7 +33,11 @@ def llm():
 def llm_for_reasoning():
     # pytest caches the fixture so we use weakref.proxy to
     # enable garbage collection
-    llm = LLM(model=MODEL_FOR_REASONING_NAME, max_model_len=1024)
+    llm = LLM(
+        model=MODEL_FOR_REASONING_NAME,
+        max_model_len=1024,
+        gpu_memory_utilization=0.3,
+    )
 
     with llm.deprecate_legacy_api():
         yield weakref.proxy(llm)

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -336,6 +336,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "If specified, will override the default guided decoding backend "
             "of the server for this specific request. If set, must be either "
             "'outlines' / 'lm-format-enforcer'"))
+    guided_decoding_trigger_token: Optional[str] = Field(
+        default=None,
+        description=("If specified, guided decoding begins only after this "
+                     "token is produced."))
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,
         description=(
@@ -464,7 +468,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
             grammar=self.guided_grammar,
             json_object=guided_json_object,
             backend=self.guided_decoding_backend,
-            whitespace_pattern=self.guided_whitespace_pattern)
+            whitespace_pattern=self.guided_whitespace_pattern,
+            trigger_token=self.guided_decoding_trigger_token,
+        )
 
         return SamplingParams.from_optional(
             n=self.n,
@@ -712,6 +718,10 @@ class CompletionRequest(OpenAIBaseModel):
             "If specified, will override the default guided decoding backend "
             "of the server for this specific request. If set, must be one of "
             "'outlines' / 'lm-format-enforcer'"))
+    guided_decoding_trigger_token: Optional[str] = Field(
+        default=None,
+        description=("If specified, guided decoding begins only after this "
+                     "token is produced."))
     guided_whitespace_pattern: Optional[str] = Field(
         default=None,
         description=(
@@ -827,7 +837,9 @@ class CompletionRequest(OpenAIBaseModel):
             grammar=self.guided_grammar,
             json_object=guided_json_object,
             backend=self.guided_decoding_backend,
-            whitespace_pattern=self.guided_whitespace_pattern)
+            whitespace_pattern=self.guided_whitespace_pattern,
+            trigger_token=self.guided_decoding_trigger_token,
+        )
 
         return SamplingParams.from_optional(
             n=self.n,

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -63,6 +63,14 @@ def maybe_backend_fallback(
                 "Falling back to use outlines instead.")
             guided_params.backend = "outlines"
 
+            # @jacobthebanana: revisit this check after adding support for
+            # trigger_token in outline.
+            if guided_params.trigger_token is not None:
+                raise AttributeError(
+                    "trigger_token requires xgrammar, but xgrammar does not "
+                    "support advanced JSON schema features like patterns or "
+                    "numeric ranges.")
+
         # xgrammar only supports GBNF grammars, so we must convert Lark.
         # We must check if the grammar is likely Lark and if that
         # grammar is convertible to GBNF

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -255,7 +255,7 @@ class XGrammarLogitsProcessor:
     prefilled: bool = field(default=False)
 
     # Same length as batch_size (one boolean value for each item in batch)
-    is_triggered: list[bool] = field(default=[True])
+    is_triggered: list[bool] = field(default_factory=lambda: [True])
 
     def __getstate__(self) -> dict[str, Any]:
         return {'config': self.config}

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -255,7 +255,7 @@ class XGrammarLogitsProcessor:
     prefilled: bool = field(default=False)
 
     # Same length as batch_size (one boolean value for each item in batch)
-    is_triggered: list[bool] = field(default=None)  # type: ignore[assignment]
+    is_triggered: list[bool] = field(default=[True])
 
     def __getstate__(self) -> dict[str, Any]:
         return {'config': self.config}

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -37,6 +37,7 @@ class GuidedDecodingParams:
     """These are other options that can be set"""
     backend: Optional[str] = None
     whitespace_pattern: Optional[str] = None
+    trigger_token: Optional[str] = None
 
     @staticmethod
     def from_optional(
@@ -47,6 +48,7 @@ class GuidedDecodingParams:
         json_object: Optional[bool] = None,
         backend: Optional[str] = None,
         whitespace_pattern: Optional[str] = None,
+        trigger_token: Optional[str] = None
     ) -> Optional["GuidedDecodingParams"]:
         if all(arg is None
                for arg in (json, regex, choice, grammar, json_object)):
@@ -62,6 +64,7 @@ class GuidedDecodingParams:
             json_object=json_object,
             backend=backend,
             whitespace_pattern=whitespace_pattern,
+            trigger_token=trigger_token,
         )
 
     def __post_init__(self):


### PR DESCRIPTION
This PR allows the user to specify a "trigger token" that needs to be produced before xgrammar is applied to structured decoding. For example, when generating with r1-like models, the end-of-thought token `</think>` can be the trigger token, as seen in the example in the added unit test. 

Additional work might be required to:

- Extend these logic to the other logit processor options:
  - [ ] outlines
  - [ ] lm-format-enforcer
- Allow the user to specify strings consisting of more than one tokens (e.g., `JSON Output: ` or `\boxed` in math prompts) as the trigger for structured decoding.

FIX #12619 

I was not aware of #12955 from Saturday morning before I started working on this PR on Sunday- I apologize to [@gaocegege](https://github.com/gaocegege) if this PR partially overlapped with their contribution. From what I understand, the main difference between these two PR is the handling of [`batch_size`](https://github.com/vllm-project/vllm/blob/29f1d47e7/vllm/model_executor/guided_decoding/xgrammar_decoding.py#L243) in `xgrammar_decoding`, in case more than one stream of generations are being sent through this logic processor at a time. Though it is unclear whether that would ever be the case in the current setup.