### PR TITLE
[Bugfix][Frontend] Fix validation of `logprobs` in `ChatCompletionRequest`

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -546,7 +546,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             if top_logprobs < 0:
                 raise ValueError("`top_logprobs` must be a positive value.")
 
-            if not data.get("logprobs"):
+            if top_logprobs > 0 and not data.get("logprobs"):
                 raise ValueError(
                     "when using `top_logprobs`, `logprobs` must be set to true."
                 )


### PR DESCRIPTION
This fixes the validation of `logprobs` and `top_logprobs` for `ChatCompletionRequest` so that the class accepts its own default values.

FIX [#14351](https://github.com/vllm-project/vllm/issues/14351)
