### PR TITLE
[INTEL-HPU] Deepseek R1 model enabling for Intel Gaudi

### DIFF
--- a/Dockerfile.hpu
+++ b/Dockerfile.hpu
@@ -1,4 +1,4 @@
-FROM vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
+FROM vault.habana.ai/gaudi-docker/1.20.0/ubuntu24.04/habanalabs/pytorch-installer-2.6.0:latest
 
 COPY ./ /workspace/vllm
 

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -119,7 +119,7 @@ class HPUAttentionBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-    ) -> Tuple[int, ...]:
+    ) -> List[Tuple[int, ...]]:
         return HPUPagedAttention.get_kv_cache_shape(num_blocks, block_size,
                                                     num_kv_heads, head_size)
 
@@ -163,8 +163,8 @@ class HPUMLAAttentionBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-    ) -> Tuple[int, ...]:
-        return (num_blocks, block_size, head_size // 9 * 1, head_size // 9 * 8)
+    ) -> List[Tuple[int, ...]]:
+        return [(num_blocks, block_size, head_size // 9 * 1), (num_blocks, block_size, head_size // 9 * 8)]
 
     @staticmethod
     def swap_blocks(

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -8,8 +8,17 @@ import os
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type
 
+import habana_frameworks.torch as htorch  # noqa: F401
 import torch
 import vllm_hpu_extension.ops as ops
+from neural_compressor.torch.algorithms.fp8_quant._core.quant_dequant import (
+    DequantOutput, QuantInput)
+from neural_compressor.torch.algorithms.fp8_quant._quant_common.helper_modules import (  # noqa: E501
+    PatchedVLLMKVCache)
+from neural_compressor.torch.algorithms.fp8_quant._quant_common.quant_config import (  # noqa: E501
+    Fp8cfg)
+from neural_compressor.torch.algorithms.fp8_quant.model_configs import (
+    ModuleConfig, ModuleExtraConfig)
 from vllm_hpu_extension.utils import (Matmul, ModuleFusedSDPA, Softmax,
                                       VLLMKVCache)
 
@@ -17,10 +26,71 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionLayer,
                                               AttentionMetadata, AttentionType,
                                               is_quantized_kv_cache)
+from vllm.attention.backends.mla.common import MLACommonImpl
 from vllm.attention.backends.utils import CommonAttentionState
 from vllm.attention.ops.hpu_paged_attn import (HPUPagedAttention,
                                                HPUPagedAttentionMetadata)
 from vllm.logger import init_logger
+
+
+def forward_quant(self, input, *args, **kwargs):
+    qinput = self.quant_input(input)
+    return self.orig_mod(qinput, *args, **kwargs)
+
+
+def fetch_from_cache(self, quant_cache, blocks, permutations=None):
+    if permutations:
+        output_cache = self.orig_mod.fetch_from_cache(quant_cache, blocks,
+                                                      permutations)
+        for i in range(len(output_cache)):
+            output_cache[i] = self.dequant_output(output_cache[i])
+        return output_cache
+    output_cache = self.orig_mod.fetch_from_cache(quant_cache, blocks)
+    return self.dequant_output(output_cache)
+
+
+PatchedVLLMKVCache.forward_quant = forward_quant
+PatchedVLLMKVCache.fetch_from_cache = fetch_from_cache
+
+
+def initialize_fp8_kv_cache(mod, parent, load_device="hpu"):
+    cfg = Fp8cfg.parse({"scale_method": "UNIT_SCALE", "scale_format": "CONST"})
+    mod.__hqt_config__ = cfg
+    mod_extra_config = ModuleExtraConfig(
+        inputs=[
+            QuantInput(lp_dtype=torch.float8_e4m3fn,
+                       hp_dtype=torch.bfloat16,
+                       scale_inv=torch.tensor(1.,
+                                              device=load_device,
+                                              dtype=torch.bfloat16))
+        ],
+        outputs=[
+            DequantOutput(lp_dtype=torch.float8_e4m3fn,
+                          hp_dtype=torch.bfloat16,
+                          scale=torch.tensor(1.,
+                                             device=load_device,
+                                             dtype=torch.bfloat16))
+        ],
+        scale=ModuleConfig(inputs=[
+            torch.tensor(1., device=load_device, dtype=torch.bfloat16)
+        ],
+                           outputs=[
+                               torch.tensor(1.,
+                                            device=load_device,
+                                            dtype=torch.bfloat16)
+                           ]),
+        config_params={
+            "lp_dtype": torch.float8_e4m3fn,
+            "hp_dtype": torch.bfloat16
+        },
+    )
+    kwargs = {
+        "mod": mod,
+        "mod_extra_config": mod_extra_config,
+        "parent": parent
+    }
+    return PatchedVLLMKVCache(**kwargs)
+
 
 logger = init_logger(__name__)
 
@@ -57,16 +127,101 @@ class HPUAttentionBackend(AttentionBackend):
     def swap_blocks(
         src_kv_cache: torch.Tensor,
         dst_kv_cache: torch.Tensor,
-        src_to_dst: Dict[int, int],
+        src_to_dst: torch.Tensor,
     ) -> None:
         HPUPagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
 
     @staticmethod
     def copy_blocks(
         kv_caches: List[torch.Tensor],
-        src_to_dists: Dict[int, List[int]],
+        src_to_dists: torch.Tensor,
     ) -> None:
         HPUPagedAttention.copy_blocks(kv_caches, src_to_dists)
+
+
+class HPUMLAAttentionBackend(AttentionBackend):
+
+    @staticmethod
+    def get_name() -> str:
+        return "HPU_MLA"
+
+    @staticmethod
+    def get_impl_cls() -> Type["HPUMLAImpl"]:
+        return HPUMLAImpl
+
+    @staticmethod
+    def get_metadata_cls() -> Type["AttentionMetadata"]:
+        return HPUMLAMetadata
+
+    @staticmethod
+    def get_state_cls() -> Type["CommonAttentionState"]:
+        return CommonAttentionState
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+    ) -> Tuple[int, ...]:
+        return (num_blocks, block_size, head_size // 9 * 1, head_size // 9 * 8)
+
+    @staticmethod
+    def swap_blocks(
+        src_kv_cache: torch.Tensor,
+        dst_kv_cache: torch.Tensor,
+        src_to_dst: torch.Tensor,
+    ) -> None:
+        HPUPagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
+
+    @staticmethod
+    def copy_blocks(
+        kv_caches: List[torch.Tensor],
+        src_to_dists: torch.Tensor,
+    ) -> None:
+        HPUPagedAttention.copy_blocks(kv_caches, src_to_dists)
+
+
+def flat_pa_mla(query, key_cache, value_cache, block_list, block_mapping,
+                block_bias, block_scales, block_groups, scale, matmul_qk_op,
+                matmul_av_op, batch2block_matmul_op, block2batch_matmul_op,
+                keys_fetch_func, values_fetch_func):
+    batch_size = query.size(0)
+    q_heads = query.size(1)
+    kv_heads = key_cache.size(2)
+
+    query = ops.batch2block(scale * query, block_mapping,
+                            batch2block_matmul_op).unsqueeze(-2)
+    key = keys_fetch_func(key_cache, block_list).transpose(1, 2)
+    value = values_fetch_func(value_cache, block_list).transpose(1, 2)
+    # get concat key
+    key = torch.concat((value, key), dim=-1)
+    block_bias = block_bias.view(key.size(0), 1, 1, -1)
+    if kv_heads != q_heads:
+        block_bias = block_bias.unsqueeze(1)
+        query = query.unflatten(1, (kv_heads, -1))
+        key = key.unflatten(1, (kv_heads, 1))
+        value = value.unflatten(1, (kv_heads, 1))
+        key = key.transpose(3, 4)
+    else:
+        key = key.transpose(2, 3)
+
+    attn = matmul_qk_op(query, key)
+    attn = attn + block_bias
+    attn = ops.pipelined_pa(attn,
+                            value,
+                            block_groups,
+                            block_mapping,
+                            block_scales=block_scales,
+                            batch_size=batch_size,
+                            matmul_av_op=matmul_av_op,
+                            batch2block_matmul_op=batch2block_matmul_op,
+                            block2batch_matmul_op=block2batch_matmul_op)
+    attn = ops.block2batch(attn, block_mapping, block2batch_matmul_op)
+    attn = attn.squeeze(-2)
+    if kv_heads != q_heads:
+        attn = attn.flatten(1, 2)
+    return attn
 
 
 @dataclass
@@ -77,6 +232,226 @@ class HPUAttentionMetadata(HPUPagedAttentionMetadata, AttentionMetadata):
     is_prompt: bool
     attn_bias: Optional[torch.Tensor]
     seq_lens_tensor: Optional[torch.Tensor]
+    input_positions: torch.Tensor
+
+
+@dataclass
+class HPUMLAMetadata(HPUAttentionMetadata, AttentionMetadata):
+    pass
+
+
+class HPUMLAImpl(
+        MLACommonImpl[HPUMLAMetadata],  # type: ignore
+        torch.nn.Module):
+
+    def __init__(
+            self,
+            num_heads: int,
+            head_size: int,
+            scale: float,
+            num_kv_heads: int,
+            alibi_slopes: Optional[List[float]],
+            sliding_window: Optional[int],
+            kv_cache_dtype: str,
+            blocksparse_params: Optional[Dict[str, Any]],
+            logits_soft_cap: Optional[float],
+            attn_type: str,
+            # MLA Specific Arguments
+            **kwargs) -> None:
+        torch.nn.Module.__init__(self)
+        MLACommonImpl.__init__(
+            self,
+            num_heads,
+            head_size,
+            scale,
+            num_kv_heads,  # type: ignore
+            alibi_slopes,
+            sliding_window,
+            kv_cache_dtype,
+            blocksparse_params,
+            logits_soft_cap,
+            attn_type,
+            **kwargs)
+
+        self.matmul_qk = Matmul()
+        self.softmax = Softmax()
+        self.matmul_av = Matmul()
+        self.batch2block_matmul = Matmul()
+        self.block2batch_matmul = Matmul()
+        self.latent_cache_k = VLLMKVCache()
+        self.latent_cache_v = VLLMKVCache()
+        if kv_cache_dtype == 'fp8_inc':
+            self.latent_cache_k = initialize_fp8_kv_cache(
+                self.latent_cache_k, self)
+            self.latent_cache_v = initialize_fp8_kv_cache(
+                self.latent_cache_v, self)
+        self.prefill_usefusedsdpa = os.getenv('VLLM_PROMPT_USE_FUSEDSDPA',
+                                              '1').lower() in ['1', 'true']
+        self.fused_scaled_dot_product_attention = None
+        if self.prefill_usefusedsdpa:
+            assert alibi_slopes is None, \
+                'Prefill with FusedSDPA not supported with alibi slopes!'
+            try:
+                from habana_frameworks.torch.hpex.kernels import FusedSDPA
+                self.fused_scaled_dot_product_attention = ModuleFusedSDPA(
+                    FusedSDPA)
+            except ImportError:
+                logger.warning("Could not import HPU FusedSDPA kernel. "
+                               "vLLM will use native implementation.")
+
+        unsupported_features = [
+            alibi_slopes, sliding_window, blocksparse_params, logits_soft_cap
+        ]
+        if any(unsupported_features):
+            raise NotImplementedError(
+                "TritonMLAImpl does not support one of the following: "
+                "alibi_slopes, sliding_window, blocksparse_params, "
+                "logits_soft_cap")
+
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError("Encoder self-attention and "
+                                      "encoder/decoder cross-attention "
+                                      "are not implemented for "
+                                      "TritonMLAImpl")
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        hidden_states_or_q_c: torch.Tensor,  # query in unified attn
+        k_c_normed: torch.Tensor,  # key in unified attn
+        k_pe: torch.Tensor,  # value in unified attn
+        kv_cache: torch.Tensor,
+        attn_metadata: HPUMLAMetadata,
+        output: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if output is not None:
+            raise NotImplementedError(
+                "output is not yet supported for MLAImplBase")
+
+        batch_size = hidden_states_or_q_c.shape[0]
+
+        is_prefill = attn_metadata.is_prompt
+
+        k_pe = k_pe.view(-1, 1, self.qk_rope_head_dim)
+
+        # Restore head dim (for rotary embedding)
+        assert hasattr(attn_metadata,
+                       "input_positions"), f"attn meta: {attn_metadata}"
+
+        if not is_prefill:
+            q_nope = self._q_proj_and_k_up_proj(hidden_states_or_q_c)
+            q_pe = torch.matmul(hidden_states_or_q_c, self.W_QR)\
+                .view(-1, self.num_heads, self.qk_rope_head_dim)
+            input_positions = attn_metadata.input_positions.view(-1)
+            q_pe, k_pe = \
+                self.rotary_emb(input_positions, q_pe, k_pe)
+        else:
+            q = self.q_proj(hidden_states_or_q_c)[0]\
+                .view(-1, self.num_heads, self.qk_head_dim)
+
+            q_pe = q[..., self.qk_nope_head_dim:]
+
+            input_positions = attn_metadata.input_positions.view(-1)
+            # TODO(lucas): there must be a nicer way to write this line
+            q[..., self.qk_nope_head_dim:], k_pe = \
+                self.rotary_emb(input_positions, q_pe, k_pe)
+
+        block_indices = attn_metadata.block_indices
+        block_offsets = attn_metadata.block_offsets
+
+        latent_vec_k = torch.concat(
+            (k_c_normed, k_pe.view(batch_size, -1, self.qk_rope_head_dim)),
+            dim=-1)
+        latent_vec_k = latent_vec_k.view(
+            -1, self.qk_rope_head_dim + self.kv_lora_rank)
+        if is_prefill and block_indices is not None:
+            latent_vec_k = latent_vec_k.unflatten(0,
+                                                  (block_indices.size(0), -1))
+
+        # write the latent and rope to kv cache
+        if kv_cache is not None and len(kv_cache) == 2:
+            latent_vec_v = latent_vec_k[..., :self.kv_lora_rank]
+            latent_vec_k = latent_vec_k[..., self.kv_lora_rank:]
+            k_cache = self.latent_cache_k(latent_vec_k, kv_cache[0],
+                                          block_indices, block_offsets)
+            v_cache = self.latent_cache_v(latent_vec_v, kv_cache[1],
+                                          block_indices, block_offsets)
+            kv_cache_splitted = (k_cache, v_cache)
+
+        if is_prefill:
+            return self._forward_prefill(q, k_c_normed, k_pe, None,
+                                         attn_metadata, batch_size)
+        else:
+            return self._forward_decode(q_nope, q_pe, kv_cache_splitted,
+                                        attn_metadata, batch_size)
+
+    def _forward_prefill(  # type: ignore[override]
+            self, q: torch.Tensor, k_c_normed: torch.Tensor,
+            k_pe: torch.Tensor, kv_c_and_k_pe_cache: Optional[torch.Tensor],
+            attn_metadata: HPUMLAMetadata, batch_size: int) -> torch.Tensor:
+        kv_nope = self.kv_b_proj(k_c_normed)[0]\
+            .view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+        k_nope, v = kv_nope\
+            .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+
+        k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))), dim=-1)
+
+        # For MLA the v head dim is smaller than qk head dim so we pad out
+        # v with 0s to match the qk head dim
+        v_padded = torch.nn.functional.pad(v, [0, q.shape[-1] - v.shape[-1]],
+                                           value=0)
+        q = q.view(batch_size, -1, self.num_heads, self.qk_head_dim)
+        k = k.view(batch_size, -1, self.num_heads, self.qk_head_dim)
+        v_padded = v_padded.view(batch_size, -1, self.num_heads,
+                                 self.qk_head_dim)
+        out = ops.prompt_attention(
+            q,
+            k,
+            v_padded,
+            attn_bias=None,
+            p=0.0,
+            scale=self.scale,
+            matmul_qk_op=self.matmul_qk,
+            softmax_op=self.softmax,
+            matmul_av_op=self.matmul_av,
+            valid_seq_lengths=attn_metadata.seq_lens_tensor,
+            fsdpa_op=self.fused_scaled_dot_product_attention,
+        )
+        attn_output = out.view(batch_size, -1, self.num_heads,
+                               q.shape[-1])[..., :v.shape[-1]].reshape(
+                                   batch_size, -1,
+                                   self.num_heads * v.shape[-1])
+
+        return self.o_proj(attn_output)[0]
+
+    def _forward_decode(  # type: ignore[override]
+            self, q_nope: torch.Tensor, q_pe: torch.Tensor,
+            kv_cache: tuple[torch.Tensor, torch.Tensor],
+            attn_metadata: HPUMLAMetadata, batch_size: int) -> torch.Tensor:
+        q = torch.cat([q_nope, q_pe], dim=-1)
+        kv_c_and_k_pe_cache = kv_cache[0].unsqueeze(2)
+        kv_c_cache = kv_cache[1].unsqueeze(2)
+
+        output = flat_pa_mla(
+            query=q,
+            key_cache=kv_c_and_k_pe_cache,
+            value_cache=kv_c_cache,
+            block_list=attn_metadata.block_list,
+            block_mapping=attn_metadata.block_mapping,
+            block_bias=attn_metadata.attn_bias,
+            block_scales=attn_metadata.block_scales,
+            block_groups=attn_metadata.block_groups,
+            scale=self.scale,
+            matmul_qk_op=self.matmul_qk,
+            matmul_av_op=self.matmul_av,
+            batch2block_matmul_op=self.batch2block_matmul,
+            block2batch_matmul_op=self.block2batch_matmul,
+            keys_fetch_func=self.latent_cache_k.fetch_from_cache,
+            values_fetch_func=self.latent_cache_v.fetch_from_cache)
+        output = output.view(batch_size, 1, -1)
+        result = self._v_up_proj_and_o_proj(output)
+        result = result.view(batch_size, 1, -1)
+        return result
 
 
 class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
