### PR TITLE
Fix string parsing error

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -272,7 +272,7 @@ def get_config(
                 "   - For Hugging Face models: ensure the presence of a "
                 "'config.json'.\n"
                 "   - For Mistral models: ensure the presence of a "
-                "'params.json'.\n")
+                "'params.json'.\n").format(model=model)
 
             raise ValueError(error_message) from e
 


### PR DESCRIPTION
Fix s string parsing error caused by https://github.com/vllm-project/vllm/pull/13724
before
```shell
ValueError: Invalid repository ID or local directory specified: '{model}'.
``` 
after
```shell
ValueError: Invalid repository ID or local directory specified: '/home/model-does-not-exist'.
``` 