### PR TITLE
Use 88 as the line length to be compatible with Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 88 to be compatible with Black.
-line-length = 88
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 80.
-line-length = 80
+# Allow lines to be as long as 88 to be compatible with Black.
+line-length = 88
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py"
@@ -95,6 +95,8 @@ ignore = [
     "UP006", "UP035",
     # Can remove once 3.10+ is the minimum Python version
     "UP007",
+    # May need to add some comment to some branch.
+    "SIM108",
 ]
 
 [tool.mypy]

--- a/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/utils.py
@@ -74,10 +74,7 @@ def check_equal_or_regex_match(layer_name: str,
     Checks whether a layer_name is exactly equal or a regex match for
     if target starts with 're:' to any target in list.
     """
-    for target in targets:
-        if _is_equal_or_regex_match(layer_name, target):
-            return True
-    return False
+    return any(_is_equal_or_regex_match(layer_name, target) for target in targets)
 
 
 def find_matched_target(

--- a/vllm/model_executor/layers/quantization/quark/utils.py
+++ b/vllm/model_executor/layers/quantization/quark/utils.py
@@ -75,10 +75,7 @@ def check_equal_or_regex_match(layer_name: str,
     Checks whether a layer_name is exactly equal or a regex match for 
     if target starts with 're:' to any target in list.
     """
-    for target in targets:
-        if _is_equal_or_regex_match(layer_name, target):
-            return True
-    return False
+    return any(_is_equal_or_regex_match(layer_name, target) for target in targets)
 
 
 def _is_equal_or_regex_match(value: str,


### PR DESCRIPTION
Black by default uses 88 characters as line length, and reasoning is here: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length

To be compatible with Black, using 88 seems a wise choice. 