### PR TITLE
[Feature]: Pin vLLM process to the right NUMA Region

### DIFF
--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -16,9 +16,9 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms.cuda import set_cpu_affinity
 from vllm.triton_utils.importing import HAS_TRITON
 from vllm.utils import _check_multiproc_method, get_mp_context, run_method
-from vllm.platforms.cuda import set_cpu_affinity
 
 if HAS_TRITON:
     from vllm.triton_utils import maybe_set_triton_cache_manager

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -18,6 +18,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.triton_utils.importing import HAS_TRITON
 from vllm.utils import _check_multiproc_method, get_mp_context, run_method
+from vllm.platforms.cuda import set_cpu_affinity
 
 if HAS_TRITON:
     from vllm.triton_utils import maybe_set_triton_cache_manager
@@ -213,6 +214,9 @@ def _run_worker_process(
     rank: int,
 ) -> None:
     """Worker process event loop"""
+
+    # Set CPU affinity
+    set_cpu_affinity()
 
     # Add process-specific prefix to stdout and stderr
     process_name = get_mp_context().current_process().name

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -437,7 +437,7 @@ def set_cpu_affinity():
     if nvml_available:
         # The below code is based on https://github.com/NVIDIA/DeepLearningExamples/blob/master/TensorFlow2/LanguageModeling/BERT/gpu_affinity.py
         pynvml.nvmlInit()
-        num_elements = math.ceil(os.cpu_count() / 64)
+        num_elements = math.ceil((os.cpu_count() or 2) / 64)
         handle = pynvml.nvmlDeviceGetHandleByIndex(envs.LOCAL_RANK)
         affinity_string = ""
         for j in pynvml.nvmlDeviceGetCpuAffinity(handle, num_elements):

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -17,7 +17,6 @@ import vllm._C  # noqa
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils import import_pynvml
-import vllm.envs as envs
 
 from .interface import DeviceCapability, Platform, PlatformEnum, _Backend
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -3,8 +3,8 @@
 pynvml. However, it should not initialize cuda context.
 """
 
-import os
 import math
+import os
 from functools import lru_cache, wraps
 from typing import (TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar,
                     Union)
@@ -431,6 +431,7 @@ try:
         CudaPlatform.log_warnings()
 except ModuleNotFoundError:
     CudaPlatform.log_warnings()
+
 
 def set_cpu_affinity():
     if nvml_available:

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -25,6 +25,8 @@ from vllm.worker.model_runner_base import (BroadcastableModelInput,
                                            ModelRunnerBase,
                                            ModelRunnerInputBase)
 
+from vllm.platforms.cuda import set_cpu_affinity
+
 logger = init_logger(__name__)
 
 
@@ -566,6 +568,8 @@ class WorkerWrapperBase:
             # To make vLLM config available during worker initialization
             self.worker = worker_class(**kwargs)
             assert self.worker is not None
+
+        set_cpu_affinity()
 
     def initialize_from_config(self, kv_cache_configs: List[Any]) -> None:
         kv_cache_config = kv_cache_configs[self.rpc_rank]

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -16,6 +16,7 @@ from vllm.distributed import broadcast_tensor_dict, get_pp_group, get_tp_group
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.sampler import SamplerOutput
+from vllm.platforms.cuda import set_cpu_affinity
 from vllm.sequence import ExecuteModelRequest, IntermediateTensors
 from vllm.utils import (enable_trace_function_call_for_thread,
                         resolve_obj_by_qualname, run_method,
@@ -24,8 +25,6 @@ from vllm.utils import (enable_trace_function_call_for_thread,
 from vllm.worker.model_runner_base import (BroadcastableModelInput,
                                            ModelRunnerBase,
                                            ModelRunnerInputBase)
-
-from vllm.platforms.cuda import set_cpu_affinity
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
Changes:
* Add method `set_cpu_affinity` in vllm/platforms/cuda.py
* Call `set_cpu_affinity` after the process is ready
(both in vllm/executor/multiproc_worker_utils.py and vllm/worker/worker_base.py)

FIX #13855 

