### PR TITLE
[bugfix] Fix dummy_sampler_run for PP

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -14,6 +14,7 @@ from vllm.device_allocator.cumem import CuMemAllocator
 from vllm.distributed import (ensure_model_parallel_initialized,
                               init_distributed_environment,
                               set_custom_all_reduce)
+from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor import set_random_seed
@@ -211,6 +212,17 @@ class Worker(WorkerBase):
             self.model_runner._dummy_run(size)
         if not self.model_config.enforce_eager:
             self.model_runner.capture_model()
+
+        if get_pp_group().is_last_rank:
+            # Warm up sampler and preallocate memory buffer for logits and other
+            # sampling related tensors of max possible shape to avoid memory
+            # fragmentation issue.
+            # NOTE: This is called after `capture_model` on purpose to prevent
+            # memory buffers from being cleared by `torch.cuda.empty_cache`.
+            self.model_runner._dummy_sampler_run(
+                hidden_states=self.model_runner._dummy_run(
+                    num_tokens=self.scheduler_config.max_num_seqs))
+
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
Fix dummy_sampler_run for PP > 1: Sampler should only run for last PP rank

FIX the following exception when running:
`VLLM_USE_RAY_COMPILED_DAG=1 VLLM_USE_RAY_COMPILED_DAG_NCCL_CHANNEL=1 VLLM_USE_V1="1" vllm serve meta-llama/Llama-3.2-1B-Instruct   --distributed-executor-backend "ray"    --pipeline-parallel-size 2 --enforce-eager`

```
ERROR 02-24 22:39:09 [core.py:294] EngineCore hit an exception: Traceback (most recent call last):
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/engine/core.py", line 286, in run_engine_core
ERROR 02-24 22:39:09 [core.py:294]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/engine/core.py", line 241, in __init__
ERROR 02-24 22:39:09 [core.py:294]     super().__init__(vllm_config, executor_class, log_stats)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/engine/core.py", line 59, in __init__
ERROR 02-24 22:39:09 [core.py:294]     num_gpu_blocks, num_cpu_blocks = self._initialize_kv_caches(
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/engine/core.py", line 113, in _initialize_kv_caches
ERROR 02-24 22:39:09 [core.py:294]     self.model_executor.initialize_from_config(kv_cache_configs)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/executor/abstract.py", line 63, in initialize_from_config
ERROR 02-24 22:39:09 [core.py:294]     self.collective_rpc("compile_or_warm_up_model")
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/executor/executor_base.py", line 316, in collective_rpc
ERROR 02-24 22:39:09 [core.py:294]     return self._run_workers(method, *args, **(kwargs or {}))
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/executor/ray_distributed_executor.py", line 485, in _run_workers
ERROR 02-24 22:39:09 [core.py:294]     ray_worker_outputs = ray.get(ray_worker_outputs)
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
ERROR 02-24 22:39:09 [core.py:294]     return fn(*args, **kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
ERROR 02-24 22:39:09 [core.py:294]     return func(*args, **kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/ray/_private/worker.py", line 2755, in get
ERROR 02-24 22:39:09 [core.py:294]     values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/ray/_private/worker.py", line 906, in get_objects
ERROR 02-24 22:39:09 [core.py:294]     raise value.as_instanceof_cause()
ERROR 02-24 22:39:09 [core.py:294] ray.exceptions.RayTaskError(AttributeError): ray::RayWorkerWrapper.execute_method() (pid=1743995, ip=172.31.15.128, actor_id=c6ea8fd3a46be69aefdd379e01000000, repr=<vllm.executor.ray_utils.RayWorkerWrapper object at 0x7fc9b3b802b0>)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/worker/worker_base.py", line 594, in execute_method
ERROR 02-24 22:39:09 [core.py:294]     raise e
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/worker/worker_base.py", line 585, in execute_method
ERROR 02-24 22:39:09 [core.py:294]     return run_method(self, method, args, kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/utils.py", line 2232, in run_method
ERROR 02-24 22:39:09 [core.py:294]     return func(*args, **kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/worker/gpu_worker.py", line 220, in compile_or_warm_up_model
ERROR 02-24 22:39:09 [core.py:294]     self.model_runner._dummy_sampler_run(
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 02-24 22:39:09 [core.py:294]     return func(*args, **kwargs)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/v1/worker/gpu_model_runner.py", line 1188, in _dummy_sampler_run
ERROR 02-24 22:39:09 [core.py:294]     logits = self.model.compute_logits(hidden_states, None)
ERROR 02-24 22:39:09 [core.py:294]   File "/home/ubuntu/vllm/vllm/model_executor/models/llama.py", line 553, in compute_logits
ERROR 02-24 22:39:09 [core.py:294]     logits = self.logits_processor(self.lm_head, hidden_states,
ERROR 02-24 22:39:09 [core.py:294]   File "/opt/conda/envs/vllm-env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1931, in __getattr__
ERROR 02-24 22:39:09 [core.py:294]     raise AttributeError(
ERROR 02-24 22:39:09 [core.py:294] AttributeError: 'LlamaForCausalLM' object has no attribute 'logits_processor'
```

<!--- pyml disable-next-line no-emphasis-as-heading -->

cc: @comaniac @ywang96 @WoosukKwon 