### PR TITLE
[Bugfix] Garbage collect memory before measuring with DeviceMemoryProfiler

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -145,7 +145,8 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def empty_cache(cls) -> None:
-        return torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
 
     @classmethod
     def get_current_memory_usage(cls,

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -144,6 +144,10 @@ class CudaPlatformBase(Platform):
             cache_config.block_size = 16
 
     @classmethod
+    def empty_cache(cls) -> None:
+        return torch.cuda.empty_cache()
+
+    @classmethod
     def get_current_memory_usage(cls,
                                  device: Optional[torch.types.Device] = None
                                  ) -> float:

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -306,6 +306,13 @@ class Platform:
         return True
 
     @classmethod
+    def empty_cache(cls) -> None:
+        """
+        Release all unoccupied cached memory.
+        """
+        raise NotImplementedError
+
+    @classmethod
     def get_current_memory_usage(cls,
                                  device: Optional[torch.types.Device] = None
                                  ) -> float:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -166,7 +166,8 @@ class RocmPlatform(Platform):
 
     @classmethod
     def empty_cache(cls) -> None:
-        return torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
 
     @classmethod
     def get_current_memory_usage(cls,

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -165,6 +165,10 @@ class RocmPlatform(Platform):
         return "vllm.lora.punica_wrapper.punica_gpu.PunicaWrapperGPU"
 
     @classmethod
+    def empty_cache(cls) -> None:
+        return torch.cuda.empty_cache()
+
+    @classmethod
     def get_current_memory_usage(cls,
                                  device: Optional[torch.types.Device] = None
                                  ) -> float:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -118,6 +118,11 @@ class XPUPlatform(Platform):
         return False
 
     @classmethod
+    def empty_cache(cls) -> None:
+        # There seems to be no torch.xpu.empty_cache()
+        pass
+
+    @classmethod
     def get_current_memory_usage(cls,
                                  device: Optional[torch.types.Device] = None
                                  ) -> float:

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -715,7 +715,9 @@ class DeviceMemoryProfiler:
 
     def current_memory_usage(self) -> float:
         # Return the memory usage in bytes.
+        gc.collect()
         from vllm.platforms import current_platform
+        current_platform.empty_cache()
         return current_platform.get_current_memory_usage(self.device)
 
     def __enter__(self):
@@ -726,9 +728,6 @@ class DeviceMemoryProfiler:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.final_memory = self.current_memory_usage()
         self.consumed_memory = self.final_memory - self.initial_memory
-
-        # Force garbage collection
-        gc.collect()
 
 
 def make_ndarray_with_pad(


### PR DESCRIPTION
I don't know why we weren't doing this but DeviceMemoryProfiler certainly wasn't measuring peak memory before, so let's take care of clearing unused memory before each measurement

This is important when we could have high peak memory due to quantization post processing since the result of this utility is used to calculate kv cache allocation