### PR TITLE
[Misc] Modify xgrammar version

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -20,7 +20,7 @@ tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.11, < 0.11
 outlines == 0.1.11
 lark == 1.2.2
-xgrammar == 0.1.11; platform_machine == "x86_64"
+xgrammar == 0.1.14
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs


### PR DESCRIPTION
# What this PR does

As mentioned in this PR (https://github.com/vllm-project/vllm/pull/13894), xgrammar have supported aarch64 system.

After my test, the result showed that guided decoding worker well with xgrammar on aarch64 system.

So we should modify the xgrammar version in `requirement.txt` after merging this PR (https://github.com/vllm-project/vllm/pull/13894).

Find more details about xgrammar [v0.1.14](https://github.com/mlc-ai/xgrammar/releases/tag/v0.1.14).

Part of test logs:

```bash
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.49s/it, est. speed input: 7.41 toks/s, output: 1.35 toks/s]
Positive
WARNING 02-28 09:29:50 [__init__.py:33] xgrammar does not support regex guided decoding. Falling back to use outlines instead.
('Warning: torch.save with "_use_new_zipfile_serialization = False" is not recommended for npu tensor, which may bring unexpected errors and hopefully set "_use_new_zipfile_serialization = True"', 'if it is necessary to use this, please convert the npu tensor to cpu tensor for saving')
Processed prompts: 100%|█████████████████████████████████████████████████████████████████████████| 1/1 [00:04<00:00,  4.21s/it, est. speed input: 7.59 toks/s, output: 1.90 toks/s]
alan_turing@enigma.com
```