### PR TITLE
Correction to TP logic for Mamba Mixer 2 when Num Groups not divisible by TP Size

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -133,7 +133,8 @@ def extra_groups_for_head_shards(ngroups: int, tp_size: int):
     if ngroups % tp_size == 0:
         return 0
 
-    return tp_size - ngroups % tp_size
+    # for n_groups == 1, this is exactly tp_size - n_groups
+    return tp_size - ngroups 
 
 
 def mamba_v2_sharded_weight_loader(
@@ -153,7 +154,7 @@ def mamba_v2_sharded_weight_loader(
         boundary, loaded_boundary = 0, 0
 
         # - iterate over the shard specs
-        for full_dim, extra, ratio in shard_spec:
+        for full_dim, extra, duplicate_groups in shard_spec:
             # - full dim is the model dim (before TP).
             # - extra > 0, means there is expected overall increase
             #   of dimensions. This is so because of replication.
@@ -167,7 +168,12 @@ def mamba_v2_sharded_weight_loader(
             # - compute the rank into the loaded shard.
             # - if there is replication, different TP shards will
             #   take from the same rank.
-            rank = tp_rank // ratio
+            if duplicate_groups:
+                # NOTE: currently we only support duplication
+                # in the case where num_groups == 1
+                rank = 0
+            else:
+                rank = tp_rank 
 
             # - leftmost boundary index into loaded weight.
             loaded_skip = rank * shard_size
@@ -233,11 +239,19 @@ class MambaMixer2(CustomOp):
         # - HOWEVER IF, world_size DOES NOT divide groups, then we need
         #   to allocate extra space in the shard, such that groups
         #   may be replicated to follow the head shard.
+        # - NOTE: currently for the world size DOES NOT divide groups
+        #   case, we only support the case when n_groups == 1
         self.tp_size = get_tensor_model_parallel_world_size()
         tp_rank = get_tensor_model_parallel_rank()
 
         assert num_heads % self.tp_size == 0, \
             "Tensor parallel world size must divide num heads."
+
+        assert (n_groups % self.tp_size) != 0 and n_groups == 0, \
+            (
+                "If tensor parallel world size does not divide num_heads, "
+                "then num_groups must equal 0."
+            )
 
         self.ssm_state_size = ssm_state_size
         self.activation = activation
@@ -284,11 +298,10 @@ class MambaMixer2(CustomOp):
             self.n_groups * self.ssm_state_size,  # expected model size
             (self.n_groups - n_groups) *
             self.ssm_state_size,  # extra dims assigned
-            self.num_heads //
-            n_groups,  # ratio for mapping back to original group
+            n_groups == 1,  # if there was only one group
         )
-        intermediate_settings = (intermediate_size, 0, 1)
-        head_setings = (self.num_heads, 0, 1)
+        intermediate_settings = (intermediate_size, 0, False)
+        head_setings = (self.num_heads, 0, False)
 
         # - the weight already has a "weight_loader" attribute
         #   which set_weight_attrs will raise if we do not

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -247,10 +247,11 @@ class MambaMixer2(CustomOp):
         assert num_heads % self.tp_size == 0, \
             "Tensor parallel world size must divide num heads."
 
-        assert (n_groups % self.tp_size) != 0 and n_groups == 0, \
+        
+        assert (n_groups % self.tp_size) == 0 or n_groups == 1, \
             (
                 "If tensor parallel world size does not divide num_heads, "
-                "then num_groups must equal 0."
+                "then num_groups must equal 1."
             )
 
         self.ssm_state_size = ssm_state_size


### PR DESCRIPTION
The current logic is incorrect for the case when `n_groups` ~cannot~ can  be divided by TP size, this requires more change to the kernels. This is because it currently uses this simple ratio [logic](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/mamba/ops/ssd_chunk_scan.py#L206) to map the head to the correct group. However, one can imagine in the more general case it is more complicated. 

For example, `n_groups=3`, `n_heads=15`, and `TP_size=5`, then in this case we end up with this kind of splitting of the heads (in the below, the numbers 0 - 2 represent which each of the 15 heads map to )

000 | 001 | 111 | 122 | 222

In this case, we will end up with a very heterogenous situation, were we need to 
- duplicate to at least 2 groups per shard,
- cannot rely on the ratio logic if we want to stay with 2 groups per shard.

Of course, if we duplicated groups to the extent that they equal heads, then its possible, but not sure if there is an more efficient method.

#### Current Strategy in this PR

For now, maybe its easier to patch it to specicially only support the following two special cases
1. If TP size divides `n_groups`, 
2. If TP_size does not divide `n_groups`, but `n_groups == 1`. 

These two scenarios support existing models such as Codestral, Bamba, Zamba, etc.., where `n_groups` are either 1 or some power of 2

cc: @tlrmchlsmth @yury-tokpanov