### PR TITLE
Fix seed parameter behavior in vLLM

### DIFF
--- a/docs/seed_parameter_behavior.md
+++ b/docs/seed_parameter_behavior.md
@@ -1,0 +1,51 @@
+# Seed Parameter Behavior in vLLM
+
+## Overview
+
+The `seed` parameter in vLLM is used to control the random states for various random number generators. This parameter can affect the behavior of random operations in user code, especially when working with models in vLLM.
+
+## Default Behavior
+
+By default, the `seed` parameter is set to `None`. When the `seed` parameter is `None`, the global random states for `random`, `np.random`, and `torch.manual_seed` are not set. This means that the random operations will behave as expected, without any fixed random states.
+
+## Specifying a Seed
+
+If a specific seed value is provided, the global random states for `random`, `np.random`, and `torch.manual_seed` will be set accordingly. This can be useful for reproducibility, as it ensures that the random operations produce the same results across multiple runs.
+
+## Example Usage
+
+### Without Specifying a Seed
+
+```python
+import random
+from vllm import LLM
+
+# Initialize a vLLM model without specifying a seed
+model = LLM(model="Qwen/Qwen2.5-0.5B-Instruct")
+
+# Try generating random numbers
+print(random.randint(0, 100))  # Outputs different numbers across runs
+```
+
+### Specifying a Seed
+
+```python
+import random
+from vllm import LLM
+
+# Initialize a vLLM model with a specific seed
+model = LLM(model="Qwen/Qwen2.5-0.5B-Instruct", seed=42)
+
+# Try generating random numbers
+print(random.randint(0, 100))  # Outputs the same number across runs
+```
+
+## Important Notes
+
+- If the `seed` parameter is not specified, the behavior of global random states remains unaffected.
+- If a specific seed value is provided, the global random states for `random`, `np.random`, and `torch.manual_seed` will be set to that value.
+- This behavior can be useful for reproducibility but may lead to non-intuitive behavior if the user is not explicitly aware of it.
+
+## Conclusion
+
+Understanding the behavior of the `seed` parameter in vLLM is crucial for ensuring the expected behavior of random operations in your code. By default, the `seed` parameter is set to `None`, which means that the global random states are not affected. However, specifying a seed value can help achieve reproducibility in your experiments.

--- a/tests/test_seed_behavior.py
+++ b/tests/test_seed_behavior.py
@@ -1,0 +1,35 @@
+import random
+import numpy as np
+import torch
+from vllm.platforms.interface import Platform
+
+def test_seed_behavior():
+    # Test with seed=None
+    Platform.seed_everything(None)
+    random_value_1 = random.randint(0, 100)
+    np_random_value_1 = np.random.randint(0, 100)
+    torch_random_value_1 = torch.randint(0, 100, (1,)).item()
+
+    Platform.seed_everything(None)
+    random_value_2 = random.randint(0, 100)
+    np_random_value_2 = np.random.randint(0, 100)
+    torch_random_value_2 = torch.randint(0, 100, (1,)).item()
+
+    assert random_value_1 != random_value_2
+    assert np_random_value_1 != np_random_value_2
+    assert torch_random_value_1 != torch_random_value_2
+
+    # Test with a specific seed
+    Platform.seed_everything(42)
+    random_value_3 = random.randint(0, 100)
+    np_random_value_3 = np.random.randint(0, 100)
+    torch_random_value_3 = torch.randint(0, 100, (1,)).item()
+
+    Platform.seed_everything(42)
+    random_value_4 = random.randint(0, 100)
+    np_random_value_4 = np.random.randint(0, 100)
+    torch_random_value_4 = torch.randint(0, 100, (1,)).item()
+
+    assert random_value_3 == random_value_4
+    assert np_random_value_3 == np_random_value_4
+    assert torch_random_value_3 == torch_random_value_4

--- a/tests/test_seed_behavior.py
+++ b/tests/test_seed_behavior.py
@@ -1,19 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
 import random
+
 import numpy as np
 import torch
+
 from vllm.platforms.interface import Platform
+
 
 def test_seed_behavior():
     # Test with seed=None
     Platform.seed_everything(None)
     random_value_1 = random.randint(0, 100)
     np_random_value_1 = np.random.randint(0, 100)
-    torch_random_value_1 = torch.randint(0, 100, (1,)).item()
+    torch_random_value_1 = torch.randint(0, 100, (1, )).item()
 
     Platform.seed_everything(None)
     random_value_2 = random.randint(0, 100)
     np_random_value_2 = np.random.randint(0, 100)
-    torch_random_value_2 = torch.randint(0, 100, (1,)).item()
+    torch_random_value_2 = torch.randint(0, 100, (1, )).item()
 
     assert random_value_1 != random_value_2
     assert np_random_value_1 != np_random_value_2
@@ -23,12 +27,12 @@ def test_seed_behavior():
     Platform.seed_everything(42)
     random_value_3 = random.randint(0, 100)
     np_random_value_3 = np.random.randint(0, 100)
-    torch_random_value_3 = torch.randint(0, 100, (1,)).item()
+    torch_random_value_3 = torch.randint(0, 100, (1, )).item()
 
     Platform.seed_everything(42)
     random_value_4 = random.randint(0, 100)
     np_random_value_4 = np.random.randint(0, 100)
-    torch_random_value_4 = torch.randint(0, 100, (1,)).item()
+    torch_random_value_4 = torch.randint(0, 100, (1, )).item()
 
     assert random_value_3 == random_value_4
     assert np_random_value_3 == np_random_value_4

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -211,16 +211,17 @@ class Platform:
         return torch.inference_mode(mode=True)
 
     @classmethod
-    def seed_everything(cls, seed: int) -> None:
+    def seed_everything(cls, seed: Optional[int] = None) -> None:
         """
         Set the seed of each random module.
         `torch.manual_seed` will set seed on all devices.
 
         Loosely based on: https://github.com/Lightning-AI/pytorch-lightning/blob/2.4.0/src/lightning/fabric/utilities/seed.py#L20
         """
-        random.seed(seed)
-        np.random.seed(seed)
-        torch.manual_seed(seed)
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+            torch.manual_seed(seed)
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:


### PR DESCRIPTION
Fixes #11953

Update the `seed_everything` method to handle `seed=None` appropriately.

* Modify `vllm/platforms/interface.py` to update the `seed_everything` method to handle `seed=None` and skip setting random seeds if `seed=None`.
* Add a new test file `tests/test_seed_behavior.py` to verify the behavior of the `seed` parameter, including cases where `seed=None` and `seed` is specified.
* Add documentation in `docs/seed_parameter_behavior.md` explaining the behavior of the `seed` parameter, its effect on global random states, and provide examples of usage with and without specifying the `seed` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/vllm-project/vllm/pull/13007?shareId=0ac8eb24-1285-4c68-bdbe-e468ec403bd3).