### PR TITLE
[rlhf] support named placement group

### DIFF
--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -34,6 +34,8 @@ class MyLLM(LLM):
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
         # set the placement group name for vLLM to use
         os.environ['VLLM_RAY_PG_NAME'] = pg_name
+        # set the ray address for vLLM to use
+        os.environ['RAY_ADDRESS'] = ray.get_runtime_context().gcs_address
         super().__init__(*args, **kwargs)
 
 

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -32,6 +32,8 @@ class MyLLM(LLM):
         # stop ray from manipulating CUDA_VISIBLE_DEVICES
         # at the top-level
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        pg = ray.util.get_current_placement_group()
+        os.environ['VLLM_RAY_PG_NAME'] = pg.name
         super().__init__(*args, **kwargs)
 
 
@@ -50,7 +52,7 @@ documentation https://docs.ray.io/en/latest/ .
 os.environ["CUDA_VISIBLE_DEVICES"] = "1,2"
 ray.init()
 
-pg_inference = placement_group([{"GPU": 1, "CPU": 0}] * 2)
+pg_inference = placement_group([{"GPU": 1, "CPU": 0}] * 2, name="inference")
 ray.get(pg_inference.ready())
 scheduling_inference = PlacementGroupSchedulingStrategy(
     placement_group=pg_inference,

--- a/examples/offline_inference/rlhf.py
+++ b/examples/offline_inference/rlhf.py
@@ -27,13 +27,13 @@ from vllm.utils import get_ip, get_open_port
 
 class MyLLM(LLM):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, pg_name, **kwargs):
         # a hack to make the script work.
         # stop ray from manipulating CUDA_VISIBLE_DEVICES
         # at the top-level
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-        pg = ray.util.get_current_placement_group()
-        os.environ['VLLM_RAY_PG_NAME'] = pg.name
+        # set the placement group name for vLLM to use
+        os.environ['VLLM_RAY_PG_NAME'] = pg_name
         super().__init__(*args, **kwargs)
 
 
@@ -73,6 +73,7 @@ llm = ray.remote(
     worker_extension_cls="rlhf_utils.WorkerExtension",
     tensor_parallel_size=2,
     distributed_executor_backend="ray",
+    pg_name="inference",
 )
 
 # Generate texts from the prompts.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -89,6 +89,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_MOE_ALIGN_BLOCK_SIZE_TRITON: bool = False
     VLLM_RAY_PER_WORKER_GPUS: float = 1.0
     VLLM_RAY_BUNDLE_INDICES: str = ""
+    VLLM_RAY_PG_NAME: Optional[str] = None
     VLLM_CUDART_SO_PATH: Optional[str] = None
     VLLM_USE_HPU_CONTIGUOUS_CACHE_FETCH: bool = True
     VLLM_DP_RANK: int = 0
@@ -589,6 +590,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Format: comma-separated list of integers, e.g. "0,1,2,3"
     "VLLM_RAY_BUNDLE_INDICES":
     lambda: os.getenv("VLLM_RAY_BUNDLE_INDICES", ""),
+
+    # ray placement group name, if it is set, it can control the
+    # placement group for vLLM to use.
+    "VLLM_RAY_PG_NAME":
+    lambda: os.getenv("VLLM_RAY_PG_NAME", None),
 
     # When on a Nvidia GPU aligns single entries (within a page) so they are 256
     # byte aligned for better performance, this increases the memory usage of

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -307,8 +307,9 @@ def initialize_ray_cluster(
     # Create placement group for worker processes
     if envs.VLLM_RAY_PG_NAME:
         # the placement group is specified by the user
-        logger.info("Looking for the placement group %s",
-                    envs.VLLM_RAY_PG_NAME)
+        logger.info(
+            "Looking for the placement group specified by"
+            " VLLM_RAY_PG_NAME: %s", envs.VLLM_RAY_PG_NAME)
         current_placement_group = ray.util.get_placement_group(
             envs.VLLM_RAY_PG_NAME)
     else:

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import msgspec
 
+import vllm.envs as envs
 import vllm.platforms
 from vllm.config import ParallelConfig
 from vllm.executor.msgspec_utils import decode_hook, encode_hook
@@ -304,7 +305,12 @@ def initialize_ray_cluster(
             "support ray.")
 
     # Create placement group for worker processes
-    current_placement_group = ray.util.get_current_placement_group()
+    if envs.VLLM_RAY_PG_NAME:
+        # the placement group is specified by the user
+        current_placement_group = ray.util.get_placement_group(
+            envs.VLLM_RAY_PG_NAME)
+    else:
+        current_placement_group = ray.util.get_current_placement_group()
     if current_placement_group:
         # We are in a placement group
         bundles = current_placement_group.bundle_specs

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -307,6 +307,8 @@ def initialize_ray_cluster(
     # Create placement group for worker processes
     if envs.VLLM_RAY_PG_NAME:
         # the placement group is specified by the user
+        logger.info("Looking for the placement group %s",
+                    envs.VLLM_RAY_PG_NAME)
         current_placement_group = ray.util.get_placement_group(
             envs.VLLM_RAY_PG_NAME)
     else:


### PR DESCRIPTION
v1 engine will create the engine in a separate process, and controlling the process placement becomes complicated.

suggested by the ray team, we can use https://docs.ray.io/en/latest/ray-core/scheduling/placement-group.html#advanced-named-placement-group , and pass the ray placement group name by an env var.

however, I find the named-placement-group does not work right now. it hangs when looking up the placement group.

steps to reproduce the hang:

```bash
$ cd examples/offline_inference
$ VLLM_USE_V1=1 python3 rlhf.py
```

it hangs when we try to get the placement group, i.e. the added line:

```python
        current_placement_group = ray.util.get_placement_group(
            envs.VLLM_RAY_PG_NAME)
```