### PR TITLE
[Misc] Add model list API in disagg proxy

### DIFF
--- a/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/disagg_prefill_proxy_server.py
@@ -28,6 +28,19 @@ async def forward_request(url, data):
                     yield content
 
 
+@app.route('/v1/models', methods=['GET'])
+async def forward_model_request():
+    async with aiohttp.ClientSession() as session:
+        headers = {
+            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"
+        }
+        async with session.get('http://localhost:8100/v1/models',
+                               headers=headers) as response:
+            if response.status == 200:
+                # Read the response from the upstream service
+                return await response.json()
+
+
 @app.route('/v1/completions', methods=['POST'])
 async def handle_request():
     try:


### PR DESCRIPTION
When no specific model name is provided,
the benchmark script utilizes the first model from the model list API. To ensure compatibility with the benchmark serving script, a model list API has been added to the disaggregation proxy.
