### PR TITLE
docs: Add a note on full CI run in contributing guide

### DIFF
--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -145,6 +145,9 @@ review process:
 - Please respond to all comments within a reasonable time frame. If a comment
   isn't clear or you disagree with a suggestion, feel free to ask for
   clarification or discuss the suggestion.
+- Note that not all CI checks will be executed due to limited computational
+  resources. The reviewer will add `ready` label to the PR when the PR is
+  ready to merge or a full CI run is needed.
 
 ## Thank You
 


### PR DESCRIPTION
This is based on my observation through the past PRs. Feel free to correct if I have missed anything or misunderstood the process.