### PR TITLE
[Bugfix] Ensure LoRA path from the request can be included in err msg

### DIFF
--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -133,7 +133,7 @@ class WorkerLoRAManager(AbstractWorkerManager):
             # For NotFoundError
             raise ValueError(
                 f"Loading lora {lora_request.lora_name} failed: No adapter "
-                f"found for {lora_path}") from e
+                f"found for {lora_request.lora_path}") from e
         except Exception as e:
             # For BadRequestError
             raise e


### PR DESCRIPTION
Currently, `lora_path` is used but it's defined in a try block, which means that if anything fails before this variable is defined, we would not get the error message that we want which includes lora path and name information. 

An illustration:

```
>>> try:
...     raise Exception("failed in try block")
...     lora_path = "succeeded"
... except Exception:
...     raise Exception(f"expected: succeeded, actual: {lora_path}")
... 
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
Exception: failed in try block

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 5, in <module>
NameError: name 'lora_path' is not defined

```