### PR TITLE
[Misc] Define instance attr in init and change maybe_pull_model_tokenizer_for_s3() to internal

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -246,7 +246,7 @@ class ModelConfig:
         override_generation_config: Optional[Dict[str, Any]] = None,
         model_impl: Union[str, ModelImpl] = ModelImpl.AUTO,
     ) -> None:
-        self.model_weights = None
+        self.model_weights = ""
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -246,6 +246,7 @@ class ModelConfig:
         override_generation_config: Optional[Dict[str, Any]] = None,
         model_impl: Union[str, ModelImpl] = ModelImpl.AUTO,
     ) -> None:
+        self.model_weights = None
         self.model = model
         self.tokenizer = tokenizer
         self.tokenizer_mode = tokenizer_mode
@@ -281,7 +282,7 @@ class ModelConfig:
                    f"'Please instead use `--hf-overrides '{hf_override!r}'`")
             warnings.warn(DeprecationWarning(msg), stacklevel=2)
 
-        self.maybe_pull_model_tokenizer_for_s3(model, tokenizer)
+        self._maybe_pull_model_tokenizer_for_s3(model, tokenizer)
 
         # The tokenizer version is consistent with the model version by default.
         if tokenizer_revision is None:
@@ -395,8 +396,8 @@ class ModelConfig:
         self._verify_cuda_graph()
         self._verify_bnb_config()
 
-    def maybe_pull_model_tokenizer_for_s3(self, model: str,
-                                          tokenizer: str) -> None:
+    def _maybe_pull_model_tokenizer_for_s3(self, model: str,
+                                           tokenizer: str) -> None:
         """
         Pull the model config or tokenizer to a temporary
         directory in case of S3.

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -1382,7 +1382,7 @@ class RunaiModelStreamerLoader(BaseModelLoader):
                 model = _initialize_model(vllm_config=vllm_config)
 
             model_weights = model_config.model
-            if hasattr(model_config, "model_weights"):
+            if model_config.model_weights:
                 model_weights = model_config.model_weights
             model.load_weights(
                 self._get_weights_iterator(model_weights,


### PR DESCRIPTION
* `model_weights` is used in loader but not `maybe_pull_model_tokenizer_for_s3` so this PR moves the function to internal.
* `self.model_weights` should be defined in init method since it's an instance attribute that will be used externally.
