### PR TITLE
Update LMFE version to v0.10.11 to support new versions of transforme…

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -17,7 +17,7 @@ prometheus_client >= 0.18.0
 pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
-lm-format-enforcer >= 0.10.9, < 0.11
+lm-format-enforcer >= 0.10.11, < 0.11
 outlines == 0.1.11
 lark == 1.2.2
 xgrammar == 0.1.11; platform_machine == "x86_64"


### PR DESCRIPTION
…rs library

I received reports in vLLM slack that this issue makes compiling vLLM with transformers 4.49 impossible. This fixes that problem.


<!--- pyml disable-next-line no-emphasis-as-heading -->
