### PR TITLE
[BUG] Addreses #3935 and #3683, by making `intial_incremental_detokenization_offset` configurable

### DIFF
--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Generator, List, Optional
 import pytest
 from transformers import AutoTokenizer
 
+from vllm.config import _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET
 from vllm.inputs import token_inputs
 from vllm.sequence import Logprob, SamplingParams, Sequence, SequenceGroup
 from vllm.transformers_utils.detokenizer import (Detokenizer,
@@ -50,7 +51,9 @@ def _run_incremental_decode(tokenizer, all_input_ids,
             prev_tokens,
             offset,
             token_offset,
-            skip_special_tokens=skip_special_tokens)
+            skip_special_tokens=skip_special_tokens,
+            intial_incremental_detokenization_offset=
+            _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
         decoded_text += text
         if prev_tokens is None:
             prev_tokens = new_tokens
@@ -158,7 +161,9 @@ def detokenizer(tokenizer_name: str) -> Detokenizer:
         **init_kwargs,
     )
 
-    return Detokenizer(tokenizer_group)
+    return Detokenizer(tokenizer_group,
+                       intial_incremental_detokenization_offset=
+                       _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
 
 
 @pytest.fixture(name="complete_sequence_token_ids")

--- a/tests/tool_use/test_jamba_tool_parser.py
+++ b/tests/tool_use/test_jamba_tool_parser.py
@@ -7,6 +7,7 @@ import partial_json_parser
 import pytest
 from partial_json_parser.core.options import Allow
 
+from vllm.config import _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET
 from vllm.entrypoints.openai.protocol import (DeltaMessage, FunctionCall,
                                               ToolCall)
 from vllm.entrypoints.openai.tool_parsers import JambaToolParser
@@ -63,7 +64,8 @@ def stream_delta_message_generator(
              read_offset=read_offset,
              skip_special_tokens=False,
              spaces_between_special_tokens=True,
-         )
+             intial_incremental_detokenization_offset=
+             _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
 
         current_text = previous_text + delta_text
 

--- a/tests/transformer_utils/test_detokenizer_utils.py
+++ b/tests/transformer_utils/test_detokenizer_utils.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+from unittest.mock import Mock
+
+from vllm.transformers_utils.detokenizer_utils import (
+    convert_prompt_ids_to_tokens)
+
+return_tokens = [
+    "�this", "�is", "�a", "�test", "�for", "�initial", "�incremental",
+    "�detokenization", "�offset"
+]
+
+
+def mock_convert_ids_to_tokens(ids: list[int], *args, **kwargs):
+    return return_tokens[-len(ids):]
+
+
+def test_intial_incremental_detokenization_offset():
+    mock_tokenizer = Mock()
+    mock_tokenizer.convert_ids_to_tokens = mock_convert_ids_to_tokens
+    new_tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
+        mock_tokenizer,
+        prompt_ids=list(range(len(return_tokens))),
+    )
+    assert prefix_offset == 2
+    assert read_offset == 7
+    assert new_tokens == return_tokens[-7:]
+
+    new_tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
+        mock_tokenizer,
+        prompt_ids=list(range(len(return_tokens))),
+        intial_incremental_detokenization_offset=0,
+    )
+    assert prefix_offset == 2
+    assert read_offset == 2

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -11,6 +11,7 @@ from tests.v1.engine.utils import (NUM_PROMPT_LOGPROBS_UNDER_TEST,
                                    STOP_STRINGS,
                                    DummyOutputProcessorTestVectors,
                                    MockEngineCore)
+from vllm.config import _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET
 from vllm.sampling_params import RequestOutputKind, SamplingParams
 from vllm.sequence import PromptLogprobs, SampleLogprobs
 from vllm.transformers_utils.tokenizer import AnyTokenizer
@@ -40,8 +41,11 @@ def _ref_convert_id_to_token(
     [RequestOutputKind.DELTA, RequestOutputKind.FINAL_ONLY])
 def test_incremental_detokenization(request_output_kind: RequestOutputKind,
                                     dummy_test_vectors):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer_group,
