### PR TITLE
[V1][Easy] Add empty allowed_token_ids in the v1 sampler test

### DIFF
--- a/tests/v1/sample/test_sampling_params_e2e.py
+++ b/tests/v1/sample/test_sampling_params_e2e.py
@@ -121,6 +121,10 @@ def test_allowed_token_ids(model):
         PROMPT, SamplingParams(allowed_token_ids=allowed_token_ids))
     assert output[0].outputs[0].token_ids[-1] == TOKEN_ID
 
+    # Reject empty allowed_token_ids.
+    with pytest.raises(ValueError):
+        _ = model.generate(PROMPT, SamplingParams(allowed_token_ids=[]))
+
     # Reject negative token id.
     with pytest.raises(ValueError):
         _ = model.generate(PROMPT, SamplingParams(allowed_token_ids=[-1]))


### PR DESCRIPTION
Raise error if allowed_token_ids is not None and empty, we raise the error. Adding a test to cover this case.