### PR TITLE
[ROCm] Disable a few more kernel tests that are broken on ROCm

### DIFF
--- a/.buildkite/run-amd-test.sh
+++ b/.buildkite/run-amd-test.sh
@@ -94,7 +94,12 @@ if [[ $commands == *" kernels "* ]]; then
   --ignore=kernels/test_rand.py \
   --ignore=kernels/test_sampler.py \
   --ignore=kernels/test_cascade_flash_attn.py \
-  --ignore=kernels/test_mamba_mixer2.py"
+  --ignore=kernels/test_mamba_mixer2.py \
+  --ignore=kernels/test_aqlm.py \
+  --ignore=kernels/test_machete_mm.py \
+  --ignore=kernels/test_mha_attn.py \
+  --ignore=kernels/test_block_fp8.py \
+  --ignore=kernels/test_permute_cols.py"
 fi
 
 #ignore certain Entrypoints tests


### PR DESCRIPTION
The `kernels/test_block_fp8.py` test gets max diffs and triton compiler errors. The rest all crash trying to import kernels that aren't compiled for ROCm.

I'm somewhat concerned about the max diffs in the `test_per_token_group_quant_fp8` and I'm open to removing the `kernels/test_block_fp8.py` test from the disabled list in this PR. I do think it's worth just trying to get the AMD build green first, though, and then turning more tests back on and fixing issues we find them.