### PR TITLE
[ROCm][V1] Update reshape_and_cache to properly work with CUDA graph padding

### DIFF
--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -375,7 +375,7 @@ void reshape_and_cache(
     torch::Tensor& slot_mapping,  // [num_tokens]
     const std::string& kv_cache_dtype, torch::Tensor& k_scale,
     torch::Tensor& v_scale) {
-  int num_tokens = key.size(0);
+  int num_tokens = slot_mapping.size(0);
   int num_heads = key.size(1);
   int head_size = key.size(2);
   int block_size = key_cache.size(3);


### PR DESCRIPTION
This patch updates reshape_and_cache to account for the case where slot_mapping.size(0) is not equal to key.size(0). This occurs when we use CUDA graph padding on V1.

Fixes: https://github.com/vllm-project/vllm/issues/13418