### PR TITLE
[Bugfix] Fix max_num_batched_tokens for MLA

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -50,6 +50,9 @@ else:
 
 logger = init_logger(__name__)
 
+# This value is chosen to have a balance between ITL and TTFT. Note it is
+# not optimized for throughput.
+_DEFAULT_MAX_NUM_BATCHED_TOKENS = 2048
 _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS = 32768
 _MULTIMODAL_MODEL_MAX_NUM_BATCHED_TOKENS = 5120
 
@@ -1525,15 +1528,17 @@ class SchedulerConfig:
                     # for now. Have max_num_batched_tokens set to max_model_len
                     # so we don't reject sequences on account of a short
                     # max_num_batched_tokens.
-                    self.max_num_batched_tokens = max(self.max_model_len, 2048)
+                    self.max_num_batched_tokens = max(
+                        self.max_model_len, _DEFAULT_MAX_NUM_BATCHED_TOKENS)
                 else:
-                    # This value is chosen to have a balance between ITL
-                    # and TTFT. Note it is not optimized for throughput.
-                    self.max_num_batched_tokens = 2048
+                    self.max_num_batched_tokens = (
+                        _DEFAULT_MAX_NUM_BATCHED_TOKENS)
             else:
-                # If max_model_len is too short, use 2048 as the default value
+                # If max_model_len is too short, use
+                # _DEFAULT_MAX_NUM_BATCHED_TOKENS as the default value
                 # for higher throughput.
-                self.max_num_batched_tokens = max(self.max_model_len, 2048)
+                self.max_num_batched_tokens = max(
+                    self.max_model_len, _DEFAULT_MAX_NUM_BATCHED_TOKENS)
 
             if self.runner_type == "pooling":
                 # Choose specific value for higher throughput
@@ -3330,6 +3335,8 @@ class VllmConfig:
                         "caching to be disabled.")
             self.scheduler_config.enable_chunked_prefill = False
             self.scheduler_config.chunked_prefill_enabled = False
+            self.scheduler_config.max_num_batched_tokens = max(
+                self.max_model_len, _DEFAULT_MAX_NUM_BATCHED_TOKENS)
 
             if self.cache_config is not None:
                 self.cache_config.enable_prefix_caching = False

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3336,7 +3336,8 @@ class VllmConfig:
             self.scheduler_config.enable_chunked_prefill = False
             self.scheduler_config.chunked_prefill_enabled = False
             self.scheduler_config.max_num_batched_tokens = max(
-                self.max_model_len, _DEFAULT_MAX_NUM_BATCHED_TOKENS)
+                self.scheduler_config.max_model_len,
+                _DEFAULT_MAX_NUM_BATCHED_TOKENS)
 
             if self.cache_config is not None:
                 self.cache_config.enable_prefix_caching = False


### PR DESCRIPTION
Without this change we are stuck with a very short allowed prompt length by default with deepseek models

Before this PR:
```
vllm serve /home/vllm-dev/DeepSeek-R1 --trust-remote-code --tensor-parallel-size 8
...
WARNING 02-20 17:08:38 scheduler.py:949] Input prompt (100005 tokens) is too long and exceeds limit of 2048
```

You can get past this manually by setting max_num_batched_tokens, but we should take care of this automatically
```
vllm serve /home/vllm-dev/DeepSeek-R1 --trust-remote-code --tensor-parallel-size 8 --max-num-batched-tokens 163840
```

Client:
```python
from openai import OpenAI

openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(api_key=openai_api_key, base_url=openai_api_base)
model_id = client.models.list().data[0].id

# Query a prompt of roughly 100k tokens by repeating a simple token.
prompt = ("A " * 100000).strip()
chat_response = client.chat.completions.create(
    model=model_id,
    messages=[{"role": "user", "content": [{"type": "text", "text": prompt}]}],
)
print("Text Chat completion output:", chat_response.choices[0].message.content)
```