@@ -144,14 +519,8 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
                 self.fused_scaled_dot_product_attention = ModuleFusedSDPA(
                     FusedSDPA)
             except ImportError:
-                logger().warning("Could not import HPU FusedSDPA kernel. "
-                                 "vLLM will use native implementation.")
-
-        suppored_head_sizes = HPUPagedAttention.get_supported_head_sizes()
-        if head_size not in suppored_head_sizes:
-            raise ValueError(
-                f"Head size {head_size} is not supported by PagedAttention. "
-                f"Supported head sizes are: {suppored_head_sizes}.")
+                logger.warning("Could not import HPU FusedSDPA kernel. "
+                               "vLLM will use native implementation.")
 
         if attn_type != AttentionType.DECODER:
             raise NotImplementedError("Encoder self-attention and "

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -31,6 +31,8 @@ from vllm.attention.backends.utils import CommonAttentionState
 from vllm.attention.ops.hpu_paged_attn import (HPUPagedAttention,
                                                HPUPagedAttentionMetadata)
 from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    Fp8LinearGenericOp)
 
 
 def forward_quant(self, input, *args, **kwargs):
@@ -164,7 +166,8 @@ class HPUMLAAttentionBackend(AttentionBackend):
         num_kv_heads: int,
         head_size: int,
     ) -> List[Tuple[int, ...]]:
