### PR TITLE
[Bugfix] fix(logging): add missing opening square bracket

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -20,7 +20,7 @@ VLLM_LOGGING_LEVEL = envs.VLLM_LOGGING_LEVEL
 VLLM_LOGGING_PREFIX = envs.VLLM_LOGGING_PREFIX
 
 _FORMAT = (f"{VLLM_LOGGING_PREFIX}%(levelname)s %(asctime)s "
-           "%(filename)s:%(lineno)d] %(message)s")
+           "[%(filename)s:%(lineno)d] %(message)s")
 _DATE_FORMAT = "%m-%d %H:%M:%S"
 
 DEFAULT_LOGGING_CONFIG = {


### PR DESCRIPTION
before:
`INFO 02-10 07:39:31 launcher.py:29] Route: /v1/rerank, Methods: POST`

after:
`INFO 02-09 11:36:52 [launcher.py:29] Route: /v1/rerank, Methods: POST`

⚒️ with ❤️ by @siemens