### PR TITLE
[Bugfix] Fix gptq_marlin for deepseek-v3

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -569,7 +569,9 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, "w13_scales", marlin_w13_scales)
         marlin_w2_scales = marlin_moe_permute_scales(
             s=layer.w2_scales,
-            size_k=layer.w2_scales.shape[1] * self.quant_config.pack_factor,
+            size_k=layer.w2_scales.shape[1] *
+            (self.quant_config.group_size if self.quant_config.group_size != -1
+             else self.quant_config.pack_factor),
             size_n=layer.w2_scales.shape[2],
             group_size=self.quant_config.group_size,
         )


### PR DESCRIPTION
This PR fixes the GPTQ Marlin implementation for DeepSeek-V3's FusedMoE.

Model:
https://huggingface.co/OPEA/DeepSeek-V3-int4-sym-gptq-inc

When running the model through sglang, we observed incorrect results. After a thorough investigation, we identified the following issues:

sglang invokes GPTQMarlinMoEMethod from vLLM for the FusedMoE module.

The shape of w2_scales in GPTQMarlinMoEMethod is [256, 2, 7168] (with TP = 8).

After adjusting size_k from `2*2` to `2*128`, the results became correct.

Additionally, when running this model directly through vLLM (which uses MoeWNA16Method for FusedMoE by default), the results are correct.

