### PR TITLE
[Bugfix][CPU] Fix cpu all-reduce using native pytorch implementation 

### DIFF
--- a/vllm/distributed/device_communicators/cpu_communicator.py
+++ b/vllm/distributed/device_communicators/cpu_communicator.py
@@ -30,4 +30,5 @@ class CpuCommunicator(DeviceCommunicatorBase):
             pass
 
     def all_reduce(self, input_):
-        return self.dist_module.all_reduce(input_, group=self.device_group)
+        self.dist_module.all_reduce(input_, group=self.device_group)
+        return input_


### PR DESCRIPTION

- Different from `ipex.distributed`, `all_reduce` implementation from `torch.distributed` won't return all-reduced tensor:
https://github.com/pytorch/pytorch/blob/0b0da81021e061c021e515bc35d7dc0dbbb05941/torch/distributed/distributed_c10d.py#L2753-L2755

<!--- pyml disable-next-line no-emphasis-as-heading -->
