### PR TITLE
[Feature]: PD separation supports prefix caching #12257

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -157,7 +157,7 @@ class SimpleConnector(KVConnectorBase):
     ) -> None:
 
         input_tokens_tensor = model_input.input_tokens
-        seq_lens = model_input.attn_metadata.seq_lens
+        seq_lens = (model_input.attn_metadata.seq_lens_tensor - model_input.attn_metadata.context_lens_tensor).tolist()
         slot_mapping_flat = model_input.attn_metadata.slot_mapping.flatten()
         start_layer = model_executable.model.start_layer
         end_layer = model_executable.model.end_layer
@@ -213,7 +213,7 @@ class SimpleConnector(KVConnectorBase):
         bypass_model_exec = True
 
         input_tokens_tensor = model_input.input_tokens
-        seq_lens = model_input.attn_metadata.seq_lens
+        seq_lens = (model_input.attn_metadata.seq_lens_tensor - model_input.attn_metadata.context_lens_tensor).tolist()
         num_prefill_tokens = model_input.attn_metadata.num_prefill_tokens
         slot_mapping = model_input.attn_metadata.slot_mapping.flatten()
 


### PR DESCRIPTION
PD separation supports when prefix_caching=Ture

Restore seq_lens to the true seq_lens, because when prefill_caching=True, if the previous text hits, the seq_lens at this time is the length of the missing part.
Of course, when prefill_caching=False, all hit parts are 0, which does not affect the result