### PR TITLE
[V1][Core] Support offloading KV cache to CPU.

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -36,6 +36,7 @@ def test_prefill():
     manager = KVCacheManager(
         block_size=16,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -50,9 +51,11 @@ def test_prefill():
     unique_token_ids = [3] * 7
     all_token_ids = common_token_ids + unique_token_ids
     req0 = make_request("0", all_token_ids)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
     assert len(manager.req_to_block_hashes[req0.request_id]) == 3
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req0, 55, computed_blocks)
     assert [b.block_id for b in blocks] == [0, 1, 2, 3, 4]
@@ -75,10 +78,12 @@ def test_prefill():
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
     req1 = make_request("1", common_token_ids + unique_token_ids)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert len(manager.req_to_block_hashes[req1.request_id]) == 3
     assert [b.block_id for b in computed_blocks] == [0, 1, 2]
     assert num_computed_tokens == 3 * 16
+    assert len(computed_cpu_blocks) == 0
     num_new_tokens = 53 - 3 * 16
     blocks = manager.allocate_slots(req1, num_new_tokens, computed_blocks)
     assert [b.block_id for b in blocks] == [5, 6]
@@ -106,10 +111,12 @@ def test_prefill():
     # Incomplete 1 block (6 tokens)
     unique_token_ids = [3] * 6
     req2 = make_request("2", common_token_ids + unique_token_ids)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req2))
     assert len(manager.req_to_block_hashes[req2.request_id]) == 3
     assert [b.block_id for b in computed_blocks] == [0, 1, 2]
     assert num_computed_tokens == 3 * 16
+    assert len(computed_cpu_blocks) == 0
     num_new_tokens = 53 - 3 * 16
     blocks = manager.allocate_slots(req2, num_new_tokens, computed_blocks)
     assert [b.block_id for b in blocks] == [7, 8]
@@ -127,9 +134,11 @@ def test_prefill():
 
     # Cache miss and eviction.
     req3 = make_request("3", [99] * (16 * 9))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req3))
     assert not computed_blocks
     assert num_computed_tokens == 0
+    assert not computed_cpu_blocks
     blocks = manager.allocate_slots(req3, 16 * 9, computed_blocks)
     # This block ID order also checks the eviction order.
     assert [b.block_id for b in blocks] == [9, 4, 3, 6, 5, 8, 7, 2, 1, 0]
