### PR TITLE
[Bugfix][V1][Minor] Fix shutting_down flag checking in V1 MultiprocExecutor

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -170,7 +170,7 @@ class MultiprocExecutor(Executor):
 
     def shutdown(self):
         """Properly shut down the executor and its workers"""
-        if getattr(self, 'shutting_down', False):
+        if not getattr(self, 'shutting_down', False):
             self.shutting_down = True
             for w in self.workers:
                 w.worker_response_mq = None


### PR DESCRIPTION
I noticed the checking for ```shutting_down``` flag in V1 ```MultiprocExecutor``` will always be ```False```, and it ignores ```_ensure_worker_termination``` for terminating worker processes gracefully in some situations.

This PR fixed it.