### PR TITLE
[Bugfix][W8A8] fixed cutlass block fp8 binding

### DIFF
--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -370,7 +370,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "cutlass_scaled_mm_supports_block_fp8(int cuda_device_capability) -> "
       "bool");
   ops.impl("cutlass_scaled_mm_supports_block_fp8",
-           &cutlass_scaled_mm_supports_fp8);
+           &cutlass_scaled_mm_supports_block_fp8);
 
   // Check if cutlass sparse scaled_mm is supported for CUDA devices of the
   // given capability


### PR DESCRIPTION
fixed https://github.com/vllm-project/vllm/issues/7777 https://github.com/vllm-project/vllm/issues/7499
fixed cutlass block fp8 binding, this error will lead to random/empty output while compiled vLLM with CUDA >= 12.4 on Ada Lovelace.

- before
```C++
ops.impl("cutlass_scaled_mm_supports_block_fp8",
           &cutlass_scaled_mm_supports_fp8);
```
- after 

```bash
ops.impl("cutlass_scaled_mm_supports_block_fp8",
           &cutlass_scaled_mm_supports_block_fp8);
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
