### PR TITLE
benchmark serving: random + sharegpt dataset

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -114,11 +114,11 @@ def download_and_cache_file(url: str, filename: Optional[str] = None):
 
     # Use tqdm to display the progress bar
     with open(filename, "wb") as f, tqdm(
-        desc=filename,
-        total=total_size,
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
+            desc=filename,
+            total=total_size,
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
     ) as bar:
         for chunk in response.iter_content(chunk_size=chunk_size):
             f.write(chunk)

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -133,9 +133,6 @@ def sample_sharegpt_requests(
     fixed_output_len: Optional[int] = None,
 ) -> List[Tuple[str, int, int, None]]:
 
-    print(dataset_path)
-    print(dataset_path)
-    print(dataset_path)
     # Download sharegpt if necessary
     if not os.path.isfile(dataset_path):
         dataset_path = download_and_cache_file(SHAREGPT_URL)

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -428,7 +428,8 @@ def sample_random_requests(
     )
 
     if dataset_path is not None:
-        # Sample token ids from ShareGPT and repeat/truncate them to satisfy the input_lens
+        # Sample token ids from ShareGPT and 
+        # repeat/truncate them to satisfy the input_lens
 
         # Download sharegpt if necessary
         if not os.path.isfile(dataset_path):
@@ -441,7 +442,8 @@ def sample_random_requests(
         dataset = [data for data in dataset if len(data["conversations"]) >= 2]
         # Only keep the first two turns of each conversation.
         dataset = [
-            (data["conversations"][0]["value"], data["conversations"][1]["value"])
+            (data["conversations"][0]["value"], 
+                data["conversations"][1]["value"])
             for data in dataset
         ]
         # Shuffle the dataset.
@@ -469,7 +471,8 @@ def sample_random_requests(
                 ratio = (input_lens[i] + prompt_len - 1) // prompt_len
                 input_ids = (prompt_token_ids * ratio)[: input_lens[i]]
             prompt = tokenizer.decode(input_ids)
-            input_requests.append((prompt, int(input_lens[i]), int(output_lens[i]), None))
+            input_requests.append((prompt, int(input_lens[i]), 
+                int(output_lens[i]), None))
     else:
         offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
         input_requests = []

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -91,7 +91,9 @@ class BenchmarkMetrics:
     std_e2el_ms: float
     percentiles_e2el_ms: List[Tuple[float, float]]
 
+
 SHAREGPT_URL = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+
 
 def download_and_cache_file(url: str, filename: Optional[str] = None):
     """Read and cache a file from a url."""
@@ -125,6 +127,7 @@ def download_and_cache_file(url: str, filename: Optional[str] = None):
             bar.update(len(chunk))
 
     return filename
+
 
 def sample_sharegpt_requests(
     dataset_path: str,
@@ -442,7 +445,6 @@ def sample_random_requests(
         # Only keep the first two turns of each conversation.
         dataset = [(data["conversations"][0]["value"],
                     data["conversations"][1]["value"]) for data in dataset]
-
 
         # Shuffle the dataset.
         random.shuffle(dataset)

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -428,8 +428,7 @@ def sample_random_requests(
     )
 
     if dataset_path is not None:
-        # Sample token ids from ShareGPT and 
-        # repeat/truncate them to satisfy the input_lens
+        # From ShareGPT repeat/truncate them to satisfy the input_lens
 
         # Download sharegpt if necessary
         if not os.path.isfile(dataset_path):
@@ -441,11 +440,10 @@ def sample_random_requests(
         # Filter out the conversations with less than 2 turns.
         dataset = [data for data in dataset if len(data["conversations"]) >= 2]
         # Only keep the first two turns of each conversation.
-        dataset = [
-            (data["conversations"][0]["value"], 
-                data["conversations"][1]["value"])
-            for data in dataset
-        ]
+        dataset = [(data["conversations"][0]["value"],
+                    data["conversations"][1]["value"]) for data in dataset]
+
+
         # Shuffle the dataset.
         random.shuffle(dataset)
 
@@ -466,19 +464,20 @@ def sample_random_requests(
                 continue
 
             if prompt_len > input_lens[i]:
-                input_ids = prompt_token_ids[: input_lens[i]]
+                input_ids = prompt_token_ids[:input_lens[i]]
             else:
                 ratio = (input_lens[i] + prompt_len - 1) // prompt_len
-                input_ids = (prompt_token_ids * ratio)[: input_lens[i]]
+                input_ids = (prompt_token_ids * ratio)[:input_lens[i]]
             prompt = tokenizer.decode(input_ids)
-            input_requests.append((prompt, int(input_lens[i]), 
-                int(output_lens[i]), None))
+            input_requests.append(
+                (prompt, int(input_lens[i]), int(output_lens[i]), None))
     else:
         offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
         input_requests = []
         for i in range(num_prompts):
             prompt = tokenizer.decode(prefix_token_ids +
-                                      [(offsets[i] + i + j) % tokenizer.vocab_size
+                                      [(offsets[i] + i + j) %
+                                       tokenizer.vocab_size
                                        for j in range(input_lens[i])])
 
             input_requests.append((prompt, int(prefix_len + input_lens[i]),

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -38,6 +38,7 @@ from datetime import datetime
 from typing import Any, AsyncGenerator, Collection, Dict, List, Optional, Tuple
 
 import numpy as np
+import requests
 import pandas as pd
 from backend_request_func import (ASYNC_REQUEST_FUNCS, RequestFuncInput,
                                   RequestFuncOutput)
@@ -90,6 +91,40 @@ class BenchmarkMetrics:
     std_e2el_ms: float
     percentiles_e2el_ms: List[Tuple[float, float]]
 
+SHAREGPT_URL = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+
+def download_and_cache_file(url: str, filename: Optional[str] = None):
+    """Read and cache a file from a url."""
+    if filename is None:
+        filename = os.path.join("./", url.split("/")[-1])
+
+    # Check if the cache file already exists
+    if os.path.exists(filename):
+        return filename
+
+    print(f"Downloading from {url} to {filename}")
+
+    # Stream the response to show the progress bar
+    response = requests.get(url, stream=True)
+    response.raise_for_status()  # Check for request errors
+
+    # Total size of the file in bytes
+    total_size = int(response.headers.get("content-length", 0))
+    chunk_size = 1024  # Download in chunks of 1KB
+
+    # Use tqdm to display the progress bar
+    with open(filename, "wb") as f, tqdm(
+        desc=filename,
+        total=total_size,
+        unit="B",
+        unit_scale=True,
+        unit_divisor=1024,
+    ) as bar:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+            f.write(chunk)
+            bar.update(len(chunk))
+
+    return filename
 
 def sample_sharegpt_requests(
     dataset_path: str,
@@ -97,6 +132,14 @@ def sample_sharegpt_requests(
     tokenizer: PreTrainedTokenizerBase,
     fixed_output_len: Optional[int] = None,
 ) -> List[Tuple[str, int, int, None]]:
+
+    print(dataset_path)
+    print(dataset_path)
+    print(dataset_path)
+    # Download sharegpt if necessary
+    if not os.path.isfile(dataset_path):
+        dataset_path = download_and_cache_file(SHAREGPT_URL)
+
     # Load the dataset.
     with open(dataset_path, encoding='utf-8') as f:
         dataset = json.load(f)
@@ -370,6 +413,7 @@ def sample_random_requests(
     num_prompts: int,
     range_ratio: float,
     tokenizer: PreTrainedTokenizerBase,
+    dataset_path: str,
 ) -> List[Tuple[str, int, int]]:
     prefix_token_ids = np.random.randint(0,
                                          tokenizer.vocab_size,
@@ -385,15 +429,60 @@ def sample_random_requests(
         output_len + 1,
         size=num_prompts,
     )
-    offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
-    input_requests = []
-    for i in range(num_prompts):
-        prompt = tokenizer.decode(prefix_token_ids +
-                                  [(offsets[i] + i + j) % tokenizer.vocab_size
-                                   for j in range(input_lens[i])])
 
-        input_requests.append((prompt, int(prefix_len + input_lens[i]),
-                               int(output_lens[i]), None))
+    if dataset_path is not None:
+        # Sample token ids from ShareGPT and repeat/truncate them to satisfy the input_lens
+
+        # Download sharegpt if necessary
+        if not os.path.isfile(dataset_path):
+            dataset_path = download_and_cache_file(SHAREGPT_URL)
+
+        # Load the dataset.
+        with open(dataset_path) as f:
+            dataset = json.load(f)
+        # Filter out the conversations with less than 2 turns.
+        dataset = [data for data in dataset if len(data["conversations"]) >= 2]
+        # Only keep the first two turns of each conversation.
+        dataset = [
+            (data["conversations"][0]["value"], data["conversations"][1]["value"])
+            for data in dataset
+        ]
+        # Shuffle the dataset.
+        random.shuffle(dataset)
+
+        # Filter out sequences that are too long or too short
+        input_requests: List[Tuple[str, int, int]] = []
+        for data in dataset:
+            i = len(input_requests)
+            if i == num_prompts:
+                break
+
+            # Tokenize the prompts and completions.
+            prompt = data[0]
+            prompt_token_ids = tokenizer.encode(prompt)
+            prompt_len = len(prompt_token_ids)
+
+            # Skip empty prompt
+            if prompt_len == 0:
+                continue
+
+            if prompt_len > input_lens[i]:
+                input_ids = prompt_token_ids[: input_lens[i]]
+            else:
+                ratio = (input_lens[i] + prompt_len - 1) // prompt_len
+                input_ids = (prompt_token_ids * ratio)[: input_lens[i]]
+            prompt = tokenizer.decode(input_ids)
+            input_requests.append((prompt, int(input_lens[i]), int(output_lens[i]), None))
+    else:
+        offsets = np.random.randint(0, tokenizer.vocab_size, size=num_prompts)
+        input_requests = []
+        for i in range(num_prompts):
+            prompt = tokenizer.decode(prefix_token_ids +
+                                      [(offsets[i] + i + j) % tokenizer.vocab_size
+                                       for j in range(input_lens[i])])
+
+            input_requests.append((prompt, int(prefix_len + input_lens[i]),
+                                   int(output_lens[i]), None))
 
     return input_requests
 
@@ -936,6 +1025,7 @@ def main(args: argparse.Namespace):
             num_prompts=args.num_prompts,
             range_ratio=args.random_range_ratio,
             tokenizer=tokenizer,
+            dataset_path=args.dataset_path,
         )
 
     else:

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -38,8 +38,8 @@ from datetime import datetime
 from typing import Any, AsyncGenerator, Collection, Dict, List, Optional, Tuple
 
 import numpy as np
-import requests
 import pandas as pd
+import requests
 from backend_request_func import (ASYNC_REQUEST_FUNCS, RequestFuncInput,
                                   RequestFuncOutput)
 from datasets import load_dataset


### PR DESCRIPTION
Adding random inputs from sharegpt dataset in the  "--dataset-name random" from benchmark_serving.py

Background: when comparing online serving performance against sglang. We witnessed the random inputs are different from vllm client vs sglang client. To narrow this gap, adding new feature like this: 

![image](https://github.com/user-attachments/assets/fb28e4c0-d84d-4ad2-9a78-88d21205cbb2)

Usage:
1. random inputs (default)
python3 vllm/benchmarks/benchmark_serving.py \
            --backend vllm \
            --dataset-name random \

2. random inputs from sharegpt dataset
        python3 vllm/benchmarks/benchmark_serving.py \
            --backend vllm \
            --dataset-name random \
            --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \

@andylolu2  @billishyahao @haic0
