### PR TITLE
[Bugfix] Fix DeepSeek MTP crash when using TP1ModelRunner with CUDA graph due to shape mismatch

### DIFF
--- a/vllm/spec_decode/draft_model_runner.py
+++ b/vllm/spec_decode/draft_model_runner.py
@@ -303,8 +303,9 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
 
             if self.return_hidden_states and is_fallback:
                 if use_cuda_graph:
-                    indices = model_input.sampling_metadata.selected_token_indices
-                    output.hidden_states = hidden_states[: len(indices)]
+                    indices = model_input.sampling_metadata\
+                      .selected_token_indices
+                    output.hidden_states = hidden_states[:len(indices)]
                 else:
                     output.hidden_states = hidden_states
 

--- a/vllm/spec_decode/draft_model_runner.py
+++ b/vllm/spec_decode/draft_model_runner.py
@@ -133,7 +133,7 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
     def supports_gpu_multi_step(self, execute_model_req: ExecuteModelRequest):
         """Determines if draft_model_runner GPU multi-step can be used.
         Currently required conditions are:
-            1. Only decodes 
+            1. Only decodes
             2. Only flash-attn
             3. No LORA
             4. No prompt_adapter_config
@@ -171,12 +171,12 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
         num_steps: int = 1,
         **kwargs,
     ) -> Optional[List[SamplerOutput]]:
-        """Executes num_steps forward passes with advacement of input tensors 
+        """Executes num_steps forward passes with advacement of input tensors
         on the GPU. Look at supports_gpu_multi_step(..) for pre-conditions.
 
         Optimizations used:
             1. Input tensors are updated on the GPU directly
-            2. Skips GPU=>CPU serialization of sampler outputs (we don't need 
+            2. Skips GPU=>CPU serialization of sampler outputs (we don't need
                 them since we do batch expansion later that uses GPU outputs)
             3. Reuses sampling tensors (since we run only decodes and they have
                 a repeating sampling logic)
@@ -302,7 +302,11 @@ class TP1DraftModelRunner(ModelRunnerWrapperBase):
             outputs.append(output)
 
             if self.return_hidden_states and is_fallback:
-                output.hidden_states = hidden_states
+                if use_cuda_graph:
+                    indices = model_input.sampling_metadata.selected_token_indices
+                    output.hidden_states = hidden_states[: len(indices)]
+                else:
+                    output.hidden_states = hidden_states
 
             if model_input.attn_metadata.num_prefills == 0 \
                 and self.indices_of_seq_with_bonus_tokens is not None:


### PR DESCRIPTION
When using DeepSeek MTP module with TP1 model runner and cuda graph, the server will crash due to shape mismatch. The crash only happens when BS > 1. This PR fixes the mismatch by removing padded items in hidden states. 

Launch command:

```
python -m vllm.entrypoints.openai.api_server --disable-log-requests --gpu-memory-utilization 0.6  --max-model-len 4096 --max-num-seqs 32 --seed 0 --tensor-parallel-size 16 --model deepseek-ai/DeepSeek-R1 --trust-remote-code --num-speculative-tokens 3 --speculative-draft-tensor-parallel-size 1
```

Before: [Crash]
```
ERROR 03-04 09:59:21 [worker_base.py:593] Error executing method 'execute_model'. This might cause deadlock in distributed execution.
ERROR 03-04 09:59:21 [worker_base.py:593] Traceback (most recent call last):
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/worker/worker_base.py", line 585, in execute_method
ERROR 03-04 09:59:21 [worker_base.py:593]     return run_method(self, method, args, kwargs)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/utils.py", line 2232, in run_method
ERROR 03-04 09:59:21 [worker_base.py:593]     return func(*args, **kwargs)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-env/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 03-04 09:59:21 [worker_base.py:593]     return func(*args, **kwargs)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 545, in execute_model
ERROR 03-04 09:59:21 [worker_base.py:593]     return self._run_speculative_decoding_step(execute_model_req,
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/usr/lib/python3.12/contextlib.py", line 81, in inner
ERROR 03-04 09:59:21 [worker_base.py:593]     return func(*args, **kwds)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 786, in _run_speculative_decoding_step
ERROR 03-04 09:59:21 [worker_base.py:593]     proposals = self.proposer_worker.get_spec_proposals(
ERROR 03-04 09:59:21 [worker_base.py:593]                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/smaller_tp_proposer_worker.py", line 147, in get_spec_proposals
ERROR 03-04 09:59:21 [worker_base.py:593]     return self._worker.get_spec_proposals(
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/multi_step_worker.py", line 246, in get_spec_proposals
ERROR 03-04 09:59:21 [worker_base.py:593]     return self._proposer.get_spec_proposals(
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/top1_proposer.py", line 79, in get_spec_proposals
ERROR 03-04 09:59:21 [worker_base.py:593]     maybe_sampler_output, transposed = self._worker.sampler_output(
ERROR 03-04 09:59:21 [worker_base.py:593]                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-env/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 03-04 09:59:21 [worker_base.py:593]     return func(*args, **kwargs)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/multi_step_worker.py", line 107, in sampler_output
ERROR 03-04 09:59:21 [worker_base.py:593]     self._maybe_update_previous_hidden_states(
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/spec_decode/multi_step_worker.py", line 131, in _maybe_update_previous_hidden_states
ERROR 03-04 09:59:21 [worker_base.py:593]     expanded_request.previous_hidden_states = HiddenStates(
ERROR 03-04 09:59:21 [worker_base.py:593]                                               ^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593]   File "/vllm-oss/vllm/sequence.py", line 1220, in __post_init__
ERROR 03-04 09:59:21 [worker_base.py:593]     assert len(self.seq_group_metadata_list) == len(self.hidden_states)
ERROR 03-04 09:59:21 [worker_base.py:593]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-04 09:59:21 [worker_base.py:593] AssertionError
```

After: No crash anymore
