### PR TITLE
[V1][Minor] Print KV cache size in token counts

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -519,11 +519,13 @@ def _get_kv_cache_config_uniform_type(vllm_config: VllmConfig,
             "num_gpu_blocks_override=%d", num_blocks, num_gpu_blocks_override)
         num_blocks = num_gpu_blocks_override
 
-    logger.info("# GPU blocks: %d", num_blocks)
-    max_concurrency = (num_blocks * vllm_config.cache_config.block_size /
-                       vllm_config.model_config.max_model_len)
+    num_tokens = num_blocks * vllm_config.cache_config.block_size
+    num_tokens_str = f"{num_tokens:,}"
+    logger.info("GPU KV cache size: %s tokens", num_tokens_str)
+    max_model_len_str = f"{vllm_config.model_config.max_model_len:,}"
+    max_concurrency = num_tokens / vllm_config.model_config.max_model_len
     logger.info("Maximum concurrency for %s tokens per request: %.2fx",
-                vllm_config.model_config.max_model_len, max_concurrency)
+                max_model_len_str, max_concurrency)
 
     per_layer_size = page_size * num_blocks
 


### PR DESCRIPTION
Change

* from:
```
INFO 02-20 00:01:02 kv_cache_utils.py:522] # GPU blocks: 127626
INFO 02-20 00:01:02 kv_cache_utils.py:525] Maximum concurrency for 2048 tokens per request: 997.08x
```
* to:
```
INFO 02-19 23:56:55 kv_cache_utils.py:524] GPU KV cache size: 2,042,016 tokens
INFO 02-19 23:56:55 kv_cache_utils.py:527] Maximum concurrency for 2,048 tokens per request: 997.08x
```