### PR TITLE
[Perf] Optimize Qwen2/2.5-VL ViT tensor generating performance

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -47,3 +47,5 @@ opentelemetry-sdk>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-api>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-exporter-otlp>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0  # vllm.tracing
+numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding & Qwen2/2.5-VL
+numba == 0.61.2; python_version > '3.9'

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,9 +1,6 @@
 # Common dependencies
 -r common.txt
 
-numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
-numba == 0.61.2; python_version > '3.9'
-
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.43.0, !=2.44.* # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch==2.6.0

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,9 +1,6 @@
 # Common dependencies
 -r common.txt
 
-numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
-numba == 0.61.2; python_version > '3.9'
-
 # Dependencies for AMD GPUs
 awscli
 boto3

--- a/tests/model_executor/test_qwen2_5_vl_window_index.py
+++ b/tests/model_executor/test_qwen2_5_vl_window_index.py
@@ -46,7 +46,7 @@ def test_qwen2_5_vl_get_window_indices_correctness(window_size, patch_size,
                     seqlens_window_numba,
                     cu_seqlens_full_numba,
                     cu_seqlens_window_numba,
-                ) = scheduler.generate_by_numba(grid_thw)
+                ) = scheduler.generate_by_torch_with_numba(grid_thw)
 
                 assert window_indices_torch.dtype == \
                     window_indices_numba.dtype, get_assertion_msg(grid_thw)
@@ -150,7 +150,7 @@ def test_qwen2_5_vl_get_window_indices_multi_items_correctness(
                 seqlens_window_numba,
                 cu_seqlens_full_numba,
                 cu_seqlens_window_numba,
-            ) = scheduler.generate_by_numba(grid_thw)
+            ) = scheduler.generate_by_torch_with_numba(grid_thw)
 
             assert window_indices_torch.dtype == \
                 window_indices_numba.dtype, get_assertion_msg(grid_thw)

