### PR TITLE
[Misc] Add log information for handle_process_request.

### DIFF
--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -292,6 +292,8 @@ class MQLLMEngine:
             # We do not set self._errored = True here, since the error
             # is due to an issue adding this request to the engine,
             # rather than an issue with the engine itself.
+            logger.debug("Failed to add request %s to engine. %s",
+                         request.request_id, e)
             is_errored = self._errored_with is not None
             rpc_err = RPCError(request_id=request_id,
                                is_engine_errored=is_errored,


### PR DESCRIPTION
```
export VLLM_LOGGING_LEVEL=DEBUG
```
When I was debugging #13955, I encountered this error at https://github.com/vllm-project/vllm/blob/main/vllm/multimodal/processing.py#L1423.

However, vllm did not print any error logs or return any information.


I spent a long time debugging before I found where the exception was thrown.

Therefore, I suggest adding a log print to easily observe the error information from `raise RuntimeError`.