-                                       log_stats=False)
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer_group,
+        log_stats=False,
+        intial_incremental_detokenization_offset=
+        _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
     engine_core = MockEngineCore(
         tokens_list=dummy_test_vectors.generation_tokens)
 
@@ -380,8 +384,11 @@ def test_logprobs_processor(request_output_kind: RequestOutputKind,
                             num_sample_logprobs: Optional[int],
                             num_prompt_logprobs: Optional[int],
                             dummy_test_vectors):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer_group,
-                                       log_stats=False)
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer_group,
+        log_stats=False,
+        intial_incremental_detokenization_offset=
+        _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
     engine_core = MockEngineCore(
         tokens_list=dummy_test_vectors.generation_tokens,
         generated_logprobs_raw=None if num_sample_logprobs is None else
@@ -478,8 +485,11 @@ def test_logprobs_processor(request_output_kind: RequestOutputKind,
 def test_stop_string(include_stop_str_in_output: bool,
                      num_sample_logprobs: Optional[int],
                      num_prompt_logprobs: Optional[int], dummy_test_vectors):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer_group,
-                                       log_stats=False)
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer_group,
+        log_stats=False,
+        intial_incremental_detokenization_offset=
+        _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
     engine_core = MockEngineCore(
         tokens_list=dummy_test_vectors.generation_tokens,
         generated_logprobs_raw=dummy_test_vectors.generation_logprobs
@@ -602,8 +612,11 @@ def test_stop_string(include_stop_str_in_output: bool,
 
 
 def test_iteration_stats(dummy_test_vectors):
-    output_processor = OutputProcessor(dummy_test_vectors.tokenizer_group,
-                                       log_stats=True)
+    output_processor = OutputProcessor(
+        dummy_test_vectors.tokenizer_group,
+        log_stats=True,
+        intial_incremental_detokenization_offset=
+        _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET)
     engine_core = MockEngineCore(dummy_test_vectors.generation_tokens)
     engine_core_timestamp = time.monotonic()
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -50,6 +50,7 @@ else:
 
 logger = init_logger(__name__)
 
+_INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS = 32768
 _MULTIMODAL_MODEL_MAX_NUM_BATCHED_TOKENS = 5120
 
@@ -105,6 +106,9 @@ class ModelConfig:
             available, "slow" will always use the slow tokenizer,
             "mistral" will always use the tokenizer from `mistral_common`, and
             "custom" will use --tokenizer to select the preregistered tokenizer.
+        intial_incremental_detokenization_offset: Initial incremental
+            detoakenization offset. Non default value can be used with
+            sentencepiece based tokenizers such as mistral in chat api.
         trust_remote_code: Trust remote code (e.g., from HuggingFace) when
             downloading the model and tokenizer.
         allowed_local_media_path: Allowing API requests to read local images or
@@ -216,6 +220,8 @@ class ModelConfig:
         trust_remote_code: bool,
         dtype: Union[str, torch.dtype],
         seed: int,
+        intial_incremental_detokenization_offset:
+        int = _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
         allowed_local_media_path: str = "",
         revision: Optional[str] = None,
         code_revision: Optional[str] = None,
@@ -248,6 +254,8 @@ class ModelConfig:
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
         self.trust_remote_code = trust_remote_code
         self.allowed_local_media_path = allowed_local_media_path
         self.seed = seed
@@ -1793,6 +1801,8 @@ class SpeculativeConfig:
                 task="draft",
                 tokenizer=target_model_config.tokenizer,
                 tokenizer_mode=target_model_config.tokenizer_mode,
+                intial_incremental_detokenization_offset=target_model_config.
+                intial_incremental_detokenization_offset,
                 trust_remote_code=target_model_config.trust_remote_code,
                 allowed_local_media_path=target_model_config.
                 allowed_local_media_path,
@@ -3350,6 +3360,8 @@ class VllmConfig:
             f" tokenizer={self.model_config.tokenizer!r}, "
             f"skip_tokenizer_init={self.model_config.skip_tokenizer_init},"
             f" tokenizer_mode={self.model_config.tokenizer_mode}, "
+            " intial_incremental_detokenization_offset="
+            f"{self.model_config.intial_incremental_detokenization_offset}, "
             f"revision={self.model_config.revision}, "
             f"override_neuron_config={self.model_config.override_neuron_config},"
             f" tokenizer_revision={self.model_config.tokenizer_revision}, "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -10,7 +10,8 @@ from typing import (TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional,
 import torch
 
 import vllm.envs as envs
-from vllm.config import (CacheConfig, CompilationConfig, ConfigFormat,
+from vllm.config import (_INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
+                         CacheConfig, CompilationConfig, ConfigFormat,
                          DecodingConfig, DeviceConfig, HfOverrides,
                          KVTransferConfig, LoadConfig, LoadFormat, LoRAConfig,
                          ModelConfig, ModelImpl, ObservabilityConfig,
@@ -94,6 +95,8 @@ class EngineArgs:
     task: TaskOption = "auto"
     skip_tokenizer_init: bool = False
     tokenizer_mode: str = 'auto'
+    intial_incremental_detokenization_offset: int = \
+        _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET
     trust_remote_code: bool = False
     allowed_local_media_path: str = ""
     download_dir: Optional[str] = None
@@ -291,6 +294,13 @@ class EngineArgs:
             '"mistral" will always use the `mistral_common` tokenizer. \n* '
             '"custom" will use --tokenizer to select the '
             'preregistered tokenizer.')
+        parser.add_argument('--intial-incremental-detokenization-offset',
+                            type=int,
+                            default=_INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
+                            help='Initial incremental detoakenization '
+                            'offset. Non default value can be used with '
+                            'sentencepiece based tokenizers '
+                            'such as mistral in chat api.')
         parser.add_argument('--trust-remote-code',
                             action='store_true',
                             help='Trust remote code from huggingface.')
@@ -1014,6 +1024,8 @@ class EngineArgs:
             # We know this is not None because we set it in __post_init__
             tokenizer=cast(str, self.tokenizer),
             tokenizer_mode=self.tokenizer_mode,
+            intial_incremental_detokenization_offset=self.
+            intial_incremental_detokenization_offset,
             trust_remote_code=self.trust_remote_code,
             allowed_local_media_path=self.allowed_local_media_path,
             dtype=self.dtype,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -244,7 +244,9 @@ class LLMEngine:
 
         if not self.model_config.skip_tokenizer_init:
             self.tokenizer = self._init_tokenizer()
-            self.detokenizer = Detokenizer(self.tokenizer)
+            self.detokenizer = Detokenizer(
+                self.tokenizer, vllm_config.model_config.
+                intial_incremental_detokenization_offset)
             tokenizer_group = self.get_tokenizer_group()
         else:
             self.tokenizer = None

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -15,7 +15,8 @@ from typing_extensions import TypeVar, deprecated
 from vllm import envs
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence, get_beam_search_score)
-from vllm.config import CompilationConfig
+from vllm.config import (_INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
+                         CompilationConfig)
 from vllm.engine.arg_utils import (EngineArgs, HfOverrides, PoolerConfig,
                                    TaskOption)
 from vllm.engine.llm_engine import LLMEngine
@@ -63,6 +64,9 @@ class LLM:
         tokenizer: The name or path of a HuggingFace Transformers tokenizer.
         tokenizer_mode: The tokenizer mode. "auto" will use the fast tokenizer
             if available, and "slow" will always use the slow tokenizer.
+        intial_incremental_detokenization_offset: Initial incremental
+            detoakenization offset. Non default value can be used with
+            sentencepiece based tokenizers such as mistral in chat api.
         skip_tokenizer_init: If true, skip initialization of tokenizer and
             detokenizer. Expect valid prompt_token_ids and None for prompt
             from the input.
@@ -159,6 +163,8 @@ class LLM:
         model: str,
         tokenizer: Optional[str] = None,
         tokenizer_mode: str = "auto",
+        intial_incremental_detokenization_offset:
+        int = _INTIAL_INCREMENTAL_DETOKENIZATION_OFFSET,
         skip_tokenizer_init: bool = False,
         trust_remote_code: bool = False,
         allowed_local_media_path: str = "",
@@ -214,6 +220,8 @@ class LLM:
             task=task,
             tokenizer=tokenizer,
             tokenizer_mode=tokenizer_mode,
+            intial_incremental_detokenization_offset=
+            intial_incremental_detokenization_offset,
             skip_tokenizer_init=skip_tokenizer_init,
             trust_remote_code=trust_remote_code,
             allowed_local_media_path=allowed_local_media_path,

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -14,8 +14,11 @@ from .tokenizer_group import BaseTokenizerGroup
 class Detokenizer:
     """Provides methods to decode the output of a model into text."""
 
-    def __init__(self, tokenizer_group: BaseTokenizerGroup):
+    def __init__(self, tokenizer_group: BaseTokenizerGroup,
+                 intial_incremental_detokenization_offset: int):
         self.tokenizer_group = tokenizer_group
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
 
     def get_tokenizer_for_seq(self, sequence: Sequence) -> AnyTokenizer:
         """Returns the HF tokenizer to use for a given sequence."""
@@ -76,7 +79,8 @@ class Detokenizer:
                          skip_special_tokens=prms.skip_special_tokens,
                          spaces_between_special_tokens=prms.
                          spaces_between_special_tokens,
-                     )
+                         intial_incremental_detokenization_offset=self.
+                         intial_incremental_detokenization_offset)
 
                     sample_logprob.decoded_token = new_text
 
@@ -120,6 +124,8 @@ class Detokenizer:
                  tokenizer=tokenizer,
                  prompt_ids=all_input_ids[:-1],
                  skip_special_tokens=prms.skip_special_tokens,
+                 intial_incremental_detokenization_offset=self.
+                 intial_incremental_detokenization_offset,
              )
 
         (new_tokens, new_decoded_token_text, prefix_offset,
@@ -131,7 +137,8 @@ class Detokenizer:
              read_offset=seq.read_offset,
              skip_special_tokens=prms.skip_special_tokens,
              spaces_between_special_tokens=prms.spaces_between_special_tokens,
-         )
+             intial_incremental_detokenization_offset=self.
+             intial_incremental_detokenization_offset)
 
         # Decode logprobs
         logprobs = seq.output_logprobs[-1]
