### PR TITLE
[Frontend] [Minor] Fix tqdm progress bar for n > 1

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1411,7 +1411,9 @@ class LLM:
                             pbar.postfix = (
                                 f"est. speed input: {in_spd:.2f} toks/s, "
                                 f"output: {out_spd:.2f} toks/s")
-                        pbar.update(1)
+                            pbar.update(len(output.outputs))
+                        else:
+                            pbar.update(1)
 
         if use_tqdm:
             pbar.close()


### PR DESCRIPTION
When generating multiple outputs for single prompts (`n > 1`) the tqdm progress bar provides incorrect progress ([#11519](https://github.com/vllm-project/vllm/issues/11519)).

This pull request updates the progress bar by the number of generated responses as the total requests consider `n`.

Fixes #11519 