### PR TITLE
Allow dynamic loading of LoRA adapters in a cache dir

### DIFF
--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -153,6 +153,13 @@ curl -X POST http://localhost:8000/v1/unload_lora_adapter \
 }'
 ```
 
+## Dynamically load LoRA Adapters from a directory
+
+vLLM also supports setting a local directory to check for cached LoRA adapters. While dynamic LoRA is enabled, set
+`--lora-cache-dir {path}`. When vLLM receives a request for a LoRA adapter `foobar` that it doesn't recognize, it
+will check `path/foobar` for that adapter, load the adapter if able, and then service the request using that adapter.
+Thereafter the adapter will be available for use by incoming requests as normal.
+
 ## New format for `--lora-modules`
 
 In the previous version, users would provide LoRA modules via the following format, either as a key-value pair or in JSON format. For example:

--- a/tests/entrypoints/openai/conftest.py
+++ b/tests/entrypoints/openai/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def adapter_cache(request, tmpdir_factory):
+    # Create dir that mimics the structure of the adapter cache
+    adapter_cache = tmpdir_factory.mktemp(
+        request.module.__name__) / "adapter_cache"
+    return adapter_cache

--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -330,6 +330,7 @@ async def main(args):
         model_config,
         openai_serving_models,
         args.response_role,
+        lora_cache_dir=None,
         request_logger=request_logger,
         chat_template=None,
         chat_template_content_format="auto",
@@ -339,6 +340,7 @@ async def main(args):
         engine,
         model_config,
         openai_serving_models,
+        lora_cache_dir=None,
         request_logger=request_logger,
         chat_template=None,
         chat_template_content_format="auto",
@@ -347,6 +349,7 @@ async def main(args):
         engine,
         model_config,
         openai_serving_models,
+        lora_cache_dir=None,
         request_logger=request_logger,
     ) if model_config.task == "score" else None)
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -59,10 +59,12 @@ class OpenAIServingChat(OpenAIServing):
         enable_auto_tools: bool = False,
         tool_parser: Optional[str] = None,
         enable_prompt_tokens_details: bool = False,
+        lora_cache_dir: Optional[str] = None,
     ) -> None:
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger,
                          return_tokens_as_token_ids=return_tokens_as_token_ids)
 
@@ -142,7 +144,7 @@ class OpenAIServingChat(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             model_name = self._get_model_name(request.model, lora_request)
 

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -46,11 +46,13 @@ class OpenAIServingCompletion(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
+        lora_cache_dir: Optional[str] = None,
         return_tokens_as_token_ids: bool = False,
     ):
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger,
                          return_tokens_as_token_ids=return_tokens_as_token_ids)
         self.default_sampling_params = (
@@ -101,7 +103,7 @@ class OpenAIServingCompletion(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             tokenizer = await self.engine_client.get_tokenizer(lora_request)
 

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -55,10 +55,12 @@ class OpenAIServingEmbedding(OpenAIServing):
         request_logger: Optional[RequestLogger],
         chat_template: Optional[str],
         chat_template_content_format: ChatTemplateContentFormatOption,
+        lora_cache_dir: Optional[str] = None,
     ) -> None:
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger)
 
         self.chat_template = chat_template
@@ -103,7 +105,7 @@ class OpenAIServingEmbedding(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             tokenizer = await self.engine_client.get_tokenizer(lora_request)
 

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -54,10 +54,12 @@ class OpenAIServingPooling(OpenAIServing):
         request_logger: Optional[RequestLogger],
         chat_template: Optional[str],
         chat_template_content_format: ChatTemplateContentFormatOption,
+        lora_cache_dir: Optional[str] = None,
     ) -> None:
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger)
 
         self.chat_template = chat_template
@@ -100,7 +102,7 @@ class OpenAIServingPooling(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             tokenizer = await self.engine_client.get_tokenizer(lora_request)
 

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -40,10 +40,12 @@ class ServingScores(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
+        lora_cache_dir: Optional[str] = None,
     ) -> None:
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger)
 
     async def _embedding_score(
@@ -239,7 +241,7 @@ class ServingScores(OpenAIServing):
         (
             lora_request,
             prompt_adapter_request,
-        ) = self._maybe_get_adapters(request)
+        ) = await self._maybe_get_adapters(request)
 
         if prompt_adapter_request is not None:
             raise NotImplementedError("Prompt adapter is not supported "

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -36,10 +36,12 @@ class OpenAIServingTokenization(OpenAIServing):
         request_logger: Optional[RequestLogger],
         chat_template: Optional[str],
         chat_template_content_format: ChatTemplateContentFormatOption,
+        lora_cache_dir: Optional[str] = None,
     ) -> None:
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger)
 
         self.chat_template = chat_template
@@ -60,7 +62,7 @@ class OpenAIServingTokenization(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             tokenizer = await self.engine_client.get_tokenizer(lora_request)
 
@@ -124,7 +126,7 @@ class OpenAIServingTokenization(OpenAIServing):
         (
             lora_request,
             prompt_adapter_request,
-        ) = self._maybe_get_adapters(request)
+        ) = await self._maybe_get_adapters(request)
 
         tokenizer = await self.engine_client.get_tokenizer(lora_request)
 

--- a/vllm/entrypoints/openai/serving_transcription.py
+++ b/vllm/entrypoints/openai/serving_transcription.py
@@ -153,11 +153,13 @@ class OpenAIServingTranscription(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: Optional[RequestLogger],
+        lora_cache_dir: Optional[str] = None,
         return_tokens_as_token_ids: bool = False,
     ):
         super().__init__(engine_client=engine_client,
                          model_config=model_config,
                          models=models,
+                         lora_cache_dir=lora_cache_dir,
                          request_logger=request_logger,
                          return_tokens_as_token_ids=return_tokens_as_token_ids)
 
@@ -257,7 +259,7 @@ class OpenAIServingTranscription(OpenAIServing):
             (
                 lora_request,
                 prompt_adapter_request,
-            ) = self._maybe_get_adapters(request)
+            ) = await self._maybe_get_adapters(request)
 
             if lora_request:
                 return self.create_error_response(


### PR DESCRIPTION
FIX #12174 

Per the discussion in #12174, this PR implements a simple in-place solution that doesn't depend on external infrastructure other than disk. Allows VLLM to be configured with the location of a directory that LORA adapters might be present in. When receiving a request for a LORA adapter that isn't recognized, check if it is in the directory under a location that matches the name of the model, i.e. `VLLM_ADAPATER_CACHE/model_name`. If found, load the model and continue as normal.

Note this implementation only does this for LORA adapters, but it would be easy to extend to other model types.
