### PR TITLE
[Misc] Remove misleading log

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -99,8 +99,6 @@ def with_retry(func: Callable[[], Any],
             if attempt == max_retries - 1:
                 logger.error("%s: %s", log_msg, e)
                 raise
-            logger.error("%s: %s, retrying %d of %d", log_msg, e, attempt + 1,
-                         max_retries)
             time.sleep(retry_delay)
             retry_delay *= 2
 


### PR DESCRIPTION
When loading a local model like:
```python
from vllm import LLM
llm = LLM(model="./opt-125m")
```
The log will show  some info in error level, but actually it doesn't raises any error.

```bash
ERROR 02-14 07:06:48 config.py:102] Error retrieving file list: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: './opt-125m'., retrying 1 of 2
ERROR 02-14 07:06:50 config.py:100] Error retrieving file list: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: './opt-125m'.
```

This PR remove this misleading log.

Related to: https://github.com/vllm-project/vllm/pull/13107
