### PR TITLE
[CI/Build] force writing version file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ Slack="http://slack.vllm.ai/"
 vllm = "vllm.entrypoints.cli.main:main"
 
 [tool.setuptools_scm]
-version_file = "vllm/_version.py"
+# no extra settings needed, presence enables setuptools-scm
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -499,7 +499,7 @@ def get_gaudi_sw_version():
 
 
 def get_vllm_version() -> str:
-    version = get_version()
+    version = get_version(write_to="vllm/_version.py")
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
     if _no_device():


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/8772 migrated static metadata to `pyproject.toml`, but had the unintended consequence of not creating the `vllm/_version.py` at build time.
