### PR TITLE
[BUG] Addreses #3935 and #3683, by making `intial_incremental_detokenization_offset` configurable

### DIFF
--- a/tests/transformer_utils/test_detokenizer_utils.py
+++ b/tests/transformer_utils/test_detokenizer_utils.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock
+
+from vllm.transformers_utils.detokenizer_utils import (
+    convert_prompt_ids_to_tokens)
+
+return_tokens = [
+    "�this", "�is", "�a", "�test", "�for", "�initial", "�incremental",
+    "�detokenization", "�offset"
+]
+
+
+def mock_convert_ids_to_tokens(ids: list[int], *args, **kwargs):
+    return return_tokens[-len(ids):]
+
+
+def test_intial_incremental_detokenization_offset():
+    mock_tokenizer = Mock()
+    mock_tokenizer.convert_ids_to_tokens = mock_convert_ids_to_tokens
+    new_tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
+        mock_tokenizer,
+        prompt_ids=list(range(len(return_tokens))),
+    )
+    assert prefix_offset == 2
+    assert read_offset == 7
+    assert new_tokens == return_tokens[-7:]
+
+    new_tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
+        mock_tokenizer,
+        prompt_ids=list(range(len(return_tokens))),
+        intial_incremental_detokenization_offset=0,
+    )
+    assert prefix_offset == 2
+    assert read_offset == 2

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -104,6 +104,9 @@ class ModelConfig:
         tokenizer_mode: Tokenizer mode. "auto" will use the fast tokenizer if
             available, "slow" will always use the slow tokenizer, and
             "mistral" will always use the tokenizer from `mistral_common`.
+        intial_incremental_detokenization_offset: Initial incremental
+            detoakenization offset. Non default value can be used with
+            sentencepiece based tokenizers such as mistral in chat api.
         trust_remote_code: Trust remote code (e.g., from HuggingFace) when
             downloading the model and tokenizer.
         allowed_local_media_path: Allowing API requests to read local images or
@@ -212,6 +215,7 @@ class ModelConfig:
         task: Union[TaskOption, Literal["draft"]],
         tokenizer: str,
         tokenizer_mode: str,
+        intial_incremental_detokenization_offset: int,
         trust_remote_code: bool,
         dtype: Union[str, torch.dtype],
         seed: int,
@@ -247,6 +251,8 @@ class ModelConfig:
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
         self.trust_remote_code = trust_remote_code
         self.allowed_local_media_path = allowed_local_media_path
         self.seed = seed
@@ -1792,6 +1798,8 @@ class SpeculativeConfig:
                 task="draft",
                 tokenizer=target_model_config.tokenizer,
                 tokenizer_mode=target_model_config.tokenizer_mode,
+                intial_incremental_detokenization_offset=target_model_config.
+                intial_incremental_detokenization_offset,
                 trust_remote_code=target_model_config.trust_remote_code,
                 allowed_local_media_path=target_model_config.
                 allowed_local_media_path,
@@ -3348,6 +3356,8 @@ class VllmConfig:
             f" tokenizer={self.model_config.tokenizer!r}, "
             f"skip_tokenizer_init={self.model_config.skip_tokenizer_init},"
             f" tokenizer_mode={self.model_config.tokenizer_mode}, "
+            " intial_incremental_detokenization_offset="
+            f"{self.model_config.intial_incremental_detokenization_offset}, "
             f"revision={self.model_config.revision}, "
             f"override_neuron_config={self.model_config.override_neuron_config},"
             f" tokenizer_revision={self.model_config.tokenizer_revision}, "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -93,6 +93,7 @@ class EngineArgs:
     task: TaskOption = "auto"
     skip_tokenizer_init: bool = False
     tokenizer_mode: str = 'auto'
+    intial_incremental_detokenization_offset: int = 5
     trust_remote_code: bool = False
     allowed_local_media_path: str = ""
     download_dir: Optional[str] = None
@@ -286,6 +287,13 @@ class EngineArgs:
             'fast tokenizer if available.\n* "slow" will '
             'always use the slow tokenizer. \n* '
             '"mistral" will always use the `mistral_common` tokenizer.')
