### PR TITLE
[Misc] Print FusedMoE detail info

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -717,3 +717,23 @@ class FusedMoE(torch.nn.Module):
             # If we are in the row parallel case (down_proj)
             else:
                 param_data[expert_id] = loaded_weight
+
+    def extra_repr(self) -> str:
+
+        s = (
+            f"global_num_experts={self.global_num_experts}, "
+            f"local_num_experts={self.local_num_experts}, "
+            f"top_k={self.top_k}, "
+            f"intermediate_size_per_partition={self.intermediate_size_per_partition}, "  # noqa: E501
+            f"tp_size={self.tp_size},\n"
+            f"ep_size={self.ep_size}, "
+            f"reduce_results={self.reduce_results}, "
+            f"renormalize={self.renormalize}, "
+            f"use_grouped_topk={self.use_grouped_topk}")
+
+        if self.use_grouped_topk:
+            s += f", num_expert_group={self.num_expert_group}, topk_group={self.topk_group}"  # noqa: E501
+
+        s += f", scoring_func='{self.scoring_func}', activation='{self.activation}'"  # noqa: E501
+
+        return s


### PR DESCRIPTION
The effect is shown as follows:
```python
DeepseekV2ForCausalLM(
  (model): DeepseekV2Model(
    (embed_tokens): VocabParallelEmbedding(num_embeddings=102400, embedding_dim=2048, org_vocab_size=102400, num_embeddings_padded=102400, tp_size=1)
    (layers): ModuleList(
      (0): DeepseekV2DecoderLayer(
        (self_attn): DeepseekV2MLAAttention(
          (q_proj): ColumnParallelLinear(in_features=2048, output_features=3072, bias=False, tp_size=1, gather_output=False)
          (kv_a_proj_with_mqa): ReplicatedLinear(in_features=2048, output_features=576, bias=False)
          (kv_a_layernorm): RMSNorm(hidden_size=512, eps=1e-06)
          (kv_b_proj): ColumnParallelLinear(in_features=512, output_features=4096, bias=False, tp_size=1, gather_output=False)
          (o_proj): RowParallelLinear(input_features=2048, output_features=2048, bias=False, tp_size=1, reduce_results=True)
          (rotary_emb): DeepseekScalingRotaryEmbedding(head_size=64, rotary_dim=64, max_position_embeddings=4096, base=10000, is_neox_style=False)
          (mla_attn): Attention(head_size=512, num_heads=16, num_kv_heads=1, scale=0.1147213867929261, backend=TritonMLAImpl)
        )
        (mlp): DeepseekV2MLP(
          (gate_up_proj): MergedColumnParallelLinear(in_features=2048, output_features=21888, bias=False, tp_size=1, gather_output=False)
          (down_proj): RowParallelLinear(input_features=10944, output_features=2048, bias=False, tp_size=1, reduce_results=True)
          (act_fn): SiluAndMul()
        )
        (input_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
        (post_attention_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
      )
      (1-26): 26 x DeepseekV2DecoderLayer(
        (self_attn): DeepseekV2MLAAttention(
          (q_proj): ColumnParallelLinear(in_features=2048, output_features=3072, bias=False, tp_size=1, gather_output=False)
          (kv_a_proj_with_mqa): ReplicatedLinear(in_features=2048, output_features=576, bias=False)
          (kv_a_layernorm): RMSNorm(hidden_size=512, eps=1e-06)
          (kv_b_proj): ColumnParallelLinear(in_features=512, output_features=4096, bias=False, tp_size=1, gather_output=False)
          (o_proj): RowParallelLinear(input_features=2048, output_features=2048, bias=False, tp_size=1, reduce_results=True)
          (rotary_emb): DeepseekScalingRotaryEmbedding(head_size=64, rotary_dim=64, max_position_embeddings=4096, base=10000, is_neox_style=False)
          (mla_attn): Attention(head_size=512, num_heads=16, num_kv_heads=1, scale=0.1147213867929261, backend=TritonMLAImpl)
        )
        (mlp): DeepseekV2MoE(
          (gate): ReplicatedLinear(in_features=2048, output_features=64, bias=False)
          (experts): FusedMoE(
            global_num_experts=64, local_num_experts=64, top_k=6, intermediate_size_per_partition=1408, tp_size=1,
            ep_size=1, reduce_results=False, renormalize=False, use_grouped_topk=True, num_expert_group=1, topk_group=1, scoring_func='softmax', activation='silu'
            (quant_method): UnquantizedFusedMoEMethod()
          )
          (shared_experts): DeepseekV2MLP(
            (gate_up_proj): MergedColumnParallelLinear(in_features=2048, output_features=5632, bias=False, tp_size=1, gather_output=False)
            (down_proj): RowParallelLinear(input_features=2816, output_features=2048, bias=False, tp_size=1, reduce_results=False)
            (act_fn): SiluAndMul()
          )
        )
        (input_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
        (post_attention_layernorm): RMSNorm(hidden_size=2048, eps=1e-06)
      )
    )
    (norm): RMSNorm(hidden_size=2048, eps=1e-06)
  )
  (lm_head): ParallelLMHead(num_embeddings=102400, embedding_dim=2048, org_vocab_size=102400, num_embeddings_padded=102400, tp_size=1)
  (logits_processor): LogitsProcessor(vocab_size=102400, forg_vocab_size=102400, scale=1.0, logits_as_input=False)
  (sampler): Sampler()
)
```