### PR TITLE
[Benchmark] Add BurstGPT to benchmark_serving

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -19,3 +19,11 @@ mkdir coco -p
 wget http://images.cocodataset.org/zips/train2017.zip -O coco/train2017.zip
 unzip coco/train2017.zip -d coco/
 ```
+
+# Downloading the BurstGPT dataset
+
+You can download the BurstGPT v1.1 dataset by running:
+
+```bash
+wget https://github.com/HPMLL/BurstGPT/releases/download/v1.1/BurstGPT_without_fails_2.csv
+```

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -38,6 +38,7 @@ from datetime import datetime
 from typing import Any, AsyncGenerator, Collection, Dict, List, Optional, Tuple
 
 import numpy as np
+import pandas as pd
 from backend_request_func import (ASYNC_REQUEST_FUNCS, RequestFuncInput,
                                   RequestFuncOutput)
 from datasets import load_dataset
@@ -129,6 +130,30 @@ def sample_sharegpt_requests(
         filtered_dataset.append((prompt, prompt_len, output_len, None))
 
     return filtered_dataset
+
+
+def sample_burstgpt_requests(
+    dataset_path: str,
+    num_requests: int,
+    random_seed: int,
+    tokenizer: PreTrainedTokenizerBase,
+) -> List[Tuple[str, int, int, None]]:
+    df = pd.read_csv(dataset_path)
+    gpt4_df = df[df["Model"] == "GPT-4"]
+    # Remove the failed requests (i.e., response length is 0)
+    gpt4_df = gpt4_df[gpt4_df["Response tokens"] > 0]
+    # Randomly sample num_requests from the dataset
+    gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed)
+    # Convert the dataframe to a list of tuples
+    dataset = gpt4_df.values.tolist()
+    input_requests = []
+    for i in range(num_requests):
+        input_len = int(dataset[i][2])
+        output_len = int(dataset[i][3])
+        prompt = tokenizer.decode([(i + j) % tokenizer.vocab_size
+                                   for j in range(input_len)])
+        input_requests.append((prompt, input_len, output_len, None))
+    return input_requests
 
 
 def sample_sonnet_requests(
@@ -830,6 +855,14 @@ def main(args: argparse.Namespace):
             fixed_output_len=args.sharegpt_output_len,
         )
 
+    elif args.dataset_name == "burstgpt":
+        input_requests = sample_burstgpt_requests(
+            dataset_path=args.dataset_path,
+            num_requests=args.num_prompts,
+            random_seed=args.seed,
+            tokenizer=tokenizer,
+        )
+
     elif args.dataset_name == "sonnet":
         # Do not format the prompt, pass to message directly
         if args.backend == "openai-chat":
@@ -995,7 +1028,7 @@ if __name__ == "__main__":
         "--dataset-name",
         type=str,
         default="sharegpt",
-        choices=["sharegpt", "sonnet", "random", "hf"],
+        choices=["sharegpt", "burstgpt", "sonnet", "random", "hf"],
         help="Name of the dataset to benchmark on.",
     )
     parser.add_argument("--dataset-path",

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -146,7 +146,9 @@ def sample_burstgpt_requests(
     if num_requests <= len(gpt4_df):
         gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed)
     else:
-        gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed, replace=True)
+        gpt4_df = gpt4_df.sample(n=num_requests,
+                                 random_state=random_seed,
+                                 replace=True)
     # Convert the dataframe to a list of tuples
     dataset = gpt4_df.values.tolist()
     input_requests = []

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -143,7 +143,10 @@ def sample_burstgpt_requests(
     # Remove the failed requests (i.e., response length is 0)
     gpt4_df = gpt4_df[gpt4_df["Response tokens"] > 0]
     # Randomly sample num_requests from the dataset
-    gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed)
+    if num_requests <= len(gpt4_df):
+        gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed)
+    else:
+        gpt4_df = gpt4_df.sample(n=num_requests, random_state=random_seed, replace=True)
     # Convert the dataframe to a list of tuples
     dataset = gpt4_df.values.tolist()
     input_requests = []


### PR DESCRIPTION
This PR adds the [BurstGPT](https://github.com/HPMLL/BurstGPT) dataset to `benchmark_serving.py`. Compared to ShareGPT (single-turn), BurstGPT contains longer prompts (avg. 763 tokens) and outputs (avg. 348 tokens). This PR doesn't use the timestamps in the dataset yet.

*The dataset only contains the lengths of the prompt and output. It does not include the content of the requests.