### PR TITLE
[Bugfix][CI] Inherit codespell settings from pyproject.toml in the pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,8 @@ repos:
   rev: v2.4.0
   hooks:
   - id: codespell
-    exclude: 'benchmarks/sonnet.txt|(build|tests/(lora/data|models/fixtures|prompts))/.*|vllm/third_party/.*'
+    additional_dependencies: ['tomli']
+    args: ['--toml', 'pyproject.toml']
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,6 @@ repos:
   - id: codespell
     additional_dependencies: ['tomli']
     args: ['--toml', 'pyproject.toml']
-    exclude: 'benchmarks/sonnet.txt|(build|tests/(lora/data|models/fixtures|prompts))/.*|vllm/third_party/.*'
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
   - id: codespell
     additional_dependencies: ['tomli']
     args: ['--toml', 'pyproject.toml']
+    exclude: 'benchmarks/sonnet.txt|(build|tests/(lora/data|models/fixtures|prompts))/.*|vllm/third_party/.*'
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 [tool.codespell]
 ignore-words-list = "dout, te, indicies, subtile, ElementE"
-skip = "tests/models/fixtures,tests/prompts,benchmarks/sonnet.txt,tests/lora/data,build,vllm/third_party"
+skip = "tests/models/fixtures/*,tests/prompts/*,benchmarks/sonnet.txt,tests/lora/data/*,build/*,vllm/third_party/*"
 
 [tool.isort]
 use_parentheses = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 [tool.codespell]
 ignore-words-list = "dout, te, indicies, subtile, ElementE"
-skip = "./tests/models/fixtures,./tests/prompts,./benchmarks/sonnet.txt,./tests/lora/data,./build,./vllm/third_party"
+skip = "tests/models/fixtures,tests/prompts,benchmarks/sonnet.txt,tests/lora/data,build,vllm/third_party"
 
 [tool.isort]
 use_parentheses = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ exclude = [
 
 [tool.codespell]
 ignore-words-list = "dout, te, indicies, subtile, ElementE"
-skip = "./tests/models/fixtures,./tests/prompts,./benchmarks/sonnet.txt,./tests/lora/data,./build"
+skip = "./tests/models/fixtures,./tests/prompts,./benchmarks/sonnet.txt,./tests/lora/data,./build,./vllm/third_party"
 
 [tool.isort]
 use_parentheses = true

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,2 +1,3 @@
 # formatting
+tomli
 pre-commit==4.0.1

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,2 @@
 # formatting
-tomli
 pre-commit==4.0.1


### PR DESCRIPTION
This is mainly to resolve an issue where the pre-commit hook does not look at `ignore-words-list` in `pyproject.toml`, which popped up during the development of #13198 (`ElementE` in this case).

~~This also removes the `exclude` regex from `.pre-commit-config.yaml` in favor of the `skip` list in `pyproject.toml` although there are some differences that may need to be sorted out.~~

For reference: https://github.com/vllm-project/vllm/blob/d84cef76eb9e16190cfdd97ae24511c8c819f179/pyproject.toml#L94-L96