### PR TITLE
[Bugfix] Revert QKVCrossParallelLinear usage in Mllama to keep BNB quantization work

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1242,8 +1242,15 @@ class QKVCrossParallelLinear(torch.nn.Module):
                  quant_config: Optional[QuantizationConfig] = None,
                  prefix: str = ""):
         super().__init__()
-
-        self.q_proj_decoder = ColumnParallelLinear(
+        # Empty placeholders for loading as a single module.
+        self.weight = torch.nn.Parameter()
+        set_weight_attrs(self.weight, {
+            "weight_loader": self.weight_loader_weight,
+        })
+        # Use a dictionary to avoid submodules parameters auto-registration:
+        # drop-in replacement for a `QKVParallelLinear` module.
+        self.proj = dict()
+        self.proj["q_proj_decoder"] = ColumnParallelLinear(
             input_size=hidden_size,
             output_size=total_num_heads * head_size,
             bias=bias,
@@ -1252,7 +1259,7 @@ class QKVCrossParallelLinear(torch.nn.Module):
             params_dtype=params_dtype,
             prefix=f"{prefix}.q_proj_decoder")
 
-        self.kv_proj_encoder = QKVParallelLinear(
+        self.proj["kv_proj_encoder"] = QKVParallelLinear(
             hidden_size=hidden_size,
             head_size=head_size,
             total_num_heads=0,
@@ -1266,6 +1273,20 @@ class QKVCrossParallelLinear(torch.nn.Module):
         # `kv_proj_encoder.num_kv_heads` accounts for sharding with tp>1.
         self.kv_size = self.kv_proj_encoder.num_kv_heads * head_size
 
+        if bias:
+            self.bias = torch.nn.Parameter()
+            set_weight_attrs(self.bias, {
+                "weight_loader": self.weight_loader_bias,
+            })
+
+    @property
+    def q_proj_decoder(self):
+        return self.proj["q_proj_decoder"]
+
+    @property
+    def kv_proj_encoder(self):
+        return self.proj["kv_proj_encoder"]
+
     def forward(self, decoder_hidden_states, encoder_hidden_states):
         q, _ = self.q_proj_decoder(decoder_hidden_states)
         if encoder_hidden_states is None:
@@ -1278,3 +1299,26 @@ class QKVCrossParallelLinear(torch.nn.Module):
             # Split kv in half
             k, v = kv_enc.split(self.kv_size, dim=-1)
         return q, k, v
+
+    def weight_loader_weight(self,
+                             param: torch.nn.Parameter,
+                             loaded_weight: torch.Tensor,
+                             loaded_shard_id: Optional[str] = None):
+        # NOTE Use QKV/ColumnParallel weight_loader, ignore placeholder param.
+        param = self.q_proj_decoder.weight if loaded_shard_id == "q" \
+            else self.kv_proj_encoder.weight
+        param.weight_loader(
+            param,
+            loaded_weight) if loaded_shard_id == "q" else param.weight_loader(
+                param, loaded_weight, loaded_shard_id)
+
+    def weight_loader_bias(self,
+                           param: torch.nn.Parameter,
+                           loaded_weight: torch.Tensor,
+                           loaded_shard_id: Optional[str] = None):
+        param = self.q_proj_decoder.bias if loaded_shard_id == "q" \
+            else self.kv_proj_encoder.bias
+        param.weight_loader(
+            param,
+            loaded_weight) if loaded_shard_id == "q" else param.weight_loader(
+                param, loaded_weight, loaded_shard_id)

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -43,7 +43,6 @@ from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
-                                               QKVCrossParallelLinear,
                                                QKVParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -814,11 +813,20 @@ class MllamaTextCrossAttention(nn.Module):
         self.q_local_size = self.num_local_heads * self.head_dim
         self.kv_local_size = self.num_local_key_value_heads * self.head_dim
 
-        self.qkv_proj = QKVCrossParallelLinear(
+        # TODO(Isotr0py): Use QKVCrossParallelLinear when it supports
+        # quantization
+        self.q_proj = ColumnParallelLinear(
+            input_size=self.hidden_size,
+            output_size=self.num_heads * self.head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_proj",
+        )
+        self.kv_proj = QKVParallelLinear(
             self.hidden_size,
             self.head_dim,
-            self.num_heads,
-            self.num_key_value_heads,
+            total_num_heads=0,
+            total_num_kv_heads=self.num_key_value_heads,
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.qkv_proj",
@@ -854,11 +862,15 @@ class MllamaTextCrossAttention(nn.Module):
         kv_range_for_decode: Optional[List[Tuple[int, int]]],
         cross_attention_states: Optional[torch.Tensor],
     ) -> torch.Tensor:
-        q, k, v = self.qkv_proj(hidden_states, cross_attention_states)
+        q, _ = self.q_proj(hidden_states)
         if cross_attention_states is not None:
+            kv, _ = self.kv_proj(cross_attention_states)
+            k, v = kv.split([self.kv_local_size, self.kv_local_size], dim=-1)
             k = k.view(-1, self.num_local_key_value_heads, self.head_dim)
             v = v.view(-1, self.num_local_key_value_heads, self.head_dim)
             k = self.k_norm(k)
+        else:
+            k = v = None
 
         q = q.view(-1, self.num_local_heads, self.head_dim)
         q = self.q_norm(q)
@@ -1149,11 +1161,12 @@ class MllamaForCausalLM(nn.Module):
 class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal,
                                      SupportsV0Only):
     packed_modules_mapping = {
-        "cross_attn.qkv_proj.q_proj_decoder": ["cross_attn.q_proj"],
-        "cross_attn.qkv_proj.kv_proj_encoder":
-        ["cross_attn.k_proj", "cross_attn.v_proj"],
-        "self_attn.qkv_proj":
-        ["self_attn.q_proj", "self_attn.k_proj", "self_attn.v_proj"],
+        "self_attn.qkv_proj": [
+            "self_attn.q_proj",
+            "self_attn.k_proj",
+            "self_attn.v_proj",
+        ],
+        "cross_attn.kv_proj": ["cross_attn.k_proj", "cross_attn.v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
 
@@ -1424,15 +1437,11 @@ class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal,
                                                    torch.Tensor]]) -> Set[str]:
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)
-            (".cross_attn.qkv_proj.q_proj_decoder", ".cross_attn.q_proj", None
-             ),
-            (".cross_attn.qkv_proj.kv_proj_encoder", ".cross_attn.k_proj",
-             "k"),
-            (".cross_attn.qkv_proj.kv_proj_encoder", ".cross_attn.v_proj",
-             "v"),
-            (".qkv_proj", ".q_proj", "q"),
-            (".qkv_proj", ".k_proj", "k"),
-            (".qkv_proj", ".v_proj", "v"),
+            (".self_attn.qkv_proj", ".self_attn.q_proj", "q"),
+            (".self_attn.qkv_proj", ".self_attn.k_proj", "k"),
+            (".self_attn.qkv_proj", ".self_attn.v_proj", "v"),
+            (".cross_attn.kv_proj", ".cross_attn.k_proj", "k"),
+            (".cross_attn.kv_proj", ".cross_attn.v_proj", "v"),
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
         ]
@@ -1461,8 +1470,7 @@ class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal,
                 param = params_dict[name]
                 updated_params.add(name)
                 weight_loader = param.weight_loader
-                shard_id = (shard_id, ) if shard_id is not None else ()
-                weight_loader(param, loaded_weight, *shard_id)
+                weight_loader(param, loaded_weight, shard_id)
                 break
             else:
                 orig_name = name


### PR DESCRIPTION

- Unfortunately, `QKVCrossParallelLinear` doesn't support quantization that needs extra weight and weight_attrs registration (https://github.com/vllm-project/vllm/pull/12325#discussion_r1986121157) 😢 
- I revert the `QKVCrossParallelLinear` usage in mllama, and use model-level QKVCrossLinear implementation like whisper temporarily before `QKVCrossParallelLinear` supports quantization.

cc @NickLucche 

<!--- pyml disable-next-line no-emphasis-as-heading -->
