### PR TITLE
[Misc] Clean Up `EngineArgs.create_engine_config`

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1095,6 +1095,10 @@ class CacheConfig:
         return {key: str(value) for key, value in self.__dict__.items()}
 
     def _verify_args(self) -> None:
+        if self.cpu_offload_gb < 0:
+            raise ValueError("CPU offload space must be non-negative"
+                             f", but got {self.cpu_offload_gb}")
+
         if self.gpu_memory_utilization > 1.0:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "


### PR DESCRIPTION
SUMMARY:
* clean up `EngineArgs.create_engine_config` by moving misc methods into helper methods to improve code readibility

<!--- pyml disable-next-line no-emphasis-as-heading -->