--- a/tests/model_executor/test_qwen2_5_vl_window_index.py
+++ b/tests/model_executor/test_qwen2_5_vl_window_index.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from vllm.model_executor.models.qwen2_5_vl import (
+    Qwen2_5_VisionAttentionScheduler)
+
+
+@pytest.mark.parametrize("window_size, patch_size, spatial_merge_size", [
+    (112, 14, 2),
+    (128, 16, 2),
+])
+def test_qwen2_5_vl_get_window_indices_correctness(window_size, patch_size,
+                                                   spatial_merge_size):
+    scheduler = Qwen2_5_VisionAttentionScheduler(
+        spatial_merge_size=spatial_merge_size,
+        window_size=window_size,
+        patch_size=patch_size,
+        max_position_embeddings=32768,
+        device=torch.device("cpu"),
+    )
+
+    get_assertion_msg = lambda grid_thw: f"mismatch at grid_thw={grid_thw}"
+
+    for t in range(1, 3):
+        for h in range(1, 50):
+            for w in range(1, 50):
+                grid_thw = torch.tensor(
+                    [[t, h * spatial_merge_size, w * spatial_merge_size]],
+                    dtype=torch.int64,
+                )
+
+                (
+                    window_indices_torch,
+                    reverse_indices_torch,
+                    seqlens_full_torch,
+                    seqlens_window_torch,
+                    cu_seqlens_full_torch,
+                    cu_seqlens_window_torch,
+                ) = scheduler.generate_by_torch(grid_thw)
+
+                (
+                    window_indices_numba,
+                    reverse_indices_numba,
+                    seqlens_full_numba,
+                    seqlens_window_numba,
+                    cu_seqlens_full_numba,
+                    cu_seqlens_window_numba,
+                ) = scheduler.generate_by_numba(grid_thw)
+
+                assert window_indices_torch.dtype == \
+                    window_indices_numba.dtype, get_assertion_msg(grid_thw)
+                assert reverse_indices_torch.dtype == \
+                    reverse_indices_numba.dtype, get_assertion_msg(grid_thw)
+                assert seqlens_full_torch.dtype == \
+                    seqlens_full_numba.dtype, get_assertion_msg(grid_thw)
+                assert seqlens_window_torch.dtype == \
+                    seqlens_window_numba.dtype, get_assertion_msg(grid_thw)
+                assert cu_seqlens_full_torch.dtype == \
+                    cu_seqlens_full_numba.dtype, get_assertion_msg(grid_thw)
+                assert cu_seqlens_window_torch.dtype == \
+                    cu_seqlens_window_numba.dtype, get_assertion_msg(grid_thw)
+
+                assert window_indices_torch.shape == \
+                    window_indices_numba.shape, get_assertion_msg(grid_thw)
+                assert reverse_indices_torch.shape == \
+                    reverse_indices_numba.shape, get_assertion_msg(grid_thw)
+                assert seqlens_full_torch.shape == \
+                    seqlens_full_numba.shape, get_assertion_msg(grid_thw)
+                assert seqlens_window_torch.shape == \
+                    seqlens_window_numba.shape, get_assertion_msg(grid_thw)
+                assert cu_seqlens_full_torch.shape == \
+                    cu_seqlens_full_numba.shape, get_assertion_msg(grid_thw)
+                assert cu_seqlens_window_torch.shape == \
+                    cu_seqlens_window_numba.shape, get_assertion_msg(grid_thw)
+
+                assert torch.equal(window_indices_torch,
+                                   window_indices_numba), \
+                       get_assertion_msg(grid_thw)
+                assert torch.equal(reverse_indices_torch,
+                                   reverse_indices_numba), \
+                       get_assertion_msg(grid_thw)
+                assert torch.equal(seqlens_full_torch,
+                                   seqlens_full_numba), \
+                       get_assertion_msg(grid_thw)
+                assert torch.equal(seqlens_window_torch,
+                                   seqlens_window_numba), \
+                       get_assertion_msg(grid_thw)
+                assert torch.equal(cu_seqlens_full_torch,
+                                   cu_seqlens_full_numba), \
+                       get_assertion_msg(grid_thw)
+                assert torch.equal(cu_seqlens_window_torch,
+                                    cu_seqlens_window_numba), \
+                       get_assertion_msg(grid_thw)
+
+
+def _grid_thw_generator(t_range, h_range, w_range, spatial_merge_size):
+    for t in t_range:
+        for h in h_range:
+            for w in w_range:
+                yield torch.tensor(
+                    [[t, h * spatial_merge_size, w * spatial_merge_size]],
+                    dtype=torch.int64,
+                )
+
+
+@pytest.mark.parametrize("window_size, patch_size, spatial_merge_size", [
+    (112, 14, 2),
+    (128, 16, 2),
+])
+def test_qwen2_5_vl_get_window_indices_multi_items_correctness(
+        window_size, patch_size, spatial_merge_size):
+    scheduler = Qwen2_5_VisionAttentionScheduler(
+        spatial_merge_size=spatial_merge_size,
+        window_size=window_size,
+        patch_size=patch_size,
+        max_position_embeddings=32768,
+        device=torch.device("cpu"),
+    )
+
+    get_assertion_msg = lambda grid_thw: f"mismatch at grid_thw={grid_thw}"
+
+    for grid_thw1 in _grid_thw_generator(
+            range(1, 3),
+            range(1, 18, 3),
+            range(1, 18, 3),
+            spatial_merge_size,
+    ):
+        for grid_thw2 in _grid_thw_generator(
+                range(1, 3),
+                range(1, 18, 3),
+                range(1, 18, 3),
+                spatial_merge_size,
+        ):
+            grid_thw = torch.cat([grid_thw1, grid_thw2])
+
+            (
+                window_indices_torch,
+                reverse_indices_torch,
+                seqlens_full_torch,
+                seqlens_window_torch,
+                cu_seqlens_full_torch,
+                cu_seqlens_window_torch,
+            ) = scheduler.generate_by_torch(grid_thw)
+
+            (
+                window_indices_numba,
+                reverse_indices_numba,
+                seqlens_full_numba,
+                seqlens_window_numba,
+                cu_seqlens_full_numba,
+                cu_seqlens_window_numba,
+            ) = scheduler.generate_by_numba(grid_thw)
+
+            assert window_indices_torch.dtype == \
+                window_indices_numba.dtype, get_assertion_msg(grid_thw)
+            assert reverse_indices_torch.dtype == \
+                reverse_indices_numba.dtype, get_assertion_msg(grid_thw)
+            assert seqlens_full_torch.dtype == \
+                seqlens_full_numba.dtype, get_assertion_msg(grid_thw)
+            assert seqlens_window_torch.dtype == \
+                seqlens_window_numba.dtype, get_assertion_msg(grid_thw)
+            assert cu_seqlens_full_torch.dtype == \
+                cu_seqlens_full_numba.dtype, get_assertion_msg(grid_thw)
+            assert cu_seqlens_window_torch.dtype == \
+                cu_seqlens_window_numba.dtype, get_assertion_msg(grid_thw)
+
+            assert window_indices_torch.shape == \
+                window_indices_numba.shape, get_assertion_msg(grid_thw)
+            assert reverse_indices_torch.shape == \
+                reverse_indices_numba.shape, get_assertion_msg(grid_thw)
+            assert seqlens_full_torch.shape == \
+                seqlens_full_numba.shape, get_assertion_msg(grid_thw)
+            assert seqlens_window_torch.shape == \
+                seqlens_window_numba.shape, get_assertion_msg(grid_thw)
+            assert cu_seqlens_full_torch.shape == \
+                cu_seqlens_full_numba.shape, get_assertion_msg(grid_thw)
+            assert cu_seqlens_window_torch.shape == \
+                cu_seqlens_window_numba.shape, get_assertion_msg(grid_thw)
+
+            assert torch.equal(window_indices_torch,
+                                window_indices_numba), \
+                    get_assertion_msg(grid_thw)
+            assert torch.equal(reverse_indices_torch,
+                                reverse_indices_numba), \
+                    get_assertion_msg(grid_thw)
+            assert torch.equal(seqlens_full_torch,
+                                seqlens_full_numba), \
+                    get_assertion_msg(grid_thw)
+            assert torch.equal(seqlens_window_torch,
+                                seqlens_window_numba), \
+                    get_assertion_msg(grid_thw)
+            assert torch.equal(cu_seqlens_full_torch,
+                                cu_seqlens_full_numba), \
+                    get_assertion_msg(grid_thw)
+            assert torch.equal(cu_seqlens_window_torch,
+                                cu_seqlens_window_numba), \
+                    get_assertion_msg(grid_thw)

