### PR TITLE
[Perf] Reduce MLA CPU overheads in V1

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -165,8 +165,8 @@ class RotaryEmbedding(CustomOp):
         # is expensive, so avoid calling it if possible
         if self.cos_sin_cache.device != query.device or \
             self.cos_sin_cache.dtype != query.dtype:
-            self.cos_sin_cache = self.cos_sin_cache\
-                .to(query.device, dtype=query.dtype)
+            self.cos_sin_cache = self.cos_sin_cache.to(query.device,
+                                                       dtype=query.dtype)
 
         # ops.rotary_embedding()/batched_rotary_embedding()
         # are in-place operations that update the query and key tensors.

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -161,8 +161,13 @@ class RotaryEmbedding(CustomOp):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         from vllm import _custom_ops as ops
 
-        self.cos_sin_cache = self.cos_sin_cache.to(query.device,
-                                                   dtype=query.dtype)
+        # __setattr__ in nn.Module (called by `self.cos_sin_cache = ...`)
+        # is expensive, so avoid calling it if possible
+        if self.cos_sin_cache.device != query.device or \
+            self.cos_sin_cache.dtype != query.dtype:
+            self.cos_sin_cache = self.cos_sin_cache\
+                .to(query.device, dtype=query.dtype)
+
         # ops.rotary_embedding()/batched_rotary_embedding()
         # are in-place operations that update the query and key tensors.
         if offsets is not None:

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -631,7 +631,9 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if current_platform.is_cuda():
             # Hack for V1 for now to avoid torch library overhead (since we are
             # already inside an attention custom op), pull out the forward
-            # method from the rotary embedding and all it directly
+            # method from the rotary embedding and all it directly (and avoid c
+            # alling forward_native)
+            # TODO(lucas): we should probably find a cleaner way to do this
             self.rotary_emb = rotary_emb.forward_cuda
 
         self.q_proj = q_proj

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -631,8 +631,8 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if current_platform.is_cuda():
             # Hack for V1 for now to avoid torch library overhead (since we are
             # already inside an attention custom op), pull out the forward
-            # method from the rotary embedding and all it directly (and avoid c
-            # alling forward_native)
+            # method from the rotary embedding and call it directly (and avoid
+            # calling forward_native, when we can call forward_cuda)
             # TODO(lucas): we should probably find a cleaner way to do this
             self.rotary_emb = rotary_emb.forward_cuda
 

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -222,8 +222,8 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     apply_fp8_linear_generic, current_platform_fp8_dtype, is_fp8)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     scaled_quantize)
-from vllm.model_executor.layers.rotary_embedding import (
-    DeepseekScalingRotaryEmbedding, RotaryEmbedding)
+from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+from vllm.platforms import current_platform
 from vllm.utils import cdiv, round_down
 
 try:
@@ -627,8 +627,13 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         self.v_head_dim = v_head_dim
 
         self.rotary_emb = rotary_emb
-        self.use_yarn_rope = isinstance(rotary_emb,
-                                        DeepseekScalingRotaryEmbedding)
+
+        if current_platform.is_cuda():
+            # Hack for V1 for now to avoid torch library overhead (since we are
+            # already inside an attention custom op), pull out the forward
+            # method from the rotary embedding and all it directly
+            self.rotary_emb = rotary_emb.forward_cuda
+
         self.q_proj = q_proj
         self.kv_b_proj = kv_b_proj
         self.o_proj = o_proj


### PR DESCRIPTION
Some temporary hacks to reduce CPU overheads in MLA caused by rotary embeddings (not in torch.compile, or a cuda-graph)

Main

<img width="794" alt="Screenshot 2025-03-06 at 3 14 37 PM" src="https://github.com/user-attachments/assets/f7f46f74-86dd-47b3-8642-b34d25712d1d" />

This PR

<img width="408" alt="image" src="https://github.com/user-attachments/assets/da3b88e9-10a3-431f-9b9d-e65974cb9e9b" />
