### PR TITLE
[Quant] Add packed_modules_mapping attribute to CLIPVisionModel

### DIFF
--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -2,7 +2,7 @@
 
 import inspect
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Mapping, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 import torch
 from torch import nn
@@ -59,7 +59,7 @@ def method_has_implemented_embedding(
 
 class QuantizationConfig(ABC):
     """Base class for quantization configs."""
-    packed_modules_mapping: Mapping[str, List[str]] = dict()
+    packed_modules_mapping: Dict[str, List[str]] = dict()
 
     @abstractmethod
     def get_name(self) -> str:

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -470,6 +470,9 @@ class CLIPVisionTransformer(nn.Module):
 
 class CLIPVisionModel(nn.Module):
 
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    }
     config_class = CLIPVisionConfig
     main_input_name = "pixel_values"
 
@@ -483,6 +486,7 @@ class CLIPVisionModel(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        quant_config.packed_modules_mapping.update(self.packed_modules_mapping)
         self.vision_model = CLIPVisionTransformer(
             config=config,
             quant_config=quant_config,


### PR DESCRIPTION
## Purpose ##
* Support loading quantized clip models (namely, phi3v)

## Changes ##
* Add `packed_modules_mapping` attribute to `CLIPVisionModel`
  * Note that the quantization config is updated prior to the model weights being initialized
* Narrow `packed_modules_mapping` type hint on `QuantizationConfig`

## Testing ##
* Can now load `neuralmagic/Phi-3-vision-128k-instruct-W4A16-G128` without issue