@@ -142,6 +151,7 @@ def test_decode():
     manager = KVCacheManager(
         block_size=16,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -155,9 +165,11 @@ def test_decode():
     # Incomplete 1 block (7 tokens)
     unique_token_ids = [3] * 7
     req0 = make_request("0", common_token_ids + unique_token_ids)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
     assert not computed_blocks
     assert num_computed_tokens == 0
+    assert not computed_cpu_blocks
     blocks = manager.allocate_slots(req0, 55, computed_blocks)
     assert [b.block_id for b in blocks] == [0, 1, 2, 3, 4]
 
@@ -195,6 +207,7 @@ def test_evict():
     manager = KVCacheManager(
         block_size=16,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -203,8 +216,10 @@ def test_evict():
 
     last_token_id = 5 * 16 + 7
     req0 = make_request("0", list(range(last_token_id)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req0, 5 * 16 + 7, computed_blocks)
     assert len(blocks) == 7  # 5 full + 1 partial + 1 preallocated
@@ -212,8 +227,10 @@ def test_evict():
     # 3 blocks.
     req1 = make_request("1", list(range(last_token_id,
                                         last_token_id + 3 * 16)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req1, 3 * 16, computed_blocks)
     assert len(blocks) == 3  # 3 full blocks
@@ -230,8 +247,10 @@ def test_evict():
 
     # Touch the first 2 blocks.
     req2 = make_request("2", list(range(2 * 16 + 3)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req2))
     assert [b.block_id for b in computed_blocks] == [0, 1]
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 2 * 16
     blocks = manager.allocate_slots(req2, 3, computed_blocks)
     assert [b.block_id for b in blocks] == [6, 5]
@@ -247,6 +266,7 @@ def test_hash_block_correct_reuse():
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=1,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -256,8 +276,10 @@ def test_hash_block_correct_reuse():
     # Allocate 1 block and cache it.
     num_tokens = block_size * 1
     req = make_request("0", list(range(num_tokens)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req, num_tokens, computed_blocks)
     assert len(blocks) == 1
@@ -268,8 +290,10 @@ def test_hash_block_correct_reuse():
     # Allocate a new block that's not full, make sure hash info on the
     # block is cleared.
     req = make_request("1", list(range(num_tokens - 1)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req, num_tokens - 1, computed_blocks)
     assert len(blocks) == 1
@@ -286,6 +310,7 @@ def test_computed_blocks_not_evicted():
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=2,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -295,8 +320,10 @@ def test_computed_blocks_not_evicted():
     # Allocate a block and cache it.
     num_tokens = block_size * 1
     req0 = make_request("0", list(range(num_tokens)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req0, num_tokens, computed_blocks)
     assert len(blocks) == 1
@@ -304,8 +331,10 @@ def test_computed_blocks_not_evicted():
 
     # Allocate another block.
     req1 = make_request("1", list(range(num_tokens, num_tokens * 2)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req1, num_tokens, computed_blocks)
     assert len(blocks) == 1
@@ -318,9 +347,11 @@ def test_computed_blocks_not_evicted():
     # Now if we have a cache hit on the first block, we should evict the second
     # cached block rather than the first one.
     req2 = make_request("2", list(range(num_tokens * 2)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req2))
     assert len(computed_blocks) == 1
     assert computed_blocks[0].block_id == 0
+    assert not computed_cpu_blocks
     assert num_computed_tokens == block_size
 
     blocks = manager.allocate_slots(req2, num_tokens * 2 - num_tokens,
@@ -337,6 +368,7 @@ def test_basic_prefix_caching_disabled():
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=4,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=False,
@@ -345,8 +377,10 @@ def test_basic_prefix_caching_disabled():
 
     req1 = make_request("1", list(range(10)))  # 2 blocks and some more
 
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req1, 10, computed_blocks)
     assert len(blocks) == 3
@@ -356,16 +390,20 @@ def test_basic_prefix_caching_disabled():
 
     # No caching.
     req2 = make_request("2", list(range(16)))  # shared prefix
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req2))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req2, 16, computed_blocks)
     assert len(blocks) == 4
 
     # New requests should not have any blocks.
     req3 = make_request("3", list(range(4)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req3))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     blocks = manager.allocate_slots(req3, 4, computed_blocks)
     assert not blocks
@@ -380,6 +418,7 @@ def test_preallocate_blocks(num_preallocate_tokens: int, block_size: int):
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -388,9 +427,11 @@ def test_preallocate_blocks(num_preallocate_tokens: int, block_size: int):
     num_preallocated_blocks = cdiv(num_preallocate_tokens, block_size)
 
     req = make_request("0", list(range(block_size * 30)))
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req))
     assert not computed_blocks
     assert num_computed_tokens == 0
+    assert not computed_cpu_blocks
     # Just ask for 1 block.
     blocks = manager.allocate_slots(req, block_size, computed_blocks)
     req.num_computed_tokens = block_size
@@ -416,6 +457,7 @@ def test_cache_blocks():
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=5,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -460,6 +502,7 @@ def test_mm_prefix_caching():
     manager = KVCacheManager(
         block_size=16,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -489,10 +532,12 @@ def test_mm_prefix_caching():
                         all_token_ids,
                         mm_positions=mm_positions,
                         mm_hashes=mm_hashes)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
 
     # Completed block should have hashes with extra keys.
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     block_hashes = manager.req_to_block_hashes[req0.request_id]
     assert len(block_hashes) == 3
@@ -525,8 +570,10 @@ def test_mm_prefix_caching():
                         all_token_ids,
                         mm_positions=mm_positions,
                         mm_hashes=mm_hashes)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert len(computed_blocks) == 3
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 3 * 16
 
 
@@ -541,6 +588,7 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     manager = KVCacheManager(
         block_size=block_size,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -550,17 +598,21 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     # | Common-0 | Common-1 | Common-2 | ... |
     common_token_ids = [i for i in range(3) for _ in range(16)]
     req0 = make_request("0", common_token_ids)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req0))
     assert not computed_blocks
+    assert not computed_cpu_blocks
     assert num_computed_tokens == 0
     manager.allocate_slots(req0, 48, computed_blocks)
     block_part0 = manager.req_to_blocks[req0.request_id]
 
     # | Common-0 | Common-1 | Common-2 | Req1-3 | Req1-4 | Req1-5 | ... |
     req1 = make_request("1", common_token_ids * 2)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req1))
     assert computed_blocks == block_part0
     assert num_computed_tokens == 3 * 16
