### PR TITLE
[Frontend] Fix log message to use http vs https

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -955,8 +955,10 @@ async def run_server(args, **uvicorn_kwargs) -> None:
                 return '[' + a + ']'
             return a or "0.0.0.0"
 
-        logger.info("Starting vLLM API server on http://%s:%d",
-                    _listen_addr(sock_addr[0]), sock_addr[1])
+        is_ssl = args.ssl_keyfile and args.ssl_certfile
+        logger.info("Starting vLLM API server on http%s://%s:%d",
+                    "s" if is_ssl else "", _listen_addr(sock_addr[0]),
+                    sock_addr[1])
 
         shutdown_task = await serve_http(
             app,


### PR DESCRIPTION
This log message specified `http://` unconditionally. It should use
`https://` when SSL is in use.

Closes #14767

Signed-off-by: Russell Bryant <rbryant@redhat.com>
