### PR TITLE
[WIP][Core] Support tensor parallelism with uneven heads

### DIFF
--- a/examples/parallelism_tests/qwen-reference.py
+++ b/examples/parallelism_tests/qwen-reference.py
@@ -1,0 +1,17 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+device = "cuda"  # or "cpu" if you don't have a GPU
+model = AutoModelForCausalLM.from_pretrained(
+    "Qwen/Qwen2-1.5B",  # using the base model instead of the instruct version
+    torch_dtype="auto"
+).to(device)
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-1.5B")
+
+# Provide a single input prompt without system/user formatting.
+prompt = "This is a brief introduction to large language models. Large language models (LLMs) are "
+inputs = tokenizer(prompt, return_tensors="pt").to(device)
+
+output_ids = model.generate(inputs.input_ids, max_new_tokens=100)
+response = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(response)

--- a/examples/parallelism_tests/test-qwen.py
+++ b/examples/parallelism_tests/test-qwen.py
@@ -4,7 +4,7 @@ from vllm import LLM
 llm = LLM(
     model="Qwen/Qwen2-1.5B",
     task="generate",
-    tensor_parallel_size=4
+    tensor_parallel_size=8
 )
 output = llm.generate("Hello, my name is")
 print(output)

--- a/examples/parallelism_tests/test-qwen.py
+++ b/examples/parallelism_tests/test-qwen.py
@@ -1,0 +1,10 @@
+# NCCL_DEBUG=INFO python examples/parallelism_tests/test-qwen.py
+
+from vllm import LLM
+llm = LLM(
+    model="Qwen/Qwen2-1.5B",
+    task="generate",
+    tensor_parallel_size=4
+)
+output = llm.generate("Hello, my name is")
+print(output)

--- a/examples/parallelism_tests/test-qwen.py
+++ b/examples/parallelism_tests/test-qwen.py
@@ -1,10 +1,41 @@
 # NCCL_DEBUG=INFO python examples/parallelism_tests/test-qwen.py
 
 from vllm import LLM
+
 llm = LLM(
     model="Qwen/Qwen2-1.5B",
     task="generate",
     tensor_parallel_size=8
 )
-output = llm.generate("Hello, my name is")
+
+# Use a chat-style prompt that includes the system and user messages.
+prompt = "This is a brief introduction to large language models. Large language models (LLMs) are "
+
+output = llm.generate(prompt)
 print(output)
+
+"""
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+# Use the instruct version of the Qwen2 model.
+model_id = "Qwen/Qwen2-1.5B-Instruct"
+sampling_params = SamplingParams(temperature=0.7, top_p=0.8, max_tokens=512)
+
+# Load the tokenizer and format the prompt using system and user roles.
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Give me a short introduction to large language models."}
+]
+# Apply the chat template to produce the final prompt string.
+prompt = tokenizer.apply_chat_template(messages, tokenize=False)
+
+# Initialize vLLM with tensor parallelism as desired.
+llm = LLM(model=model_id, task="generate", tensor_parallel_size=8)
+
+# Generate the output.
+outputs = llm.generate(prompt, sampling_params)
+generated_text = outputs[0].outputs[0].text
+print(generated_text)
+"""

--- a/examples/parallelism_tests/test-qwen.py
+++ b/examples/parallelism_tests/test-qwen.py
@@ -5,7 +5,8 @@ from vllm import LLM
 llm = LLM(
     model="Qwen/Qwen2-1.5B",
     task="generate",
-    tensor_parallel_size=8
+    tensor_parallel_size=8,
+    enforce_eager=True,
 )
 
 # Use a chat-style prompt that includes the system and user messages.

