### PR TITLE
[Bugfix/CI] Turn test_compressed_tensors_2of4_sparse back on

### DIFF
--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -495,7 +495,6 @@ def test_compressed_tensors_2of4_quant_int8(vllm_runner, args_2of4):
         assert output
 
 
-@pytest.mark.skip(reason="2of4 sparse w16a16 CUTLASS produces bad output.")
 @pytest.mark.skipif(
     not sparse_cutlass_supported(),
     reason="2of4 Sparse is not yet supported on this GPU type.",


### PR DESCRIPTION
Missed turning this one on in https://github.com/vllm-project/vllm/pull/13198