### PR TITLE
[Misc] Correct deepseek-vl2 chat template

### DIFF
--- a/examples/template_deepseek_vl2.jinja
+++ b/examples/template_deepseek_vl2.jinja
@@ -12,12 +12,12 @@
     {%- endif -%}
 
     {%- if message['role'] == 'user' -%}
-        {{ '<|User|>: ' + message['content'] + '\n' }}
+        {{ '<|User|>: ' + message['content'] + '\n\n' }}
     {%- elif message['role'] == 'assistant' -%}
-        {{ '<|Assistant|>: ' + message['content'] + eos_token + '\n' }}
+        {{ '<|Assistant|>: ' + message['content'] + eos_token + '\n\n' }}
     {%- endif -%}
 {%- endfor -%}
 
 {%- if add_generation_prompt -%}
     {{ '<|Assistant|>: ' }}
-{% endif %}
+{%- endif -%}


### PR DESCRIPTION

FIX #14421

Correct the deepseek-vl2 template
- Deepseek-vl2 template use two lb as separator: https://github.com/deepseek-ai/DeepSeek-VL2/blob/ef9f91e2b6426536b83294c11742c27be66361b1/deepseek_vl2/models/conversation.py#L219
- Remove lb at the end of generation prompt.

<!--- pyml disable-next-line no-emphasis-as-heading -->