--- a/tests/model_executor/test_qwen2_vl_rot_pos.py
+++ b/tests/model_executor/test_qwen2_vl_rot_pos.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from vllm.model_executor.models.qwen2_vl import Qwen2VLViTRotaryPosGenerator
+
+
+@pytest.mark.parametrize("spatial_merge_size", [2, 3])
+@pytest.mark.parametrize("impl_name, device", [
+    ("generate_by_torch_fused", "cuda"),
+    ("generate_by_numba", "cpu"),
+])
+def test_qwen2_vl_rot_pos_correctness(
+    spatial_merge_size,
+    impl_name,
+    device,
+):
+    rot_pos_generator = Qwen2VLViTRotaryPosGenerator(
+        spatial_merge_size=spatial_merge_size,
+        max_position_embeddings=32768,
+        device=torch.device(device),
+    )
+
+    get_assertion_msg = lambda grid_thw: f"mismatch at grid_thw={grid_thw}"
+
+    for t in range(1, 3):
+        for h in range(1, 32):
+            for w in range(1, 32):
+                for grid_thw in [
+                        torch.tensor([
+                            [
+                                t, h * spatial_merge_size,
+                                w * spatial_merge_size
+                            ],
+                        ],
+                                     dtype=torch.int64),
+                        torch.tensor([
+                            [
+                                t, h * spatial_merge_size,
+                                w * spatial_merge_size
+                            ],
+                        ] * 2,
+                                     dtype=torch.int64),
+                        torch.tensor([
+                            [
+                                t, h * spatial_merge_size,
+                                w * spatial_merge_size
+                            ],
+                            [
+                                1, 2 * spatial_merge_size,
+                                2 * spatial_merge_size
+                            ],
+                        ],
+                                     dtype=torch.int64),
+                ]:
+                    groundtruth = rot_pos_generator.generate_by_torch(grid_thw)
+                    testing_impl = getattr(rot_pos_generator, impl_name)
+                    actual = testing_impl(grid_thw)
+
+                    assert actual.device.type == device, \
+                        get_assertion_msg(grid_thw)
+                    assert groundtruth.dtype == actual.dtype, \
+                        get_assertion_msg(grid_thw)
+                    assert groundtruth.shape == actual.shape, \
+                        get_assertion_msg(grid_thw)
+
+                    actual = actual.cpu()
+                    assert torch.equal(groundtruth, actual), \
+                        get_assertion_msg(grid_thw)

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -684,10 +684,22 @@ class MultiModalKwargs(UserDict[str, NestedTensors]):
     ) -> BatchedTensorInputs:
         json_inputs = cast(JSONTree[torch.Tensor], batched_inputs)
 
