### PR TITLE
Improve logging on VLLM V1 for common errors in initialization

### DIFF
--- a/tests/v1/core/test_kv_cache_error_handling.py
+++ b/tests/v1/core/test_kv_cache_error_handling.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm.config import CacheConfig
+from vllm.v1.core.kv_cache_utils import (check_enough_kv_cache_memory,
+                                         get_kv_cache_configs,
+                                         is_kv_cache_type_uniform)
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+
+class TestKVCacheErrorHandlingFunctional:
+    """Functional tests for KV cache error handling without using mocks."""
+
+    def setup_method(self):
+        """Setup common test configuration."""
+        # Create actual KV cache specs without requiring model loading
+        self.block_size = 16
+
+        # Create a uniform KV cache spec
+        self.uniform_spec = self._create_uniform_spec(
+            2)  # 2 layers with same specs
+
+        # Create a non-uniform KV cache spec
+        self.non_uniform_spec = self._create_non_uniform_spec()
+
+        # Create a basic cache config with required parameters
+        self.cache_config = CacheConfig(block_size=self.block_size,
+                                        gpu_memory_utilization=0.8,
+                                        swap_space=1.0,
+                                        cache_dtype="auto")
+        # Add the min_required_gpu_blocks attribute since it's not a parameter
+        self.cache_config.min_required_gpu_blocks = 100
+
+    def _create_uniform_spec(self, num_layers):
+        """Create uniform KV cache spec with the specified number of layers."""
+        kv_cache_spec = {}
+        for i in range(num_layers):
+            kv_cache_spec[f"layer{i}"] = FullAttentionSpec(
+                block_size=self.block_size,
+                num_kv_heads=8,
+                head_size=128,
+                dtype=torch.float16,
+                use_mla=False)
+        return kv_cache_spec
+
+    def _create_non_uniform_spec(self):
+        """Create a non-uniform KV cache spec."""
+        return {
+            "layer0":
+            FullAttentionSpec(block_size=self.block_size,
+                              num_kv_heads=8,
+                              head_size=128,
+                              dtype=torch.float16,
+                              use_mla=False),
+            "layer1":
+            FullAttentionSpec(
+                block_size=self.block_size,
+                num_kv_heads=8,
+                head_size=128,
+                dtype=torch.float16,
+                use_mla=True  # Different type - MLA vs non-MLA
+            )
+        }
+
+    def test_check_enough_kv_cache_memory_no_memory(self, monkeypatch):
+        """Test error handling when no memory is available."""
+        # Create a minimal config with just what's needed for the test
+        from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.max_model_len = 2048
+
+        scheduler_config = SchedulerConfig.__new__(SchedulerConfig)
+        scheduler_config.gpu_memory_utilization = 0.9
+
+        vllm_config = VllmConfig.__new__(VllmConfig)
+        vllm_config.model_config = model_config
+        vllm_config.scheduler_config = scheduler_config
+        vllm_config.cache_config = self.cache_config
+
+        with pytest.raises(ValueError) as excinfo:
+            check_enough_kv_cache_memory(vllm_config,
+                                         self.uniform_spec,
+                                         available_memory=0)
+
+        # Check error message contains helpful information
+        error_msg = str(excinfo.value)
+        assert "No available memory for the KV cache blocks" in error_msg
+        assert "Try one of the following" in error_msg
+        assert "Increase `gpu_memory_utilization`" in error_msg
+        assert "Use a smaller model" in error_msg
+        assert "Use a GPU with more memory" in error_msg
+        assert "Reduce model_max_len" in error_msg
+
+    def test_check_enough_kv_cache_memory_insufficient_memory(
+            self, monkeypatch):
+        """Test error handling if insufficient memory for KV cache."""
+        # Create a minimal config with just what's needed for the test
+        from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.max_model_len = 2048
+
+        scheduler_config = SchedulerConfig.__new__(SchedulerConfig)
+        scheduler_config.gpu_memory_utilization = 0.9
+
+        vllm_config = VllmConfig.__new__(VllmConfig)
+        vllm_config.model_config = model_config
+        vllm_config.scheduler_config = scheduler_config
+        vllm_config.cache_config = self.cache_config
+
+        # Calculate needed memory based on the spec
+        # For non-MLA, the page size is
+        # 2 * block_size * num_kv_heads * head_size * dtype_size
+        # With block_size=16, num_kv_heads=8, head_size=128, dtype=float16
+        # Page size = 2 * 16 * 8 * 128 * 2 = 65,536 bytes per page per layer
+        # With 2 layers: 2 * 65,536 = 131,072 bytes per page
+        # For max_model_len=2048, we need ceil(2048/16) = 128 pages
+        # Total = 128 * 131,072 = 16,777,216 bytes (16 MB)
+
+        # Provide less than needed: 8 MB
+        available_memory = 8 * 1024 * 1024
+
+        with pytest.raises(ValueError) as excinfo:
+            check_enough_kv_cache_memory(vllm_config,
+                                         self.uniform_spec,
+                                         available_memory=available_memory)
+
+        # Check error message contains helpful information
+        error_msg = str(excinfo.value)
+        assert "Insufficient memory for KV cache allocation" in error_msg
+        assert "Required:" in error_msg
+        assert "Available:" in error_msg
+        assert "deficit:" in error_msg
+        assert "Approximate max possible sequence length" in error_msg
+        assert "Solutions:" in error_msg
+        assert "Increase `gpu_memory_utilization`" in error_msg
+        assert "Decrease `max_model_len`" in error_msg
+        assert "Use a smaller model or a GPU with more memory" in error_msg
+
+    def test_is_kv_cache_type_uniform(self):
+        """Test is_kv_cache_type_uniform function with actual KV cache specs."""
+        # Test with uniform spec
+        assert is_kv_cache_type_uniform(self.uniform_spec) is True
+
+        # Test with non-uniform spec
+        assert is_kv_cache_type_uniform(self.non_uniform_spec) is False
+
+    def test_get_kv_cache_configs_non_uniform_kv_cache(self, monkeypatch):
+        """Test error handling with non-uniform KV cache types."""
+        # Create a minimal config with just what's needed for the test
+        from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+
+        model_config = ModelConfig.__new__(ModelConfig)
+        model_config.max_model_len = 2048
+
+        scheduler_config = SchedulerConfig.__new__(SchedulerConfig)
+        scheduler_config.gpu_memory_utilization = 0.9
+
+        vllm_config = VllmConfig.__new__(VllmConfig)
+        vllm_config.model_config = model_config
+        vllm_config.scheduler_config = scheduler_config
+        vllm_config.cache_config = self.cache_config
+
+        with pytest.raises(NotImplementedError) as excinfo:
+            get_kv_cache_configs(
+                vllm_config,
+                [self.non_uniform_spec],
+                available_memory=1024 * 1024 * 1024  # 1 GB (plenty of memory)
+            )
+
+        assert "Models with non-uniform KV cache types not supported" in str(
+            excinfo.value)

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -1,262 +1,245 @@
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import MagicMock, patch
+
+import asyncio
+import time
+import uuid
+from typing import Optional
 
 import pytest
