### PR TITLE
[core] Bump ray to 2.43

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       - dependency-name: "lm-format-enforcer"
       - dependency-name: "gguf"
       - dependency-name: "compressed-tensors"
-      - dependency-name: "ray[cgraph]"
+      - dependency-name: "ray[cgraph]" # Ray Compiled Graph
       - dependency-name: "lm-eval"
     groups:
       minor-update:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       - dependency-name: "lm-format-enforcer"
       - dependency-name: "gguf"
       - dependency-name: "compressed-tensors"
-      - dependency-name: "ray[adag]"
+      - dependency-name: "ray[cgraph]"
       - dependency-name: "lm-eval"
     groups:
       minor-update:

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray[adag] == 2.40.0 # Required for pipeline parallelism in V1.
+ray[cgraph] == 2.43.0 # Required for pipeline parallelism in V1.
 torch == 2.5.1
 torchaudio==2.5.1
 # These must be updated alongside torch

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray[cgraph] == 2.43.0 # Required for pipeline parallelism in V1.
+ray[cgraph] >= 2.43.0 # Required for pipeline parallelism in V1.
 torch == 2.5.1
 torchaudio==2.5.1
 # These must be updated alongside torch

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -2,7 +2,7 @@
 -r requirements-common.txt
 
 # Dependencies for NVIDIA GPUs
-ray[cgraph] >= 2.43.0 # Required for pipeline parallelism in V1.
+ray[cgraph] >= 2.43.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch == 2.5.1
 torchaudio==2.5.1
 # These must be updated alongside torch

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -16,7 +16,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[cgraph]==2.43.0
+ray[cgraph]>=2.43.0
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -16,7 +16,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[cgraph]>=2.43.0
+ray[cgraph]>=2.43.0 # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -16,7 +16,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[adag]==2.40.0
+ray[cgraph]==2.43.0
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -23,10 +23,6 @@ anyio==4.6.2.post1
     # via httpx
 argcomplete==3.5.1
     # via datamodel-code-generator
-async-timeout==4.0.3
-    # via
-    #   aiohttp
-    #   redis
 attrs==24.2.0
     # via
     #   aiohttp
@@ -120,10 +116,6 @@ encodec==0.1.1
     # via vocos
 evaluate==0.4.3
     # via lm-eval
-exceptiongroup==1.2.2
-    # via
-    #   anyio
-    #   pytest
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -552,7 +544,9 @@ sentence-transformers==3.2.1
 sentencepiece==0.2.0
     # via mistral-common
 setuptools==75.8.0
-    # via pytablewriter
+    # via
+    #   pytablewriter
+    #   torch
 six==1.16.0
     # via
     #   python-dateutil
@@ -597,12 +591,6 @@ timm==1.0.11
     # via -r requirements-test.in
 tokenizers==0.21.0
     # via transformers
-toml==0.10.2
-    # via datamodel-code-generator
-tomli==2.2.1
-    # via
-    #   black
-    #   pytest
 torch==2.5.1
     # via
     #   -r requirements-test.in
@@ -663,17 +651,13 @@ typepy==1.3.2
     #   tabledata
 typing-extensions==4.12.2
     # via
-    #   anyio
     #   bitsandbytes
-    #   black
     #   huggingface-hub
     #   librosa
     #   mistral-common
-    #   multidict
     #   pqdm
     #   pydantic
     #   pydantic-core
-    #   rich
     #   torch
 tzdata==2024.2
     # via pandas

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -23,6 +23,10 @@ anyio==4.6.2.post1
     # via httpx
 argcomplete==3.5.1
     # via datamodel-code-generator
+async-timeout==4.0.3
+    # via
+    #   aiohttp
+    #   redis
 attrs==24.2.0
     # via
     #   aiohttp
@@ -116,6 +120,10 @@ encodec==0.1.1
     # via vocos
 evaluate==0.4.3
     # via lm-eval
+exceptiongroup==1.2.2
+    # via
+    #   anyio
+    #   pytest
 fastparquet==2024.11.0
     # via genai-perf
 fastrlock==0.8.2
@@ -472,7 +480,7 @@ pyyaml==6.0.2
     #   vocos
 rapidfuzz==3.12.1
     # via jiwer
-ray==2.40.0
+ray==2.43.0
     # via -r requirements-test.in
 redis==5.2.0
     # via tensorizer
@@ -544,9 +552,7 @@ sentence-transformers==3.2.1
 sentencepiece==0.2.0
     # via mistral-common
 setuptools==75.8.0
-    # via
-    #   pytablewriter
-    #   torch
+    # via pytablewriter
 six==1.16.0
     # via
     #   python-dateutil
@@ -591,6 +597,12 @@ timm==1.0.11
     # via -r requirements-test.in
 tokenizers==0.21.0
     # via transformers
+toml==0.10.2
+    # via datamodel-code-generator
+tomli==2.2.1
+    # via
+    #   black
+    #   pytest
 torch==2.5.1
     # via
     #   -r requirements-test.in
@@ -651,13 +663,17 @@ typepy==1.3.2
     #   tabledata
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   bitsandbytes
+    #   black
     #   huggingface-hub
     #   librosa
     #   mistral-common
+    #   multidict
     #   pqdm
     #   pydantic
     #   pydantic-core
+    #   rich
     #   torch
 tzdata==2024.2
     # via pandas


### PR DESCRIPTION
Bump ray version to 2.43

- Using `ray[cgraph]` as the new pip dependency. `ray[adag]` is still supported for backwards compatibility. Both of them refer to Ray Compiled Graph: https://docs.ray.io/en/latest/ray-core/compiled-graph/ray-compiled-graph.html
- Update with small Compiled Graph API change

FIX #13935 #12747