### PR TITLE
[Bugfix] Fix small typo in the example of Streaming delimiter

### DIFF
--- a/examples/online_serving/api_client.py
+++ b/examples/online_serving/api_client.py
@@ -42,7 +42,7 @@ def post_http_request(prompt: str,
 def get_streaming_response(response: requests.Response) -> Iterable[list[str]]:
     for chunk in response.iter_lines(chunk_size=8192,
                                      decode_unicode=False,
-                                     delimiter=b"\0"):
+                                     delimiter=b"\n"):
         if chunk:
             data = json.loads(chunk.decode("utf-8"))
             output = data["text"]

--- a/examples/online_serving/gradio_webserver.py
+++ b/examples/online_serving/gradio_webserver.py
@@ -21,7 +21,7 @@ def http_bot(prompt):
 
     for chunk in response.iter_lines(chunk_size=8192,
                                      decode_unicode=False,
-                                     delimiter=b"\0"):
+                                     delimiter=b"\n"):
         if chunk:
             data = json.loads(chunk.decode("utf-8"))
             output = data["text"][0]


### PR DESCRIPTION
fix small typo in the example of Streaming delimiter
This is [apiserver delimiter](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/api_server.py#L74)