### PR TITLE
[Bugfix] Missing Content Type returns 500 Internal Server Error

### DIFF
--- a/tests/entrypoints/openai/test_basic.py
+++ b/tests/entrypoints/openai/test_basic.py
@@ -156,3 +156,19 @@ async def test_request_cancellation(server: RemoteOpenAIServer):
                                                     max_tokens=10)
 
     assert len(response.choices) == 1
+
+
+@pytest.mark.asyncio
+async def test_request_wrong_content_type(server: RemoteOpenAIServer):
+
+    chat_input = [{"role": "user", "content": "Write a long story"}]
+    client = server.get_async_client()
+
+    with pytest.raises(openai.APIStatusError):
+        await client.chat.completions.create(
+            messages=chat_input,
+            model=MODEL_NAME,
+            max_tokens=10000,
+            extra_headers={
+                "Content-Type": "application/x-www-form-urlencoded"
+            })

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -255,7 +255,7 @@ async def build_async_engine_client_from_engine_args(
 
 async def validate_json_request(raw_request: Request):
     content_type = raw_request.headers.get("content-type", "").lower()
-    if "application/json" not in content_type:
+    if content_type != "application/json":
         raise HTTPException(
             status_code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
             detail="Unsupported Media Type: Only 'application/json' is allowed"

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -20,7 +20,7 @@ from http import HTTPStatus
 from typing import AsyncIterator, Dict, Optional, Set, Tuple, Union
 
 import uvloop
-from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -253,7 +253,17 @@ async def build_async_engine_client_from_engine_args(
             multiprocess.mark_process_dead(engine_process.pid)
 
 
-router = APIRouter()
+async def validate_json_request(raw_request: Request):
+    if raw_request.method == "POST":
+        content_type = raw_request.headers.get("content-type", "").lower()
+        if "application/json" not in content_type:
+            raise HTTPException(
+                status_code=415,
+                detail=
+                "Unsupported Media Type: Only 'application/json' is allowed")
+
+
+router = APIRouter(dependencies=[Depends(validate_json_request)])
 
 
 def mount_metrics(app: FastAPI):

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -258,7 +258,7 @@ async def validate_json_request(raw_request: Request):
         content_type = raw_request.headers.get("content-type", "").lower()
         if "application/json" not in content_type:
             raise HTTPException(
-                status_code=415,
+                status_code=HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
                 detail=
                 "Unsupported Media Type: Only 'application/json' is allowed")
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -593,7 +593,7 @@ if envs.VLLM_SERVER_DEV_MODE:
         return Response(status_code=200)
 
 
-@router.post("/invocations")
+@router.post("/invocations", dependencies=[Depends(validate_json_request)])
 async def invocations(raw_request: Request):
     """
     For SageMaker, routes requests to other handlers based on model `task`.


### PR DESCRIPTION
Missing Content Type returns 500 Internal Server Error instead of 415 Unsupported Media Type

FIX [#11171](https://github.com/vllm-project/vllm/issues/11171) 

Request :

```
curl -v http://0.0.0.0:8000/v1/chat/completions \                                                                                                        ✔  vllm Py  08:42:51 AM 
   -H "Authorization: Bearer $VLLM_API_KEY" \
   -d '{
  "model": "facebook/opt-125m",
  "messages": [
    {
      "role": "user",
      "content": "why is the sky blue?"
    }
  ],
  "stream": false,
  "chat_template": "{% for message in messages %}{% if message['role'] == 'user' %}User: {{ message['content'] }}{% elif message['role'] == 'assistant' %}Assistant: {{ message['content'] }}{% endif %}{% endfor %}"
}'
```

**Response without fix :**
```
*   Trying 0.0.0.0:8000...
* Connected to 0.0.0.0 (0.0.0.0) port 8000
> POST /v1/chat/completions HTTP/1.1
> Host: 0.0.0.0:8000
> User-Agent: curl/8.6.0
> Accept: */*
> Authorization: Bearer 
> Content-Length: 351
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 500 Internal Server Error
< date: Thu, 13 Feb 2025 03:15:01 GMT
< server: uvicorn
< content-length: 21
< content-type: text/plain; charset=utf-8
< 
* Connection #0 to host 0.0.0.0 left intact
Internal Server Error
```

**Response with fix :**
```
*   Trying 0.0.0.0:8000...
* Connected to 0.0.0.0 (0.0.0.0) port 8000
> POST /v1/chat/completions HTTP/1.1
> Host: 0.0.0.0:8000
> User-Agent: curl/8.6.0
> Accept: */*
> Authorization: Bearer 
> Content-Length: 351
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 415 Unsupported Media Type
< date: Thu, 13 Feb 2025 03:12:50 GMT
< server: uvicorn
< content-length: 71
< content-type: application/json
< 
* Connection #0 to host 0.0.0.0 left intact
{"detail":"Unsupported Media Type: Only 'application/json' is allowed"}
```

