### PR TITLE
[Minor] Update the tqdm bar for parallel sampling

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -316,10 +316,8 @@ def main(args: argparse.Namespace):
         raise ValueError(f"Unknown backend: {args.backend}")
     total_num_tokens = sum(request.prompt_len + request.expected_output_len
                            for request in requests)
-    total_num_tokens *= args.n
     total_output_tokens = sum(request.expected_output_len
                               for request in requests)
-    total_output_tokens *= args.n
     if is_multi_modal:
         print("\033[91mWARNING\033[0m: Multi-modal request detected. The "
               "following metrics are not accurate because image tokens are not"

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -464,8 +464,10 @@ def main(args: argparse.Namespace):
         raise ValueError(f"Unknown backend: {args.backend}")
     total_num_tokens = sum(request.prompt_len + request.expected_output_len
                            for request in requests)
+    total_num_tokens *= args.n
     total_output_tokens = sum(request.expected_output_len
                               for request in requests)
+    total_output_tokens *= args.n
     if is_multi_modal:
         print("\033[91mWARNING\033[0m: Multi-modal request detected. The "
               "following metrics are not accurate because image tokens are not"

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1382,10 +1382,11 @@ class LLM:
                 if output.finished:
                     outputs.append(output)
                     if use_tqdm:
+                        n = len(output.outputs)
                         if isinstance(output, RequestOutput):
                             # Calculate tokens only for RequestOutput
                             assert output.prompt_token_ids is not None
-                            total_in_toks += len(output.prompt_token_ids)
+                            total_in_toks += len(output.prompt_token_ids) * n
                             in_spd = total_in_toks / pbar.format_dict["elapsed"]
                             total_out_toks += sum(
                                 len(stp.token_ids) for stp in output.outputs)
@@ -1394,7 +1395,7 @@ class LLM:
                             pbar.postfix = (
                                 f"est. speed input: {in_spd:.2f} toks/s, "
                                 f"output: {out_spd:.2f} toks/s")
-                        pbar.update(1)
+                        pbar.update(n)
 
         if use_tqdm:
             pbar.close()


### PR DESCRIPTION
This PR changes the logic to calculate the number of processed input tokens when `n` > 1.
Before: `total_in_toks += len(output.prompt_token_ids)`
After: `total_in_toks += len(output.prompt_token_ids) * n`