+from transformers import AutoTokenizer
 
+from tests.utils import fork_new_process_for_each_test
+from vllm import SamplingParams
+from vllm.engine.arg_utils import EngineArgs
 from vllm.platforms import current_platform
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine import EngineCoreRequest
 from vllm.v1.engine.core import EngineCore
-from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
+from vllm.v1.engine.core_client import (AsyncMPClient, EngineCoreClient,
+                                        SyncMPClient)
+from vllm.v1.executor.abstract import Executor
 
 if not current_platform.is_cuda():
     pytest.skip(reason="V1 currently only supported on CUDA.",
                 allow_module_level=True)
 
-
-# Unit tests for _initialize_kv_caches function
-def test_initialize_kv_caches_no_gpu_memory():
-    """Test handling of no available GPU memory."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
-    # No memory available
-    model_executor.determine_available_memory.return_value = -10
-
-    # Create a minimal config required for the test with mocked ModelConfig
-    vllm_config = MagicMock()
-    cache_config = MagicMock()
-    cache_config.min_required_gpu_blocks = 16
-    vllm_config.cache_config = cache_config
-
-    engine_core = EngineCore.__new__(
-        EngineCore)  # Create instance without calling __init__
-    engine_core.model_executor = model_executor
-
-    with pytest.raises(RuntimeError) as exc_info:
-        engine_core._initialize_kv_caches(vllm_config)
-
-    assert "Not enough GPU memory available to fit the model" in str(
-        exc_info.value)
+MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
+TOKENIZER = AutoTokenizer.from_pretrained(MODEL_NAME)
+PROMPT = "Hello my name is Robert and I love quantization kernels"
+PROMPT_TOKENS = TOKENIZER(PROMPT).input_ids
 
 
-def test_initialize_kv_caches_zero_blocks():
-    """Test handling of zero KV cache blocks allocation."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
-
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
-
-    # Mock the get_kv_cache_configs function to return an empty set of configs
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = []  # No blocks allocated
-
-        # Create a minimal config required for the test with mocked ModelConfig
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 16
-        vllm_config.cache_config = cache_config
-
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
-
-        with pytest.raises(RuntimeError) as exc_info:
-            engine_core._initialize_kv_caches(vllm_config)
-
-        assert "Could not allocate any KV cache blocks" in str(exc_info.value)
+def make_request(params: SamplingParams) -> EngineCoreRequest:
+    return EngineCoreRequest(
+        request_id=str(uuid.uuid4()),
+        prompt=PROMPT,
+        prompt_token_ids=PROMPT_TOKENS,
+        mm_inputs=None,
+        mm_hashes=None,
+        mm_placeholders=None,
+        sampling_params=params,
+        eos_token_id=None,
+        arrival_time=time.time(),
+        lora_request=None,
+    )
 
 
-def test_initialize_kv_caches_insufficient_blocks():
-    """Test handling of insufficient KV cache blocks."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
+def loop_until_done(client: EngineCoreClient, outputs: dict):
 
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
+    while True:
+        engine_core_outputs = client.get_output().outputs
 
-    # Create the KVCacheConfig with appropriate properties
-    mock_kv_config = MagicMock(spec=KVCacheConfig)
-    mock_kv_config.num_blocks = 10  # Fewer blocks than minimum required
+        if len(engine_core_outputs) == 0:
+            continue
 
-    # Mock the get_kv_cache_configs to return configs with insufficient blocks
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = [mock_kv_config]
+        all_finished = True
+        for out in engine_core_outputs:
+            outputs[out.request_id].append(out)
+            if not out.finished:
+                all_finished = False
 
-        # Create a minimal config with minimum required blocks
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 20  #min required 20, but only 10
-        vllm_config.cache_config = cache_config
-
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
-
-        with pytest.raises(RuntimeError) as exc_info:
-            engine_core._initialize_kv_caches(vllm_config)
-
-        assert "Could only allocate 10 KV cache blocks, " in str(
-            exc_info.value)
-        assert "but minimum required is 20" in str(exc_info.value)
+        if all_finished:
+            break
 
 
-def test_initialize_kv_caches_cuda_out_of_memory():
-    """Test handling of CUDA out of memory during initialization."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
+async def loop_until_done_async(client: EngineCoreClient, outputs: dict):
 
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
+    while True:
+        engine_core_outputs = (await client.get_output_async()).outputs
 