-        return [(num_blocks, block_size, head_size // 9 * 1), (num_blocks, block_size, head_size // 9 * 8)]
+        return [(num_blocks, block_size, head_size // 9 * 1),
+                (num_blocks, block_size, head_size // 9 * 8)]
 
     @staticmethod
     def swap_blocks(
@@ -280,6 +283,7 @@ class HPUMLAImpl(
         self.block2batch_matmul = Matmul()
         self.latent_cache_k = VLLMKVCache()
         self.latent_cache_v = VLLMKVCache()
+        self.fp8_linear_generic = Fp8LinearGenericOp()
         if kv_cache_dtype == 'fp8_inc':
             self.latent_cache_k = initialize_fp8_kv_cache(
                 self.latent_cache_k, self)

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1121,6 +1121,11 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         def get_scale_group_shapes_for_fp8(layer: LinearBase) -> \
             Tuple[Tuple[int, int], Tuple[int, int]]:
             if isinstance(layer.quant_method, Fp8LinearMethod):
+                if layer.quant_method.block_quant and current_platform.is_hpu(
+                ):
+                    # hpu doesn't have block_scale support yet
+                    # using per-tensor.
+                    return (-1, -1), (-1, -1)  # per-tensor, per-tensor
                 if layer.quant_method.block_quant:
                     weight_block_size = \
                         layer.quant_method.quant_config.weight_block_size

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -5,7 +5,7 @@
 ###############################################################################
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from vllm_hpu_extension import cache_ops, ops
@@ -86,7 +86,7 @@ class HPUPagedAttention:
     def swap_blocks(
         src_kv_cache: torch.Tensor,
         dst_kv_cache: torch.Tensor,
-        src_to_dst: Dict[int, int],
+        src_to_dst: torch.Tensor,
     ) -> None:
         src_key_cache = src_kv_cache[0]
         dst_key_cache = dst_kv_cache[0]
@@ -99,7 +99,7 @@ class HPUPagedAttention:
     @staticmethod
     def copy_blocks(
         kv_caches: List[torch.Tensor],
-        src_to_dists: Dict[int, List[int]],
+        src_to_dists: torch.Tensor,
     ) -> None:
         key_caches = [kv_cache[0] for kv_cache in kv_caches]
         value_caches = [kv_cache[1] for kv_cache in kv_caches]

--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -38,8 +38,8 @@ class HPUPagedAttention:
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-    ) -> Tuple[int, ...]:
-        return (num_blocks, block_size, num_kv_heads, head_size)
+    ) -> List[Tuple[int, ...]]:
+        return [(num_blocks, block_size, num_kv_heads, head_size)] * 2
 
     @staticmethod
     def split_kv_cache(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2134,6 +2134,8 @@ class SpeculativeConfig:
             ray_workers_use_nsight=target_parallel_config.
             ray_workers_use_nsight,
             placement_group=target_parallel_config.placement_group,
+            enable_expert_parallel=target_parallel_config.
+            enable_expert_parallel,
         )
 
         return draft_parallel_config

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1133,7 +1133,7 @@ class CacheConfig:
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":
             pass
-        elif self.cache_dtype in ("fp8", "fp8_e4m3", "fp8_e5m2"):
+        elif self.cache_dtype in ("fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"):
             logger.info(
                 "Using fp8 data type to store kv cache. It reduces the GPU "
                 "memory footprint and boosts the performance. "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -375,7 +375,7 @@ class EngineArgs:
         parser.add_argument(
             '--kv-cache-dtype',
             type=str,
-            choices=['auto', 'fp8', 'fp8_e5m2', 'fp8_e4m3'],
+            choices=['auto', 'fp8', 'fp8_e5m2', 'fp8_e4m3', 'fp8_inc'],
             default=EngineArgs.kv_cache_dtype,
             help='Data type for kv cache storage. If "auto", will use model '
             'data type. CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. '

--- a/vllm/executor/multiproc_worker_utils.py
+++ b/vllm/executor/multiproc_worker_utils.py
@@ -16,6 +16,7 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.triton_utils.importing import HAS_TRITON
 from vllm.utils import _check_multiproc_method, get_mp_context, run_method
 
@@ -250,6 +251,9 @@ def _run_worker_process(
     except Exception:
         logger.exception("Worker failed")
 
+    if current_platform.is_hpu():
+        logger.info("Worker exiting")
+        return
     # Flush TunableOp results when TunableOp is enabled and
     # online (in situ) tuning is enabled.
     # Offline tuning API (record_untuned_is_enabled()) only

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -158,6 +158,11 @@ class RayDistributedExecutor(DistributedExecutorBase):
                           **ray_remote_kwargs):
         num_gpus = envs.VLLM_RAY_PER_WORKER_GPUS
 
+        def retain_envs(var_name):
+            retain_var_list = ['GLOO_SOCKET_IFNAME']
+            return ('HPU' in var_name or 'RAY' in var_name
+                    or 'VLLM' in var_name or var_name in retain_var_list)
+
         # The driver dummy worker does not actually use any resources.
         # It holds the resource for the driver worker.
         self.driver_dummy_worker: Optional[RayWorkerWrapper] = None
@@ -215,11 +220,16 @@ class RayDistributedExecutor(DistributedExecutorBase):
                 )(RayWorkerWrapper).remote(vllm_config=self.vllm_config,
                                            rpc_rank=rank)
             else:
+                runtime_env_vars = {
+                    k: v
+                    for k, v in os.environ.items() if retain_envs(k)
+                }
                 worker = ray.remote(
                     num_cpus=0,
                     num_gpus=0,
                     resources={current_platform.ray_device_key: num_gpus},
                     scheduling_strategy=scheduling_strategy,
+                    runtime_env={"env_vars": runtime_env_vars},
                     **ray_remote_kwargs,
                 )(RayWorkerWrapper).remote(vllm_config=self.vllm_config,
                                            rpc_rank=rank)

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 from vllm.platforms import current_platform
 from vllm.utils import direct_register_custom_op
 
+if current_platform.is_hpu():
+    import habana_frameworks.torch as htorch
+
 logger = init_logger(__name__)
 
 
@@ -1088,6 +1091,8 @@ def grouped_topk(hidden_states: torch.Tensor,
         scores = gating_output.sigmoid()
     else:
         raise ValueError(f"Unsupported scoring function: {scoring_func}")
+    if current_platform.is_hpu():
+        htorch.core.mark_step()
 
     num_token = scores.shape[0]
     if e_score_correction_bias is not None:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -180,6 +180,69 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                              global_num_experts=global_num_experts,
                              expert_map=expert_map)
 
+    def forward_hpu(self,
+                    layer: torch.nn.Module,
+                    x: torch.Tensor,
+                    use_grouped_topk: bool,
+                    top_k: int,
+                    router_logits: torch.Tensor,
+                    renormalize: bool,
+                    topk_group: Optional[int] = None,
+                    num_expert_group: Optional[int] = None,
+                    custom_routing_function: Optional[Callable] = None,
+                    scoring_func: str = "softmax",
+                    e_score_correction_bias: Optional[torch.Tensor] = None):
+        assert len(x.shape) == 2
+        import habana_frameworks.torch as htorch
+        htorch.core.mark_step()
+        if use_grouped_topk:
+            topk_weights, topk_ids = FusedMoE.select_experts(
+                hidden_states=x,
+                router_logits=router_logits,
+                use_grouped_topk=use_grouped_topk,
+                top_k=top_k,
+                renormalize=renormalize,
+                topk_group=topk_group,
+                num_expert_group=num_expert_group,
+                custom_routing_function=custom_routing_function,
+                scoring_func=scoring_func,
+                e_score_correction_bias=e_score_correction_bias)
+        else:
+            import torch.nn.functional as F
+            topk_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
+            topk_weights, topk_ids = torch.topk(topk_weights, top_k, dim=-1)
+            topk_weights /= topk_weights.sum(dim=-1, keepdim=True)
+            topk_weights = topk_weights.to(x.dtype)
+
+        final_hidden_states = torch.zeros_like(x)
+        num_experts = layer.w13_weight.data.shape[0]
+        n_expert_slice = layer.w13_weight.data.shape[0] // 8
+        assert n_expert_slice * 8 == num_experts
+
+        for i in range(8):
+            min_expert = i * n_expert_slice
+            max_expert = (i + 1) * n_expert_slice
+            w13_list_slice = [
+                layer.w13_weight[j].data.squeeze().clone()
+                for j in range(min_expert, max_expert)
+            ]
+            w2_list_slice = [
+                layer.w2_weight[j].data.squeeze().clone()
+                for j in range(min_expert, max_expert)
+            ]
+            final_hidden_states += torch.ops.hpu.mixture_of_experts(
+                hidden_states=x,
+                expert_routing_table=topk_ids.to(torch.int64),
+                router_weights=topk_weights.to(x.dtype),
+                w12=w13_list_slice,
+                w3=w2_list_slice,
+                permuted_weights=True,
+                activation="silu",
+                experts_min=min_expert,
+                experts_max=max_expert - 1)
+            htorch.core.mark_step()
+        return final_hidden_states.view(-1, x.shape[1])
+
     def forward_cpu(
         self,
         layer: torch.nn.Module,
@@ -786,6 +849,7 @@ class FusedMoE(torch.nn.Module):
             scoring_func=self.scoring_func,
             e_score_correction_bias=self.e_score_correction_bias,
             activation=self.activation,
+            ep_rank=self.ep_rank,
         )
 
         if self.dp_size > 1:

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -106,6 +106,9 @@ class RMSNorm(CustomOp):
         residual: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         from vllm_hpu_extension.ops import HPUFusedRMSNorm
+        if x.dim() < 3:
+            # fix an known bug before synapse 1.21 release
+            HPUFusedRMSNorm = None
         if HPUFusedRMSNorm is None:
             return self.forward_native(x, residual)
         if residual is not None:

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -891,8 +891,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     ):
         hidden_dim = x.shape[-1]
         num_experts = layer.w13_weight.shape[0]
-        # hpu.moe supports maximum 64 experts
-        moe_n_slice = 4 if num_experts > 64 else 1
+        # hpu.moe supports maximum 32 experts,
+        # otherwise segment fault might trigger
+        moe_n_slice = 8 if num_experts > 32 else 1
         n_expert_slice = num_experts // moe_n_slice
         assert n_expert_slice * moe_n_slice == num_experts
         x = x.view(-1, hidden_dim)

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
 from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    apply_block_fp8_linear_hpu_dequant, apply_block_fp8_linear_hpu_dynamic,
+    apply_block_fp8_linear_hpu_dequant, apply_fp8_linear_hpu_dynamic,
     dequant_block_fp8_weight_naive, dynamic_quant, pad_block_fp8_weight_naive)
 from vllm.model_executor.layers.quantization.utils.marlin_utils_fp8 import (
     apply_fp8_marlin_linear, prepare_fp8_layer_for_marlin)
@@ -442,7 +442,7 @@ class Fp8LinearMethod(LinearMethodBase):
                         do_unpad=True,
                     )
                 else:
-                    return apply_block_fp8_linear_hpu_dynamic(
+                    return apply_fp8_linear_hpu_dynamic(
                         input=x,
                         weight=layer.weight,
                         weight_scale=layer.weight_scale_inv,
@@ -460,7 +460,7 @@ class Fp8LinearMethod(LinearMethodBase):
             )
         if current_platform.is_hpu(
         ) and self.quant_config.activation_scheme == "dynamic":
-            return apply_block_fp8_linear_hpu_dynamic(
+            return apply_fp8_linear_hpu_dynamic(
                 input=x,
                 weight=layer.weight,
                 weight_scale=layer.weight_scale_inv,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -610,7 +610,7 @@ def initialize_dummy_weights(
     """
     for param in model.state_dict().values():
         if torch.is_floating_point(param):
-            if current_platform.is_tpu():
+            if current_platform.is_tpu() or current_platform.is_hpu():
                 # XLA device does not support torch.Generator()
                 param.uniform_(low, high)
                 continue

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -32,7 +32,10 @@ class HpuPlatform(Platform):
                              block_size: int, use_v1: bool,
                              use_mla: bool) -> str:
         logger.info("Using HPUAttention backend.")
-        return "vllm.attention.backends.hpu_attn.HPUAttentionBackend"
+        if use_mla:
+            return "vllm.attention.backends.hpu_attn.HPUMLAAttentionBackend"
+        else:
+            return "vllm.attention.backends.hpu_attn.HPUAttentionBackend"
 
     @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -53,13 +53,15 @@ class HpuPlatform(Platform):
             raise NotImplementedError(
                 "Multi-step execution is not implemented for HPU")
 
-        if vllm_config.speculative_config is not None:
-            raise NotImplementedError(
-                "Speculative decoding is not implemented for HPU")
-
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
-            parallel_config.worker_cls = "vllm.worker.hpu_worker.HPUWorker"
+            if vllm_config.speculative_config:
+                parallel_config.worker_cls = \
+                    "vllm.spec_decode.spec_decode_worker.create_spec_worker"
+                parallel_config.sd_worker_cls = \
+                    "vllm.worker.hpu_worker.HPUWorker"
+            else:
+                parallel_config.worker_cls = "vllm.worker.hpu_worker.HPUWorker"
 
         # NOTE(kzawora): default block size for Gaudi should be 128
         # smaller sizes still work, but very inefficiently

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -153,6 +153,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8": torch.uint8,
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
+    "fp8_inc": torch.float8_e4m3fn,
 }
 
 TORCH_DTYPE_TO_NUMPY_DTYPE = {

--- a/vllm/worker/hpu_model_runner.py
+++ b/vllm/worker/hpu_model_runner.py
@@ -32,6 +32,7 @@ from vllm_hpu_extension.profiler import (HabanaHighLevelProfiler,
 import vllm.envs as envs
 from vllm.attention import AttentionMetadata, get_attn_backend
 from vllm.config import DeviceConfig, VllmConfig
+from vllm.distributed import broadcast_tensor_dict
 from vllm.distributed.parallel_state import get_world_group
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
@@ -44,11 +45,13 @@ from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     VocabParallelEmbedding)
 from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.sampling_metadata import SequenceGroupToSample
 from vllm.multimodal import (MULTIMODAL_REGISTRY, BatchedTensorInputs,
                              MultiModalKwargs)
 from vllm.sampling_params import SamplingParams
-from vllm.sequence import (IntermediateTensors, SequenceData,
-                           SequenceGroupMetadata)
+from vllm.sequence import (CompletionSequenceGroupOutput, IntermediateTensors,
+                           Logprob, SequenceData, SequenceGroupMetadata,
+                           SequenceOutput)
 from vllm.utils import (bind_kv_cache, is_pin_memory_available,
                         make_tensor_with_pad)
 from vllm.worker.model_runner_base import (
@@ -70,6 +73,10 @@ _PAD_SLOT_ID = 0
 _PAD_BLOCK_ID = 0
 
 LORA_WARMUP_RANK = 8
+
+VLLM_DELAYED_SAMPLING = os.environ.get('VLLM_DELAYED_SAMPLING',
+                                       'false').lower() == 'true'
+DUMMY_TOKEN_ID = -1
 
 
 class Singleton(type):
@@ -667,6 +674,9 @@ class HPUModelRunnerBase(ModelRunnerBase[TModelInputForHPU]):
         if self.model_type in ("medusa", "mlp_speculator", "eagle",
                                "deepseek_mtp"):
             self.skip_warmup = True
+        self.cached_step_outputs: List[torch.Tensor] = []
+        self.cached_step_inputs: List[
+            ModelInputForHPUWithSamplingMetadata] = []
 
     def _set_gc_threshold(self) -> None:
         # Read https://docs.python.org/3/library/gc.html#gc.set_threshold
@@ -2008,6 +2018,21 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
 
         return lora_mask, lora_logits_mask
 
+    def _get_seq_ids(self, model_input):
+        return ([
+            sg.seq_ids[0] for sg in model_input.sampling_metadata.seq_groups
+        ])
+
+    def _pad_to_max_num_seqs(self, tensor, value):
+        padding_needed = self.max_num_seqs - tensor.size(0)
+        if padding_needed:
+            padding = torch.full((padding_needed, *tensor.shape[1:]),
+                                 value,
+                                 device=tensor.device,
+                                 dtype=tensor.dtype)
+            tensor = torch.cat([tensor, padding])
+        return tensor
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -2020,15 +2045,55 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         if num_steps > 1:
             raise ValueError(
                 "num_steps > 1 is not supported in HPUModelRunner")
+        warmup_mode = kwargs.get('warmup_mode', False)
+        previous_hidden_states = kwargs.get('previous_hidden_states')
+        use_delayed_sampling = VLLM_DELAYED_SAMPLING and not warmup_mode
+        assert model_input.input_tokens is not None
+        if use_delayed_sampling and not model_input.is_prompt and \
+                self.is_driver_worker:
+            num_cached = len(self.cached_step_outputs)
+            assert num_cached > 0
+            cur_seq_ids = self._get_seq_ids(model_input)
+            cur_seq_id_pos = {
+                sid: idx
+                for idx, sid in enumerate(cur_seq_ids) if sid >= 0
+            }
+            htorch.core.mark_step()
+            for i in range(num_cached):
+                prev_seq_ids = self._get_seq_ids(self.cached_step_inputs[i])
+                target_indices = [
+                    cur_seq_id_pos.get(psi, -1) for psi in prev_seq_ids
+                ]
+                padding = self.cached_step_outputs[i].size(0) - len(
+                    target_indices)
+                target_indices.extend([-1] * padding)
+                target_indices = torch.tensor(
+                    target_indices,
+                    device=model_input.input_tokens.device,
+                    dtype=model_input.input_tokens.dtype)
+                model_input.input_tokens.index_copy_(
+                    0, target_indices, self.cached_step_outputs[i])
+                htorch.core.mark_step()
 
         if self.lora_config:
             assert model_input.lora_requests is not None
             assert model_input.lora_mapping is not None
             self.set_active_loras(model_input.lora_requests,
                                   model_input.lora_mapping)
-        warmup_mode = kwargs.get('warmup_mode', False)
-        previous_hidden_states = kwargs.get('previous_hidden_states')
-        input_tokens = model_input.input_tokens
+        if use_delayed_sampling and not model_input.is_prompt and \
+                    model_input.input_tokens.size(1) == 1:
+            if self.is_driver_worker:
+                model_kwargs_broadcast_data = {
+                    "input_tokens": model_input.input_tokens
+                }
+                broadcast_tensor_dict(model_kwargs_broadcast_data, src=0)
+                input_tokens = model_input.input_tokens
+
+            else:
+                model_kwargs_broadcast_data = broadcast_tensor_dict(src=0)
+                input_tokens = model_kwargs_broadcast_data["input_tokens"]
+        else:
+            input_tokens = model_input.input_tokens
         input_positions = model_input.input_positions
         attn_metadata = model_input.attn_metadata
         sampling_metadata = model_input.sampling_metadata
@@ -2091,6 +2156,11 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                                 f"graphs{'T' if use_graphs else 'F'}")
         else:
             model_event_name = 'model_executable'
+        if use_delayed_sampling:
+            # in case of multi-step scheduling
+            # we only want to pythonize in the last step
+            sampling_metadata.skip_sampler_cpu_output = True
+            self.model.model.sampler.include_gpu_probs_tensor = True
         with self.profiler.record_event('internal', model_event_name):
             hidden_states = self.model.forward(
                 **execute_model_kwargs,
@@ -2117,8 +2187,8 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
         if not self.is_driver_worker:
             return []
 
-        if model_input.async_callback is not None:
-            model_input.async_callback()
+        if use_delayed_sampling:
+            fake_output = self._delayed_sampler_outputs(model_input)
 
         # Sample the next token.
         with self.profiler.record_event(
@@ -2131,9 +2201,17 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
                 logits=logits,
                 sampling_metadata=sampling_metadata,
             )
-        output.outputs = output.outputs[:real_batch_size]
+        if use_delayed_sampling and self.is_driver_worker:
+            self._patch_prev_output()
+            output = self._pad_to_max_num_seqs(output.sampled_token_ids,
+                                               DUMMY_TOKEN_ID)
+            self.cached_step_outputs.append(output)
+            self.cached_step_inputs.append(model_input)
+        else:
+            output.outputs = output.outputs[:real_batch_size]
         htorch.core.mark_step()
-
+        if model_input.async_callback is not None:
+            model_input.async_callback()
         if self.is_driver_worker and self.profiler.enabled:
             # Stop recording 'execute_model' event
             self.profiler.end()
@@ -2159,8 +2237,69 @@ class HPUModelRunner(HPUModelRunnerBase[ModelInputForHPUWithSamplingMetadata]):
             if model_input.is_prompt:
                 output.prefill_hidden_states = hidden_states
             output.hidden_states = hidden_states
-
+        if use_delayed_sampling:
+            if self.is_driver_worker:
+                return [fake_output]
+            else:
+                return []
         return [output]
+
+    def _delayed_sampler_outputs(self, model_input):
+        next_token_ids = [[DUMMY_TOKEN_ID]] * len(
+            model_input.sampling_metadata.seq_groups)
+        sampler_output = self._make_decode_output(
+            next_token_ids, model_input.sampling_metadata.seq_groups)
+        return sampler_output
+
+    def _make_decode_output(
+        self,
+        next_token_ids: List[List[int]],
+        seq_groups: List[SequenceGroupToSample],
+    ) -> SamplerOutput:
+        zero_logprob = Logprob(0.0)
+        sampler_outputs = []
+        batch_idx = 0
+        for seq_group in seq_groups:
+            seq_ids = seq_group.seq_ids
+            seq_outputs = []
+            for seq_id in seq_ids:
+                next_token_id = next_token_ids[batch_idx][0]
+                seq_outputs.append(
+                    SequenceOutput(seq_id, next_token_id,
+                                   {next_token_id: zero_logprob}))
+                batch_idx += 1
+            sampler_outputs.append(
+                CompletionSequenceGroupOutput(seq_outputs, None))
+        return SamplerOutput(sampler_outputs)
+
+    def _patch_prev_output(self):
+        assert len(self.cached_step_inputs) == len(self.cached_step_outputs), \
+            f'''Inputs and outputs are out of sync!
+            {len(self.cached_step_inputs)} vs {len(self.cached_step_outputs)}'''
+        if len(self.cached_step_inputs) == 0:
+            return
+        model_input = self.cached_step_inputs.pop(0)
+        delayed_output = self.cached_step_outputs.pop(0).cpu().squeeze(
+            -1).tolist()
+        ctx = model_input.async_callback.keywords["ctx"]  # type: ignore
+        # If there's no output to patch with, which is usually the case when
+        # we're starting a new request after all requests are completed.
+        if len(ctx.output_queue) == 0:
+            return
+        assert len(
+            ctx.output_queue) == 1, 'There should be exactly 1 output waiting!'
+        output_data = ctx.output_queue[0]
+        assert len(output_data.outputs) == 1
+        for fake_out, real_out in zip(output_data.outputs[0], delayed_output):
+            fake_out.samples[0].output_token = real_out
+        for sg, real_out in zip(output_data.seq_group_metadata_list,
+                                delayed_output):
+            assert len(sg.seq_data) == 1
+            seq_data = list(sg.seq_data.values())[0]
+            # This is a hack. Assigning output_token_ids triggers
+            # a cache recomputation and we only need to update the last token
+            seq_data.output_token_ids_array[-1] = real_out
+            seq_data._cached_all_token_ids[-1] = real_out
 
     def shutdown_inc(self):
         can_finalize_inc = False

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -489,12 +489,8 @@ class HPUCacheEngine(CacheEngine):
         """Allocates KV cache on the specified device."""
         kv_cache_shape = self.attn_backend.get_kv_cache_shape(
             num_blocks, self.block_size, self.num_kv_heads, self.head_size)
-        if len(kv_cache_shape) == 4:
-            k_cache_shape = list(kv_cache_shape[:-2]) + [kv_cache_shape[-2]]
-            v_cache_shape = list(kv_cache_shape[:-2]) + [kv_cache_shape[-1]]
-        else:
-            k_cache_shape = kv_cache_shape
-            v_cache_shape = kv_cache_shape
+        k_cache_shape = kv_cache_shape[0]
+        v_cache_shape = kv_cache_shape[1]
         kv_cache: List[Tuple[torch.Tensor, torch.Tensor]] = []
         for _ in range(self.num_attention_layers):
             key_cache = torch.zeros(k_cache_shape,

--- a/vllm/worker/hpu_worker.py
+++ b/vllm/worker/hpu_worker.py
@@ -26,7 +26,7 @@ from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sequence import ExecuteModelRequest
 from vllm.utils import bind_kv_cache
 from vllm.worker.cache_engine import CacheEngine
-from vllm.worker.hpu_model_runner import HPUModelRunner, HPUModelRunnerBase
+from vllm.worker.hpu_model_runner import HPUModelRunner
 from vllm.worker.model_runner_base import ModelRunnerBase
 from vllm.worker.worker_base import (LocalOrDistributedWorkerBase, WorkerBase,
                                      WorkerInput)
@@ -74,13 +74,14 @@ class HPUWorker(LocalOrDistributedWorkerBase):
                 not in ("medusa", "mlp_speculator", "eagle", "deepseek_mtp")) \
                     else {"return_hidden_states": True}
 
-        ModelRunnerClass: Type[HPUModelRunnerBase] = HPUModelRunner
+        ModelRunnerClass: Type[HPUModelRunner] = HPUModelRunner
         self.model_runner: HPUModelRunner = ModelRunnerClass(
             vllm_config=vllm_config,
             is_driver_worker=is_driver_worker,
             **speculative_args)
         if model_runner_cls is not None:
-            self.model_runner = model_runner_cls(self.model_runner)
+            self.model_runner = model_runner_cls(
+                self.model_runner)  # type: ignore
         # Uninitialized cache engine. Will be initialized by
         # initialize_cache.
         self.cache_engine: List[HPUCacheEngine]

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -262,6 +262,17 @@ class ModelRunnerWrapperBase:
     def __getattr__(self, attr):
         return getattr(self.model_runner, attr)
 
+    def __setattr__(self, name, value):
+        """
+        Ensure that setting the 'model_runner' attribute
+        does not delegate to model_runner
+        """
+
+        if name == "model_runner":
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self.model_runner, name, value)
+
 
 class InputProcessingError(Exception):
     """This exception is raised when an error occurs preparing the inputs for


### PR DESCRIPTION
updated in 03/24/2025

convert this PR as a draft and waiting for 1.21 HPU synapse release

----

Accuracy is verified as below
```
VLLM_SKIP_WARMUP=true \
PT_HPU_ENABLE_LAZY_COLLECTIVES=true \
PT_HPU_WEIGHT_SHARING=0 \
VLLM_TEST_ENABLE_EP=1 \
VLLM_MLA_DISABLE_REQUANTIZATION=1 \
bash .buildkite/lm-eval-harness/run-lm-eval-gsm-vllm-baseline.sh -m deepseek-ai/DeepSeek-R1 -b 128 -l 256 -f 5 -t 8
```
![image](https://github.com/user-attachments/assets/871af252-2cbd-46ff-b8b9-d568bda9bc32)

3 options for running fp8 on HPU:
1. dynamic quant + static MOE => **default option** . Supported by public released hpu 1.20 synapse container
2. dynamic quant + dynamic MOE => enabled by "VLLM_DMOE_DYNAMIC_SCALE=1". Working with internal hpu synapse build and will release container later
3. static quant + dynamic MOE => enabled by using a converted model from original block-based quant to channel-based quant. Please refer https://github.com/HabanaAI/vllm-fork/blob/deepseek_r1/scripts/DEEPSEEK_R1_ON_GAUDI.md#option-3-run-with-static-quantization for instruction of how to convert model 