### PR TITLE
[Bugfix][Platform][CPU] Fix cuda platform detection on CPU backend edge case

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -33,12 +33,14 @@ def cuda_platform_plugin() -> Optional[str]:
     is_cuda = False
 
     try:
+        import torch
+
         from vllm.utils import import_pynvml
         pynvml = import_pynvml()
         pynvml.nvmlInit()
         try:
-            if pynvml.nvmlDeviceGetCount() > 0:
-                is_cuda = True
+            is_cuda = (pynvml.nvmlDeviceGetCount() > 0
+                       and torch.cuda.is_available())
         finally:
             pynvml.nvmlShutdown()
     except Exception as e:


### PR DESCRIPTION
- There is an edge case bug for cuda platform activation about CPU backend after #12963.

- If vllm cpu backend is built on a GPU machine, cpu platform and gpu platform will be activated at the same time:
```
RuntimeError: Only one platform plugin can be activated, but got: ['cpu', 'cuda']
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
