### PR TITLE
Fix copyright year to auto get current year

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
+import datetime
 import inspect
 import logging
 import os
@@ -27,7 +28,7 @@ sys.path.append(os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = 'vLLM'
-copyright = '2024, vLLM Team'
+copyright = f'{datetime.now().year}, vLLM Team'
 author = 'the vLLM Team'
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ sys.path.append(os.path.abspath("../.."))
 # -- Project information -----------------------------------------------------
 
 project = 'vLLM'
-copyright = f'{datetime.now().year}, vLLM Team'
+copyright = f'{datetime.datetime.now().year}, vLLM Team'
 author = 'the vLLM Team'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The copyright year is still 2024:
![image](https://github.com/user-attachments/assets/20365098-6a56-40ac-86b6-2253029c32ef)

after fix like below:
![image](https://github.com/user-attachments/assets/1e3fc67f-6c9c-47cd-8bc5-181f429fcfe7)
