### PR TITLE
[V1] Allow best_of=1 in sampling params

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -94,7 +94,7 @@ class Processor:
         params: SamplingParams,
     ) -> None:
         # Best of not yet supported.
-        if params.best_of:
+        if params.best_of is not None and params.best_of > 1:
             raise ValueError("VLLM V1 does not yet support best_of.")
         # Bad words not yet supported.
         if params.bad_words:


### PR DESCRIPTION
Recent validation made V1 reject request if best_of is specified. Allow the
request if it is specified using the default of 1.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
