### PR TITLE
Fix typo in benchmark_serving_structured_output.py

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -989,12 +989,11 @@ if __name__ == "__main__":
                         type=float,
                         default=1.0,
                         help="Ratio of Structured Outputs requests")
-    parser.add_argument(
-        "--structured-output-backend",
-        type=str,
-        choices=["outlines", "lm-format-enforcer", "xgrammar", "json-unique"],
-        default="xgrammar",
-        help="Backend to use for structured outputs")
+    parser.add_argument("--structured-output-backend",
+                        type=str,
+                        choices=["outlines", "lm-format-enforcer", "xgrammar"],
+                        default="xgrammar",
+                        help="Backend to use for structured outputs")
 
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
I accidentally put the new `json-unique` dataset option in the choices
for the backend. It shouldn't be there. I was probably quickly searching
for "xgrammar" for where to add it since there is a dataset called
`xgrammar_bench`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
