### PR TITLE
set chunked_prefill off when use mla

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1196,6 +1196,9 @@ class EngineArgs:
             msg = "Chunked prefill is not supported for pooling models"
             raise ValueError(msg)
 
+        if model_config.use_mla:
+            logger.info("MLA is enabled; forcing chunked prefill disabled.")
+            self.enable_chunked_prefill = False
 
         speculative_config = SpeculativeConfig.maybe_create_spec_config(
             target_model_config=model_config,


### PR DESCRIPTION

FIX #13370  (*link existing issues this PR will resolve*)

in vllm/config.py , it will forcing chunked prefill and prefix caching to be disabled, but it's too late, the max_num_batched_tokens will be set 2048 by default when user use --enable-chunked-prefill for mla attention model

<!--- pyml disable-next-line no-emphasis-as-heading -->
