### PR TITLE
[Bugfix] deepseek_r1_reasoning_parser put reason content in wrong field in certain edge case

### DIFF
--- a/tests/entrypoints/openai/reasoning_parsers/test_deepseekr1_reasoning_parser.py
+++ b/tests/entrypoints/openai/reasoning_parsers/test_deepseekr1_reasoning_parser.py
@@ -24,10 +24,10 @@ COMPLETE_REASONING = {
     "reasoning_content": "This is a reasoning section",
     "content": None,
 }
-NO_REASONING = {
+NO_CONTENT = {
     "output": "This is content",
-    "reasoning_content": None,
-    "content": "This is content",
+    "reasoning_content": "This is content",
+    "content": None,
 }
 NO_REASONING_STREAMING = {
     "output": "This is a reasoning section",
@@ -98,8 +98,8 @@ TEST_CASES = [
     ),
     pytest.param(
         False,
-        NO_REASONING,
-        id="no_reasoning_token",
+        NO_CONTENT,
+        id="no_content_token",
     ),
     pytest.param(
         True,

--- a/vllm/entrypoints/openai/reasoning_parsers/deepseek_r1_reasoning_parser.py
+++ b/vllm/entrypoints/openai/reasoning_parsers/deepseek_r1_reasoning_parser.py
@@ -128,7 +128,7 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         # Thus we assume the reasoning content is always at the start.
         # Ref https://huggingface.co/deepseek-ai/DeepSeek-R1/commit/8a58a132790c9935686eb97f042afa8013451c9f
         if self.think_end_token not in model_output:
-            return None, model_output
+            return model_output, None
         else:
             # Add a start token if it's missing to keep compatibility.
             if self.think_start_token not in model_output:


### PR DESCRIPTION
There's an edge case where close think token </think> is not generated in output due to length limit, in such case, current reasoning parse put the partial reasoning token in `content`.

Given the model alway generate reasoning tokens(new chat template always append a open think tag), when no close tag detected, we should put in `reasoning_content`.