### PR TITLE
fix(chunked prefill): don't schedule prefill if freeing kv cache

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1345,18 +1345,21 @@ class Scheduler:
             partial_prefill_metadata=partial_prefill_metadata,
         )
 
-        # Schedule swapped out requests.
-        # If preemption happens, it means we don't have space for swap-in.
+        # If preemption happens, it means we don't have space for other
+        # requests.
         if len(running_scheduled.preempted) + len(
                 running_scheduled.swapped_out) == 0:
+            # Schedule swapped out requests.
             swapped_in = self._schedule_swapped(budget, curr_loras)
 
-        prefills = self._schedule_prefills(
-            budget,
-            curr_loras,
-            enable_chunking=True,
-            partial_prefill_metadata=partial_prefill_metadata,
-        )
+            # Schedule new prefills.
+            if len(self.swapped) == 0:
+                prefills = self._schedule_prefills(
+                    budget,
+                    curr_loras,
+                    enable_chunking=True,
+                    partial_prefill_metadata=partial_prefill_metadata,
+                )
 
         assert (budget.num_batched_tokens
                 <= self.scheduler_config.max_num_batched_tokens)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -1353,7 +1353,7 @@ class Scheduler:
             swapped_in = self._schedule_swapped(budget, curr_loras)
 
             # Schedule new prefills.
-            if len(self.swapped) == 0:
+            if not self.swapped:
                 prefills = self._schedule_prefills(
                     budget,
                     curr_loras,


### PR DESCRIPTION
FIX #5578

This PR makes the priority "running > swapped > waiting" strict. The previous code has chance to schedule new prefills even if preemption/swap happens or there's a swapped request, which (unintentionally) changes the order of requests. 

#3853 says

> ```
> 1. Schedule all decodes
> 2. Schedule all chunked prefills (running prefills)
> 3. Schedule swapped
> 4. Schedule new prefills
> ```

and it has been implemented that (3.) is skipped if (1.) or (2.) fails to schedule all. The new change is to skip (4.) if any previous step fails to schedule all.


Re-adding preempted requests to chunked prefill may be OK but it seems better to implement "partial preemption" of a sequence (i.e. freeing some tail part of KV cache), which is out of scope of the PR.

---

The previous PR is #5633. The commits there are squashed into the first commit here.