### PR TITLE
[Bugfix] Limit profiling run sequence length by max_model_len

### DIFF
--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -142,7 +142,6 @@ def run_whisper(question: str, audio_count: int):
     prompt = "<|startoftranscript|>"
 
     llm = LLM(model=model_name,
-              max_model_len=448,
               max_num_seqs=5,
               limit_mm_per_prompt={"audio": audio_count})
     stop_token_ids = None

--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -142,6 +142,7 @@ def run_whisper(question: str, audio_count: int):
     prompt = "<|startoftranscript|>"
 
     llm = LLM(model=model_name,
+              max_model_len=448,
               max_num_seqs=5,
               limit_mm_per_prompt={"audio": audio_count})
     stop_token_ids = None

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -330,6 +330,11 @@ class InputRegistry:
         from vllm.multimodal import MultiModalKwargs
         from vllm.multimodal.profiling import MultiModalProfiler
 
+        if seq_len > model_config.max_model_len:
+            raise AssertionError(
+                f"Profiling attempted with sequence length ({seq_len}) "
+                f"greater than model length ({model_config.max_model_len})")
+
         if mm_registry.has_processor(model_config):
             tokenizer = cached_tokenizer_from_config(model_config)
             processor = mm_registry.create_processor(model_config,

--- a/vllm/worker/enc_dec_model_runner.py
+++ b/vllm/worker/enc_dec_model_runner.py
@@ -281,6 +281,7 @@ class EncoderDecoderModelRunner(GPUModelRunnerBase[EncoderDecoderModelInput]):
         for group_id in range(max_num_seqs):
             seq_len = (max_num_batched_tokens // max_num_seqs +
                        (group_id < max_num_batched_tokens % max_num_seqs))
+            seq_len = min(seq_len, self.model_config.max_model_len)
             batch_size += seq_len
 
             decoder_dummy_data = self.input_registry \

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1302,6 +1302,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             for group_id in range(max_num_seqs):
                 seq_len = (max_num_batched_tokens // max_num_seqs +
                            (group_id < max_num_batched_tokens % max_num_seqs))
+                seq_len = min(seq_len, self.model_config.max_model_len)
                 batch_size += seq_len
 
                 dummy_data = self.input_registry \

--- a/vllm/worker/openvino_model_runner.py
+++ b/vllm/worker/openvino_model_runner.py
@@ -148,6 +148,7 @@ class OpenVINOModelRunner(ModelRunnerBase):
                 seq_len = min(
                     seq_data.get_len(),
                     computed_len + seq_group_metadata.token_chunk_size,
+                    self.model_config.max_model_len,
                 )
                 if is_prompt:
                     tokens = seq_data.get_token_ids()[computed_len:seq_len]

--- a/vllm/worker/xpu_model_runner.py
+++ b/vllm/worker/xpu_model_runner.py
@@ -466,6 +466,7 @@ class XPUModelRunner(ModelRunnerBase[ModelInputForXPUWithSamplingMetadata]):
         for group_id in range(max_num_seqs):
             seq_len = (max_num_batched_tokens // max_num_seqs +
                        (group_id < max_num_batched_tokens % max_num_seqs))
+            seq_len = min(seq_len, self.model_config.max_model_len)
             batch_size += seq_len
 
             dummy_data = self.input_registry \


### PR DESCRIPTION
## Purpose ##
* Fix whisper offline inference example
* Under specific conditions (short `max_model_len` and low `max_num_seqs`), the sequence length generated for the profiling run can be larger than the max model length

## Changes ##
* Add `max_model_len` cap to enc_dec and standard model runners

## Testing ##
This example used to fail during profiling
* `python3 examples/offline_inference/audio_language.py --model whisper`