### PR TITLE
[bug fix]: benchmark enabling torch profiler in openai chat backend 

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -307,9 +307,9 @@ async def async_request_openai_chat_completions(
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
-    assert api_url.endswith(
-        "chat/completions"
-    ), "OpenAI Chat Completions API URL must end with 'chat/completions'."
+    assert api_url.endswith(("chat/completions", "profile")), (
+        "OpenAI Chat Completions API URL must end with 'chat/completions'"
+        " or 'profile'.")
 
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         content = [{"type": "text", "text": request_func_input.prompt}]


### PR DESCRIPTION
The 'profile' feature failed in running benchmark_server.py. Reason is the '/start_profile' and '/stop_profile' is prevented by the async_request_openai_chat_completions check. 
Just like what async_request_openai_completions function does, make urls ending with 'profile' valid in the request check function.
