### PR TITLE
[Bugfix/CI] Fix test_whisper by setting task to "generate"

### DIFF
--- a/tests/models/encoder_decoder/audio_language/test_whisper.py
+++ b/tests/models/encoder_decoder/audio_language/test_whisper.py
@@ -104,6 +104,7 @@ def run_test(
         model=model,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
+        task="generate",
     )
 
     sampling_params = SamplingParams(


### PR DESCRIPTION
Test is broken on current main with the error:
```
ValueError: LLM.generate() is only supported for (conditional) generation models (XForCausalLM, XForConditionalGeneration). Your model supports the 'generate' runner, but is currently initialized for the 'transcription' runner. Please initialize vLLM using `--task generate`.
```
