### PR TITLE
Fix TPU tests in CI

### DIFF
--- a/.buildkite/run-tpu-test.sh
+++ b/.buildkite/run-tpu-test.sh
@@ -19,7 +19,7 @@ docker run --privileged --net host --shm-size=16G -it \
     vllm-tpu /bin/bash -c "python3 -m pip install git+https://github.com/thuml/depyf.git \
     && python3 -m pip install pytest \
     && python3 -m pip install lm_eval[api]==0.4.4 \
-    && pytest -v -s /workspace/vllm/tests/entrypoints/openai/test_accuracy.py \
+    && pytest -v -s /workspace/vllm/tests/entrypoints/openai/correctness/test_lmeval.py \
     && pytest -v -s /workspace/vllm/tests/tpu/test_custom_dispatcher.py \
     && python3 /workspace/vllm/tests/tpu/test_compilation.py \
     && python3 /workspace/vllm/tests/tpu/test_quantization_accuracy.py \

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuvm
+ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuvm"
 
 FROM $BASE_IMAGE
 WORKDIR /workspace/vllm

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -9,15 +9,11 @@ RUN apt-get update && apt-get install -y \
     git \
     ffmpeg libsm6 libxext6 libgl1
 
-# Install uv for faster pip installs
-RUN --mount=type=cache,target=/root/.cache/uv \
-    python3 -m pip install uv
-
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --system -r requirements-tpu.txt
+    python3 -m pip install -r requirements-tpu.txt
 
 # Build vLLM.
 COPY . .
@@ -29,6 +25,6 @@ ENV VLLM_TARGET_DEVICE="tpu"
 RUN python3 setup.py develop
 
 # install development dependencies (for testing)
-RUN uv pip install --system -e tests/vllm_test_utils
+RUN python3 -m pip install -e tests/vllm_test_utils
 
 CMD ["/bin/bash"]

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
+RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    grep -v -E "^torch(_xla)?\b" requirements-tpu.txt | \
-    python3 -m pip install -r /dev/stdin
+    python3 -m pip install -r requirements-filtered.txt
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -8,6 +8,12 @@ RUN apt-get update && apt-get install -y \
     git \
     ffmpeg libsm6 libxext6 libgl1
 
+# Install Python dependencies
+COPY requirements-common.txt requirements-common.txt
+COPY requirements-tpu.txt requirements-tpu.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install -r requirements-tpu.txt
+
 # Build vLLM.
 COPY . .
 ARG GIT_REPO_CHECK=0
@@ -15,10 +21,6 @@ RUN --mount=type=bind,source=.git,target=.git \
     if [ "$GIT_REPO_CHECK" != 0 ]; then bash tools/check_repo.sh; fi
 
 ENV VLLM_TARGET_DEVICE="tpu"
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,source=.git,target=.git \
-    python3 -m pip install \
-        -r requirements-tpu.txt
 RUN python3 setup.py develop
 
 # install development dependencies (for testing)

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,5 +1,5 @@
 ARG NIGHTLY_DATE="20250224"
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"
+ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_cxx11_$NIGHTLY_DATE"
 
 FROM $BASE_IMAGE
 WORKDIR /workspace/vllm

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuvm"
+ARG NIGHTLY_DATE="20250224"
+ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"
 
 FROM $BASE_IMAGE
 WORKDIR /workspace/vllm

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,8 +12,9 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
-RUN --mount=type=cache,target=/root/.cache/uv \
-    python3 -m pip install -r requirements-tpu.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    grep -v -E "^torch(_xla)?\b" requirements-tpu.txt | \
+    python3 -m pip install -r /dev/stdin
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,12 +12,8 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
-# Filter out torch and torch_xla to use versions that came with image
-# RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
-# Image does not come with pallas dependencies so we must add them manually 
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements-tpu.txt
-    # jax==0.5.1.dev20250210 jaxlib==0.5.1.dev20250210
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -16,7 +16,7 @@ COPY requirements-tpu.txt requirements-tpu.txt
 RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
 # Image does not come with pallas dependencies so we must add them manually 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-filtered.txt jax==0.5.1.dev20250210 jaxlib
+    python3 -m pip install -r requirements-filtered.txt jax==0.5.1.dev20250210 jaxlib==0.5.1.dev20250210
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,9 +12,11 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
+# Filter out torch and torch_xla to use versions that came with image
 RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
+# Image does not come with pallas dependencies so we must add them manually 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-filtered.txt jax jaxlib
+    python3 -m pip install -r requirements-filtered.txt jax==0.5.1.dev20250210 jaxlib
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
-RUN grep -v -E "^torch\b" requirements-tpu.txt > requirements-filtered.txt
+RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements-filtered.txt
 

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -13,10 +13,11 @@ RUN apt-get update && apt-get install -y \
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
 # Filter out torch and torch_xla to use versions that came with image
-RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
+# RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
 # Image does not come with pallas dependencies so we must add them manually 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-filtered.txt jax==0.5.1.dev20250210 jaxlib==0.5.1.dev20250210
