### PR TITLE
[Misc] Remove lru_cache in NvmlCudaPlatform

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -4,7 +4,7 @@ pynvml. However, it should not initialize cuda context.
 """
 
 import os
-from functools import lru_cache, wraps
+from functools import wraps
 from typing import (TYPE_CHECKING, Callable, List, Optional, Tuple, TypeVar,
                     Union)
 
@@ -284,7 +284,6 @@ class CudaPlatformBase(Platform):
 class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
-    @lru_cache(maxsize=8)
     @with_nvml_context
     def get_device_capability(cls,
                               device_id: int = 0
@@ -298,7 +297,6 @@ class NvmlCudaPlatform(CudaPlatformBase):
             return None
 
     @classmethod
-    @lru_cache(maxsize=8)
     @with_nvml_context
     def has_device_capability(
         cls,
@@ -311,14 +309,12 @@ class NvmlCudaPlatform(CudaPlatformBase):
             return False
 
     @classmethod
-    @lru_cache(maxsize=8)
     @with_nvml_context
     def get_device_name(cls, device_id: int = 0) -> str:
         physical_device_id = device_id_to_physical_device_id(device_id)
         return cls._get_physical_device_name(physical_device_id)
 
     @classmethod
-    @lru_cache(maxsize=8)
     @with_nvml_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
         physical_device_id = device_id_to_physical_device_id(device_id)
@@ -326,7 +322,6 @@ class NvmlCudaPlatform(CudaPlatformBase):
         return pynvml.nvmlDeviceGetUUID(handle)
 
     @classmethod
-    @lru_cache(maxsize=8)
     @with_nvml_context
     def get_device_total_memory(cls, device_id: int = 0) -> int:
         physical_device_id = device_id_to_physical_device_id(device_id)


### PR DESCRIPTION
The `lru_cache` mis-caches certain `get_device_capability` functions and results in errors in the RayExecutor. Since removing lru_cache won't cause any other issue and doesn't affect the server launch time, this PR removes it.

Launch time for Llama-3-8B-FP8 with TP=1 on L4 GPU (the model is pre-downloaded):
* Main: 63s.
* This PR: 62s.

CLI: 
```
VLLM_USE_V1=1 vllm serve neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8 --max-model-len 8192
```

cc @youkaichao @kouroshHakha