--- a/test-qwen-root.py
+++ b/test-qwen-root.py
@@ -1,0 +1,41 @@
+# NCCL_DEBUG=INFO python examples/parallelism_tests/test-qwen.py
+
+from vllm import LLM
+
+llm = LLM(
+    model="Qwen/Qwen2-1.5B",
+    task="generate",
+    # tensor_parallel_size=8
+)
+
+# Use a chat-style prompt that includes the system and user messages.
+prompt = "This is a brief introduction to large language models. Large language models (LLMs) are "
+
+output = llm.generate(prompt)
+print(output)
+
+"""
+from vllm import LLM, SamplingParams
+from transformers import AutoTokenizer
+
+# Use the instruct version of the Qwen2 model.
+model_id = "Qwen/Qwen2-1.5B-Instruct"
+sampling_params = SamplingParams(temperature=0.7, top_p=0.8, max_tokens=512)
+
+# Load the tokenizer and format the prompt using system and user roles.
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Give me a short introduction to large language models."}
+]
+# Apply the chat template to produce the final prompt string.
+prompt = tokenizer.apply_chat_template(messages, tokenize=False)
+
+# Initialize vLLM with tensor parallelism as desired.
+llm = LLM(model=model_id, task="generate", tensor_parallel_size=8)
+
+# Generate the output.
+outputs = llm.generate(prompt, sampling_params)
+generated_text = outputs[0].outputs[0].text
+print(generated_text)
+"""

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -707,10 +707,13 @@ class ModelConfig:
                                             "num_attention_heads", 0)
         tensor_parallel_size = parallel_config.tensor_parallel_size
         if total_num_attention_heads % tensor_parallel_size != 0:
-            raise ValueError(
-                f"Total number of attention heads ({total_num_attention_heads})"
-                " must be divisible by tensor parallel size "
-                f"({tensor_parallel_size}).")
+            # raise ValueError(
+            #     f"Total number of attention heads ({total_num_attention_heads})"
+            #     " must be divisible by tensor parallel size "
+            #     f"({tensor_parallel_size}).")
+            print(
+                f"FIXING NOW: Total number of attention heads ({total_num_attention_heads})"
+                " with tensor parallel size " f"({tensor_parallel_size}).")
 
         pipeline_parallel_size = parallel_config.pipeline_parallel_size
         if pipeline_parallel_size > 1:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -711,7 +711,7 @@ class QKVParallelLinear(ColumnParallelLinear):
         # Divide the weight matrix along the last dimension.
         tp_size = get_tensor_model_parallel_world_size()
         self.num_heads = divide(self.total_num_heads, tp_size)
-        print("NUMHEADS", self.total_num_heads, self.num_heads)
+        # print("NUMHEADS", self.total_num_heads, self.num_heads)
         if tp_size >= self.total_num_kv_heads:
             self.num_kv_heads = 1
             self.num_kv_head_replicas = divide(tp_size,
@@ -774,7 +774,6 @@ class QKVParallelLinear(ColumnParallelLinear):
              (self.total_num_heads + self.total_num_kv_heads) * self.head_size,
              self.total_num_kv_heads * self.head_size),
         ]
-        print("OFFSET1")
 
         for shard_id, shard_offset, shard_size in shard_offsets:
             # Special case for Quantization.
@@ -807,8 +806,6 @@ class QKVParallelLinear(ColumnParallelLinear):
             return
 
         assert loaded_shard_id in ["q", "k", "v"]
-
-        print("OFFSET2")
 
         shard_offset = self._get_shard_offset_mapping(loaded_shard_id)
         shard_size = self._get_shard_size_mapping(loaded_shard_id)
@@ -867,7 +864,6 @@ class QKVParallelLinear(ColumnParallelLinear):
         needs_scalar_to_array = getattr(param, "needs_scalar_to_array", False)
 
         if loaded_shard_id is None:
-            print("OFFSET3")
             # Loaded weight is already fused on disk (qkv).
             # (e.g., Phi-3's qkv_proj).
             if output_dim is None:
@@ -983,12 +979,12 @@ class QKVParallelLinear(ColumnParallelLinear):
             start_idx = shard_id * shard_size
 
             if not is_sharded_weight:
-                print(f"GPU {tp_rank}: expecting slice from {start_idx} to {start_idx + shard_size} "
-      f"out of total {loaded_weight.size(output_dim)}", end="\t")
+    #             print(f"GPU {tp_rank}: expecting slice from {start_idx} to {start_idx + shard_size} "
+    #   f"out of total {loaded_weight.size(output_dim)}", end="\t")
 
                 if start_idx + shard_size > loaded_weight.size(output_dim):
                     # print("DUMMYLOADERSIZE", start_idx, shard_size, loaded_weight.size())
