### PR TITLE
[Frontend] Relax 'method' field constraint in BatchRequestInput

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1290,7 +1290,7 @@ class BatchRequestInput(OpenAIBaseModel):
 
     # The HTTP method to be used for the request. Currently only POST is
     # supported.
-    method: str
+    method: Literal["POST"] = "POST"
 
     # The OpenAI API relative URL to be used for the request. Currently
     # /v1/chat/completions is supported.


### PR DESCRIPTION
Minor quality-of-life change to provide a default value for this field.

<!--- pyml disable-next-line no-emphasis-as-heading -->
