### PR TITLE
[V1] Allow sliding window + prefix caching

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1124,7 +1124,7 @@ class CacheConfig:
         if not self.enable_prefix_caching:
             return
 
-        if self.sliding_window is not None:
+        if self.sliding_window is not None and not envs.VLLM_USE_V1:
             raise NotImplementedError(
                 "Prefix caching is not supported with sliding window. "
                 "Run with --disable-sliding-window to use prefix caching.")


### PR DESCRIPTION
The KV cache manager in V1 ignores sliding window, so prefix caching is compatible with sliding window attention.