+        # keep Qwen2/2.5-VL's image_grid_thw and video_grid_thw in cpu
+        image_grid_thw = None
+        video_grid_thw = None
+        if isinstance(json_inputs, dict):
+            image_grid_thw = json_inputs.pop("image_grid_thw", None)
+            video_grid_thw = json_inputs.pop("video_grid_thw", None)
+
         json_mapped = json_map_leaves(
             lambda x: x.to(device, non_blocking=True),
             json_inputs,
         )
+
+        if image_grid_thw is not None:
+            json_mapped["image_grid_thw"] = image_grid_thw  # type: ignore
+        if video_grid_thw is not None:
+            json_mapped["video_grid_thw"] = video_grid_thw  # type: ignore
 
         return cast(BatchedTensorInputs, json_mapped)
 

--- a/vllm/numba_utils.py
+++ b/vllm/numba_utils.py
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+"""
+Utilities for numba-based operations
+"""
 
 from ctypes import c_void_p
 from typing import overload
@@ -16,10 +19,14 @@ from numba.extending import intrinsic
 def numba_array_memcpy(dst_arr: c_void_p, dst_offset: int, src_arr: c_void_p,
                        src_offset: int, elem_count: int) -> None:
     """
-    memcpy for numpy array in numba nopython mode
+    Copy a block of data within a numpy array for numba nopython mode.
 
-    NOTE:
-    - pass `dst_arr` and `src_arr` arg by `arr.ctypes`
+    Parameters:
+        dst_arr: c_void_p           # pointer to destination array buffer
+        dst_offset: int             # start offset (in elements) for destination
+        src_arr: c_void_p           # pointer to source array buffer
+        src_offset: int             # start offset (in elements) for source
+        elem_count: int             # number of elements to copy
     """
     ...
 
@@ -34,11 +41,10 @@ def numba_array_memcpy(
     elem_count: types.Integer,
 ):
     """
-    memcpy for numpy array in numba nopython mode
+    LLVM intrinsic for `numba_array_memcpy`
 
-    NOTE:
-    - this is the llvm ir code generator, 
-      for actual usage please see the overload above
+    This is the LLVM IR code generator, for actual func signature 
+    please refer to the overload above.
     """
 
     assert dst_arr.dtype == src_arr.dtype, \
