### PR TITLE
[Doc] Added QwQ-32B to the supported models list in the reasoning out…

### DIFF
--- a/docs/source/features/reasoning_outputs.md
+++ b/docs/source/features/reasoning_outputs.md
@@ -13,6 +13,7 @@ vLLM currently supports the following reasoning models:
 | Model Series | Parser Name | Structured Output Support |
 |--------------|-------------|------------------|
 | [DeepSeek R1 series](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) | `deepseek_r1` | `guided_json`, `guided_regex` |
+| [QwQ-32B](https://huggingface.co/Qwen/QwQ-32B) | `deepseek_r1` | `guided_json`, `guided_regex` |
 
 ## Quickstart
 


### PR DESCRIPTION
Added QwQ-32B to the supported models list in the reasoning outputs documentation.