+        parser.add_argument('--intial-incremental-detokenization-offset',
+                            type=int,
+                            default=5,
+                            help='Initial incremental detoakenization '
+                            'offset. Non default value can be used with '
+                            'sentencepiece based tokenizers '
+                            'such as mistral in chat api.')
         parser.add_argument('--trust-remote-code',
                             action='store_true',
                             help='Trust remote code from huggingface.')
@@ -1001,6 +1009,8 @@ class EngineArgs:
             # We know this is not None because we set it in __post_init__
             tokenizer=cast(str, self.tokenizer),
             tokenizer_mode=self.tokenizer_mode,
+            intial_incremental_detokenization_offset=self.
+            intial_incremental_detokenization_offset,
             trust_remote_code=self.trust_remote_code,
             allowed_local_media_path=self.allowed_local_media_path,
             dtype=self.dtype,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -244,7 +244,9 @@ class LLMEngine:
 
         if not self.model_config.skip_tokenizer_init:
             self.tokenizer = self._init_tokenizer()
-            self.detokenizer = Detokenizer(self.tokenizer)
+            self.detokenizer = Detokenizer(
+                self.tokenizer, vllm_config.model_config.
+                intial_incremental_detokenization_offset)
             tokenizer_group = self.get_tokenizer_group()
         else:
             self.tokenizer = None

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -63,6 +63,9 @@ class LLM:
         tokenizer: The name or path of a HuggingFace Transformers tokenizer.
         tokenizer_mode: The tokenizer mode. "auto" will use the fast tokenizer
             if available, and "slow" will always use the slow tokenizer.
+        intial_incremental_detokenization_offset: Initial incremental
+            detoakenization offset. Non default value can be used with
+            sentencepiece based tokenizers such as mistral in chat api.
         skip_tokenizer_init: If true, skip initialization of tokenizer and
             detokenizer. Expect valid prompt_token_ids and None for prompt
             from the input.
@@ -159,6 +162,7 @@ class LLM:
         model: str,
         tokenizer: Optional[str] = None,
         tokenizer_mode: str = "auto",
+        intial_incremental_detokenization_offset: int = 5,
         skip_tokenizer_init: bool = False,
         trust_remote_code: bool = False,
         allowed_local_media_path: str = "",
@@ -214,6 +218,8 @@ class LLM:
             task=task,
             tokenizer=tokenizer,
             tokenizer_mode=tokenizer_mode,
+            intial_incremental_detokenization_offset=
+            intial_incremental_detokenization_offset,
             skip_tokenizer_init=skip_tokenizer_init,
             trust_remote_code=trust_remote_code,
             allowed_local_media_path=allowed_local_media_path,

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -14,8 +14,11 @@ from .tokenizer_group import BaseTokenizerGroup
 class Detokenizer:
     """Provides methods to decode the output of a model into text."""
 
-    def __init__(self, tokenizer_group: BaseTokenizerGroup):
+    def __init__(self, tokenizer_group: BaseTokenizerGroup,
+                 intial_incremental_detokenization_offset: int):
         self.tokenizer_group = tokenizer_group
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
 
     def get_tokenizer_for_seq(self, sequence: Sequence) -> AnyTokenizer:
         """Returns the HF tokenizer to use for a given sequence."""
@@ -120,6 +123,8 @@ class Detokenizer:
                  tokenizer=tokenizer,
                  prompt_ids=all_input_ids[:-1],
                  skip_special_tokens=prms.skip_special_tokens,
