### PR TITLE
[misc] Spawn process when vLLM is used as Ray actor

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -591,6 +591,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_RAY_BUNDLE_INDICES":
     lambda: os.getenv("VLLM_RAY_BUNDLE_INDICES", ""),
 
+    # Ray placement group name, if it is set, it can control the
+    # placement group for vLLM to use.
+    "VLLM_RAY_PG_NAME":
+    lambda: os.getenv("VLLM_RAY_PG_NAME", None),
+
+    # Ray namespace, if it is set, it can control the namespace for vLLM to use.
+    "VLLM_RAY_NAMESPACE":
+    lambda: os.getenv("VLLM_RAY_NAMESPACE", None),
+
     # When on a Nvidia GPU aligns single entries (within a page) so they are 256
     # byte aligned for better performance, this increases the memory usage of
     # the cache. Currently this only affects MLA that results in non-256

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -283,9 +283,9 @@ def initialize_ray_cluster(
     """
     assert_ray_available()
     from vllm.platforms import current_platform
-
-    # Connect to a ray cluster.
-    if current_platform.is_rocm() or current_platform.is_xpu():
+    if ray.is_initialized():
+        logger.info("Ray is already initialized. Skipping Ray initialization.")
+    elif current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
             ray.init("auto", ignore_reinit_error=True)
@@ -331,6 +331,9 @@ def initialize_ray_cluster(
                 f"Required number of devices: {parallel_config.world_size}. "
                 f"Total number of devices: {device_bundles}.")
     else:
+        logger.info(
+            "Current placement group is not set. Creating a new placement group."
+        )
         num_devices_in_cluster = ray.cluster_resources().get(device_str, 0)
         # Log a warning message and delay resource allocation failure response.
         # Avoid immediate rejection to allow user-initiated placement group

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -312,6 +312,7 @@ def initialize_ray_cluster(
     # Create placement group for worker processes
     current_placement_group = ray.util.get_current_placement_group()
     if current_placement_group:
+        logger.info("Using current placement group")
         # We are in a placement group
         bundles = current_placement_group.bundle_specs
         # Verify that we can use the placement group.
@@ -331,9 +332,8 @@ def initialize_ray_cluster(
                 f"Required number of devices: {parallel_config.world_size}. "
                 f"Total number of devices: {device_bundles}.")
     else:
-        logger.info(
-            "Current placement group is not set. Creating a new placement group."
-        )
+        logger.info("No current placement group found. "
+                    "Creating a new placement group.")
         num_devices_in_cluster = ray.cluster_resources().get(device_str, 0)
         # Log a warning message and delay resource allocation failure response.
         # Avoid immediate rejection to allow user-initiated placement group

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 import msgspec
 
 import vllm.platforms
+from vllm import envs
 from vllm.config import ParallelConfig
 from vllm.executor.msgspec_utils import decode_hook, encode_hook
 from vllm.logger import init_logger
@@ -288,7 +289,9 @@ def initialize_ray_cluster(
     elif current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
-            ray.init("auto", ignore_reinit_error=True)
+            ray.init("auto",
+                     ignore_reinit_error=True,
+                     namespace=envs.VLLM_RAY_NAMESPACE)
         except ConnectionError:
             logger.warning(
                 "No existing RAY instance detected. "
@@ -297,7 +300,9 @@ def initialize_ray_cluster(
                      ignore_reinit_error=True,
                      num_gpus=parallel_config.world_size)
     else:
-        ray.init(address=ray_address, ignore_reinit_error=True)
+        ray.init(address=ray_address,
+                 ignore_reinit_error=True,
+                 namespace=envs.VLLM_RAY_NAMESPACE)
 
     if parallel_config.placement_group:
         # Placement group is already set.
@@ -310,7 +315,15 @@ def initialize_ray_cluster(
             "support ray.")
 
     # Create placement group for worker processes
-    current_placement_group = ray.util.get_current_placement_group()
+    if envs.VLLM_RAY_PG_NAME:
+        # the placement group is specified by the user
+        logger.info(
+            "Looking for the placement group specified by"
+            " VLLM_RAY_PG_NAME: %s", envs.VLLM_RAY_PG_NAME)
+        current_placement_group = ray.util.get_placement_group(
+            envs.VLLM_RAY_PG_NAME)
+    else:
+        current_placement_group = ray.util.get_current_placement_group()
     if current_placement_group:
         logger.info("Using current placement group")
         # We are in a placement group

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2176,9 +2176,10 @@ def _check_multiproc_method():
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
     try:
         import ray
-        if ray.is_initialized():
+        if (ray.is_initialized()
+                and ray.get_runtime_context().get_actor_id() is not None):
             logger.info(
-                "Ray is initialized. "
+                "vLLM is running as a Ray actor. "
                 "Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn', "
                 "because Ray process can only be spawned, but not forked.")
             os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -2174,6 +2174,16 @@ def _check_multiproc_method():
                        "troubleshooting.html#python-multiprocessing "
                        "for more information.")
         os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    try:
+        import ray
+        if ray.is_initialized():
+            logger.info(
+                "Ray is initialized. "
+                "Setting VLLM_WORKER_MULTIPROC_METHOD to 'spawn', "
+                "because Ray process can only be spawned, but not forked.")
+            os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    except ImportError:
+        pass
 
 
 def get_mp_context():


### PR DESCRIPTION
By default `VLLM_WORKER_MULTIPROC_METHOD` is set to `fork`. However, forking a Ray actor will cause undefined behavior, this leads to hangs in placement group methods using V1.

This PR fixes the issue by detecting if vLLM is used as a Ray actor, and if so, uses `spawn` instead of `fork` for new process creation.

This PR also skips ray initialization if ray is already initialized.

Tested with `VLLM_USE_V1=1 python /home/ubuntu/vllm/examples/offline_inference/rlhf.py` , server started and served requests:

```
(MyLLM pid=2966292) INFO 03-13 16:18:58 [core.py:51] Initializing a V1 LLM engine (v0.6.6.dev668+gc4c11eae.d20250209) with config: model='facebook/opt-125m', speculative_config=None, tokenizer='facebook/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=2048, download_dir=None, load_format=auto, tensor_parallel_size=2, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=facebook/opt-125m, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=False, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":["vllm.unified_attention","vllm.unified_attention_with_output"],"compile_sizes":[],"cudagraph_capture_sizes":[],"max_capture_size":0}

Prompt: 'Hello, my name is', Generated text: ' J.C. and I am a student at the University of California, Berkeley'
Prompt: 'The president of the United States is', Generated text: " not a racist. He is a racist.\nHe's a racist because he"
Prompt: 'The capital of France is', Generated text: ' the capital of the French Republic.\n\nThe capital of France is the capital'
Prompt: 'The future of AI is', Generated text: ' in the hands of the people.\n\nThe future of AI is in the'
```