### PR TITLE
[V1][Spec Decode] Change Spec Decode Rejection Sampling API

### DIFF
--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -29,7 +29,6 @@ def create_sampling_metadata(spec_tokens: List[List[int]]) -> SamplingMetadata:
         temperature=torch.tensor([]),
         all_greedy=True,
         all_random=False,
-        spec_token_ids=spec_tokens,
         top_p=None,
         top_k=None,
         min_p=torch.empty(batch_size, ),
@@ -55,7 +54,7 @@ def test_perfect_match(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 2, 3, 4]],
                             dtype=torch.int,
                             device=logits.device)
@@ -70,7 +69,7 @@ def test_early_mismatch(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 5, INVALID_TOKEN_ID, INVALID_TOKEN_ID]],
                             dtype=torch.int,
                             device=logits.device)
@@ -85,7 +84,7 @@ def test_multiple_sequences(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 2, 5], [3, 4, INVALID_TOKEN_ID]],
                             dtype=torch.int,
                             device=logits.device)
@@ -100,7 +99,7 @@ def test_single_token_sequence(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 2]], dtype=torch.int, device=logits.device)
     assert torch.equal(output.sampled_token_ids, expected)
 
@@ -113,7 +112,7 @@ def test_empty_sequence(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[5]], dtype=torch.int, device=logits.device)
     assert torch.equal(output.sampled_token_ids, expected)
 
@@ -126,7 +125,7 @@ def test_multiple_mismatches(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 2, 7, INVALID_TOKEN_ID],
                              [4, 8, INVALID_TOKEN_ID, INVALID_TOKEN_ID]],
                             dtype=torch.int,
@@ -147,7 +146,7 @@ def test_parametrized_cases(sampler, spec_tokens, output_tokens, expected):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected_tensor = torch.tensor(expected,
                                    dtype=torch.int,
                                    device=logits.device)
@@ -163,7 +162,7 @@ def test_logits_shape_handling(sampler):
     metadata = create_sampling_metadata(spec_tokens)
     logits = create_logits_tensor(output_tokens, vocab_size)
 
-    output = sampler(logits, metadata)
+    output = sampler(spec_tokens, logits, metadata)
     expected = torch.tensor([[1, 2, 3]], dtype=torch.int, device=logits.device)
     assert torch.equal(output.sampled_token_ids, expected)
     assert logits.shape[-1] == vocab_size

