### PR TITLE
Fix performance when `--generation-config` is not `None`

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -244,6 +244,7 @@ class LLM:
             engine_args, usage_context=UsageContext.LLM_CLASS)
 
         self.request_counter = Counter()
+        self.default_sampling_params = None
 
     @staticmethod
     def get_engine_class() -> type[LLMEngine]:
@@ -268,10 +269,11 @@ class LLM:
             tokenizer_group.tokenizer = get_cached_tokenizer(tokenizer)
 
     def get_default_sampling_params(self) -> SamplingParams:
-        diff_sampling_param = (
-            self.llm_engine.model_config.get_diff_sampling_param())
-        if diff_sampling_param:
-            return SamplingParams.from_optional(**diff_sampling_param)
+        if self.default_sampling_params is None:
+            self.default_sampling_params = (
+                self.llm_engine.model_config.get_diff_sampling_param())
+        if self.default_sampling_params:
+            return SamplingParams.from_optional(**self.default_sampling_params)
         return SamplingParams()
 
     @overload

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -244,7 +244,7 @@ class LLM:
             engine_args, usage_context=UsageContext.LLM_CLASS)
 
         self.request_counter = Counter()
-        self.default_sampling_params = None
+        self.default_sampling_params: Union[dict[str, Any], None] = None
 
     @staticmethod
     def get_engine_class() -> type[LLMEngine]:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -105,10 +105,11 @@ class OpenAIServingChat(OpenAIServing):
                                 "been registered") from e
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
-        diff_sampling_param = self.model_config.get_diff_sampling_param()
-        if diff_sampling_param:
+        self.default_sampling_params = (
+            self.model_config.get_diff_sampling_param())
+        if self.default_sampling_params:
             logger.info("Overwriting default chat sampling param with: %s",
-                        diff_sampling_param)
+                        self.default_sampling_params)
 
     async def create_chat_completion(
         self,
@@ -210,17 +211,14 @@ class OpenAIServingChat(OpenAIServing):
                 sampling_params: Union[SamplingParams, BeamSearchParams]
                 default_max_tokens = self.max_model_len - len(
                     engine_prompt["prompt_token_ids"])
-                # Build default sampling params
-                default_sampling_params = (
-                    self.model_config.get_diff_sampling_param())
                 if request.use_beam_search:
                     sampling_params = request.to_beam_search_params(
-                        default_max_tokens, default_sampling_params)
+                        default_max_tokens, self.default_sampling_params)
                 else:
                     sampling_params = request.to_sampling_params(
                         default_max_tokens,
                         self.model_config.logits_processor_pattern,
-                        default_sampling_params)
+                        self.default_sampling_params)
 
                 self._log_inputs(request_id,
                                  request_prompts[i],

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -51,11 +51,12 @@ class OpenAIServingCompletion(OpenAIServing):
                          models=models,
                          request_logger=request_logger,
                          return_tokens_as_token_ids=return_tokens_as_token_ids)
-        diff_sampling_param = self.model_config.get_diff_sampling_param()
-        if diff_sampling_param:
+        self.default_sampling_params = (
+            self.model_config.get_diff_sampling_param())
+        if self.default_sampling_params:
             logger.info(
                 "Overwriting default completion sampling param with: %s",
-                diff_sampling_param)
+                self.default_sampling_params)
 
     async def create_completion(
         self,
@@ -119,17 +120,14 @@ class OpenAIServingCompletion(OpenAIServing):
                 sampling_params: Union[SamplingParams, BeamSearchParams]
                 default_max_tokens = self.max_model_len - len(
                     engine_prompt["prompt_token_ids"])
-                # Build default sampling params
-                default_sampling_params = (
-                    self.model_config.get_diff_sampling_param())
                 if request.use_beam_search:
                     sampling_params = request.to_beam_search_params(
-                        default_max_tokens, default_sampling_params)
+                        default_max_tokens, self.default_sampling_params)
                 else:
                     sampling_params = request.to_sampling_params(
                         default_max_tokens,
                         self.model_config.logits_processor_pattern,
-                        default_sampling_params)
+                        self.default_sampling_params)
 
                 request_id_item = f"{request_id}-{i}"
 

