### PR TITLE
Bump up the transformers version to v4.49.0

### DIFF
--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -893,10 +893,6 @@ Currently the PaliGemma model series is implemented without PrefixLM attention m
 `mistral-community/pixtral-12b` does not support V1 yet.
 :::
 
-:::{note}
-To use Qwen2.5-VL series models, you have to install Huggingface `transformers` library from source via `pip install git+https://github.com/huggingface/transformers`.
-:::
-
 ### Pooling Models
 
 See [this page](pooling-models) for more information on how to use pooling models.

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -6,7 +6,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.48.2  # Required for Bamba model and Transformers backend.
+transformers >= 4.49.0  # Required for Qwen 2.5-VL.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.107.0, < 0.113.0; python_version < '3.9'

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -28,7 +28,7 @@ matplotlib # required for qwen-vl test
 mistral_common[opencv] >= 1.5.0 # required for pixtral test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.4 # required for model evaluation test
-transformers==4.48.2 
+transformers==4.49.0 
 # quantization
 bitsandbytes>=0.45.0
 buildkite-test-collector==0.1.9

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -630,7 +630,7 @@ tqdm==4.66.6
     #   transformers
 tqdm-multiprocess==0.0.11
     # via lm-eval
-transformers==4.48.2
+transformers==4.49.0
     # via
     #   -r requirements-test.in
     #   genai-perf


### PR DESCRIPTION
As transformers v4.49.0 is now released, we can bump up the version in our dependency.