### PR TITLE
[Bugfix][V1] Exclude HBM used by other processes when calculating peak memory during profile runs

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -179,9 +179,6 @@ class Worker(WorkerBase):
         non_torch_allocations = total_allocated_bytes - torch_allocated_bytes
         non_torch_allocations_increase = non_torch_allocations - max(
             0, non_torch_allocations_before)
-        logger.warning(
-            f"{non_torch_allocations=}, {non_torch_allocations_before=}")
-        logger.warning(f"{non_torch_allocations_increase=}")
         if non_torch_allocations_increase > 0:
             peak_memory += non_torch_allocations_increase
         available_kv_cache_memory = (


### PR DESCRIPTION
## Summary
Running into an issue that I couldn't get V1 up and running when there's other process using HBM on the same host.

Existing non_torch_allocations takes into consideration not only non PyTorch allocations, but also memory used by other running processes: https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu_worker.py#L176.

Updating peak memory to only consider delta of non torch allocations.

## Test Plan

Started a different process that takes up 70% memory. Then runs the following:
```
CUDA_VISIBLE_DEVICES=0 VLLM_USE_V1=1 python3 benchmarks/benchmark_latency.py --model "meta-llama/Llama-3.2-1B" --tensor-parallel-size 1 --trust-remote-code --gpu-memory-utilization 0.2
```

Before
```
ERROR 03-07 00:47:48 core.py:291] ValueError: No available memory for the cache blocks. Try increasing `gpu_memory_utilization` when initializing the engine.
```

After
Confirmed it with logging in 48413ca5618ec7ac28b8479e3f5ff146900b3e11
```
WARNING 03-07 00:42:13 gpu_worker.py:182] non_torch_allocations=65225883648, non_torch_allocations_before=65156677632
WARNING 03-07 00:42:13 gpu_worker.py:184] non_torch_allocations_increase=69206016
```

It runs properly:
```
Warmup iterations: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.71it/s]
Profiling iterations: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:11<00:00,  2.73it/s]
Avg latency: 0.36662105659876637 seconds
10% percentile latency: 0.3646833716309629 seconds
25% percentile latency: 0.3652373214426916 seconds
50% percentile latency: 0.3656990180024877 seconds
75% percentile latency: 0.3671194420021493 seconds
90% percentile latency: 0.3688002397422679 seconds
99% percentile latency: 0.37638884922489524 seconds
```