@@ -79,5 +85,7 @@ def numba_array_memcpy(
 
 @jit(nopython=True, inline="always")
 def numba_cdiv(a: int, b: int) -> int:
-    """inline ceiling division in numba nopython mode"""
-    return -(-a // b)
+    """
+    Compute integer ceiling division in numba.
+    """
+    return -(a // -b)

--- a/vllm/numba_utils.py
+++ b/vllm/numba_utils.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ctypes import c_void_p
+from typing import overload
+
+from llvmlite import ir
+from numba import jit, types
+from numba.core.base import BaseContext
+from numba.core.cgutils import raw_memcpy
+from numba.core.typing.context import BaseContext as TypingContext
+from numba.core.typing.templates import Signature
+from numba.extending import intrinsic
+
+
+@overload  # type: ignore[misc]
+def numba_array_memcpy(dst_arr: c_void_p, dst_offset: int, src_arr: c_void_p,
+                       src_offset: int, elem_count: int) -> None:
+    """
+    memcpy for numpy array in numba nopython mode
+
+    NOTE:
+    - pass `dst_arr` and `src_arr` arg by `arr.ctypes`
+    """
+    ...
+
+
+@intrinsic(inline=True)
+def numba_array_memcpy(
+    typingctx: TypingContext,
+    dst_arr: types.ArrayCTypes,
+    dst_offset: types.Integer,
+    src_arr: types.ArrayCTypes,
+    src_offset: types.Integer,
+    elem_count: types.Integer,
+):
+    """
+    memcpy for numpy array in numba nopython mode
+
+    NOTE:
+    - this is the llvm ir code generator, 
+      for actual usage please see the overload above
+    """
+
+    assert dst_arr.dtype == src_arr.dtype, \
+        "dst_arr and src_arr must have the same dtype"
+
+    def codegen(
+        context: BaseContext,
+        builder: ir.IRBuilder,
+        signature: Signature,
+        args: tuple[
+            ir.Value,
+            ir.Value,
+            ir.Value,
+            ir.Value,
+            ir.Value,
+        ],
+    ):
+        dst, dst_offset, src, src_offset, elem_count = args
+
+        dst_ptr = builder.gep(dst, [dst_offset])
+        src_ptr = builder.gep(src, [src_offset])
+        item_size = context.get_abi_sizeof(dst_ptr.type)
+
+        raw_memcpy(builder, dst_ptr, src_ptr, elem_count, item_size)
+
+        return context.get_dummy_value()
+
+    sig = types.void(
+        types.CPointer(dst_arr.dtype),
+        dst_offset,
+        types.CPointer(src_arr.dtype),
+        src_offset,
+        elem_count,
+    )
+
+    return sig, codegen
+
+
+@jit(nopython=True, inline="always")
+def numba_cdiv(a: int, b: int) -> int:
+    """inline ceiling division in numba nopython mode"""
+    return -(-a // b)


### PR DESCRIPTION
This PR optimize the tensor generation performance of Qwen2/2.5-VL ViT (including `rot_pos_ids`, `window_indices`, `cu_seqlens`, `seqlens`), by introducing optimized numba / torch impl.

## What this PR do

1. keep `image_grid_thw` and `video_grid_thw` in CPU all the time
   - this prevents a lot of **Device to Host Memcpy** and **CUDA Synchronize**, see the profiling result below
2. bring `numba` as a common dependencies (up to now it is only required by CUDA / RoCm build)
   - required by following optimization
3. optimize Qwen2/2.5-VL's `rot_pos_ids` generation by rewriting the impl with 2 different impl: numba ver (for CPU backend) and torch ver (for other backends, e.g. CUDA)
   - make them runs faster than original torch impl
4. optimize Qwen2.5-VL's `window_indices` generation by rewriting the impl with numba + torch together
   - make them runs faster than original torch impl
5. add tests to ensure the optimized version producing correct results (compared to the original impl)

## Benchmark and profiling

> Tested on NVIDIA A10, with Intel(R) Xeon(R) Platinum 8372HC CPU @ 3.40GHz 12 cores, using vLLM V1, Flash Attention 2

### Profiling result

**main branch Qwen2.5-VL ViT**

| grid_thw | tokens num | cudaStreamSynchronize | Memcpy DtoH | Memcpy HtoD | Memcpy HtoD Tx |
| -- | -- | -- | -- | -- | -- |
| `[[1, 36, 36]]` | 324 | 33 times | 28 times | 5 times | 28616 bytes |
| `[[10, 36, 36]]` | 3240 | 222 times | 217 times | 5 times | 286124 bytes |

**this PR Qwen2.5-VL ViT**

| grid_thw | tokens num | cudaStreamSynchronize | Memcpy DtoH | Memcpy HtoD | Memcpy HtoD Tx |
| -- | -- | -- | -- | -- | -- |
| `[[1, 36, 36]]` | 324 | 0 times | 0 times | 1 times | 2816 bytes |
| `[[10, 36, 36]]` | 3240 | 0 times | 0 times | 1 times | 28016 bytes |

### Piecewise benchmark

**Generating `rot_pos_ids` for Qwen2/2.5-VL (GPU)**

| grid_thw | tokens num | main branch | this PR (torch) | numba then move to GPU<br>(currently not used) |
| -- | -- | -- | -- | -- |
| `[[1, 8, 8]]` | 16 | 0.464ms | 0.270ms | **0.163ms** |
| `[[1, 36, 36]]` | 324 | 0.490ms | 0.274ms | **0.170ms** |
| `[[10, 36, 36]]` | 3240 | 0.507ms | 0.274ms | **0.170ms** |
| `[[10, 36, 36]]` * 10 | 32400 | 3.132ms | **0.277ms** | 1.134ms |
| `[[10, 36 ± 2, 36 ± 2]]` * 10 <br>(different frame sizes handled seperately) | 28200 | 3.028ms | **0.432ms** | 0.982ms |

NOTE: 
- For "this PR (torch)", a lot of time we are waiting to allocate the output tensor via `torch.empty`, maybe we can auto-tune by using the numba impl for smaller batch size?
- I have tested `torch.compile` on it, and write a similar triton jit kernel. They seems not faster than the optimized torch impl in this PR.


**Generating `rot_pos_ids` for Qwen2/2.5-VL (CPU)**

| grid_thw | tokens num | main branch | this PR (numba) |
| -- | -- | -- | -- |
| `[[1, 8, 8]]` | 16 | 0.151ms | **0.025ms** |
| `[[1, 36, 36]]` | 324 | 0.175ms | **0.025ms** |
| `[[10, 36, 36]]` | 3240 | 0.196ms | **0.033ms** |
| `[[10, 36, 36]]` * 10 | 32400 | 1.584ms | **0.192ms** |
| `[[10, 36 ± 2, 36 ± 2]]` * 10 <br>(different frame sizes handled seperately) | 28200 | 1.505ms | **0.714ms** |


**Generating `window_indices` and so on for Qwen2.5-VL (GPU)**

| grid_thw | tokens num | main branch | this PR (numba + torch) |
| -- | -- | -- | -- |
| `[[1, 8, 8]]` | 16 | 1.107ms | **0.326ms** |
| `[[1, 36, 36]]` | 324 | 1.130ms | **0.328ms** |
| `[[10, 36, 36]]` | 3240 | 1.176ms | **0.344ms** |
| `[[10, 36, 36]]` * 10 | 32400 | 7.677ms | **0.485ms** |
| `[[10, 36 ± 2, 36 ± 2]]` * 10 <br>(different frame sizes handled seperately) | 28200 | 6.832ms | **0.450ms** |


### ViT e2e benchmark

**Qwen2-VL ViT (GPU)**

| grid_thw | tokens num | main branch | this PR |
| -- | -- | -- | -- |
| `[[1, 36, 36]]` | 324 | 54.83ms | **53.87ms** |
| `[[10, 36, 36]]` | 3240 | 484.79ms | **481.14ms** |

**Qwen2.5-VL ViT (GPU)**

| grid_thw | tokens num | main branch | this PR |
| -- | -- | -- | -- |
| `[[1, 36, 36]]` | 324 | 48.28ms | **46.72ms** |
| `[[10, 36, 36]]` | 3240 | 454.65ms | **446.90ms** |

> Benchmark script: https://gist.github.com/imkero/590b31e500443a31a07386ae8539e9d8
