### PR TITLE
[Bugfix] Pin xgrammar to 0.1.11

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -20,7 +20,7 @@ tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
 outlines == 0.1.11
 lark == 1.2.2 
-xgrammar >= 0.1.11; platform_machine == "x86_64"
+xgrammar == 0.1.11; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
There seems to be an breaking change to the apply_token_bitmask_inplace_cuda op in the latest release of xgrammar `0.1.13`, so let's pin for now to fix

https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1739652025939989?thread_ts=1739650060.428689&cid=C07R5PAL2L9
```
[2025-02-15T00:55:01Z]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/guided_decoding/xgrammar_decoding.py", line 343, in __call__
[2025-02-15T00:55:01Z]     xgr.apply_token_bitmask_inplace(
[2025-02-15T00:55:01Z]   File "/usr/local/lib/python3.12/dist-packages/xgrammar/matcher.py", line 133, in apply_token_bitmask_inplace
[2025-02-15T00:55:01Z]     apply_token_bitmask_inplace_cuda(logits, bitmask, indices)
[2025-02-15T00:55:01Z]   File "/usr/local/lib/python3.12/dist-packages/xgrammar/kernels/apply_token_bitmask_inplace_cuda.py", line 77, in apply_token_bitmask_inplace_cuda
[2025-02-15T00:55:01Z]     torch.ops.xgrammar.apply_token_bitmask_inplace_cuda(logits, bitmask, indices)
[2025-02-15T00:55:01Z]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1116, in __call__
[2025-02-15T00:55:01Z]     return self._op(*args, **(kwargs or {}))
[2025-02-15T00:55:01Z]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2025-02-15T00:55:01Z] RuntimeError: bitmask must have the hidden size equal to ceilDiv(vocabSize, 32).
```