### PR TITLE
[CI/Build] Add examples/ directory to be labelled by `mergify`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
     - or:
       - files~=^[^/]+\.md$
       - files~=^docs/
+      - files~=^examples/
   actions:
     label:
       add:


### PR DESCRIPTION
The examples folder is published to the existing documentation, so this should be helpful in labelling PRs that touch this directory.

We could also narrow the scope with `files~=^examples/.*\.(py|md|sh)$` if necessary...