### PR TITLE
[Benchmark] Unset best_of when running v1 benchmark

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -33,7 +33,7 @@ REQUEST_FUNC_INPUT_FIELDS = [
 if not os.environ.get("VLLM_USE_V1", 0):
     # From https://github.com/vllm-project/vllm/pull/14159, v1 doesn't yet
     # support best_of parameter
-    REQUEST_FUNC_INPUT_FIELDS.extend([("best_of", int, field(default=1))])
+    REQUEST_FUNC_INPUT_FIELDS.append(("best_of", int, field(default=1)))
 
 RequestFuncInput = make_dataclass("RequestFuncInput",
                                   REQUEST_FUNC_INPUT_FIELDS)

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -18,24 +18,25 @@ from vllm.model_executor.model_loader.weight_utils import get_lock
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
-RequestFuncInput = make_dataclass(
-    "RequestFuncInput",
-    [
-        ("prompt", str),
-        ("api_url", str),
-        ("prompt_len", int),
-        ("output_len", int),
-        ("model", str),
-        ("model_name", Optional[str], field(default=None)),
-        ("logprobs", Optional[int], field(default=None)),
-        ("extra_body", Optional[dict], field(default=None)),
-        ("multi_modal_content", Optional[dict], field(default=None)),
-        ("ignore_eos", bool, field(default=False)),
-    ].extend(
-        # From https://github.com/vllm-project/vllm/pull/14159, v1 doesn't yet
-        # support best_of parameter
-        [] if os.environ.get("VLLM_USE_V1", 0) else [("best_of", int,
-                                                      field(default=1))]))
+REQUEST_FUNC_INPUT_FIELDS = [
+    ("prompt", str),
+    ("api_url", str),
+    ("prompt_len", int),
+    ("output_len", int),
+    ("model", str),
+    ("model_name", Optional[str], field(default=None)),
+    ("logprobs", Optional[int], field(default=None)),
+    ("extra_body", Optional[dict], field(default=None)),
+    ("multi_modal_content", Optional[dict], field(default=None)),
+    ("ignore_eos", bool, field(default=False)),
+]
+if not os.environ.get("VLLM_USE_V1", 0):
+    # From https://github.com/vllm-project/vllm/pull/14159, v1 doesn't yet
+    # support best_of parameter
+    REQUEST_FUNC_INPUT_FIELDS.extend([("best_of", int, field(default=1))])
+
+RequestFuncInput = make_dataclass("RequestFuncInput",
+                                  REQUEST_FUNC_INPUT_FIELDS)
 
 
 @dataclass

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 import traceback
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, make_dataclass
 from typing import Optional, Union
 
 import aiohttp
@@ -18,20 +18,24 @@ from vllm.model_executor.model_loader.weight_utils import get_lock
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
-
-@dataclass
-class RequestFuncInput:
-    prompt: str
-    api_url: str
-    prompt_len: int
-    output_len: int
-    model: str
-    model_name: Optional[str] = None
-    best_of: int = 1
-    logprobs: Optional[int] = None
-    extra_body: Optional[dict] = None
-    multi_modal_content: Optional[dict] = None
-    ignore_eos: bool = False
+RequestFuncInput = make_dataclass(
+    "RequestFuncInput",
+    [
+        ("prompt", str),
+        ("api_url", str),
+        ("prompt_len", int),
+        ("output_len", int),
+        ("model", str),
+        ("model_name", Optional[str], field(default=None)),
+        ("logprobs", Optional[int], field(default=None)),
+        ("extra_body", Optional[dict], field(default=None)),
+        ("multi_modal_content", Optional[dict], field(default=None)),
+        ("ignore_eos", bool, field(default=False)),
+    ].extend(
+        # From https://github.com/vllm-project/vllm/pull/14159, v1 doesn't yet
+        # support best_of parameter
+        [] if os.environ.get("VLLM_USE_V1", 0) else [("best_of", int,
+                                                      field(default=1))]))
 
 
 @dataclass

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -5,7 +5,7 @@ import os
 import sys
 import time
 import traceback
-from dataclasses import dataclass, field, make_dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Union
 
 import aiohttp
@@ -18,25 +18,20 @@ from vllm.model_executor.model_loader.weight_utils import get_lock
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
-REQUEST_FUNC_INPUT_FIELDS = [
-    ("prompt", str),
-    ("api_url", str),
-    ("prompt_len", int),
-    ("output_len", int),
-    ("model", str),
-    ("model_name", Optional[str], field(default=None)),
-    ("logprobs", Optional[int], field(default=None)),
-    ("extra_body", Optional[dict], field(default=None)),
-    ("multi_modal_content", Optional[dict], field(default=None)),
-    ("ignore_eos", bool, field(default=False)),
-]
-if not os.environ.get("VLLM_USE_V1", 0):
-    # From https://github.com/vllm-project/vllm/pull/14159, v1 doesn't yet
-    # support best_of parameter
-    REQUEST_FUNC_INPUT_FIELDS.append(("best_of", int, field(default=1)))
 
-RequestFuncInput = make_dataclass("RequestFuncInput",
-                                  REQUEST_FUNC_INPUT_FIELDS)
+@dataclass
+class RequestFuncInput:
+    prompt: str
+    api_url: str
+    prompt_len: int
+    output_len: int
+    model: str
+    model_name: Optional[str] = None
+    best_of: Optional[int] = None if os.environ.get("VLLM_USE_V1", 0) else 1
+    logprobs: Optional[int] = None
+    extra_body: Optional[dict] = None
+    multi_modal_content: Optional[dict] = None
+    ignore_eos: bool = False
 
 
 @dataclass

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1084,7 +1084,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--best-of",
         type=int,
-        default=0 if os.environ.get("VLLM_USE_V1", 0) else 1,
+        default=None if os.environ.get("VLLM_USE_V1", 0) else 1,
         help="Generates `best_of` sequences per prompt and "
         "returns the best one.",
     )

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -1084,7 +1084,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--best-of",
         type=int,
-        default=1,
+        default=0 if os.environ.get("VLLM_USE_V1", 0) else 1,
         help="Generates `best_of` sequences per prompt and "
         "returns the best one.",
     )


### PR DESCRIPTION
The check is introduced by https://github.com/vllm-project/vllm/pull/14159 and it will fail the benchmark serving script on V1 with `VLLM V1 does not yet support best_of` error as the parameter is not yet supported.  All the serving metrics fail to show up on [v1 dashboard](https://hud.pytorch.org/benchmark/llms?startTime=Wed%2C%2026%20Feb%202025%2019%3A22%3A46%20GMT&stopTime=Wed%2C%2005%20Mar%202025%2019%3A22%3A46%20GMT&granularity=day&lBranch=main&lCommit=257e200a2537a8175392d3bb285473ab80867576&rBranch=main&rCommit=257e200a2537a8175392d3bb285473ab80867576&repoName=vllm-project%2Fvllm&benchmarkName=&modelName=All%20Models&backendName=All%20Backends&modeName=All%20Modes&dtypeName=All%20DType&deviceName=All%20Devices&archName=All%20Platforms) after https://github.com/vllm-project/vllm/pull/14159 lands.

### Testing

`ENGINE_VERSION=v1 HF_TOKEN=<REDACTED> bash .buildkite/nightly-benchmarks/scripts/run-performance-benchmarks.sh` works locally again

cc @robertgshaw2-redhat @houseroad @ywang96 @WoosukKwon  