### PR TITLE
[CI/Build] Ignore ruff warning up007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,8 @@ ignore = [
     "UP032",
     # Python 3.8 typing
     "UP006", "UP035",
-
+    # Can remove once 3.10+ is the minimum Python version
+    "UP007",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
This change ignores the following warning from ruff:

  UP007 Use `X | Y` for type annotations

We need to continue using the `Optiona[T]` syntax until Python 3.10
or above is our minimum supported version. I'm not sure why I only
see this in one of my environments, but not another. In any case,
it seems harmless to explicitly ignore it.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
