### PR TITLE
Moved numba from common requirements to cuda/rocm specific requirements

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,7 +1,6 @@
 psutil
 sentencepiece  # Required for LLaMA tokenizer.
 numpy < 2.0.0
-numba == 0.60.0 # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding.
 requests >= 2.26.0
 tqdm
 blake3

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,6 +1,8 @@
 # Common dependencies
 -r requirements-common.txt
 
+numba == 0.60.0 # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
+
 # Dependencies for NVIDIA GPUs
 ray[cgraph] >= 2.43.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch == 2.5.1

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,6 +1,8 @@
 # Common dependencies
 -r requirements-common.txt
 
+numba == 0.60.0 # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
+
 # Dependencies for AMD GPUs
 awscli
 boto3


### PR DESCRIPTION

As per this comment https://github.com/vllm-project/vllm/pull/13365/files#r1960689585, numba shouldn't be a part of requirements-common.txt. So, moved it to cuda/rocm specific requirements file. This will also help us not to numba in cpu only vllm.

<!--- pyml disable-next-line no-emphasis-as-heading -->
