### PR TITLE
[V1][PP] Fix & Pin Ray version in requirements-cuda.txt

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray[default] >= 2.9
+ray[adag] == 2.41.0 # Required for pipeline parallelism in V1.
 torch == 2.5.1
 torchaudio==2.5.1
 # These must be updated alongside torch


### PR DESCRIPTION
Pipeline parallelism in V1 requires `ray[adag]` instead of `ray[default]`.
Also, because of the API changes in 2.42.0, we have to pin the version to `2.41.0` (or 2.40.0).

NOTE: Importantly, having `ray[adag]` will add CuPy (cu12) as a dependency. Since PP is not used for all models, we can consider keeping `ray[adag]` as an optional dependency if it's not acceptable.