### PR TITLE
[Doc] Fix a typo

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -174,7 +174,7 @@ def sample_sonnet_requests(
 ) -> list[tuple[str, str, int, int, None]]:
     assert (
         input_len > prefix_len
-    ), "'args.sonnet-input-len' must be greater than 'args.prefix-input-len'."
+    ), "'args.sonnet-input-len' must be greater than 'args.sonnet-prefix-len'."
 
     # Load the dataset.
     with open(dataset_path, encoding='utf-8') as f:


### PR DESCRIPTION
There is no argument called prefix-input-len. Maybe it should be sonnet-prefix-len