### PR TITLE
[bugfix] Fix profiling for RayDistributedExecutor

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -324,7 +324,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
                     args[name] = os.environ[name]
 
         logger.info(
-            "Copied the following environment variables to workers: %s",
+            "Copying the following environment variables to workers: %s",
             [v for v in env_vars_to_copy if v in os.environ])
 
         self._env_vars_for_all_workers = (

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -313,11 +313,9 @@ class RayDistributedExecutor(DistributedExecutorBase):
             # some carry-over env vars from the driver
             # TODO: refactor platform-specific env vars
             for name in [
-                    "VLLM_ATTENTION_BACKEND",
-                    "TPU_CHIPS_PER_HOST_BOUNDS",
-                    "TPU_HOST_BOUNDS",
-                    "VLLM_USE_V1",
-                    "VLLM_TRACE_FUNCTION",
+                    "VLLM_ATTENTION_BACKEND", "TPU_CHIPS_PER_HOST_BOUNDS",
+                    "TPU_HOST_BOUNDS", "VLLM_USE_V1", "VLLM_TRACE_FUNCTION",
+                    "VLLM_TORCH_PROFILER_DIR"
             ]:
                 if name in os.environ:
                     args[name] = os.environ[name]

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -309,16 +309,23 @@ class RayDistributedExecutor(DistributedExecutorBase):
             ",".join(map(str, node_gpus[node_id])),
         } for (node_id, _) in worker_node_and_gpu_ids]
 
+        # Environment variables to copy from driver to workers
+        env_vars_to_copy = [
+            "VLLM_ATTENTION_BACKEND", "TPU_CHIPS_PER_HOST_BOUNDS",
+            "TPU_HOST_BOUNDS", "VLLM_USE_V1", "VLLM_TRACE_FUNCTION",
+            "VLLM_TORCH_PROFILER_DIR"
+        ]
+
+        # Copy existing env vars to each worker's args
         for args in all_args_to_update_environment_variables:
-            # some carry-over env vars from the driver
             # TODO: refactor platform-specific env vars
-            for name in [
-                    "VLLM_ATTENTION_BACKEND", "TPU_CHIPS_PER_HOST_BOUNDS",
-                    "TPU_HOST_BOUNDS", "VLLM_USE_V1", "VLLM_TRACE_FUNCTION",
-                    "VLLM_TORCH_PROFILER_DIR"
-            ]:
+            for name in env_vars_to_copy:
                 if name in os.environ:
                     args[name] = os.environ[name]
+
+        logger.info(
+            "Copied the following environment variables to workers: %s",
+            [v for v in env_vars_to_copy if v in os.environ])
 
         self._env_vars_for_all_workers = (
             all_args_to_update_environment_variables)

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -313,7 +313,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         env_vars_to_copy = [
             "VLLM_ATTENTION_BACKEND", "TPU_CHIPS_PER_HOST_BOUNDS",
             "TPU_HOST_BOUNDS", "VLLM_USE_V1", "VLLM_TRACE_FUNCTION",
-            "VLLM_TORCH_PROFILER_DIR"
+            "VLLM_TORCH_PROFILER_DIR", "VLLM_TEST_ENABLE_EP"
         ]
 
         # Copy existing env vars to each worker's args


### PR DESCRIPTION
Need to pass the environment variable `VLLM_TORCH_PROFILER_DIR` to all workers.

Otherwise seeing the following error even if the environment variable is set:

```
ERROR 02-27 04:38:54 core.py:349]   File "/home/ray/anaconda3/lib/python3.10/site-packages/vllm/v1/worker/gpu_worker.py", line 232, in profile
ERROR 02-27 04:38:54 core.py:349]     raise RuntimeError("Profiler is not enabled.")
ERROR 02-27 04:38:54 core.py:349] RuntimeError: Profiler is not enabled.
```

Tested with PP=2 TP=4 for ray distributed backend.

Also passing **`VLLM_TEST_ENABLE_EP`** to workers.
