### PR TITLE
[v0][Core] Use xgrammar shared context to avoid copy overhead for offline engine

### DIFF
--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -3,7 +3,6 @@
 # noqa: UP007
 from __future__ import annotations
 
-import copy
 import json
 import re
 from dataclasses import dataclass, field
@@ -348,7 +347,8 @@ class XGrammarLogitsProcessor:
         return scores
 
     def clone(self) -> XGrammarLogitsProcessor:
-        """Create a new instance with shared compiled grammar but separate state"""
+        """Create a new instance with shared compiled grammar
+          but separate state"""
         new_processor = XGrammarLogitsProcessor(self.config)
         
         # Share the compiled grammar context (immutable after compilation)
@@ -356,15 +356,17 @@ class XGrammarLogitsProcessor:
         
         # Create fresh matchers for the new sequence
         if self.ctx is not None:
-            new_processor.matchers = [xgr.GrammarMatcher(self.ctx) for _ in range(self.batch_size)]
+            new_processor.matchers = [
+                xgr.GrammarMatcher(self.ctx) for _ in range(self.batch_size)
+            ]
         
         # Create a new token bitmask with the same size
         if hasattr(self, 'token_bitmask') and self.token_bitmask is not None:
-            new_processor.token_bitmask = xgr.allocate_token_bitmask(
-                self.batch_size, self.config.vocab_size)
+            new_processor.token_bitmask = self.token_bitmask
         
         # Copy simple attributes
         new_processor.batch_size = self.batch_size
-        new_processor.prefilled = False  # Reset prefilled state for new sequence
+        # Reset prefilled state for new sequence
+        new_processor.prefilled = False  
         
         return new_processor

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -348,5 +348,23 @@ class XGrammarLogitsProcessor:
         return scores
 
     def clone(self) -> XGrammarLogitsProcessor:
-        """Deepcopy due to per-sequence state in the matchers"""
-        return copy.deepcopy(self)
+        """Create a new instance with shared compiled grammar but separate state"""
+        new_processor = XGrammarLogitsProcessor(self.config)
+        
+        # Share the compiled grammar context (immutable after compilation)
+        new_processor.ctx = self.ctx
+        
+        # Create fresh matchers for the new sequence
+        if self.ctx is not None:
+            new_processor.matchers = [xgr.GrammarMatcher(self.ctx) for _ in range(self.batch_size)]
+        
+        # Create a new token bitmask with the same size
+        if hasattr(self, 'token_bitmask') and self.token_bitmask is not None:
+            new_processor.token_bitmask = xgr.allocate_token_bitmask(
+                self.batch_size, self.config.vocab_size)
+        
+        # Copy simple attributes
+        new_processor.batch_size = self.batch_size
+        new_processor.prefilled = False  # Reset prefilled state for new sequence
+        
+        return new_processor

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -367,6 +367,6 @@ class XGrammarLogitsProcessor:
         # Copy simple attributes
         new_processor.batch_size = self.batch_size
         # Reset prefilled state for new sequence
-        new_processor.prefilled = False  
+        new_processor.prefilled = False
 
         return new_processor

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -350,23 +350,23 @@ class XGrammarLogitsProcessor:
         """Create a new instance with shared compiled grammar
           but separate state"""
         new_processor = XGrammarLogitsProcessor(self.config)
-        
+
         # Share the compiled grammar context (immutable after compilation)
         new_processor.ctx = self.ctx
-        
+
         # Create fresh matchers for the new sequence
         if self.ctx is not None:
             new_processor.matchers = [
                 xgr.GrammarMatcher(self.ctx) for _ in range(self.batch_size)
             ]
-        
+
         # Create a new token bitmask with the same size
         if hasattr(self, 'token_bitmask') and self.token_bitmask is not None:
             new_processor.token_bitmask = self.token_bitmask
-        
+
         # Copy simple attributes
         new_processor.batch_size = self.batch_size
         # Reset prefilled state for new sequence
         new_processor.prefilled = False  
-        
+
         return new_processor

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -481,7 +481,7 @@ class SamplingParams(
         """
 
         logit_processor_refs = None if self.logits_processors is None else {
-            id(lp): lp.clone() if hasattr(lp, 'clone') else lp
+            id(lp): lp
             for lp in self.logits_processors
         }
         return copy.deepcopy(self, memo=logit_processor_refs)

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -481,7 +481,7 @@ class SamplingParams(
         """
 
         logit_processor_refs = None if self.logits_processors is None else {
-            id(lp): lp
+            id(lp): lp.clone() if hasattr(lp, 'clone') else lp
             for lp in self.logits_processors
         }
         return copy.deepcopy(self, memo=logit_processor_refs)


### PR DESCRIPTION
The deepcopy introduced in https://github.com/vllm-project/vllm/pull/11637 adds a lot of overhead when adding a large number of requests to an `llm_engine`. This adds a more efficient method of copying the `XGrammarLogitsProcessor` data structure to remove that overhead.

cc: @mgoin @aarnphm 
<!--- pyml disable-next-line no-emphasis-as-heading -->
