### PR TITLE
[bugfix] fixup warning message for plugged schedulers for v1

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -22,6 +22,7 @@ from vllm.transformers_utils.config import (
 from vllm.utils import (get_exception_traceback, resolve_obj_by_qualname,
                         zmq_socket_ctx)
 from vllm.v1.core.kv_cache_utils import get_kv_cache_configs
+from vllm.v1.core.scheduler import Scheduler as V1Scheduler
 from vllm.v1.core.scheduler import SchedulerOutput
 from vllm.v1.engine import (EngineCoreOutputs, EngineCoreRequest,
                             EngineCoreRequestType, UtilityOutput)
@@ -67,15 +68,21 @@ class EngineCore:
 
         # Setup scheduler.
         if isinstance(vllm_config.scheduler_config.scheduler_cls, str):
+            Scheduler = resolve_obj_by_qualname(
+                vllm_config.scheduler_config.scheduler_cls)
+        else:
+            Scheduler = vllm_config.scheduler_config.scheduler_cls
+
+        # This warning can be removed once the V1 Scheduler interface is
+        # finalized and we can maintain support for scheduler classes that
+        # implement it
+        if Scheduler != V1Scheduler:
             logger.warning(
                 "Using configured V1 scheduler class %s. "
                 "This scheduler interface is not public and "
                 "compatibility may not be maintained.",
                 vllm_config.scheduler_config.scheduler_cls)
-            Scheduler = resolve_obj_by_qualname(
-                vllm_config.scheduler_config.scheduler_cls)
-        else:
-            Scheduler = vllm_config.scheduler_config.scheduler_cls
+
         self.scheduler = Scheduler(
             scheduler_config=vllm_config.scheduler_config,
             model_config=vllm_config.model_config,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -76,7 +76,7 @@ class EngineCore:
         # This warning can be removed once the V1 Scheduler interface is
         # finalized and we can maintain support for scheduler classes that
         # implement it
-        if Scheduler != V1Scheduler:
+        if Scheduler is not V1Scheduler:
             logger.warning(
                 "Using configured V1 scheduler class %s. "
                 "This scheduler interface is not public and "


### PR DESCRIPTION
Quick fix for a small bug with the log introduced in https://github.com/vllm-project/vllm/pull/14466

That warning log always prints, since we actually configure the v1 scheduler as a string. 🤦 

This change instead checks the resolved class, using an equality check against the existing V1 scheduler class. I did it this way, instead of `isinstance(scheduler, V1Scheduler)`, since existing scheduler classes may inherit from the V1 scheduler and we still want to print the warning if that's the case.
