### PR TITLE
[v1] fix parallel config rank

### DIFF
--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -41,6 +41,7 @@ class WorkerBase(WorkerBaseV0):
         # Configuration storage
         super().__init__(vllm_config=vllm_config)
 
+        self.parallel_config.rank = rank
         self.local_rank = local_rank
         self.rank = rank
         self.distributed_init_method = distributed_init_method


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/12816 forgot to copy this line of code, and workers cannot get their rank correctly. that information is used in https://github.com/vllm-project/vllm/blob/b3942e157ed540ca6cb82ef4a431233ffd9c03b2/vllm/compilation/backends.py#L400