+                 intial_incremental_detokenization_offset=self.
+                 intial_incremental_detokenization_offset,
              )
 
         (new_tokens, new_decoded_token_text, prefix_offset,

--- a/vllm/transformers_utils/detokenizer_utils.py
+++ b/vllm/transformers_utils/detokenizer_utils.py
@@ -45,15 +45,16 @@ def _convert_tokens_to_string_with_added_encoders(
         return "".join(sub_texts)
 
 
-# 5 is an arbitrary value that should work for all
+# intial_incremental_detokenization_offset = 5
+# is an arbitrary value that should work for all
 # tokenizers (bigger = more conservative).
-INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 
 
 def convert_prompt_ids_to_tokens(
     tokenizer: AnyTokenizer,
     prompt_ids: List[int],
     skip_special_tokens: bool = False,
+    intial_incremental_detokenization_offset: int = 5,
 ) -> Tuple[List[str], int, int]:
     """Converts the prompt ids to tokens and returns the tokens and offsets
     for incremental detokenization.
@@ -64,11 +65,11 @@ def convert_prompt_ids_to_tokens(
     # We do not need to convert the whole prompt to tokens.
     # Offset a little more in case we have special tokens.
     new_tokens = tokenizer.convert_ids_to_tokens(
-        prompt_ids[-INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET - 2:],
+        prompt_ids[-intial_incremental_detokenization_offset - 2:],
         skip_special_tokens=skip_special_tokens)
     read_offset = len(new_tokens)
-    prefix_offset = max(
-        read_offset - INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET, 0)
+    prefix_offset = max(read_offset - intial_incremental_detokenization_offset,
+                        0)
     # This is required to guard against out-of-vocab prompt token ids
     _replace_none_with_empty(new_tokens)  # type: ignore[arg-type]
     return new_tokens, prefix_offset, read_offset

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -76,8 +76,11 @@ class AsyncLLM(EngineClient):
         )
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(self.tokenizer,
-                                                log_stats=self.log_stats)
+        self.output_processor = OutputProcessor(
+            self.tokenizer,
+            log_stats=self.log_stats,
+            intial_incremental_detokenization_offset=vllm_config.model_config.
+            intial_incremental_detokenization_offset)
 
         # EngineCore (starts the engine in background process).
         self.engine_core = EngineCoreClient.make_client(

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -49,12 +49,15 @@ class IncrementalDetokenizer:
         cls,
         tokenizer: AnyTokenizer,
         request: EngineCoreRequest,
+        intial_incremental_detokenization_offset: int,
     ) -> "IncrementalDetokenizer":
 
         tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
             tokenizer=tokenizer,
             prompt_ids=request.prompt_token_ids,
             skip_special_tokens=request.sampling_params.skip_special_tokens,
+            intial_incremental_detokenization_offset=
+            intial_incremental_detokenization_offset,
         )
 
         stops = request.sampling_params.stop

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -64,8 +64,11 @@ class LLMEngine:
                                    mm_registry=mm_registry)
 
         # OutputProcessor (convert EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(self.tokenizer,
-                                                log_stats=False)
+        self.output_processor = OutputProcessor(
+            self.tokenizer,
+            log_stats=False,
+            intial_incremental_detokenization_offset=vllm_config.model_config.
+            intial_incremental_detokenization_offset)
 
         # EngineCore (gets EngineCoreRequests and gives EngineCoreOutputs)
         self.engine_core = EngineCoreClient.make_client(

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -52,6 +52,7 @@ class RequestState:
         cls,
         tokenizer: AnyTokenizer,
         request: EngineCoreRequest,
+        intial_incremental_detokenization_offset: int,
         queue: Optional[asyncio.Queue[RequestOutput]] = None,
     ) -> "RequestState":
         return cls(
@@ -66,6 +67,8 @@ class RequestState:
             detokenizer=IncrementalDetokenizer.from_new_request(
                 tokenizer=tokenizer,
                 request=request,
+                intial_incremental_detokenization_offset=
+                intial_incremental_detokenization_offset,
             ),
             arrival_time=request.arrival_time,
             queue=queue,
@@ -79,9 +82,12 @@ class OutputProcessor:
         self,
         tokenizer: BaseTokenizerGroup,
         log_stats: bool,
+        intial_incremental_detokenization_offset: int,
     ):
         self.log_stats = log_stats
         self.tokenizer = tokenizer
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
         self.request_states: Dict[str, RequestState] = {}
 
     def is_request_active(self, request_id: str) -> bool:
@@ -112,6 +118,8 @@ class OutputProcessor:
         self.request_states[request_id] = RequestState.from_new_request(
             tokenizer=self.tokenizer.get_lora_tokenizer(request.lora_request),
             request=request,
+            intial_incremental_detokenization_offset=self.
+            intial_incremental_detokenization_offset,
             queue=queue)
 
     def process_outputs(


### PR DESCRIPTION
In this PR makes `INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET` (which had a default value of 5), configurable. This is particularly useful for sentencepiece based tokenizers. For example by setting 

```
intial_incremental_detokenization_offset = 0
```
Mistral chat api will work as expected