### PR TITLE
Fix GuidedDecodingParams backend_name issue

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2754,7 +2754,7 @@ class DecodingConfig:
         valid_guided_backends = ['outlines', 'lm-format-enforcer', 'xgrammar']
 
         backend = GuidedDecodingParams(
-            backend=self.guided_decoding_backend).backend_name
+            backend=self.guided_decoding_backend).backend_name()
         if backend not in valid_guided_backends:
             raise ValueError(f"Invalid guided_decoding_backend '{backend},"
                              f" must be one of {valid_guided_backends}")

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -146,20 +146,20 @@ def get_local_guided_decoding_logits_processor(
     # Get the reasoner if needed, it will be None if reasoning_
     reasoner = get_reasoner(tokenizer, reasoning_backend)
 
-    print(f"guided_params backend_name: {guided_params.backend_name}")
+    backend_name = guided_params.backend_name
     # CFG grammar not supported by LMFE, so we use outlines instead
-    if guided_params.backend_name == 'outlines':
+    if backend_name == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
         from vllm.model_executor.guided_decoding.outlines_decoding import (  # noqa
             get_local_outlines_guided_decoding_logits_processor)
         return get_local_outlines_guided_decoding_logits_processor(
             guided_params, tokenizer, reasoner)
-    if guided_params.backend_name == 'lm-format-enforcer':
+    if backend_name == 'lm-format-enforcer':
         from vllm.model_executor.guided_decoding.lm_format_enforcer_decoding import (  # noqa
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
-    if guided_params.backend_name == 'xgrammar':
+    if backend_name == 'xgrammar':
         from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
             get_local_xgrammar_guided_decoding_logits_processor)
         return get_local_xgrammar_guided_decoding_logits_processor(

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -114,7 +114,7 @@ async def get_guided_decoding_logits_processor(
     guided_params = maybe_backend_fallback(guided_params)
 
     # CFG grammar not supported by LMFE, so we use outlines instead
-    if guided_params.backend_name == 'outlines':
+    if guided_params.backend_name() == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
         from vllm.model_executor.guided_decoding.outlines_decoding import (  # noqa
             get_outlines_guided_decoding_logits_processor)
@@ -125,7 +125,7 @@ async def get_guided_decoding_logits_processor(
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
-    if guided_params.backend_name == 'xgrammar':
+    if guided_params.backend_name() == 'xgrammar':
         from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
             get_local_xgrammar_guided_decoding_logits_processor)
         return get_local_xgrammar_guided_decoding_logits_processor(
@@ -146,20 +146,19 @@ def get_local_guided_decoding_logits_processor(
     # Get the reasoner if needed, it will be None if reasoning_
     reasoner = get_reasoner(tokenizer, reasoning_backend)
 
-    backend_name = guided_params.backend_name
     # CFG grammar not supported by LMFE, so we use outlines instead
-    if backend_name == 'outlines':
+    if guided_params.backend_name() == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193
         from vllm.model_executor.guided_decoding.outlines_decoding import (  # noqa
             get_local_outlines_guided_decoding_logits_processor)
         return get_local_outlines_guided_decoding_logits_processor(
             guided_params, tokenizer, reasoner)
-    if backend_name == 'lm-format-enforcer':
+    if guided_params.backend_name() == 'lm-format-enforcer':
         from vllm.model_executor.guided_decoding.lm_format_enforcer_decoding import (  # noqa
             get_local_lm_format_enforcer_guided_decoding_logits_processor)
         return get_local_lm_format_enforcer_guided_decoding_logits_processor(
             guided_params, tokenizer)
-    if backend_name == 'xgrammar':
+    if guided_params.backend_name() == 'xgrammar':
         from vllm.model_executor.guided_decoding.xgrammar_decoding import (  # noqa
             get_local_xgrammar_guided_decoding_logits_processor)
         return get_local_xgrammar_guided_decoding_logits_processor(

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -146,6 +146,7 @@ def get_local_guided_decoding_logits_processor(
     # Get the reasoner if needed, it will be None if reasoning_
     reasoner = get_reasoner(tokenizer, reasoning_backend)
 
+    print(f"guided_params backend_name: {guided_params.backend_name}")
     # CFG grammar not supported by LMFE, so we use outlines instead
     if guided_params.backend_name == 'outlines':
         # NOTE: lazy import outlines to avoid https://github.com/vllm-project/vllm/issues/4193

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -63,7 +63,6 @@ class GuidedDecodingParams:
             whitespace_pattern=whitespace_pattern,
         )
 
-    @property
     def backend_name(self) -> str:
         """Return the backend name without any options.
         


### PR DESCRIPTION
For some reason the "@property" decorator on backend_name is creating issues, where the ValueError `Unknown guided decoding backend..` gets raised when trying to use a backend like `xgrammar:disable-any-whitespace`. 

What's especially odd is that printing out `guided_params.backend_name` before the conditional checks makes it work, as does assigning it to a variable. I have a feeling there's some kind of observer effect or race condition going on. Regardless, this seems to fix it and its unclear why this is a property rather than a method anyway.
