### PR TITLE
[Bugfix][V1] forward compatible flashinfer sampling api

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     VLLM_LOGITS_PROCESSOR_THREADS: Optional[int] = None
     VLLM_TRACE_FUNCTION: int = 0
     VLLM_ATTENTION_BACKEND: Optional[str] = None
-    VLLM_USE_FLASHINFER_SAMPLER: Optional[bool] = None
+    VLLM_USE_FLASHINFER_SAMPLER: Optional[bool] = False
     VLLM_USE_FLASHINFER_REJECTION_SAMPLER: bool = False
     VLLM_FLASHINFER_FORCE_TENSOR_CORES: bool = False
     VLLM_PP_LAYER_PARTITION: Optional[str] = None

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -169,19 +169,21 @@ def flashinfer_sample(
     if generators:
         for i, generator in generators.items():
             uniform_samples[:, i].uniform_(generator=generator)
-    
+
     # The sampling API removes the success return value of all sampling API,
     # which is not compatible with earlier design.
     # https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.3
     if flashinfer.__version__ < "0.2.3":
         if k is None:
             # Top-p only.
-            next_token_ids, success = flashinfer.sampling.top_p_sampling_from_probs(
-                probs, uniform_samples, p, deterministic=True)
+            next_token_ids, success = (
+                flashinfer.sampling.top_p_sampling_from_probs(
+                    probs, uniform_samples, p, deterministic=True))
         elif p is None:
             # Top-k only.
-            next_token_ids, success = flashinfer.sampling.top_k_sampling_from_probs(
-                probs, uniform_samples, k, deterministic=True)
+            next_token_ids, success = (
+                flashinfer.sampling.top_k_sampling_from_probs(
+                    probs, uniform_samples, k, deterministic=True))
         else:
             # Both top-k and top-p.
             next_token_ids, success = (


### PR DESCRIPTION


 The sampling API removes the success return value of all sampling API,
 which is not compatible with earlier design.
 https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.3

<!--- pyml disable-next-line no-emphasis-as-heading -->
