### PR TITLE
[Bugfix] Add `mm_processor_kwargs` to chat-related protocols

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -974,6 +974,10 @@ class EmbeddingChatRequest(OpenAIBaseModel):
         description=("Additional kwargs to pass to the template renderer. "
                      "Will be accessible by the chat template."),
     )
+    mm_processor_kwargs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=("Additional kwargs to pass to the HF processor."),
+    )
     priority: int = Field(
         default=0,
         description=(

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1398,6 +1398,10 @@ class TokenizeChatRequest(OpenAIBaseModel):
         description=("Additional kwargs to pass to the template renderer. "
                      "Will be accessible by the chat template."),
     )
+    mm_processor_kwargs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=("Additional kwargs to pass to the HF processor."),
+    )
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION
#13533 added a new `mm_processor_kwarg` field to `ChatCompletionRequest` but it should be added to all chat-related protocols with `messages: List[ChatCompletionMessageParam]`. This PR fixes this issue.