### PR TITLE
[CI] Fix model path in runai streamer

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1067,8 +1067,7 @@ class EngineArgs:
             self.quantization = self.load_format = "gguf"
 
         # NOTE: This is to allow model loading from S3 in CI
-        if (not isinstance(self, AsyncEngineArgs) and envs.VLLM_CI_USE_S3
-                and self.model in MODELS_ON_S3
+        if (envs.VLLM_CI_USE_S3 and self.model in MODELS_ON_S3
                 and self.load_format == LoadFormat.AUTO):  # noqa: E501
             self.model = f"{MODEL_WEIGHTS_S3_BUCKET}/{self.model}"
             self.load_format = LoadFormat.RUNAI_STREAMER

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -1370,7 +1370,10 @@ class RunaiModelStreamerLoader(BaseModelLoader):
 
     def download_model(self, model_config: ModelConfig) -> None:
         """Download model if necessary"""
-        self._prepare_weights(model_config.model, model_config.revision)
+        model_weights = model_config.model
+        if hasattr(model_config, "model_weights"):
+            model_weights = model_config.model_weights
+        self._prepare_weights(model_weights, model_config.revision)
 
     def load_model(self, vllm_config: VllmConfig) -> nn.Module:
         """Perform streaming of the model to destination"""


### PR DESCRIPTION
- If model path is S3, model name gets converted to a temp dir which doesn't work with `download_model` in RunAI Loader because there's no weight file found when searching in a temp_dir
- This PR is to use `model_weights` attribute in the model config instead so the model name that gets sent into `_prepare_weights` is a valid S3 path instead of a temp dir, which is similar to how `load_model` works.
This would allow `download_model` to work properly and allow S3 model loading when `RemoteOpenAI` server is used