### PR TITLE
[Bugfix][CI] Fix broken whisper test by default transcription task

### DIFF
--- a/tests/models/encoder_decoder/audio_language/test_whisper.py
+++ b/tests/models/encoder_decoder/audio_language/test_whisper.py
@@ -104,6 +104,7 @@ def run_test(
         model=model,
         tensor_parallel_size=tensor_parallel_size,
         distributed_executor_backend=distributed_executor_backend,
+        task="generate",
     )
 
     sampling_params = SamplingParams(


### PR DESCRIPTION

- Default `transcription` task for whisper broke the multimodal test

<!--- pyml disable-next-line no-emphasis-as-heading -->
