### PR TITLE
[Bugfix] Fix missing parentheses

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -381,7 +381,7 @@ class SequenceData(msgspec.Struct,
                 f"prompt_token_ids={self._prompt_token_ids}, "
                 f"output_token_ids={self.output_token_ids}, "
                 f"cumulative_logprob={self.cumulative_logprob}, "
-                f"get_num_computed_tokens={self.get_num_computed_tokens()}")
+                f"get_num_computed_tokens={self.get_num_computed_tokens()})")
 
 
 class Sequence:
@@ -606,7 +606,7 @@ class Sequence:
     def __repr__(self) -> str:
         return (f"Sequence(seq_id={self.seq_id}, "
                 f"status={self.status.name}, "
-                f"num_blocks={self.n_blocks}, ")
+                f"num_blocks={self.n_blocks})")
 
 
 class SequenceGroupState(msgspec.Struct,


### PR DESCRIPTION

Fix missing parentheses

## Before

```sh
(Pdb) p seq
Sequence(seq_id=0, status=RUNNING, num_blocks=78,
```

## After
```sh
(Pdb) p seq
Sequence(seq_id=0, status=RUNNING, num_blocks=78)
```