### PR TITLE
[BUGFIX] fix the need_recv method of model_runner

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1838,7 +1838,7 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         We need to receive KV when
             1. current vLLM instance is KV cache consumer/decode vLLM instance
             2. this batch is not a profiling run
-            3. this batch is a prefill run
+            3. this batch is a decode run
 
         Args:
             model_input: input to the model executable
@@ -1848,15 +1848,15 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
         if self.vllm_config.kv_transfer_config is None:
             return False
 
-        prefill_meta = model_input.attn_metadata.prefill_metadata
+        decode_meta = model_input.attn_metadata.decode_metadata
 
         # check if the current run is profiling
         is_profile_run = (kv_caches[0].numel() == 0)
-        # check if the current run is prefill
-        is_prefill_run = prefill_meta is not None
+        # check if the current run is a decode run
+        is_decode_run = decode_meta is not None
 
         return self.vllm_config.kv_transfer_config.is_kv_consumer and (
-            not is_profile_run) and is_prefill_run
+            not is_profile_run) and is_decode_run
 
     def need_send_kv(self, model_input, kv_caches) -> bool:
         """Check if we need to send kv-cache to the other worker.


### PR DESCRIPTION
Not sure this is a typo issue, the code body of need_recv_kv is similar with `need_send_kv`, but actually, only `decode run` should receive the kv.