@@ -156,6 +163,8 @@ class Detokenizer:
                         skip_special_tokens=prms.skip_special_tokens,
                         spaces_between_special_tokens=prms.
                         spaces_between_special_tokens,
+                        intial_incremental_detokenization_offset=self.
+                        intial_incremental_detokenization_offset,
                     )
                     sample_logprob.decoded_token = new_text
 

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -78,8 +78,11 @@ class AsyncLLM(EngineClient):
         )
 
         # OutputProcessor (converts EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(self.tokenizer,
-                                                log_stats=self.log_stats)
+        self.output_processor = OutputProcessor(
+            self.tokenizer,
+            log_stats=self.log_stats,
+            intial_incremental_detokenization_offset=vllm_config.model_config.
+            intial_incremental_detokenization_offset)
 
         # EngineCore (starts the engine in background process).
         self.engine_core = EngineCoreClient.make_client(

--- a/vllm/v1/engine/detokenizer.py
+++ b/vllm/v1/engine/detokenizer.py
@@ -20,6 +20,7 @@ class IncrementalDetokenizer:
     tokens: List[str]
     token_ids: List[int]
     prompt_len: int
+    intial_incremental_detokenization_offset: int
 
     # Stop strings
     stop: List[str]
@@ -49,12 +50,15 @@ class IncrementalDetokenizer:
         cls,
         tokenizer: AnyTokenizer,
         request: EngineCoreRequest,
+        intial_incremental_detokenization_offset: int,
     ) -> "IncrementalDetokenizer":
 
         tokens, prefix_offset, read_offset = convert_prompt_ids_to_tokens(
             tokenizer=tokenizer,
             prompt_ids=request.prompt_token_ids,
             skip_special_tokens=request.sampling_params.skip_special_tokens,
+            intial_incremental_detokenization_offset=
+            intial_incremental_detokenization_offset,
         )
 
         stops = request.sampling_params.stop
