### PR TITLE
[v1] Add `__repr__` to KVCacheBlock to avoid recursive print

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -128,6 +128,19 @@ class KVCacheBlock:
         """Reset the block hash when the block is evicted."""
         self._block_hash = None
 
+    def __repr__(self) -> str:
+        # Use block_id instead of KVCacheBlock object to avoid calling __repr__
+        # on KVCacheBlock object recursively.
+        prev_block_id = self.prev_free_block.block_id \
+            if self.prev_free_block else None
+        next_block_id = self.next_free_block.block_id \
+            if self.next_free_block else None
+        return (f"KVCacheBlock(block_id={self.block_id}, "
+                f"ref_cnt={self.ref_cnt}, "
+                f"_block_hash={self._block_hash}, "
+                f"prev_free_block={prev_block_id}, "
+                f"next_free_block={next_block_id})")
+
 
 class FreeKVCacheBlockQueue:
     """This class organizes a list of KVCacheBlock objects to a doubly linked


### PR DESCRIPTION
As KVCacheBlock is a doubly linked list, the default print of one block will recursively print all KVCacheBlock objects in the list, and can cause stack overflow. To avoid this problem, print `prev_block_id` and `next_block_id` instead.
<details>
<summary>Reproduce script</summary>
from vllm.multimodal.inputs import MultiModalKwargs
from vllm.sampling_params import SamplingParams
from vllm.v1.core.kv_cache_manager import KVCacheManager
from vllm.v1.request import Request


def make_request(request_id,
                 prompt_token_ids,
                 mm_positions=None,
                 mm_hashes=None):
    if mm_positions is None:
        multi_modal_inputs = None
    else:
        multi_modal_inputs = [MultiModalKwargs({})] * len(mm_positions)

    return Request(
        request_id=request_id,
        prompt=None,
        prompt_token_ids=prompt_token_ids,
        multi_modal_inputs=multi_modal_inputs,
        multi_modal_hashes=mm_hashes,
        multi_modal_placeholders=mm_positions,
        sampling_params=SamplingParams(max_tokens=17),
        eos_token_id=100,
        arrival_time=0,
        lora_request=None,
    )


manager = KVCacheManager(
    block_size=16,
    num_gpu_blocks=10000,
    max_model_len=819200,
    sliding_window=None,
    enable_caching=True,
    num_preallocate_tokens=16,
)

common_token_ids = [i for i in range(10) for _ in range(16)]
req0 = make_request("0", common_token_ids)
computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
blocks = manager.allocate_slots(req0, 55, computed_blocks)
manager.free(req0)

req1 = make_request("1", common_token_ids)
computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
print("computed_blocks", computed_blocks)
</details>