### PR TITLE
[V1][PP] Cache Intermediate Tensors

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -91,10 +91,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.head_size = model_config.get_head_size()
         self.hidden_size = model_config.get_hidden_size()
 
-        # Parallelism related.
-        self.tp_size = parallel_config.tensor_parallel_size
-        self.pp_size = parallel_config.pipeline_parallel_size
-
         # Multi-modal data support
         self.input_registry = INPUT_REGISTRY
         self.mm_registry = MULTIMODAL_REGISTRY


### PR DESCRIPTION
If I understand correctly, we should cache the intermediate tensors and reuse them for CUDA graphs. This could be another reason why current PP is not working correctly.

cc @comaniac @youkaichao 