### PR TITLE
[CI/CD] fix: test metric tag setting

### DIFF
--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -142,9 +142,10 @@ def test_metric_set_tag_model_name(vllm_runner, model: str, dtype: str,
         metrics_tag_content = stat_logger.labels["model_name"]
 
     if served_model_name is None or served_model_name == []:
-        assert metrics_tag_content == f"{MODEL_WEIGHTS_S3_BUCKET}/{model}", (
-            f"Metrics tag model_name is wrong! expect: {model!r}\n"
-            f"actual: {metrics_tag_content!r}")
+        assert (f"{MODEL_WEIGHTS_S3_BUCKET}/{metrics_tag_content}" ==
+                f"{MODEL_WEIGHTS_S3_BUCKET}/{model}"), (
+                    f"Metrics tag model_name is wrong! expect: {model!r}\n"
+                    f"actual: {metrics_tag_content!r}")
     else:
         assert metrics_tag_content == served_model_name[0], (
             f"Metrics tag model_name is wrong! expect: "


### PR DESCRIPTION
https://github.com/vllm-project/vllm/issues/13716
There are some test failures in test_metrics.py. This PR aims to fix these errors.

```
[2025-02-23T04:29:50Z] =========================== short test summary info ============================
--
  | [2025-02-23T04:29:50Z] FAILED metrics/test_metrics.py::test_metric_set_tag_model_name[None-float-distilbert/distilgpt2] - AssertionError: Metrics tag model_name is wrong! expect: 'distilbert/distilgpt2'
  | [2025-02-23T04:29:50Z]   actual: 'distilbert/distilgpt2'
  | [2025-02-23T04:29:50Z] assert 'distilbert/distilgpt2' == 's3://vllm-ci...rt/distilgpt2'
  | [2025-02-23T04:29:50Z]
  | [2025-02-23T04:29:50Z]   - s3://vllm-ci-model-weights/distilbert/distilgpt2
  | [2025-02-23T04:29:50Z]   + distilbert/distilgpt2
  | [2025-02-23T04:29:50Z] FAILED metrics/test_metrics.py::test_metric_set_tag_model_name[served_model_name1-float-distilbert/distilgpt2] - AssertionError: Metrics tag model_name is wrong! expect: 'distilbert/distilgpt2'
  | [2025-02-23T04:29:50Z]   actual: 'distilbert/distilgpt2'
  | [2025-02-23T04:29:50Z] assert 'distilbert/distilgpt2' == 's3://vllm-ci...rt/distilgpt2'
  | [2025-02-23T04:29:50Z]
  | [2025-02-23T04:29:50Z]   - s3://vllm-ci-model-weights/distilbert/distilgpt2
  | [2025-02-23T04:29:50Z]   + distilbert/distilgpt2
  | [2025-02-23T04:29:50Z] FAILED metrics/test_metrics.py::test_engine_log_metrics_regression[False-4-half-distilbert/distilgpt2] - AssertionError: Metrics should be collected
  | [2025-02-23T04:29:50Z] assert None == 8
  | [2025-02-23T04:29:50Z] =================== 3 failed, 17 passed in 527.27s (0:08:47) ===================
```
