### PR TITLE
[Bugfix] Modify the method of generating random datasets to avoid creating duplicate prompts.

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -383,11 +383,11 @@ def sample_random_requests(
         output_len + 1,
         size=num_prompts,
     )
-    offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
+    offsets = np.random.choice(tokenizer.vocab_size, size=num_prompts, replace=False)
     input_requests = []
     for i in range(num_prompts):
         prompt = tokenizer.decode(prefix_token_ids +
-                                  [(offsets[i] + i + j) % tokenizer.vocab_size
+                                  [(offsets[i] + j) % tokenizer.vocab_size
                                    for j in range(input_lens[i])])
 
         input_requests.append((prompt, int(prefix_len + input_lens[i]),


### PR DESCRIPTION
The previous generation method could result in duplicate prompts, which may cause test inaccuracies for servers with prefix caching enabled. After modification, it ensures that no duplicate random prompts are generated.
