### PR TITLE
[Neuron][CI][WIP] Refactor Neuron kernel tests to improve coverage

### DIFF
--- a/tests/neuron/test_prefix_prefill.py
+++ b/tests/neuron/test_prefix_prefill.py
@@ -1,195 +1,244 @@
 # SPDX-License-Identifier: Apache-2.0
-
-from typing import Optional
+import os
 
 import pytest
 import torch
-import torch.nn.functional as F
+import torch_xla.core.xla_model as xm
+from utils import (convert_to_kernel_input_format, pad_to_multiple,
+                   pad_to_next_power_of_2, ref_context_attention,
+                   sample_input_sizes, sample_paged_attention_inputs)
+
+from vllm.attention.ops.nki_flash_attn import (context_mask_reorder_helper,
+                                               flash_attn_varlen_nkifunc)
 
 
-class BlockDiagonalCausalFromBottomRightMask:
+class FlashPagedAttentionTest:
 
-    @staticmethod
-    def _from_seqlens(query_lens, seq_lens, block_size=None):
-        from torch import logical_and, logical_or
+    def __init__(
+        self,
+        query_lens,
+        ctx_lens,
+        max_model_len,
+        num_heads,
+        num_queries_per_kv,
+        head_size,
+        block_size,
+        large_tile_size,
+        mixed_precision,
+        return_debug_tensors=False,
+    ):
+        self.query_lens = query_lens
+        self.ctx_lens = ctx_lens
+        self.seq_lens = self.query_lens + self.ctx_lens
+        self.max_model_len = max_model_len
+        self.num_heads = num_heads
+        self.num_queries_per_kv = num_queries_per_kv
+        self.head_size = head_size
+        self.block_size = block_size
+        self.large_tile_size = large_tile_size
+        self.mixed_precision = mixed_precision
+        self.return_debug_tensors = return_debug_tensors
+        self.dtype = torch.float32
 
-        contexted = block_size is None
-        context_lens = torch.tensor(seq_lens) - torch.tensor(query_lens)
-        n_queries = sum(query_lens)
-        num_seqs = len(query_lens)
-        if contexted:
-            key_lens_blockaligned = seq_lens
-        else:
-            n_blocks_per_seq = (context_lens + block_size - 1) // block_size
-            offset_per_seq = n_blocks_per_seq * block_size
-            key_lens_blockaligned = offset_per_seq[:num_seqs].tolist()
-        n_keys = sum(key_lens_blockaligned)
+    def run(self, **kwargs):
+        query, k_active, v_active, k_cache, v_cache, block_table, key, value = (
+            self.prepare_test_inputs())
 
-        a = (torch.arange(n_queries).reshape(n_queries,
-                                             1).expand(n_queries, n_keys))
-        b = torch.arange(n_keys).reshape(1, n_keys).expand(n_queries, n_keys)
-        q_cumsum = torch.tensor([0] + query_lens).cumsum(dim=0)
-        k_cumsum = torch.tensor([0] + key_lens_blockaligned).cumsum(dim=0)
+        output_ref, debug_tensors_ref = self.run_reference_version(
+            query, key, value, **kwargs)
 
