### PR TITLE
[Bugfix] Offline example of disaggregated prefill

### DIFF
--- a/examples/offline_inference/disaggregated_prefill.py
+++ b/examples/offline_inference/disaggregated_prefill.py
@@ -22,7 +22,7 @@ def run_prefill(prefill_done):
     # and 3 and do prefilling on request 2.
     prompts = [
         "Hello, my name is",
-        # "Hi, your name is",
+        "Hi, your name is",
         # The decode node will actually "prefill" this request.
         "Tell me a very long story",
     ]


### PR DESCRIPTION
The decode instance's prompts should be the same as the prefill instance's prompts, if not, the decode instance will have a hang issue.
![image](https://github.com/user-attachments/assets/b415da64-d6f1-4fac-be2b-ab8f058a42c8)
