### PR TITLE
[Model] Mamba2 Prefill Performance Tweaks: Fixing Flurry of Unnecessary Memory Copies 

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -466,11 +466,17 @@ class MambaMixer2(CustomOp):
         if has_prefill:
 
             initial_states = None
+
             if has_initial_states is not None and torch.any(
                     has_initial_states):
-                for idx in mamba_cache_params.state_indices_tensor[
-                        ~has_initial_states]:
-                    mamba_cache_params.ssm_state[idx].zero_()
+
+                # vectorized ssm_state zero init
+                batched_zero_init_func = torch.vmap(
+                    lambda idx: mamba_cache_params.ssm_state[idx].zero_())
+                batched_zero_init_func(
+                    mamba_cache_params.
+                    state_indices_tensor[~has_initial_states].unsqueeze(
+                        dim=-1), )
                 initial_states = mamba_cache_params.ssm_state[
                     mamba_cache_params.state_indices_tensor]
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -466,7 +466,8 @@ class MambaMixer2(CustomOp):
         if has_prefill:
 
             initial_states = None
-            if has_initial_states is not None and torch.any(has_initial_states):
+            if has_initial_states is not None and torch.any(
+                    has_initial_states):
                 for idx in mamba_cache_params.state_indices_tensor[
                         ~has_initial_states]:
                     mamba_cache_params.ssm_state[idx].zero_()
@@ -494,13 +495,16 @@ class MambaMixer2(CustomOp):
             )
 
             # vectorized ssm state update using vmap
-            # the 1d state_indices_tensor needs to be unsqueezed to avoid vmap 
+            # the 1d state_indices_tensor needs to be unsqueezed to avoid vmap
             # limitation which doesn't allow use of `item()`
-            # Note: the lambda capture can happen where ssm_state is initialized instead of here
-            batched_copy = torch.vmap(lambda idx, source_state: 
-                mamba_cache_params.ssm_state[idx].copy_(source_state)
-            )
-            batched_copy(mamba_cache_params.state_indices_tensor.unsqueeze(dim=-1), varlen_state)
+            # Note: the lambda capture can happen where ssm_state is initialized
+            #       instead of here
+            batched_copy = torch.vmap(
+                lambda idx, source_state: mamba_cache_params.ssm_state[
+                    idx].copy_(source_state))
+            batched_copy(
+                mamba_cache_params.state_indices_tensor.unsqueeze(dim=-1),
+                varlen_state)
 
             # - reshape
             hidden_states = scan_output.view(seq_len, -1)

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -466,7 +466,7 @@ class MambaMixer2(CustomOp):
         if has_prefill:
 
             initial_states = None
-            if has_initial_states is not None and any(has_initial_states):
+            if has_initial_states is not None and torch.any(has_initial_states):
                 for idx in mamba_cache_params.state_indices_tensor[
                         ~has_initial_states]:
                     mamba_cache_params.ssm_state[idx].zero_()

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -493,10 +493,14 @@ class MambaMixer2(CustomOp):
                 dt_limit=(0.0, float("inf")),
             )
 
-            # update ssm states
-            # - varlen state is a (batch, nheads, headdim, dstate) tensor
-            for i, idx in enumerate(mamba_cache_params.state_indices_tensor):
-                mamba_cache_params.ssm_state[idx].copy_(varlen_state[i])
+            # vectorized ssm state update using vmap
+            # the 1d state_indices_tensor needs to be unsqueezed to avoid vmap 
+            # limitation which doesn't allow use of `item()`
+            # Note: the lambda capture can happen where ssm_state is initialized instead of here
+            batched_copy = torch.vmap(lambda idx, source_state: 
+                mamba_cache_params.ssm_state[idx].copy_(source_state)
+            )
+            batched_copy(mamba_cache_params.state_indices_tensor.unsqueeze(dim=-1), varlen_state)
 
             # - reshape
             hidden_states = scan_output.view(seq_len, -1)


### PR DESCRIPTION
We found an issue while profiling vLLM running Bamba-9B model inference.

Before:
![image (12)](https://github.com/user-attachments/assets/06e71567-e74d-4578-b698-30f7889f397b)

As can be seen in the Nsight Systems trace, per Mamba layer there are 2 phases where frequent memory copies happen. They are not necessary, or can be fused to reduce the number of copies. This PR fixes these issues.

After:
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/dfcde710-75c8-4293-a2c0-eb2c5e7100f8" />

For the test case (offline mode, batch size=64, short prompt) I used, the fix reduces the prefill mamba layer latency from 5ms to 3ms.

The results from benchmark_serving on single H100-80GB GPU
Before:
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  283.22    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              3.53      
Output token throughput (tok/s):         700.32    
Total Token throughput (tok/s):          1460.17   
---------------Time to First Token----------------
Mean TTFT (ms):                          105627.40 
Median TTFT (ms):                        94728.54  
P99 TTFT (ms):                           264194.77 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          393.83    
Median TPOT (ms):                        413.59    
P99 TPOT (ms):                           615.34    
---------------Inter-token Latency----------------
Mean ITL (ms):                           339.72    
Median ITL (ms):                         589.56    
P99 ITL (ms):                            751.76    
==================================================
```
After:
```
 python benchmarks/benchmark_serving.py --model $MODEL_PATH  --dataset-name sharegpt     --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json

============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  260.19    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              3.84      
Output token throughput (tok/s):         762.29    
Total Token throughput (tok/s):          1589.37   
---------------Time to First Token----------------
Mean TTFT (ms):                          96566.51  
Median TTFT (ms):                        84883.05  
P99 TTFT (ms):                           245639.66 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          366.31    
Median TPOT (ms):                        371.88    
P99 TPOT (ms):                           680.49    
---------------Inter-token Latency----------------
Mean ITL (ms):                           311.69    
Median ITL (ms):                         507.96    
P99 ITL (ms):                            741.83    
==================================================
```

The total token throughput improved by about 8%.

Note:
There is another sequential for loop which can be fixed similarly. My test case doesn't hit this control path, though. @fabianlim could you comment?