-    # Set up the model_executor to raise a CUDA OOM error during initialization
-    cuda_error = RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
-    model_executor.initialize_from_config.side_effect = cuda_error
+        if len(engine_core_outputs) == 0:
+            continue
 
-    # Create the KVCacheConfig with appropriate properties
-    mock_kv_config = MagicMock(spec=KVCacheConfig)
-    mock_kv_config.num_blocks = 50
+        all_finished = True
+        for out in engine_core_outputs:
+            outputs[out.request_id].append(out)
+            if not out.finished:
+                all_finished = False
 
-    # Mock the get_kv_cache_configs function to return valid configs
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = [mock_kv_config]
-
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 16
-        vllm_config.cache_config = cache_config
-
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
-
-        with pytest.raises(RuntimeError) as exc_info:
-            engine_core._initialize_kv_caches(vllm_config)
-
-        assert "CUDA out of memory during model initialization" in str(
-            exc_info.value)
+        if all_finished:
+            break
 
 
-def test_initialize_kv_caches_operation_not_implemented():
-    """Test 'operation not implemented' error during initialization."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
-
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
-
-    # Set up the model_executor to raise an 'operation not implemented' error
-    not_implemented_error = RuntimeError("operation not implemented for dtype")
-    model_executor.initialize_from_config.side_effect = not_implemented_error
-
-    # Create the KVCacheConfig with appropriate properties
-    mock_kv_config = MagicMock(spec=KVCacheConfig)
-    mock_kv_config.num_blocks = 50
-
-    # Mock the get_kv_cache_configs function to return valid configs
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = [mock_kv_config]
-
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 16
-        vllm_config.cache_config = cache_config
-
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
-
-        with pytest.raises(RuntimeError) as exc_info:
-            engine_core._initialize_kv_caches(vllm_config)
-
-        assert "Model operation not supported on this hardware" in str(
-            exc_info.value)
+# Dummy utility function to monkey-patch into engine core.
+def echo(self, msg: str, err_msg: Optional[str] = None) -> str:
+    print(f"echo util function called: {msg}, {err_msg}")
+    if err_msg is not None:
+        raise ValueError(err_msg)
+    return msg
 
 
-def test_initialize_kv_caches_general_runtime_error():
-    """Test handling of general runtime errors during initialization."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
+@fork_new_process_for_each_test
+@pytest.mark.parametrize("multiprocessing_mode", [True, False])
+def test_engine_core_client(monkeypatch, multiprocessing_mode: bool):
 
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
 
