### PR TITLE
[BugFix] Add explict defualt ctor for RankData to make it can be built with clang

### DIFF
--- a/csrc/custom_all_reduce.cuh
+++ b/csrc/custom_all_reduce.cuh
@@ -40,6 +40,9 @@ struct Signal {
 
 struct __align__(16) RankData {
   const void* __restrict__ ptrs[8];
+  RankData()
+      : ptrs{nullptr, nullptr, nullptr, nullptr,
+             nullptr, nullptr, nullptr, nullptr} {}
 };
 
 struct __align__(16) RankSignals {


### PR DESCRIPTION
When built with clang, the compiler emits error: cannot initialize a parameter of type 'void *' with an rvalue of type 'const void *__restrict (*)[8]'
