### PR TITLE
Support non-attention path operators in Triton

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -96,7 +96,7 @@ if TYPE_CHECKING:
     VLLM_DP_SIZE: int = 1
     VLLM_DP_MASTER_IP: str = ""
     VLLM_DP_MASTER_PORT: int = 0
-
+    VLLM_USE_TRITON_NON_ATTN: bool = False
 
 def get_default_cache_root():
     return os.getenv(
@@ -630,6 +630,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Whether to use S3 path for model loading in CI via RunAI Streamer
     "VLLM_CI_USE_S3":
     lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",
+
+    # Flag to control if vllm should use triton operators except for attention
+    "VLLM_USE_TRITON_NON_ATTN":
+    lambda: (os.environ.get("VLLM_USE_TRITON_NON_ATTN", "False").lower() in
+                ("true", "1")),
 }
 
 # end-env-vars-definition

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -14,6 +14,41 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.utils import LazyDict
 
+import triton
+import triton.language as tl
+
+@triton.jit
+def silu_and_mul_kernel(out_ptr, x_ptr, d: tl.constexpr, d_padded: tl.constexpr):
+    token_idx = tl.program_id(0)
+    idx = tl.arange(0, d_padded)
+
+    # Load A and B from x
+    mask = idx < d  # Mask for values within the original range of d
+    x_a = tl.load(x_ptr + token_idx * 2 * d + idx, mask=mask, other=0.0)
+    x_b = tl.load(x_ptr + token_idx * 2 * d + d + idx, mask=mask, other=0.0)
+
+    # SiLU activation on A and element-wise multiplication with B
+    x_a_fp32 = x_a.to(tl.float32)
+    x_silu = x_a_fp32 / (1.0 + tl.exp(-x_a_fp32))
+    result = x_silu * x_b
+
+    # Write result to output
+    tl.store(out_ptr + token_idx * d + idx, result, mask=mask)
+
+
+class _SiluAndMul(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, out, x):
+        d = x.shape[-1] // 2
+        d_padded = 1 << (d - 1).bit_length()  # Calculate d_padded in Python
+        num_tokens = x.shape[0]
+
+        # Launch the Triton kernel
+        silu_and_mul_kernel[(num_tokens,)](out, x, d=d, d_padded=d_padded)
+
+
+def _silu_and_mul(out, x):
+    _SiluAndMul.apply(out, x)
 
 @CustomOp.register("fatrelu_and_mul")
 class FatreluAndMul(CustomOp):
@@ -95,6 +130,13 @@ class SiluAndMul(CustomOp):
         s = x_reshaped[:, :d] * F.sigmoid(x_reshaped[:, :d])
         result = s * x_reshaped[:, d:]
         return result.view(*x.shape[:-1], d)
+
+    def forward_triton(self, x: torch.Tensor) -> torch.Tensor:
+        d = x.shape[-1] // 2
+        output_shape = (x.shape[:-1] + (d, ))
+        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+        _silu_and_mul(out, x)
+        return out
 
 
 @CustomOp.register("mul_and_silu")

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -8,6 +8,123 @@ import torch.nn as nn
 from vllm.model_executor.custom_op import CustomOp
 
 
