### PR TITLE
[V1][Bugfix] DeepSeek-V3 v1 attn_backend miss q_lora_rank

### DIFF
--- a/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
+++ b/tests/plugins/vllm_add_dummy_platform/vllm_add_dummy_platform/dummy_platform.py
@@ -7,5 +7,6 @@ class DummyPlatform(CudaPlatform):
     device_name = "DummyDevice"
 
     def get_attn_backend_cls(self, backend_name, head_size, dtype,
-                             kv_cache_dtype, block_size, use_v1, use_mla):
+                             kv_cache_dtype, block_size, use_v1, use_mla,
+                             **kwargs):
         return "vllm_add_dummy_platform.dummy_attention_backend.DummyAttentionBackend"  # noqa E501

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -104,13 +104,15 @@ class Attention(nn.Module):
         # During model initialization, the default dtype is set as the model
         # weight and activation dtype.
         dtype = torch.get_default_dtype()
-        attn_backend = get_attn_backend(head_size,
-                                        dtype,
-                                        kv_cache_dtype,
-                                        block_size,
-                                        is_attention_free,
-                                        blocksparse_params is not None,
-                                        use_mla=use_mla)
+        attn_backend = get_attn_backend(
+            head_size,
+            dtype,
+            kv_cache_dtype,
+            block_size,
+            is_attention_free,
+            blocksparse_params is not None,
+            use_mla=use_mla,
+            has_extra_impl_args=len(extra_impl_args) > 0)
         impl_cls = attn_backend.get_impl_cls()
         self.impl = impl_cls(num_heads, head_size, scale, num_kv_heads,
                              alibi_slopes, sliding_window, kv_cache_dtype,

--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -33,8 +33,8 @@ class CpuPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         if selected_backend and selected_backend != _Backend.TORCH_SDPA:
             logger.info("Cannot use %s backend on CPU.", selected_backend)
         logger.info("Using Torch SDPA backend.")

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -152,11 +152,19 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,
-                             kv_cache_dtype, block_size, use_v1,
-                             use_mla) -> str:
+                             kv_cache_dtype, block_size, use_v1, use_mla,
+                             **kwargs) -> str:
         if use_v1:
-            logger.info("Using Flash Attention backend on V1 engine.")
-            return "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend"
+            has_extra_impl_args = kwargs.get('has_extra_impl_args', False)
+            if has_extra_impl_args:
+                logger.info("Using Triton MLA backend on V1 engine.")
+                attn_backend = ("vllm.attention.backends."
+                                "triton_mla.TritonMLABackend")
+            else:
+                logger.info("Using Flash Attention backend on V1 engine.")
+                attn_backend = ("vllm.v1.attention.backends."
+                                "flash_attn.FlashAttentionBackend")
+            return attn_backend
         if use_mla:
             logger.info("Using Triton MLA backend.")
             return "vllm.attention.backends.triton_mla.TritonMLABackend"

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -29,8 +29,8 @@ class HpuPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         logger.info("Using HPUAttention backend.")
         return "vllm.attention.backends.hpu_attn.HPUAttentionBackend"
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -142,8 +142,8 @@ class Platform:
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         """Get the attention backend class of a device."""
         return ""
 

--- a/vllm/platforms/openvino.py
+++ b/vllm/platforms/openvino.py
@@ -32,8 +32,8 @@ class OpenVinoPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         if selected_backend != _Backend.OPENVINO:
             logger.info("Cannot use %s backend on OpenVINO.", selected_backend)
         logger.info("Using OpenVINO Attention backend.")

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -77,8 +77,8 @@ class RocmPlatform(Platform):
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, head_size, dtype,
-                             kv_cache_dtype, block_size, use_v1,
-                             use_mla) -> str:
+                             kv_cache_dtype, block_size, use_v1, use_mla,
+                             **kwargs) -> str:
         if use_mla:
             logger.info("Using Triton MLA backend.")
             return "vllm.attention.backends.triton_mla.TritonMLABackend"

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -31,8 +31,8 @@ class TpuPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         if selected_backend != _Backend.PALLAS:
             logger.info("Cannot use %s backend on TPU.", selected_backend)
         logger.info("Using Pallas backend.")

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -29,8 +29,8 @@ class XPUPlatform(Platform):
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,
                              dtype: torch.dtype, kv_cache_dtype: Optional[str],
-                             block_size: int, use_v1: bool,
-                             use_mla: bool) -> str:
+                             block_size: int, use_v1: bool, use_mla: bool,
+                             **kwargs) -> str:
         if selected_backend != _Backend.IPEX:
             logger.info("Cannot use %s backend on XPU.", selected_backend)
         logger.info("Using IPEX attention backend.")


### PR DESCRIPTION
If we use V1 (`os.environ["VLLM_USE_V1"]="1"`) for "deepseek-ai/DeepSeek-V3", it will throw the following error:

```
[rank0]:   File "/home/ubuntu/pytorch_gpu_base_ubuntu_uw2_workplace/aws-neuron/aoyu_vllm_gpu/vllm/vllm/attention/layer.py", line 115, in __init__
[rank0]:     self.impl = impl_cls(num_heads, head_size, scale, num_kv_heads,
[rank0]: TypeError: FlashAttentionImpl.__init__() got an unexpected keyword argument 'q_lora_rank'
```
The root cause is when the model has extra MLA args, like q_lora_rank, kv_lora_rank and so on, we shouldn't use current flash's implementation (`vllm.v1.attention.backends.flash_attn.FlashAttentionBackend`), but rather Triton's implementation (`vllm.attention.backends.triton_mla.TritonMLABackend`). So this PR mainly makes the following changes:

* add kwargs for get_attn_backend_cls
* when has extra_impl_args for mla model config, use TritonMLAImpl