-    # Set up the model_executor to raise a general error
-    general_error = RuntimeError("Some unexpected error occurred")
-    model_executor.initialize_from_config.side_effect = general_error
+        # Monkey-patch core engine utility function to test.
+        m.setattr(EngineCore, "echo", echo, raising=False)
 
-    # Create the KVCacheConfig with appropriate properties
-    mock_kv_config = MagicMock(spec=KVCacheConfig)
-    mock_kv_config.num_blocks = 50
+        engine_args = EngineArgs(model=MODEL_NAME, enforce_eager=True)
+        vllm_config = engine_args.create_engine_config(
+            UsageContext.UNKNOWN_CONTEXT)
+        executor_class = Executor.get_class(vllm_config)
+        client = EngineCoreClient.make_client(
+            multiprocess_mode=multiprocessing_mode,
+            asyncio_mode=False,
+            vllm_config=vllm_config,
+            executor_class=executor_class,
+            log_stats=False,
+        )
 
-    # Mock the get_kv_cache_configs function to return valid configs
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = [mock_kv_config]
+        MAX_TOKENS = 20
+        params = SamplingParams(max_tokens=MAX_TOKENS)
+        """Normal Request Cycle."""
+        requests = [make_request(params) for _ in range(10)]
+        request_ids = [req.request_id for req in requests]
 
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 16
-        vllm_config.cache_config = cache_config
+        # Add requests to the engine.
+        for request in requests:
+            client.add_request(request)
+            time.sleep(0.01)
 
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
+        outputs: dict[str, list] = {req_id: [] for req_id in request_ids}
+        loop_until_done(client, outputs)
 
-        with pytest.raises(RuntimeError) as exc_info:
-            engine_core._initialize_kv_caches(vllm_config)
+        for req_id in request_ids:
+            assert len(outputs[req_id]) == MAX_TOKENS, (
+                f"{outputs[req_id]=}, {MAX_TOKENS=}")
+        """Abort Request Cycle."""
 
