### PR TITLE
[V1][Bugfix] Copy encoder input ids to fix set iteration issue during VLM abort

### DIFF
--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -54,7 +54,7 @@ class EncoderCacheManager:
 
     def free(self, request: Request) -> None:
         """Free all cached input ids for the request."""
-        input_ids = self.get_cached_input_ids(request)
+        input_ids = self.get_cached_input_ids(request).copy()
         for input_id in input_ids:
             self.free_encoder_input(request, input_id)
 


### PR DESCRIPTION
This is a follow up to https://github.com/vllm-project/vllm/pull/12545. When aborting requests, there is a rare chance to run into the following error:

```
EngineCore hit an exception: Traceback (most recent call last):
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 203, in run_engine_core
    engine_core.run_busy_loop()
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 240, in run_busy_loop
    self._handle_client_request(req)
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 260, in _handle_client_request
    self.abort_requests(request)
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 118, in abort_requests
    self.scheduler.finish_requests(request_ids,
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/core/scheduler.py", line 532, in finish_requests
    self._free_request(request)
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/core/scheduler.py", line 537, in _free_request
    self.encoder_cache_manager.free(request)
  File "/cserve_user/.local/lib/python3.10/site-packages/vllm/v1/core/encoder_cache_manager.py", line 58, in free
    for input_id in input_ids:
RuntimeError: Set changed size during iteration
```

I believe this is due to calling `self.cached[req_id].discard(input_id)` in `self.free_encoder_input` which causes the set size to change. Have not been able to verify this because reproduction is not easy, but I think this should fix it.