### PR TITLE
[Bugfix] make every logger instance created by init_logger respect to VLLM_LOGGING_LEVEL 

### DIFF
--- a/vllm/logger.py
+++ b/vllm/logger.py
@@ -127,7 +127,7 @@ def init_logger(name: str) -> _VllmLogger:
     retrieved in such a way that we can be sure the root vllm logger has
     already been configured."""
 
-    logger = logging.getLogger(name)
+    logger = logging.getLogger(f"vllm.{name}")
 
     methods_to_patch = {
         "info_once": _print_info_once,


### PR DESCRIPTION
Although the default log output level of VLLM is set to `INFO`, VLLM does not print `INFO`-level logs from other modules. The reason is that the logger object created in the `init_logger` function inherits its log level from `logging.root`, and the default level for `logging.root` is `WARN`. Therefore, `init_logger` function is modified so that all loggers inherit log level from the `vllm` logger instead which is set via environment variable `VLLM_LOGGING_LEVEL` defaults to `INFO`. 