### PR TITLE
Fix `/v1/audio/transcriptions ` Bad Request Error

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -9,8 +9,7 @@ py-cpuinfo
 transformers >= 4.48.2  # Required for Bamba model and Transformers backend.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
-fastapi[standard] >= 0.107.0, < 0.113.0; python_version < '3.9'
-fastapi[standard]  >= 0.107.0, != 0.113.*, != 0.114.0; python_version >= '3.9'
+fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.
 aiohttp
 openai >= 1.52.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)
 pydantic >= 2.9

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from typing import Annotated, AsyncIterator, Dict, Optional, Set, Tuple, Union
 
 import uvloop
-from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -530,9 +530,10 @@ async def create_score_v1(request: ScoreRequest, raw_request: Request):
 
 @router.post("/v1/audio/transcriptions")
 @with_cancellation
-async def create_transcriptions(request: Annotated[TranscriptionRequest,
-                                                   Form()],
-                                raw_request: Request):
+async def create_transcriptions(
+        request: Annotated[TranscriptionRequest,
+                           Depends(TranscriptionRequest.from_form_data)],
+        raw_request: Request):
 
     handler = transcription(raw_request)
     if handler is None:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -19,7 +19,7 @@ from http import HTTPStatus
 from typing import Annotated, AsyncIterator, Dict, Optional, Set, Tuple, Union
 
 import uvloop
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
+from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -530,10 +530,9 @@ async def create_score_v1(request: ScoreRequest, raw_request: Request):
 
 @router.post("/v1/audio/transcriptions")
 @with_cancellation
-async def create_transcriptions(
-        request: Annotated[TranscriptionRequest,
-                           Depends(TranscriptionRequest.from_form_data)],
-        raw_request: Request):
+async def create_transcriptions(request: Annotated[TranscriptionRequest,
+                                                   Form()],
+                                raw_request: Request):
 
     handler = transcription(raw_request)
     if handler is None:

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1456,7 +1456,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
     """
 
-    model: Optional[str] = None
+    model: str
     """ID of the model to use.
     """
 
@@ -1468,7 +1468,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     will improve accuracy and latency.
     """
 
-    prompt: str = Field(default="")
+    prompt: Optional[str] = Field(default="")
     """An optional text to guide the model's style or continue a previous audio
     segment.
 
@@ -1476,14 +1476,14 @@ class TranscriptionRequest(OpenAIBaseModel):
     should match the audio language.
     """
 
-    response_format: AudioResponseFormat = Field(default="json")
+    response_format: Optional[AudioResponseFormat] = Field(default="json")
     """
     The format of the output, in one of these options: `json`, `text`, `srt`,
     `verbose_json`, or `vtt`.
     """
 
     ## TODO (varun) : Support if set to 0, certain thresholds are met !!
-    temperature: float = Field(default=0.0)
+    temperature: Optional[float] = Field(default=0.0)
     """The sampling temperature, between 0 and 1.
 
     Higher values like 0.8 will make the output more random, while lower values
@@ -1492,8 +1492,9 @@ class TranscriptionRequest(OpenAIBaseModel):
     to automatically increase the temperature until certain thresholds are hit.
     """
 
-    timestamp_granularities: List[Literal["word", "segment"]] = Field(
-        alias="timestamp_granularities[]", default=[])
+    timestamp_granularities: Optional[List[Literal[
+        "word", "segment"]]] = Field(alias="timestamp_granularities[]",
+                                     default=["segment"])
     """The timestamp granularities to populate for this transcription.
 
     `response_format` must be set `verbose_json` to use timestamp granularities.
@@ -1511,17 +1512,18 @@ class TranscriptionRequest(OpenAIBaseModel):
     def from_form_data(
         cls,
         file: UploadFile,
-        model: Annotated[Optional[str], Form()] = None,
+        model: Annotated[str, Form()],
         language: Annotated[Optional[str], Form()] = None,
-        prompt: Annotated[str, Form()] = "",
-        response_format: Annotated[AudioResponseFormat,
+        prompt: Annotated[Optional[str], Form()] = "",
+        response_format: Annotated[Optional[AudioResponseFormat],
                                    Form()] = "json",
-        temperature: Annotated[float, Form()] = 0.0,
-        timestamp_granularities: Annotated[List[Literal["word", "segment"]],
+        temperature: Annotated[Optional[float], Form()] = 0.0,
+        timestamp_granularities: Annotated[Optional[List[Literal["word",
+                                                                 "segment"]]],
                                            Form()] = None
     ) -> "TranscriptionRequest":
         if timestamp_granularities is None:
-            timestamp_granularities = []
+            timestamp_granularities = ["segment"]
         return cls(file=file,
                    model=model,
                    language=language,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -8,7 +8,7 @@ from argparse import Namespace
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Union
 
 import torch
-from fastapi import UploadFile
+from fastapi import Form, UploadFile
 from pydantic import (BaseModel, ConfigDict, Field, TypeAdapter,
                       ValidationInfo, field_validator, model_validator)
 from typing_extensions import Annotated, TypeAlias
@@ -1448,7 +1448,7 @@ AudioResponseFormat: TypeAlias = Literal["json", "text", "srt", "verbose_json",
 
 class TranscriptionRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
-    #https://platform.openai.com/docs/api-reference/audio/createTranscription
+    # https://platform.openai.com/docs/api-reference/audio/createTranscription
 
     file: UploadFile
     """
