### PR TITLE
[Misc] Fix yapf linting tools etc not running on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,6 @@ repos:
   hooks:
   - id: actionlint
     exclude: 'vllm/third_party/.*'
-repos:
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.6.2
   hooks:


### PR DESCRIPTION

FIX yapf etc not triggered by pre-commit:
```
$ pre-commit run --show-diff-on-failure --color=always --hook-stage manual
pip-compile..........................................(no files to check)Skipped
Run mypy for Python 3.9..............................(no files to check)Skipped
Run mypy for Python 3.10.............................(no files to check)Skipped
Run mypy for Python 3.11.............................(no files to check)Skipped
Run mypy for Python 3.12.............................(no files to check)Skipped
Lint shell scripts...................................(no files to check)Skipped
Lint PNG exports from excalidraw.....................(no files to check)Skipped
Check SPDX headers...................................(no files to check)Skipped
Check for spaces in all filenames........................................Passed
Suggestion...........................................(no files to check)Skipped
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
