### PR TITLE
[Misc] fixed qwen_vl_utils parameter error

### DIFF
--- a/examples/offline_inference/vision_language_multi_image.py
+++ b/examples/offline_inference/vision_language_multi_image.py
@@ -439,7 +439,7 @@ def load_qwen2_5_vl(question, image_urls: List[str]) -> ModelRequestData:
         image_data = [fetch_image(url) for url in image_urls]
     else:
         image_data, _ = process_vision_info(messages,
-                                            return_video_sample_fps=False)
+                                            return_video_kwargs=False)
 
     return ModelRequestData(
         llm=llm,


### PR DESCRIPTION
https://github.com/QwenLM/Qwen2.5-VL/blob/main/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L354

The parameters of the function `process_vision_info` in the `qwen_vl_utils` library have changed.

```
python examples/offline_inference/vision_language_multi_image.py --model-type qwen2_5_vl
```
```
[rank0]: Traceback (most recent call last):
[rank0]:   File "/root/vllm/examples/offline_inference/vision_language_multi_image.py", line 552, in <module>
[rank0]:     main(args)
[rank0]:   File "/root/vllm/examples/offline_inference/vision_language_multi_image.py", line 527, in main
[rank0]:     run_generate(model, QUESTION, IMAGE_URLS)
[rank0]:   File "/root/vllm/examples/offline_inference/vision_language_multi_image.py", line 470, in run_generate
[rank0]:     req_data = model_example_map[model](question, image_urls)
[rank0]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/root/vllm/examples/offline_inference/vision_language_multi_image.py", line 441, in load_qwen2_5_vl
[rank0]:     image_data, _ = process_vision_info(messages,
[rank0]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: process_vision_info() got an unexpected keyword argument 'return_video_sample_fps'

```