### PR TITLE
[Bugfix] Missing thumbnail from NVLM-D processor

### DIFF
--- a/vllm/model_executor/models/nvlm_d.py
+++ b/vllm/model_executor/models/nvlm_d.py
@@ -45,7 +45,7 @@ class NVLMProcessor(BaseInternVLProcessor):
             raise NotImplementedError("Embedding inputs are not supported")
 
         tile_pos_identifiers = [f"<tile_{i}>" for i in range(1, num_patches)]
-        if self.use_thumbnail and num_patches != 1:
+        if self.use_thumbnail:
             tile_pos_identifiers += ["<tile_global_thumbnail>"]
 
         context_size = feature_size // num_patches


### PR DESCRIPTION
If num_patches evaluate to 1 for the input image prompt, the existing code does not generate any image token leading to the error "Unable to allocate 256 multimodal tokens to 0 placeholders". For images of particular dimensions eg. 220x229 or 200x229, I received this error. 

The code currently breaks the input image prompt into multiple images by cropping certain parts of the image. It then appends all these cropped images plus a thumbnail image which is the resized version of the original image into a list. The number of elements in this list is dependent on the num_patches variable which is calculated based on the size of the original image. 

If the num_patches variable is 1, then the code currently does not crop the image and also doesn't add the thumbnail image, therefore adding 0 image placeholders. Therefore, to consider the thumbnail image, which is the original image when num_patches==1 we need to remove the condition num_patches != 1.


To reproduce the bug you can try giving a prompt with this image (https://github.com/user-attachments/assets/7cd2df26-c765-43d8-bab2-9783d33c792f). 