+    assert not computed_cpu_blocks
     manager.allocate_slots(req1, 48, computed_blocks)
     block_part1 = manager.req_to_blocks[req1.request_id]
     # | Common-0 | Common-1 | Common-2 | Req1-3 (F) | Req1-4 (F) |
@@ -572,9 +624,11 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     # | Common-0 | Common-1 | Common-2 | Req1-3 (F) | Req1-4 (F) |
     # | Req1-5(F)| Req2-0   | Req2-1   | ... |
     req2 = make_request("2", [7] * block_size * 2)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req2))
     assert not computed_blocks
     assert num_computed_tokens == 0
+    assert not computed_cpu_blocks
     manager.allocate_slots(req2, block_size * 2, computed_blocks)
 
     # Req3 is Req2 + 3 new blocks, so the first 6 blocks are computed,
@@ -582,9 +636,11 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     # In this case, the ref_cnt of the computed blocks should not be changed.
     assert manager.free_block_queue.num_free_blocks == 5
     req3 = make_request("3", common_token_ids * 3)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req3)
+    computed_blocks, computed_cpu_blocks, num_computed_tokens = (
+        manager.get_computed_blocks(req3))
     assert computed_blocks == block_part1
     assert num_computed_tokens == 6 * 16
+    assert not computed_cpu_blocks
     # Req3 cannot be allocated.
     assert manager.allocate_slots(req3, 48, computed_blocks) is None
     # Block 0-2 are used by Req 1.
@@ -597,6 +653,7 @@ def test_reset_prefix_cache():
     manager = KVCacheManager(
         block_size=16,
         num_gpu_blocks=10,
+        num_cpu_blocks=0,
         max_model_len=8192,
         sliding_window=None,
         enable_caching=True,
@@ -613,9 +670,10 @@ def test_reset_prefix_cache():
     unique_token_ids = [4] * 7
     all_token_ids = full_block_token_ids + unique_token_ids
     req1 = make_request("1", all_token_ids)
-    computed_blocks, _ = manager.get_computed_blocks(req1)
+    computed_blocks, computed_cpu_blocks, _ = manager.get_computed_blocks(req1)
     assert len(manager.req_to_block_hashes[req1.request_id]) == 3
     assert len(computed_blocks) == 3
+    assert not computed_cpu_blocks
     blocks = manager.allocate_slots(req1, 7, computed_blocks)
     assert [b.block_id for b in blocks] == [4]
 

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -37,6 +37,7 @@ def create_scheduler(
         cache_dtype="auto",
     )
     cache_config.num_gpu_blocks = 10000
+    cache_config.num_cpu_blocks = 0
     return Scheduler(scheduler_config,
                      model_config,
                      cache_config,

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -250,7 +250,9 @@ def test_stop_via_update_from_output():
                                        },
                                        num_common_prefix_blocks=0,
                                        finished_req_ids=set(),
-                                       free_encoder_input_ids=[])
+                                       free_encoder_input_ids=[],
+                                       h2d_swap_map={},
+                                       d2h_swap_map={})
 
     model_output = ModelRunnerOutput(
         req_ids=[req.request_id for req in requests],
@@ -300,7 +302,9 @@ def test_stop_via_update_from_output():
                                        },
                                        num_common_prefix_blocks=0,
                                        finished_req_ids=set(),
-                                       free_encoder_input_ids=[])
+                                       free_encoder_input_ids=[],
+                                       h2d_swap_map={},
+                                       d2h_swap_map={})
 
     model_output = ModelRunnerOutput(
         req_ids=[req.request_id for req in requests],
@@ -348,7 +352,9 @@ def test_stop_via_update_from_output():
                                        },
                                        num_common_prefix_blocks=0,
                                        finished_req_ids=set(),
