### PR TITLE
[Bugfix] Fix failing transformers dynamic module resolving with spawn multiproc method

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -50,9 +50,15 @@ def resolve_transformers_fallback(model_config: ModelConfig,
         custom_module = None
         auto_map = getattr(model_config.hf_config, "auto_map", None)
         if auto_map is not None and "AutoModel" in auto_map:
-            custom_module = get_class_from_dynamic_module(
-                model_config.hf_config.auto_map["AutoModel"],
-                model_config.model)
+            # NOTE(Isotr0py): we need to resolve all modules in auto_map across
+            # executor to avoid relative dynamic module imports error, otherwise
+            # some using related imported dynamic modules will be false-positive
+            # and failed to be imported in multiproc executor.
+            auto_modules = {
+                name: get_class_from_dynamic_module(module, model_config.model)
+                for name, module in auto_map.items()
+            }
+            custom_module = auto_modules["AutoModel"]
         # TODO(Isotr0py): Further clean up these raises.
         # perhaps handled them in _ModelRegistry._raise_for_unsupported?
         if model_config.model_impl == ModelImpl.TRANSFORMERS:

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -49,6 +49,10 @@ def resolve_transformers_fallback(model_config: ModelConfig,
             continue
         auto_map: dict[str, str] = getattr(model_config.hf_config, "auto_map",
                                            None) or dict()
+        # We need to get all dynamic modules from auto_map to make sure that
+        # they're all initialized properly. Otherwise, it will raise an error
+        # due to missing relative imported dynamic modules on spawn multiproc
+        # executor.
         auto_modules = {
             name: get_class_from_dynamic_module(module, model_config.model)
             for name, module in auto_map.items()


### PR DESCRIPTION

Issue discussion on Slack: https://vllm-dev.slack.com/archives/C07R5Q1Q2BB/p1739776343893149?thread_ts=1739553140.299949&cid=C07R5Q1Q2BB
- `transformers` backend failed to load custom module on multiproc executor with `VLLM_WORKER_MULTIPROC_METHOD=spawn` because false-positive loaded custom module.
- This PR optimize the automap resolving to make sure all custom modules initialized across processes

<!--- pyml disable-next-line no-emphasis-as-heading -->
