### PR TITLE
[CI] Disable spawn when running V1 Test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -198,7 +198,6 @@ steps:
     - tests/v1
   commands:
     # split the test to avoid interference
-    - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     - VLLM_USE_V1=1 pytest -v -s v1/core
     - VLLM_USE_V1=1 pytest -v -s v1/engine
     - VLLM_USE_V1=1 pytest -v -s v1/sample


### PR DESCRIPTION
I noticed that V1 Test is failing on main branch ever since we merged: https://github.com/vllm-project/vllm/pull/14243

The error suggests that the [monkeypatch](https://github.com/vllm-project/vllm/blob/main/tests/v1/engine/test_engine_core_client.py#L99) that is used in `test_engine_core_client` does not get picked up when using spawn. It looks like this is a [known issue](https://github.com/pytest-dev/pytest/issues/12045) with monkeypatch. 

If we really need to use spawn for this test, a proper solution would be to re-write the test to not use monkeypatch. However, since this issue is actually failing all PR builds currently I would suggest reverting using spawn when running this test (since they seem to pass).

Have confirmed this reproduces locally and disabling spawn resolves it. 

cc @russellb @youkaichao @aarnphm 
