### PR TITLE
[Doc] Update python-json-logger URL to active repository

### DIFF
--- a/examples/other/logging_configuration.md
+++ b/examples/other/logging_configuration.md
@@ -49,7 +49,7 @@ disabled, an error will occur while starting vLLM.
 ### Example 1: Customize vLLM root logger
 
 For this example, we will customize the vLLM root logger to use
-[`python-json-logger`](https://github.com/madzak/python-json-logger) to log to
+[`python-json-logger`](https://github.com/nhairs/python-json-logger) to log to
 STDOUT of the console in JSON format with a log level of `INFO`.
 
 To begin, first, create an appropriate JSON logging configuration file:
@@ -65,7 +65,7 @@ To begin, first, create an appropriate JSON logging configuration file:
   },
   "handlers": {
     "console": {
-      "class" : "logging.StreamHandler",
+      "class": "logging.StreamHandler",
       "formatter": "json",
       "level": "INFO",
       "stream": "ext://sys.stdout"
@@ -122,7 +122,7 @@ configuration for the root vLLM logger and for the logger you wish to silence:
   },
   "handlers": {
     "vllm": {
-      "class" : "logging.StreamHandler",
+      "class": "logging.StreamHandler",
       "formatter": "vllm",
       "level": "INFO",
       "stream": "ext://sys.stdout"


### PR DESCRIPTION
### Summary
Updated the reference to `python-json-logger` from the archived repository (`madzak/python-json-logger`)
to the actively maintained repository (`nhairs/python-json-logger`).

### Changes
- Changed the repository URL from `https://github.com/madzak/python-json-logger` to `https://github.com/nhairs/python-json-logger`
- No functional changes were made. The example code still works as expected.

### Testing
- Verified that `pip install python-json-logger` correctly installs `nhairs/python-json-logger`.
- Confirmed that logging still functions correctly with `vllm serve`.

### Related Issues
None

Let me know if further changes are needed!
