### PR TITLE
[CI/Build][Bugfix] Fix CPU backend default threads num

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -115,6 +115,9 @@ class CpuPlatform(Platform):
         # Environment variables for CPU executor
         #
 
+        # Set default threads num for OpenMP parallel
+        os.environ["OMP_NUM_THREADS"] = str(torch.get_num_threads())
+
         # Disable torch async compiling which won't work with daemonic processes
         os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = "1"
 


### PR DESCRIPTION
```MultiprocessingDistributedExecutor``` will set the default openmp threads num to 1 and leads to slow CPU CI testing. This PR bypasses it by setting default ```OMP_NUM_THREADS``` ahead.