### PR TITLE
[Doc] Fix env path name in `uv` Python env setup instructions

### DIFF
--- a/docs/source/getting_started/installation/python_env_setup.inc.md
+++ b/docs/source/getting_started/installation/python_env_setup.inc.md
@@ -14,6 +14,6 @@ Or you can create a new Python environment using [uv](https://docs.astral.sh/uv/
 
 ```console
 # (Recommended) Create a new uv environment. Use `--seed` to install `pip` and `setuptools` in the environment.
-uv venv --python 3.12 --seed
-source vllm/bin/activate
+uv venv myenv --python 3.12 --seed
+source myenv/bin/activate
 ```

--- a/docs/source/getting_started/installation/python_env_setup.inc.md
+++ b/docs/source/getting_started/installation/python_env_setup.inc.md
@@ -14,6 +14,6 @@ Or you can create a new Python environment using [uv](https://docs.astral.sh/uv/
 
 ```console
 # (Recommended) Create a new uv environment. Use `--seed` to install `pip` and `setuptools` in the environment.
-uv venv vllm --python 3.12 --seed
+uv venv --python 3.12 --seed
 source vllm/bin/activate
 ```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -19,7 +19,7 @@ If you are using NVIDIA GPUs, you can install vLLM using [pip](https://pypi.org/
 It's recommended to use [uv](https://docs.astral.sh/uv/), a very fast Python environment manager, to create and manage Python environments. Please follow the [documentation](https://docs.astral.sh/uv/#getting-started) to install `uv`. After installing `uv`, you can create a new Python environment and install vLLM using the following commands:
 
 ```console
-uv venv --python 3.12 --seed
+uv venv myenv --python 3.12 --seed
 source myenv/bin/activate
 uv pip install vllm
 ```

--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -19,7 +19,7 @@ If you are using NVIDIA GPUs, you can install vLLM using [pip](https://pypi.org/
 It's recommended to use [uv](https://docs.astral.sh/uv/), a very fast Python environment manager, to create and manage Python environments. Please follow the [documentation](https://docs.astral.sh/uv/#getting-started) to install `uv`. After installing `uv`, you can create a new Python environment and install vLLM using the following commands:
 
 ```console
-uv venv myenv --python 3.12 --seed
+uv venv --python 3.12 --seed
 source myenv/bin/activate
 uv pip install vllm
 ```


### PR DESCRIPTION
~~Drops the path argument from `uv venv` instructions in favor of default `uv` behavior.~~

**Update:** Per reviewer feedback, this PR now updates the `uv venv` command to use `myenv` as the env path name.

The current instructions say `uv venv vllm`, where `vllm` is the alternative path we’re telling `uv` to use for setting up the Python virtual environment. This throws an error, because the `vllm` directory already exists and is used for Python source code.

```shell
Using CPython 3.12.9 interpreter at: /opt/homebrew/opt/python@3.12/bin/python3.12
Creating virtual environment with seed packages at: vllm
uv::venv::creation

  × Failed to create virtualenv
  ╰─▶ The directory `vllm` exists, but it's not a virtual environment
```

~~We can drop the path argument from the `uv venv` completely — by default, [`uv` will create a `.venv` directory for the project environment](https://docs.astral.sh/uv/concepts/projects/layout/#the-project-environment). This directory won’t get checked into Git because it includes its own match-all `.gitignore`. We already list `.venv` in the root-level `.gitignore`, too.~~

**Update:** This PR originally proposed completely removing the optional env path name from `uv venv`, but we ended up keeping `myenv` as the name for clarity.

<!--- pyml disable-next-line no-emphasis-as-heading -->
