### PR TITLE
Support cuda 12.8.0 and SBSA wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,16 @@ jobs:
   release:
     # Retrieve tag and create release
     name: Create Release
-    runs-on: ubuntu-latest
+    matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        arch: [x86_64, aarch64]
+        exclude:
+          - os: windows-latest
+            arch: aarch64
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: ubuntu-24.04-arm 
+            arch: x86_64
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,6 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         arch: [x86_64, aarch64]
         exclude:
-          - os: windows-latest
-            arch: aarch64
           - os: ubuntu-latest
             arch: aarch64
           - os: ubuntu-24.04-arm 

--- a/.github/workflows/scripts/cuda-install.sh
+++ b/.github/workflows/scripts/cuda-install.sh
@@ -1,20 +1,44 @@
 #!/bin/bash
 
+# Usage: ./install_cuda.sh <cuda_version> <distro_version>
+#   e.g. ./install_cuda.sh 11.8 ubuntu-20.04
+
 # Replace '.' with '-' ex: 11.8 -> 11-8
 cuda_version=$(echo "$1" | tr "." "-")
+
 # Removes '-' and '.' ex: ubuntu-20.04 -> ubuntu2004
 OS=$(echo "$2" | tr -d ".\-")
 
-# Installs CUDA
-wget -nv "https://developer.download.nvidia.com/compute/cuda/repos/${OS}/x86_64/cuda-keyring_1.1-1_all.deb"
+# Detect system architecture for the CUDA repo
+arch=$(uname -m)
+if [ "$arch" = "x86_64" ]; then
+    repo_arch="x86_64"
+elif [ "$arch" = "aarch64" ]; then
+    repo_arch="sbsa"
+else
+    echo "Unsupported architecture: $arch"
+    exit 1
+fi
+
+# Fetch and install the CUDA public key package
+wget -nv "https://developer.download.nvidia.com/compute/cuda/repos/${OS}/${repo_arch}/cuda-keyring_1.1-1_all.deb"
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 rm cuda-keyring_1.1-1_all.deb
+
+# Update and install the requested CUDA version
 sudo apt -qq update
-sudo apt -y install "cuda-${cuda_version}" "cuda-nvcc-${cuda_version}" "cuda-libraries-dev-${cuda_version}"
+sudo apt -y install \
+    "cuda-${cuda_version}" \
+    "cuda-nvcc-${cuda_version}" \
+    "cuda-libraries-dev-${cuda_version}"
+
+# Cleanup
 sudo apt clean
 
+# Put nvcc on PATH
+export PATH="/usr/local/cuda-$1/bin:${PATH}"
+
 # Test nvcc
-PATH=/usr/local/cuda-$1/bin:${PATH}
 nvcc --version
 
 # Log gcc, g++, c++ versions


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/publish.yml` and `.github/workflows/scripts/cuda-install.sh` files to enhance the compatibility and installation process. The most important changes include adding support for different operating systems and architectures in the release job matrix and improving the CUDA installation script to handle multiple architectures.

Improvements to workflow compatibility:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L19-R26): Modified the release job to support a matrix of operating systems (`ubuntu-latest` and `ubuntu-24.04-arm`) and architectures (`x86_64` and `aarch64`), excluding incompatible combinations.

Enhancements to CUDA installation script:

* [`.github/workflows/scripts/cuda-install.sh`](diffhunk://#diff-c6aa57e7d53a42c4e2f06f2793213cc70eb377d8b25cff527ebe84536e30fd45R3-L17): Added usage instructions for the script to clarify how to run it with the required parameters.
* [`.github/workflows/scripts/cuda-install.sh`](diffhunk://#diff-c6aa57e7d53a42c4e2f06f2793213cc70eb377d8b25cff527ebe84536e30fd45R3-L17): Implemented architecture detection to fetch the appropriate CUDA repository and install the CUDA public key package based on the system architecture (`x86_64` or `aarch64`).
* [`.github/workflows/scripts/cuda-install.sh`](diffhunk://#diff-c6aa57e7d53a42c4e2f06f2793213cc70eb377d8b25cff527ebe84536e30fd45R3-L17): Enhanced the script to update and install the requested CUDA version, ensuring the correct packages are installed and cleaning up afterward.
* [`.github/workflows/scripts/cuda-install.sh`](diffhunk://#diff-c6aa57e7d53a42c4e2f06f2793213cc70eb377d8b25cff527ebe84536e30fd45R3-L17): Added a step to export the CUDA binary directory to the `PATH` environment variable to ensure `nvcc` is accessible.


Why this PR ?

Github: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
windows arm q2 2025: https://github.com/github/roadmap/issues/1098
ubuntu 20.04 is deprecated from today
Devices: Digits, jetson thor, cuda arm laptops are coming, support also GH200
Nvidia is merging SBSA and ARM64 together
I add cuda 12.8.0 and arm runners on https://github.com/Jimver/cuda-toolkit/releases/tag/v0.2.21