### PR TITLE
Minor fix in documentation for tool_calling.md

### DIFF
--- a/docs/source/features/tool_calling.md
+++ b/docs/source/features/tool_calling.md
@@ -51,7 +51,7 @@ response = client.chat.completions.create(
 tool_call = response.choices[0].message.tool_calls[0].function
 print(f"Function called: {tool_call.name}")
 print(f"Arguments: {tool_call.arguments}")
-print(f"Result: {get_weather(**json.loads(tool_call.arguments))}")
+print(f"Result: {tool_functions[tool_call.name](**json.loads(tool_call.arguments))}")
 ```
 
 Example output:


### PR DESCRIPTION
We can slightly improve the documentation here. 

Instead of hardcoding the get_weather function name we can just get it from the dict above `tool_functions`.

I guess this was the reason for creating this variable in the first place anyway