### PR TITLE
[V1][Metrics] Implement vllm:lora_requests_info metric

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -155,7 +155,7 @@ class AsyncLLM(EngineClient):
                                                 priority)
 
         # 3) Add the request to OutputProcessor (this process).
-        self.output_processor.add_request(request, queue)
+        self.output_processor.add_request(request, lora_request, queue)
 
         # 4) Add the EngineCoreRequest to EngineCore (separate process).
         await self.engine_core.add_request_async(request)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -155,7 +155,7 @@ class AsyncLLM(EngineClient):
                                                 priority)
 
         # 3) Add the request to OutputProcessor (this process).
-        self.output_processor.add_request(request, lora_request, queue)
+        self.output_processor.add_request(request, queue)
 
         # 4) Add the EngineCoreRequest to EngineCore (separate process).
         await self.engine_core.add_request_async(request)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -4,7 +4,6 @@ import asyncio
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
-from vllm.lora.request import LoRARequest
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import RequestOutputKind
 from vllm.transformers_utils.tokenizer import AnyTokenizer
@@ -56,13 +55,13 @@ class RequestState:
         cls,
         tokenizer: AnyTokenizer,
         request: EngineCoreRequest,
-        lora_request: Optional[LoRARequest],
         queue: Optional[asyncio.Queue[RequestOutput]],
         log_stats: bool,
     ) -> "RequestState":
         return cls(
             request_id=request.request_id,
-            lora_name=lora_request.name if lora_request is not None else None,
+            lora_name=(request.lora_request.name
+                       if request.lora_request is not None else None),
             output_kind=request.sampling_params.output_kind,
             prompt=request.prompt,
             prompt_token_ids=request.prompt_token_ids,
@@ -112,7 +111,6 @@ class OutputProcessor:
     def add_request(
         self,
         request: EngineCoreRequest,
-        lora_request: Optional[LoRARequest] = None,
         queue: Optional[asyncio.Queue[RequestOutput]] = None,
     ) -> None:
         request_id = request.request_id
@@ -122,7 +120,6 @@ class OutputProcessor:
         self.request_states[request_id] = RequestState.from_new_request(
             tokenizer=self.tokenizer.get_lora_tokenizer(request.lora_request),
             request=request,
-            lora_request=lora_request,
             queue=queue,
             log_stats=self.log_stats)
 

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -219,6 +219,8 @@ class OutputProcessor:
                                                      finish_reason,
                                                      iteration_stats)
 
+        self._update_lora_iteration_stats(iteration_stats)
+
         return OutputProcessorOutput(
             request_outputs=request_outputs,
             reqs_to_abort=reqs_to_abort,

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -37,6 +37,12 @@ class SchedulerStats:
 
 
 @dataclass
+class LoRAStats:
+    waiting_requests: Set[str] = field(default_factory=set)
+    running_requests: Set[str] = field(default_factory=set)
+
+
+@dataclass
 class RequestStateStats:
     """Stats that need to be tracked across delta updates."""
 
@@ -50,12 +56,6 @@ class RequestStateStats:
     scheduled_ts: float = 0.0
     first_token_ts: float = 0.0
     last_token_ts: float = 0.0
-
-
-@dataclass
-class LoRAStats:
-    waiting_requests: Set[str] = field(default_factory=set)
-    running_requests: Set[str] = field(default_factory=set)
 
 
 @dataclass

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -174,7 +174,7 @@ class LoRARequestStates:
     def __init__(self):
         self.lora_name_to_stats: Dict[str, LoRAStats] = {}
 
-    def get_stats(self, req_state) -> Optional[LoRAStats]:
+    def get_stats(self, req_state: 'RequestState') -> Optional[LoRAStats]:
         if req_state.lora_name is None:
             return None
         if req_state.lora_name not in self.lora_name_to_stats:


### PR DESCRIPTION
```
vllm:lora_requests_info{max_lora="1",running_lora_adapters="",waiting_lora_adapters=""} 1.7395575657589855e+09
vllm:lora_requests_info{max_lora="1",running_lora_adapters="test-lora",waiting_lora_adapters=""} 1.7395575723949368e+09
vllm:lora_requests_info{max_lora="1",running_lora_adapters="test-lora",waiting_lora_adapters="test-lora"} 1.7395575717647147e+09
```

As discussed in #13303, this metric perhaps isn't the most ideal solution for the use case but, given there is an existing user, we should retain compatibility in V1 and deprecate it if we replace it with a different metric.

See also kubernetes-sigs/gateway-api-inference-extension#354