### PR TITLE
Bump xgrammar to 0.1.13

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -21,7 +21,7 @@ tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
 outlines == 0.1.11
 lark == 1.2.2
-xgrammar == 0.1.11; platform_machine == "x86_64"
+xgrammar == 0.1.13; platform_machine == "x86_64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
This is required for https://github.com/vllm-project/vllm/pull/13164 as this version has wheels for python 3.13

See also https://github.com/mlc-ai/xgrammar/issues/193