### PR TITLE
Replaces os.environ with monkeypatch in test suite

### DIFF
--- a/tests/basic_correctness/test_basic_correctness.py
+++ b/tests/basic_correctness/test_basic_correctness.py
@@ -47,6 +47,7 @@ def test_vllm_gc_ed():
 @pytest.mark.parametrize("max_tokens", [5])
 @pytest.mark.parametrize("enforce_eager", [False])
 def test_models(
+    monkeypatch,
     hf_runner,
     model: str,
     backend: str,
@@ -63,7 +64,7 @@ def test_models(
         pytest.skip(
             f"{backend} does not support gemma2 with full context length.")
 
-    os.environ["VLLM_ATTENTION_BACKEND"] = backend
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", backend)
 
     # 5042 tokens for gemma2
     # gemma2 has alternating sliding window size of 4096
@@ -104,6 +105,7 @@ def test_models(
         ("meta-llama/Meta-Llama-3-8B", "ray", "FLASHINFER", "A100"),
     ])
 def test_models_distributed(
+    monkeypatch,
     hf_runner,
     vllm_runner,
     example_prompts,
@@ -118,11 +120,11 @@ def test_models_distributed(
 
     if model == "meta-llama/Llama-3.2-1B-Instruct" and distributed_executor_backend == "ray" and attention_backend == "" and test_suite == "L4":  # noqa
         # test Ray Compiled Graph
-        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "1"
-        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "1"
+        monkeypatch.setenv("VLLM_USE_RAY_SPMD_WORKER", "1")
+        monkeypatch.setenv("VLLM_USE_RAY_COMPILED_DAG", "1")
 
     if attention_backend:
-        os.environ["VLLM_ATTENTION_BACKEND"] = attention_backend
+        monkeypatch.setenv("VLLM_ATTENTION_BACKEND", attention_backend)
 
     dtype = "half"
     max_tokens = 5

--- a/tests/basic_correctness/test_chunked_prefill.py
+++ b/tests/basic_correctness/test_chunked_prefill.py
@@ -94,8 +94,8 @@ def test_models_distributed(
     if (model == "meta-llama/Llama-3.2-1B-Instruct"
             and distributed_executor_backend == "ray"):
         # test Ray Compiled Graph
-        os.environ['VLLM_USE_RAY_SPMD_WORKER'] = "1"
-        os.environ['VLLM_USE_RAY_COMPILED_DAG'] = "1"
+        monkeypatch.setenv("VLLM_USE_RAY_SPMD_WORKER", "1")
+        monkeypatch.setenv("VLLM_USE_RAY_COMPILED_DAG", "1")
 
     dtype = "half"
     max_tokens = 5

--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -123,9 +123,9 @@ def test_cumem_with_cudagraph():
         # sleep mode with pytorch checkpoint
         ("facebook/opt-125m", False),
     ])
-def test_end_to_end(model: str, use_v1: bool):
+def test_end_to_end(monkeypatch, model: str, use_v1: bool):
     import os
-    os.environ["VLLM_USE_V1"] = "1" if use_v1 else "0"
+    monkeypatch.setenv("VLLM_USE_V1", "1" if use_v1 else "0")
     free, total = torch.cuda.mem_get_info()
     used_bytes_baseline = total - free  # in case other process is running
     llm = LLM(model, enable_sleep_mode=True)
@@ -159,4 +159,4 @@ def test_end_to_end(model: str, use_v1: bool):
     # cmp output
     assert output[0].outputs[0].text == output2[0].outputs[0].text
 
-    del os.environ["VLLM_USE_V1"]
+    monkeypatch.delenv("VLLM_USE_V1", raising=False)

--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -90,7 +90,7 @@ test_settings = [
 # we cannot afford testing the full Catesian product
 # of all models and all levels
 @pytest.mark.parametrize("test_setting", test_settings)
-def test_compile_correctness(test_setting: TestSetting):
+def test_compile_correctness(monkeypatch, test_setting: TestSetting):
     # this test is run under multiple suits, with different GPUs.
     # make sure we only run the test with correct CUDA devices.
     # don't use "<", as it will duplicate the tests.
@@ -104,7 +104,7 @@ def test_compile_correctness(test_setting: TestSetting):
     if cuda_device_count_stateless() != pp_size * tp_size:
         pytest.skip("Not correct CUDA devices for the test.")
     import os
-    os.environ["VLLM_ATTENTION_BACKEND"] = attn_backend
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", attn_backend)
     final_args = ["--enforce-eager"] + model_args + ["-pp", str(pp_size)] + \
                 ["-tp", str(tp_size)]
 

--- a/tests/compile/utils.py
+++ b/tests/compile/utils.py
@@ -61,12 +61,13 @@ if not current_platform.is_rocm() and is_quant_method_supported("awq"):
     }))
 
 
