### PR TITLE
[sleep mode] error out with expandable_segments

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -8,6 +8,7 @@
 # not sure why, they are created from a different context.
 # the only successful approach is to call cuda driver API in C.
 import dataclasses
+import os
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -140,6 +141,12 @@ class CuMemAllocator:
         return CuMemAllocator.instance
 
     def __init__(self):
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", None)
+        assert "expandable_segments:True" not in conf, \
+            ("Expandable segments are not compatible with memory pool. "
+            "Please track https://github.com/pytorch/pytorch/issues/147851 "
+            "for the latest updates.")
+
         self.pointer_to_data: Dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: Dict[str, Any] = {}

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -141,7 +141,7 @@ class CuMemAllocator:
         return CuMemAllocator.instance
 
     def __init__(self):
-        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", None)
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
         assert "expandable_segments:True" not in conf, \
             ("Expandable segments are not compatible with memory pool. "
             "Please track https://github.com/pytorch/pytorch/issues/147851 "

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -551,13 +551,6 @@ class WorkerWrapperBase:
             "vllm_config is required to initialize the worker")
         enable_trace_function_call_for_thread(self.vllm_config)
 
-        if self.vllm_config.model_config.enable_sleep_mode:
-            conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", None)
-            assert "expandable_segments:True" not in conf, \
-                ("Expandable segments are not compatible with sleep mode. "
-                "Please track https://github.com/pytorch/pytorch/issues/147851 "
-                "for the latest updates.")
-
         from vllm.plugins import load_general_plugins
         load_general_plugins()
 

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -551,6 +551,13 @@ class WorkerWrapperBase:
             "vllm_config is required to initialize the worker")
         enable_trace_function_call_for_thread(self.vllm_config)
 
+        if self.vllm_config.model_config.enable_sleep_mode:
+            conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", None)
+            assert "expandable_segments:True" not in conf, \
+                ("Expandable segments are not compatible with sleep mode. "
+                "Please track https://github.com/pytorch/pytorch/issues/147851 "
+                "for the latest updates.")
+
         from vllm.plugins import load_general_plugins
         load_general_plugins()
 


### PR DESCRIPTION
as reported in https://github.com/vllm-project/vllm/pull/11743#issuecomment-2681730438 , and confirmed with the pytorch team at https://github.com/pytorch/pytorch/issues/147851#issuecomment-2695220576 , the sleep mode implementation is not compatible with expandable_segments, and it cannot be fixed in the short term.

let's give users clear error message until that is solved from pytorch side.