### PR TITLE
[Bugfix] Flush TunableOp results before worker processes are destroyed.

### DIFF
--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -250,6 +250,14 @@ def _run_worker_process(
     except Exception:
         logger.exception("Worker failed")
 
+    # Flush TunableOp results when TunableOp is enabled and
+    # online (in situ) tuning is enabled.
+    import torch.cuda.tunable as tunable
+    if ((tunable.is_enabled() is True) and
+        (tunable.tuning_is_enabled() is True) and
+        (tunable.record_untuned_is_enabled() is False)):
+        tunable.write_file()
+
     logger.info("Worker exiting")
 
 

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -253,9 +253,8 @@ def _run_worker_process(
     # Flush TunableOp results when TunableOp is enabled and
     # online (in situ) tuning is enabled.
     import torch.cuda.tunable as tunable
-    if ((tunable.is_enabled() is True) and
-        (tunable.tuning_is_enabled() is True) and
-        (tunable.record_untuned_is_enabled() is False)):
+    if (tunable.is_enabled() and tunable.tuning_is_enabled() and
+        not tunable.record_untuned_is_enabled()):
         tunable.write_file()
 
     logger.info("Worker exiting")

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -252,9 +252,11 @@ def _run_worker_process(
 
     # Flush TunableOp results when TunableOp is enabled and
     # online (in situ) tuning is enabled.
+    # Offline tuning API (record_untuned_is_enabled()) only
+    # available in PyTorch 2.6 or later.
     import torch.cuda.tunable as tunable
-    if (tunable.is_enabled() and tunable.tuning_is_enabled() and
-        not tunable.record_untuned_is_enabled()):
+    if (tunable.is_enabled() and tunable.tuning_is_enabled()
+            and not tunable.record_untuned_is_enabled()):
         tunable.write_file()
 
     logger.info("Worker exiting")


### PR DESCRIPTION
This PR is a bug fix for users that run TunableOp on multi-GPU vLLM workloads. This is mostly ROCm users.

Currently, TunableOp with worker processes enabled will only write the results for GPU 0 from the main process. Normally, the TunableOp results are flushed to the file system when the TunableOp C++ destructor is called. The worker processes appear to be destroyed before TunableOp destructor is called.  What users are experiencing is that the main process ends up with TunableOp results, while the other worker processes that are driving the other GPU end up with an empty TunableOp results file. We now force a flush of the TunableOp results before the worker processes are terminated.

cc: @hongxiayang 

