### PR TITLE
[MISC][V1] Handle exception of current_platform.get_device_name() in arg_utils

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1440,8 +1440,19 @@ class EngineArgs:
         # When no user override, set the default values based on the usage
         # context.
         # Use different default values for different hardware.
-        from vllm.platforms import current_platform
-        device_name = current_platform.get_device_name().lower()
+
+        # Try to query the device name on the current platform. If it fails,
+        # it may be because the platform that imports vLLM is not the same
+        # as the platform that vLLM is running on (e.g. the case of scaling
+        # vLLM with Ray) and has no GPUs. In this case we use the default
+        # values for non-H100/H200 GPUs.
+        try:
+            from vllm.platforms import current_platform
+            device_name = current_platform.get_device_name().lower()
+        except Exception:
+            # This is only used to set default_max_num_batched_tokens
+            device_name = "no-device"
+
         if "h100" in device_name or "h200" in device_name:
             # For H100 and H200, we use larger default values.
             default_max_num_batched_tokens = {


### PR DESCRIPTION
The use of `current_platform.get_device_name()` in `arg_utils.py` is too early and is not compatible with Ray, because Ray Serve may import vLLM at the main actor to use some of its data structures. Since this actor doesn't have GPU and is not the actor that actually runs the engine, we will get an exception about no GPU devices. This PR makes this early device query optional to workaround this issue. It should not affect any existing use cases and should not impact user experience, given that the only difference without querying device in `EngineArgs._override_v1_engine_args` is `default_max_num_batched_tokens`.

cc @WoosukKwon 