### PR TITLE
[BugFix][TritonMLA] Process weights after model loading for GGUF

### DIFF
--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -1330,11 +1330,14 @@ class GGUFModelLoader(BaseModelLoader):
                 local_model_path, gguf_weights_map):
             model_config.hf_config.update({"tie_word_embeddings": True})
 
+        target_device = torch.device(device_config.device)
         with set_default_torch_dtype(model_config.dtype):
-            with torch.device(device_config.device):
+            with target_device:
                 model = _initialize_model(vllm_config=vllm_config)
             model.load_weights(
                 self._get_weights_iterator(local_model_path, gguf_weights_map))
+
+            _process_weights_after_loading(model, model_config, target_device)
         return model
 
 


### PR DESCRIPTION
**Issue Description**
Observed the following error message when trying to deploy DeepSeek R1 Unsloth GGUF quantized model with MLA enabled on Triton MLA backend: 
```
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]   File "vllm/attention/layer.py", line 329, in unified_attention
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]     return self.impl.forward(self, query, key, value, kv_cache, attn_metadata)
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]   File "vllm/attention/backends/mla/common.py", line 1537, in forward
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]     decode_q_nope = self._q_proj_and_k_up_proj(decode_hs_or_q_c)
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]   File "vllm/attention/backends/mla/common.py", line 1089, in _q_proj_and_k_up_proj
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242]     if is_fp8(self.W_Q_UK):
ERROR 03-10 04:33:58 [multiproc_worker_utils.py:242] AttributeError: 'TritonMLAImpl' object has no attribute 'W_Q_UK'
```

**Fix**
It turns out that `W_Q_UK` never got initialized. To fix it, call `_process_weights_after_loading()` right after model loading to properly process the weight attributes.

**Local Verification**
With this PR, the mentioned error message cannot be reproduced anymore, and the DeepSeek GGUF model can be deployed successfully. 