### PR TITLE
[Bugfix][TPU][V1] Disable `StructuredOutputManager` import on TPU

### DIFF
--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -10,7 +10,6 @@ from typing import Optional, Union
 from vllm.config import (CacheConfig, LoRAConfig, ModelConfig, SchedulerConfig,
                          SpeculativeConfig)
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
                                                 compute_encoder_budget)
 from vllm.v1.core.kv_cache_manager import KVCacheManager
@@ -21,19 +20,7 @@ from vllm.v1.engine import (EngineCoreEvent, EngineCoreEventType,
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-
-if not current_platform.is_tpu():
-    from vllm.v1.structured_output import StructuredOutputManager
-else:
-
-    class StructuredOutputManager:
-
-        def __init__(self, *args, **kwargs):
-            pass
-
-        def grammar_bitmask(self, *args, **kwargs):
-            pass
-
+from vllm.v1.structured_output import StructuredOutputManager
 
 logger = init_logger(__name__)
 

--- a/vllm/v1/core/scheduler.py
+++ b/vllm/v1/core/scheduler.py
@@ -10,6 +10,7 @@ from typing import Optional, Union
 from vllm.config import (CacheConfig, LoRAConfig, ModelConfig, SchedulerConfig,
                          SpeculativeConfig)
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
                                                 compute_encoder_budget)
 from vllm.v1.core.kv_cache_manager import KVCacheManager
@@ -20,7 +21,19 @@ from vllm.v1.engine import (EngineCoreEvent, EngineCoreEventType,
 from vllm.v1.metrics.stats import SchedulerStats
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.structured_output import StructuredOutputManager
+
+if not current_platform.is_tpu():
+    from vllm.v1.structured_output import StructuredOutputManager
+else:
+
+    class StructuredOutputManager:
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def grammar_bitmask(self, *args, **kwargs):
+            pass
+
 
 logger = init_logger(__name__)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -17,6 +17,7 @@ import zmq.asyncio
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
+from vllm.platforms import current_platform
 from vllm.transformers_utils.config import (
     maybe_register_config_serialize_by_value)
 from vllm.utils import get_exception_traceback, zmq_socket_ctx
@@ -31,6 +32,18 @@ from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
 from vllm.version import __version__ as VLLM_VERSION
+if not current_platform.is_tpu():
+    from vllm.v1.structured_output import StructuredOutputManager
+else:
+
+    class StructuredOutputManager:
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __getattr__(self, name):
+            return lambda *args, **kwargs: None
+
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
V1 Engine on TPU is currently broken as `StructuredOutputManager` appears to have a hard dependency on `triton`, failing on server startup with:

```
INFO 03-10 17:21:34 [core.py:120] init engine (profile, create kv cache, warmup model) took 49.99 seconds
ERROR 03-10 17:21:34 [core.py:324] EngineCore hit an exception: Traceback (most recent call last):
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/v1/engine/core.py", line 316, in run_engine_core
ERROR 03-10 17:21:34 [core.py:324]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 03-10 17:21:34 [core.py:324]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/v1/engine/core.py", line 271, in __init__
ERROR 03-10 17:21:34 [core.py:324]     super().__init__(vllm_config, executor_class, log_stats)
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/v1/engine/core.py", line 65, in __init__
ERROR 03-10 17:21:34 [core.py:324]     self.structured_output_manager = StructuredOutputManager(vllm_config)
ERROR 03-10 17:21:34 [core.py:324]                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/v1/structured_output/__init__.py", line 42, in __init__
ERROR 03-10 17:21:34 [core.py:324]     tokenizer_info = xgr.TokenizerInfo.from_huggingface(
ERROR 03-10 17:21:34 [core.py:324]                      ^^^^^^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/utils.py", line 2357, in __getattr__
ERROR 03-10 17:21:34 [core.py:324]     self._module = self._load()
ERROR 03-10 17:21:34 [core.py:324]                    ^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/utils.py", line 2347, in _load
ERROR 03-10 17:21:34 [core.py:324]     raise err from None
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/vllm/utils.py", line 2341, in _load
ERROR 03-10 17:21:34 [core.py:324]     module = importlib.import_module(self.__name__)
ERROR 03-10 17:21:34 [core.py:324]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/.local/share/uv/python/cpython-3.11.11-linux-x86_64-gnu/lib/python3.11/importlib/__init__.py", line 126, in import_module
ERROR 03-10 17:21:34 [core.py:324]     return _bootstrap._gcd_import(name[level:], package, level)
ERROR 03-10 17:21:34 [core.py:324]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
ERROR 03-10 17:21:34 [core.py:324]   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/.venv/lib/python3.11/site-packages/xgrammar/__init__.py", line 1, in <module>
ERROR 03-10 17:21:34 [core.py:324]     from . import testing
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/.venv/lib/python3.11/site-packages/xgrammar/testing.py", line 11, in <module>
ERROR 03-10 17:21:34 [core.py:324]     from .matcher import GrammarMatcher, bitmask_dtype, get_bitmask_shape
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/.venv/lib/python3.11/site-packages/xgrammar/matcher.py", line 11, in <module>
ERROR 03-10 17:21:34 [core.py:324]     from .kernels import apply_token_bitmask_inplace_cpu, apply_token_bitmask_inplace_triton
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/.venv/lib/python3.11/site-packages/xgrammar/kernels/__init__.py", line 4, in <module>
ERROR 03-10 17:21:34 [core.py:324]     from .apply_token_bitmask_inplace_triton import apply_token_bitmask_inplace_triton
ERROR 03-10 17:21:34 [core.py:324]   File "/home/nick/vllm/.venv/lib/python3.11/site-packages/xgrammar/kernels/apply_token_bitmask_inplace_triton.py", line 4, in <module>
ERROR 03-10 17:21:34 [core.py:324]     import triton
ERROR 03-10 17:21:34 [core.py:324] ModuleNotFoundError: No module named 'triton'
``` 

Open to any way to more gracefully solve this (quickly), especially with an impl that makes mypy happy (current one does not). 