### PR TITLE
[Misc] Fix typo in get_config_dtype_str function of fused_moe.py

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -982,7 +982,7 @@ def get_config_dtype_str(dtype: torch.dtype,
     elif use_int8_w8a16:
         return "int8_w8a16"
     elif use_int4_w4a16:
-        return "int4_w8a16"
+        return "int4_w4a16"
     elif dtype == torch.float:
         # avoiding cases where kernel fails when float32 MoE
         # use fp16/bfloat16 configs


### PR DESCRIPTION
This PR corrects a minor typo in fused_moe.py within the get_config_dtype_str function.
The string "int4_w8a16" is changed to "int4_w4a16" to better align with the intended configuration naming.