### PR TITLE
benchmarks: simplify test jsonschema

### DIFF
--- a/benchmarks/structured_schemas/structured_schema_1.json
+++ b/benchmarks/structured_schemas/structured_schema_1.json
@@ -1,25 +1,11 @@
 {
-  "type": "array",
-  "items": {
     "type": "object",
     "properties": {
       "name": { "type": "string" },
-      "race": { "type": "string" },
-      "class": { "type": "string" },
-      "level": { "type": "integer" },
-      "background": { "type": "string" },
-      "alignment": { "type": "string" },
-      "backstory": { "type": "string" }
+      "email": { "type": "string" }
     },
     "required": [
       "name",
-      "race",
-      "class",
-      "level",
-      "background",
-      "alignment",
-      "backstory"
+      "email"
     ]
-  }
 }
-

--- a/benchmarks/structured_schemas/structured_schema_1.json
+++ b/benchmarks/structured_schemas/structured_schema_1.json
@@ -2,7 +2,15 @@
     "type": "object",
     "properties": {
       "name": { "type": "string" },
-      "email": { "type": "string" }
+      "email": { "type": "string" },
+      "street": { "type": "string" },
+      "city": { "type": "string" },
+      "state": { "type": "string" },
+      "zip": { "type": "string" },
+      "phone": { "type": "string" },
+      "website": { "type": "string" },
+      "company": { "type": "string" },
+      "age": { "type": "integer" }
     },
     "required": [
       "name",


### PR DESCRIPTION
benchmarks: Simplify test jsonschema

PR #13288 changed this schema from an object to an array. The real issue
was that the original schema used features unsupported by xgrammar.
However, by switching to an array, I saw the failure rate go up a lot in
my benchmark runs. This is because as an unbounded array, we would often
cut off generation in the middle of a json response, so it failed to be
parsed.

This change replaces it with a trivial jsonschema. This should be
effective in focusing benchmarks more on the overhead vs the generation.

The change also broke the `json-unique` option, since the code for
inserting the unique property assumbed the top level was an object. This
change makes `json-unique` work again.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
