### PR TITLE
[V1][Minor] Use FakeAttentionMetadata for dummy run

### DIFF
--- a/vllm/v1/attention/backends/fake.py
+++ b/vllm/v1/attention/backends/fake.py
@@ -5,5 +5,5 @@ from dataclasses import dataclass
 @dataclass
 class FakeAttentionMetadata:
 
-    # For logging.
+    # Used for DP.
     num_input_tokens: int  # Number of tokens including padding.

--- a/vllm/v1/attention/backends/fake.py
+++ b/vllm/v1/attention/backends/fake.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+from dataclasses import dataclass
+
+
+@dataclass
+class FakeAttentionMetadata:
+
+    # For logging.
+    num_input_tokens: int  # Number of tokens including padding.

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -161,7 +161,7 @@ class FlashAttentionImpl(AttentionImpl):
         assert output is not None, "Output tensor must be provided."
 
         if isinstance(attn_metadata, FakeAttentionMetadata):
-            # Profiling run.
+            # Dummy run.
             return output
 
         # IMPORTANT!

--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -171,14 +171,14 @@ class PallasAttentionBackendImpl(AttentionImpl):
             kv_cache[0] = [num_kv_heads, num_blocks, block_size, head_size]
             kv_cache[1] = [num_kv_heads, num_blocks, block_size, head_size]
                 NOTE: kv_cache[0] and kv_cache[1] will be an empty tensor 
-                with shape [0] for profiling run.
+                with shape [0] for dummy run.
             attn_metadata: Metadata for attention.
         Returns:
             shape = [batch_size, seq_len, num_heads * head_size]
         """
 
         if isinstance(attn_metadata, FakeAttentionMetadata):
-            # Profiling run.
+            # Dummy run.
             if output is None:
                 output = torch.ones_like(query)
             return output

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Attention layer with PagedAttention on rocm"""
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
 
@@ -10,6 +10,7 @@ from vllm.attention.ops.paged_attn import PagedAttention
 from vllm.attention.ops.prefix_prefill import context_attention_fwd
 from vllm.logger import init_logger
 from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
+from vllm.v1.attention.backends.fake import FakeAttentionMetadata
 
 logger = init_logger(__name__)
 
@@ -103,7 +104,7 @@ class ROCmAttentionImpl(AttentionImpl):
         key: torch.Tensor,
         value: torch.Tensor,
         kv_cache: torch.Tensor,
-        attn_metadata: FlashAttentionMetadata,
+        attn_metadata: Union[FlashAttentionMetadata, FakeAttentionMetadata],
         output: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention.
@@ -119,7 +120,7 @@ class ROCmAttentionImpl(AttentionImpl):
         """
         assert output is not None, "Output tensor must be provided."
 
-        if attn_metadata is None:
+        if isinstance(attn_metadata, FakeAttentionMetadata):
             # Profiling run.
             return output
 

--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -121,7 +121,7 @@ class ROCmAttentionImpl(AttentionImpl):
         assert output is not None, "Output tensor must be provided."
 
         if isinstance(attn_metadata, FakeAttentionMetadata):
-            # Profiling run.
+            # Dummy run.
             return output
 
         assert attn_metadata.use_cascade is False

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -26,6 +26,7 @@ from vllm.utils import (STR_DTYPE_TO_TORCH_DTYPE, DeviceMemoryProfiler,
                         LayerBlockType, cdiv, is_pin_memory_available)
 from vllm.v1.attention.backends.flash_attn import (FlashAttentionBackend,
                                                    FlashAttentionMetadata)
+from vllm.v1.attention.backends.fake import FakeAttentionMetadata
 from vllm.v1.core.encoder_cache_manager import compute_encoder_budget
 from vllm.v1.engine.mm_input_cache import MMInputCacheClient
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -1164,7 +1165,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 for k, v in self.intermediate_tensors.items()
             })
 
-        with set_forward_context(None, self.vllm_config):
+        fake_metadata = FakeAttentionMetadata(num_input_tokens=num_tokens)
+        with set_forward_context(fake_metadata, self.vllm_config):
             hidden_states = model(
                 input_ids=input_ids,
                 positions=positions,


### PR DESCRIPTION
This PR introduces `FakeAttentionMetdata` which is used for dummy run (running the model with dummy inputs).
Dummy run is used for 1) initial memory profiling and 2) DP+EP execution.

Address the request in https://github.com/vllm-project/vllm/pull/13591#discussion_r1965978947