### PR TITLE
[Perf] support Eplb for deepseek v3

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1335,6 +1335,7 @@ class ParallelConfig:
     data_parallel_master_ip: str = "127.0.0.1"
     data_parallel_master_port: int = 29500  # Port of the data parallel master.
     enable_expert_parallel: bool = False  # Use EP instead of TP for MoE layers.
+    expert_map_path: Optional[str] = None  # Path to the expert map file.
 
     # Maximum number of multiple batches
     # when load model sequentially. To avoid RAM OOM when using tensor

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -115,6 +115,7 @@ class EngineArgs:
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
     enable_expert_parallel: bool = False
+    expert_map_path: Optional[str] = None
     max_parallel_loading_workers: Optional[int] = None
     block_size: Optional[int] = None
     enable_prefix_caching: Optional[bool] = None
@@ -449,6 +450,10 @@ class EngineArgs:
             action='store_true',
             help='Use expert parallelism instead of tensor parallelism '
             'for MoE layers.')
+        parser.add_argument(
+            '--expert-map-path',
+            action=str,
+            help='Path to expert map file.')
         parser.add_argument(
             '--max-parallel-loading-workers',
             type=int,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -452,7 +452,8 @@ class EngineArgs:
             'for MoE layers.')
         parser.add_argument(
             '--expert-map-path',
-            action=str,
+            type=str,
+            default=EngineArgs.expert_map_path,
             help='Path to expert map file.')
         parser.add_argument(
             '--max-parallel-loading-workers',

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1232,6 +1232,7 @@ class EngineArgs:
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
             enable_expert_parallel=self.enable_expert_parallel,
+            expert_map_path=self.expert_map_path,
             max_parallel_loading_workers=self.max_parallel_loading_workers,
             disable_custom_all_reduce=self.disable_custom_all_reduce,
             tokenizer_pool_config=TokenizerPoolConfig.create_config(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -450,11 +450,10 @@ class EngineArgs:
             action='store_true',
             help='Use expert parallelism instead of tensor parallelism '
             'for MoE layers.')
-        parser.add_argument(
-            '--expert-map-path',
-            type=str,
-            default=EngineArgs.expert_map_path,
-            help='Path to expert map file.')
+        parser.add_argument('--expert-map-path',
+                            type=str,
+                            default=EngineArgs.expert_map_path,
+                            help='Path to expert map file.')
         parser.add_argument(
             '--max-parallel-loading-workers',
             type=int,

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -311,7 +311,7 @@ def get_expert_map(
         ranks, expert_nums = layer_prior_expert_map.shape
         assert ep_size == ranks, "The size of the expert map does not match the number of experts."
         assert global_num_experts == expert_nums, "The size of the expert map does not match the number of experts."
-        expert_map = layer_prior_expert_map[ep_rank]
+        expert_map = layer_prior_expert_map[ep_rank].to(torch.cuda.current_device())
         local_num_experts = torch.sum(torch.ne(expert_map, -1)).item()
         return (local_num_experts, expert_map)
     else:

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -292,11 +292,11 @@ def determine_expert_map(
             torch.arange(0, local_num_experts, dtype=torch.int32)
     return (local_num_experts, expert_map)
 
+
 def get_expert_map(
-        ep_size: int, 
-        ep_rank: int,
-        global_num_experts: int,
-        layer_prior_expert_map: Optional[torch.Tensor]) -> Tuple[int, Optional[torch.Tensor]]:
+    ep_size: int, ep_rank: int, global_num_experts: int,
+    layer_prior_expert_map: Optional[torch.Tensor]
+) -> Tuple[int, Optional[torch.Tensor]]:
     """Get the expert map for the current rank.
 
     Args:
@@ -309,9 +309,11 @@ def get_expert_map(
     if layer_prior_expert_map is not None:
         # If a prior expert map is provided, use it.
         ranks, expert_nums = layer_prior_expert_map.shape
-        assert ep_size == ranks, "The size of the expert map does not match the number of experts."
-        assert global_num_experts == expert_nums, "The size of the expert map does not match the number of experts."
-        expert_map = layer_prior_expert_map[ep_rank].to(torch.cuda.current_device())
+        assert ep_size == ranks, "The expert ranks doesn't match ep_size."
+        assert global_num_experts == expert_nums, \
+            "The expert nums doesn't match global experts."
+        expert_map = layer_prior_expert_map[ep_rank].to(
+            torch.cuda.current_device())
         local_num_experts = torch.sum(torch.ne(expert_map, -1)).item()
         return (local_num_experts, expert_map)
     else:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -649,7 +649,8 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         self.config = config
         self.quant_config = quant_config
 
-        prior_expert_map = torch.load(config.expert_map_path)
+        prior_expert_map = torch.load(vllm_config.parallel_config.expert_map_path, map_location=torch.device('cpu'))
+        # prior_expert_map = torch.load("/data/zzd/EPLB/expert_map_lite_en.pth", map_location=torch.device('cpu'))
         self.model = DeepseekV2Model(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "model"),
                                      prior_expert_map=prior_expert_map)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -650,7 +650,6 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         self.quant_config = quant_config
 
         prior_expert_map = torch.load(vllm_config.parallel_config.expert_map_path, map_location=torch.device('cpu'))
-        # prior_expert_map = torch.load("/data/zzd/EPLB/expert_map_lite_en.pth", map_location=torch.device('cpu'))
         self.model = DeepseekV2Model(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "model"),
                                      prior_expert_map=prior_expert_map)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -649,7 +649,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         self.config = config
         self.quant_config = quant_config
 
-        prior_expert_map = torch.load("/data/zzd/EPLB/expert_weight_r1_en.pth")
+        prior_expert_map = torch.load("/data/zzd/EPLB/expert_map_r1_en.pth")
         self.model = DeepseekV2Model(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "model"),
                                      prior_expert_map=prior_expert_map)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -649,7 +649,7 @@ class DeepseekV2ForCausalLM(nn.Module, SupportsPP):
         self.config = config
         self.quant_config = quant_config
 
-        prior_expert_map = torch.load("/data/zzd/EPLB/expert_map_r1_en.pth")
+        prior_expert_map = torch.load(config.expert_map_path)
         self.model = DeepseekV2Model(vllm_config=vllm_config,
                                      prefix=maybe_prefix(prefix, "model"),
                                      prior_expert_map=prior_expert_map)


### PR DESCRIPTION
This PR is to integrate [EPLB](https://github.com/deepseek-ai/EPLB) into vllm, not just map experts according to ranks.
we can get prior expert map as following:
1. Select a dataset to  the model for inference, and count the frequency of all layers and all experts being selected, and get `weight`  of shape `[layers, experts]`.
2. use  [EPLB](https://github.com/deepseek-ai/EPLB)  to got the global optimal expert map according to `weight` and GPUs, and get prior expert map of shape `[layers, ranks, experts]` by
```
phy2log, log2phy, logcnt = eplb.rebalance_experts(weight_matrix, num_replicas, num_groups, num_nodes, num_gpus)
phy2log = phy2log.view(layers, num_gpus, -1)  # [layers, gpu_ranks, expert_per_gpu]
e_maps = torch.full((layers, num_gpus, num_replicas), -1, dtype=torch.int32)
for l in range(layers):
    for r in range(num_gpus):
        e_ids = phy2log[l,r]
        e_maps[l, r, e_ids] = torch.arange(num_replicas // num_gpus, dtype=torch.int32)
torch.save(e_maps, 'expert_map.pth')
```

3. using the prior expert map to load MoE model by 
```
vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat -tp 8 --enable-expert-parallel --trust-remote-code --expert-map-path /path/to/expert_map.pth
```


