### PR TITLE
[Bugfix] Initialize attention bias on the same device as Query/Key/Value for QwenVL Series

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -323,7 +323,7 @@ class Qwen2_5_VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None, 
+                                                       kv_seqlen=None,
                                                        device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -323,7 +323,8 @@ class Qwen2_5_VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None, device=q.device)
+                                                       kv_seqlen=None, 
+                                                       device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(
                 q, k, v, attn_bias=attn_bias, p=0, scale=None)

--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -323,7 +323,7 @@ class Qwen2_5_VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None)
+                                                       kv_seqlen=None, device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(
                 q, k, v, attn_bias=attn_bias, p=0, scale=None)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -367,7 +367,7 @@ class Qwen2VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None)
+                                                       kv_seqlen=None, device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(
                 q, k, v, attn_bias=attn_bias, p=0, scale=None)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -367,7 +367,8 @@ class Qwen2VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None, device=q.device)
+                                                       kv_seqlen=None, 
+                                                       device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(
                 q, k, v, attn_bias=attn_bias, p=0, scale=None)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -367,7 +367,7 @@ class Qwen2VisionAttention(nn.Module):
 
             seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
             attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
-                                                       kv_seqlen=None, 
+                                                       kv_seqlen=None,
                                                        device=q.device)
 
             context_layer = xops.memory_efficient_attention_forward(


### PR DESCRIPTION
Similar issue as [https://github.com/vllm-project/vllm/pull/13468](https://github.com/vllm-project/vllm/pull/13468) where the attention bias in vLLM's xformers backend is currently initialized on the default device, rather than the device of the Q/K/V tensors.

The [https://github.com/vllm-project/vllm/pull/13468](https://github.com/vllm-project/vllm/pull/13468) workaround doesn't quite solve the problem for QwenVL series when vLLM is used in conjunction with libraries like trl for GRPO training. 

The cuda device mismatched issue still exists for xformer backend.

`[rank0]: ValueError: Attention bias and Query/Key/Value should be on the same device`

This PR solve cuda device mismatch problem for QwenVL Series