### PR TITLE
fp8 no-absorb enable

### DIFF
--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -55,7 +55,7 @@ W_UQ        project q_c to q_nope               shape [Lq, N * P]
 W_QR        project q_c to q_pe                 shape [Lq, N * R]
 W_DKV       project h_t to kv_c                 shape [H, Lkv]
 W_UK        project kv_c to k_nope              shape [Lkv, N * P]
-W_KR        project h_t to k_pe                 shape [H, N * R]
+W_KR        project h_t to k_pe                 shape [H, R]
 W_UV        project kv_c to v                   shape [Lkv, N * V]
 W_O         project v to h_t                    shape [N * V, H]
 
@@ -673,9 +673,13 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 output = output_parallel
             return output
         else:
-            x = torch.einsum("bnl,lnv->bnv", x, self.W_UV)
-            return self.o_proj(x.reshape(-1,
-                                         self.num_heads * self.v_head_dim))[0]
+            # Convert from (B, N, L) to (N, B, L)
+            x = x.view(-1, self.num_heads, self.kv_lora_rank).transpose(0, 1)
+            # Multiply (N, B, L) x (N, L, V) -> (N, B, V)
+            x = torch.bmm(x, self.W_UV)
+            # Convert from (N, B, V) to (B, N * V)
+            x = x.transpose(0, 1).reshape(-1, self.num_heads * self.v_head_dim)
+            return self.o_proj(x)[0]
 
     def _q_proj_and_k_up_proj(self, x):
         if envs.VLLM_MLA_PERFORM_MATRIX_ABSORPTION:
@@ -690,8 +694,12 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         else:
             x = torch.matmul(x, self.W_Q)\
                 .view(-1, self.num_heads, self.qk_nope_head_dim)
-            return torch.einsum("bnp,lnp->bnl", x, self.W_UK)\
-                .view(-1, self.num_heads, self.kv_lora_rank)
+            # Convert from (B, N, P) to (N, B, P)
+            x = x.transpose(0, 1)
+            # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
+            x = torch.bmm(x, self.W_UK_T)
+            # Convert from (N, B, L) to (B, N, L)
+            return x.transpose(0, 1)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
 
@@ -853,12 +861,10 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
 
             self.tp_size = get_tensor_model_parallel_world_size()
         else:
-            if is_fp8(weight_dtype):
-                raise NotImplementedError(
-                    "Currently fp8 requires matrix absorption")
-
-            self.W_UV = W_UV
-            self.W_UK = W_UK
+            # Convert from (L, N, V) to (N, L, V)
+            self.W_UV = W_UV.transpose(0, 1)
+            # Convert from (L, N, P) to (N, P, L)
+            self.W_UK_T = W_UK.permute(1, 2, 0)
             self.W_Q = W_Q.flatten(start_dim=1)
 
     def _compute_prefill_context(


### PR DESCRIPTION
Enable `VLLM_MLA_PERFORM_MATRIX_ABSORPTION=0` for fp8 by just up converting to fp16, also switch to using bmm from einsum to make it more obvious the kernels needed / easier to integrate an fp8 bmm (we would need block-scale support for 64x128, or 128x64, I need to work through it)

Based on these calculations (may be bugged): https://docs.google.com/spreadsheets/d/17eoqEbhblvtNsRRlFSjCQnEXZiBxtLgZGKD4IgZUz38/edit?usp=sharing

`VLLM_MLA_PERFORM_MATRIX_ABSORPTION=0`  should introduce 143% memory overhead 
while:
`VLLM_MLA_PERFORM_MATRIX_ABSORPTION=1` (default) should introduce 318% memory overhead 

we will likely want to make `VLLM_MLA_PERFORM_MATRIX_ABSORPTION=0` the default 

with `VLLM_MLA_PERFORM_MATRIX_ABSORPTION=0`:
```
lm_eval --model local-completions --tasks gsm8k --model_args model=/home/vllm-dev/DeepSeek-R1,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=5,max_retries=3,tokenized_requests=False --limit 100

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.97|±  |0.0171|
|     |       |strict-match    |     5|exact_match|↑  | 0.97|±  |0.0171|
```

```
VLLM_MLA_PERFORM_MATRIX_ABSORPTION=0 VLLM_USE_V1=1

Data Preview:
  backend  input_tokens  output_tokens  output_toks/s     req/s  median_itl_ms  median_ttft_ms
2    vllm          1000           1000    1269.083834  1.269084      31.285999     2318.670340
1    vllm          5000           1000    1046.350954  1.046351      33.370881     5510.511930
3    vllm         10000           1000     865.023539  0.865024      37.076649     8501.588057
0    vllm         32000           1000     190.611408  0.190611      35.992813   107927.603456

VLLM_MLA_PERFORM_MATRIX_ABSORPTION=1 VLLM_USE_V1=1

Data Preview:
  backend  input_tokens  output_tokens  output_toks/s     req/s  median_itl_ms  median_ttft_ms
2    vllm          1000           1000    1379.393797  1.379394      30.282677     2025.573374
1    vllm          5000           1000    1038.084492  1.038084      33.778368     5517.865633
3    vllm         10000           1000     571.708739  0.571709      36.978330     8523.583977
0    vllm         32000           1000     161.668698  0.161669      43.343701   115767.377675
```