### PR TITLE
Set `torch_dtype` in `TransformersModel`

### DIFF
--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -143,6 +143,7 @@ class TransformersModel(nn.Module):
         self.model: PreTrainedModel = AutoModel.from_config(
             self.config,
             attn_implementation="vllm",
+            torch_dtype=vllm_config.model_config.dtype,
             trust_remote_code=vllm_config.model_config.trust_remote_code,
         )
         prefix = self.model.base_model_prefix


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/12785#discussion_r1943473390 turned out to be incorrect and it was missed because the PR that made this change never had full CI run.