### PR TITLE
[utils] Update DNS server IPs in get_ip function to avoid rate limiting

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -458,7 +458,7 @@ def get_ip() -> str:
     # try ipv4
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
-        s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
+        s.connect(("208.67.222.222", 80))  # using OpenDNS ip due to google's rate limiting Doesn't need to be reachable
         return s.getsockname()[0]
     except Exception:
         pass
@@ -466,9 +466,8 @@ def get_ip() -> str:
     # try ipv6
     try:
         s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
-        # Google's public DNS server, see
-        # https://developers.google.com/speed/public-dns/docs/using#addresses
-        s.connect(("2001:4860:4860::8888", 80))  # Doesn't need to be reachable
+        # OpenDNS's public DNS server, see
+        s.connect(("2620:119:35::35", 80))  # Doesn't need to be reachable
         return s.getsockname()[0]
     except Exception:
         pass


### PR DESCRIPTION
# Summary
This PR addresses an issue in the `get_ip` function in the VLLM code. Currently, the function attempts to retrieve the local IP address by opening a socket to `8.8.8.8:80` (Google's DNS). This approach may lead to stalls, timeouts, and crashes due to potential rate-limiting.

# Details
I've identified that the reliance on Google's DNS server can cause performance issues in certain environments. To mitigate this risk, this PR modifies the `get_ip` function to:

- For general usage, use OpenDNS's server:
  - **IPv4:** `208.67.222.222:80`
  - **IPv6:** `2620:119:35::35`

These changes aim to improve the stability and reliability of the IP retrieval process across different network conditions.

# Testing
Confirmed that the updated `get_ip` function retrieves the correct local IP address without stalling.


# Thanks
Thanks to [@yarons](https://github.com/yarons) for the assistance in identifying and diagnosing this issue.