-                                       free_encoder_input_ids=[])
+                                       free_encoder_input_ids=[],
+                                       h2d_swap_map={},
+                                       d2h_swap_map={})
 
     model_output = ModelRunnerOutput(
         req_ids=[req.request_id for req in requests],
@@ -393,7 +399,9 @@ def test_stop_via_update_from_output():
         },
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
-        free_encoder_input_ids=[])
+        free_encoder_input_ids=[],
+        h2d_swap_map={},
+        d2h_swap_map={})
 
     model_output = ModelRunnerOutput(
         req_ids=[requests[0].request_id],

--- a/tests/v1/test_utils.py
+++ b/tests/v1/test_utils.py
@@ -23,7 +23,7 @@ def test_bind_kv_cache():
         'layers.3.self_attn': torch.zeros((1, )),
     }
     runner_kv_caches: List[torch.Tensor] = []
-    bind_kv_cache(kv_cache, ctx, runner_kv_caches)
+    bind_kv_cache(kv_cache, runner_kv_caches, ctx)
     assert ctx['layers.0.self_attn'].kv_cache[0] is kv_cache[
         'layers.0.self_attn']
     assert ctx['layers.1.self_attn'].kv_cache[0] is kv_cache[
@@ -53,7 +53,7 @@ def test_bind_kv_cache_non_attention():
     }
 
     runner_kv_caches: List[torch.Tensor] = []
-    bind_kv_cache(kv_cache, ctx, runner_kv_caches)
+    bind_kv_cache(kv_cache, runner_kv_caches, ctx)
 
     assert ctx['model.layers.20.attn'].kv_cache[0] is kv_cache[
         'model.layers.20.attn']

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -72,6 +72,8 @@ def _schedule_new_request(*req_ids: str) -> SchedulerOutput:
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
 
@@ -123,6 +125,8 @@ def test_update_states_request_finished(model_runner):
         num_common_prefix_blocks=0,
         finished_req_ids={req_id},
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
     metadata_before = model_runner.input_batch.sampling_metadata
@@ -153,6 +157,8 @@ def test_update_states_request_resumed(model_runner):
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
     model_runner._update_states(scheduler_output)
@@ -178,6 +184,8 @@ def test_update_states_request_resumed(model_runner):
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
     metadata_before = model_runner.input_batch.sampling_metadata
@@ -208,6 +216,8 @@ def test_update_states_no_changes(model_runner):
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
     metadata_before = model_runner.input_batch.sampling_metadata
@@ -242,6 +252,8 @@ def test_update_states_request_unscheduled(model_runner):
         num_common_prefix_blocks=0,
         finished_req_ids=set(),
         free_encoder_input_ids=[],
+        d2h_swap_map={},
+        h2d_swap_map={},
     )
 
     metadata_before = model_runner._update_states(scheduler_output)

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -419,9 +419,9 @@ class KVCacheManager:
 
     def end_schedule_step(self) -> None:
         """A callback hook that is called when a scheduling step ends."""
