### PR TITLE
[Bugfix] Massage MLA's usage of flash attn for RoCM

### DIFF
--- a/vllm/attention/backends/mla/utils.py
+++ b/vllm/attention/backends/mla/utils.py
@@ -505,8 +505,8 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         if self.vllm_flash_attn_version is not None:
             fa_args["fa_version"] = self.vllm_flash_attn_version
 
-        attn_output = flash_attn_varlen_func(**fa_args).view(
-            -1, self.num_heads, q.shape[-1])[..., :v.shape[-1]].reshape(
-                -1, self.num_heads * v.shape[-1])
+        attn_output = flash_attn_varlen_func(**fa_args)\
+                .view(-1, self.num_heads, q.shape[-1])[..., :v.shape[-1]]\
+                    .reshape(-1, self.num_heads * v.shape[-1])
 
         return self.o_proj(attn_output)[0]

--- a/vllm/attention/backends/mla/utils.py
+++ b/vllm/attention/backends/mla/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Optional, Tuple
@@ -182,6 +183,15 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         self.kv_b_proj = kv_b_proj
         self.o_proj = o_proj
         self.vllm_flash_attn_version = get_flash_attn_version()
+
+        # Handle the differences between the flash_attn_varlen from flash_attn
+        # and the one from vllm_flash_attn. The former is used on RoCM and the
+        # latter has an additional parameter to control FA2 vs FA3
+        self.flash_attn_varlen_func = flash_attn_varlen_func
+        if self.vllm_flash_attn_version is not None:
+            self.flash_attn_varlen_func = \
+                functools.partial(flash_attn_varlen_func,
+                                  fa_version=self.vllm_flash_attn_version)
 
     def _v_up_proj_and_o_proj(self, x):
         if envs.VLLM_MLA_PERFORM_MATRIX_ABSORPTION:
@@ -487,26 +497,19 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         v_padded = torch.nn.functional.pad(v, [0, q.shape[-1] - v.shape[-1]],
                                            value=0)
 
-        # Here we massage the flash_attn_varlen_func interface since we use this
-        # codepath via vllm-flash-attn on NVIDIA and the upstream branch
-        # on AMD .
-        fa_args = {
-            "q": q,
-            "k": k,
-            "v": v_padded,
-            "cu_seqlens_q": seq_start_loc,
-            "cu_seqlens_k": seq_start_loc,
-            "max_seqlen_q": max_prefill_seq_len,
-            "max_seqlen_k": max_prefill_seq_len,
-            "softmax_scale": self.scale,
-            "causal": True,
-        }
-
-        if self.vllm_flash_attn_version is not None:
-            fa_args["fa_version"] = self.vllm_flash_attn_version
-
-        attn_output = flash_attn_varlen_func(**fa_args)\
-                .view(-1, self.num_heads, q.shape[-1])[..., :v.shape[-1]]\
-                    .reshape(-1, self.num_heads * v.shape[-1])
+        attn_output = self.flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v_padded,
+            cu_seqlens_q=seq_start_loc,
+            cu_seqlens_k=seq_start_loc,
+            max_seqlen_q=max_prefill_seq_len,
+            max_seqlen_k=max_prefill_seq_len,
+            softmax_scale=self.scale,
+            causal=True,
+        )
+        attn_output = attn_output\
+            .view(-1, self.num_heads, q.shape[-1])[..., :v.shape[-1]]\
+                .reshape(-1, self.num_heads * v.shape[-1])
 
         return self.o_proj(attn_output)[0]


### PR DESCRIPTION
This PR massages some `vllm_flash_attn` vs `flash_attn` interface differences that appeared between a couple of PRs:

https://github.com/vllm-project/vllm/pull/12662 added a this fallback to `flash_attn` in order to support MLA on RoCM:
https://github.com/vllm-project/vllm/blob/5e5c8e091eacc16672a0a8265eb5cb0ece85d24b/vllm/attention/backends/mla/utils.py#L33-L36

Subsequently https://github.com/vllm-project/vllm/pull/12807 updated to use the `vllm_flash_attn` specific arguments that control whether we use FA2 or FA3.

