### PR TITLE
[V1] Remove cache from StructuredOutputManager

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -137,7 +137,7 @@ class EngineCore:
         req = Request.from_engine_core_request(request)
         if req.use_structured_output:
             # Start grammar compilation asynchronously
-            self.structured_output_manager.populate_cache(req)
+            self.structured_output_manager.grammar_init(req)
 
         self.scheduler.add_request(req)
 


### PR DESCRIPTION
This change simplifies the code in StrucutredOutputManager by removing
the cache. It turns out this is not necessary since xgrammar does its
own caching. This simplification is a nice prerequisite to simplify
things a bit before refactoring this further to support multiple
backends.

Signed-off-by: Russell Bryant <rbryant@redhat.com>

---

![image](https://github.com/user-attachments/assets/fbcecb02-e4cd-4b57-9846-f791f3ede5e1)
