### PR TITLE
[Bug] Fix Attention when ignored in by quant_method

### DIFF
--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -11,6 +11,7 @@ from vllm.attention import AttentionType
 from vllm.attention.selector import backend_name_to_enum, get_attn_backend
 from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -97,7 +98,9 @@ class Attention(nn.Module):
 
         quant_method = quant_config.get_quant_method(
             self, prefix=prefix) if quant_config else None
-        if quant_method is not None:
+        if quant_method is not None and not isinstance(
+                quant_method, UnquantizedLinearMethod):
+            print(type(quant_method))
             assert isinstance(quant_method, BaseKVCacheMethod)
             # TODO (mgoin): kv cache dtype should be specified in the FP8
             # checkpoint config and become the "auto" behavior

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -11,7 +11,7 @@ from vllm.attention import AttentionType
 from vllm.attention.selector import backend_name_to_enum, get_attn_backend
 from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.forward_context import ForwardContext, get_forward_context
-from vllm.model_executor.layers import UnquantizedLinearMethod
+from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
@@ -100,7 +100,6 @@ class Attention(nn.Module):
             self, prefix=prefix) if quant_config else None
         if quant_method is not None and not isinstance(
                 quant_method, UnquantizedLinearMethod):
-            print(type(quant_method))
             assert isinstance(quant_method, BaseKVCacheMethod)
             # TODO (mgoin): kv cache dtype should be specified in the FP8
             # checkpoint config and become the "auto" behavior


### PR DESCRIPTION
There was a bug in the Attention module when a quantized model has the attention module ignored. Many `quant_config.get_quant_method` calls will return `UnquantizedLinearMethod` rather than `None` if the layer is ignored. Maybe we should be returning `UnquantizedAttentionMethod` to be more clear, but that isn't functionally important

On main we hit `assert isinstance(quant_method, BaseKVCacheMethod)`