-        self.step_d2h_swap_map.clear()
-        self.step_h2d_swap_map.clear()
-        self.step_cpu_block_in_use.clear()
+        self.step_d2h_swap_map = {}
+        self.step_h2d_swap_map = {}
+        self.step_cpu_block_in_use = set()
 
     def _get_new_blocks(self, num_blocks: int) -> List[KVCacheBlock]:
         """Get new blocks from the free block pool.

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -103,10 +103,10 @@ class KVCacheManager:
 
         # The following swap maps are accumulated over a scheduling step.
         # Then they are "flushed" as part of the scheduler output.
-        # CPU block ID -> GPU block ID
-        self.step_h2d_swap_map: Dict[int, int] = {}
         # GPU block ID -> CPU block ID
         self.step_d2h_swap_map: Dict[int, int] = {}
+        # CPU block ID -> GPU block ID
+        self.step_h2d_swap_map: Dict[int, int] = {}
         # CPU blocks in use in this scheduling step i.e. source block for
         # swap-in and destination block for swap-out.
         self.step_cpu_block_in_use: Set[int] = set()
@@ -419,8 +419,8 @@ class KVCacheManager:
 
     def end_schedule_step(self) -> None:
         """A callback hook that is called when a scheduling step ends."""
-        self.step_h2d_swap_map.clear()
         self.step_d2h_swap_map.clear()
+        self.step_h2d_swap_map.clear()
         self.step_cpu_block_in_use.clear()
 
     def _get_new_blocks(self, num_blocks: int) -> List[KVCacheBlock]:

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -377,8 +377,8 @@ class Scheduler:
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_input_ids=self.encoder_cache_manager.get_freed_ids(),
-            h2d_swap_map=self.kv_cache_manager.step_h2d_swap_map,
             d2h_swap_map=self.kv_cache_manager.step_d2h_swap_map,
+            h2d_swap_map=self.kv_cache_manager.step_h2d_swap_map,
         )
 
         self.kv_cache_manager.end_schedule_step()

--- a/vllm/v1/core/scheduler_output.py
+++ b/vllm/v1/core/scheduler_output.py
@@ -113,7 +113,7 @@ class SchedulerOutput:
     free_encoder_input_ids: List[Tuple[str, int]]
 
     # Block swap maps for the current scheduling step.
-    # CPU block ID -> GPU block ID
-    h2d_swap_map: Dict[int, int]
     # GPU block ID -> CPU block ID
     d2h_swap_map: Dict[int, int]
+    # CPU block ID -> GPU block ID
+    h2d_swap_map: Dict[int, int]

--- a/vllm/v1/core/scheduler_output.py
+++ b/vllm/v1/core/scheduler_output.py
@@ -111,3 +111,9 @@ class SchedulerOutput:
     # List of (req_id, encoder_input_index) tuples.
     # Used to free the encoder cache.
     free_encoder_input_ids: List[Tuple[str, int]]
+
+    # Block swap maps for the current scheduling step.
+    # CPU block ID -> GPU block ID
+    h2d_swap_map: Dict[int, int]
+    # GPU block ID -> CPU block ID
+    d2h_swap_map: Dict[int, int]

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -47,11 +47,8 @@ class EngineCore:
     ):
         assert vllm_config.model_config.runner_type != "pooling"
 
-        logger.info(
-            "Initializing a V1 LLM engine (v%s) with config: %s",
-            VLLM_VERSION,
-            vllm_config,
-        )
+        logger.info("Initializing a V1 LLM engine (v%s) with config: %s",
+                    VLLM_VERSION, vllm_config)
 
         self.log_stats = log_stats
 
@@ -122,11 +119,8 @@ class EngineCore:
         self.model_executor.initialize_from_config(kv_cache_configs)
 
         elapsed = time.time() - start
-        logger.info(
-            ("init engine (profile, create kv cache, "
-             "warmup model) took %.2f seconds"),
-            elapsed,
-        )
+        logger.info(("init engine (profile, create kv cache, "
+                     "warmup model) took %.2f seconds"), elapsed)
         return num_gpu_blocks, num_cpu_blocks
 
     def add_request(self, request: EngineCoreRequest):
@@ -283,7 +277,7 @@ class EngineCoreProc(EngineCore):
         # model forward pass.
         # Threads handle Socket <-> Queues and core_busy_loop uses Queue.
         self.input_queue: queue.Queue[Tuple[EngineCoreRequestType,
-                                            Any]] = (queue.Queue())
+                                            Any]] = queue.Queue()
         self.output_queue: queue.Queue[EngineCoreOutputs] = queue.Queue()
         threading.Thread(target=self.process_input_socket,
                          args=(input_path, ),

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -169,8 +169,8 @@ class EngineCore:
         # where we can get the intersection of h2d destinations and d2h
         # sources and just do d2d copies.
         self.model_executor.swap_blocks(
-            scheduler_output.h2d_swap_map,
             scheduler_output.d2h_swap_map,
+            scheduler_output.h2d_swap_map,
         )
 
         output = self.model_executor.execute_model(scheduler_output)

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -88,8 +88,8 @@ class Executor(ExecutorBase):
     def profile(self, is_start: bool = True):
         self.collective_rpc("profile", args=(is_start, ))
 
-    def swap_blocks(self, h2d_map: Dict[int, int], d2h_map: Dict[int, int]):
-        self.collective_rpc("swap_blocks", args=(h2d_map, d2h_map))
+    def swap_blocks(self, d2h_map: Dict[int, int], h2d_map: Dict[int, int]):
+        self.collective_rpc("swap_blocks", args=(d2h_map, h2d_map))
 
 
 class UniProcExecutor(UniProcExecutorV0, Executor):

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from concurrent.futures import Future
-from typing import List, Type, Union
+from typing import Dict, List, Type, Union
 
 import torch
 import torch.distributed as dist
@@ -87,6 +87,9 @@ class Executor(ExecutorBase):
 
     def profile(self, is_start: bool = True):
         self.collective_rpc("profile", args=(is_start, ))
+
+    def swap_blocks(self, h2d_map: Dict[int, int], d2h_map: Dict[int, int]):
+        self.collective_rpc("swap_blocks", args=(h2d_map, d2h_map))
 
 
 class UniProcExecutor(UniProcExecutorV0, Executor):

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -94,6 +94,8 @@ class KVCacheConfig:
     """
     """The number of KV cache blocks"""
     num_blocks: int