+    python3 -m pip install -r requirements-tpu.txt
+    # jax==0.5.1.dev20250210 jaxlib==0.5.1.dev20250210
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
-RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
+RUN grep -v -E "^torch\b" requirements-tpu.txt > requirements-filtered.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
     python3 -m pip install -r requirements-filtered.txt
 

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -1,5 +1,4 @@
-ARG NIGHTLY_DATE="20250124"
-ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:nightly_3.10_tpuvm_$NIGHTLY_DATE"
+ARG BASE_IMAGE="us-central1-docker.pkg.dev/tpu-pytorch-releases/docker/xla:r2.6.0_3.10_tpuvm
 
 FROM $BASE_IMAGE
 WORKDIR /workspace/vllm

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -14,7 +14,7 @@ COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
 RUN grep -v -E "^torch(_xla)?\b" requirements-tpu.txt > requirements-filtered.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-filtered.txt
+    python3 -m pip install -r requirements-filtered.txt jax jaxlib
 
 # Build vLLM.
 COPY . .

--- a/Dockerfile.tpu
+++ b/Dockerfile.tpu
@@ -8,11 +8,15 @@ RUN apt-get update && apt-get install -y \
     git \
     ffmpeg libsm6 libxext6 libgl1
 
+# Install uv for faster pip installs
+RUN --mount=type=cache,target=/root/.cache/uv \
+    python3 -m pip install uv
+
 # Install Python dependencies
 COPY requirements-common.txt requirements-common.txt
 COPY requirements-tpu.txt requirements-tpu.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install -r requirements-tpu.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system -r requirements-tpu.txt
 
 # Build vLLM.
 COPY . .
@@ -24,6 +28,6 @@ ENV VLLM_TARGET_DEVICE="tpu"
 RUN python3 setup.py develop
 
 # install development dependencies (for testing)
-RUN python3 -m pip install -e tests/vllm_test_utils
+RUN uv pip install --system -e tests/vllm_test_utils
 
 CMD ["/bin/bash"]

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -19,6 +19,4 @@ ray[default]
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.7.0.dev20250224+cpu
 torchvision==0.22.0.dev20250224+cpu
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch_xla[tpu, pallas]  # Install whichever version is compatible with torch

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -17,7 +17,7 @@ ray[default]
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.6.0.dev20241216+cpu
+torch==2.7.0.dev20250124+cpu
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -11,12 +11,11 @@ jinja2
 ray[default]
 
 # Install torch_xla
---pre
---extra-index-url https://download.pytorch.org/whl/nightly/cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://storage.googleapis.com/libtpu-wheels/index.html
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.6.0
-torchvision==0.21.0
-torch_xla[tpu, pallas]==2.6.0
+torchvision  # Install whichever version is compatible with torch
+torch_xla[tpu, pallas]  # Install whichever version is compatible with torch

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -11,11 +11,12 @@ jinja2
 ray[default]
 
 # Install torch_xla
---extra-index-url https://download.pytorch.org/whl/cpu
+--pre
+--extra-index-url https://download.pytorch.org/whl/nightly/cpu
 --find-links https://storage.googleapis.com/libtpu-wheels/index.html
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.6.0
+torch==2.7.0.dev20250224+cpu
 torchvision  # Install whichever version is compatible with torch
 torch_xla[tpu, pallas]  # Install whichever version is compatible with torch

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -19,6 +19,4 @@ ray[default]
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.6.0+cpu
 torchvision==0.21.0+cpu
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch_xla[tpu, pallas]==2.6.0

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -18,5 +18,5 @@ ray[default]
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.7.0.dev20250224+cpu
-torchvision  # Install whichever version is compatible with torch
+torchvision==0.22.0.dev20250224+cpu
 torch_xla[tpu, pallas]  # Install whichever version is compatible with torch

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -17,8 +17,8 @@ ray[default]
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.7.0.dev20250124+cpu
-torchvision==0.22.0.dev20250124+cpu
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch==2.6.0+cpu
+torchvision==0.21.0+cpu
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.6.0-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -18,6 +18,7 @@ ray[default]
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.7.0.dev20250124+cpu
+torchvision==0.22.0.dev20250124+cpu
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -17,6 +17,6 @@ ray[default]
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.6.0+cpu
-torchvision==0.21.0+cpu
+torch==2.6.0
+torchvision==0.21.0
 torch_xla[tpu, pallas]==2.6.0

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -19,4 +19,6 @@ ray[default]
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
 torch==2.7.0.dev20250224+cpu
 torchvision==0.22.0.dev20250224+cpu
-torch_xla[tpu, pallas]  # Install whichever version is compatible with torch
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250224-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"


### PR DESCRIPTION
Attempts to fix https://github.com/vllm-project/vllm/pull/12453#issuecomment-2672607801:
- Update nightly `torch` and `torch_xla`
- Update nightly image (use `cxx11` now that it's using torch 2.7.0)
- Add `torchvision` as a requirement because build fails otherwise
- Update path to test file that was moved while TPU CI was broken
