### PR TITLE
[Misc]Code Cleanup

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -95,7 +95,6 @@ class RayDistributedExecutor(DistributedExecutorBase):
         self.use_v1 = envs.VLLM_USE_V1
 
         self.pp_locks: Optional[List[asyncio.Lock]] = None
-        self.use_ray_spmd_worker = envs.VLLM_USE_RAY_SPMD_WORKER
         if not self.use_ray_compiled_dag:
             self.driver_exec_method = make_async(
                 self.driver_worker.execute_method)


### PR DESCRIPTION
Code cleanup: The assignment `self.use_ray_spmd_worker = envs.VLLM_USE_RAY_SPMD_WORKER` has already been made on line 69 and validated, so there is no need for redundant assignment here.