### PR TITLE
[Bugfix] Restrict MacOS CPU detection

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -129,8 +129,8 @@ def cpu_platform_plugin() -> Optional[str]:
     try:
         is_cpu = vllm_version_matches_substr("cpu")
         if not is_cpu:
-            import platform
-            is_cpu = platform.machine().lower().startswith("arm")
+            import sys
+            is_cpu = sys.platform.startswith("darwin")
 
     except Exception:
         pass


### PR DESCRIPTION
There is a concern that the ARM CPU detection would affect NVIDIA ARM devices like GH200, so we should restrict the special case to just MacOS as it was intended for in https://github.com/vllm-project/vllm/pull/12227