### PR TITLE
[ROCm][V1][Bugfix] Add get_builder_cls method to the ROCmAttentionBackend class

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -9,7 +9,8 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
 from vllm.attention.ops.paged_attn import PagedAttention
 from vllm.attention.ops.prefix_prefill import context_attention_fwd
 from vllm.logger import init_logger
-from vllm.v1.attention.backends.flash_attn import FlashAttentionMetadata
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionMetadata, FlashAttentionMetadataBuilder)
 
 logger = init_logger(__name__)
 
@@ -48,6 +49,10 @@ class ROCmAttentionBackend(AttentionBackend):
     @staticmethod
     def use_cascade_attention(*args, **kwargs) -> bool:
         return False
+
+    @staticmethod
+    def get_builder_cls() -> Type["FlashAttentionMetadataBuilder"]:
+        return FlashAttentionMetadataBuilder
 
 
 class ROCmAttentionImpl(AttentionImpl):


### PR DESCRIPTION
The ROCmAttentionBackend currently just uses the FlashAttentionMetadata so it can use the FlashAttentionMetadataBuilder. This PR is required now that the V1 GPUModelRunner supports other meta data structures.