--- a/tests/v1/sample/test_sampler.py
+++ b/tests/v1/sample/test_sampler.py
@@ -105,7 +105,6 @@ def _create_default_sampling_metadata(
         prompt_token_ids=_create_prompt_tokens_tensor(prompt_token_ids,
                                                       vocab_size, device),
         output_token_ids=output_token_ids,
-        spec_token_ids=None,
         frequency_penalties=_create_penalty_tensor(batch_size, 0.0, device),
         presence_penalties=_create_penalty_tensor(batch_size, 0.0, device),
         repetition_penalties=_create_penalty_tensor(batch_size, 1.0, device),

--- a/tests/v1/worker/test_gpu_input_batch.py
+++ b/tests/v1/worker/test_gpu_input_batch.py
@@ -123,7 +123,6 @@ def _construct_expected_sampling_metadata(
                                           dtype=torch.float,
                                           device=device),
         output_token_ids=output_token_ids,
-        spec_token_ids=None,
         min_tokens=min_tokens,
         no_penalties=(all(x == 0 for x in presence_penalties)
                       and all(x == 0 for x in frequency_penalties)

--- a/vllm/v1/sample/metadata.py
+++ b/vllm/v1/sample/metadata.py
@@ -13,9 +13,6 @@ class SamplingMetadata:
     all_greedy: bool
     all_random: bool
 
-    # None when there are no speculated tokens.
-    spec_token_ids: Optional[List[List[int]]]
-
     top_p: Optional[torch.Tensor]
     top_k: Optional[torch.Tensor]
     min_p: Optional[torch.Tensor]

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -102,7 +102,7 @@ class RejectionSampler(nn.Module):
         target_probs = _create_greedy_token_probs(target_token_ids, vocab_size,
                                                   target_probs.device)
         uniform_samples = torch.zeros(draft_token_ids_tensor.size(0),
-                                      draft_token_ids_tensor.size(1),
+                                      draft_token_ids_tensor.size(1) + 1,
                                       device=target_probs.device)
 
         sampled_token_ids, _, _ = fs.chain_speculative_sampling(
@@ -129,6 +129,7 @@ class RejectionSampler(nn.Module):
         draft_token_ids_tensor = pad_sequence(draft_token_ids_tensor,
                                               batch_first=True,
                                               padding_value=INVALID_TOKEN_ID)
+        draft_token_ids_tensor = draft_token_ids_tensor.to(target_probs.device)
         # Add 1 to include the 'bonus' token.
         if sampling_metadata.all_greedy:
             output_token_ids = target_probs.argmax(dim=-1).view(-1)

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -123,10 +123,10 @@ class RejectionSampler(nn.Module):
     ) -> SamplerOutput:
         sample_lens = [len(x) + 1 for x in draft_token_ids]
         # Convert draft token IDs to a tensor, split by sample_lens, then pad.
-        draft_token_ids_tensor = [
+        draft_token_ids = [
             torch.tensor(x, dtype=int, device='cpu') for x in draft_token_ids
         ]
-        draft_token_ids_tensor = pad_sequence(draft_token_ids_tensor,
+        draft_token_ids_tensor = pad_sequence(draft_token_ids,
                                               batch_first=True,
                                               padding_value=INVALID_TOKEN_ID)
         draft_token_ids_tensor = draft_token_ids_tensor.to(target_probs.device)

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -9,7 +9,6 @@ from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.penalties import (apply_all_penalties,
                                           apply_min_token_penalties)
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
-from vllm.v1.sample.rejection_sampler import RejectionSampler
 
 _SAMPLING_EPS = 1e-5
 
@@ -19,7 +18,6 @@ class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
         self.topk_topp_sampler = TopKTopPSampler()
-        self.rejection_sampler = RejectionSampler()
 
     def forward(
         self,

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -121,7 +121,7 @@ class Sampler(nn.Module):
     def compute_probs(self, 
                       logits: torch.Tensor,
                       sampling_metadata: SamplingMetadata) -> torch.Tensor:
-        if sampling_metadata.all_random:
+        if sampling_metadata.all_greedy:
             return logits
         # Apply temperature.
         logits = self.apply_temperature(logits, sampling_metadata.temperature)

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -118,15 +118,14 @@ class Sampler(nn.Module):
         )
         return sampled
 
-    def compute_probs(self, 
-                      logits: torch.Tensor,
+    def compute_probs(self, logits: torch.Tensor,
                       sampling_metadata: SamplingMetadata) -> torch.Tensor:
         if sampling_metadata.all_greedy:
             return logits
         # Apply temperature.
         logits = self.apply_temperature(logits, sampling_metadata.temperature)
         return logits.softmax(dim=-1, dtype=torch.float32)
-    
+
     def compute_logprobs(self, logits: torch.Tensor) -> torch.Tensor:
         return logits.log_softmax(dim=-1, dtype=torch.float32)
 

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -120,7 +120,7 @@ class Sampler(nn.Module):
                       sampling_metadata: SamplingMetadata) -> torch.Tensor:
         if sampling_metadata.all_greedy:
             return logits
-        # Apply temperature.
+        # Apply temperature. This is an in-place op changing logits.
         logits = self.apply_temperature(logits, sampling_metadata.temperature)
         return logits.softmax(dim=-1, dtype=torch.float32)
 

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -497,16 +497,6 @@ class InputBatch:
             allowed_token_ids_mask=allowed_token_ids_mask,
         )
 
-    def get_sampling_metadata(
-        self,
-        req_id_to_spec_token_ids: Dict[str, List[int]],
-    ) -> SamplingMetadata:
-        # Set the new spec token ids in the cached sampling metadata.
-        self.sampling_metadata.spec_token_ids = [
-            req_id_to_spec_token_ids.get(req_id, []) for req_id in self.req_ids
-        ] if req_id_to_spec_token_ids else None
-        return self.sampling_metadata
-
     def _make_prompt_token_ids_tensor(self) -> torch.Tensor:
         max_prompt_len = self.num_prompt_tokens[:self.num_reqs].max()
         prompt_token_ids_cpu_tensor = torch.empty(

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -490,7 +490,6 @@ class InputBatch:
             presence_penalties=self.presence_penalties[:num_reqs],
             repetition_penalties=self.repetition_penalties[:num_reqs],
             output_token_ids=cast(List[List[int]], self.req_output_token_ids),
-            spec_token_ids=None,
             min_tokens=self.min_tokens,
             no_penalties=self.no_penalties,
             logit_bias=self.logit_bias[:num_reqs],

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -33,7 +33,6 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 from vllm.v1.outputs import LogprobsTensors, ModelRunnerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import INVALID_TOKEN_ID
-from vllm.v1.sample.sampler import SamplerOutput
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
@@ -961,7 +960,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 sampling_metadata=sampling_metadata,
             )
         else:
-            target_probs = self.model.sampler.compute_probs(logits, sampling_metadata)
+            target_probs = self.model.sampler.compute_probs(
+                logits, sampling_metadata)
             scheduled_request_ids = scheduler_output.num_scheduled_tokens.keys(
             )
             draft_token_ids = [

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -961,19 +961,15 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                 sampling_metadata=sampling_metadata,
             )
         else:
-            target_probs = self.model.sampler.compute_probs(logits)
+            target_probs = self.model.sampler.compute_probs(logits, sampling_metadata)
             scheduled_request_ids = scheduler_output.num_scheduled_tokens.keys(
             )
             draft_token_ids = [
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id, [])
                 for req_id in scheduled_request_ids
             ]
-            sampled_token_ids = self.model.sampler.rejection_sampler(
+            sampler_output = self.model.sampler.rejection_sampler(
                 draft_token_ids, target_probs, sampling_metadata)
-            sampler_output = SamplerOutput(
-                sampled_token_ids=sampled_token_ids,
-                logprobs_tensors=None,
-            )
 
         # TODO(woosuk): The following loop can be slow since it iterates over
         # the requests one by one. Optimize.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -37,6 +37,7 @@ from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
+from vllm.v1.sample.sampler import SamplerOutput
 
 if TYPE_CHECKING:
     from vllm.v1.core.scheduler_output import SchedulerOutput
@@ -953,12 +954,27 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         logits = self.model.compute_logits(sample_hidden_states, None)
 
         # Sample the next token and get logprobs if needed.
-        sampling_metadata = self.input_batch.get_sampling_metadata(
-            scheduler_output.scheduled_spec_decode_tokens)
-        sampler_output = self.model.sample(
-            logits=logits,
-            sampling_metadata=sampling_metadata,
-        )
+        sampling_metadata = self.input_batch.sampling_metadata
+        if not self.use_spec_decode:
+            sampler_output = self.model.sample(
+                logits=logits,
+                sampling_metadata=sampling_metadata,
+            )
+        else:
+            target_probs = self.model.sampler.compute_probs(logits)
+            scheduled_request_ids = num_scheduled_tokens.keys()
+            draft_token_ids = [scheduler_output.scheduled_spec_decode_tokens.get(req_id, [])
+                for req_id in scheduled_request_ids]
+            sampled_token_ids = self.model.sampler.rejection_sampler(
+                draft_token_ids,    
+                target_probs,
+                sampling_metadata
+            )
+            sampler_output = SamplerOutput(
+                sampled_token_ids=sampled_token_ids,
+                logprobs_tensors=None,
+            )
+            
 
         # TODO(woosuk): The following loop can be slow since it iterates over
         # the requests one by one. Optimize.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -33,11 +33,11 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 from vllm.v1.outputs import LogprobsTensors, ModelRunnerOutput
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import INVALID_TOKEN_ID
+from vllm.v1.sample.sampler import SamplerOutput
 from vllm.v1.spec_decode.ngram_proposer import NgramProposer
 from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.sample.sampler import SamplerOutput
 
 if TYPE_CHECKING:
     from vllm.v1.core.scheduler_output import SchedulerOutput
@@ -962,19 +962,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             )
         else:
             target_probs = self.model.sampler.compute_probs(logits)
-            scheduled_request_ids = num_scheduled_tokens.keys()
-            draft_token_ids = [scheduler_output.scheduled_spec_decode_tokens.get(req_id, [])
-                for req_id in scheduled_request_ids]
-            sampled_token_ids = self.model.sampler.rejection_sampler(
-                draft_token_ids,    
-                target_probs,
-                sampling_metadata
+            scheduled_request_ids = scheduler_output.num_scheduled_tokens.keys(
             )
+            draft_token_ids = [
+                scheduler_output.scheduled_spec_decode_tokens.get(req_id, [])
+                for req_id in scheduled_request_ids
+            ]
+            sampled_token_ids = self.model.sampler.rejection_sampler(
+                draft_token_ids, target_probs, sampling_metadata)
             sampler_output = SamplerOutput(
                 sampled_token_ids=sampled_token_ids,
                 logprobs_tensors=None,
             )
-            
 
         # TODO(woosuk): The following loop can be slow since it iterates over
         # the requests one by one. Optimize.
@@ -1329,7 +1328,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                     temperature=dummy_tensors(0.5),
                     all_greedy=False,
                     all_random=False,
-                    spec_token_ids=None,
                     top_p=dummy_tensors(0.9),
                     top_k=dummy_tensors(logits.size(1) - 1),
                     min_p=None,


### PR DESCRIPTION
This PR tries to change the API of rejection sampler of speculative decoding. This is the preliminary step to support random sampling.

Tasks outside the scope of this PR.
1. write `draft_token_ids` to persistent batch, which can avoid list operations to convert tensor.
2. implement random sampling [here](https://github.com/LiuXiaoxuanPKU/vllm/blob/18a18153e933e8f607a69a0f881d9998ff16389c/vllm/v1/sample/rejection_sampler.py#L146) and [here](https://github.com/LiuXiaoxuanPKU/vllm/blob/18a18153e933e8f607a69a0f881d9998ff16389c/vllm/v1/sample/rejection_sampler.py#L92). Rejection sampling guarantees that the output distribution with spec decode matches that without spec decode. The drafting method/distribution will not affect the correctness, but only affect the token acceptance rate.
