### PR TITLE
[Bugfix] Fix memory_profiling for speculative decoding

### DIFF
--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -384,8 +384,11 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         scorer cache is divided evenly between the proposer and scorer model KV,
         such that the number of blocks is equal in both KV caches.
         """
+        proposer_model_memory_usage = 0
+        if hasattr(self.proposer_worker, 'model_runner') and hasattr(self.proposer_worker.model_runner, 'model_memory_usage'):
+            proposer_model_memory_usage = self.proposer_worker.model_runner.model_memory_usage
         num_gpu_blocks, num_cpu_blocks = (
-            self.scorer_worker.determine_num_available_blocks(self.proposer_worker.model_runner.model_memory_usage))
+            self.scorer_worker.determine_num_available_blocks(other_memory_usage=proposer_model_memory_usage))
 
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -385,10 +385,13 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         such that the number of blocks is equal in both KV caches.
         """
         proposer_model_memory_usage = 0
-        if hasattr(self.proposer_worker, 'model_runner') and hasattr(self.proposer_worker.model_runner, 'model_memory_usage'):
-            proposer_model_memory_usage = self.proposer_worker.model_runner.model_memory_usage
+        if (hasattr(self.proposer_worker, 'model_runner') and 
+            hasattr(self.proposer_worker.model_runner, 'model_memory_usage')):
+            proposer_model_memory_usage = (
+                self.proposer_worker.model_runner.model_memory_usage)
         num_gpu_blocks, num_cpu_blocks = (
-            self.scorer_worker.determine_num_available_blocks(other_memory_usage=proposer_model_memory_usage))
+            self.scorer_worker.determine_num_available_blocks(
+                other_memory_usage=proposer_model_memory_usage))
 
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -385,7 +385,7 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         such that the number of blocks is equal in both KV caches.
         """
         num_gpu_blocks, num_cpu_blocks = (
-            self.scorer_worker.determine_num_available_blocks())
+            self.scorer_worker.determine_num_available_blocks(self.proposer_worker.model_runner.model_memory_usage))
 
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -385,7 +385,8 @@ class SpecDecodeWorker(LoraNotSupportedWorkerBase):
         such that the number of blocks is equal in both KV caches.
         """
         num_gpu_blocks, num_cpu_blocks = (
-            self.scorer_worker.determine_num_available_blocks(self.proposer_worker.model_runner.model_memory_usage))
+            self.scorer_worker.determine_num_available_blocks(
+                self.proposer_worker.model_runner.model_memory_usage))
 
         scorer_cache_block_size_bytes = (
             self.scorer_worker.get_cache_block_size_bytes())

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -202,13 +202,15 @@ class Worker(LocalOrDistributedWorkerBase):
             tensorizer_config=tensorizer_config, )
 
     @torch.inference_mode()
-    def determine_num_available_blocks(self) -> Tuple[int, int]:
+    def determine_num_available_blocks(self, other_model_memory_usage=0) -> Tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 
         The engine will first conduct a profiling of the existing memory usage.
         Then, it calculate the maximum possible number of GPU and CPU blocks
         that can be allocated with the remaining free memory.
+        
+        other_model_memory_usage is the memory usage of the other model, eg. proposal model in speculative decoding
 
         .. tip::
             You may limit the usage of GPU memory
@@ -225,7 +227,7 @@ class Worker(LocalOrDistributedWorkerBase):
         # of the model.
         with memory_profiling(
                 self.baseline_snapshot,
-                weights_memory=self.model_runner.model_memory_usage) as result:
+                weights_memory=self.model_runner.model_memory_usage + other_model_memory_usage) as result:
             self.model_runner.profile_run()
 
         self._assert_memory_footprint_increased_during_profiling()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -202,7 +202,7 @@ class Worker(LocalOrDistributedWorkerBase):
             tensorizer_config=tensorizer_config, )
 
     @torch.inference_mode()
-    def determine_num_available_blocks(self, other_model_memory_usage=0) -> Tuple[int, int]:
+    def determine_num_available_blocks(self, other_memory_usage: int=0) -> Tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 
@@ -210,7 +210,8 @@ class Worker(LocalOrDistributedWorkerBase):
         Then, it calculate the maximum possible number of GPU and CPU blocks
         that can be allocated with the remaining free memory.
         
-        other_model_memory_usage is the memory usage of the other model, eg. proposal model in speculative decoding
+        Args:
+	        other_memory_usage: The other memory usage in bytes, such as the draft model in speculative decoding.
 
         .. tip::
             You may limit the usage of GPU memory
@@ -227,7 +228,7 @@ class Worker(LocalOrDistributedWorkerBase):
         # of the model.
         with memory_profiling(
                 self.baseline_snapshot,
-                weights_memory=self.model_runner.model_memory_usage + other_model_memory_usage) as result:
+                weights_memory=self.model_runner.model_memory_usage + other_memory_usage) as result:
             self.model_runner.profile_run()
 
         self._assert_memory_footprint_increased_during_profiling()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -202,7 +202,9 @@ class Worker(LocalOrDistributedWorkerBase):
             tensorizer_config=tensorizer_config, )
 
     @torch.inference_mode()
-    def determine_num_available_blocks(self, other_model_memory_usage=0) -> Tuple[int, int]:
+    def determine_num_available_blocks(self,
+                                       other_model_memory_usage=0
+                                       ) -> Tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 
@@ -227,7 +229,8 @@ class Worker(LocalOrDistributedWorkerBase):
         # of the model.
         with memory_profiling(
                 self.baseline_snapshot,
-                weights_memory=self.model_runner.model_memory_usage + other_model_memory_usage) as result:
+                weights_memory=self.model_runner.model_memory_usage +
+                other_model_memory_usage) as result:
             self.model_runner.profile_run()
 
         self._assert_memory_footprint_increased_during_profiling()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -202,7 +202,10 @@ class Worker(LocalOrDistributedWorkerBase):
             tensorizer_config=tensorizer_config, )
 
     @torch.inference_mode()
-    def determine_num_available_blocks(self, other_memory_usage: int=0) -> Tuple[int, int]:
+    def determine_num_available_blocks(
+        self, 
+        other_memory_usage: int=0
+    ) -> Tuple[int, int]:
         """Profiles the peak memory usage of the model to determine how many
         KV blocks may be allocated without OOMs.
 
@@ -211,7 +214,8 @@ class Worker(LocalOrDistributedWorkerBase):
         that can be allocated with the remaining free memory.
         
         Args:
-	        other_memory_usage: The other memory usage in bytes, such as the draft model in speculative decoding.
+            other_memory_usage: The other memory usage in bytes, 
+            such as the draft model in speculative decoding.
 
         .. tip::
             You may limit the usage of GPU memory


### PR DESCRIPTION
FIX #8073 OutOfMemoryError error when using speculative decoding

The original code does not count the proposal model weight during the memory_profiling.

Test on GTX 4090
`python -m vllm.entrypoints.openai.api_server  --enforce-eager --no-enable-prefix-caching --model /data/model/llama3 --gpu-memory-utilization 0.9 --speculative-model /data/model/eagle-llama3 --num-speculative-tokens 3   --speculative-disable-by-batch-size 10 --max-model-len 10000`

`python benchmarks/benchmark_serving.py         --backend vllm         --model /data/model/llama3         --dataset-name sharegpt         --dataset-path /data/sharegpt.json         --num-prompts 100`
