### PR TITLE
Add sync in moe_align kernel to prevent garbled inference results in …

### DIFF
--- a/csrc/moe/moe_align_sum_kernels.cu
+++ b/csrc/moe/moe_align_sum_kernels.cu
@@ -218,6 +218,8 @@ __global__ void sgl_moe_align_block_size_kernel(
     }
   }
 
+  __syncthreads();
+
   const size_t tokens_per_thread = CEILDIV(numel, blockDim.x);
   const size_t start_idx = threadIdx.x * tokens_per_thread;
 


### PR DESCRIPTION
When deploying the DeepSeek R1 model, there is a probabilistic occurrence of garbled text or no output. Our analysis indicates that a synchronization mechanism needs to be added in the **sgl_moe_align_block_size_kernel**. Specifically, a **__syncthreads**() should be used when initializing shared memory to zero; otherwise, the result obtained by **atomicAdd** may be incorrect, particularly when the shared memory contains dirty data (i.e., not fully zeroed)."