-        prior_mask = torch.zeros(n_queries, n_keys)
-        new_masks: list[torch.Tensor] = []
-        for seq_id in range(num_seqs):
-            ri = q_cumsum[seq_id]
-            ci = k_cumsum[seq_id]
-            nr = query_lens[seq_id]
-
-            if contexted:
-                nc = seq_lens[seq_id]
-                a_offset = ci + nc - ri - nr
-                new_mask = (a + a_offset) >= b
-            else:
-                nc = context_lens[seq_id]
-                a_offset = ci + nc - 1
-                new_mask = a_offset >= b
-
-            left_mask = b >= ci
-            top_mask = a >= ri
-            bottom_mask = a < (ri + nr)
-
-            new_mask = logical_and(
-                logical_and(logical_and(new_mask, left_mask), top_mask),
-                bottom_mask,
-            )
-            prior_mask = logical_or(prior_mask, new_mask)
-            new_masks = new_masks + [new_mask]
-        return prior_mask
-
-    @staticmethod
-    def from_seqlens(query_lens, seq_lens, block_size=None):
-        contexted = block_size is None
-        if contexted:
-            prior_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
-                query_lens, seq_lens)
-            active_mask = None
-        else:
-            prior_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
-                query_lens, seq_lens, block_size)
-            active_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
-                query_lens, query_lens)
-        return prior_mask, active_mask
-
-
-def ref_softmax(x: torch.Tensor,
-                dim: int,
-                mixed_precision=False,
-                return_max_reduce=False):
-    max_value = torch.amax(x, dim=dim, keepdims=True)
-    exp = torch.exp(x - max_value)
-    if mixed_precision:
-        sum_value = torch.sum(exp.astype(torch.float32),
-                              dim=dim,
-                              keepdims=True).astype(x.dtype)
-    else:
-        sum_value = torch.sum(exp, dim=dim, keepdims=True)
-    if return_max_reduce:
-        return exp / sum_value, max_value, torch.reciprocal(sum_value)
-    return exp / sum_value
-
-
-def ref_masked_attention(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    scale: float,
-    attn_mask: Optional[torch.Tensor] = None,
-    return_max_reduce: Optional[bool] = False,
-) -> torch.Tensor:
-    scaled_qk = scale * torch.einsum("qhd,khd->hqk", query, key).float()
-    if attn_mask is not None:
-        masked_score = scaled_qk + attn_mask.float()
-    if return_max_reduce:
-        norm_score, cached_max, cached_sum_reciprocal = ref_softmax(
-            masked_score, dim=-1, return_max_reduce=True)
-    else:
-        norm_score = ref_softmax(masked_score, dim=-1)
-    out = torch.einsum("hqk,khd->qhd", norm_score, value)
-    if return_max_reduce:
-        return (
-            out,
-            cached_max,
-            cached_sum_reciprocal,
-            norm_score,
-            masked_score,
-            scaled_qk,
+        compiler_flags = [
+            "--model-type=transformer -O1",
+            "--internal-hlo2tensorizer-options='--verify-hlo'",
+            "--retry_failed_compilation",
+        ]
+        compiler_flags_str = " ".join(compiler_flags)
+        os.environ["NEURON_CC_FLAGS"] = compiler_flags_str
+        output_nki, debug_tensors_nki = self.run_neuron_version(
+            query,
+            k_active,
+            v_active,
+            k_cache,
+            v_cache,
+            block_table,
+            **kwargs,
         )
-    else:
-        return out
+        self.compare_outputs(output_nki, output_ref, debug_tensors_nki,
+                             debug_tensors_ref)
 
+    def prepare_test_inputs(self):
+        max_block_per_request = (self.max_model_len + self.block_size -
+                                 1) // self.block_size
+        batch_size = len(self.query_lens)
+        num_blocks_in_cache = (batch_size * max_block_per_request) * 2
+        num_kv_heads = self.num_heads // self.num_queries_per_kv
 
-def ref_context_attention(
-    query,
-    key,
-    value,
-    query_lens,
-    seq_lens,
-    head_size,
-    num_kv_heads,
-    num_heads,
-    num_queries_per_kv,
-    return_max_reduce=False,
-):
-    scale = float(1.0 / (head_size**0.5))
-    if num_queries_per_kv > 1:
-        # Handle MQA and GQA
-        key = torch.repeat_interleave(key, num_queries_per_kv, dim=1)
-        value = torch.repeat_interleave(value, num_queries_per_kv, dim=1)
+        return sample_paged_attention_inputs(
+            query_lens=self.query_lens,
+            ctx_lens=self.ctx_lens,
+            max_block_per_request=max_block_per_request,
+            num_blocks_in_cache=num_blocks_in_cache,
+            block_size=self.block_size,
+            num_heads=self.num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=self.head_size,
+            dtype=self.dtype,
+        )
 
-    attn_mask, _ = BlockDiagonalCausalFromBottomRightMask.from_seqlens(
-        query_lens, seq_lens)
-
-    # convert binary mask to -inf values
-    attn_mask = torch.logical_not(attn_mask)
-    attn_mask = attn_mask.float() * -30000
-
-    output, cached_max, cached_sum_reciprocal, lse, masked_score, scaled_qk = (
-        ref_masked_attention(
+    def run_reference_version(self, query, key, value, **kwargs):
+        output_ref, *debug_tensors = ref_context_attention(
             query,
             key,
             value,
-            scale,
-            attn_mask,
-            return_max_reduce=return_max_reduce,
-        ))
-
-    output = output.unsqueeze(1)
-    if return_max_reduce:
-        return (
-            output,
-            cached_max,
-            cached_sum_reciprocal,
-            lse,
-            masked_score,
-            scaled_qk,
+            self.query_lens,
+            self.seq_lens,
+            self.head_size,
+            self.num_queries_per_kv,
+            return_max_reduce=self.return_debug_tensors,
         )
-    else:
-        return output
+        return output_ref, debug_tensors
+
+    def convert_to_neuron_inputs(self, query, k_active, v_active, k_cache,
+                                 v_cache, block_table):
+        # build neuron program
+        B_P_SIZE = 128
+        B_F_SIZE = 512
+        LARGE_TILE_SZ = self.large_tile_size
+        assert LARGE_TILE_SZ >= B_P_SIZE
+
+        max_num_queries = sum(self.query_lens)
+        if max_num_queries > B_F_SIZE:
+            # Due to underlying PE tiling
+            max_num_queries = pad_to_multiple(max_num_queries, B_F_SIZE)
+        else:
+            max_num_queries = pad_to_next_power_of_2(max_num_queries)
+        # kernel defines REDUCTION_TILE = min(2048, LARGE_TILE_SZ // 2)
+        MAX_REDUCTION_TILE = 2048
+        if max_num_queries // 2 > MAX_REDUCTION_TILE:
+            max_num_queries = pad_to_multiple(max_num_queries,
+                                              MAX_REDUCTION_TILE)
+
+        return convert_to_kernel_input_format(
+            query_lens=self.query_lens,
+            context_lens=self.ctx_lens,
+            block_table=block_table,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            query=query,
+            k_active=k_active,
+            v_active=v_active,
+            block_size=self.block_size,
+            LARGE_TILE_SZ=LARGE_TILE_SZ,
+            max_num_queries=max_num_queries,
+        )
+
+    def run_neuron_version(
+        self,
+        query,
+        k_active,
+        v_active,
+        k_cache,
+        v_cache,
+        block_table,
+        **kwargs,
+    ):
+        (
+            query,
+            k_active,
+            v_active,
+            k_cache,
+            v_cache,
+            active_block_table,
+            attn_mask,
+        ) = self.convert_to_neuron_inputs(
+            query,
+            k_active,
+            v_active,
+            k_cache,
+            v_cache,
+            block_table,
+        )
+        reorder_mask_outside_kernel = kwargs.get("reorder_mask_outside_kernel",
+                                                 False)
+        attn_mask = context_mask_reorder_helper(
+            attn_mask,
+            self.large_tile_size,
+            self.block_size,
+        )
+
+        device = xm.xla_device()
+        input_args = (
+            query.to(device=device),
+            k_active.to(device=device),
+            v_active.to(device=device),
+            k_cache.to(device=device),
+            v_cache.to(device=device),
+            active_block_table.to(device=device),
+            attn_mask.to(device=device),
+        )
+        LARGE_TILE_SZ = self.large_tile_size
+        num_kv_heads = self.num_heads // self.num_queries_per_kv
+        input_kwargs = dict(
+            n_kv_head=num_kv_heads,
+            head_size=self.head_size,
+            mixed_precision=self.mixed_precision,
+            LARGE_TILE_SZ=LARGE_TILE_SZ,
+            mask_reordered=reorder_mask_outside_kernel,
+            return_debug_tensors=self.return_debug_tensors,
+        )
+
+        if self.return_debug_tensors:
+            output_nki, *debug_tensors = flash_attn_varlen_nkifunc(
+                *input_args, **input_kwargs)
+            debug_tensors = [torch.tensor(dt).cpu() for dt in debug_tensors]
+        else:
+            output_nki = flash_attn_varlen_nkifunc(*input_args, **input_kwargs)
+            debug_tensors = []
+
+        num_actual_tokens = sum(self.query_lens)
+        # - o: shape (bs, n_heads, seq_q, d) -> (bs, seq_q, n_heads, d)
+        output_nki = output_nki.cpu().permute(0, 2, 1, 3)
+        output_nki = output_nki[0, :num_actual_tokens, :, :]
+        return output_nki, debug_tensors
+
+    def compare_outputs(self, out_nki, out_ref, debug_nki, debug_ref):
+        torch.testing.assert_close(out_nki, out_ref, atol=1e-2, rtol=0)
 
 
 @pytest.mark.parametrize(
-    "block_size, large_tile_size",
+    "block_size,large_tile_size",
     [
+        (256, 2048),  # 8 blocks
         (32, 2048),  # 64 blocks
+        (16, 2048),  # 128 blocks
         (32, 4096),  # 128 blocks
-        (32, 8192),  # 256 blocks
         (64, 8192),  # 128 blocks
+        (32, 8192),  # 256 blocks
+        (4, 1024),  # 256 blocks
+        (1, 512),  # 512 blocks
     ],
 )
 @pytest.mark.parametrize(
-    "num_heads,num_queries_per_kv,head_size,mixed_precision",
+    "num_heads,num_queries_per_kv,head_size",
     [
-        (4, 2, 8, False),
-        (4, 2, 8, True),
-        (32, 8, 64, True),
-        (16, 2, 128, True),
+        (4, 2, 8),
+        (32, 8, 64),
+        (4, 4, 128),
+        (8, 1, 32),
     ],
 )
+@pytest.mark.parametrize(
+    "prefill_batch_size,decode_batch_size",
+    [
+        (4, 12),
+        (1, 199),
+    ],
+)
+@pytest.mark.parametrize("mixed_precision", [True, False])
 @torch.inference_mode()
-def test_contexted_kv_attention(
+def test_flash_paged_attention_numerical(
+    prefill_batch_size: int,
+    decode_batch_size: int,
     num_heads: int,
     num_queries_per_kv: int,
     head_size: int,
@@ -197,278 +246,37 @@ def test_contexted_kv_attention(
     large_tile_size,
     mixed_precision: bool,
 ) -> None:
-    import os
 
-    import torch_xla.core.xla_model as xm
-
-    from vllm.attention.ops.nki_flash_attn import flash_attn_varlen_nkifunc
+    torch.manual_seed(1000)
+    torch.set_printoptions(sci_mode=False)
 
     assert large_tile_size % block_size == 0
 
-    device = xm.xla_device()
-
-    compiler_flags = [
-        "--model-type=transformer -O1",
-        "--internal-hlo2tensorizer-options='--verify-hlo'",
-        "--retry_failed_compilation",
-    ]
-    compiler_flags_str = " ".join(compiler_flags)
-    os.environ["NEURON_CC_FLAGS"] = compiler_flags_str
-
-    torch.manual_seed(0)
-    torch.set_printoptions(sci_mode=False)
+    reorder_mask_outside_kernel = True
 
     min_ctx_len = 32
     max_ctx_len = 1024
     min_query_len = 16
     max_query_len = 512
-    prefill_batch_size = 4
-    decode_batch_size = 12
-    batch_size = prefill_batch_size + decode_batch_size
-    max_model_len = (max_query_len + max_ctx_len) * 4
+    query_lens, ctx_lens = sample_input_sizes(
+        prefill_batch_size=prefill_batch_size,
+        decode_batch_size=decode_batch_size,
+        min_query_len=min_query_len,
+        max_query_len=max_query_len,
+        min_ctx_len=min_ctx_len,
+        max_ctx_len=max_ctx_len,
+    )
 
-    max_block_per_request = max_model_len // block_size
-    dtype = torch.float32
-    cache_size = (batch_size * max_block_per_request) + 2
-    prefill_ctx_lens = torch.randint(min_ctx_len,
-                                     max_ctx_len + 1, (prefill_batch_size, ),
-                                     dtype=torch.long).tolist()
-    decode_ctx_lens = torch.randint(min_ctx_len,
-                                    max_ctx_len + 1, (decode_batch_size, ),
-                                    dtype=torch.long).tolist()
-    ctx_lens = prefill_ctx_lens + decode_ctx_lens
-    query_lens = torch.randint(
-        min_query_len,
-        max_query_len + 1,
-        (prefill_batch_size, ),
-        dtype=torch.long,
-    ).tolist() + [1 for _ in range(decode_batch_size)]
-    seq_lens = [a + b for a, b in zip(query_lens, ctx_lens)]
-    num_kv_heads = num_heads // num_queries_per_kv
-
-    num_tokens = sum(query_lens)
-    query = torch.empty(num_tokens, num_heads, head_size, dtype=dtype)
-    query.uniform_(-1, 1)
-    torch.empty(num_tokens, num_heads, head_size, dtype=dtype)
-
-    kv = torch.empty(sum(seq_lens), 2, num_kv_heads, head_size, dtype=dtype)
-    kv.uniform_(-1, 1)
-    key, value = kv.unbind(dim=1)
-
-    k_cache = torch.zeros(cache_size,
-                          block_size,
-                          num_kv_heads,
-                          head_size,
-                          dtype=dtype)
-    v_cache = torch.zeros(cache_size,
-                          block_size,
-                          num_kv_heads,
-                          head_size,
-                          dtype=dtype)
-    k = torch.zeros(sum(query_lens), num_kv_heads, head_size, dtype=dtype)
-    v = torch.zeros(sum(query_lens), num_kv_heads, head_size, dtype=dtype)
-    values = torch.arange(0, cache_size, dtype=torch.long)
-    values = values[torch.randperm(cache_size)]
-    block_table = values[:batch_size * max_block_per_request].view(
-        batch_size, max_block_per_request)
-    b_ctx_len = torch.tensor(ctx_lens, dtype=torch.long)
-    b_start_loc = torch.cumsum(torch.tensor([0] + query_lens[:-1],
-                                            dtype=torch.long),
-                               dim=0)
-    # copy kv to cache
-    b_seq_start_loc = torch.cumsum(torch.tensor([0] + seq_lens[:-1],
-                                                dtype=torch.long),
-                                   dim=0)
-    for i in range(batch_size):
-        for j in range(query_lens[i]):
-            k[b_start_loc[i] + j].copy_(key[b_seq_start_loc[i] + b_ctx_len[i] +
-                                            j])
-            v[b_start_loc[i] + j].copy_(value[b_seq_start_loc[i] +
-                                              b_ctx_len[i] + j])
-        cur_ctx = 0
-        block_id = 0
-        while cur_ctx < b_ctx_len[i]:
-            start_loc = b_seq_start_loc[i] + cur_ctx
-            if cur_ctx + block_size > b_ctx_len[i]:
-                end_loc = b_seq_start_loc[i] + b_ctx_len[i]
-            else:
-                end_loc = start_loc + block_size
-            start_slot = block_table[i, block_id] * block_size
-            end_slot = start_slot + end_loc - start_loc
-            k_cache.view(-1, num_kv_heads,
-                         head_size)[start_slot:end_slot].copy_(
-                             key[start_loc:end_loc])
-            v_cache.view(-1, num_kv_heads,
-                         head_size)[start_slot:end_slot].copy_(
-                             value[start_loc:end_loc])
-            cur_ctx += block_size
-            block_id += 1
-
-    (
-        output_ref,
-        cached_max,
-        cached_sum_reciprocal,
-        lse,
-        masked_score,
-        scaled_qk,
-    ) = ref_context_attention(
-        query,
-        key,
-        value,
+    max_model_len = max(max_query_len, max_ctx_len) * 4
+    test = FlashPagedAttentionTest(
         query_lens,
-        seq_lens,
-        head_size,
-        num_kv_heads,
+        ctx_lens,
+        max_model_len,
         num_heads,
         num_queries_per_kv,
-        return_max_reduce=True,
-    )
-
-    # build neuron program
-    return_debug_tensors = False
-    B_P_SIZE = 128
-    LARGE_TILE_SZ = large_tile_size
-
-    def get_active_block_tables(block_tables, query_lens, seq_lens, block_size,
-                                num_blocks):
-        context_lens = seq_lens - query_lens
-        blocks_per_seq = (context_lens + block_size - 1) // block_size
-        num_seqs = len(seq_lens)
-        active_blocks: list[int] = []
-        for seq_id in range(num_seqs):
-            active_blocks = (
-                active_blocks +
-                block_tables[seq_id, :blocks_per_seq[seq_id]].tolist())
-        return F.pad(
-            torch.tensor(active_blocks),
-            (0, num_blocks - len(active_blocks)),
-            "constant",
-            0,
-        )
-
-    def ceil_div(a, b):
-        return (a + b - 1) // b
-
-    def pad_to_multiple(a, b):
-        return ceil_div(a, b) * b
-
-    def pad_to_next_power_of_2(a):
-        assert a > 0
-        return 2**int(a - 1).bit_length()
-
-    # calculate input shapes
-    max_num_queries = pad_to_multiple(sum(query_lens), block_size)
-    max_num_queries = pad_to_next_power_of_2(max_num_queries)
-    head_size_padded = B_P_SIZE
-    assert head_size_padded >= head_size
-    context_lens = torch.tensor(seq_lens) - torch.tensor(query_lens)
-    num_active_blocks = ceil_div(context_lens, block_size).sum().item()
-    num_active_blocks = pad_to_multiple(num_active_blocks,
-                                        LARGE_TILE_SZ // block_size)
-    context_kv_len = num_active_blocks * block_size
-    assert (context_kv_len %
-            LARGE_TILE_SZ == 0), f"invalid context_kv_len={context_kv_len}"
-
-    # pad QKV tensors
-    pad_dims = (
-        0,
-        head_size_padded - query.shape[2],
-        0,
-        0,
-        0,
-        max_num_queries - query.shape[0],
-    )
-    query = F.pad(query, pad_dims, "constant", 0)
-    k = F.pad(k, pad_dims, "constant", 0)
-    v = F.pad(v, pad_dims, "constant", 0)
-    k_cache = F.pad(k_cache, (0, head_size_padded - head_size), "constant", 0)
-    v_cache = F.pad(v_cache, (0, head_size_padded - head_size), "constant", 0)
-
-    # permute QKV tensors
-    # query: (1, n_heads, d, seq_q)
-    # key:   (1, n_kv_heads, d, seq_k)
-    # value: (1, n_kv_heads, seq_v, d)
-    query = query.unsqueeze(0).permute(0, 2, 3, 1).contiguous()
-    k = k.unsqueeze(0).permute(0, 2, 3, 1).contiguous()
-    v = v.unsqueeze(0).permute(0, 2, 1, 3).contiguous()
-
-    # transform block table
-    active_block_table = get_active_block_tables(
-        block_table,
-        torch.tensor(query_lens),
-        torch.tensor(seq_lens),
+        head_size,
         block_size,
-        num_active_blocks,
+        large_tile_size,
+        mixed_precision,
     )
-
-    # Build attention masks
-    prior_mask, active_mask = (
-        BlockDiagonalCausalFromBottomRightMask.from_seqlens(
-            query_lens, seq_lens, block_size=block_size))
-    attn_mask = torch.concat(
-        [
-            F.pad(
-                prior_mask,
-                (
-                    0,
-                    context_kv_len - prior_mask.shape[1],
-                    0,
-                    max_num_queries - prior_mask.shape[0],
-                ),
-                "constant",
-                0,
-            ).bool(),
-            F.pad(
-                active_mask,
-                (
-                    0,
-                    max_num_queries - active_mask.shape[1],
-                    0,
-                    max_num_queries - active_mask.shape[0],
-                ),
-                "constant",
-                0,
-            ).bool(),
-        ],
-        dim=1,
-    )
-
-    input_args = (
-        query.to(device=device),
-        k.to(device=device),
-        v.to(device=device),
-        k_cache.to(device=device),
-        v_cache.to(device=device),
-        active_block_table.to(torch.int32).to(device=device),
-        attn_mask.to(device=device),
-    )
-    input_kwargs = dict(
-        n_kv_head=num_kv_heads,
-        head_size=head_size,
-        mixed_precision=mixed_precision,
-        LARGE_TILE_SZ=LARGE_TILE_SZ,
-        return_debug_tensors=return_debug_tensors,
-    )
-
-    if return_debug_tensors:
-        output_nki, *debug_tensors = flash_attn_varlen_nkifunc(
-            *input_args, **input_kwargs)
-    else:
-        output_nki = flash_attn_varlen_nkifunc(*input_args, **input_kwargs)
-        debug_tensors = []
-
-    debug_tensors = [torch.tensor(dt).cpu() for dt in debug_tensors]
-
-    num_actual_tokens = sum(query_lens)
-    # - o: shape (bs, n_heads, seq_q, d) -> (bs, seq_q, n_heads, d)
-    output_nki = output_nki.cpu().permute(0, 2, 1, 3)[:, :, :, :head_size]
-    output_nki = output_nki[0, :num_actual_tokens, :, :]
-    output_ref_padded = F.pad(
-        output_ref,
-        (0, 0, 0, 0, 0, 0, 0, max_num_queries - output_ref.shape[0]),
-        "constant",
-        0,
-    )
-    output_ref = output_ref_padded.transpose(0, 1)[0, :num_actual_tokens, :, :]
-
-    torch.testing.assert_close(output_nki, output_ref, atol=1e-2, rtol=0)
+    test.run(reorder_mask_outside_kernel=reorder_mask_outside_kernel)

--- a/tests/neuron/utils.py
+++ b/tests/neuron/utils.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+
+def pad_to_multiple(a, b):
+    return ceil_div(a, b) * b
+
+
+def pad_to_next_power_of_2(a):
+    return 2**int(a - 1).bit_length() if a > 0 else 0
+
+
+def is_power_of_2(x):
+    return x > 0 and (x & (x - 1)) == 0
+
+
+class BlockDiagonalCausalFromBottomRightMask:
+
+    @staticmethod
+    def _from_seqlens(query_lens, seq_lens, block_size=None):
+        from torch import logical_and, logical_or
+
+        contexted = block_size is None
+        context_lens = seq_lens - query_lens
+        n_queries = query_lens.sum().item()
+        num_seqs = len(query_lens)
+        if contexted:
+            key_lens_blockaligned = seq_lens
+        else:
+            n_blocks_per_seq = (context_lens + block_size - 1) // block_size
+            offset_per_seq = n_blocks_per_seq * block_size
+            key_lens_blockaligned = offset_per_seq[:num_seqs]
+        n_keys = key_lens_blockaligned.sum().item()
+
+        a = (torch.arange(n_queries).reshape(n_queries,
+                                             1).expand(n_queries, n_keys))
+        b = torch.arange(n_keys).reshape(1, n_keys).expand(n_queries, n_keys)
+        q_cumsum = F.pad(query_lens, (1, 0)).cumsum(dim=0)
+        k_cumsum = F.pad(key_lens_blockaligned, (1, 0)).cumsum(dim=0)
+
+        prior_mask = torch.zeros(n_queries, n_keys)
+        new_masks: list[torch.Tensor] = []
+        for seq_id in range(num_seqs):
+            ri = q_cumsum[seq_id]
+            ci = k_cumsum[seq_id]
+            nr = query_lens[seq_id]
+
+            if contexted:
+                nc = seq_lens[seq_id]
+                a_offset = ci + nc - ri - nr
+                new_mask = (a + a_offset) >= b
+            else:
+                nc = context_lens[seq_id]
+                a_offset = ci + nc - 1
+                new_mask = a_offset >= b
+
+            left_mask = b >= ci
+            top_mask = a >= ri
+            bottom_mask = a < (ri + nr)
+
+            new_mask = logical_and(
+                logical_and(logical_and(new_mask, left_mask), top_mask),
+                bottom_mask,
+            )
+            prior_mask = logical_or(prior_mask, new_mask)
+            new_masks = new_masks + [new_mask]
+        return prior_mask
+
+    @staticmethod
+    def from_seqlens(query_lens, seq_lens, block_size=None):
+        contexted = block_size is None
+        if contexted:
+            prior_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
+                query_lens, seq_lens)
+            active_mask = None
+        else:
+            prior_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
+                query_lens, seq_lens, block_size)
+            active_mask = BlockDiagonalCausalFromBottomRightMask._from_seqlens(
+                query_lens, query_lens)
+        return prior_mask, active_mask
+
+
+def ref_softmax(x: torch.Tensor,
+                dim: int,
+                mixed_precision=False,
+                return_max_reduce=False):
+    max_value = torch.amax(x, dim=dim, keepdims=True)
+    exp = torch.exp(x - max_value)
+    if mixed_precision:
+        sum_value = torch.sum(exp.astype(torch.float32),
+                              dim=dim,
+                              keepdims=True).astype(x.dtype)
+    else:
+        sum_value = torch.sum(exp, dim=dim, keepdims=True)
+    if return_max_reduce:
+        return exp / sum_value, max_value, torch.reciprocal(sum_value)
+    return exp / sum_value
+
+
+def ref_masked_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+    attn_mask: Optional[torch.Tensor] = None,
+    return_max_reduce: Optional[bool] = False,
+) -> torch.Tensor:
+    scaled_qk = scale * torch.einsum("qhd,khd->hqk", query, key).float()
+    if attn_mask is not None:
+        masked_score = scaled_qk + attn_mask.float()
+    if return_max_reduce:
+        norm_score, cached_max, cached_sum_reciprocal = ref_softmax(
+            masked_score, dim=-1, return_max_reduce=True)
+    else:
+        norm_score = ref_softmax(masked_score, dim=-1)
+    out = torch.einsum("hqk,khd->qhd", norm_score.to(value.dtype), value)
+    if return_max_reduce:
+        return (
+            out,
+            cached_max,
+            cached_sum_reciprocal,
+            norm_score,
+            masked_score,
+            scaled_qk,
+        )
+    else:
+        return (out, )
+
+
+def is_int_tensor(x):
+    return isinstance(x, torch.Tensor) and (x.dtype == torch.int32
+                                            or x.dtype == torch.int64)
+
+
+def ref_context_attention(
+    query,
+    key,
+    value,
+    query_lens,
+    seq_lens,
+    head_size,
+    num_queries_per_kv,
+    return_max_reduce=False,
+):
+    assert is_int_tensor(query_lens) and is_int_tensor(seq_lens)
+    scale = float(1.0 / (head_size**0.5))
+    if num_queries_per_kv > 1:
+        # Handle MQA and GQA
+        key = torch.repeat_interleave(key, num_queries_per_kv, dim=1)
+        value = torch.repeat_interleave(value, num_queries_per_kv, dim=1)
+
+    attn_mask, _ = BlockDiagonalCausalFromBottomRightMask.from_seqlens(
+        query_lens, seq_lens)
+
+    # convert binary mask to -inf values
+    attn_mask = torch.logical_not(attn_mask)
+    attn_mask = attn_mask.float() * -30000
+
+    output, *debug_tensors = ref_masked_attention(
+        query,
+        key,
+        value,
+        scale,
+        attn_mask,
+        return_max_reduce=return_max_reduce,
+    )
+
+    return output, debug_tensors
+
+
+def _sample_lengths(num, min_len, max_len):
+    return torch.randint(min_len, max_len + 1, size=(num, ))
+
+
+def sample_input_sizes(
+    prefill_batch_size,
+    decode_batch_size,
+    min_query_len,
+    max_query_len,
+    min_ctx_len,
+    max_ctx_len,
+):
+    batch_size = prefill_batch_size + decode_batch_size
+    prefill_query_lens = _sample_lengths(prefill_batch_size, min_query_len,
+                                         max_query_len)
+    decode_query_lens = torch.ones(decode_batch_size, dtype=torch.long)
+    query_lens = torch.cat([prefill_query_lens, decode_query_lens])
+    if max_ctx_len == 0:
+        ctx_lens = torch.zeros(batch_size, dtype=torch.long)
+    else:
+        ctx_lens = _sample_lengths(batch_size, min_ctx_len, max_ctx_len)
+    return query_lens, ctx_lens
+
+
+def sample_paged_attention_inputs(
+    query_lens,
+    ctx_lens,
+    max_block_per_request,
+    num_blocks_in_cache,
+    block_size,
+    num_heads,
+    num_kv_heads,
+    head_size,
+    dtype,
+    init_tensor=True,
+):
+    # max_model_len = (max_query_len + max_ctx_len) * 4
+    query_lens = torch.tensor(query_lens, dtype=torch.long)
+    ctx_lens = torch.tensor(ctx_lens, dtype=torch.long)
+    seq_lens = query_lens + ctx_lens
+    num_query_tokens = query_lens.sum()
+    num_seq_tokens = seq_lens.sum()
+
+    def _sample_tensor(shape, dtype):
+        tensor = torch.empty(shape, dtype=dtype)
+        if init_tensor:
+            tensor.uniform_(-1, 1)
+        return tensor
+
+    # prepare query key value for vanilla (dense and contiguous) attention
+    query = _sample_tensor(shape=(num_query_tokens, num_heads, head_size),
+                           dtype=dtype)
+    all_keys = _sample_tensor(shape=(num_seq_tokens, num_kv_heads, head_size),
+                              dtype=dtype)
+    all_values = _sample_tensor(shape=(num_seq_tokens, num_kv_heads,
+                                       head_size),
+                                dtype=dtype)
+
+    # prepare for paged attention
+
+    # sample block table
+    batch_size = query_lens.shape[0]
+    block_table = torch.randperm(num_blocks_in_cache)[:batch_size *
+                                                      max_block_per_request]
+    block_table = block_table.view(batch_size, max_block_per_request)
+
+    k_cache = _sample_tensor(
+        shape=(num_blocks_in_cache, block_size, num_kv_heads, head_size),
+        dtype=dtype,
+    )
+    v_cache = _sample_tensor(
+        shape=(num_blocks_in_cache, block_size, num_kv_heads, head_size),
+        dtype=dtype,
+    )
+
+    if not init_tensor:
+        # does not need to initialize
+        k_new = torch.empty_like(query)
+        v_new = torch.empty_like(query)
+        return (
+            query,
+            k_new,
+            v_new,
+            k_cache,
+            v_cache,
+            block_table,
+            all_keys,
+            all_values,
+        )
+
+    # use broadcast add to convert block indices to token indices
+    token_indices = (block_table * block_size).reshape(
+        (batch_size, max_block_per_request,
+         1)) + torch.arange(block_size).reshape((1, 1, -1))
+    token_indices = token_indices.reshape((batch_size, -1))
+
+    # prepare gather/scatter indices to set key/value into kv cache
+    seq_starts = F.pad(torch.cumsum(seq_lens, dim=0), (1, 0))
+    ctx_token_indices = []
+    new_token_indices = []
+    ctx_to_cache_indices = []
+    for seq_id, (offset, q_len,
+                 c_len) in enumerate(zip(seq_starts, query_lens, ctx_lens)):
+        ctx_token_indices.append(torch.arange(c_len) + offset)
+        new_token_indices.append(torch.arange(q_len) + (offset + c_len))
+        ctx_to_cache_indices.append(token_indices[seq_id, :c_len])
+    ctx_token_indices = torch.cat(ctx_token_indices)
+    new_token_indices = torch.cat(new_token_indices)
+    ctx_to_cache_indices = torch.cat(ctx_to_cache_indices)
+
+    k_new = all_keys[new_token_indices]
+    v_new = all_values[new_token_indices]
+    if len(ctx_to_cache_indices) > 0:
+        k_ctx = all_keys[ctx_token_indices].view(ctx_lens.sum(), -1)
+        v_ctx = all_values[ctx_token_indices].view(ctx_lens.sum(), -1)
+        k_cache.view(num_blocks_in_cache * block_size,
+                     -1)[ctx_to_cache_indices] = k_ctx
+        v_cache.view(num_blocks_in_cache * block_size,
+                     -1)[ctx_to_cache_indices] = v_ctx
+
+    return (
+        query,
+        k_new,
+        v_new,
+        k_cache,
+        v_cache,
+        block_table,
+        all_keys,
+        all_values,
+    )
+
+
+def get_active_block_tables(block_tables, context_lens, block_size,
+                            num_blocks):
+    blocks_per_seq = ceil_div(context_lens, block_size)
+    num_seqs = len(context_lens)
+    active_blocks: list[int] = []
+    for seq_id in range(num_seqs):
+        active_blocks.append(block_tables[seq_id, :blocks_per_seq[seq_id]])
+    active_blocks = torch.cat(active_blocks)
+    return F.pad(
+        active_blocks,
+        (0, num_blocks - len(active_blocks)),
+        "constant",
+        0,
+    )
+
+
+def convert_to_kernel_input_format(
+    query_lens,
+    context_lens,
+    block_table,
+    k_cache,
+    v_cache,
+    query,
+    k_active,
+    v_active,
+    block_size,
+    LARGE_TILE_SZ,
+    max_num_queries,
+):
+    # calculate input shapes
+    num_active_blocks = ceil_div(context_lens, block_size).sum().item()
+    num_active_blocks = pad_to_multiple(num_active_blocks,
+                                        LARGE_TILE_SZ // block_size)
+    context_kv_len = num_active_blocks * block_size
+    assert (context_kv_len %
+            LARGE_TILE_SZ == 0), f"invalid context_kv_len={context_kv_len}"
+    assert (max_num_queries
+            >= query.shape[0]), f"invalid max_num_queries={max_num_queries}"
+
+    # pad QKV tensors
+    pad_dims = (
+        0,
+        0,
+        0,
+        0,
+        0,
+        max_num_queries - query.shape[0],
+    )
+    query = F.pad(query, pad_dims, "constant", 0)
+    k = F.pad(k_active, pad_dims, "constant", 0)
+    v = F.pad(v_active, pad_dims, "constant", 0)
+
+    # permute QKV tensors
+    # query: (1, n_heads, d, seq_q)
+    # key:   (1, n_kv_heads, d, seq_k)
+    # value: (1, n_kv_heads, seq_v, d)
+    query = query.unsqueeze(0).permute(0, 2, 3, 1).contiguous()
+    k = k.unsqueeze(0).permute(0, 2, 3, 1).contiguous()
+    v = v.unsqueeze(0).permute(0, 2, 1, 3).contiguous()
+    # permute KV cache tensors
+    # cache layout: (n_blocks, n_kv_heads, block_size, d)
+    k_cache = k_cache.permute(0, 2, 1, 3).contiguous()
+    v_cache = v_cache.permute(0, 2, 1, 3).contiguous()
+
+    # transform block table to active block tables
+    active_block_table = get_active_block_tables(
+        block_table,
+        context_lens,
+        block_size,
+        num_active_blocks,
+    ).to(torch.int32)  # kernel require int32
+
+    # Build attention masks
+    seq_lens = query_lens + context_lens
+    prior_mask, active_mask = (
+        BlockDiagonalCausalFromBottomRightMask.from_seqlens(
+            query_lens, seq_lens, block_size=block_size))
+    active_mask_padded = F.pad(
+        active_mask,
+        (
+            0,
+            max_num_queries - active_mask.shape[1],
+            0,
+            max_num_queries - active_mask.shape[0],
+        ),
+        "constant",
+        0,
+    ).bool()
+    if prior_mask.numel() > 0:
+        prior_mask_padded = F.pad(
+            prior_mask,
+            (
+                0,
+                context_kv_len - prior_mask.shape[1],
+                0,
+                max_num_queries - prior_mask.shape[0],
+            ),
+            "constant",
+            0,
+        ).bool()
+        attn_mask = torch.cat([prior_mask_padded, active_mask_padded], dim=1)
+    else:
+        attn_mask = active_mask_padded
+    return query, k, v, k_cache, v_cache, active_block_table, attn_mask


### PR DESCRIPTION
This PR aims to modularize testing logic and decompose combinatorial test spaces into many small tests to improve test coverage and code reuse.

Changes in this PR:
- Move input sampling code and pytorch cpu reference version into `utils.py`
- A `FlashPagedAttentionTest` to perform Neuron kernel testing logic. This class will be subclassed in later BlockSparse Kernel PR (#13249 )
- [WIP] decompose large test into many small tests for different corner cases