### PR TITLE
[CI/Build] Remove limitation of NVCC_THREADS and MAX_JOBS > CPU count

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ class cmake_build_ext(build_ext):
                     nvcc_threads)
             else:
                 nvcc_threads = 1
-            num_jobs = max(1, num_jobs // nvcc_threads)
 
         return num_jobs, nvcc_threads
 


### PR DESCRIPTION
If `NVCC_THREADS * MAX_JOBS` exceeds the logical CPU core count, the number of parallel compilation jobs is limited to 1 (probably to reduce context switches and required memory). However, since some kernels require longer compilation times, setting a higher number of parallel compilation tasks and the number of threads for nvcc can help accelerate the process, especially on build machines with more memory and a large CPU core count. 
In memory-constrained environments, users should have the flexibility to adjust the number of parallel threads to a suitable level.