### PR TITLE
[Bugfix][v1] fixed llava-hf/llava-1.5-7b-hf is broken on V1

### DIFF
--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -783,7 +783,9 @@ class LlavaForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
         if image_input is None:
             return None
         vision_embeddings = self._process_image_input(image_input)
-        if kwargs.get("v0_path", False):
+        if kwargs.get("v0_path", False) or \
+            image_input.get("feat_is_patch") is None or \
+                image_input.get("embed_is_patch") is None:
             return vision_embeddings
         else:
             nested_emb = [

--- a/vllm/model_executor/models/llava.py
+++ b/vllm/model_executor/models/llava.py
@@ -783,17 +783,19 @@ class LlavaForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
         if image_input is None:
             return None
         vision_embeddings = self._process_image_input(image_input)
+
         if kwargs.get("v0_path", False) or \
             image_input.get("feat_is_patch") is None or \
                 image_input.get("embed_is_patch") is None:
+            # The path is used for pixtral (V0 only) and llava (V0/V1)
             return vision_embeddings
-        else:
-            nested_emb = [
-                self._get_mm_embeds(*args) for args in zip(
-                    vision_embeddings, image_input["feat_is_patch"],
-                    image_input["num_crops"], image_input["embed_is_patch"])
-            ]
-            return flatten_2d_lists(nested_emb)
+
+        nested_emb = [
+            self._get_mm_embeds(*args) for args in zip(
+                vision_embeddings, image_input["feat_is_patch"],
+                image_input["num_crops"], image_input["embed_is_patch"])
+        ]
+        return flatten_2d_lists(nested_emb)
 
     def get_input_embeddings(
         self,


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/14523 
https://github.com/vllm-project/vllm/blob/5d802522a783ba31a150df80499a71acabd8009c/vllm/model_executor/models/llava.py#L386-L395

The root cause of the issue is that PR #14275 introduced additional parameters `feat_is_patch` and `embed_is_patch` for `PixtralHFMultiModalProcessor`, but these two parameters are not present in the `LlavaMultiModalProcessor`. 


https://github.com/vllm-project/vllm/blob/5d802522a783ba31a150df80499a71acabd8009c/vllm/model_executor/models/llava.py#L298-L310
