### PR TITLE
[Misc][V1] Enhance performance of KVCacheManager._get_cached_block

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -71,7 +71,8 @@ class KVCacheManager:
             int, KVCacheBlock]] = defaultdict(dict)
 
         # NOTE: this is used in `self._get_cached_block` for better performance
-        self.cached_block_hash_to_block_get = self.cached_block_hash_to_block.get
+        self.cached_block_hash_to_block_get = \
+            self.cached_block_hash_to_block.get
 
         # Mapping from request ID to blocks to track the blocks allocated
         # for each request, so that we can free the blocks when the request
@@ -312,7 +313,8 @@ class KVCacheManager:
 
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = defaultdict(dict)
-        self.cached_block_hash_to_block_get = self.cached_block_hash_to_block.get
+        self.cached_block_hash_to_block_get = \
+            self.cached_block_hash_to_block.get
 
         # Remove all hashes from all blocks.
         for block in self.block_pool:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -312,6 +312,7 @@ class KVCacheManager:
 
         # Remove all hashes so that no new blocks will hit.
         self.cached_block_hash_to_block = defaultdict(dict)
+        self.cached_block_hash_to_block_get = self.cached_block_hash_to_block.get
 
         # Remove all hashes from all blocks.
         for block in self.block_pool:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -432,10 +432,9 @@ class KVCacheManager:
         Returns:
             The cached block if it exists, or None.
         """
-        if block_hash in self.cached_block_hash_to_block:
-            first_block_id = list(
-                self.cached_block_hash_to_block[block_hash].keys())[0]
-            return self.cached_block_hash_to_block[block_hash][first_block_id]
+        cached_block_dict = self.cached_block_hash_to_block.get(block_hash, None)
+        if cached_block_dict:
+            return next(iter(cached_block_dict.values()))
         return None
 
     def _touch(self, blocks: List[KVCacheBlock]) -> None:


### PR DESCRIPTION
Enhance KVCacheManager cached block dict retrieve by:
- fusing `key in dict` check and `dict getitem` operation
- cache `dict.get` fn (cache the fn itself, rather than access `dict.get` every time) will get better performance
- use `for _ in dict.values()` for better performance than `next(iter(dict.values()))` because `for loop` use native `GET_ITER` and `FOR_ITER` instruction with better performance

A slight time cost grow in case of "unknown block", but we may expect one or more "cached block" hit when enable_prefix_cache=True, and it would act like `cache_hit, cache_hit, cache_hit, ..., cache_hit, cache_miss`. So I think it's worth to choose this impl?

## Benchmark

accmulate 10000 times call with 128 cached blocks

| code | unknown block | cached block |
| - | - | - |
| main | 0.00107s | 0.00427s |
| [ver 0](https://github.com/vllm-project/vllm/pull/13878/commits/add39d40beb6ff788ec9270b4a55ef4f4154f7ab) (worse performance when cache miss) | 0.00139s (+29.9%) | 0.00225s (-47.3%) |
| ver 1 (this PR) | 0.00114s (**+6.5%**) | 0.00179s (**-58.1%**) |

## Reference

### 10+ years performance problem of `dict.get`

https://www.reddit.com/r/Python/comments/1atp5s/comment/c90onqq/

### Iteration instruction compare

```
def v0(dict):
    return next(iter(dict.values()), None)
---
  1           0 RESUME                   0

  2           2 LOAD_GLOBAL              1 (NULL + next)
             12 LOAD_GLOBAL              3 (NULL + iter)
             22 LOAD_FAST                0 (dict)
             24 LOAD_ATTR                5 (NULL|self + values)
             44 CALL                     0
             52 CALL                     1
             60 LOAD_CONST               0 (None)
             62 CALL                     2
             70 RETURN_VALUE
```

```
def v1(dict):
    for v in dict.values():
        return v
    return None
---
  1           0 RESUME                   0

  2           2 LOAD_FAST                0 (dict)
              4 LOAD_ATTR                1 (NULL|self + values)
             24 CALL                     0
             32 GET_ITER
             34 FOR_ITER                 5 (to 48)
             38 STORE_FAST               1 (v)

  3          40 LOAD_FAST                1 (v)
             42 SWAP                     2
             44 POP_TOP
             46 RETURN_VALUE

  2     >>   48 END_FOR

  4          50 RETURN_CONST             0 (None)
```