### PR TITLE
[V1][core] Support allowed_token_ids in V1 sampler

### DIFF
--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -38,3 +38,4 @@ class SamplingMetadata:
     stop_token_ids: List[Set[int]]
 
     logit_bias: List[Optional[Dict[int, float]]]
+    allowed_token_ids: Optional[List[int]] = None


### PR DESCRIPTION
Introduce allowed_token_id support in v1 Sampler.

Tested with:
pytest tests/v1/sample/test_sampler.py -k "test_sampler_allowed_token_ids"

Fixes #13058