### PR TITLE
[V1][TPU] Pad the block_table.shape[1] so the ragged paged attention can handle correctly

### DIFF
--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -145,13 +145,6 @@ class TPUModelRunner:
             (self.max_num_tokens, padded_max_num_blocks_per_req),
             dtype=self.input_batch.block_table.get_cpu_tensor().dtype,
             device="cpu")
-        # page_indices: [max_num_seqs, pages_per_seq],
-        # pages_per_seq=9, NUM_KV_PAGES_PER_BLOCK=4
-        # 4, 4, 4: 
-        # 4, 4, 1: 9, -1, int.max, _
-        #   
-        # pages_per_seq%NUM_KV_PAGES_PER_BLOCK==0
-
 
         self.query_start_loc_cpu = torch.zeros(self.max_num_tokens + 1,
                                                dtype=torch.int32,


### PR DESCRIPTION
We uncovered an ragged paged attention constraint that will cause trouble if it is not handle properly. The kernel assumes that block_table.shape[1]%NUM_KV_PAGES_PER_BLOCK==0. If this constraint is violated, there may be out-of-bound issue and the kernel will crash.

While we are fixing the kernel internally, we want to fix the vLLM in the interim so that our vLLM users won't see the error. Once the kernel is fixed, we can safely revert this PR.

Test plan:
1. VLLM_USE_V1=1 python vllm/examples/offline_inference/tpu.py  (add `max_model_len=64` in the LLM constructor)
2. VLLM_USE_V1=1 pytest -s -v vllm/tests/entrypoints/llm/test_accuracy.py::test_lm_eval_accuracy_v1_engine 2>&1 | tee out.txt
3.
```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.1-8B-Instruct --disable-log-requests --port 8003 --gpu-memory-utilization 0.95 --max-num-batched-tokens 8192 --tensor-parallel-size 1 --max-model-len 2048 &
python3 benchmark_serving.py --model meta-llama/Llama-3.1-8B-Instruct     --dataset-name sonnet     --dataset-path sonnet_4x.txt     --num-prompts 1000     --sonnet-input-len 2000     --sonnet-output-len 128     --port 8003
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
