### PR TITLE
[Core] xgrammar: Expand list of unsupported jsonschema keywords

### DIFF
--- a/vllm/model_executor/guided_decoding/utils.py
+++ b/vllm/model_executor/guided_decoding/utils.py
@@ -33,6 +33,18 @@ def has_xgrammar_unsupported_json_features(schema: dict) -> bool:
         ]):
             return True
 
+        # Unsupported keywords for strings
+        if obj.get("type") == "string" and any(
+                key in obj for key in ["minLength", "maxLength", "format"]):
+            return True
+
+        # Unsupported keywords for objects
+        if obj.get("type") == "object" and any(key in obj for key in [
+                "minProperties", "maxProperties", "propertyNames",
+                "patternProperties"
+        ]):
+            return True
+
         # Recursively check all nested objects and arrays
         for value in obj.values():
             if isinstance(value, dict):


### PR DESCRIPTION
While doing some testing with xgrammar, I ran into an supported
attribute for a string type. I checked the code and found some things
we weren't checking for.

Details can be found by searching for `warnUnsupportedKeywords` in
this file:

https://github.com/mlc-ai/xgrammar/blob/main/cpp/json_schema_converter.cc

Signed-off-by: Russell Bryant <rbryant@redhat.com>
