### PR TITLE
[V1][TPU] Support standard V1 Sampler

### DIFF
--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -1,15 +1,13 @@
 # Common dependencies
 -r requirements-common.txt
-
 # Dependencies for TPU
-cmake>=3.26
+#cmake>=3.26
 ninja
 packaging
 setuptools-scm>=8
 wheel
 jinja2
 ray[default]
-
 # Install torch_xla
 --pre
 --extra-index-url https://download.pytorch.org/whl/nightly/cpu
@@ -17,7 +15,9 @@ ray[default]
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.6.0.dev20241216+cpu
+torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.6.0.dev20241216%2Bcpu-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.6.0.dev20241216%2Bcpu-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch @ https://download.pytorch.org/whl/nightly/cpu/torch-2.6.0.dev20241216%2Bcpu-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
 torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.7.0.dev20250124-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"

--- a/requirements-tpu.txt
+++ b/requirements-tpu.txt
@@ -1,7 +1,7 @@
 # Common dependencies
 -r requirements-common.txt
 # Dependencies for TPU
-#cmake>=3.26
+cmake>=3.26
 ninja
 packaging
 setuptools-scm>=8

--- a/tests/v1/tpu/test_sampler.py
+++ b/tests/v1/tpu/test_sampler.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+from time import time
+
+import pytest
+
+from vllm import LLM, envs
+from vllm.platforms import current_platform
+from vllm.sampling_params import SamplingParams
+
+if not envs.VLLM_USE_V1:
+    pytest.skip(
+        "Skipping V1 tests. Rerun with `VLLM_USE_V1=1` to test.",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.parametrize("model_name", ["D4nt3/Qwen2.5-two-layers"])
+@pytest.mark.skipif(not current_platform.is_tpu(),
+                    reason="This test needs a TPU")
+def test_sampler_compilation(model_name: str):
+    """
+    Check that no recompilation happens despite changing sampling parameters.
+    We can't read XLA metrics from the engine process, hence we measure time.  
+    """
+    # Compiling model init may still take some time, enforce_eager to skip it.
+    llm = LLM(model_name,
+              enforce_eager=True,
+              max_num_seqs=16,
+              max_model_len=1024,
+              gpu_memory_utilization=0.5)
+    prompts = [
+        "A robot may not injure a human being",
+        "It is only with the heart that one can see rightly;",
+    ]
+    # First inference should be slow
+    sampling_params = SamplingParams(
+        temperature=0.7,
+        # top_p=0.6, # too slow!
+        # top_k=10,
+        min_p=0.2,
+        max_tokens=16)
+    s = time()
+    _ = llm.generate(prompts, sampling_params)
+    run1 = time() - s
+
+    # Second request with different params, but for which we
+    # compiled for in previous eager iteration.
+    sampling_params = SamplingParams(temperature=0.1, min_p=0.8, max_tokens=24)
+    s = time()
+    _ = llm.generate(prompts, sampling_params)
+    run2 = time() - s
+
+    # much faster after compiling
+    assert run1 * 0.1 > run2
+
+    # Third request with min_p set to "None". It will not trigger recompilation
+    # as a default 0 value will be used.
+    sampling_params = SamplingParams(max_tokens=24, temperature=1.0)
+    s = time()
+    _ = llm.generate(prompts, sampling_params)
+    run3 = time() - s
+
+    assert run1 * 0.1 > run3

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -22,7 +22,7 @@ class TopKTopPSampler(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if current_platform.is_cuda:
+        if current_platform.is_cuda():
             if is_flashinfer_available:
                 if envs.VLLM_USE_FLASHINFER_SAMPLER is not False:
                     # NOTE(woosuk): The V0 sampler doesn't use FlashInfer for

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -95,9 +95,11 @@ def apply_top_k_top_p(
 
     if k is not None:
         # Apply top-k.
-        top_k_mask = logits_sort.size(1) - k.to(torch.long)
+        top_k_mask = logits_sort.size(1) - k
+        # Broadcast to each element (xla friendly). 
+        indices = torch.ones((logits.shape[0], 1), dtype=torch.long, device=logits_sort.device) * top_k_mask
         # Get all the top_k values.
-        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
+        top_k_mask = logits_sort.gather(1, indices)
         top_k_mask = logits_sort < top_k_mask
         logits_sort.masked_fill_(top_k_mask, -float("inf"))
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -89,7 +89,7 @@ class TopKTopPSampler(nn.Module):
         p: Optional[torch.Tensor],
     ) -> torch.Tensor:
         # TODO Placeholder for TPU optimized topk/p kernel
-        return self.forward_cuda(logits, generators, k, p)
+        return self.forward_native(logits, generators, k, p)
 
 
 def apply_top_k_top_p(

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -107,7 +107,7 @@ def apply_top_k_top_p(
 
     if k is not None:
         # Apply top-k.
-        top_k_mask = logits_sort.size(1) - k.to(torch.long) # shape: B
+        top_k_mask = logits_sort.size(1) - k.to(torch.long)  # shape: B
         # Get all the top_k values.
         top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
         top_k_mask = logits_sort < top_k_mask

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -95,11 +95,9 @@ def apply_top_k_top_p(
 
     if k is not None:
         # Apply top-k.
-        top_k_mask = logits_sort.size(1) - k
-        # Broadcast to each element (xla friendly). 
-        indices = torch.ones((logits.shape[0], 1), dtype=torch.long, device=logits_sort.device) * top_k_mask
+        top_k_mask = logits_sort.size(1) - k.to(torch.long) # shape: B
         # Get all the top_k values.
-        top_k_mask = logits_sort.gather(1, indices)
+        top_k_mask = logits_sort.gather(1, top_k_mask.unsqueeze(dim=1))
         top_k_mask = logits_sort < top_k_mask
         logits_sort.masked_fill_(top_k_mask, -float("inf"))
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -48,6 +48,8 @@ class TopKTopPSampler(nn.Module):
                     "native implementation of top-p & top-k sampling. For the "
                     "best performance, please install FlashInfer.")
                 self.forward = self.forward_native
+        elif current_platform.is_tpu():
+            self.forward = self.forward_tpu
         else:
             self.forward = self.forward_native
 
@@ -78,6 +80,16 @@ class TopKTopPSampler(nn.Module):
             # CPU-GPU synchronization while `flashinfer_sample` does.
             return random_sample(probs, generators)
         return flashinfer_sample(probs, k, p, generators)
+
+    def forward_tpu(
+        self,
+        logits: torch.Tensor,
+        generators: Dict[int, torch.Generator],
+        k: Optional[torch.Tensor],
+        p: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        # TODO Placeholder for TPU optimized topk/p kernel
+        return self.forward_cuda(logits, generators, k, p)
 
 
 def apply_top_k_top_p(

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -23,7 +23,7 @@ class RejectionSampler(nn.Module):
 
     def __init__(self):
         super().__init__()
-        if current_platform.is_cuda:
+        if current_platform.is_cuda():
             if is_flashinfer_available:
                 if envs.VLLM_USE_FLASHINFER_SAMPLER is not False:
                     # NOTE(woosuk): The V0 sampler doesn't use FlashInfer for

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -213,8 +213,8 @@ class Sampler(nn.Module):
         adjusted_min_p = min_p.unsqueeze(1) * max_probabilities
         # Identify valid tokens using threshold comparison
         valid_token_mask = probability_values >= adjusted_min_p
-        # Apply mask using boolean indexing
-        logits[~valid_token_mask] = -float('inf')
+        # Apply mask using boolean indexing (xla friendly)
+        logits.masked_fill_(~valid_token_mask, -float("inf"))
         return logits
 
     def apply_logits_bias(

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -760,11 +760,11 @@ class TPUModelRunner:
         model = ModelWrapperV1(model)
         self.model = model
         # TODO (Nicolo) will yield multiple fxsubgraph that trigger more
-        # recompilations xla-side..can we benchmark this before enabling?
-        # self.model = torch.compile(model,
-                                #    backend="openxla",
-                                #    fullgraph=True,
-                                #    dynamic=False)
+        # recompilations xla-side..but disabling it will break things(??)
+        self.model = torch.compile(model,
+                                   backend="openxla",
+                                   fullgraph=True,
+                                   dynamic=False)
 
     def dummy_run(
         self,
@@ -1071,8 +1071,7 @@ class ModelWrapperV1(nn.Module):
         sampler_output = self.sample(logits, sampling_metadata)
         # TODO support logprobs here
         sampled_token_ids = sampler_output.sampled_token_ids
-        return sampled_token_ids
-
+        return sampled_token_ids.squeeze(dim=-1)
 
 def swap_positions(b: InputBatch, id_1, id_2):
     assert id_1 != id_2

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -991,8 +991,6 @@ class TPUModelRunner:
             torch._dynamo.mark_dynamic(attn_metadata.slot_mapping, 1)
         else:
             # Decode
-            torch._dynamo.mark_dynamic(token_ids, 0)
-            torch._dynamo.mark_dynamic(position_ids, 0)
             torch._dynamo.mark_dynamic(attn_metadata.slot_mapping, 0)
             torch._dynamo.mark_dynamic(attn_metadata.context_lens, 0)
             torch._dynamo.mark_dynamic(attn_metadata.block_tables, 0)


### PR DESCRIPTION
This PR aims to enable the support of the V1 Sampler for `TPUModelRunner`.

TL;DR: topk/topp is way too slow now, but we should be able to interface the other options with the current `Sampler` code.

The idea is to add the sampling operations to the model xla graph. Since re-utilizing a subgraph (the model fwd) is not supported in xla (this could've been useful to compile a bunch of different sampling graphs on top of the model), a single traced sampling function should be recorded. 
This entails we have to provide default values to all sampling options so that we can toggle off the unneeded ones by evaluating them to an Identity operation (eg `top_p=1.0`).

The Sampler's code is mostly already compatible for being compiled into an xla graph, apart from a few minor options: `logit_bias` , `min_tokens` , `all_greedy`.
The main issue is in executing the topk/topp code on TPU, as it results in a significant slowdown in both compilation/inti and run time. For now, I've resolved to disable both options until we have some faster kernel.

The rest of the PR is just making sure to have an xla-friendly `SamplingMetadata` interface,  which avoids recompiling optional parameters and handles the "padding to a pre-compiled shape" that we have on TPUs. 


Test sampling with `VLLM_USE_V1=1 python -m pytest -s tests/v1/tpu/test_sampler.py` for "~jit" execution or `VLLM_USE_V1=1 vllm serve Qwen/Qwen2.5-1.5B-Instruct --max-model-len 1024 --max-num-seqs 256` for pre-compiling.
```bash
INFO 02-27 18:18:39 [tpu_model_runner.py:1009] Compiling the model with different input shapes for prefill:

INFO 02-27 18:19:08 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 16
INFO 02-27 18:19:08 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 32
INFO 02-27 18:19:09 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 64
INFO 02-27 18:19:09 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 128
INFO 02-27 18:19:10 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 256
INFO 02-27 18:19:10 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 512
INFO 02-27 18:19:11 [tpu_model_runner.py:1020]   batch_size: 1, seq_len: 1024
INFO 02-27 18:19:11 [tpu_model_runner.py:1028]     -- Compilation for prefill done in 31.66 [secs].
INFO 02-27 18:19:11 [tpu_model_runner.py:1057] Compiling the model with different input shapes for decode:
INFO 02-27 18:19:21 [tpu_model_runner.py:1068]   batch_size: 8, seq_len: 1
INFO 02-27 18:19:31 [tpu_model_runner.py:1068]   batch_size: 16, seq_len: 1
INFO 02-27 18:19:43 [tpu_model_runner.py:1068]   batch_size: 32, seq_len: 1
INFO 02-27 18:19:54 [tpu_model_runner.py:1068]   batch_size: 48, seq_len: 1
INFO 02-27 18:20:06 [tpu_model_runner.py:1068]   batch_size: 64, seq_len: 1
INFO 02-27 18:20:17 [tpu_model_runner.py:1068]   batch_size: 80, seq_len: 1
INFO 02-27 18:20:28 [tpu_model_runner.py:1068]   batch_size: 96, seq_len: 1
INFO 02-27 18:20:41 [tpu_model_runner.py:1068]   batch_size: 112, seq_len: 1
INFO 02-27 18:20:52 [tpu_model_runner.py:1068]   batch_size: 128, seq_len: 1
INFO 02-27 18:21:03 [tpu_model_runner.py:1068]   batch_size: 144, seq_len: 1
INFO 02-27 18:21:17 [tpu_model_runner.py:1068]   batch_size: 160, seq_len: 1
INFO 02-27 18:21:28 [tpu_model_runner.py:1068]   batch_size: 176, seq_len: 1
INFO 02-27 18:21:40 [tpu_model_runner.py:1068]   batch_size: 192, seq_len: 1
INFO 02-27 18:21:51 [tpu_model_runner.py:1068]   batch_size: 208, seq_len: 1
INFO 02-27 18:22:05 [tpu_model_runner.py:1068]   batch_size: 224, seq_len: 1
INFO 02-27 18:22:17 [tpu_model_runner.py:1068]   batch_size: 240, seq_len: 1
INFO 02-27 18:22:28 [tpu_model_runner.py:1068]   batch_size: 256, seq_len: 1
INFO 02-27 18:22:28 [tpu_model_runner.py:1075]     -- Compilation for decode done in 197.66 [secs].

```


TODO:
 - [ ] test sampling param produce different outputs
 - [ ] enable more options. Probably in following PRs to better check impact on performance too.


<details>

<summary>UPDATE: On topk/topp performace</summary>

I've run some micro-benchmarks on the current topk/topp implementation to highlight differences in time.
It runs a random linear layer (simulated lm_head) followed by sampling. Code [here](https://github.com/NickLucche/llm-scripts/tree/master/vllm/tpu-sampler-benchmark), feel free to double check the scripts.

vLLM sampler on TPUv6 (torch-xla):
```bash
   python vllm/tpu-sampler-benchmark/sampler_microbenchmark.py
INFO 03-03 11:20:11 [__init__.py:207] Automatically detected platform tpu.
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
Compiling/Warmup 1 elapsed time: 4.442102432250977
Compiling/Warmup 4 elapsed time: 4.5806968212127686
Compiling/Warmup 16 elapsed time: 4.375824928283691
Compiling/Warmup 32 elapsed time: 4.597050428390503
Running 1 elapsed time: 0.02094721794128418
Running 1 elapsed time: 0.020517826080322266
Running 1 elapsed time: 0.020459890365600586
Running 1 elapsed time: 0.02043437957763672
Running 4 elapsed time: 0.0777747631072998
Running 4 elapsed time: 0.07848191261291504
Running 4 elapsed time: 0.07846784591674805
Running 4 elapsed time: 0.07887482643127441
Running 16 elapsed time: 0.25572896003723145
Running 16 elapsed time: 0.2562577724456787
Running 16 elapsed time: 0.25624656677246094
Running 16 elapsed time: 0.2562131881713867
Running 32 elapsed time: 0.5071756839752197
Running 32 elapsed time: 0.5076909065246582
Running 32 elapsed time: 0.5076868534088135
Running 32 elapsed time: 0.5077009201049805
```
vLLM sampler on CUDA, no flashinfer (forward_native) on L4:
```bash
INFO 03-03 10:41:46 [__init__.py:207] Automatically detected platform cuda.
WARNING 03-03 10:41:46 [topk_topp_sampler.py:46] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
Compiling/Warmup 1 elapsed time: 0.8291933536529541
Compiling/Warmup 4 elapsed time: 0.10055041313171387
Compiling/Warmup 16 elapsed time: 0.013581037521362305
Compiling/Warmup 32 elapsed time: 0.013128995895385742
Running 1 elapsed time: 0.008679866790771484
Running 1 elapsed time: 0.008601188659667969
Running 1 elapsed time: 0.008600711822509766
Running 1 elapsed time: 0.008601903915405273
Running 4 elapsed time: 0.009422063827514648
Running 4 elapsed time: 0.009502649307250977
Running 4 elapsed time: 0.009497880935668945
Running 4 elapsed time: 0.00953054428100586
Running 16 elapsed time: 0.01054692268371582
Running 16 elapsed time: 0.010563373565673828
Running 16 elapsed time: 0.01054239273071289
Running 16 elapsed time: 0.01055598258972168
Running 32 elapsed time: 0.013098955154418945
Running 32 elapsed time: 0.013221025466918945
Running 32 elapsed time: 0.013271808624267578
```

I also benchmarked a barebone jax implementation of the sampling, for comparison.

JAX on same TPU
```bash
python vllm/tpu-sampler-benchmark/jax_proto_sampler.py     
[TpuDevice(id=0, process_index=0, coords=(0,0,0), core_on_chip=0), TpuDevice(id=1, process_index=0, coords=(1,0,0), core_on_chip=0), TpuDevice(id=2, process_index=0, coords=(0,1,0), core_on_chip=0), TpuDevice(id=3, process_index=0, coords=(1,1,0), core_on_chip=0)]


Compiling/Warmup 1 40.11301302909851
Compiling/Warmup 4 19.129047632217407
Compiling/Warmup 16 17.657644033432007
Compiling/Warmup 32 17.789708852767944
Running 1 0.0032927989959716797
Running 1 0.003267049789428711
Running 1 0.0032567977905273438
Running 1 0.0032553672790527344
Running 4 0.006731271743774414
Running 4 0.006708860397338867
Running 4 0.0067102909088134766
Running 4 0.006703615188598633
Running 16 0.022034168243408203
Running 16 0.02204728126525879
Running 16 0.022046566009521484
Running 16 0.022042274475097656
Running 32 0.04318523406982422
Running 32 0.04320979118347168
Running 32 0.043207406997680664
Running 32 0.04319953918457031
```

</details>
