### PR TITLE
[Misc] Avoid calling unnecessary `hf_list_repo_files` for local model path

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -116,6 +116,13 @@ def list_repo_files(
 ) -> list[str]:
 
     def lookup_files():
+        # directly list files if model is local
+        if (local_path := Path(repo_id)).exists():
+            return [
+                str(file.relative_to(local_path))
+                for file in local_path.rglob('*') if file.is_file()
+            ]
+        # if model is remote, use hf_hub api to list files
         try:
             return hf_list_repo_files(repo_id,
                                       revision=revision,
@@ -149,8 +156,8 @@ def file_exists(
 # In offline mode the result can be a false negative
 def file_or_path_exists(model: Union[str, Path], config_name: str,
                         revision: Optional[str]) -> bool:
-    if Path(model).exists():
-        return (Path(model) / config_name).is_file()
+    if (local_path := Path(model)).exists():
+        return (local_path / config_name).is_file()
 
     # Offline mode support: Check if config file is cached already
     cached_filepath = try_to_load_from_cache(repo_id=model,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -115,7 +115,7 @@ def list_repo_files(
     token: Union[str, bool, None] = None,
 ) -> list[str]:
 
-    def lookup_files():
+    def lookup_files() -> list[str]:
         # directly list files if model is local
         if (local_path := Path(repo_id)).exists():
             return [


### PR DESCRIPTION

- There will be error logs due to `hf_list_repo_files` calling when model repo is local:
```
INFO 02-16 13:46:11 __init__.py:190] Automatically detected platform cuda.
ERROR 02-16 13:46:11 config.py:102] Error retrieving file list: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: '../Florence-2-base'., retrying 1 of 2
ERROR 02-16 13:46:13 config.py:100] Error retrieving file list: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: '../Florence-2-base'.
INFO 02-16 13:46:13 config.py:2407] Downcasting torch.float32 to torch.float16.
```
- Avoid unnecessary `hf_list_repo_files` calling if the model repo is local so that we can prevent misleading error logs.

<!--- pyml disable-next-line no-emphasis-as-heading -->
