### PR TITLE
[core] Pass all driver env vars to ray workers unless excluded

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -48,6 +48,21 @@ class RayWorkerMetaData:
 
 
 class RayDistributedExecutor(DistributedExecutorBase):
+    """Ray-based distributed executor"""
+
+    # These env vars are used at installation time, therefore are NOT copied
+    # from the driver to the workers
+    INSTALL_TIME_ENV_VARS = set([
+        "VLLM_TARGET_DEVICES", "MAX_JOBS", "NVCC_THREADS",
+        "VLLM_USE_PRECOMPILED", "CMAKE_BUILD_TYPE", "VERBOSE",
+        "VLLM_CONFIG_ROOT"
+    ])
+
+    # These env vars are worker-specific, therefore are NOT copied
+    # from the driver to the workers
+    WORKER_SPECIFIC_ENV_VARS = set([
+        "VLLM_HOST_IP", "VLLM_HOST_PORT", "LOCAL_RANK", "CUDA_VISIBLE_DEVICES"
+    ])
 
     uses_ray: bool = True
 
@@ -311,9 +326,9 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
         # Environment variables to copy from driver to workers
         env_vars_to_copy = [
-            "VLLM_ATTENTION_BACKEND", "TPU_CHIPS_PER_HOST_BOUNDS",
-            "TPU_HOST_BOUNDS", "VLLM_USE_V1", "VLLM_TRACE_FUNCTION",
-            "VLLM_TORCH_PROFILER_DIR", "VLLM_TEST_ENABLE_EP"
+            v for v in envs.environment_variables
+            if v not in self.INSTALL_TIME_ENV_VARS
+            and v not in self.WORKER_SPECIFIC_ENV_VARS
         ]
 
         # Copy existing env vars to each worker's args

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -52,17 +52,17 @@ class RayDistributedExecutor(DistributedExecutorBase):
 
     # These env vars are used at installation time, therefore are NOT copied
     # from the driver to the workers
-    INSTALL_TIME_ENV_VARS = set([
+    INSTALL_TIME_ENV_VARS = {
         "VLLM_TARGET_DEVICES", "MAX_JOBS", "NVCC_THREADS",
         "VLLM_USE_PRECOMPILED", "CMAKE_BUILD_TYPE", "VERBOSE",
         "VLLM_CONFIG_ROOT"
-    ])
+    }
 
     # These env vars are worker-specific, therefore are NOT copied
     # from the driver to the workers
-    WORKER_SPECIFIC_ENV_VARS = set([
+    WORKER_SPECIFIC_ENV_VARS = {
         "VLLM_HOST_IP", "VLLM_HOST_PORT", "LOCAL_RANK", "CUDA_VISIBLE_DEVICES"
-    ])
+    }
 
     uses_ray: bool = True
 

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -51,14 +51,6 @@ class RayWorkerMetaData:
 class RayDistributedExecutor(DistributedExecutorBase):
     """Ray-based distributed executor"""
 
-    # These env vars are used at installation time, therefore are NOT copied
-    # from the driver to the workers
-    INSTALL_TIME_ENV_VARS = {
-        "VLLM_TARGET_DEVICES", "MAX_JOBS", "NVCC_THREADS",
-        "VLLM_USE_PRECOMPILED", "CMAKE_BUILD_TYPE", "VERBOSE",
-        "VLLM_CONFIG_ROOT"
-    }
-
     # These env vars are worker-specific, therefore are NOT copied
     # from the driver to the workers
     WORKER_SPECIFIC_ENV_VARS = {
@@ -339,8 +331,8 @@ class RayDistributedExecutor(DistributedExecutorBase):
         # Environment variables to copy from driver to workers
         env_vars_to_copy = [
             v for v in envs.environment_variables
-            if v not in self.INSTALL_TIME_ENV_VARS and v not in self.
-            WORKER_SPECIFIC_ENV_VARS and v not in self.non_carry_over_env_vars
+            if v not in self.WORKER_SPECIFIC_ENV_VARS
+            and v not in self.non_carry_over_env_vars
         ]
 
         # Copy existing env vars to each worker's args
@@ -355,6 +347,9 @@ class RayDistributedExecutor(DistributedExecutorBase):
         logger.info(
             "Copying the following environment variables to workers: %s",
             [v for v in env_vars_to_copy if v in os.environ])
+        logger.info(
+            "If certain env vars should NOT be copied to workers, add them to "
+            "%s file", self.non_carry_over_env_vars_file)
 
         self._env_vars_for_all_workers = (
             all_args_to_update_environment_variables)


### PR DESCRIPTION
Currently many driver env vars are not passed to ray workers while they should have been. This has caused bugs and confusions.

To fix this, we are passing all driver env vars to ray workers unless excluded, based on the following consideration:

- Many driver env vars are intended to pass through to the workers
- Even if some of the driver env vars (prefixed with `VLLM_`) are not used in workers, passing them to workers typically create no harm. Instead of creating a very long inclusion list, using a short exclusion list would be easier to maintain.

We specifically exclude two types of env vars to pass from driver to workers:
- The ones are specific for workers and need to be configured per worker
- The ones that are specified in a config file by user
