### PR TITLE
[Bugfix]Fix search start_index of stop_checker

### DIFF
--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -112,7 +112,8 @@ class StopChecker:
         for stop_str in stop:
             stop_string_len = len(stop_str)
             # Avoid searching already-searched text.
-            stop_index = output_text.find(stop_str, 1 - new_char_count - stop_string_len)
+            stop_index = output_text.find(stop_str,
+                                          1 - new_char_count - stop_string_len)
             if stop_index == -1:
                 continue
 

--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -112,8 +112,7 @@ class StopChecker:
         for stop_str in stop:
             stop_string_len = len(stop_str)
             # Avoid searching already-searched text.
-            stop_index = output_text.find(stop_str, 
-                                          len(output_text) - new_char_count - stop_string_len + 1)
+            stop_index = output_text.find(stop_str, 1 - new_char_count - stop_string_len)
             if stop_index == -1:
                 continue
 

--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -112,8 +112,8 @@ class StopChecker:
         for stop_str in stop:
             stop_string_len = len(stop_str)
             # Avoid searching already-searched text.
-            stop_index = output_text.find(stop_str,
-                                          -new_char_count - stop_string_len)
+            stop_index = output_text.find(stop_str, 
+                                          len(output_text) - new_char_count - stop_string_len + 1)
             if stop_index == -1:
                 continue
 


### PR DESCRIPTION
Fix search `start_index` of stop_checker


## test script



For example
`output_text="abcdef"`, `new_char="cdef"`, `stop_str="de"`, `start_index` should be 1.

Below is a comprehensive test script:

```py
def find_test(output_text, stop_str, new_char_count):
    print(
        f"output_text: {output_text} (old_char|new_char: {output_text[:-new_char_count]}|{output_text[-new_char_count:]})"
    )
    print(f"stop_str: {stop_str}")
    stop_string_len = len(stop_str)
    search_start = len(output_text) - new_char_count - stop_string_len + 1
    # search_start = 1 - new_char_count - stop_string_len
    print(f"should search start at: {search_start}")

    stop_index = output_text.find(stop_str, search_start)

    print(f"searched_index: {stop_index}")
    if stop_index >= 0:
        print(output_text[:stop_index])
    print("")


examples = [
    ("abcdef", "de", 5),
    ("abcdef", "de", 4),
    ("abcdef", "de", 3),
    ("abcdef", "de", 2),
]
for example in examples:
    find_test(*example)

```

log 
```yml
output_text: abcdef (old_char|new_char: a|bcdef)
stop_str: de
should search start at: 0
searched_index: 3
abc

output_text: abcdef (old_char|new_char: ab|cdef)
stop_str: de
should search start at: 1
searched_index: 3
abc

output_text: abcdef (old_char|new_char: abc|def)
stop_str: de
should search start at: 2
searched_index: 3
abc

output_text: abcdef (old_char|new_char: abcd|ef)
stop_str: de
should search start at: 3
searched_index: 3
abc
```