### PR TITLE
[ROCm][Quantization][Kernel] Use FP8 FNUZ when OCP flag is 0 or undefined

### DIFF
--- a/csrc/quantization/fp8/amd/quant_utils.cuh
+++ b/csrc/quantization/fp8/amd/quant_utils.cuh
@@ -24,12 +24,12 @@ __inline__ __device__ Tout scaled_vec_conversion(const Tin& x,
   return x;
 }
 
-    #if HIP_FP8_TYPE_FNUZ
-using fp8_type = __hip_fp8_e4m3_fnuz;
-using fp8x2_type = __hip_fp8x2_e4m3_fnuz;
-    #elif HIP_FP8_TYPE_OCP
+    #if HIP_FP8_TYPE_OCP
 using fp8_type = __hip_fp8_e4m3;
 using fp8x2_type = __hip_fp8x2_e4m3;
+    #else
+using fp8_type = __hip_fp8_e4m3_fnuz;
+using fp8x2_type = __hip_fp8x2_e4m3_fnuz;
     #endif
 
 // fp8 -> half


### PR DESCRIPTION
In older versions of "hip/hip_fp8.h" header (before https://github.com/ROCm/clr/commit/353f15afa6cfb0fc1eebbc618be47e0cb639c321), both `HIP_FP8_TYPE_OCP` and `HIP_FP8_TYPE_FNUZ` are not defined, and the code implementation is in FNUZ, so it's better to write it in this way, such that we don't check if `HIP_FP8_TYPE_FNUZ` is there or not, and we just use FP8 FNUZ when `HIP_FP8_TYPE_OCP` is 0 or undefined.

Related to #12593

<!--- pyml disable-next-line no-emphasis-as-heading -->
