### PR TITLE
[bugfix] LLMEngine.seq_id_to_seq_group_size causes memory leak

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1470,6 +1470,7 @@ class LLMEngine:
                 self.do_tracing(scheduler_outputs)
         else:
             # Multi-step case
+            self.seq_id_to_seq_group.clear()
             return ctx.request_outputs
 
         if not self.has_unfinished_requests():
@@ -1486,6 +1487,7 @@ class LLMEngine:
             logger.debug("Stopping remote worker execution loop.")
             self.model_executor.stop_remote_worker_execution_loop()
 
+        self.seq_id_to_seq_group.clear()
         return ctx.request_outputs
 
     def _abort_and_cache_schedule(


### PR DESCRIPTION
Bugfix #14353 , memory leak due to LLMEngine.seq_id_to_seq_group_size