-        # The original error should be re-raised
-        assert "Some unexpected error occurred" in str(exc_info.value)
+        # Note: this code pathway will only work for multiprocessing
+        # since we have to call get_output() explicitly
+
+        # Add requests to the engine.
+        for idx, request in enumerate(requests):
+            client.add_request(request)
+            time.sleep(0.01)
+            if idx % 2 == 0:
+                client.abort_requests([request.request_id])
+
+        outputs = {req_id: [] for req_id in request_ids}
+        loop_until_done(client, outputs)
+
+        for idx, req_id in enumerate(request_ids):
+            if idx % 2 == 0:
+                assert len(outputs[req_id]) < MAX_TOKENS, (
+                    f"{len(outputs[req_id])=}, {MAX_TOKENS=}")
+            else:
+                assert len(outputs[req_id]) == MAX_TOKENS, (
+                    f"{len(outputs[req_id])=}, {MAX_TOKENS=}")
+        """Abort after request is finished."""
+
+        # Note: this code pathway will only work for multiprocessing
+        # since we have to call get_output() explicitly
+
+        request = requests[0]
+        client.add_request(request)
+        time.sleep(10.)
+
+        client.abort_requests([request.request_id])
+
+        if multiprocessing_mode:
+            """Utility method invocation"""
+
+            core_client: SyncMPClient = client
+
+            result = core_client._call_utility("echo", "testarg")
+            assert result == "testarg"
+
+            with pytest.raises(Exception) as e_info:
+                core_client._call_utility("echo", None, "help!")
+
+            assert str(e_info.value) == "Call to echo method failed: help!"
 
 
-def test_initialize_kv_caches_success():
-    """Test successful initialization of KV caches."""
-    model_executor = MagicMock()
-    model_executor.get_kv_cache_specs.return_value = [
-        KVCacheSpec(block_size=16, num_blocks=100)
-    ]
-    # Some memory available
-    model_executor.determine_available_memory.return_value = 1000
+@pytest.mark.asyncio(loop_scope="function")
+async def test_engine_core_client_asyncio(monkeypatch):
 
-    # Create the KVCacheConfig with appropriate properties
-    mock_kv_config = MagicMock(spec=KVCacheConfig)
-    mock_kv_config.num_blocks = 50
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
 
-    # Mock the get_kv_cache_configs function to return valid configs
-    with patch('vllm.v1.engine.core.get_kv_cache_configs') as mock_get_configs:
-        mock_get_configs.return_value = [mock_kv_config]
+        # Monkey-patch core engine utility function to test.
+        m.setattr(EngineCore, "echo", echo, raising=False)
 
-        vllm_config = MagicMock()
-        cache_config = MagicMock()
-        cache_config.min_required_gpu_blocks = 16
-        vllm_config.cache_config = cache_config
+        engine_args = EngineArgs(model=MODEL_NAME, enforce_eager=True)
+        vllm_config = engine_args.create_engine_config(
+            usage_context=UsageContext.UNKNOWN_CONTEXT)
+        executor_class = Executor.get_class(vllm_config)
+        client = EngineCoreClient.make_client(
+            multiprocess_mode=True,
+            asyncio_mode=True,
+            vllm_config=vllm_config,
+            executor_class=executor_class,
+            log_stats=True,
+        )
 
-        engine_core = EngineCore.__new__(
-            EngineCore)  # Create instance without calling __init__
-        engine_core.model_executor = model_executor
-        engine_core.structured_output_manager = MagicMock(
-        )  # Add this to avoid AttributeError
+        MAX_TOKENS = 20
+        params = SamplingParams(max_tokens=MAX_TOKENS)
+        """Normal Request Cycle."""
 
-        # Patching the logger to check for success message
-        with patch('vllm.v1.engine.core.logger') as mock_logger:
-            num_gpu_blocks, num_cpu_blocks = engine_core._initialize_kv_caches(
-                vllm_config)
+        requests = [make_request(params) for _ in range(10)]
+        request_ids = [req.request_id for req in requests]
 
