### PR TITLE
[Misc] QoL: add speculative_model to SpeculativeConfig

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2029,6 +2029,7 @@ class SpeculativeConfig:
             disable_logprobs = True
 
         return SpeculativeConfig(
+            speculative_model,
             draft_model_config,
             draft_parallel_config,
             num_speculative_tokens,
@@ -2139,6 +2140,7 @@ class SpeculativeConfig:
 
     def __init__(
         self,
+        speculative_model: str,
         draft_model_config: ModelConfig,
         draft_parallel_config: ParallelConfig,
         num_speculative_tokens: int,
@@ -2155,6 +2157,9 @@ class SpeculativeConfig:
         """Create a SpeculativeConfig object.
 
         Args:
+            speculative_model: The name of the speculative model.
+                Can be [ngram] for ngram draft model, otherwise the
+                name of the draft model.
             draft_model_config: ModelConfig for the draft model.
             draft_parallel_config: ParallelConfig for the draft model.
             num_speculative_tokens: The number of tokens to sample from the
@@ -2186,6 +2191,7 @@ class SpeculativeConfig:
             disable_log_stats: Whether to disable periodic printing of stage
                 times in speculative decoding.
         """
+        self.speculative_model = speculative_model
         self.draft_model_config = draft_model_config
         self.draft_parallel_config = draft_parallel_config
         self.num_speculative_tokens = num_speculative_tokens
@@ -2249,12 +2255,8 @@ class SpeculativeConfig:
         return self.num_speculative_tokens
 
     def __repr__(self) -> str:
-        if self.ngram_prompt_lookup_max > 0:
-            draft_model = "[ngram]"
-        else:
-            draft_model = self.draft_model_config.model
         num_spec_tokens = self.num_speculative_tokens
-        return f"SpeculativeConfig({draft_model=}, {num_spec_tokens=})"
+        return f"SpeculativeConfig({self.speculative_model=}, {num_spec_tokens=})"
 
 
 @dataclass

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2255,9 +2255,8 @@ class SpeculativeConfig:
         return self.num_speculative_tokens
 
     def __repr__(self) -> str:
-        num_spec_tokens = self.num_speculative_tokens
         return (f"SpeculativeConfig({self.speculative_model=}, "
-                f"{num_spec_tokens=})")
+                f"{self.num_speculative_tokens=})")
 
 
 @dataclass

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2256,7 +2256,8 @@ class SpeculativeConfig:
 
     def __repr__(self) -> str:
         num_spec_tokens = self.num_speculative_tokens
-        return f"SpeculativeConfig({self.speculative_model=}, {num_spec_tokens=})"
+        return (f"SpeculativeConfig({self.speculative_model=}, "
+                f"{num_spec_tokens=})")
 
 
 @dataclass

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -98,6 +98,7 @@ def create_spec_worker(*args, **kwargs) -> "SpecDecodeWorker":
 
     spec_decode_worker = SpecDecodeWorker.create_worker(
         scorer_worker=target_worker,
+        speculative_model=speculative_config.speculative_model,
         draft_worker_kwargs=draft_worker_kwargs,
         disable_mqa_scorer=speculative_config.speculative_disable_mqa_scorer,
         disable_by_batch_size=speculative_config.
@@ -148,6 +149,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
     def create_worker(
         cls,
         scorer_worker: WorkerBase,
+        speculative_model: str,
         draft_worker_kwargs: Dict[str, Any],
         disable_mqa_scorer: bool,
         disable_by_batch_size: Optional[int],
@@ -169,7 +171,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         draft_model_config = draft_worker_kwargs["vllm_config"].model_config
         draft_parallel_config: ParallelConfig = draft_worker_kwargs[
             'vllm_config'].parallel_config
-        if ngram_prompt_lookup_max > 0:
+        if speculative_model == "[ngram]":
             draft_worker_kwargs[
                 "device_type"] = scorer_worker.device_config.device.type
             proposer_worker = NGramWorker(**draft_worker_kwargs)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -151,7 +151,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         if self.speculative_config:
             self.use_spec_decode = True
             self.rejection_sampler = RejectionSampler()
-            # TODO: find a better way to check if we are using ngram.
             assert self.speculative_config.speculative_model == "[ngram]", \
                     "Currently, only ngram spec decode is supported in V1."
             if get_pp_group().is_last_rank:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -152,7 +152,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.use_spec_decode = True
             self.rejection_sampler = RejectionSampler()
             # TODO: find a better way to check if we are using ngram.
-            assert self.speculative_config.ngram_prompt_lookup_min, \
+            assert self.speculative_config.speculative_model == "[ngram]", \
                     "Currently, only ngram spec decode is supported in V1."
             if get_pp_group().is_last_rank:
                 self.drafter = NgramProposer()


### PR DESCRIPTION
Adding the `speculative_model` field to SpeculativeConfig:
- Makes it easier & clearer to deduce which speculative model is wanted, instead of trying to deduce from the fields.
- As a result easier to add more spec decode models.
