### PR TITLE
[#14109][bug] Fix Ray placement group allocation is not respecting env VLLM_RAY_PER_WORKER_GPUS (fractional gpu)

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import msgspec
 
+import vllm.envs as envs
 import vllm.platforms
 from vllm.config import ParallelConfig
 from vllm.executor.msgspec_utils import decode_hook, encode_hook
@@ -342,7 +343,7 @@ def initialize_ray_cluster(
                 device_str)
         # Create a new placement group
         placement_group_specs: List[Dict[str, float]] = ([{
-            device_str: 1.0
+            device_str: envs.VLLM_RAY_PER_WORKER_GPUS if device_str == "GPU" else 1.0
         } for _ in range(parallel_config.world_size)])
 
         # vLLM engine is also a worker to execute model with an accelerator,

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -352,11 +352,12 @@ def initialize_ray_cluster(
         current_ip = get_ip()
         current_node_id = ray.get_runtime_context().get_node_id()
         current_node_resource = available_resources_per_node()[current_node_id]
-        if current_node_resource.get(device_str, 0) < 1:
+        device_resource_threshold = envs.VLLM_RAY_PER_WORKER_GPUS if device_str == "GPU" else 1.0
+        if current_node_resource.get(device_str, 0) <= device_resource_threshold:
             raise ValueError(
                 f"Current node has no {device_str} available. "
                 f"{current_node_resource=}. vLLM engine cannot start without "
-                f"{device_str}. Make sure you have at least 1 {device_str} "
+                f"{device_str}. Make sure you have at least {device_resource_threshold} {device_str} "
                 f"available in a node {current_node_id=} {current_ip=}.")
         # This way, at least bundle is required to be created in a current
         # node.


### PR DESCRIPTION

FIX #14109 

## Context
In #14109, when we are trying to use fractional GPU with `VLLM_RAY_PER_WORKER_GPUS`, it raises error. Turns out in [ray_util.py](https://github.com/vllm-project/vllm/blob/main/vllm/executor/ray_utils.py), the placement group allocation is not respecting this env VAR. All resources are hardcoded to `1.0`.

## Fix
Before
```python
...

  # Create a new placement group
        placement_group_specs: List[Dict[str, float]] = ([{
            device_str: 1.0
        } for _ in range(parallel_config.world_size)])

...
```

we fix this to 

```python
...

    placement_group_specs: List[Dict[str, float]] = ([{
            device_str: envs.VLLM_RAY_PER_WORKER_GPUS if device_str == "GPU" else 1.0
        } for _ in range(parallel_config.world_size)])

...
```

Also this patch fixes the related resource check logic which directly raised the error in #14109 

## Test
In our use case, we use the fixed patch. And we successfully deploy two models on a 6-nodes ray cluster by sharing 6 GPUS.

The placement group will look like
```json
[
   {
      "placement_group_id":"9690865994bfbf3e57a8ea939c9502000000",
      "name":"",
      "bundles":{
         "0":{
            "node:172.31.29.53":0.001,
            "GPU":0.25
         },
         "1":{
            "GPU":0.25
         },
         "2":{
            "GPU":0.25
         },
         "3":{
            "GPU":0.25
         }
      },
      "bundles_to_node_id":{
         "0":"1a6fc73e7dcc2d22eade80e25f03b6996c6b67b7a9a5dbdccc842159",
         "1":"9ed96579935bdc329215181312a554e524ed4d4ed92eaaa78b66f089",
         "2":"e24954b814f89171393473826f50b2c21613c0a78fa731aa150f47ba",
         "3":"b081093cc50385d4f54171e3697fa554f7b13b4bdd03c9ead07d8b72"
      },
      "strategy":"PACK",
      "state":"CREATED",
      "stats":{
         "end_to_end_creation_latency_ms":4.287,
         "scheduling_latency_ms":4.19,
         "scheduling_attempt":1,
         "highest_retry_delay_ms":0.0,
         "scheduling_state":"FINISHED"
      }
   },
   {
      "placement_group_id":"43d9a119aba5fa10c12fcf5f5de102000000",
      "name":"",
      "bundles":{
         "0":{
            "node:172.31.16.112":0.001,
            "GPU":0.6000000238418579
         },
         "1":{
            "GPU":0.6000000238418579
         },
         "2":{
            "GPU":0.6000000238418579
         },
         "3":{
            "GPU":0.6000000238418579
         },
         "4":{
            "GPU":0.6000000238418579
         },
         "5":{
            "GPU":0.6000000238418579
         }
      },
      "bundles_to_node_id":{
         "0":"361135eb2b1c7f44cb7c845dd2d2a1e9ca4579e8c14dbe2cb54220d1",
         "1":"1a6fc73e7dcc2d22eade80e25f03b6996c6b67b7a9a5dbdccc842159",
         "2":"e24954b814f89171393473826f50b2c21613c0a78fa731aa150f47ba",
         "3":"9ed96579935bdc329215181312a554e524ed4d4ed92eaaa78b66f089",
         "4":"b081093cc50385d4f54171e3697fa554f7b13b4bdd03c9ead07d8b72",
         "5":"17a30cb471d30afc4d818df51fe4fe6d8925e03aeb3c651a24a624b3"
      },
      "strategy":"PACK",
      "state":"CREATED",
      "stats":{
         "end_to_end_creation_latency_ms":3.161,
         "scheduling_latency_ms":3.094,
         "scheduling_attempt":1,
         "highest_retry_delay_ms":0.0,
         "scheduling_state":"FINISHED"
      }
   }
]
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