+import math
+import triton
+import triton.language as tl
+from vllm.model_executor.utils import libentry
+
+# From FlagGems
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def rms_norm_kernel(
+    Y,  # pointer to the output
+    X,  # pointer to the input
+    W,  # pointer to the weights
+    y_stride_r,
+    y_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    Y += pid * y_stride_r
+    X += pid * x_stride_r
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(X + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+
+    var = tl.sum(x * x, axis=0) / N
+    rrms = 1 / tl.sqrt(var + eps)
+
+    w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
+    y = (x * rrms).to(Y.dtype.element_ty) * w
+    tl.store(Y + cols * y_stride_c, y, mask=mask)
+
+# Integrated from FlagGems
+class _RmsNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, normalized_shape, weight, eps=1e-5):
+        dim = x.ndim - len(normalized_shape)
+        M = math.prod(x.shape[:dim])
+        N = math.prod(normalized_shape)
+
+        BLOCK_SIZE = triton.next_power_of_2(N)
+        x = x.contiguous()
+        weight = weight.contiguous()
+        y = torch.empty_like(x)
+
+        rms_norm_kernel[M,](y, x, weight, N, 1, N, 1, N, eps, BLOCK_SIZE)
+        return y
+
+
+def _rms_norm(x, normalized_shape, weight, eps=1e-5):
+    return _RmsNorm.apply(x, normalized_shape, weight, eps)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def fused_add_rms_norm_kernel(
+    input_ptr,   # [..., hidden_size]
+    residual_ptr,  # [..., hidden_size]
+    weight_ptr,  # [hidden_size]
+    y_stride_r,
+    y_stride_c,
+    x_stride_r,  # stride for input rows
+    x_stride_c,  # stride for input columns
+    N,           # hidden_size
+    eps,         # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    input_ptr += pid * y_stride_r
+    residual_ptr += pid * y_stride_r
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+
+    # Load data from input and residual, then add them together
+    x = tl.load(input_ptr + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    r = tl.load(residual_ptr + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    z = x + r
+    tl.store(residual_ptr + cols * y_stride_c, z, mask=mask)
+
+    # Compute variance
+    var = tl.sum(z * z, axis=0) / N
+    rrms = 1 / tl.sqrt(var + eps)
+
+    # Load weight and apply RMS normalization
+    weight = tl.load(weight_ptr + cols, mask=mask, other=0.0)
+    normed_z = (z * rrms).to(input_ptr.dtype.element_ty) * weight
+
+    # Store result back to input
+    tl.store(input_ptr + cols * y_stride_c, normed_z, mask=mask)
+
+
+class _FusedAddRMSNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input, residual, normalized_shape, weight, eps=1e-5):
+        dim = input.ndim - len(normalized_shape)
+        M = math.prod(input.shape[:dim])
+        N = math.prod(normalized_shape)
+
+        BLOCK_SIZE = triton.next_power_of_2(N)
+        input = input.contiguous()
+        residual = residual.contiguous()
+        weight = weight.contiguous()
+
+        # Launch the Triton kernel
+        fused_add_rms_norm_kernel[(M,)](
+            input, residual, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+        )
+        return input
+
+
+def _fused_add_rms_norm(input, residual, normalized_shape, weight, eps=1e-5):
+    return _FusedAddRMSNorm.apply(input, residual, normalized_shape, weight, eps)
+
 @CustomOp.register("rms_norm")
 class RMSNorm(CustomOp):
     """Root mean square normalization.
@@ -142,6 +259,35 @@ class RMSNorm(CustomOp):
             self.weight.data,
             self.variance_epsilon,
         )
+
+    def forward_triton(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        if self.variance_size_override is not None:
+            return self.forward_native(x, residual)
+
+        from vllm import _custom_ops as ops
+
+        if residual is not None:
+            _fused_add_rms_norm(
+                x,
+                residual,
+                [len(self.weight.data)],
+                self.weight.data,
+                self.variance_epsilon,
+            )
+            return x, residual
+
+        out = torch.empty_like(x)
+        out = _rms_norm(
+                x,
+                [len(self.weight.data)],
+                self.weight.data,
+                self.variance_epsilon
+        )
+        return out
 
     def extra_repr(self) -> str:
         s = f"hidden_size={self.weight.data.size(0)}"

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -26,6 +26,11 @@ from vllm.model_executor.parameter import (BasevLLMParameter,
 # yapf: enable
 from vllm.model_executor.utils import set_weight_attrs
 
+import triton
+import triton.language as tl
+from vllm import envs
+from vllm.model_executor.utils import libentry
+
 logger = init_logger(__name__)
 
 WEIGHT_LOADER_V2_SUPPORTED = [
@@ -84,6 +89,376 @@ def adjust_scalar_to_fused_array(param, loaded_weight, shard_id):
     return param[shard_id], loaded_weight
 
 
+# from FlagGems
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 64},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 32},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 32},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 64, "BLOCK_SIZE_N": 32, "BLOCK_SIZE_K": 32},
+            num_stages=5,
+            num_warps=2,
+        ),
+        triton.Config(
+            {"BLOCK_SIZE_M": 32, "BLOCK_SIZE_N": 64, "BLOCK_SIZE_K": 32},
+            num_stages=5,
+            num_warps=2,
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.jit(do_not_specialize=["alpha", "beta"])
+def addmm_kernel(
+    a_ptr,
+    b_ptr,
+    bias_ptr,
+    c_ptr,
+    alpha,
+    beta,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+    bias_ptrs = bias_ptr + offs_bn
+
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl.load(
+            a_ptrs,
+            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptrs,
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            other=0.0,
+        )
+        accumulator += tl.dot(a, b, allow_tf32=False)
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    bias = tl.load(bias_ptrs, mask=offs_bn < N, other=0.0)
+    accumulator = accumulator * alpha + bias * beta
+    c = accumulator.to(bias.dtype)
+
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+# Integrated from FlagGems
+def _addmm(bias, mat1, mat2, *, beta=1, alpha=1):
+    assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
+    M, K = mat1.shape
+    _, N = mat2.shape
+
+    mat1 = mat1.contiguous()
+    mat2 = mat2.contiguous()
+    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]),
+        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
+
+    addmm_kernel[grid](
+        mat1,
+        mat2,
+        bias,
+        out,
+        alpha,
+        beta,
+        M,
+        N,
+        K,
+        mat1.stride(0),
+        mat1.stride(1),
+        mat2.stride(0),
+        mat2.stride(1),
+        out.stride(0),
+        out.stride(1),
+    )
+    return out
+
+
+def heur_even_k(args):
+    return args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0
+
+# From FlagGems
+@libentry()
+@triton.autotune(
+    configs=[
+        # basic configs for compute-bound matmuls
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 32, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+        # good for int8
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 256, "BLOCK_N": 64, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=4,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 32, "BLOCK_K": 64, "SPLIT_K": 1},
+            num_stages=5,
+            num_warps=2,
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.heuristics(
+    {
+        "EVEN_K": heur_even_k,
+    }
+)
+@triton.jit
+def mm_kernel(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    dot_out_dtype: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    # matrix multiplication
+    pid = tl.program_id(0)
+    pid_z = tl.program_id(1)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    rk = pid_z * BLOCK_K + tl.arange(0, BLOCK_K)
+    # pointers
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=dot_out_dtype)
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            k_remaining = K - k * (BLOCK_K * SPLIT_K)
+            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
+            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
+        if a.dtype != b.dtype:
+            a = a.to(C.dtype.element_ty)
+            b = b.to(C.dtype.element_ty)
+        acc += tl.dot(a, b, out_dtype=dot_out_dtype, allow_tf32=False)
+        A += BLOCK_K * SPLIT_K * stride_ak
+        B += BLOCK_K * SPLIT_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    # handles write-back with reduction-splitting
+    if SPLIT_K == 1:
+        tl.store(C, acc, mask=mask)
+    else:
+        tl.atomic_add(C, acc, mask=mask)
+
+_ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32]
+def get_higher_dtype(a, b):
+    if a is b:
+        return a
+
+    assert a in _ordered_datatypes
+    assert b in _ordered_datatypes
+
+    for d in _ordered_datatypes:
+        if a is d:
+            return b
+        if b is d:
+            return a
+
+# Integrated from FlagGems
+def _mm(a, b):
+    device = a.device
+    # handle non-contiguous inputs if necessary
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # checks constraints
+    assert a.shape[1] == b.shape[0], "incompatible dimensions"
+    M, K = a.shape
+    _, N = b.shape
+    # allocates output
+    c_dtype = get_higher_dtype(a.dtype, b.dtype)
+    c = torch.empty((M, N), device=device, dtype=c_dtype)
+    dot_out_dtype = tl.float32
+    # launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        META["SPLIT_K"],
+    )
+
+    mm_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        dot_out_dtype=dot_out_dtype,
+        GROUP_M=8,
+    )
+    return c
+
+
 class LinearMethodBase(QuantizeMethodBase):
     """Base class for different (maybe quantized) linear methods."""
 
@@ -138,8 +513,15 @@ class UnquantizedLinearMethod(LinearMethodBase):
               layer: torch.nn.Module,
               x: torch.Tensor,
               bias: Optional[torch.Tensor] = None) -> torch.Tensor:
-
-        return F.linear(x, layer.weight, bias)
+        if (envs.VLLM_USE_TRITON_NON_ATTN):
+            transposed = layer.weight
+            transposed = transposed.transpose(0, 1)
+            if bias is None:
+                return _mm(x, transposed)
+            else:
+                return _addmm(bias, x, transposed)
+        else:
+            return F.linear(x, layer.weight, bias)
 
 
 class LinearBase(torch.nn.Module):

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -32,6 +32,9 @@ from transformers import PretrainedConfig
 from vllm.model_executor.custom_op import CustomOp
 from vllm.platforms import current_platform
 
+import triton
+import triton.language as tl
+from vllm.model_executor.utils import libentry
 
 def _rotate_neox(x: torch.Tensor) -> torch.Tensor:
     x1 = x[..., :x.shape[-1] // 2]
@@ -73,6 +76,214 @@ def _apply_rotary_emb(
         return torch.cat((o1, o2), dim=-1)
     else:
         return torch.stack((o1, o2), dim=-1).flatten(-2)
+
+# From FlagGems
+@libentry()
+@triton.jit
+def apply_rotary_pos_emb_kernel(
+    oq_ptr,
+    ok_ptr,
+    q_ptr,  # (n_tokens, q_heads, head_dim)
+    k_ptr,  # (n_tokens, k_heads, head_dim)
+    cos_ptr,  # (max_seq_len, dim // 2)
+    sin_ptr,  # (max_seq_len, dim // 2)
+    pos_ptr,  # (n_tokens, )
+    q_stride_s,
+    q_stride_h,
+    q_stride_d,
+    k_stride_s,
+    k_stride_h,
+    k_stride_d,
+    oq_stride_s,
+    oq_stride_h,
+    oq_stride_d,
+    ok_stride_s,
+    ok_stride_h,
+    ok_stride_d,
+    p_stride_s,
+    cos_stride_s,
+    sin_stride_s,
+    seq_len,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_K_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PADDED_HEAD_DIM: tl.constexpr,
+    ROTARY_INTERLEAVED: tl.constexpr,
+    MAX_POSITION_EMBEDDINGS: tl.constexpr,
+):
+    s_id = tl.program_id(0)
+
+    if pos_ptr is None:
+        pos_id = s_id % seq_len
+    else:
+        pos_ptr += s_id * p_stride_s
+        pos_id = tl.load(pos_ptr)
+    cos_ptr += pos_id * cos_stride_s
+    sin_ptr += pos_id * sin_stride_s
+
+    # note: set TRITON_DEBUG=1 to enable this check
+    tl.device_assert(pos_id < MAX_POSITION_EMBEDDINGS, "position id out of bound")
+
+    ordered_block = tl.arange(0, PADDED_HEAD_DIM)
+    mask = ordered_block < HEAD_DIM
+    if ROTARY_INTERLEAVED:
+        odd_mask = ordered_block % 2 == 0
+        rotated_block = tl.where(odd_mask, ordered_block + 1, ordered_block - 1)
+        sin_cos_block = ordered_block // 2
+        cos = tl.load(cos_ptr + sin_cos_block, mask=mask, other=0.0).to(tl.float32)
+        sin = tl.load(sin_ptr + sin_cos_block, mask=mask, other=0.0).to(tl.float32)
+        sin = tl.where(odd_mask, -sin, sin)
+    else:
+        rotated_block = (ordered_block + HEAD_DIM // 2) % HEAD_DIM
+        sin_cos_block = ordered_block % (HEAD_DIM // 2)
+        cos = tl.load(cos_ptr + sin_cos_block, mask=mask, other=0.0).to(tl.float32)
+        sin = tl.load(sin_ptr + sin_cos_block, mask=mask, other=0.0).to(tl.float32)
+        sin = tl.where(rotated_block < HEAD_DIM // 2, sin, -sin)
+
+    oq_ptr += s_id * oq_stride_s
+    q_ptr += s_id * q_stride_s
+
+    for off_h in range(0, NUM_Q_HEADS):
+        ordered_cols = off_h * q_stride_h + (ordered_block * q_stride_d)
+        rotated_cols = off_h * q_stride_h + (rotated_block * q_stride_d)
+        output_offs = off_h * oq_stride_h + (ordered_block * oq_stride_d)
+
+        q = tl.load(q_ptr + ordered_cols, mask=mask, other=0.0)
+        rotated_q = tl.load(q_ptr + rotated_cols, mask=mask, other=0.0)
+        y = q * cos + rotated_q * sin
+        tl.store(oq_ptr + output_offs, y, mask=mask)
+
+    ok_ptr += s_id * ok_stride_s
+    k_ptr += s_id * k_stride_s
+
+    for off_h in range(0, NUM_K_HEADS):
+        ordered_cols = off_h * k_stride_h + (ordered_block * k_stride_d)
+        rotated_cols = off_h * k_stride_h + (rotated_block * k_stride_d)
+        output_offs = off_h * ok_stride_h + (ordered_block * ok_stride_d)
+
+        k = tl.load(k_ptr + ordered_cols, mask=mask, other=0.0)
+        rotated_k = tl.load(k_ptr + rotated_cols, mask=mask, other=0.0)
+        y = k * cos + rotated_k * sin
+        tl.store(ok_ptr + output_offs, y, mask=mask)
+
+# Integrated from FlagGems
+def _apply_rotary_pos_emb(
+    q,
+    k,
+    cos,
+    sin,
+    position_ids: Optional[torch.IntTensor] = None,
+    rotary_interleaved: bool = False,
+):
+    """
+    Apply rotary position embedding to q and k
+
+    Args:
+        q: (*, q_heads, head_dim)
+        k: (*, k_heads, head_dim)
+        cos: (max_seq_len, head_dim // 2)
+        sin: (max_seq_len, head_dim // 2)
+        position_ids: (*, ), optional, position ids for each token
+        rotary_interleaved: whether the head_dim is rotated in an interleaved way
+
+    Returns:
+        q_embed: (*, q_heads, head_dim)
+        k_embed: (*, k_heads, head_dim)
+    """
+    assert (
+        k.shape[-1] == q.shape[-1] # 128
+    ), f"q and k must have the same last dimension, got {q.shape} and {k.shape}"
+    assert (
+        cos.shape[-1] == sin.shape[-1] # 128 / 2 = 64
+    ), f"cos and sin must have the same last dimension, got {cos.shape} and {sin.shape}"
+    assert (
+        cos.shape[-1] * 2 == q.shape[-1] # 128
+    ), f"cos/sin dim must be half of q/k dim, got {cos.shape} and {q.shape}"
+    assert cos.stride(-1) == 1, "cos must be contiguous at the last dimension"
+    assert sin.stride(-1) == 1, "sin must be contiguous at the last dimension"
+
+    q_shape = q.shape
+    k_shape = k.shape
+
+    assert (
+        q.shape[:-2] == k.shape[:-2]
+    ), f"q and k must have the same length, got {q.shape[:-2]} and {k.shape[:-2]}"
+    if position_ids is None:
+        assert (
+            len(q.shape) == 4
+        ), f"q must have 4 dimensions if position_ids is not provided, got {q.shape}"
+        seq_len = q.shape[-3]
+    else:
+        assert (
+            position_ids.shape == q.shape[:-2] # num_head 32
+        ), f"position_ids must have the same length as q, got {position_ids.shape} and {q.shape[:-2]}"
+
+        position_ids = position_ids.view(-1)
+        seq_len = None
+
+    q = q.view(-1, q.shape[-2], q.shape[-1])
+    k = k.view(-1, k.shape[-2], k.shape[-1])
+
+    q_embed = torch.empty_like(q)
+    k_embed = torch.empty_like(k)
+
+    n_tokens, q_heads, head_dim = q.shape
+
+    # The block size must be the next power of two, sometimes we need to pad it.
+    padded_head_dim = max(triton.next_power_of_2(head_dim), 16)
+
+    grid = (n_tokens,)
+
+    apply_rotary_pos_emb_kernel[grid](
+        q_embed,
+        k_embed,
+        q,
+        k,
+        cos,
+        sin,
+        position_ids,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k.stride(0),
+        k.stride(1),
+        k.stride(2),
+        q_embed.stride(0),
+        q_embed.stride(1),
+        q_embed.stride(2),
+        k_embed.stride(0),
+        k_embed.stride(1),
+        k_embed.stride(2),
+        position_ids.stride(0) if position_ids is not None else 0,
+        cos.stride(0),
+        sin.stride(0),
+        seq_len,
+        q.shape[-2],
+        k.shape[-2],
+        head_dim,
+        padded_head_dim,
+        rotary_interleaved,
+        MAX_POSITION_EMBEDDINGS=cos.shape[0],
+    )
+
+    q_embed = q_embed.view(q_shape)
+    k_embed = k_embed.view(k_shape)
+    return q_embed, k_embed
+
+def _rotary_embedding(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    head_size: int,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+) -> None:
+    cos_cache, sin_cache = torch.chunk(cos_sin_cache, chunks=2, dim=-1)
+    reshaped_query = query.reshape(-1, query.shape[1]//head_size, head_size)
+    reshaped_key = key.reshape(-1, key.shape[1]//head_size, head_size)
+    reshaped_query, reshaped_key = _apply_rotary_pos_emb(reshaped_query, reshaped_key, cos_cache, sin_cache, positions, False)
+    query.copy_(reshaped_query.reshape(-1, query.shape[1]))
+    key.copy_(reshaped_key.reshape(-1, key.shape[1]))
 
 
 @CustomOp.register("rotary_embedding")
@@ -329,6 +540,23 @@ class RotaryEmbedding(CustomOp):
                                                self.is_neox_style)
             key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
         return query, key
+
+    def forward_triton(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        offsets: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self.cos_sin_cache = self.cos_sin_cache.to(query.device,
+                                                   dtype=query.dtype)
+        if offsets is not None:
+            raise Exception("Terminating the code as batched_rotary_embedding is not supported yet.")
+        else:
+            _rotary_embedding(positions, query, key, self.head_size,
+                             self.cos_sin_cache, self.is_neox_style)
+        return query, key
+
 
     def extra_repr(self) -> str:
         s = f"head_size={self.head_size}, rotary_dim={self.rotary_dim}"

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -4,6 +4,180 @@ from typing import Any, Dict, Optional
 
 import torch
 
+import inspect
+import threading
+import triton
+
+def _get_device_count():
+    """
+    Not supported: neuron(AWS Inferentia), openvino
+    """
+    if hasattr(torch, 'cuda') and torch.cuda.is_available:
+        return torch.cuda.device_count()  # NVIDIA/AMD GPUs
+    elif hasattr(torch, 'xpu') and torch.xpu.is_available():
+        return torch.xpu.device_count()  # Intel XPU devices
+    elif hasattr(torch, 'mlu') and torch.mlu.is_available():
+        return torch.mlu.device_count()  # Cambricon MLU devices
+    elif hasattr(torch, 'ipu') and torch.ipu.is_available():
+        return torch.ipu.device_count()  # Graphcore IPU devices
+    elif hasattr(torch, 'hpu') and torch.hpu.is_available():
+        return torch.hpu.device_count()  # Habana Gaudi HPU devices
+    elif hasattr(torch, 'tpu') and torch.tpu.is_available(): # PyTorch/XLA
+        import torch_xla.core.xla_model as xm
+        return xm.xrt_world_size() # Google TPUs
+    elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        return 1  # Apple MPS (Metal), only one device available
+    else:
+        return 1  # Default to CPU if no other devices are available
+
+DEVICE_COUNT = _get_device_count()
+
+# Integrated from FlagGems
+class LibEntry(triton.KernelInterface):
+    def __init__(
+        self,
+        fn,
+    ):
+        self.fn = fn
+        self.arg_names = fn.arg_names
+        self.divisibility = 16
+        self.kernel_cache = tuple(dict() for _ in range(DEVICE_COUNT))
+
+        fn = self.fn
+        while not isinstance(fn, triton.runtime.JITFunction):
+            fn = fn.fn
+        self.jit_function: triton.runtime.JITFunction = fn
+        self.specialize_indices = [
+            p.num
+            for p in self.jit_function.params
+            if not p.is_constexpr and not p.do_not_specialize
+        ]
+        self.do_not_specialize_indices = [
+            p.num
+            for p in self.jit_function.params
+            if not p.is_constexpr and p.do_not_specialize
+        ]
+        self.lock = threading.Lock()
+
+    def key(self, spec_args, dns_args, const_args):
+        spec_key = [
+            (arg.dtype, arg.data_ptr() % self.divisibility == 0)
+            if hasattr(arg, "data_ptr")
+            else (type(arg), arg)
+            for arg in spec_args
+        ]
+        dns_key = [
+            arg.dtype
+            if hasattr(arg, "data_ptr")
+            else type(arg)
+            if not isinstance(arg, int)
+            else "i32"
+            if -(2**31) <= arg and arg <= 2**31 - 1
+            else "u64"
+            if 2**63 <= arg and arg <= 2**64 - 1
+            else "i64"
+            for arg in dns_args
+        ]
+        # const args passed by position
+        return tuple(spec_key + dns_key + const_args)
+
+    def run(self, *args, **kwargs):
+        grid = kwargs["grid"]
+
+        # collect all the arguments
+        spec_args = []  # specialize arguments
+        dns_args = []  # do not specialize arguments
+        const_args = []  # constexpr arguments
+        k_args = []  # kernel arguments
+        for i, arg in enumerate(args):
+            if i in self.specialize_indices:
+                k_args.append(arg)
+                spec_args.append(arg)
+            elif i in self.do_not_specialize_indices:
+                k_args.append(arg)
+                dns_args.append(arg)
+            else:
+                const_args.append(arg)
+        for p in self.jit_function.params[len(args) :]:
+            if p.name in kwargs:
+                val = kwargs[p.name]
+            elif p.default is inspect._empty:
+                continue
+            else:
+                val = p.default
+
+            if p.is_constexpr:
+                const_args.append(val)
+            elif p.do_not_specialize:
+                dns_args.append(val)
+                k_args.append(val)
+            else:
+                spec_args.append(val)
+                k_args.append(val)
+
+        entry_key = self.key(spec_args, dns_args, const_args)
+        device = torch.cuda.current_device()
+        cache = self.kernel_cache[device]
+        while entry_key not in cache:
+            # NOTE: we serialize the first run of a jit function regardless of which device to run on
+            # because Triton runtime is currently not threadsafe.
+            with self.lock:
+                if entry_key in cache:
+                    break
+                kernel = self.fn.run(*args, **kwargs)
+                fn = self.fn
+                # collect constexpr arguments for grid computation
+                constexprs = {}
+                while not isinstance(fn, triton.runtime.JITFunction):
+                    if isinstance(fn, triton.runtime.Autotuner):
+                        config = fn.best_config
+                        constexprs["num_warps"] = config.num_warps
+                        constexprs["num_stages"] = config.num_stages
+                        constexprs["num_ctas"] = config.num_ctas
+                        constexprs = {**constexprs, **config.kwargs}
+                    elif isinstance(fn, triton.runtime.Heuristics):
+                        for v, heur in fn.values.items():
+                            constexprs[v] = heur(
+                                {
+                                    **dict(zip(fn.arg_names, args)),
+                                    **kwargs,
+                                    **constexprs,
+                                }
+                            )
+                    else:
+                        raise RuntimeError("Invalid Runtime Function")
+                    fn = fn.fn
+                for p in self.jit_function.params:
+                    if p.is_constexpr and p.name not in constexprs:
+                        constexprs[p.name] = p.default
+                cache[entry_key] = (kernel, constexprs)
+            return kernel, constexprs
+
+        kernel, constexprs = cache[entry_key]
+
+        if callable(grid):
+            # collect all arguments to the grid fn，ie:
+            # 1. args,
+            # 2. kwargs,
+            # 3. all all other captured arguments in CompiledKernel from Autotunner & Heuristics
+            # when kwargs & captured args conflict, captured args have higher priority
+            meta = {**dict(zip(self.arg_names, args)), **kwargs, **constexprs}
+            grid = grid(meta)
+        grid = grid + (1, 1)
+
+        kernel[grid[0:3]](*k_args)
+        return kernel, constexprs
+
+# Integrated from FlagGems
+def libentry():
+    """
+    Decorator for triton library entries.
+    """
+
+    def decorator(fn):
+        return LibEntry(fn)
+
+    return decorator
 
 def set_random_seed(seed: int) -> None:
     from vllm.platforms import current_platform


### PR DESCRIPTION
This is the PR1 for #13319. Please refer to it for a comprehensive proposal, including the motivation and the full proposed design.

Add a new environment flag called VLLM_USE_TRITON_NON_ATTN. Implement all non-attention path operators in Triton, categorized into two major types:
- CustomOP-Based Operators: Includes RMSNorm, activation functions, and RoPE.
- Non-CustomOP Operators: Covers other operators, including linear operators.

We have verified it on L4 and H20 using OPT, Llma2, Deepseek V2 Lite. Although we have not yet implemented DeepSeek v2 Lite’s RoPE(yarn) in Triton, other operators have been successfully replaced, and the functionality remains fully operational.