### PR TITLE
[misc] Add retries with exponential backoff for HF file existence check

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -126,6 +126,8 @@ def file_or_path_exists(model: Union[str, Path], config_name: str,
                 raise
             time.sleep(retry_delay)
             retry_delay *= 2
+            continue
+    return False
 
 
 def patch_rope_scaling(config: PretrainedConfig) -> None:


### PR DESCRIPTION
`file_exists` usually timeout on CI causing jobs to fail. This is to add retry policy with exponential backoff to hopefully get requests to HF to go through