### PR TITLE
Deal with off-by-one error

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -302,7 +302,7 @@ class Processor:
         if self.model_config.is_multimodal_model:
             max_prompt_len = self.model_config.max_model_len
 
-            if len(prompt_ids) > max_prompt_len:
+            if len(prompt_ids) >= max_prompt_len:
                 raise ValueError(
                     f"The prompt (total length {len(prompt_ids)}) is too long "
                     f"to fit into the model (context length {max_prompt_len}). "


### PR DESCRIPTION

There is one here!
Right near it we have:
So we should align the two.
https://github.com/vincent-4/vllm/blob/b9f1d4294e30b700dcb25390c74831a5c178f5fd/vllm/v1/engine/processor.py#L265

<!--- pyml disable-next-line no-emphasis-as-heading -->