@@ -82,6 +86,8 @@ class IncrementalDetokenizer:
             prompt_len=len(request.prompt_token_ids),
             tokenizer=tokenizer,
             stop_buffer_length=stop_buffer_length,
+            intial_incremental_detokenization_offset=
+            intial_incremental_detokenization_offset,
         )
 
     def update(self, new_token_ids: List[int]) -> Optional[str]:
@@ -109,6 +115,8 @@ class IncrementalDetokenizer:
                  skip_special_tokens=self.skip_special_tokens,
                  spaces_between_special_tokens=self.
                  spaces_between_special_tokens,
+                 intial_incremental_detokenization_offset=self.
+                 intial_incremental_detokenization_offset,
              )
 
             self.tokens.extend(new_tokens)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -64,8 +64,11 @@ class LLMEngine:
                                    mm_registry=mm_registry)
 
         # OutputProcessor (convert EngineCoreOutputs --> RequestOutput).
-        self.output_processor = OutputProcessor(self.tokenizer,
-                                                log_stats=False)
+        self.output_processor = OutputProcessor(
+            self.tokenizer,
+            log_stats=False,
+            intial_incremental_detokenization_offset=vllm_config.model_config.
+            intial_incremental_detokenization_offset)
 
         # EngineCore (gets EngineCoreRequests and gives EngineCoreOutputs)
         self.engine_core = EngineCoreClient.make_client(

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -55,6 +55,7 @@ class RequestState:
         request: EngineCoreRequest,
         queue: Optional[asyncio.Queue[RequestOutput]],
         log_stats: bool,
+        intial_incremental_detokenization_offset: int,
     ) -> "RequestState":
         return cls(
             request_id=request.request_id,
@@ -68,6 +69,8 @@ class RequestState:
             detokenizer=IncrementalDetokenizer.from_new_request(
                 tokenizer=tokenizer,
                 request=request,
+                intial_incremental_detokenization_offset=
+                intial_incremental_detokenization_offset,
             ),
             arrival_time=request.arrival_time,
             queue=queue,
@@ -82,9 +85,12 @@ class OutputProcessor:
         self,
         tokenizer: BaseTokenizerGroup,
         log_stats: bool,
+        intial_incremental_detokenization_offset: int,
     ):
         self.log_stats = log_stats
         self.tokenizer = tokenizer
+        self.intial_incremental_detokenization_offset = \
+            intial_incremental_detokenization_offset
         self.request_states: Dict[str, RequestState] = {}
 
     def is_request_active(self, request_id: str) -> bool:
@@ -115,6 +121,8 @@ class OutputProcessor:
         self.request_states[request_id] = RequestState.from_new_request(
             tokenizer=self.tokenizer.get_lora_tokenizer(request.lora_request),
             request=request,
+            intial_incremental_detokenization_offset=self.
+            intial_incremental_detokenization_offset,
             queue=queue,
             log_stats=self.log_stats)
 


### PR DESCRIPTION
In this PR makes INITIAL_INCREMENTAL_DETOKENIZATION_OFFSET (which had a default value of 5), configurable. This is particularly useful for sentencepiece based tokenizers. For example by setting

```
intial_incremental_detokenization_offset = 0
```

Mistral chat API will work as expected


FIX #3935 #3683

<!--- pyml disable-next-line no-emphasis-as-heading -->
