### PR TITLE
add num_concurrency_requests metric to track concurrent requests running/waiting

### DIFF
--- a/examples/online_serving/prometheus_grafana/grafana.json
+++ b/examples/online_serving/prometheus_grafana/grafana.json
@@ -610,6 +610,22 @@
           "range": true,
           "refId": "C",
           "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "vllm:num_concurrency_requests{model_name=\"$model_name\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "Total Num",
+          "range": true,
+          "refId": "D",
+          "useBackend": false
         }
       ],
       "title": "Scheduler State",

--- a/tests/entrypoints/openai/test_metrics.py
+++ b/tests/entrypoints/openai/test_metrics.py
@@ -166,6 +166,7 @@ async def test_metrics_counts(server: RemoteOpenAIServer,
 EXPECTED_METRICS = [
     "vllm:num_requests_running",
     "vllm:num_requests_swapped",
+    "vllm:num_concurrency_requests",
     "vllm:num_requests_waiting",
     "vllm:gpu_cache_usage_perc",
     "vllm:cpu_cache_usage_perc",
@@ -223,6 +224,7 @@ EXPECTED_METRICS = [
 
 EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
+    "vllm:num_concurrency_requests",
     "vllm:num_requests_waiting",
     "vllm:gpu_cache_usage_perc",
     "vllm:gpu_prefix_cache_queries",

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -218,3 +218,8 @@ class LoRARequestStates:
             if stats.running_requests:
                 iteration_stats.running_lora_adapters[lora_name] = \
                     len(stats.running_requests)
+
+
+@dataclass
+class SystemStats:
+    concurrent_requests: int = 0


### PR DESCRIPTION
Add "vllm:num_requests_total" Metric for Scheduler State, which combines the total from "vllm:num_requests_running" and "vllm:num_requests_waiting" into a single metric.

This PR introduces a new metric, vllm:num_requests_total, which tracks the total number of requests running or waiting in the scheduler. This metric provides a more comprehensive view of the scheduler's state and helps with monitoring and debugging.
