### PR TITLE
[Misc] Refactor platform to get device specific stream and event

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -403,6 +403,15 @@ class Platform:
     ) -> None:
         """Raises if this request is unsupported on this platform"""
 
+    def __getattr__(self, key: str):
+        device = getattr(torch, self.device_name, None)
+        if device is not None and hasattr(device, key):
+            return getattr(device, key)
+        else:
+            logger.warning("Current platform %s doesn't has '%s' attribute.",
+                           self.device_name, key)
+            return None
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED


### PR DESCRIPTION
# What does this PR do?

Add a `__getitem__` method for `Platform` class.

When using cuda, `current_platform.xxx` is equal to `torch.cuda.xxx`, whereas when using npu, `current_platform.xxx` is equal to `torch.npu.xxx`. Thus, we do not need to abstract `Stream` or `Event` anymore.
