### PR TITLE
allow tokenizer to count output tokens if completion_tokens not provided

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -39,7 +39,7 @@ class RequestFuncOutput:
     generated_text: str = ""
     success: bool = False
     latency: float = 0.0
-    output_tokens: int = 0
+    output_tokens: int = None 
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(
         default_factory=list)  # list of inter-token latencies


### PR DESCRIPTION
Currently RequestFuncOutput data class output_tokens initializes to 0. This means if an openai_completion response doesn't include_usage set, the output_tokens would stay at 0, and when read later for calculate_metrics would not invoke the client tokenzier to count the correct number of tokens, and would remain 0 for the benchmark metrics printout. By setting this to None the tokenizer would be invoked to count the correctly