### PR TITLE
[V1][PP] Do not block engine core when no requests to schedule

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -205,23 +205,22 @@ class EngineCore:
                 self.batch_queue.put_nowait(
                     (future, scheduler_output))  # type: ignore
 
-        # If all requests are scheduled or the job queue is full,
+                # Successfully scheduled a new batch. Immediately return without
+                # checking the job queue for result.
+                return None
+
+        assert (scheduler_output is not None
+                and scheduler_output.total_num_scheduled_tokens > 0)
+
+        # If no more requests can be scheduled and the job queue is not empty,
         # block until the first batch in the job queue is finished.
-        if (scheduler_output is None
-                or scheduler_output.total_num_scheduled_tokens == 0):
-            try:
-                future, scheduler_output = self.batch_queue.get(
-                    timeout=POLLING_TIMEOUT_S)
-                # Blocking until the first result is available.
-                model_output = future.result()
-                self.batch_queue.task_done()
-                engine_core_outputs = self.scheduler.update_from_output(
-                    scheduler_output, model_output)
-            except queue.Empty:
-                # If the queue is empty (timeout at .get), return
-                # an empty EngineCoreOutputs for logging.
-                engine_core_outputs = EngineCoreOutputs(
-                    outputs=[], scheduler_stats=self.scheduler.make_stats())
+        if not self.batch_queue.empty():
+            future, scheduler_output = self.batch_queue.get_nowait()
+            # Blocking until the first result is available.
+            model_output = future.result()
+            self.batch_queue.task_done()
+            engine_core_outputs = self.scheduler.update_from_output(
+                scheduler_output, model_output)
 
         return engine_core_outputs
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -205,16 +205,12 @@ class EngineCore:
                 self.batch_queue.put_nowait(
                     (future, scheduler_output))  # type: ignore
 
-                # Successfully scheduled a new batch. Immediately return without
-                # checking the job queue for result.
-                return None
-
-        assert (scheduler_output is not None
-                and scheduler_output.total_num_scheduled_tokens > 0)
+        scheduled_batch = (scheduler_output is not None
+                           and scheduler_output.total_num_scheduled_tokens > 0)
 
         # If no more requests can be scheduled and the job queue is not empty,
         # block until the first batch in the job queue is finished.
-        if not self.batch_queue.empty():
+        if not scheduled_batch and not self.batch_queue.empty():
             future, scheduler_output = self.batch_queue.get_nowait()
             # Blocking until the first result is available.
             model_output = future.result()


### PR DESCRIPTION
The current engine step with batch queue blocks the busy loop for `POLLING_TIMEOUT_S` when the batch queue is empty. This results in unstable and possibly longer TTFT when the first request comes in. This PR solves the issue.

* Serving command on L4 GPUs (with and without VLLM_USE_V1=1
```
VLLM_USE_V1=1 vllm serve unsloth/Llama-3.1-8B-Instruct \
--no-enable-prefix-caching \
--distributed-executor-backend="ray" \
--max-model-len=8192 \
--pipeline-parallel-size=2
```

* Benchmark command
```
python benchmarks/benchmark_serving.py \
    --backend vllm \
    --model unsloth/Llama-3.1-8B-Instruct \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json \
    --request-rate 2 \
    --num-prompts 200
```

V0
```
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  143.01
Total input tokens:                      42659
Total generated tokens:                  43128
Request throughput (req/s):              1.40
Output token throughput (tok/s):         301.57
Total Token throughput (tok/s):          599.86
---------------Time to First Token----------------
Mean TTFT (ms):                          157.58
Median TTFT (ms):                        150.50
P99 TTFT (ms):                           289.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          94.65
Median TPOT (ms):                        96.47
P99 TPOT (ms):                           115.44
---------------Inter-token Latency----------------
Mean ITL (ms):                           93.56
Median ITL (ms):                         86.70
P99 ITL (ms):                            277.66
==================================================
```

V1 (main)
```
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  138.58
Total input tokens:                      42659
Total generated tokens:                  43325
Request throughput (req/s):              1.44
Output token throughput (tok/s):         312.63
Total Token throughput (tok/s):          620.45
---------------Time to First Token----------------
Mean TTFT (ms):                          201.24
Median TTFT (ms):                        151.40
P99 TTFT (ms):                           1611.02
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          80.32
Median TPOT (ms):                        81.41
P99 TPOT (ms):                           92.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.94
Median ITL (ms):                         76.87
P99 ITL (ms):                            202.60
==================================================
```

V1 (this PR)
```
============ Serving Benchmark Result ============
Successful requests:                     200
Benchmark duration (s):                  138.82
Total input tokens:                      42659
Total generated tokens:                  43463
Request throughput (req/s):              1.44
Output token throughput (tok/s):         313.10
Total Token throughput (tok/s):          620.40
---------------Time to First Token----------------
Mean TTFT (ms):                          159.05
Median TTFT (ms):                        149.20
P99 TTFT (ms):                           288.27
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          80.24
Median TPOT (ms):                        81.46
P99 TPOT (ms):                           93.69
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.99
Median ITL (ms):                         76.96
P99 ITL (ms):                            205.92
==================================================
```

cc @ruisearch42 