### PR TITLE
[BugFix]Fix performance serving benchmark when enable profiling

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -333,7 +333,7 @@ async def async_request_openai_chat_completions(
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
-        "chat/completions"
+        ("chat/completions", "profile")
     ), "OpenAI Chat Completions API URL must end with 'chat/completions'."
 
     async with aiohttp.ClientSession(trust_env=True,


### PR DESCRIPTION

Fix the endpoint assertion  to enable profiling , [#14036](https://github.com/vllm-project/vllm/pull/14036)

<!--- pyml disable-next-line no-emphasis-as-heading -->