+    """The number of CPU KV cache blocks"""
+    num_cpu_blocks: int
     """layer_name -> how to initialize KV cache for that layer"""
     tensors: Dict[str, KVCacheTensor]
     """

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -147,8 +147,10 @@ def shutdown(proc: multiprocessing.Process, input_path: str, output_path: str):
 
 def bind_kv_cache(
     kv_caches: Dict[str, torch.Tensor],
+    cpu_kv_caches: Optional[Dict[str, torch.Tensor]],
     forward_context: Dict[str, "Attention"],
     runner_kv_caches: List[torch.Tensor],
+    runner_cpu_kv_caches: Optional[List[torch.Tensor]],
 ) -> None:
     """
     Bind the allocated KV cache to both ModelRunner and forward context so
@@ -183,6 +185,8 @@ def bind_kv_cache(
             raise NotImplementedError
         layer_name = layer_names[0]
         runner_kv_caches.append(kv_caches[layer_name])
+        if cpu_kv_caches is not None and runner_cpu_kv_caches is not None:
+            runner_cpu_kv_caches.append(cpu_kv_caches[layer_name])
 
     # Bind kv_caches to forward context
     for layer_name, kv_cache in kv_caches.items():

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -147,10 +147,10 @@ def shutdown(proc: multiprocessing.Process, input_path: str, output_path: str):
 
 def bind_kv_cache(
     kv_caches: Dict[str, torch.Tensor],
-    cpu_kv_caches: Optional[Dict[str, torch.Tensor]],
-    forward_context: Dict[str, "Attention"],
     runner_kv_caches: List[torch.Tensor],
-    runner_cpu_kv_caches: Optional[List[torch.Tensor]],
+    forward_context: Dict[str, "Attention"],
+    cpu_kv_caches: Optional[Dict[str, torch.Tensor]] = None,
+    runner_cpu_kv_caches: Optional[List[torch.Tensor]] = None,
 ) -> None:
     """
     Bind the allocated KV cache to both ModelRunner and forward context so
@@ -164,9 +164,11 @@ def bind_kv_cache(
 
     Args:
         kv_caches: The allocated kv_caches with layer names as keys.
+        runner_kv_caches: The kv_cache declared by ModelRunner.
         forward_context: The global forward context containing all Attention 
         layers with layer names as keys.
-        runner_kv_caches: The kv_cache declared by ModelRunner.
+        cpu_kv_caches: The allocated cpu kv_caches with layer names as keys.
+        runner_cpu_kv_caches: The cpu kv_cache declared by ModelRunner.
     """
     # Bind kv_caches to ModelRunner
     assert len(runner_kv_caches) == 0

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1391,9 +1391,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         bind_kv_cache(
             kv_caches,
-            cpu_kv_caches,
-            self.vllm_config.compilation_config.static_forward_context,
             self.kv_caches,
+            self.vllm_config.compilation_config.static_forward_context,
+            cpu_kv_caches,
             self.cpu_kv_caches,
         )
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -253,8 +253,8 @@ class Worker(WorkerBase):
         # worker will always be healthy as long as it's running.
         return
 
-    def swap_blocks(self, h2d_map: Dict[int, int], d2h_map: Dict[int, int]):
-        self.model_runner.swap_blocks(h2d_map, d2h_map)
+    def swap_blocks(self, d2h_map: Dict[int, int], h2d_map: Dict[int, int]):
+        self.model_runner.swap_blocks(d2h_map, h2d_map)
 
 
 def init_worker_distributed_environment(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -2,7 +2,7 @@
 """A GPU worker class."""
 import gc
 import os
-from typing import TYPE_CHECKING, Optional, Set
+from typing import TYPE_CHECKING, Dict, Optional, Set
 
 import torch
 import torch.distributed

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -253,6 +253,9 @@ class Worker(WorkerBase):
         # worker will always be healthy as long as it's running.
         return
 
+    def swap_blocks(self, h2d_map: Dict[int, int], d2h_map: Dict[int, int]):
+        self.model_runner.swap_blocks(h2d_map, d2h_map)
+
 
 def init_worker_distributed_environment(
     parallel_config: ParallelConfig,

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -945,9 +945,10 @@ class TPUModelRunner:
                 raise NotImplementedError
 
         bind_kv_cache(
-            kv_caches, None,
+            kv_caches,
+            self.kv_caches,
             self.vllm_config.compilation_config.static_forward_context,
-            self.kv_caches, None)
+        )
 
 
 class ModelWrapperV1(nn.Module):

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -945,9 +945,9 @@ class TPUModelRunner:
                 raise NotImplementedError
 
         bind_kv_cache(
-            kv_caches,
+            kv_caches, None,
             self.vllm_config.compilation_config.static_forward_context,
-            self.kv_caches)
+            self.kv_caches, None)
 
 
 class ModelWrapperV1(nn.Module):

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -120,9 +120,9 @@ class TPUWorker:
 
         runner_kv_caches: List[torch.Tensor] = []
         bind_kv_cache(
-            kv_caches,
+            kv_caches, None,
             self.vllm_config.compilation_config.static_forward_context,
-            runner_kv_caches)
+            runner_kv_caches, None)
 
         self.model_runner.dummy_run(
             runner_kv_caches,

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -120,9 +120,10 @@ class TPUWorker:
 
         runner_kv_caches: List[torch.Tensor] = []
         bind_kv_cache(
-            kv_caches, None,
+            kv_caches,
+            runner_kv_caches,
             self.vllm_config.compilation_config.static_forward_context,
-            runner_kv_caches, None)
+        )
 
         self.model_runner.dummy_run(
             runner_kv_caches,


### PR DESCRIPTION
## TL;DR  
In V1, swap GPU KV cache blocks to CPU upon eviction and swap them back if there's a cache hit.  

## Swap Strategy  

CPU → GPU swap-in happens naturally when requests hit the cache (unless we do prefetching).  
GPU → CPU swap-out can be handled in two ways:  

1. **Eagerly**: Immediately after a request completes and its blocks are freed.  
2. **Lazily**: When evicting a GPU block while scheduling new requests.  

This PR adopts **(2)** to minimize unnecessary swaps. However, the downside is that the swap-out overhead might be exposed.  

Ideally, an optimal approach would asynchronously offload X cache blocks at a certain cadence (e.g., hidden behind the main CUDA graph) while maintaining free GPU block headroom. This would add complexity and is left for future work.  

## Implementation  

This PR builds on the excellent V1 KV cache manager, blend in with the existing interface.  
Newly introduced metadata states:  
- `cpu_block_pool` and `cached_block_hash_to_cpu_block` mirror their GPU counterparts.  

### High-Level Flow:  
- The KV cache manager accumulates swap-in/out decisions during each scheduling cycle.  
- These swap decisions are then "flushed" to the scheduler output, allowing model runners to issue aggregated swap calls before model execution, minimizing dispatch overhead.  

For simplicity, we avoid threading the scheduler output through multiple KV cache manager calls. Instead, swap-related data is accumulated in `step_*` fields (e.g., `step_h2d_swap_map`).  
A new `end_schedule_step` callback resets them at the end of each scheduling iteration. (Open to alternative designs.)

### CPU Cache Eviction Policy
We currently adopt a simple round-robin strategy to do CPU cache eviction. LRU will be added in a followup PR.

### User Configuration:  
We reuse the existing `--swap-space` flag (previously unused in V1) to control the number of CPU blocks.  
Whether to change the default (currently **4GB**) remains up for discussion.  

## Benchmark
TBA


## TODO
- [ ] write tests
- [ ] benchmarks and profiling
- [ ] docs