### PR TITLE
[Config][Disaggregated] Add timeout configuration for the torch.store and add KVTransferConfig.kv_connector_extra_config

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2820,6 +2820,9 @@ class KVTransferConfig(BaseModel):
     # The KV connector port, used to build distributed connection
     kv_port: int = 14579
 
+    # any extra config that the connector may need
+    kv_connector_extra_config: dict[str, Any] = {}
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -2878,6 +2881,9 @@ class KVTransferConfig(BaseModel):
     def is_kv_consumer(self) -> bool:
         return self.kv_connector is not None and \
             self.kv_role in ["kv_consumer", "kv_both"]
+
+    def get_from_extra_config(self, key, default) -> Any:
+        return self.kv_connector_extra_config.get(key, default)
 
 
 class CompilationLevel:

--- a/vllm/distributed/kv_transfer/kv_lookup_buffer/simple_buffer.py
+++ b/vllm/distributed/kv_transfer/kv_lookup_buffer/simple_buffer.py
@@ -6,7 +6,7 @@
     - Distributed KV cache transmission using PyNccl pipes.
     - Non-blocking `insert`, blocking `drop_select`.
     - Use CPU signal pipe to avoid racing condition
-    - Handles buffer size constraints and provide backpressure mechanism to 
+    - Handles buffer size constraints and provide backpressure mechanism to
       stop the prefill instance when the decode instance is slow.
 """
 import threading

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -5,6 +5,7 @@
 # https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/utils.py
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 import dataclasses
+import datetime
 import pickle
 import time
 from collections import deque
@@ -217,6 +218,7 @@ class StatelessProcessGroup:
         rank: int,
         world_size: int,
         data_expiration_seconds: int = 3600,
+        store_timeout: int = 300,
     ) -> "StatelessProcessGroup":
         """A replacement for `torch.distributed.init_process_group` that does not
         pollute the global state.
@@ -238,6 +240,7 @@ class StatelessProcessGroup:
             port=port,
             world_size=world_size,
             is_master=(rank == 0),
+            timeout=datetime.timedelta(seconds=store_timeout),
         )
 
         return StatelessProcessGroup(


### PR DESCRIPTION
Hello,

Adding a kv_connector_extra_config will help custom connectors to use it to hack around if they need.
I'm using it within the SimpleBuffer/PyNcclPipe to set the `torch.distributed` Store's timeout (in the example, I set the timeout for 1 hour):

```
--kv-transfer-config '{
   "kv_connector": "PyNcclConnector",
   "kv_role": "kv_consumer",
   "kv_rank": 1,
   "kv_parallel_size": 2,
   "kv_buffer_size": 5e9,
   "kv_ip": "localhost",
   "kv_port": 12345,
   "kv_connector_extra_config": {"store_timeout": 3600}
}'
```

Issue like this: https://github.com/vllm-project/vllm/pull/10502#issuecomment-2511001387 `torch.distributed.DistStoreError: wait timeout after 300000ms, keys: /send_to/0/4`
Would happen less frequently, since it only happen when you have no requests.

I think it's not safe to increase it too much, but I have been able to increase this safely to more than 1 hour. It can be useful for dev purposes, or to reduce the need of a frequent heartbeat.