### PR TITLE
[Bugfix] Only print out chat template when supplied

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -797,7 +797,8 @@ async def init_app_state(
     state.log_stats = not args.disable_log_stats
 
     resolved_chat_template = load_chat_template(args.chat_template)
-    logger.info("Using supplied chat template:\n%s", resolved_chat_template)
+    if resolved_chat_template is not None:
+        logger.info("Using supplied chat template:\n%s", resolved_chat_template)
 
     state.openai_serving_models = OpenAIServingModels(
         engine_client=engine_client,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -798,7 +798,8 @@ async def init_app_state(
 
     resolved_chat_template = load_chat_template(args.chat_template)
     if resolved_chat_template is not None:
-        logger.info("Using supplied chat template:\n%s", resolved_chat_template)
+        logger.info("Using supplied chat template:\n%s",
+                    resolved_chat_template)
 
     state.openai_serving_models = OpenAIServingModels(
         engine_client=engine_client,


### PR DESCRIPTION
Currently `None` is printed out. We should only print it when the chat template is supplied.
```
INFO 02-18 01:35:41 executor_base.py:115] Maximum concurrency for 32768 tokens per request: 1.00x
INFO 02-18 01:35:43 llm_engine.py:431] init engine (profile, create kv cache, warmup model) took 1.15 seconds
INFO 02-18 01:35:43 api_server.py:756] Using supplied chat template:
INFO 02-18 01:35:43 api_server.py:756] None
```