### PR TITLE
[WIP][Metrics] Re-work approach to LoRA metrics

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1812,8 +1812,8 @@ class LLMEngine:
             max_tokens_requests=max_tokens_requests,
             finished_reason_requests=finished_reason_requests,
             max_lora=str(max_lora_stat),
-            waiting_lora_adapters=list(waiting_lora_adapters.keys()),
-            running_lora_adapters=list(running_lora_adapters.keys()))
+            waiting_lora_adapters=waiting_lora_adapters,
+            running_lora_adapters=running_lora_adapters)
 
     def add_lora(self, lora_request: LoRARequest) -> bool:
         return self.model_executor.add_lora(lora_request)

--- a/vllm/engine/metrics_types.py
+++ b/vllm/engine/metrics_types.py
@@ -63,8 +63,8 @@ class Stats:
     max_num_generation_tokens_requests: List[int]
     max_tokens_requests: List[int]
     finished_reason_requests: List[str]
-    waiting_lora_adapters: List[str]
-    running_lora_adapters: List[str]
+    waiting_lora_adapters: Dict[str, int]
+    running_lora_adapters: Dict[str, int]
     max_lora: str
 
     spec_decode_metrics: Optional["SpecDecodeWorkerMetrics"] = None


### PR DESCRIPTION
Part of #10582 and discussed in #12745

The current `vllm:lora_requests_info` Gauge is somewhat similar to an Info metric (like cache_config_info) except the value is the current wall-clock time, and is updated every iteration.

The label names used are:

- running_lora_adapters: a list of adapters with running requests, formatted as a comma-separated string.
- waiting_lora_adapters: similar, except listing adapters with requests waiting to be scheduled.
- max_lora - the static "max number of LoRAs in a single batch." configuration.

It looks like this:

```
vllm:lora_requests_info{max_lora="1",running_lora_adapters="",waiting_lora_adapters=""} 1.7395575657589855e+09
vllm:lora_requests_info{max_lora="1",running_lora_adapters="test-lora",waiting_lora_adapters=""} 1.7395575723949368e+09
vllm:lora_requests_info{max_lora="1",running_lora_adapters="test-lora",waiting_lora_adapters="test-lora"} 1.7395575717647147e+09
```

I can't really make much sense of this. Encoding a running/waiting status for multiple adapters in a comma-separated string seems quite misguided - we should use labels to distinguish between per-adapter counts instead:

```
vllm:num_lora_requests_running{lora_name="test-lora",model_name="meta-llama/Llama-3.1-8B-Instruct"} 8.0
vllm:num_lora_requests_waiting{lora_name="test-lora",model_name="meta-llama/Llama-3.1-8B-Instruct"} 7.0
```

This was added in #9477 and there is at least one known user. If we revisit this design and deprecate the old metric, we should reduce the need for a significant deprecation period by making the change in v0 also and asking this project to move to the new metric.

TODO:
- [ ] Add a lora config info gauge - max_loras, max_lora_rank
- [ ] Add more unit test coverage of the new metrics
- [ ] Add the new metrics to V1
- [ ] Add the old metric to V0 (to ease the transition to V1)
- [ ] Deprecate the old metrics