### PR TITLE
[BugFix] Minor: logger import in attention backend

### DIFF
--- a/vllm/attention/backends/utils.py
+++ b/vllm/attention/backends/utils.py
@@ -12,12 +12,12 @@ from vllm import envs
 from vllm.attention import (AttentionMetadata, AttentionMetadataBuilder,
                             AttentionState)
 from vllm.attention.backends.abstract import AttentionType
-from vllm.logger import logging
+from vllm.logger import init_logger
 from vllm.multimodal import MultiModalPlaceholderMap
 from vllm.platforms import current_platform
 from vllm.utils import async_tensor_h2d, make_tensor_with_pad
 
-logger = logging.getLogger(__name__)
+logger = init_logger(__name__)
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner_base import ModelRunnerBase


### PR DESCRIPTION
`vllm/attention/backends/utils.py` is not using the logger from `vllm.logger.init_logger`