### PR TITLE
[Doc]: fix overlap of compatibility matrix headers

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,8 +1,11 @@
 .vertical-table-header th.head:not(.stub) {
     writing-mode: sideways-lr;
     white-space: nowrap;
-    max-width: 0;
     p {
        margin: 0;
     }
+}
+
+.vertical-table-header th abbr {
+    white-space: nowrap;
 }


### PR DESCRIPTION
Fix the overlap of headers of Compatibility Matrix, refer to https://docs.vllm.ai/en/latest/features/compatibility_matrix.html.
I'm not quite sure what the purpose of setting max-width to 0 was previously. But the page display problem does exist.

https://github.com/vllm-project/vllm/issues/13749

<!--- pyml disable-next-line no-emphasis-as-heading -->
