### PR TITLE
[ROCm] Make amdsmi import optional for other platforms

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -5,8 +5,6 @@ from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import torch
-from amdsmi import (amdsmi_get_gpu_asic_info, amdsmi_get_processor_handles,
-                    amdsmi_init, amdsmi_shut_down)
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -19,6 +17,12 @@ else:
     VllmConfig = None
 
 logger = init_logger(__name__)
+
+try:
+    from amdsmi import (amdsmi_get_gpu_asic_info, amdsmi_get_processor_handles,
+                        amdsmi_init, amdsmi_shut_down)
+except ImportError as e:
+    logger.warning("Failed to import from amdsmi with %r", e)
 
 try:
     import vllm._C  # noqa: F401


### PR DESCRIPTION
This fixes broken CI on other platforms: https://buildkite.com/vllm/ci/builds/13649#0195176d-c5df-4dfc-91dd-4e1b7b2bc14a