### PR TITLE
[Bugfix] Fix use_direct_call condition in FusedMoE layer for 

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -359,7 +359,7 @@ class FusedMoE(torch.nn.Module):
 
         # For smuggling this layer into the fused moe custom op
         self.use_direct_call = self.dp_size == 1
-        if self.use_direct_call:
+        if not self.use_direct_call:
             compilation_config = vllm_config.compilation_config
             if prefix in compilation_config.static_forward_context:
                 raise ValueError("Duplicate layer name: {}".format(prefix))


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/14305 made it conditional whether or not to do some of the setup code related to wrapping the FusedMoE layer in a custom op. But I got the condition backwards 🤦.