### PR TITLE
Pin Ray version to 2.40.0

### DIFF
--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray[adag] == 2.41.0 # Required for pipeline parallelism in V1.
+ray[adag] == 2.40.0 # Required for pipeline parallelism in V1.
 torch == 2.5.1
 torchaudio==2.5.1
 # These must be updated alongside torch


### PR DESCRIPTION
It turns out that TP + PP in V1 does not work with Ray 2.41.0 for some reason. 2.40.0 works though.

Just for a record, I got the following error on 2.41.0:
```
EngineCore hit an exception: Traceback (most recent call last):
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/workspace/vllm/vllm/v1/engine/core.py", line 276, in run_engine_core
ERROR 02-18 01:08:08 core.py:283]     engine_core.run_busy_loop()
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/workspace/vllm/vllm/v1/engine/core.py", line 319, in run_busy_loop
ERROR 02-18 01:08:08 core.py:283]     outputs = step_fn()
ERROR 02-18 01:08:08 core.py:283]               ^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/workspace/vllm/vllm/v1/engine/core.py", line 193, in step_with_batch_queue
ERROR 02-18 01:08:08 core.py:283]     model_output = future.result()
ERROR 02-18 01:08:08 core.py:283]                    ^^^^^^^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/workspace/vllm/vllm/v1/executor/ray_distributed_executor.py", line 24, in result
ERROR 02-18 01:08:08 core.py:283]     return self.ref.get()
ERROR 02-18 01:08:08 core.py:283]            ^^^^^^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/miniconda3/envs/vllm-py311/lib/python3.11/site-packages/ray/experimental/compiled_dag_ref.py", line 115, in get
ERROR 02-18 01:08:08 core.py:283]     return_vals = self._dag._execute_until(
ERROR 02-18 01:08:08 core.py:283]                   ^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/miniconda3/envs/vllm-py311/lib/python3.11/site-packages/ray/dag/compiled_dag_node.py", line 2074, in _execute_until
ERROR 02-18 01:08:08 core.py:283]     return self._get_execution_results(execution_index, channel_index)
ERROR 02-18 01:08:08 core.py:283]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283]   File "/data/woosuk/miniconda3/envs/vllm-py311/lib/python3.11/site-packages/ray/dag/compiled_dag_node.py", line 1982, in _get_execution_results
ERROR 02-18 01:08:08 core.py:283]     assert execution_index in self._result_buffer
ERROR 02-18 01:08:08 core.py:283]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 02-18 01:08:08 core.py:283] AssertionError
```