### PR TITLE
Use `pytest-xdist` to parallelise kernel tests

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -301,7 +301,7 @@ steps:
   - vllm/attention
   - tests/kernels
   commands:
-    - pytest -v -s kernels --numprocesses=8 --dist worksteal --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+    - pytest -v -s kernels --numprocesses=4 --dist=worksteal --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 4
 
 - label: Tensorizer Test # 11min

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -301,7 +301,7 @@ steps:
   - vllm/attention
   - tests/kernels
   commands:
-    - pytest -v -s kernels --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+    - pytest -v -s kernels --numprocesses=8 --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 4
 
 - label: Tensorizer Test # 11min

--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -301,7 +301,7 @@ steps:
   - vllm/attention
   - tests/kernels
   commands:
-    - pytest -v -s kernels --numprocesses=8 --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+    - pytest -v -s kernels --numprocesses=8 --dist worksteal --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 4
 
 - label: Tensorizer Test # 11min

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -5,6 +5,7 @@ pytest-forked
 pytest-asyncio
 pytest-rerunfailures
 pytest-shard
+pytest-xdist
 
 # testing utils
 awscli

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -120,6 +120,8 @@ encodec==0.1.1
     # via vocos
 evaluate==0.4.3
     # via lm-eval
+execnet==2.1.1
+    # via pytest-xdist
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -440,6 +442,7 @@ pytest==8.3.3
     #   pytest-mock
     #   pytest-rerunfailures
     #   pytest-shard
+    #   pytest-xdist
 pytest-asyncio==0.24.0
     # via -r requirements-test.in
 pytest-forked==1.6.0
@@ -449,6 +452,8 @@ pytest-mock==3.14.0
 pytest-rerunfailures==14.0
     # via -r requirements-test.in
 pytest-shard==0.1.2
+    # via -r requirements-test.in
+pytest-xdist==3.6.1
     # via -r requirements-test.in
 python-dateutil==2.9.0.post0
     # via

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -9,7 +9,7 @@ from vllm.utils import (create_kv_caches_with_random,
 
 def pytest_configure(config: pytest.Config):
     if torch.cuda.is_available():
-        torch.cuda.set_per_process_memory_fraction(1 / 8)
+        torch.cuda.set_per_process_memory_fraction(1 / 4)
 
 
 @pytest.fixture()

--- a/tests/kernels/conftest.py
+++ b/tests/kernels/conftest.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 
 from vllm.utils import (create_kv_caches_with_random,
                         create_kv_caches_with_random_flash)
+
+
+def pytest_configure(config: pytest.Config):
+    if torch.cuda.is_available():
+        torch.cuda.set_per_process_memory_fraction(1 / 8)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Kernels tests are currently taking >8 hours of compute on 24GB GPUs.

This change:
- Runs 4 kernel tests in parallel on each GPU
- Uses `--dist worksteal` so if a worker finishes early, it steals queued tests from busy workers
- Limits the GPU memory for each worker process to 6GB (24 / 4)

If we leave `parallelism: 4`, the kernel tests should now take 30 minutes total.