### PR TITLE
[V1] Enable Long Context LoRA tests for V1 

### DIFF
--- a/docs/source/design/v1/lora.md
+++ b/docs/source/design/v1/lora.md
@@ -24,9 +24,9 @@ When using Long Context LoRA adapters with V1, we recommend that you,
 
 The following is the expected behaviour for different scenarios when Long Context LoRA models are in play.
 
-- The engine is constructed with an unspecified `max_model_len` or the `max_model_len` is set to the base model's model length. When the engine receives Long Context LoRA requests,
-  - If prompt length <= `max_model_len` : The request will be accepted, but the output will be truncated at max_model_len
-  - If prompt length  > `max_model_len` : The request will be rejected citing that the prompt is too long
+- The engine is constructed with `max_model_len` set to None or set to the base model's model length. When the engine receives Long Context LoRA requests,
+  - If prompt length <= `max_model_len` : The request will be accepted, but the output will be truncated at max_model_len.
+  - If prompt length  > `max_model_len` : The request will be rejected citing that the prompt is too long.
 
 - The engine is constructed with `max_model_len` set to the largest context length of any adapter that it might receive requests for. As an example, let the base model’s model length be 4K and let there be 2 Long Context LoRA adapters,
   - 16K adapter : Can support a context length upto 16K

--- a/docs/source/design/v1/lora.md
+++ b/docs/source/design/v1/lora.md
@@ -1,0 +1,50 @@
+# V1 LoRA
+
+This page lists some caveats in using LoRA with V1. For general information about using LoRA adapters, please refer to [LoRA Adapters](../../features/lora.md)
+
+## Caveats
+
+### Using Long Context LoRA Adapters with V1
+
+Long Context LoRA adapters are LoRA adapters that are fine-tuned to increase the context sizes of pre-trained large language models.  
+
+Support for Long Context LoRA adapters is essentially a case for supporting request-level model-length setting. However, vLLM’s V1 architecture assumes a static `max_model_len` and is less amenable to this use case.
+
+#### Workaround
+
+When using Long Context LoRA adapters with V1, we recommend that you,
+
+- Explicitly set the engine's `max_model_len` argument to the largest context length you expect the engine to process.
+- Explicitly set each request's `max_num_tokens` appropriately. i.e.,
+
+  - For requests targeting the base model, set `max_num_tokens` to less than or equal to the base model's model length,
+  - For requests targeting LoRA adapters, set `max_num_tokens` to less than or equal to the context length of the LoRA adapter.
+
+#### Expected Behaviour
+
+The following is the expected behaviour for different scenarios when Long Context LoRA models are in play.
+
+- The engine is constructed with an unspecified `max_model_len` or the `max_model_len` is set to the base model's model length. When the engine receives Long Context LoRA requests,
+  - If prompt length <= `max_model_len` : The request will be accepted, but the output will be truncated at max_model_len
+  - If prompt length  > `max_model_len` : The request will be rejected citing that the prompt is too long
+
+- The engine is constructed with `max_model_len` set to the largest context length of any adapter that it might receive requests for. As an example, let the base model’s model length be 4K and let there be 2 Long Context LoRA adapters,
+  - 16K adapter : Can support a context length upto 16K
+  - 32K adapter : Can support a context length upto 32K
+  - In this case, the `max_model_len` will be set to 32K
+
+  - User Request Scenarios:
+    - Request for the 16K adapter, and `max_num_tokens` is None
+      - The request will produce incorrect results when the total number of tokens (prompt + generated) goes beyond 16K. (Tokens generated beyond the 16K context length will be incorrect)
+    - Request for the 32K adapter, and `max_num_tokens` is None
+      - The request will produce correct outputs.
+    - Request for the base model, and `max_num_tokens` is None
+      - The request will produce incorrect requests when the total number tokens (prompt + generated) goes beyond 4K. (Tokens generated beyond the 4K context length will be incorrect)
+    - Request for the 16K adapter, and `max_num_tokens` <= 16K
+      - The request will produce correct results
+    - Request for the 32K adapter, and `max_num_token` <= 32K
+      - The request will produce correct results
+    - Request for the base model, and `max_num_tokens` <= 4K
+      - The request will produce correct results.
+
+Reference: Please look at  `tests/lora/test_long_context.py`

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -171,6 +171,7 @@ design/multiprocessing
 design/v1/torch_compile
 design/v1/prefix_caching
 design/v1/metrics
+design/v1/lora
 :::
 
 % How to contribute to the vLLM project

--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -297,7 +297,7 @@ def llama_2_7b_model_extra_embeddings(llama_2_7b_engine_extra_embeddings):
            model_runner.model)
 
 
-@pytest.fixture(params=[True])
+@pytest.fixture(params=[True, False])
 def run_with_both_engines_lora(request, monkeypatch):
     # Automatically runs tests twice, once with V1 and once without
     use_v1 = request.param
@@ -308,23 +308,6 @@ def run_with_both_engines_lora(request, monkeypatch):
         if skip_v1:
             pytest.skip("Skipping test on vllm V1")
         monkeypatch.setenv('VLLM_USE_V1', '1')
-    else:
-        monkeypatch.setenv('VLLM_USE_V1', '0')
-
-    yield
-
-@pytest.fixture(params=[True])
-def run_with_both_engines_long_context_lora(request, monkeypatch):
-    # Automatically runs tests twice, once with V1 and once without
-    use_v1 = request.param
-    # Tests decorated with `@skip_v1` are only run without v1
-    skip_v1 = request.node.get_closest_marker("skip_v1")
-
-    if use_v1:
-        if skip_v1:
-            pytest.skip("Skipping test on vllm V1")
-        monkeypatch.setenv('VLLM_USE_V1', '1')
-        monkeypatch.setenv('VLLM_ALLOW_LONG_MAX_MODEL_LEN', '1')
     else:
         monkeypatch.setenv('VLLM_USE_V1', '0')
 