-                    print("DUMMYHEAD", get_tensor_model_parallel_rank(), end=", ")
+                    # print("DUMMYHEAD", get_tensor_model_parallel_rank(), end=", ")
                     # Create a tensor of zeros with the same size as the shard
                     weight_shape = list(loaded_weight.shape)
                     weight_shape[output_dim] = shard_size
@@ -1002,7 +998,7 @@ class QKVParallelLinear(ColumnParallelLinear):
                 else:
                     pass
                     # print("REALLOADERSIZE", start_idx, shard_size, loaded_weight.size())
-                    print("REALHEAD", get_tensor_model_parallel_rank(), end=", ")
+                    # print("REALHEAD", get_tensor_model_parallel_rank(), end=", ")
                     loaded_weight = loaded_weight.narrow(output_dim, start_idx, shard_size)
                 # loaded_weight = loaded_weight.narrow(output_dim, start_idx,
                 #                                      shard_size)

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -979,6 +979,7 @@ class QKVParallelLinear(ColumnParallelLinear):
             if not is_sharded_weight:
                 if start_idx + shard_size > loaded_weight.size(output_dim):
                     # print("LOADERSIZE", start_idx, shard_size, loaded_weight.size())
+                    # print("DUMMYHEAD", get_tensor_model_parallel_rank())
                     # Create a tensor of zeros with the same size as the shard
                     weight_shape = list(loaded_weight.shape)
                     weight_shape[output_dim] = shard_size

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -178,7 +178,6 @@ class Qwen2Attention(nn.Module):
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)
-        print("FORWARDSIZE", output.size())
         return output
 
 

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -181,14 +181,20 @@ class Qwen2Attention(nn.Module):
         # Only GPU 6 and 7 is for dummies
         # print("QHEADS", q.size(0), self.num_heads, self.head_dim, get_tensor_model_parallel_rank())
         if get_tensor_model_parallel_rank() in (6, 7):
-            # print(f"DUMMY OUTPUT {get_tensor_model_parallel_rank()}", q)
+            # print(f"DUMMY GPU {get_tensor_model_parallel_rank()}", v)
+
             q = q.view(q.size(0), self.num_heads, self.head_dim)
+            k = k.view(k.size(0), self.num_kv_heads, self.head_dim)
+            v = v.view(v.size(0), self.num_kv_heads, self.head_dim)
 
             # Zero out the dummy heads
             q[:, :, :] = 0
-            # q[:, -self.dummy_heads:, :] = -1000
+            k[:, :, :] = 0
+            v[:, :, :] = 0
 
             q = q.view(q.size(0), -1)
+            k = k.view(k.size(0), -1)
+            v = v.view(v.size(0), -1)
         else:
             pass
             # print(f"REAL OUTPUT {get_tensor_model_parallel_rank()}", q)

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -181,6 +181,7 @@ class Qwen2Attention(nn.Module):
         # Only GPU 6 and 7 is for dummies
         # print("QHEADS", q.size(0), self.num_heads, self.head_dim, get_tensor_model_parallel_rank())
         if get_tensor_model_parallel_rank() in (6, 7):
+            # print(f"DUMMY OUTPUT {get_tensor_model_parallel_rank()}", q)
             q = q.view(q.size(0), self.num_heads, self.head_dim)
 
             # Zero out the dummy heads
@@ -188,6 +189,9 @@ class Qwen2Attention(nn.Module):
             # q[:, -self.dummy_heads:, :] = -1000
 
             q = q.view(q.size(0), -1)
+        else:
+            pass
+            # print(f"REAL OUTPUT {get_tensor_model_parallel_rank()}", q)
 
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)


### PR DESCRIPTION
Currently working on supporting tensor parallelism when using attention heads that do not divide the number of GPUs evenly, for example with Qwen2.

Using a dummy head approach to pad to an even number. Currently testing with Qwen2 1.5B with 12 heads on 8 GPUs (so 4 dummy heads).

Works end to end, but has poor results.
**Prompt:** "This is a brief introduction to large language models. Large language models (LLMs) are"
**vLLM non-parallel reference:** "particularly useful language model techniques to interact with language models, so as to compress a"
**New feature (this PR)**: "10 instructions in deleting newton's law of relational networks. Common utility."

Working on debugging the accuracy issue now.

FIX #11797