### PR TITLE
[CI] Make UT cases in test_comm_ops.py compatible with more devices

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -554,7 +554,8 @@ def init_test_distributed_environment(
         world_size=pp_size * tp_size,
         rank=rank,
         distributed_init_method=distributed_init_method,
-        local_rank=local_rank)
+        local_rank=local_rank,
+        backend=current_platform.communicate_backend)
     ensure_model_parallel_initialized(tp_size, pp_size)
 
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -74,6 +74,7 @@ class CudaPlatformBase(Platform):
     dispatch_key: str = "CUDA"
     ray_device_key: str = "GPU"
     device_control_env_var: str = "CUDA_VISIBLE_DEVICES"
+    communicate_backend: str = "nccl"
 
     @classmethod
     def get_device_capability(cls,
@@ -275,6 +276,22 @@ class CudaPlatformBase(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return "vllm.distributed.device_communicators.cuda_communicator.CudaCommunicator"  # noqa
+
+    @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        """
+        Usage of this function is discouraged in favor of device. In most cases
+        it’s better to use `vllm.current_platform.device_control_env_var` 
+        environmental variable.
+        """
+        return torch.cuda.set_device(device)
+
+    @classmethod
+    def device_count(cls) -> int:
+        """
+        Return the number of devices available.
+        """
+        return torch.cuda.device_count()
 
 
 # NVML utils

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -110,6 +110,8 @@ class Platform:
     # compilation strategy.
     simple_compile_backend: str = "inductor"
 
+    communicate_backend: str
+
     supported_quantization: list[str] = []
 
     def is_cuda(self) -> bool:
@@ -331,6 +333,15 @@ class Platform:
         return "vllm.distributed.device_communicators.base_device_communicator.DeviceCommunicatorBase"  # noqa
 
     @classmethod
+    def set_device(cls, device: torch.device) -> None:
+        """
+        Usage of this function is discouraged in favor of device. In most cases
+        it’s better to use `vllm.current_platform.device_control_env_var` 
+        environmental variable.
+        """
+        raise NotImplementedError
+
+    @classmethod
     def use_all_gather(cls) -> bool:
         """
         Whether to use allgather in LogitsProcessor to gather the logits.
@@ -342,6 +353,13 @@ class Platform:
         return (envs.VLLM_USE_V1
                 or parallel_config.distributed_executor_backend
                 == "external_launcher")
+
+    @classmethod
+    def device_count(cls) -> int:
+        """
+        Return the number of devices available.
+        """
+        raise NotImplementedError
 
 
 class UnspecifiedPlatform(Platform):


### PR DESCRIPTION
At present, the test cases in `tests/distributed/test_comm_ops.py` only support CUDA but don't support other devices. This PR resolve the problem with the following modification:
1. In class `vllm.platforms.Platform`:
    - add a new class attribute `communicate_backend` 
    - add new virtual functions `set_device` and `device_count`
2. In class `vllm.platforms.cuda.CudaPlatformBase`:
    - specify value to `communicate_backend`
    - implement functions `set_device` and `device_count`
3. In function `init_test_distributed_environment`  in the code `tests/utils.py`, when calling the function `init_distributed_environment`, specify value to backend parameter based on the platform, instead of using default value.
4. In code `tests/distributed/test_comm_ops.py`，call device settings and device counting in a more general way.

