### PR TITLE
[Bugfix] Fix qwen2.5-vl image processor

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -36,7 +36,8 @@ from transformers import BatchFeature
 from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
     Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig)
-from transformers.models.qwen2_vl import Qwen2VLImageProcessor
+from transformers.models.qwen2_vl import (Qwen2VLImageProcessor,
+                                          Qwen2VLImageProcessorFast)
 
 from vllm.attention import AttentionMetadata
 from vllm.config import VllmConfig
@@ -693,7 +694,8 @@ class Qwen2_5_VLProcessingInfo(Qwen2VLProcessingInfo):
     ) -> Qwen2_5_VLProcessor:
         hf_processor = self.ctx.get_hf_processor(Qwen2_5_VLProcessor)
         image_processor = hf_processor.image_processor  # type: ignore
-        assert isinstance(image_processor, Qwen2VLImageProcessor)
+        assert isinstance(image_processor,
+                          (Qwen2VLImageProcessor, Qwen2VLImageProcessorFast))
 
         if min_pixels:
             image_processor.min_pixels = min_pixels
@@ -713,14 +715,15 @@ class Qwen2_5_VLProcessingInfo(Qwen2VLProcessingInfo):
         min_pixels: Optional[int] = None,
         max_pixels: Optional[int] = None,
         fps: Optional[float] = 2.0,
-    ) -> Qwen2VLImageProcessor:
+    ) -> Union[Qwen2VLImageProcessor, Qwen2VLImageProcessorFast]:
         hf_processor = self.get_hf_processor(
             min_pixels=min_pixels,
             max_pixels=max_pixels,
             fps=fps,
         )
         image_processor = hf_processor.image_processor  # type: ignore
-        assert isinstance(image_processor, Qwen2VLImageProcessor)
+        assert isinstance(image_processor,
+                          (Qwen2VLImageProcessor, Qwen2VLImageProcessorFast))
         return image_processor
 
 

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -33,10 +33,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 from transformers import BatchFeature
-from transformers.models.qwen2_5_vl import (Qwen2_5_VLImageProcessor,
-                                            Qwen2_5_VLProcessor)
+from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
 from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
     Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig)
+from transformers.models.qwen2_vl import Qwen2VLImageProcessor
 
 from vllm.attention import AttentionMetadata
 from vllm.config import VllmConfig
@@ -693,7 +693,7 @@ class Qwen2_5_VLProcessingInfo(Qwen2VLProcessingInfo):
     ) -> Qwen2_5_VLProcessor:
         hf_processor = self.ctx.get_hf_processor(Qwen2_5_VLProcessor)
         image_processor = hf_processor.image_processor  # type: ignore
-        assert isinstance(image_processor, Qwen2_5_VLImageProcessor)
+        assert isinstance(image_processor, Qwen2VLImageProcessor)
 
         if min_pixels:
             image_processor.min_pixels = min_pixels
@@ -713,14 +713,14 @@ class Qwen2_5_VLProcessingInfo(Qwen2VLProcessingInfo):
         min_pixels: Optional[int] = None,
         max_pixels: Optional[int] = None,
         fps: Optional[float] = 2.0,
-    ) -> Qwen2_5_VLImageProcessor:
+    ) -> Qwen2VLImageProcessor:
         hf_processor = self.get_hf_processor(
             min_pixels=min_pixels,
             max_pixels=max_pixels,
             fps=fps,
         )
         image_processor = hf_processor.image_processor  # type: ignore
-        assert isinstance(image_processor, Qwen2_5_VLImageProcessor)
+        assert isinstance(image_processor, Qwen2VLImageProcessor)
         return image_processor
 
 

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -31,7 +31,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
+from packaging.version import Version
 from transformers import BatchFeature
+from transformers import __version__ as TRANSFORMERS_VERSION
 from transformers.models.qwen2_vl import (Qwen2VLImageProcessor,
                                           Qwen2VLProcessor)
 from transformers.models.qwen2_vl.configuration_qwen2_vl import (
@@ -759,7 +761,13 @@ class Qwen2VLProcessingInfo(BaseProcessingInfo):
         hf_processor = self.get_hf_processor(min_pixels=min_pixels,
                                              max_pixels=max_pixels)
         image_processor = hf_processor.image_processor  # type: ignore
-        assert isinstance(image_processor, Qwen2VLImageProcessor)
+        if Version(TRANSFORMERS_VERSION) >= Version("4.49"):
+            from transformers.models.qwen2_vl import Qwen2VLImageProcessorFast
+            assert isinstance(
+                image_processor,
+                (Qwen2VLImageProcessor, Qwen2VLImageProcessorFast))
+        else:
+            assert isinstance(image_processor, Qwen2VLImageProcessor)
         return image_processor
 
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:


### PR DESCRIPTION
FIX #13285 

**Need to wait Qwen team update the model repo with correct preprocessor_config.json (see https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct/discussions/14)**
- `transformers` removed `Qwen2_5_VLImageProcessor` in latest commit and replaced with `Qwen2VLImageProcessor` and `Qwen2VLImageProcessorFast` instead. (see https://github.com/huggingface/transformers/pull/36164)
- Fix qwen2.5-vl implementation to make it still work.

<!--- pyml disable-next-line no-emphasis-as-heading -->
