### PR TITLE
[Bugfix] Modify modelscope api usage in transformer_utils

### DIFF
--- a/vllm/transformers_utils/utils.py
+++ b/vllm/transformers_utils/utils.py
@@ -29,9 +29,8 @@ def modelscope_list_repo_files(
 ) -> List[str]:
     """List files in a modelscope repo."""
     from modelscope.hub.api import HubApi
-    from modelscope.utils.hf_util import _try_login
-    _try_login(token)
     api = HubApi()
+    api.login(token)
     # same as huggingface_hub.list_repo_files
     files = [
         file['Path'] for file in api.get_model_files(


### PR DESCRIPTION
# What this PR does?

Modify modelscope api usage in `transformer_utils`.

Find more details at this [issue](https://github.com/modelscope/modelscope/issues/1240) in modelscope.

This `_try_login()` has been removed, now you just need code below:

```python
from modelscope.hub.api import HubApi
api = HubApi()
api.login(token)
```

If token is None, this method will not throw, if token is not correct, this method will throw an error.

This is easier to use.
