### PR TITLE
[Bugfix][API Server] Fix invalid usage of 'ge' and 'le' in port valid…

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -145,7 +145,7 @@ async def run_server(args: Namespace,
 if __name__ == "__main__":
     parser = FlexibleArgumentParser()
     parser.add_argument("--host", type=str, default=None)
-    parser.add_argument("--port", type=int, default=8000, ge=1024, le=65535)
+    parser.add_argument("--port", type=parser.check_port, default=8000)
     parser.add_argument("--ssl-keyfile", type=str, default=None)
     parser.add_argument("--ssl-certfile", type=str, default=None)
     parser.add_argument("--ssl-ca-certs",

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1194,6 +1194,17 @@ class FlexibleArgumentParser(argparse.ArgumentParser):
 
         return super().parse_args(processed_args, namespace)
 
+    def check_port(self, value):
+        try:
+            value = int(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError("Port must be an integer")
+
+        if not (1024 <= value <= 65535):
+            raise argparse.ArgumentTypeError("Port must be between 1024 and 65535")
+
+        return value
+
     def _pull_args_from_config(self, args: List[str]) -> List[str]:
         """Method to pull arguments specified in the config file
         into the command-line args variable.


### PR DESCRIPTION
 Fix invalid usage of 'ge' and 'le' in port validation in https://github.com/vllm-project/vllm/pull/13506 ,
which cause "TypeError: _StoreAction.__init__() got an unexpected keyword argument 'ge'".