@@ -1506,6 +1506,29 @@ class TranscriptionRequest(OpenAIBaseModel):
     _DEFAULT_SAMPLING_PARAMS: dict = {
         "temperature": 0,
     }
+
+    @classmethod
+    def from_form_data(
+        cls,
+        file: UploadFile,
+        model: Annotated[Optional[str], Form()] = None,
+        language: Annotated[Optional[str], Form()] = None,
+        prompt: Annotated[str, Form()] = "",
+        response_format: Annotated[AudioResponseFormat,
+                                   Form()] = "json",
+        temperature: Annotated[float, Form()] = 0.0,
+        timestamp_granularities: Annotated[List[Literal["word", "segment"]],
+                                           Form()] = None
+    ) -> "TranscriptionRequest":
+        if timestamp_granularities is None:
+            timestamp_granularities = []
+        return cls(file=file,
+                   model=model,
+                   language=language,
+                   prompt=prompt,
+                   response_format=response_format,
+                   temperature=temperature,
+                   timestamp_granularities=timestamp_granularities)
 
     def to_sampling_params(
             self,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1456,7 +1456,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
     """
 
-    model: str
+    model: Optional[str] = None
     """ID of the model to use.
     """
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -8,7 +8,7 @@ from argparse import Namespace
 from typing import Any, ClassVar, Dict, List, Literal, Optional, Set, Union
 
 import torch
-from fastapi import Form, UploadFile
+from fastapi import UploadFile
 from pydantic import (BaseModel, ConfigDict, Field, TypeAdapter,
                       ValidationInfo, field_validator, model_validator)
 from typing_extensions import Annotated, TypeAlias
@@ -1507,30 +1507,6 @@ class TranscriptionRequest(OpenAIBaseModel):
     _DEFAULT_SAMPLING_PARAMS: dict = {
         "temperature": 0,
     }
-
-    @classmethod
-    def from_form_data(
-        cls,
-        file: UploadFile,
-        model: Annotated[str, Form()],
-        language: Annotated[Optional[str], Form()] = None,
-        prompt: Annotated[Optional[str], Form()] = "",
-        response_format: Annotated[Optional[AudioResponseFormat],
-                                   Form()] = "json",
-        temperature: Annotated[Optional[float], Form()] = 0.0,
-        timestamp_granularities: Annotated[Optional[List[Literal["word",
-                                                                 "segment"]]],
-                                           Form()] = None
-    ) -> "TranscriptionRequest":
-        if timestamp_granularities is None:
-            timestamp_granularities = ["segment"]
-        return cls(file=file,
-                   model=model,
-                   language=language,
-                   prompt=prompt,
-                   response_format=response_format,
-                   temperature=temperature,
-                   timestamp_granularities=timestamp_granularities)
 
     def to_sampling_params(
             self,

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1468,7 +1468,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     will improve accuracy and latency.
     """
 
-    prompt: Optional[str] = Field(default="")
+    prompt: str = Field(default="")
     """An optional text to guide the model's style or continue a previous audio
     segment.
 
@@ -1476,14 +1476,14 @@ class TranscriptionRequest(OpenAIBaseModel):
     should match the audio language.
     """
 
-    response_format: Optional[AudioResponseFormat] = Field(default="json")
+    response_format: AudioResponseFormat = Field(default="json")
     """
     The format of the output, in one of these options: `json`, `text`, `srt`,
     `verbose_json`, or `vtt`.
     """
 
     ## TODO (varun) : Support if set to 0, certain thresholds are met !!
-    temperature: Optional[float] = Field(default=0.0)
+    temperature: float = Field(default=0.0)
     """The sampling temperature, between 0 and 1.
 
     Higher values like 0.8 will make the output more random, while lower values
@@ -1492,9 +1492,8 @@ class TranscriptionRequest(OpenAIBaseModel):
     to automatically increase the temperature until certain thresholds are hit.
     """
 
-    timestamp_granularities: Optional[List[Literal[
-        "word", "segment"]]] = Field(alias="timestamp_granularities[]",
-                                     default=["segment"])
+    timestamp_granularities: List[Literal["word", "segment"]] = Field(
+        alias="timestamp_granularities[]", default=[])
     """The timestamp granularities to populate for this transcription.
 
     `response_format` must be set `verbose_json` to use timestamp granularities.


### PR DESCRIPTION
As mentioned in [#13757](https://github.com/vllm-project/vllm/issues/13757), when creating a request to the audio transcription endpoint, a 400 error occurs.

I found that the previous code used FastAPI’s Form Models feature, which has been supported since FastAPI version 0.113.0. However, the version of FastAPI specified in requirements.txt is: https://github.com/vllm-project/vllm/blob/18e505930d789a2ad57c8a048ff7d84c025530bd/requirements-common.txt#L12-L13

Therefore, when the server uses an older version of FastAPI, the code breaks and returns a 400 error.

The easiest solution would be to update the FastAPI version. However, I noticed that Python 3.8 is still in use, and we have locked the FastAPI version. I’m unsure if there are any considerations around this, so I opted for a more complex solution instead to keep the compatibility with older versions.
