### PR TITLE
[ROCm] Avoid using the default stream on ROCm as it is a performance killer

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -942,11 +942,13 @@ def current_stream() -> torch.cuda.Stream:
     the underlying hypothesis is that we do not call `torch._C._cuda_setStream`
     from C/C++ code.
     """
+    from vllm.platforms import current_platform
     global _current_stream
     if _current_stream is None:
         # when this function is called before any stream is set,
         # we return the default stream.
-        _current_stream = torch.cuda.current_stream()
+        _current_stream = torch.cuda.Stream() if current_platform.is_rocm(
+        ) else torch.cuda.current_stream()
     return _current_stream
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -947,6 +947,9 @@ def current_stream() -> torch.cuda.Stream:
     if _current_stream is None:
         # when this function is called before any stream is set,
         # we return the default stream.
+        # On ROCm using the default 0 stream in combination with RCCL
+        # is hurting performance. Therefore creating a dedicated stream
+        # per process
         _current_stream = torch.cuda.Stream() if current_platform.is_rocm(
         ) else torch.cuda.current_stream()
     return _current_stream


### PR DESCRIPTION
Fixing a ROCm performance regression added by #11744
Using the default 0 stream on ROCm hurts the performance. With this PR there is an uplift on tp=8:
LLama-3-70B
latency goes from 1.85s to 1.7s
LLama-2-70b bs=1 in=2048 out=128 scheduler-steps=10
latency goes from 1.8s to 1.58s