### PR TITLE
[V1] Prevent xgrammar from breaking TPU support

### DIFF
--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -4,6 +4,7 @@ import time
 from collections.abc import Mapping
 from typing import Optional, Union
 
+import vllm.platforms
 from vllm.config import VllmConfig
 from vllm.inputs import (INPUT_REGISTRY, InputRegistry, ProcessorInputs,
                          PromptType, SingletonInputsAdapter)
@@ -133,6 +134,9 @@ class Processor:
         if self.vllm_config.speculative_config:
             raise ValueError("Structured output is not supported with "
                              "speculative decoding.")
+        if vllm.platforms.current_platform.is_tpu():
+            raise ValueError("Structured output is not supported on TPU.")
+
         validate_structured_output_request(params)
 
     def process_inputs(


### PR DESCRIPTION
This does a couple of things:

1. Defer initializing the grammar bitmask until the first time it is needed
   instead of at engine creation time. For environments where structured
   output is not used, this will prevent xgrammar from ever being imported.

2. Cleanly reject structured output requests for TPU since
   that is not expected to work right now.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
