### PR TITLE
[WIP][V1][Structured Output] Enable structured output test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -202,6 +202,7 @@ steps:
     # split the test to avoid interference
     - VLLM_USE_V1=1 pytest -v -s v1/core
     - VLLM_USE_V1=1 pytest -v -s v1/engine
+    - VLLM_USE_V1=1 pytest -v -s v1/entrypoints/llm
     - VLLM_USE_V1=1 pytest -v -s v1/sample
     - VLLM_USE_V1=1 pytest -v -s v1/worker
     - VLLM_USE_V1=1 pytest -v -s v1/structured_output


### PR DESCRIPTION
See https://github.com/vllm-project/vllm/pull/14512#issuecomment-2711172058

Enable `tests/v1/entrypoints/llm/test_struct_output_generate.py` in CI.

WIP while we debug why this somethimes fails with:

```
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```

The failure can be reproduced in some environments with:

```
VLLM_USE_V1=1 pytest -s -v 'tests/v1/entrypoints/llm/test_struct_output_generate.py::test_guided_grammar_ebnf[xgrammar]' 'tests/v1/entrypoints/llm/test_struct_output_generate.py::test_guided_grammar_lark[xgrammar]'
```
