### PR TITLE
[Bugfix]: DeepseekR1 model load fails with weights tied error

### DIFF
--- a/vllm/attention/backends/mla/utils.py
+++ b/vllm/attention/backends/mla/utils.py
@@ -43,7 +43,7 @@ class MLACommonMetadata(AttentionMetadata):
     input_positions: torch.Tensor
 
 
-class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
+class MLACommonImpl(MLAAttentionImpl[T], Generic[T], torch.nn.Module):
     """
     Common class for implementing repeated parts
 
@@ -162,6 +162,14 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         kv_b_proj: ColumnParallelLinear,
         o_proj: RowParallelLinear,
     ) -> None:
+        # We add the module's inheritance and initialization to support the
+        # offload mode and MLA parameter decompression. In offload, CPU
+        # tensors are transferred to the GPU for parameter modification and
+        # then returned. The device_loading_context function, which uses
+        # module.named_parameters() and is for quantization, can handle this
+        # task. Since it needs a module-type class, we've added the
+        # inheritance and initialization.
+        torch.nn.Module.__init__(self)
         self.num_heads = num_heads
         self.head_size = head_size
         self.scale = float(scale)

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -217,10 +217,6 @@ class Attention(nn.Module):
         s += f", backend={self.impl.__class__.__name__}"
         return s
 
-    def process_weights_after_loading(self, act_dtype: torch.dtype):
-        if hasattr(self.impl, "process_weights_after_loading"):
-            self.impl.process_weights_after_loading(act_dtype)
-
 
 class MultiHeadAttention(nn.Module):
     """Multi-headed attention without any cache, used for ViT."""

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -165,6 +165,12 @@ def _process_weights_after_loading(model: nn.Module, model_config: ModelConfig,
             # parameters onto device for processing and back off after.
             with device_loading_context(module, target_device):
                 quant_method.process_weights_after_loading(module)
+            # There are cases of excess memory allocation that are not
+            # cleared, leading to "cuda out of memory" errors.
+            # TODO: Investigate the cause of the memory leak. It may be
+            # related to specific Python versions.
+            import gc
+            gc.collect()
 
     # Currently only used by MLA.
     # NOTE: This intentionally happens after other modules so we can easily
@@ -174,7 +180,19 @@ def _process_weights_after_loading(model: nn.Module, model_config: ModelConfig,
             hasattr(module, "process_weights_after_loading"):
             # TODO(lucas): see if there is a way to unify the signatures
             # of process_weights_after_loading
-            module.process_weights_after_loading(model_config.dtype)
+            # At this point, we assume that the tensor is located on the
+            # global target device. This context is specifically for
+            # scenarios involving CPU offloading. When CPU offloading is
+            # in use, we transfer the parameters to the device for
+            # processing and then move them back to the CPU afterwards.
+            with device_loading_context(module.impl, target_device):
+                module.process_weights_after_loading(model_config.dtype)
+            # There are cases of excess memory allocation that are not
+            # cleared, leading to "cuda out of memory" errors.
+            # TODO: Investigate the cause of the memory leak. It may be
+            # related to specific Python versions.
+            import gc
+            gc.collect()
 
 
 class BaseModelLoader(ABC):

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -528,10 +528,15 @@ def maybe_offload_to_cpu(module: torch.nn.Module) -> torch.nn.Module:
                 k: v.to(device, non_blocking=True)
                 for k, v in module.state_dict().items()
             }
+            # Add tie_weights=False here to avoid tie weight problem in
+            # in current MLA attention. eg: e_score_correction_bias in both
+            # mlp.experts and mlp.gate; qk_weight in both mla_attn.impl and
+            # mla_attn.impl
             output = functional_call(module,
                                      device_state,
                                      args=args,
-                                     kwargs=kwargs)
+                                     kwargs=kwargs,
+                                     tie_weights=False)
             module.forward = forward
             return output
 


### PR DESCRIPTION
Fix: [12541](https://github.com/vllm-project/vllm/issues/12541)
This PR resolves the bug causing the DeepseekR1 model to fail during loading due to weight-tied errors. 

The implemented changes are as follows: 
1 Make MLACommonImpl inherit from Module for easy use of _process_weights_after_loading during parameter decompression.
2 Set tie_weights=False in maybe_offload_to_cpu to prevent weight-tying issues.
3 Add gc.collect to _process_weights_after_loading to tackle potential memory leaks that may lead to "cuda out of memory" errors.

It should be noted that due to the offload operation and the use of gc.collect, the model loading time is approximately 2 minutes longer. The startup command utilized is `llm = LLM("deepseek-ai/DeepSeek-R1", tensor_parallel_size = 8, cpu_offload_gb = 50, trust_remote_code = True)`. (on 8*H100 80G).