### PR TITLE
[CI/Build] Allow ruff to auto-fix some issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: v0.9.3
   hooks:
   - id: ruff
-    args: [--output-format, github]
+    args: [--output-format, github, --fix]
     exclude: 'vllm/third_party/.*'
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.0


### PR DESCRIPTION
`ruff` can auto-fix some types of issues. Turn that on, since we have
other tools doing the same thing, like `yapf`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