-            # Verify success
-            assert num_gpu_blocks == 50
-            assert num_cpu_blocks == 0
-            # Verify that the info log was called with elapsed time message
-            mock_logger.info.assert_called_with(
-                ("init engine (profile, create kv cache, "
-                 "warmup model) took %.2f seconds"),
-                mock_logger.info.call_args[0][1])
+        # Add requests to the engine.
+        for request in requests:
+            await client.add_request_async(request)
+            await asyncio.sleep(0.01)
+
+        outputs: dict[str, list] = {req_id: [] for req_id in request_ids}
+        await loop_until_done_async(client, outputs)
+
+        for req_id in request_ids:
+            assert len(outputs[req_id]) == MAX_TOKENS, (
+                f"{outputs[req_id]=}, {MAX_TOKENS=}")
+        """Abort Request Cycle."""
+
+        # Add requests to the engine.
+        for idx, request in enumerate(requests):
+            await client.add_request_async(request)
+            await asyncio.sleep(0.01)
+            if idx % 2 == 0:
+                await client.abort_requests_async([request.request_id])
+
+        outputs = {req_id: [] for req_id in request_ids}
+        await loop_until_done_async(client, outputs)
+
+        for idx, req_id in enumerate(request_ids):
+            if idx % 2 == 0:
+                assert len(outputs[req_id]) < MAX_TOKENS, (
+                    f"{len(outputs[req_id])=}, {MAX_TOKENS=}")
+            else:
+                assert len(outputs[req_id]) == MAX_TOKENS, (
+                    f"{len(outputs[req_id])=}, {MAX_TOKENS=}")
+        """Utility method invocation"""
+
+        core_client: AsyncMPClient = client
+
+        result = await core_client._call_utility_async("echo", "testarg")
+        assert result == "testarg"
+
+        with pytest.raises(Exception) as e_info:
+            await core_client._call_utility_async("echo", None, "help!")
+
+        assert str(e_info.value) == "Call to echo method failed: help!"

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -465,15 +465,9 @@ def check_enough_kv_cache_memory(vllm_config: VllmConfig,
     """
 
     if available_memory <= 0:
-        raise ValueError(
-            "No available memory for the KV cache blocks."
-            "This typically happens when the model weights themselves consume "
-            "almost all GPU memory."
-            "Try one of the following:\n"
-            "1. Increase `gpu_memory_utilization` when initializing engine\n"
-            "2. Use a smaller model\n"
-            "3. Use a GPU with more memory\n"
-            "4. Reduce model_max_len to decrease KV cache size requirements")
+        raise ValueError("No available memory for the cache blocks. "
+                         "Try increasing `gpu_memory_utilization` when "
+                         "initializing the engine.")
 
     max_model_len = vllm_config.model_config.max_model_len
     needed_memory = 0

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,8 +18,8 @@ logger = init_logger(__name__)
 class BlockHashType(NamedTuple):
     """Hash value of a block (int), the token IDs in the block, and extra keys.
     We keep a tuple of token IDs and extra keys to reduce the likelihood of
-    hash collisions when the hash value is the same. But please note that 
-    hash collisions can still theoretically occur, albeit with an extremely 
+    hash collisions when the hash value is the same. But please note that
+    hash collisions can still theoretically occur, albeit with an extremely
     low probability.
     """
     # Hash value of the block in an integer.
@@ -148,7 +148,7 @@ class FreeKVCacheBlockQueue:
     builtin deque to support removing a block in the middle of the queue
     in O(1) time. To close the performance gap to the builtin deque which is
     implemented in C++, this class does not allocate any Python objects when
-    manipulating the linked list. Instead, this class manipulates the 
+    manipulating the linked list. Instead, this class manipulates the
     prev_free_block and next_free_block attributes of the given blocks.
 
     The queue is ordered by block ID in the beginning. When a block is allocated
@@ -178,7 +178,7 @@ class FreeKVCacheBlockQueue:
 
     def popleft(self) -> KVCacheBlock:
         """Pop the first free block and reduce num_free_blocks by 1.
-        
+
         Returns:
             The first free block.
         """
@@ -191,7 +191,7 @@ class FreeKVCacheBlockQueue:
 
     def remove(self, block: KVCacheBlock) -> None:
         """Remove a block in the free list and reduce num_free_blocks by 1.
-        
+
         Args:
             block: The block to remove.
         """
@@ -235,7 +235,7 @@ class FreeKVCacheBlockQueue:
 
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.
-        
+
         Returns:
             A list of free blocks.
         """
@@ -251,10 +251,10 @@ def need_extra_keys(request: Request) -> bool:
     """Check whether the blocks allocated to this request need extra hash keys.
 
     Args:
-        request (Request): The request. 
+        request (Request): The request.
 
     Returns:
-        bool: Whether blocks allocated to this request need extra hash keys. 
+        bool: Whether blocks allocated to this request need extra hash keys.
     """
 
     # Multimodal requests need to include the MM hash.
@@ -269,13 +269,13 @@ def _gen_mm_extra_hash_keys(request: Request, start_token_idx: int,
     computation. For multi-modal inputs, the extra keys are
     (mm_hash, start_offset) that indicate a mm input contained in the
     block and its starting offset in the block tokens.
-    
+
     Args:
         request: The request object.
         start_token_idx: The start token index of the block.
         end_token_idx: The end token index of the block.
         start_mm_idx: The start multi-modal index of the block.
-    
+
     Returns:
         A tuple of extra keys and the next multi-modal index.
     """
@@ -333,10 +333,10 @@ def _gen_mm_extra_hash_keys(request: Request, start_token_idx: int,
 
 def _gen_lora_extra_hash_keys(request: Request) -> list[int]:
     """Generate extra keys related to LoRA for block hash computation.
-    
+
     Args:
         request: The request object.
-    
+
     Returns:
         Return LoRA id of the request if it is a LoRA request. Return empty
         list otherwise.
@@ -351,13 +351,13 @@ def generate_block_hash_extra_keys(
         start_mm_idx: int) -> tuple[Optional[tuple[Any, ...]], int]:
     """Generate extra keys for the block hash. The extra keys can come from
     the multi-modal inputs and request specific metadata (e.g., LoRA ID).
-    
+
     Args:
         request: The request object.
         start_token_idx: The start token index of the block.
         end_token_idx: The end token index of the block.
         start_mm_idx: The start multi-modal index of the block.
-    
+
     Returns:
         A tuple of extra keys and the next multi-modal index.
     """
@@ -452,7 +452,7 @@ def check_enough_kv_cache_memory(vllm_config: VllmConfig,
                                  kv_cache_spec: KVCacheSpec,
                                  available_memory: int):
     """
-    Checks whether `available_memory` is enough for the KV cache to hold at 
+    Checks whether `available_memory` is enough for the KV cache to hold at
     least one request with the model's max_model_len.
 
     Args:
@@ -465,23 +465,44 @@ def check_enough_kv_cache_memory(vllm_config: VllmConfig,
     """
 
     if available_memory <= 0:
-        raise ValueError("No available memory for the cache blocks. "
-                         "Try increasing `gpu_memory_utilization` when "
-                         "initializing the engine.")
+        raise ValueError(
+            "No available memory for the KV cache blocks."
+            "This typically happens when the model weights themselves consume "
+            "almost all GPU memory."
+            "Try one of the following:\n"
+            "1. Increase `gpu_memory_utilization` when initializing engine\n"
+            "2. Use a smaller model\n"
+            "3. Use a GPU with more memory\n"
+            "4. Reduce model_max_len to decrease KV cache size requirements")
 
     max_model_len = vllm_config.model_config.max_model_len
     needed_memory = 0
     for layer_spec in kv_cache_spec.values():
         needed_memory += layer_spec.bytes_for_tokens(max_model_len)
 
+    # Calculate more helpful metrics for error reporting
+    needed_gb = needed_memory / 1024 / 1024 / 1024
+    available_gb = available_memory / 1024 / 1024 / 1024
+    deficit_gb = needed_gb - available_gb
+
     if needed_memory > available_memory:
+        # Calculate approx max sequence length with current memory
+        possible_len = int(max_model_len * (available_memory / needed_memory))
+
         raise ValueError(
-            f"To serve at least one request with the models's max seq len "
-            f"({max_model_len}), ({needed_memory/1024/1024/1024:.2f} GB KV "
-            f"cache is needed, which is larger than the available KV cache "
-            f"memory ({available_memory/1024/1024/1024:.2f} GB). Try "
-            f"increasing `gpu_memory_utilization` or decreasing "
-            f"`max_model_len` when initializing the engine.")
+            f"Insufficient memory for KV cache allocation:\n"
+            f"- Required: {needed_gb:.2f} GB for max sequence length "
+            f"{max_model_len}\n"
+            f"- Available: {available_gb:.2f} GB "
+            f"(deficit: {deficit_gb:.2f} GB)\n"
+            f"- Approximate max possible sequence length with current memory: "
+            f"{possible_len}\n\n"
+            f"Solutions:\n"
+            f"1. Increase `gpu_memory_utilization`\n"
+            f"   (currently: "
+            f"{vllm_config.scheduler_config.gpu_memory_utilization})\n"
+            f"2. Decrease `max_model_len` to {possible_len} or less\n"
+            f"3. Use a smaller model or a GPU with more memory")
 
 
 def is_kv_cache_type_uniform(kv_cache_spec: KVCacheSpec) -> bool:
@@ -567,22 +588,52 @@ def get_kv_cache_configs(vllm_config: VllmConfig,
 
     Returns:
         The generated KVCacheConfigs
+
+    Raises:
+        ValueError: If there is not enough memory available for the KV cache
+        NotImplementedError: If the model has non-uniform KV cache types
     """
-    # Use the max number of layers to conservatively determine
-    # the number of blocks.
-    num_layers = max(len(kv_cache_spec) for kv_cache_spec in kv_cache_specs)
-    kv_cache_configs = []
-    for kv_cache_spec in kv_cache_specs:
-        check_enough_kv_cache_memory(vllm_config, kv_cache_spec,
-                                     available_memory)
-        if is_kv_cache_type_uniform(kv_cache_spec):
-            # KV cache of all layers are the same, which is true for
-            # most models. Allocate the same amount of memory for
-            # each layer.
-            kv_cache_configs.append(
-                _get_kv_cache_config_uniform_type(vllm_config, kv_cache_spec,
-                                                  available_memory,
-                                                  num_layers))
+    try:
+        # Use the max number of layers to conservatively determine
+        # the number of blocks.
+        num_layers = max(
+            len(kv_cache_spec) for kv_cache_spec in kv_cache_specs)
+        kv_cache_configs = []
+
+        for kv_cache_spec in kv_cache_specs:
+            check_enough_kv_cache_memory(vllm_config, kv_cache_spec,
+                                         available_memory)
+            if is_kv_cache_type_uniform(kv_cache_spec):
+                # KV cache of all layers are the same, which is true for
+                # most models. Allocate the same amount of memory for
+                # each layer.
+                kv_cache_configs.append(
+                    _get_kv_cache_config_uniform_type(vllm_config,
+                                                      kv_cache_spec,
+                                                      available_memory,
+                                                      num_layers))
+            else:
+                raise NotImplementedError(
+                    "Models with non-uniform KV cache types are not supported. "
+                    "This is an unusual case and might indicate an issue with"
+                    " your configuration.")
+
+        if not kv_cache_configs:
+            raise ValueError(
+                "Failed to generate any valid KV cache configurations. "
+                "This could be due to insufficient GPU memory or an "
+                "incompatible model architecture.")
+
+        return kv_cache_configs
+
+    except Exception as e:
+        # More context to any errors that occur during KV cache configuration
+        if isinstance(e, (ValueError, NotImplementedError)):
+            # Re-raise with the original message
+            raise
         else:
-            raise NotImplementedError
-    return kv_cache_configs
+            # For unexpected errors, add more context
+            raise ValueError(
+                f"Unexpected error during KV cache configuration: {str(e)}. "
+                f"This might be due to insufficient GPU memory or an "
+                f"incompatible model configuration.") from e


### PR DESCRIPTION
Aims to improve logging on VLLM V1 for common errors during initialization.

Currently handling the current cases:
* not enough memory to fit the model
* not enough kv cache space to fit the model


Related issue: [#14083](https://github.com/vllm-project/vllm/issues/14083)