-def check_full_graph_support(model,
+def check_full_graph_support(monkeypatch,
+                             model,
                              model_kwargs,
                              optimization_level,
                              tp_size=1):
     # make sure these models can be captured in full graph mode
-    os.environ["VLLM_TEST_DYNAMO_FULLGRAPH_CAPTURE"] = "1"
+    monkeypatch.setenv("VLLM_TEST_DYNAMO_FULLGRAPH_CAPTURE", "1")
 
     print(f"MODEL={model}")
 

--- a/tests/distributed/test_comm_ops.py
+++ b/tests/distributed/test_comm_ops.py
@@ -17,12 +17,13 @@ from ..utils import init_test_distributed_environment, multi_process_parallel
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_reduce_test_worker(tp_size: int, pp_size: int, rank: int,
+def all_reduce_test_worker(monkeypatch, tp_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,
@@ -39,12 +40,12 @@ def all_reduce_test_worker(tp_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def all_gather_test_worker(tp_size: int, pp_size: int, rank: int,
+def all_gather_test_worker(monkeypatch, tp_size: int, pp_size: int, rank: int,
                            distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,
@@ -67,12 +68,12 @@ def all_gather_test_worker(tp_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def broadcast_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
+def broadcast_tensor_dict_test_worker(monkeypatch, tp_size: int, pp_size: int, rank: int,
                                       distributed_init_port: str):
     # it is important to delete the CUDA_VISIBLE_DEVICES environment variable
     # so that each worker can see all the GPUs
     # they will be able to set the device to the correct GPU
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,
@@ -106,9 +107,9 @@ def broadcast_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def send_recv_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
+def send_recv_tensor_dict_test_worker(monkeypatch, tp_size: int, pp_size: int, rank: int,
                                       distributed_init_port: str):
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,
@@ -146,9 +147,9 @@ def send_recv_tensor_dict_test_worker(tp_size: int, pp_size: int, rank: int,
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def send_recv_test_worker(tp_size: int, pp_size: int, rank: int,
+def send_recv_test_worker(monkeypatch, tp_size: int, pp_size: int, rank: int,
                           distributed_init_port: str):
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,

--- a/tests/distributed/test_custom_all_reduce.py
+++ b/tests/distributed/test_custom_all_reduce.py
@@ -23,8 +23,8 @@ for i, v in enumerate(test_sizes):
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+def graph_allreduce(monkeypatch, tp_size, pp_size, rank, distributed_init_port):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,
@@ -79,8 +79,8 @@ def graph_allreduce(tp_size, pp_size, rank, distributed_init_port):
 
 
 @ray.remote(num_gpus=1, max_calls=1)
-def eager_allreduce(tp_size, pp_size, rank, distributed_init_port):
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+def eager_allreduce(monkeypatch, tp_size, pp_size, rank, distributed_init_port):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
     device = torch.device(f"cuda:{rank}")
     torch.cuda.set_device(device)
     init_test_distributed_environment(tp_size, pp_size, rank,

--- a/tests/distributed/test_pipeline_partition.py
+++ b/tests/distributed/test_pipeline_partition.py
@@ -7,15 +7,15 @@ import pytest
 from vllm.distributed.utils import get_pp_indices
 
 
-def test_custom_layer_partition():
+def test_custom_layer_partition(monkeypatch):
 
     def _verify(partition_str, num_layers, pp_size, goldens):
         bak = os.environ.get("VLLM_PP_LAYER_PARTITION", None)
-        os.environ["VLLM_PP_LAYER_PARTITION"] = partition_str
+        monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", partition_str)
         for pp_rank, golden in enumerate(goldens):
             assert get_pp_indices(num_layers, pp_rank, pp_size) == golden
         if bak is not None:
-            os.environ["VLLM_PP_LAYER_PARTITION"] = bak
+            monkeypatch.setenv("VLLM_PP_LAYER_PARTITION", bak)
 
     # Even partition
     _verify("5,5,5,5", 20, 4, [(0, 5), (5, 10), (10, 15), (15, 20)])

--- a/tests/distributed/test_pp_cudagraph.py
+++ b/tests/distributed/test_pp_cudagraph.py
@@ -15,7 +15,7 @@ from ..utils import compare_two_settings, fork_new_process_for_each_test
     "FLASHINFER",
 ])
 @fork_new_process_for_each_test
-def test_pp_cudagraph(PP_SIZE, MODEL_NAME, ATTN_BACKEND):
+def test_pp_cudagraph(monkeypatch, PP_SIZE, MODEL_NAME, ATTN_BACKEND):
     cudagraph_args = [
         # use half precision for speed and memory savings in CI environment
         "--dtype",
@@ -25,7 +25,7 @@ def test_pp_cudagraph(PP_SIZE, MODEL_NAME, ATTN_BACKEND):
         "--distributed-executor-backend",
         "mp",
     ]
-    os.environ["VLLM_ATTENTION_BACKEND"] = ATTN_BACKEND
+    monkeypatch.setenv("VLLM_ATTENTION_BACKEND", ATTN_BACKEND)
 
     eager_args = cudagraph_args + ["--enforce-eager"]
 

--- a/tests/kernels/test_awq.py
+++ b/tests/kernels/test_awq.py
@@ -11,8 +11,8 @@ from vllm import _custom_ops as ops  # noqa: F401
 
 @pytest.mark.skipif(not hasattr(torch.ops._C, "awq_dequantize"),
                     reason="AWQ is not supported on this GPU type.")
-def test_awq_dequantize_opcheck():
-    os.environ["VLLM_USE_TRITON_AWQ"] = "0"
+def test_awq_dequantize_opcheck(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_TRITON_AWQ", "0")
     qweight = torch.randint(-2000000000,
                             2000000000, (8192, 256),
                             device='cuda',
@@ -29,8 +29,8 @@ def test_awq_dequantize_opcheck():
 @pytest.mark.skip(reason="Not working; needs investigation.")
 @pytest.mark.skipif(not hasattr(torch.ops._C, "awq_gemm"),
                     reason="AWQ is not supported on this GPU type.")
-def test_awq_gemm_opcheck():
-    os.environ["VLLM_USE_TRITON_AWQ"] = "0"
+def test_awq_gemm_opcheck(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_TRITON_AWQ", "0")
     input = torch.rand((2, 8192), device='cuda', dtype=torch.float16)
     qweight = torch.randint(-2000000000,
                             2000000000, (8192, 256),

--- a/tests/kv_transfer/disagg_test.py
+++ b/tests/kv_transfer/disagg_test.py
@@ -13,14 +13,15 @@ import torch
 
 # Fixture to set up environment variables and teardown servers after tests
 @pytest.fixture(scope="module", autouse=True)
-def setup_servers():
+def setup_servers(monkeypatch):
     if torch.cuda.device_count() < 4:
         pytest.skip("Skipping test: fewer than 4 GPUs available")
 
     # Set up environment variables
     VLLM_HOST_IP = subprocess.check_output("hostname -I | awk '{print $1}'",
                                            shell=True).decode().strip()
-    os.environ["VLLM_HOST_IP"] = VLLM_HOST_IP
+    monkeypatch.setenv("VLLM_HOST_IP", VLLM_HOST_IP)
+
 
     # Start prefill instance
     prefill_cmd = [

--- a/tests/models/decoder_only/language/test_fp8.py
+++ b/tests/models/decoder_only/language/test_fp8.py
@@ -14,7 +14,12 @@ from tests.quantization.utils import is_quant_method_supported
 
 from ...utils import check_logprobs_close
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+@pytest.fixture(scope="module", autouse=True)
+#All the tests in this file to use TOKENIZERS_PARALLELISM="true"
+def enable_tokenizers_parallelism(monkeypatch):
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "true")
+    yield
+    monkeypatch.delenv("TOKENIZERS_PARALLELISM", raising=False)
 
 
 @pytest.mark.quant_model

--- a/tests/models/decoder_only/language/test_gguf.py
+++ b/tests/models/decoder_only/language/test_gguf.py
@@ -16,7 +16,12 @@ from tests.quantization.utils import is_quant_method_supported
 from ....conftest import VllmRunner
 from ...utils import check_logprobs_close
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+@pytest.fixture(scope="module", autouse=True)
+#All the tests in this file to use TOKENIZERS_PARALLELISM="true"
+def enable_tokenizers_parallelism(monkeypatch):
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "true")
+    yield
+    monkeypatch.delenv("TOKENIZERS_PARALLELISM", raising=False)
 
 MAX_MODEL_LEN = 1024
 

--- a/tests/models/decoder_only/language/test_gptq_marlin.py
+++ b/tests/models/decoder_only/language/test_gptq_marlin.py
@@ -18,7 +18,12 @@ from vllm.model_executor.layers.rotary_embedding import _ROPE_DICT
 
 from ...utils import check_logprobs_close
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+@pytest.fixture(scope="module", autouse=True)
+#All the tests in this file to use TOKENIZERS_PARALLELISM="true"
+def enable_tokenizers_parallelism(monkeypatch):
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "true")
+    yield
+    monkeypatch.delenv("TOKENIZERS_PARALLELISM", raising=False)
 
 MAX_MODEL_LEN = 1024
 

--- a/tests/models/decoder_only/language/test_modelopt.py
+++ b/tests/models/decoder_only/language/test_modelopt.py
@@ -12,7 +12,12 @@ from transformers import AutoTokenizer
 from tests.quantization.utils import is_quant_method_supported
 from vllm import LLM, SamplingParams
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+@pytest.fixture(scope="module", autouse=True)
+#All the tests in this file to use TOKENIZERS_PARALLELISM="true"
+def enable_tokenizers_parallelism(monkeypatch):
+    monkeypatch.setenv("TOKENIZERS_PARALLELISM", "true")
+    yield
+    monkeypatch.delenv("TOKENIZERS_PARALLELISM", raising=False)
 
 MAX_MODEL_LEN = 1024
 

--- a/tests/models/decoder_only/vision_language/test_models.py
+++ b/tests/models/decoder_only/vision_language/test_models.py
@@ -29,8 +29,13 @@ from .vlm_utils.types import (CustomTestOptions, ExpandableVLMTestArgs,
 # ROCm Triton FA can run into shared memory issues with these models,
 # use other backends in the meantime
 # FIXME (mattwong, gshtrasb, hongxiayan)
-if current_platform.is_rocm():
-    os.environ["VLLM_USE_TRITON_FLASH_ATTN"] = "0"
+@pytest.fixture(scope="module", autouse=True)
+# Sets VLLM_USE_TRITON_FLASH_ATTN = 0 for all the tests in this file
+def disable_triton_flash_attn_if_rocm(monkeypatch):
+    if current_platform.is_rocm():
+        monkeypatch.setenv("VLLM_USE_TRITON_FLASH_ATTN", "0")
+    yield
+    monkeypatch.delenv("VLLM_USE_TRITON_FLASH_ATTN", raising=False)
 
 # yapf: disable
 COMMON_BROADCAST_SETTINGS = {

--- a/tests/models/decoder_only/vision_language/test_phi3v.py
+++ b/tests/models/decoder_only/vision_language/test_phi3v.py
@@ -50,8 +50,13 @@ target_dtype = "half"
 # ROCm Triton FA can run into shared memory issues with these models,
 # use other backends in the meantime
 # FIXME (mattwong, gshtrasb, hongxiayan)
-if current_platform.is_rocm():
-    os.environ["VLLM_USE_TRITON_FLASH_ATTN"] = "0"
+@pytest.fixture(scope="module", autouse=True)
+# Sets VLLM_USE_TRITON_FLASH_ATTN = 0 for all the tests in this file
+def disable_triton_flash_attn_if_rocm(monkeypatch):
+    if current_platform.is_rocm():
+        monkeypatch.setenv("VLLM_USE_TRITON_FLASH_ATTN", "0")
+    yield
+    monkeypatch.delenv("VLLM_USE_TRITON_FLASH_ATTN", raising=False)
 
 
 def run_test(

--- a/tests/models/test_oot_registration.py
+++ b/tests/models/test_oot_registration.py
@@ -11,8 +11,8 @@ from ..utils import fork_new_process_for_each_test
 
 
 @fork_new_process_for_each_test
-def test_plugin(dummy_opt_path):
-    os.environ["VLLM_PLUGINS"] = ""
+def test_plugin(monkeypatch, dummy_opt_path):
+    monkeypatch.setenv("VLLM_PLUGINS", "")
     with pytest.raises(Exception) as excinfo:
         LLM(model=dummy_opt_path, load_format="dummy")
     error_msg = "has no vLLM implementation and " \
@@ -21,8 +21,8 @@ def test_plugin(dummy_opt_path):
 
 
 @fork_new_process_for_each_test
-def test_oot_registration_text_generation(dummy_opt_path):
-    os.environ["VLLM_PLUGINS"] = "register_dummy_model"
+def test_oot_registration_text_generation(monkeypatch, dummy_opt_path):
+    monkeypatch.setenv("VLLM_PLUGINS", "register_dummy_model")
     prompts = ["Hello, my name is", "The text does not matter"]
     sampling_params = SamplingParams(temperature=0)
     llm = LLM(model=dummy_opt_path, load_format="dummy")
@@ -37,8 +37,8 @@ def test_oot_registration_text_generation(dummy_opt_path):
 
 
 @fork_new_process_for_each_test
-def test_oot_registration_embedding(dummy_gemma2_embedding_path):
-    os.environ["VLLM_PLUGINS"] = "register_dummy_model"
+def test_oot_registration_embedding(monkeypatch, dummy_gemma2_embedding_path):
+    monkeypatch.setenv("VLLM_PLUGINS", "register_dummy_model")
     prompts = ["Hello, my name is", "The text does not matter"]
     llm = LLM(model=dummy_gemma2_embedding_path, load_format="dummy")
     outputs = llm.embed(prompts)
@@ -51,8 +51,8 @@ image = ImageAsset("cherry_blossom").pil_image.convert("RGB")
 
 
 @fork_new_process_for_each_test
-def test_oot_registration_multimodal(dummy_llava_path):
-    os.environ["VLLM_PLUGINS"] = "register_dummy_model"
+def test_oot_registration_multimodal(monkeypatch, dummy_llava_path):
+    monkeypatch.setenv("VLLM_PLUGINS", "register_dummy_model")
     prompts = [{
         "prompt": "What's in the image?<image>",
         "multi_modal_data": {

--- a/tests/neuron/test_block_table.py
+++ b/tests/neuron/test_block_table.py
@@ -99,6 +99,7 @@ def ref_block_tables_transform(
 )
 @torch.inference_mode()
 def test_load_and_transform_block_tables(
+    monkeypatch,
     num_tiles,
     num_blocks_per_tile,
     q_head_per_kv_head,
@@ -113,7 +114,7 @@ def test_load_and_transform_block_tables(
         "--retry_failed_compilation",
     ]
     compiler_flags_str = " ".join(compiler_flags)
-    os.environ["NEURON_CC_FLAGS"] = compiler_flags_str
+    monkeypatch.setenv("NEURON_CC_FLAGS", compiler_flags_str)
 
     torch.manual_seed(10000)
     torch.set_printoptions(sci_mode=False)

--- a/tests/neuron/test_prefix_prefill.py
+++ b/tests/neuron/test_prefix_prefill.py
@@ -316,6 +316,7 @@ def get_active_block_tables(block_tables, query_lens, seq_lens, block_size,
 @pytest.mark.parametrize("mixed_precision", [True, False])
 @torch.inference_mode()
 def test_contexted_kv_attention(
+    monkeypatch,
     prefill_batch_size: int,
     decode_batch_size: int,
     num_heads: int,
@@ -341,7 +342,7 @@ def test_contexted_kv_attention(
         "--retry_failed_compilation",
     ]
     compiler_flags_str = " ".join(compiler_flags)
-    os.environ["NEURON_CC_FLAGS"] = compiler_flags_str
+    monkeypatch.setenv("NEURON_CC_FLAGS", compiler_flags_str)
 
     torch.manual_seed(0)
     torch.set_printoptions(sci_mode=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,8 +112,8 @@ def test_deprecate_kwargs_additional_message():
         dummy(old_arg=1)
 
 
-def test_get_open_port():
-    os.environ["VLLM_PORT"] = "5678"
+def test_get_open_port(monkeypatch):
+    monkeypatch.setenv("VLLM_PORT", "5678")
     # make sure we can get multiple ports, even if the env var is set
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s1:
         s1.bind(("localhost", get_open_port()))
@@ -121,7 +121,7 @@ def test_get_open_port():
             s2.bind(("localhost", get_open_port()))
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s3:
                 s3.bind(("localhost", get_open_port()))
-    os.environ.pop("VLLM_PORT")
+    monkeypatch.delenv("VLLM_PORT")
 
 
 # Tests for FlexibleArgumentParser

--- a/tests/tpu/test_custom_dispatcher.py
+++ b/tests/tpu/test_custom_dispatcher.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-
+import pytest
 from vllm.config import CompilationLevel
 
 from ..utils import compare_two_settings
@@ -9,7 +9,12 @@ from ..utils import compare_two_settings
 # --enforce-eager on TPU causes graph compilation
 # this times out default Health Check in the MQLLMEngine,
 # so we set the timeout here to 30s
-os.environ["VLLM_RPC_TIMEOUT"] = "30000"
+@pytest.fixture(scope="module", autouse=True)
+#All tests in this file to use VLLM_RPC_TIMEOUT = 30000
+def set_vllm_rpc_timeout(monkeypatch):
+    monkeypatch.setenv("VLLM_RPC_TIMEOUT", "30000")
+    yield
+    monkeypatch.delenv("VLLM_RPC_TIMEOUT", raising=False)
 
 
 def test_custom_dispatcher():

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -70,8 +70,8 @@ def trace_service():
     server.stop(None)
 
 
-def test_traces(trace_service):
-    os.environ[OTEL_EXPORTER_OTLP_TRACES_INSECURE] = "true"
+def test_traces(monkeypatch, trace_service):
+    monkeypatch.setenv(OTEL_EXPORTER_OTLP_TRACES_INSECURE, "true")
 
     sampling_params = SamplingParams(temperature=0.01,
                                      top_p=0.1,
@@ -135,8 +135,8 @@ def test_traces(trace_service):
     assert metrics.model_execute_time is None
 
 
-def test_traces_with_detailed_steps(trace_service):
-    os.environ[OTEL_EXPORTER_OTLP_TRACES_INSECURE] = "true"
+def test_traces_with_detailed_steps(monkeypatch, trace_service):
+    monkeypatch.setenv(OTEL_EXPORTER_OTLP_TRACES_INSECURE, "true")
 
     sampling_params = SamplingParams(temperature=0.01,
                                      top_p=0.1,


### PR DESCRIPTION
Convert all os.environ(xxx) to monkeypatch.setenv in test suite

FIXES #14499 
<!--- pyml disable-next-line no-emphasis-as-heading -->

