### PR TITLE
Use getattr for hidden_act and hidden_activation in Gemma models

### DIFF
--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -217,7 +217,7 @@ class GemmaDecoderLayer(nn.Module):
         self.mlp = GemmaMLP(
             hidden_size=self.hidden_size,
             intermediate_size=config.intermediate_size,
-            hidden_act=config.hidden_act,
+            hidden_act=getattr(config, "hidden_act", None),
             hidden_activation=getattr(config, "hidden_activation", None),
             quant_config=quant_config,
             prefix=f"{prefix}.mlp",

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -201,8 +201,8 @@ class Gemma2DecoderLayer(nn.Module):
         self.mlp = Gemma2MLP(
             hidden_size=self.hidden_size,
             intermediate_size=config.intermediate_size,
-            hidden_act=config.hidden_act,
-            hidden_activation=config.hidden_activation,
+            hidden_act=getattr(config, "hidden_act", None),
+            hidden_activation=getattr(config, "hidden_activation", None),
             quant_config=quant_config,
         )
         self.input_layernorm = GemmaRMSNorm(config.hidden_size,

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -57,8 +57,8 @@ class Gemma2MLP(nn.Module):
         self,
         hidden_size: int,
         intermediate_size: int,
-        hidden_act: str,
-        hidden_activation: str,
+        hidden_act: Optional[str] = None,
+        hidden_activation: Optional[str] = None,
         quant_config: Optional[QuantizationConfig] = None,
     ) -> None:
         super().__init__()
@@ -70,7 +70,8 @@ class Gemma2MLP(nn.Module):
                                            hidden_size,
                                            bias=False,
                                            quant_config=quant_config)
-        if not (hidden_act == hidden_activation == "gelu_pytorch_tanh"):
+        if not (hidden_act == "gelu_pytorch_tanh"
+                or hidden_activation == "gelu_pytorch_tanh"):
             raise ValueError(
                 "Gemma2 uses `gelu_pytorch_tanh` as the hidden activation "
                 "function. Please set `hidden_act` and `hidden_activation` to "


### PR DESCRIPTION
If only one of `hidden_act` or `hidden_activation` is specified, vllm would crash. 

The `hidden_act` parameter is intended to be replaced by `hidden_activation`, but depending on the model version, either could be provided. 