### PR TITLE
[Bugfix] Allow shared_experts skip quantization for DeepSeekV2/V3

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -146,6 +146,7 @@ class DeepseekV2MoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Forgot to pipe the prefix down to DeepseekV2MLP for shared_experts