### PR TITLE
[V1][Minor] Restore V1 compatibility with LLMEngine class

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2028,3 +2028,8 @@ class LLMEngine:
                 sampling_params.logits_processors.extend(logits_processors)
 
         return sampling_params
+
+
+# TODO(v1): Remove this class proxy when V1 goes default.
+if envs.VLLM_USE_V1:
+    from vllm.v1.engine.llm_engine import LLMEngine  # type: ignore


### PR DESCRIPTION
The check was added to AsyncLLMEngine but not LLMEngine.
