### PR TITLE
[Misc] Don't run ruff at all on 3rd party libs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ exclude = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"vllm/third_party/**" = ["ALL"]
 "vllm/version.py" = ["F401"]
 "vllm/_version.py" = ["ALL"]
 # Python 3.8 typing. TODO: Remove these excludes after v1.0.0
@@ -84,7 +85,6 @@ exclude = [
 "vllm/profiler/**/*.py" = ["UP006", "UP035"]
 "vllm/prompt_adapter/**/*.py" = ["UP006", "UP035"]
 "vllm/spec_decode/**/*.py" = ["UP006", "UP035"]
-"vllm/third_party/**/*.py" = ["UP006", "UP035"]
 "vllm/transformers_utils/**/*.py" = ["UP006", "UP035"]
 "vllm/triton_utils/**/*.py" = ["UP006", "UP035"]
 "vllm/usage/**/*.py" = ["UP006", "UP035"]


### PR DESCRIPTION
Currently, third-party libraries are ignored in `pre-commit`, but not when running `ruff` directly from command line.
