### PR TITLE
[Misc] fixed 'required' is an invalid argument for positionals

### DIFF
--- a/examples/online_serving/openai_chat_embedding_client_for_multimodal.py
+++ b/examples/online_serving/openai_chat_embedding_client_for_multimodal.py
@@ -102,7 +102,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         "Script to call a specified VLM through the API. Make sure to serve "
         "the model with --task embed before running this.")
-    parser.add_argument("model",
+    parser.add_argument("--model",
                         type=str,
                         choices=["vlm2vec", "dse_qwen2_vl"],
                         required=True,


### PR DESCRIPTION
```
# python examples/online_serving/openai_chat_embedding_client_for_multimodal.py dse_qwen2_vl                                                                                            1 ↵
Traceback (most recent call last):
  File "/root/vllm/examples/online_serving/openai_chat_embedding_client_for_multimodal.py", line 105, in <module>
    parser.add_argument("model",
  File "/root/anaconda3/lib/python3.12/argparse.py", line 1459, in add_argument
    kwargs = self._get_positional_kwargs(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/argparse.py", line 1575, in _get_positional_kwargs
    raise TypeError(msg)
TypeError: 'required' is an invalid argument for positional
#
# python examples/online_serving/openai_chat_embedding_client_for_multimodal.py --model dse_qwen2_vl
Traceback (most recent call last):
  File "/root/vllm/examples/online_serving/openai_chat_embedding_client_for_multimodal.py", line 105, in <module>
    parser.add_argument("model",
  File "/root/anaconda3/lib/python3.12/argparse.py", line 1459, in add_argument
    kwargs = self._get_positional_kwargs(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/lib/python3.12/argparse.py", line 1575, in _get_positional_kwargs
    raise TypeError(msg)
TypeError: 'required' is an invalid argument for positionals
```