### PR TITLE
[Bugfix] Fix deepseek-v2 error: "missing 1 required positional argument: 'residual'"

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -614,7 +614,7 @@ class DeepseekV2Model(nn.Module):
             residual = intermediate_tensors["residual"]
 
         for layer in self.layers[self.start_layer:self.end_layer]:
-            hidden_states, residual = layer(positions, hidden_states)
+            hidden_states, residual = layer(positions, hidden_states, residual)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({


### PR DESCRIPTION
Fix: 
```
[rank0]: TypeError: DeepseekV2DecoderLayer.forward() missing 1 required positional argument: 'residual'
```
Introduced by: https://github.com/vllm-project/vllm/pull/13555