--- a/vllm/entrypoints/openai/serving_transcription.py
+++ b/vllm/entrypoints/openai/serving_transcription.py
@@ -161,11 +161,12 @@ class OpenAIServingTranscription(OpenAIServing):
                          request_logger=request_logger,
                          return_tokens_as_token_ids=return_tokens_as_token_ids)
 
-        diff_sampling_param = self.model_config.get_diff_sampling_param()
-        if diff_sampling_param:
+        self.default_sampling_params = (
+            self.model_config.get_diff_sampling_param())
+        if self.default_sampling_params:
             logger.info(
                 "Overwriting default completion sampling param with: %s",
-                diff_sampling_param)
+                self.default_sampling_params)
 
     async def _preprocess_transcription(
         self,
@@ -273,9 +274,8 @@ class OpenAIServingTranscription(OpenAIServing):
         try:
             # TODO(rob): subtract len of tokenized prompt.
             default_max_tokens = self.model_config.max_model_len
-            default_params = self.model_config.get_diff_sampling_param()
             sampling_params = request.to_sampling_params(
-                default_max_tokens, default_params)
+                default_max_tokens, self.default_sampling_params)
 
             self._log_inputs(
                 request_id,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -725,17 +725,11 @@ def get_hf_text_config(config: PretrainedConfig):
         return config
 
 
-@cache
 def try_get_generation_config(
     model: str,
     trust_remote_code: bool,
     revision: Optional[str] = None,
 ) -> Optional[GenerationConfig]:
-    """
-    This function is cached based on function arguments. This means that if you
-    pass a file path to `model`, changing the file and rerunning will result in
-    the old value being returned.
-    """
     try:
         return GenerationConfig.from_pretrained(
             model,

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -725,11 +725,17 @@ def get_hf_text_config(config: PretrainedConfig):
         return config
 
 
+@cache
 def try_get_generation_config(
     model: str,
     trust_remote_code: bool,
     revision: Optional[str] = None,
 ) -> Optional[GenerationConfig]:
+    """
+    This function is cached based on function arguments. This means that if you
+    pass a file path to `model`, changing the file and rerunning will result in
+    the old value being returned.
+    """
     try:
         return GenerationConfig.from_pretrained(
             model,


### PR DESCRIPTION
Adds `self.default_sampling_params` to:

- `OpenAIServingChat`
- `OpenAIServingCompletion`
- `OpenAIServingTranscription`
- `LLM`

As you can see from the benchmarks below, the performance difference is huge:

```bash
vllm serve meta-llama/Llama-3.2-1B-Instruct --disable-log-requests --generation-config auto

python benchmarks/benchmark_serving.py --model meta-llama/Llama-3.2-1B-Instruct --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
```

Before:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  149.29    
Total input tokens:                      215196    
Total generated tokens:                  179873    
Request throughput (req/s):              6.70      
Output token throughput (tok/s):         1204.82   
Total Token throughput (tok/s):          2646.24   
---------------Time to First Token----------------
Mean TTFT (ms):                          124792.06 
Median TTFT (ms):                        123725.39 
P99 TTFT (ms):                           138387.36 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          40.52     
Median TPOT (ms):                        40.52     
P99 TPOT (ms):                           67.62     
---------------Inter-token Latency----------------
Mean ITL (ms):                           36.56     
Median ITL (ms):                         37.74     
P99 ITL (ms):                            72.37     
==================================================
```

After:

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  34.24     
Total input tokens:                      215196    
Total generated tokens:                  178861    
Request throughput (req/s):              29.21     
Output token throughput (tok/s):         5224.41   
Total Token throughput (tok/s):          11510.15  
---------------Time to First Token----------------
Mean TTFT (ms):                          8481.82   
Median TTFT (ms):                        7455.52   
P99 TTFT (ms):                           21150.72  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          37.85     
Median TPOT (ms):                        37.10     
P99 TPOT (ms):                           51.13     
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.43     
Median ITL (ms):                         35.88     
P99 ITL (ms):                            72.53     
==================================================
```