### PR TITLE
Add llmaz as another integration

### DIFF
--- a/docs/source/deployment/integrations/index.md
+++ b/docs/source/deployment/integrations/index.md
@@ -6,4 +6,5 @@
 kserve
 kubeai
 llamastack
+llmaz
 :::

--- a/docs/source/deployment/integrations/llmaz.md
+++ b/docs/source/deployment/integrations/llmaz.md
@@ -1,0 +1,7 @@
+(deployment-llmaz)=
+
+# llmaz
+
+[llmaz](https://github.com/InftyAI/llmaz) is an easy-to-use and advanced inference platform for large language models on Kubernetes, aimed for production use. It uses vLLM as the default model serving backend.
+
+Please refer to the [Quick Start](https://github.com/InftyAI/llmaz?tab=readme-ov-file#quick-start) for more details.


### PR DESCRIPTION

llmaz is an inference platform building on top of kubernetes, it uses vllm as the default inference backend, would like to introduce it as one integration of vllm project.

<!--- pyml disable-next-line no-emphasis-as-heading -->
