### PR TITLE
[Misc] Warn if the vLLM version can't be retrieved

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -2,6 +2,7 @@
 
 import logging
 import traceback
+from contextlib import suppress
 from itertools import chain
 from typing import TYPE_CHECKING, Optional
 
@@ -12,6 +13,20 @@ from .interface import _Backend  # noqa: F401
 from .interface import CpuArchEnum, Platform, PlatformEnum
 
 logger = logging.getLogger(__name__)
+
+
+def vllm_version_matches_substr(substr: str) -> bool:
+    """
+    Check to see if the vLLM version matches a substring.
+    """
+    from importlib.metadata import PackageNotFoundError, version
+    try:
+        vllm_version = version("vllm")
+    except PackageNotFoundError:
+        logger.warning(
+            "The vLLM package was not found, so its version could not be "
+            "inspected. This may cause platform detection to fail.")
+    return substr in vllm_version
 
 
 def tpu_platform_plugin() -> Optional[str]:
@@ -33,8 +48,6 @@ def cuda_platform_plugin() -> Optional[str]:
     is_cuda = False
 
     try:
-        from importlib.metadata import version
-
         from vllm.utils import import_pynvml
         pynvml = import_pynvml()
         pynvml.nvmlInit()
@@ -45,7 +58,7 @@ def cuda_platform_plugin() -> Optional[str]:
             # Otherwise, vllm will always activate cuda plugin
             # on a GPU machine, even if in a cpu build.
             is_cuda = (pynvml.nvmlDeviceGetCount() > 0
-                       and "cpu" not in version("vllm"))
+                       and not vllm_version_matches_substr("cpu"))
         finally:
             pynvml.nvmlShutdown()
     except Exception as e:
@@ -113,8 +126,7 @@ def xpu_platform_plugin() -> Optional[str]:
 def cpu_platform_plugin() -> Optional[str]:
     is_cpu = False
     try:
-        from importlib.metadata import version
-        is_cpu = "cpu" in version("vllm")
+        is_cpu = vllm_version_matches_substr("cpu")
         if not is_cpu:
             import platform
             is_cpu = platform.machine().lower().startswith("arm")
@@ -138,11 +150,8 @@ def neuron_platform_plugin() -> Optional[str]:
 
 def openvino_platform_plugin() -> Optional[str]:
     is_openvino = False
-    try:
-        from importlib.metadata import version
-        is_openvino = "openvino" in version("vllm")
-    except Exception:
-        pass
+    with suppress(Exception):
+        is_openvino = vllm_version_matches_substr("openvino")
 
     return "vllm.platforms.openvino.OpenVinoPlatform" if is_openvino else None
 

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -22,10 +22,11 @@ def vllm_version_matches_substr(substr: str) -> bool:
     from importlib.metadata import PackageNotFoundError, version
     try:
         vllm_version = version("vllm")
-    except PackageNotFoundError:
+    except PackageNotFoundError as e:
         logger.warning(
             "The vLLM package was not found, so its version could not be "
             "inspected. This may cause platform detection to fail.")
+        raise e
     return substr in vllm_version
 
 


### PR DESCRIPTION
There are a few checks that vLLM runs when inferring the platform that rely on inspecting the version of the vLLM package (i.e., via `importlib.metadata.version`). If the vLLM package isn't installed though, the import error will be swallowed, and it can result in the platform not being undetectable. There are a few situations in which this could happen, e.g., running vLLM in a dev environment where the source was been cloned & shared objects were copied from a release, but the project is just on the python path instead of installed into site packages.

This PR wraps the calls to `version("vllm")` to warn if a `PackageNotFoundError` is thrown to try to help make it more clear if this is the cause of platform resolution failing, e.g., 

```
WARNING 02-18 22:05:50 __init__.py:26] The vLLM package was not found, so its version could not be inspected. This may cause platform detection to fail.
WARNING 02-18 22:05:50 __init__.py:26] The vLLM package was not found, so its version could not be inspected. This may cause platform detection to fail.
WARNING 02-18 22:05:50 __init__.py:26] The vLLM package was not found, so its version could not be inspected. This may cause platform detection to fail.
INFO 02-18 22:05:50 __init__.py:210] No platform detected, vLLM is running on UnspecifiedPlatform
```