### PR TITLE
[Bugfix] Revert "Add port number range validation"

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -145,7 +145,7 @@ async def run_server(args: Namespace,
 if __name__ == "__main__":
     parser = FlexibleArgumentParser()
     parser.add_argument("--host", type=str, default=None)
-    parser.add_argument("--port", type=int, default=8000, ge=1024, le=65535)
+    parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)
     parser.add_argument("--ssl-certfile", type=str, default=None)
     parser.add_argument("--ssl-ca-certs",


### PR DESCRIPTION
Reverts vllm-project/vllm#13506

See https://github.com/vllm-project/vllm/pull/13506#issuecomment-2674187715. It's not available in older versions of Python.
