### PR TITLE
[Misc] Ensure out-of-tree quantization method recognize by cli args

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -576,8 +576,8 @@ class EngineArgs:
         # Quantization settings.
         parser.add_argument('--quantization',
                             '-q',
-                            choices=[*QUANTIZATION_METHODS, None],
                             type=nullable_str,
+                            choices=[*QUANTIZATION_METHODS, None],
                             default=EngineArgs.quantization,
                             help='Method used to quantize the weights. If '
                             'None, we first check the `quantization_config` '


### PR DESCRIPTION
#11969 support the register of out-of-tree quantization method, but the cli args cant load the updated `QUANTIZATION_METHODS`

In this pr, The validation of quantization methods (QUANTIZATION_METHODS) is now performed after loading all plugins in the __post_init__ method of EngineArgs.
This change ensures that any newly registered quantization methods are available during validation.

This pr also allow write a quantization plugin in a general_plugin

For example:

```
@register_quantization_config("awq_turbomind")
class AWQTurbomindConfig(QuantizationConfig):
```

```
# Entrypoint
def register():
    from vllm.model_executor.layers.linear import WEIGHT_LOADER_V2_SUPPORTED

    # Register the quantization method
    from .turbomind_awq import (  # noqa: F401
        AWQTurbomindConfig,
        AWQTurbomindLinearMethod,
    )

    # This is needed for correct weight loading
    WEIGHT_LOADER_V2_SUPPORTED.append("AWQTurbomindLinearMethod")
```

After install this plugin, i can use the openai server without any code modify.

```
vllm serve qwen/qwq-32b-awq -q awq_turbomind
```