### PR TITLE
[Bugfix] Fix boolean conversion for OpenVINO env variable

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -355,8 +355,9 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Enables weights compression during model export via HF Optimum
     # default is False
     "VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS":
-    lambda: bool(os.getenv("VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS", False)),
-
+    lambda:
+    (os.environ.get("VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS", "0").lower() in
+     ("on", "true", "1")),
     # If the env var is set, then all workers will execute as separate
     # processes from the engine, and we use the same mechanism to trigger
     # execution on all workers.

--- a/vllm/model_executor/model_loader/openvino.py
+++ b/vllm/model_executor/model_loader/openvino.py
@@ -125,7 +125,8 @@ class OpenVINOCausalLM(nn.Module):
                 "as-is, all possible options that may affect model conversion "
                 "are ignored.")
 
-        load_in_8bit = envs.VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS
+        load_in_8bit = (envs.VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS
+                        if export else False)
         pt_model = OVModelForCausalLM.from_pretrained(
             model_config.model,
             export=export,


### PR DESCRIPTION
Two minor fixes for OpenVINO integration:
- improve boolean conversion for VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS. Only set it to True if user sets it to ON, True or 1.
- Only convert models that are exported to OpenVINO on the fly to INT8, keep pre-converted IR models as is, regardless of VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS value. This matches what is said in the message shown to users when loading an IR model: "This IR will be used for inference as-is, all possible options that may affect model conversion are ignored."

@ilya-lavrenov 