### PR TITLE
Integrating torchao quantization into vllm

### DIFF
--- a/docs/source/features/quantization/index.md
+++ b/docs/source/features/quantization/index.md
@@ -16,4 +16,5 @@ int4
 int8
 fp8
 quantized_kvcache
+torchao
 :::

--- a/docs/source/features/quantization/torchao.md
+++ b/docs/source/features/quantization/torchao.md
@@ -31,6 +31,7 @@ quantized_model.push_to_hub(hub_repo, safe_serialization=False)
 or with [spaces](https://huggingface.co/spaces/medmekk/TorchAO_Quantization).
 
 We can then test latency for the quantized model with vllm:
+
 ```console
 python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/llama3-8b-int8wo --batch-size 1 --quantization torchao --torchao-config int8wo
 ```
@@ -40,6 +41,7 @@ Note: torch.compile is enabled by default.
 Note: we currently need to explicitly specify torchao-config that matches the checkpoint, we'll follow up with fixes that allow loading the configuration from config file directly.
 
 Example output:
+
 ```
 Avg latency: 2.145327783127626 seconds
 10% percentile latency: 2.1314279098063706 seconds
@@ -49,5 +51,3 @@ Avg latency: 2.145327783127626 seconds
 90% percentile latency: 2.1607464250177144 seconds
 99% percentile latency: 2.1807862490043046 seconds
 ```
-
-

--- a/docs/source/features/quantization/torchao.md
+++ b/docs/source/features/quantization/torchao.md
@@ -1,0 +1,53 @@
+(torchao)=
+
+# TorchAO
+
+TorchAO is an architecture optimization library for PyTorch, it provides high performance dtypes, optimization techniques and kernels for inference and training, featuring composability with native PyTorch features like torch.compile, FSDP etc.. Some benchmark numbers can be found [here](https://github.com/pytorch/ao/tree/main/torchao/quantization#benchmarks).
+
+We recommend installing the latest torchao nightly with
+
+```console
+pip install --pre torchao --index-url https://download.pytorch.org/whl/nightly/cu124  # or other cuda versions like cu121
+```
+
+You can quantize your own huggingface model with torchao, e.g. [transformers](https://huggingface.co/docs/transformers/main/en/quantization/torchao) and [diffusers](https://huggingface.co/docs/diffusers/en/quantization/torchao), and save the checkpoint to huggingface hub like [this](https://huggingface.co/jerryzh168/llama3-8b-int8wo) either with the following example code:
+
+```python
+import torch
+from transformers import TorchAoConfig, AutoModelForCausalLM, AutoTokenizer
+
+model_name = "meta-llama/Meta-Llama-3-8B"
+quantization_config = TorchAoConfig("int8_weight_only")
+quantized_model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype="auto", device_map="auto", quantization_config=quantization_config)
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+input_text = "What are we having for dinner?"
+input_ids = tokenizer(input_text, return_tensors="pt").to("cuda")
+
+hub_repo = # YOUR HUB REPO ID
+tokenizer.push_to_hub(hub_repo)
+quantized_model.push_to_hub(hub_repo, safe_serialization=False)
+```
+
+or with [spaces](https://huggingface.co/spaces/medmekk/TorchAO_Quantization).
+
+We can then test latency for the quantized model with vllm:
+```console
+python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/llama3-8b-int8wo --batch-size 1 --quantization torchao --torchao-config int8wo
+```
+
+Note: torch.compile is enabled by default.
+
+Note: we currently need to explicitly specify torchao-config that matches the checkpoint, we'll follow up with fixes that allow loading the configuration from config file directly.
+
+Example output:
+```
+Avg latency: 2.145327783127626 seconds
+10% percentile latency: 2.1314279098063706 seconds
+25% percentile latency: 2.137767093256116 seconds
+50% percentile latency: 2.144422769546509 seconds
+75% percentile latency: 2.150923326611519 seconds
+90% percentile latency: 2.1607464250177144 seconds
+99% percentile latency: 2.1807862490043046 seconds
+```
+
+

--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test model set-up and inference for quantized HF models supported
+ on the CPU/GPU backend using IPEX (including AWQ/GPTQ).
+
+ Validating the configuration and printing results for manual checking.
+
+ Run `pytest tests/quantization/test_ipex_quant.py`.
+"""
+
+import pytest
+
+from tests.quantization.utils import is_quant_method_supported
+from tests.utils import fork_new_process_for_each_test
+
+
+MODELS = [
+    "facebook/opt-125m"
+]
+DTYPE = ["bfloat16"]
+
+
+@pytest.mark.skipif(not is_quant_method_supported("torchao"),
+                    reason="torchao is not supported on this GPU type.")
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("dtype", DTYPE)
+@fork_new_process_for_each_test
+def test_torchao(vllm_runner, model, dtype):
+    with vllm_runner(model, quantization="torchao", dtype=dtype) as llm:
+        output = llm.generate_greedy(["The capital of France is"],
+                                     max_tokens=32)
+    assert output
+    print(output)

--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -12,10 +12,7 @@ import pytest
 from tests.quantization.utils import is_quant_method_supported
 from tests.utils import fork_new_process_for_each_test
 
-
-MODELS = [
-    "facebook/opt-125m"
-]
+MODELS = ["facebook/opt-125m"]
 DTYPE = ["bfloat16"]
 
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -143,6 +143,7 @@ class ModelConfig:
             decoding draft models.
         quantization: Quantization method that was used to quantize the model
             weights. If None, we assume the model weights are not quantized.
+        torchao_config: Quantization configuration for torchao
         enforce_eager: Whether to enforce eager execution. If True, we will
             disable CUDA graph and always execute the model in eager mode.
             If False, we will use CUDA graph and eager execution in hybrid.
@@ -239,6 +240,7 @@ class ModelConfig:
         max_model_len: Optional[int] = None,
         spec_target_max_model_len: Optional[int] = None,
         quantization: Optional[str] = None,
+        torchao_config: Optional[str] = None,
         enforce_eager: Optional[bool] = None,
         max_seq_len_to_capture: Optional[int] = None,
         max_logprobs: int = 20,
@@ -311,6 +313,7 @@ class ModelConfig:
         else:
             self.tokenizer_revision = tokenizer_revision
         self.quantization = quantization
+        self.torchao_config = torchao_config
         self.enforce_eager = enforce_eager
         self.max_seq_len_to_capture = max_seq_len_to_capture
         self.max_logprobs = max_logprobs
@@ -616,6 +619,9 @@ class ModelConfig:
         ]
         if self.quantization is not None:
             self.quantization = self.quantization.lower()
+
+        if self.torchao_config is not None:
+            self.torchao_config = self.torchao_config.lower()
 
         # Parse quantization method from the HF model config, if available.
         quant_cfg = self._parse_quant_hf_config()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -135,7 +135,10 @@ class EngineArgs:
     rope_theta: Optional[float] = None
     hf_overrides: Optional[HfOverrides] = None
     tokenizer_revision: Optional[str] = None
+
     quantization: Optional[str] = None
+    torchao_config: Optional[str] = None
+
     enforce_eager: Optional[bool] = None
     max_seq_len_to_capture: int = 8192
     disable_custom_all_reduce: bool = False
@@ -583,6 +586,12 @@ class EngineArgs:
                             'None, we assume the model weights are not '
                             'quantized and use `dtype` to determine the data '
                             'type of the weights.')
+        parser.add_argument('--torchao-config',
+                            type=nullable_str,
+                            default=EngineArgs.torchao_config,
+                            help='string configration for torchao, encodes '
+                            'the type of quantization and all relevant '
+                            'arguments, for example: int4wo-128.')
         parser.add_argument(
             '--rope-scaling',
             default=None,
@@ -1100,6 +1109,7 @@ class EngineArgs:
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
             quantization=self.quantization,
+            torchao_config=self.torchao_config,
             enforce_eager=self.enforce_eager,
             max_seq_len_to_capture=self.max_seq_len_to_capture,
             max_logprobs=self.max_logprobs,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -589,7 +589,7 @@ class EngineArgs:
         parser.add_argument('--torchao-config',
                             type=nullable_str,
                             default=EngineArgs.torchao_config,
-                            help='string configration for torchao, encodes '
+                            help='string configuration for torchao, encodes '
                             'the type of quantization and all relevant '
                             'arguments, for example: int4wo-128.')
         parser.add_argument(

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1022,6 +1022,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 
+
 class RowParallelLinear(LinearBase):
     """Linear layer with row parallelism.
 

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -64,8 +64,8 @@ def adjust_bitsandbytes_4bit_shard(param: Parameter,
 def adjust_scalar_to_fused_array(param, loaded_weight, shard_id):
     """For fused modules (QKV and MLP) we have an array of length
     N that holds 1 scale for each "logical" matrix. So the param
-    is an array of length N. The loaded_weight corresponds to 
-    one of the shards on disk. Here, we slice the param based on 
+    is an array of length N. The loaded_weight corresponds to
+    one of the shards on disk. Here, we slice the param based on
     the shard_id for loading.
     """
     qkv_idxs = {"q": 0, "k": 1, "v": 2}
@@ -93,13 +93,13 @@ class LinearMethodBase(QuantizeMethodBase):
                        output_partition_sizes: list[int], input_size: int,
                        output_size: int, params_dtype: torch.dtype,
                        **extra_weight_attrs):
-        """Create weights for a linear layer. 
+        """Create weights for a linear layer.
            The weights will be set as attributes of the layer.
 
         Args:
             layer: The layer that is using the LinearMethodBase factory.
             input_size_per_partition: Size of the weight input dim on rank X.
-            output_partition_sizes: Sizes of the output dim of each logical 
+            output_partition_sizes: Sizes of the output dim of each logical
                 weight on rank X. E.g., output_partition_sizes for QKVLinear
                 is a list contains the width of Wq, Wk, Wv on rank X.
             input_size: Size of the input dim of the weight across all ranks.
@@ -290,7 +290,7 @@ class ColumnParallelLinear(LinearBase):
         output_sizes: list of output sizes packed into one output, like for QKV
                        the list would be size 3.
         prefix: The name of the layer in the state dict, including all parents
-                        (e.g. model.layers.0.qkv_proj) 
+                        (e.g. model.layers.0.qkv_proj)
     """
 
     def __init__(self,
@@ -743,7 +743,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         self.output_sizes = [
             self.num_heads * self.head_size * tp_size,  # q_proj
             self.num_kv_heads * self.head_size * tp_size,  # k_proj
-            self.num_kv_heads * self.head_size * tp_size,  # v_proj 
+            self.num_kv_heads * self.head_size * tp_size,  # v_proj
         ]
 
         super().__init__(input_size=input_size,
@@ -775,7 +775,7 @@ class QKVParallelLinear(ColumnParallelLinear):
     def _load_fused_module_from_checkpoint(self, param: BasevLLMParameter,
                                            loaded_weight: torch.Tensor):
         """
-        Handle special case for models where QKV layers are already 
+        Handle special case for models where QKV layers are already
         fused on disk. In this case, we have no shard id. This function
         determmines the shard id by splitting these layers and then calls
         the weight loader using the shard id.
@@ -936,6 +936,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                 loaded_weight_shard = loaded_weight.narrow(
                     output_dim, shard_offset, shard_size)
                 self.weight_loader(param, loaded_weight_shard, shard_id)
+
             return
 
         tp_rank = get_tensor_model_parallel_rank()
@@ -1020,7 +1021,6 @@ class QKVParallelLinear(ColumnParallelLinear):
 
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
-
 
 class RowParallelLinear(LinearBase):
     """Linear layer with row parallelism.
@@ -1136,7 +1136,6 @@ class RowParallelLinear(LinearBase):
 
     def weight_loader_v2(self, param: BasevLLMParameter,
                          loaded_weight: torch.Tensor):
-
         # Special case for loading scales off disk, which often do not
         # have a shape (such as in the case of AutoFP8).
         if len(loaded_weight.shape) == 0:

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -103,8 +103,8 @@ def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
     from .neuron_quant import NeuronQuantConfig
     from .ptpc_fp8 import PTPCFp8Config
     from .qqq import QQQConfig
-    from .tpu_int8 import Int8TpuConfig
     from .torchao import TorchAOConfig
+    from .tpu_int8 import Int8TpuConfig
 
     method_to_config: Dict[str, Type[QuantizationConfig]] = {
         "aqlm": AQLMConfig,

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -30,7 +30,8 @@ QUANTIZATION_METHODS: List[str] = [
     "neuron_quant",
     "ipex",
     "quark",
-    "moe_wna16"
+    "moe_wna16",
+    "torchao",
 ]
 
 # The customized quantization methods which will be added to this dict.
@@ -103,6 +104,7 @@ def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
     from .ptpc_fp8 import PTPCFp8Config
     from .qqq import QQQConfig
     from .tpu_int8 import Int8TpuConfig
+    from .torchao import TorchAOConfig
 
     method_to_config: Dict[str, Type[QuantizationConfig]] = {
         "aqlm": AQLMConfig,
@@ -130,6 +132,7 @@ def get_quantization_config(quantization: str) -> Type[QuantizationConfig]:
         "ipex": IPEXConfig,
         "quark": QuarkConfig,
         "moe_wna16": MoeWNA16Config,
+        "torchao": TorchAOConfig,
     }
     # Update the `method_to_config` with customized quantization methods.
     method_to_config.update(_CUSTOMIZED_METHOD_TO_QUANT_CONFIG)

--- a/vllm/model_executor/layers/quantization/base_config.py
+++ b/vllm/model_executor/layers/quantization/base_config.py
@@ -103,8 +103,8 @@ class QuantizationConfig(ABC):
                                      user_quant) -> Optional[str]:
         """
            Detects if this quantization method can support a given checkpoint
-           format by overriding the user specified quantization method -- 
-           this method should only be overwritten by subclasses in exceptional 
+           format by overriding the user specified quantization method --
+           this method should only be overwritten by subclasses in exceptional
            circumstances
         """
         return None
@@ -131,7 +131,7 @@ class QuantizationConfig(ABC):
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional[QuantizeMethodBase]:
         """Get the quantize method to use for the quantized layer.
-        
+
         Args:
             layer: The layer for the quant method.
             prefix: The full name of the layer in the state dict

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -1,0 +1,96 @@
+import torch
+from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig)
+from torch.nn.parameter import Parameter
+from torchao.quantization import (
+    int4_weight_only,
+    int8_dynamic_activation_int4_weight,
+    int8_dynamic_activation_int8_semi_sparse_weight,
+    int8_dynamic_activation_int8_weight,
+    int8_weight_only,
+    quantize_,
+)
+from vllm.model_executor.utils import set_weight_attrs
+from typing import List, Dict, Any, Optional
+import torch.nn.functional as F
+
+
+class TorchAOConfig(QuantizationConfig):
+    """Config class for torchao.
+    """
+
+    # TODO
+    def __init__(self) -> None:
+        print("in torchao config init")
+        pass
+
+    def __repr__(self) -> str:
+        return "TorchAOConfig()"
+
+    def get_name(self) -> str:
+        return "torchao"
+
+    def get_supported_act_dtypes(self) -> List[torch.dtype]:
+        return [torch.float32, torch.float16, torch.bfloat16]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # The AWQ kernel only supports Turing or newer GPUs.
+        return 75
+
+    @staticmethod
+    def get_config_filenames() -> List[str]:
+        # TODO
+        print("get config file names in torchao")
+        return ["quant_config.json"]
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "TorchAOConfig":
+        # TODO
+        return cls()
+
+    def get_quant_method(self, layer: torch.nn.Module,
+                         prefix: str) -> Optional["TorchAOLinearMethod"]:
+        if isinstance(layer, LinearBase):
+            return TorchAOLinearMethod(self)
+        return None
+
+    def get_scaled_act_names(self) -> List[str]:
+        return []
+
+class TorchAOLinearMethod(LinearMethodBase):
+    """Linear method for torchao.
+
+    Args:
+        quant_config: The torchao quantization config.
+    """
+
+    def __init__(self, quant_config: TorchAOConfig):
+        self.quant_config = quant_config
+
+    def create_weights(self, layer: torch.nn.Module,
+                       input_size_per_partition: int,
+                       output_partition_sizes: List[int], input_size: int,
+                       output_size: int, params_dtype: torch.dtype,
+                       **extra_weight_attrs):
+        # unquantized weights
+        weight = Parameter(torch.empty(sum(output_partition_sizes),
+                                       input_size_per_partition,
+                                       dtype=params_dtype),
+                           requires_grad=False)
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+        # print("quantized weights:", weight)
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        # dummy_linear = torch.nn.Linear(layer.weight.shape[1], layer.weight.shape[0], bias=False)
+        # dummy_linear.weight = layer.weight
+        # quantize_(dummy_linear, int4_weight_only())
+        # layer.weight = dummy_linear.weight
+        return F.linear(x, layer.weight, bias)

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -19,11 +19,11 @@ class TorchAOConfig(QuantizationConfig):
 
     """
 
-    def __init__(self, quant_type: str = "int4wo-128") -> None:
-        self.quant_type = quant_type
+    def __init__(self, torchao_config: str = "int4wo-128") -> None:
+        self.torchao_config = torchao_config
 
     def __repr__(self) -> str:
-        return f"TorchAOConfig({self.quant_type})"
+        return f"TorchAOConfig({self.torchao_config})"
 
     def get_name(self) -> str:
         return "torchao"
@@ -43,8 +43,8 @@ class TorchAOConfig(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "TorchAOConfig":
-        quant_type = cls.get_from_keys_or(config, ["quant_type"], "int4wo-128")
-        return cls(quant_type)
+        torchao_config = cls.get_from_keys_or(config, ["torchao_config"], "int4wo-128")
+        return cls(torchao_config)
 
     def get_quant_method(self, layer: torch.nn.Module,
                          prefix: str) -> Optional["TorchAOLinearMethod"]:
@@ -60,7 +60,7 @@ class TorchAOLinearMethod(LinearMethodBase):
     """Linear method for torchao.
 
     Args:
-        quant_config: The torchao quantization config.
+        torchao_config: The torchao quantization config, a string that encodes the type of quantization and all relevant arguments.
     """
 
     def __init__(self, quant_config: TorchAOConfig):
@@ -81,7 +81,7 @@ class TorchAOLinearMethod(LinearMethodBase):
         set_weight_attrs(weight, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer: Module) -> None:
-        torchao_config = self.quant_config.quant_type
+        torchao_config = self.quant_config.torchao_config
         layer.weight = torchao_quantize_param_data(layer.weight,
                                                    torchao_config)
 

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -63,7 +63,8 @@ class TorchAOLinearMethod(LinearMethodBase):
     """Linear method for torchao.
 
     Args:
-        torchao_config: The torchao quantization config, a string that encodes the type of quantization and all relevant arguments.
+        torchao_config: The torchao quantization config, a string
+        that encodes the type of quantization and all relevant arguments.
     """
 
     def __init__(self, quant_config: TorchAOConfig):
@@ -78,8 +79,8 @@ class TorchAOLinearMethod(LinearMethodBase):
                                        input_size_per_partition,
                                        dtype=params_dtype),
                            requires_grad=False)
-        # we load quantized model in versions after 0.9.0 and do on the fly quantization in torchao
-        # versions before 0.9.0
+        # we load quantized model in versions after 0.9.0 and do on the fly
+        # quantization in torchao versions before 0.9.0
         if version.parse(importlib.metadata.version(
                 "torchao")) > version.parse("0.9.0"):
             torchao_config = self.quant_config.torchao_config

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -85,6 +85,7 @@ class TorchAOLinearMethod(LinearMethodBase):
         layer.weight = torchao_quantize_param_data(layer.weight,
                                                    torchao_config)
 
+    @torch.compile
     def apply(self,
               layer: torch.nn.Module,
               x: torch.Tensor,

--- a/vllm/model_executor/layers/quantization/torchao.py
+++ b/vllm/model_executor/layers/quantization/torchao.py
@@ -1,32 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Dict, List, Optional
+
 import torch
+import torch.nn.functional as F
+from torch.nn import Module
+from torch.nn.parameter import Parameter
+
 from vllm.model_executor.layers.linear import LinearBase, LinearMethodBase
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
-from torch.nn.parameter import Parameter
-from torchao.quantization import (
-    int4_weight_only,
-    int8_dynamic_activation_int4_weight,
-    int8_dynamic_activation_int8_semi_sparse_weight,
-    int8_dynamic_activation_int8_weight,
-    int8_weight_only,
-    quantize_,
-)
+from vllm.model_executor.layers.quantization.torchao_utils import (
+    torchao_quantize_param_data)
 from vllm.model_executor.utils import set_weight_attrs
-from typing import List, Dict, Any, Optional
-import torch.nn.functional as F
-from torch.nn import Module
-from vllm.model_executor.layers.quantization.torchao_utils import torchao_quantize_param_data
 
 
 class TorchAOConfig(QuantizationConfig):
     """Config class for torchao.
+
     """
 
     def __init__(self, quant_type: str = "int4wo-128") -> None:
         self.quant_type = quant_type
 
     def __repr__(self) -> str:
-        return f"TorchAOConfig({quant_type})"
+        return f"TorchAOConfig({self.quant_type})"
 
     def get_name(self) -> str:
         return "torchao"
@@ -58,6 +55,7 @@ class TorchAOConfig(QuantizationConfig):
     def get_scaled_act_names(self) -> List[str]:
         return []
 
+
 class TorchAOLinearMethod(LinearMethodBase):
     """Linear method for torchao.
 
@@ -84,7 +82,8 @@ class TorchAOLinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: Module) -> None:
         torchao_config = self.quant_config.quant_type
-        layer.weight = torchao_quantize_param_data(layer.weight, torchao_config)
+        layer.weight = torchao_quantize_param_data(layer.weight,
+                                                   torchao_config)
 
     def apply(self,
               layer: torch.nn.Module,

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -1,0 +1,93 @@
+"""
+Common utilities for torchao.
+"""
+
+from typing import Dict, Set
+
+import torch
+
+
+def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
+    """Quantize a Tensor with torchao quantization specified by torchao_config
+
+    Args:
+       `param`: weight parameter of the linear module
+       `torchao_config`: type of quantization and their arguments we want to use to
+        quantize the Tensor, e.g. int4wo-128 means int4 weight only quantization with group_size
+        128
+    """
+    # Lazy import to suppress some warnings
+    from torchao.quantization import (
+        float8_dynamic_activation_float8_weight,
+        int4_weight_only,
+        int8_dynamic_activation_int8_weight,
+        int8_weight_only,
+        quantize_,
+    )
+    from torchao.quantization.observer import PerRow, PerTensor
+
+    dummy_linear = torch.nn.Linear(param.shape[1], param.shape[0], bias=False)
+    dummy_linear.weight = param
+    if "int8wo" in torchao_config:
+        quantize_(dummy_linear, int8_weight_only())
+    elif "int8dq" in torchao_config:
+        quantize_(dummy_linear, int8_dynamic_activation_int8_weight())
+    elif "int4wo" in torchao_config:
+        group_size = int(torchao_config.split("-")[-1])
+        assert group_size in [
+            32,
+            64,
+            128,
+            256,
+        ], f"int4wo groupsize needs to be one of [32, 64, 128, 256] but got {group_size}"
+        quantize_(dummy_linear, int4_weight_only(group_size=group_size))
+    elif "fp8wo" in torchao_config:
+        from torchao.quantization import float8_weight_only
+
+        # this requires newer hardware
+        # [rank0]: AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
+        quantize_(dummy_linear, float8_weight_only())
+    elif "fp8dq" in torchao_config:
+        granularity = torchao_config.split("-")[-1]
+        GRANULARITY_MAP = {
+            "per_row": PerRow(),
+            "per_tensor": PerTensor(),
+        }
+        assert (
+            granularity in GRANULARITY_MAP
+        ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, got {granularity}"
+        quantize_(
+            dummy_linear,
+            float8_dynamic_activation_float8_weight(
+                granularity=GRANULARITY_MAP[granularity]
+            ),
+        )
+
+    return dummy_linear.weight
+
+
+def apply_torchao_config_(
+    self: torch.nn.Module,
+    params_dict: Dict[str, torch.Tensor],
+    param_suffixes: Set[str],
+) -> None:
+    """A util function used for quantizing the weight parameters after they are loaded if
+       self.torchao_config is specified
+
+    Args:
+      `self`: the model we want to quantize
+      `params_dict`: dictionary mapping from param_name to the parameter Tensor
+      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these suffixes
+
+    Returns:
+       None, the `params_dict` is modified inplace and the weights of `self` model are quantized
+    """
+    if self.torchao_config:
+        for param_suffix in param_suffixes:
+            for name in params_dict:
+                param = params_dict[name]
+                if param_suffix in name and param.ndim == 2:
+                    params_dict[name] = torchao_quantize_param_data(
+                        param, self.torchao_config
+                    )
+        self.load_state_dict(params_dict, assign=True)

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -13,9 +13,9 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
 
     Args:
        `param`: weight parameter of the linear module
-       `torchao_config`: type of quantization and their arguments we want to use to
-        quantize the Tensor, e.g. int4wo-128 means int4 weight only quantization with group_size
-        128
+       `torchao_config`: type of quantization and their arguments we want to
+        use to quantize the Tensor, e.g. int4wo-128 means int4 weight only
+        quantization with group_size 128
     """
     # Lazy import to suppress some warnings
     from torchao.quantization import (float8_dynamic_activation_float8_weight,
@@ -37,13 +37,15 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
             64,
             128,
             256,
-        ], f"int4wo groupsize needs to be one of [32, 64, 128, 256] but got {group_size}"
+        ], f"int4wo groupsize needs to be one of [32, 64, 128, 256] but "
+        "got {group_size}"
         quantize_(dummy_linear, int4_weight_only(group_size=group_size))
     elif "fp8wo" in torchao_config:
         from torchao.quantization import float8_weight_only
 
         # this requires newer hardware
-        # [rank0]: AssertionError: fp8e4nv data type is not supported on CUDA arch < 89
+        # [rank0]: AssertionError: fp8e4nv data type is not supported on
+        # CUDA arch < 89
         quantize_(dummy_linear, float8_weight_only())
     elif "fp8dq" in torchao_config:
         granularity = torchao_config.split("-")[-1]
@@ -53,7 +55,8 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
         }
         assert (
             granularity in GRANULARITY_MAP
-        ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, got {granularity}"
+        ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, "
+        f"got {granularity}"
         quantize_(
             dummy_linear,
             float8_dynamic_activation_float8_weight(
@@ -68,16 +71,18 @@ def apply_torchao_config_(
     params_dict: Dict[str, torch.Tensor],
     param_suffixes: Set[str],
 ) -> None:
-    """A util function used for quantizing the weight parameters after they are loaded if
-       self.torchao_config is specified
+    """A util function used for quantizing the weight parameters after they are
+       loaded if self.torchao_config is specified
 
     Args:
       `self`: the model we want to quantize
       `params_dict`: dictionary mapping from param_name to the parameter Tensor
-      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these suffixes
+      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these
+       suffixes
 
     Returns:
-       None, the `params_dict` is modified inplace and the weights of `self` model are quantized
+       None, the `params_dict` is modified inplace and the weights of `self` model
+       are quantized
     """
     if self.torchao_config:
         for param_suffix in param_suffixes:

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -76,12 +76,12 @@ def apply_torchao_config_(
     Args:
       `self`: the model we want to quantize
       `params_dict`: dictionary mapping from param_name to the parameter Tensor
-      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching these
-       suffixes
+      `param_suffixes`: a set of suffixes, we'll quantize the Tensor matching
+       these suffixes
 
     Returns:
-       None, the `params_dict` is modified inplace and the weights of `self` model
-       are quantized
+       None, the `params_dict` is modified inplace and the weights of `self`
+       model are quantized
     """
     if self.torchao_config:
         for param_suffix in param_suffixes:

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -37,7 +37,7 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
             64,
             128,
             256,
-        ], f"int4wo groupsize needs to be one of [32, 64, 128, 256] but "
+        ], "int4wo groupsize needs to be one of [32, 64, 128, 256] but "
         "got {group_size}"
         quantize_(dummy_linear, int4_weight_only(group_size=group_size))
     elif "fp8wo" in torchao_config:
@@ -53,9 +53,8 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
             "per_row": PerRow(),
             "per_tensor": PerTensor(),
         }
-        assert (
-            granularity in GRANULARITY_MAP
-        ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, "
+        assert (granularity in GRANULARITY_MAP
+                ), f"Supported granularity are: {GRANULARITY_MAP.keys()}, "
         f"got {granularity}"
         quantize_(
             dummy_linear,

--- a/vllm/model_executor/layers/quantization/torchao_utils.py
+++ b/vllm/model_executor/layers/quantization/torchao_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """
 Common utilities for torchao.
 """
@@ -17,13 +18,10 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
         128
     """
     # Lazy import to suppress some warnings
-    from torchao.quantization import (
-        float8_dynamic_activation_float8_weight,
-        int4_weight_only,
-        int8_dynamic_activation_int8_weight,
-        int8_weight_only,
-        quantize_,
-    )
+    from torchao.quantization import (float8_dynamic_activation_float8_weight,
+                                      int4_weight_only,
+                                      int8_dynamic_activation_int8_weight,
+                                      int8_weight_only, quantize_)
     from torchao.quantization.observer import PerRow, PerTensor
 
     dummy_linear = torch.nn.Linear(param.shape[1], param.shape[0], bias=False)
@@ -59,8 +57,7 @@ def torchao_quantize_param_data(param: torch.Tensor, torchao_config: str):
         quantize_(
             dummy_linear,
             float8_dynamic_activation_float8_weight(
-                granularity=GRANULARITY_MAP[granularity]
-            ),
+                granularity=GRANULARITY_MAP[granularity]),
         )
 
     return dummy_linear.weight
@@ -88,6 +85,5 @@ def apply_torchao_config_(
                 param = params_dict[name]
                 if param_suffix in name and param.ndim == 2:
                     params_dict[name] = torchao_quantize_param_data(
-                        param, self.torchao_config
-                    )
+                        param, self.torchao_config)
         self.load_state_dict(params_dict, assign=True)

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -139,7 +139,8 @@ def get_quant_config(model_config: ModelConfig,
         return quant_cls.from_config({})
 
     if model_config.quantization == "torchao":
-        return quant_cls.from_config({"torchao_config": model_config.torchao_config})
+        return quant_cls.from_config(
+            {"torchao_config": model_config.torchao_config})
 
     # Read the quantization config from the HF model config, if available.
     hf_quant_config = getattr(model_config.hf_config, "quantization_config",

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -184,6 +184,7 @@ def get_quant_config(model_config: ModelConfig,
         return quant_cls()
 
     config_files = glob.glob(os.path.join(hf_folder, "*.json"))
+    print("hf_folder:", hf_folder)
 
     quant_config_files = [
         f for f in config_files if any(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -138,6 +138,9 @@ def get_quant_config(model_config: ModelConfig,
     if model_config.quantization == "gguf":
         return quant_cls.from_config({})
 
+    if model_config.quantization == "torchao":
+        return quant_cls.from_config({"torchao_config": model_config.torchao_config})
+
     # Read the quantization config from the HF model config, if available.
     hf_quant_config = getattr(model_config.hf_config, "quantization_config",
                               None)
@@ -151,6 +154,7 @@ def get_quant_config(model_config: ModelConfig,
                                   None)
     if hf_quant_config is not None:
         return quant_cls.from_config(hf_quant_config)
+
     # In case of bitsandbytes/QLoRA, get quant config from the adapter model.
     if model_config.quantization == "bitsandbytes":
         if (not load_config.model_loader_extra_config
@@ -184,7 +188,6 @@ def get_quant_config(model_config: ModelConfig,
         return quant_cls()
 
     config_files = glob.glob(os.path.join(hf_folder, "*.json"))
-    print("hf_folder:", hf_folder)
 
     quant_config_files = [
         f for f in config_files if any(

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -53,7 +53,6 @@ from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
-from vllm.model_executor.layers.quantization.torchao_utils import apply_torchao_config_
 
 
 class LlamaMLP(nn.Module):

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -53,6 +53,7 @@ from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
+from vllm.model_executor.layers.quantization.torchao_utils import apply_torchao_config_
 
 
 class LlamaMLP(nn.Module):


### PR DESCRIPTION
Summary:
att, initial PR that adds support for torchao as a quantization option for vllm

Test Plan:

`pytest tests/quantization/test_torchao.py`

=== process_weights_after_loading ===

Tested in A100 machine
```
python benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 --model meta-llama/Meta-Llama-3-8B
python benchmarks/benchmark_throughput.py --input-len 256 --output-len 256 --model meta-llama/Meta-Llama-3-8B --quantization torchao --torchao-config int4wo-128
```
bfloat16:
Throughput: 14.23 requests/s, 7285.92 total tokens/s, 3642.96 output tokens/s

torchao int4wo-128
Throughput: 2.34 requests/s, 1197.03 total tokens/s, 598.52 output tokens/s

Note: int4wo-128 is can only give speedup for batch size 1, we expect float8 can give overall boost, can test this later.

```
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model meta-llama/Meta-Llama-3-8B --batch-size 1
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model meta-llama/Meta-Llama-3-8B --batch-size 1 --quantization torchao --torchao-config int4wo-128
```

bfloat16:
```
Avg latency: 4.563035774851839 seconds
10% percentile latency: 3.3907309625297786 seconds
25% percentile latency: 3.424301794730127 seconds
50% percentile latency: 3.727481307461858 seconds
75% percentile latency: 5.625706314109266 seconds
90% percentile latency: 5.935522455349565 seconds
99% percentile latency: 7.159032964520157 seconds
```

torchao int4wo-128:
```
Avg latency: 2.1109102573245764 seconds
10% percentile latency: 2.089452960342169 seconds
25% percentile latency: 2.092462383210659 seconds
50% percentile latency: 2.1093569844961166 seconds
75% percentile latency: 2.119327493943274 seconds
90% percentile latency: 2.132301461696625 seconds
99% percentile latency: 2.192038407512009 seconds
```

int8wo without compile:

```
Avg latency: 11.678632816672325 seconds
10% percentile latency: 11.624498645961285 seconds
25% percentile latency: 11.638677136972547 seconds
50% percentile latency: 11.690440801903605 seconds
75% percentile latency: 11.707305849529803 seconds
90% percentile latency: 11.724864188954234 seconds
99% percentile latency: 11.745748021267355 seconds
```

int8wo with compile (enabled by default in the PR):
```
Avg latency: 2.144259312748909 seconds
10% percentile latency: 2.111430574581027 seconds
25% percentile latency: 2.117820209823549 seconds
50% percentile latency: 2.1458087861537933 seconds
75% percentile latency: 2.1610238971188664 seconds
90% percentile latency: 2.175424510613084 seconds
99% percentile latency: 2.201516461186111 seconds
```


=== loading pre quantized model results ===

need https://github.com/pytorch/ao/pull/1791 from torchao
or install nightly after it is landed

python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/llama3-8b-int8wo --batch-size 1 --quantization torchao --torchao-config int8wo

```
Avg latency: 2.145327783127626 seconds
10% percentile latency: 2.1314279098063706 seconds
25% percentile latency: 2.137767093256116 seconds
50% percentile latency: 2.144422769546509 seconds
75% percentile latency: 2.150923326611519 seconds
90% percentile latency: 2.1607464250177144 seconds
99% percentile latency: 2.1807862490043046 seconds
```


Benchmarks against existing quant method:
```
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model nm-testing/Meta-Llama-3-8B-Instruct-W4A16-G128 --batch-size 1
```

```
Avg latency: 1.780059675872326 seconds
10% percentile latency: 1.7601410120725631 seconds
25% percentile latency: 1.768859044648707 seconds
50% percentile latency: 1.775211926549673 seconds
75% percentile latency: 1.7830392718315125 seconds
90% percentile latency: 1.8060954470187425 seconds
99% percentile latency: 1.843151821307838 seconds
```

Next:
* using config file instead of command line for configuring type of quantization
* more benchmarks against existing methods (probably will need to generate the quantized checkpoint ourselves manually for benchmarking, e.g. https://docs.vllm.ai/en/latest/features/quantization/int8.html

Reviewers:

Subscribers:

Tasks:

Tags:



<!--- pyml disable-next-line no-emphasis-as-heading -->
