### PR TITLE
[Misc] Remove stale func in KVTransferConfig

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2884,12 +2884,6 @@ class KVTransferConfig(BaseModel):
             self.kv_role in ["kv_producer", "kv_consumer", "kv_both"]
 
     @property
-    def need_kv_parallel_group(self) -> bool:
-        # for those database-based connector, vLLM does not need to create
-        # parallel group, and in that case the kv parallel size will be 1.
-        return self.kv_connector is not None and self.kv_parallel_size > 1
-
-    @property
     def is_kv_producer(self) -> bool:
         return self.kv_connector is not None and \
             self.kv_role in ["kv_producer", "kv_both"]


### PR DESCRIPTION
Since https://github.com/vllm-project/vllm/pull/12953 replaces `need_kv_parallel_group` with `is_kv_transfer_instance`  when initializing KVTransferAgent in parallel_state.py, `need_kv_parallel_group` is no longer needed anywhere in the code base. Therefore, I think it should be removed. BTW, I second the change in #12953. After all, all kinds of connectors need to init KVTransferAgent first.

For those database-based connectors, vLLM also needs to init KVTransferAgent and create a parallel group in case tp is enabled.

CC @KuntaiDu 