--- a/tests/lora/conftest.py
+++ b/tests/lora/conftest.py
@@ -297,7 +297,7 @@ def llama_2_7b_model_extra_embeddings(llama_2_7b_engine_extra_embeddings):
            model_runner.model)
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True])
 def run_with_both_engines_lora(request, monkeypatch):
     # Automatically runs tests twice, once with V1 and once without
     use_v1 = request.param
@@ -308,6 +308,23 @@ def run_with_both_engines_lora(request, monkeypatch):
         if skip_v1:
             pytest.skip("Skipping test on vllm V1")
         monkeypatch.setenv('VLLM_USE_V1', '1')
+    else:
+        monkeypatch.setenv('VLLM_USE_V1', '0')
+
+    yield
+
+@pytest.fixture(params=[True])
+def run_with_both_engines_long_context_lora(request, monkeypatch):
+    # Automatically runs tests twice, once with V1 and once without
+    use_v1 = request.param
+    # Tests decorated with `@skip_v1` are only run without v1
+    skip_v1 = request.node.get_closest_marker("skip_v1")
+
+    if use_v1:
+        if skip_v1:
+            pytest.skip("Skipping test on vllm V1")
+        monkeypatch.setenv('VLLM_USE_V1', '1')
+        monkeypatch.setenv('VLLM_ALLOW_LONG_MAX_MODEL_LEN', '1')
     else:
         monkeypatch.setenv('VLLM_USE_V1', '0')
 

--- a/tests/lora/test_long_context.py
+++ b/tests/lora/test_long_context.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import vllm
+import vllm.envs as envs
 from vllm import SamplingParams
 from vllm.lora.layers import LinearScalingRotaryEmbeddingWithLoRA
 from vllm.lora.request import LoRARequest
@@ -25,6 +26,14 @@ sampling_params = SamplingParams(
     temperature=0,
     max_tokens=100,
 )
+
+
+@pytest.fixture(autouse=True)
+def v1(run_with_both_engines_long_context_lora):
+    # Simple autouse wrapper to run both engines for each test
+    # This can be promoted up to conftest.py to run for every
+    # test in a package
+    pass
 
 
 def _create_lora_request(lora_id, long_context_infos):
@@ -109,12 +118,16 @@ def batched_generate(
     return [outputs[i].outputs[0].text.strip() for i in range(len(outputs))]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def lora_llm(long_context_infos):
     scaling_factors = [
         context_len_to_scaling_factor[info["context_length"]]
         for info in long_context_infos.values()
     ]
+
+    max_model_len = None
+    if envs.VLLM_USE_V1:
+        max_model_len = 4096 * 8
 
     llm = vllm.LLM(
         "meta-llama/Llama-2-13b-chat-hf",
@@ -127,7 +140,11 @@ def lora_llm(long_context_infos):
         # FIXME enable async output processor
         disable_async_output_proc=True,
         distributed_executor_backend="mp",
-        enable_chunked_prefill=True)
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        gpu_memory_utilization=0.95,
+        max_model_len=max_model_len,
+    )
     yield llm
     del llm
 
@@ -135,15 +152,26 @@ def lora_llm(long_context_infos):
 def test_rotary_emb_replaced(dist_init):
     """Verify rotary emb in all the layers are replaced"""
     from vllm.engine.arg_utils import EngineArgs
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
     from vllm.worker.model_runner import ModelRunner
+
     engine_args = EngineArgs("meta-llama/Llama-2-7b-hf",
                              long_lora_scaling_factors=(4.0, ),
                              enable_lora=True)
     engine_config = engine_args.create_engine_config()
-    model_runner = ModelRunner(
-        vllm_config=engine_config,
-        is_driver_worker=True,
-    )
+
+    #model_runner_cls = GPUModelRunner if envs.VLLM_USE_V1 else ModelRunner
+    if envs.VLLM_USE_V1:
+        model_runner = GPUModelRunner(
+            vllm_config=engine_config,
+            device="cuda",
+        )
+    else:
+        model_runner = ModelRunner(
+            vllm_config=engine_config,
+            is_driver_worker=True,
+        )
+
     model_runner.load_model()
     rotary_emb_count = 0
     for module_name, module in model_runner.model.named_modules(


### PR DESCRIPTION
Enable Long Context LoRA tests for V1

Support for Long Context LoRA modules is essentially a case for supporting request-level model-length setting.
V1 is less amenable to this as there are some static tensors constructed in the Persistent Batch that depend on the model_config.max_model_len. Specifically, https://github.com/vllm-project/vllm/blob/4f5b059f146adeecd153fa781cf21863ed6679d8/vllm/v1/worker/block_table.py#L25
```
       self.block_table = torch.zeros(
            (max_num_reqs, max_num_blocks_per_req),
            device=self.device,
            dtype=torch.int32,
        )
```
`max_num_blocks_per_req` is derived from `max_model_len`. At engine construction time, we don’t have the information about the maximum Long Context length. The `block_table` tensor is constructed with the model’s `max_model_len` value, which becomes inadequate when Long Context LoRA requests are submitted.

Solution:
Specify the “maximum Long Context length” via max_model_len engine arg. This has 2 implications,
  - Reject any LoRA requests that request bigger contexts.
  - Normal requests, i.e. base model requests,  will generate incorrect output when the number of tokens exceeds the model’s max_model_len.

We can address these limitations based on user requests. 