### PR TITLE
[Bugfix][V1] Fix flashinfer sampling

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -26,7 +26,7 @@ class TopKTopPSampler(nn.Module):
             if is_flashinfer_available:
                 flashinfer_version = flashinfer.__version__
                 if flashinfer_version >= "0.2.3":
-                    # FIXME(DefTrue): Currently, we have errors when using
+                    # FIXME(DefTruth): Currently, we have errors when using
                     # FlashInfer>=v0.2.3 for top-p & top-k sampling. As a
                     # workaround, we disable FlashInfer for top-p & top-k
                     # sampling by default while FlashInfer>=v0.2.3.

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -25,7 +25,7 @@ class TopKTopPSampler(nn.Module):
         if current_platform.is_cuda():
             if is_flashinfer_available:
                 flashinfer_version = flashinfer.__version__
-                if flashinfer_version >= "v0.2.3":
+                if flashinfer_version >= "0.2.3":
                     # FIXME(DefTrue): Currently, we have errors when using
                     # FlashInfer>=v0.2.3 for top-p & top-k sampling. As a
                     # workaround, we disable FlashInfer for top-p & top-k

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -24,7 +24,23 @@ class TopKTopPSampler(nn.Module):
         super().__init__()
         if current_platform.is_cuda():
             if is_flashinfer_available:
-                if envs.VLLM_USE_FLASHINFER_SAMPLER is not False:
+                flashinfer_version = flashinfer.__version__
+                if flashinfer_version >= "v0.2.3":
+                    # FIXME(DefTrue): Currently, we have errors when using
+                    # FlashInfer>=v0.2.3 for top-p & top-k sampling. As a
+                    # workaround, we disable FlashInfer for top-p & top-k
+                    # sampling by default while FlashInfer>=v0.2.3.
+                    # The sampling API removes the success return value
+                    # of all sampling API, which is not compatible with
+                    # earlier design.
+                    # https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.3
+                    logger.info(
+                        "Currently, FlashInfer top-p & top-k sampling sampler is "
+                        f"disabled because {flashinfer_version} is not backward "
+                        "compatible. Falling back to the PyTorch-native "
+                        "implementation of top-p & top-k sampling.")
+                    self.forward = self.forward_native
+                elif envs.VLLM_USE_FLASHINFER_SAMPLER is not False:
                     # NOTE(woosuk): The V0 sampler doesn't use FlashInfer for
                     # sampling unless VLLM_USE_FLASHINFER_SAMPLER=1 (i.e., by
                     # default it is unused). For backward compatibility, we set

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -33,12 +33,13 @@ class TopKTopPSampler(nn.Module):
                     # The sampling API removes the success return value
                     # of all sampling API, which is not compatible with
                     # earlier design.
-                    # https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.3
+                    # https://github.com/flashinfer-ai/flashinfer/releases/
+                    # tag/v0.2.3
                     logger.info(
-                        "Currently, FlashInfer top-p & top-k sampling sampler is "
-                        f"disabled because {flashinfer_version} is not backward "
-                        "compatible. Falling back to the PyTorch-native "
-                        "implementation of top-p & top-k sampling.")
+                        "Currently, FlashInfer top-p & top-k sampling sampler "
+                        "is disabled because FlashInfer>=v0.2.3 is not "
+                        "backward compatible. Falling back to the PyTorch-"
+                        "native implementation of top-p & top-k sampling.")
                     self.forward = self.forward_native
                 elif envs.VLLM_USE_FLASHINFER_SAMPLER is not False:
                     # NOTE(woosuk): The V0 sampler doesn't use FlashInfer for


### PR DESCRIPTION

small fix base on https://github.com/vllm-project/vllm/pull/14788
Currently, we have errors when using FlashInfer>=v0.2.3 for top-p & top-k sampling. As a workaround, we disable FlashInfer for top-p & top-k sampling by default while FlashInfer>=v0.2.3. The sampling API removes the success return value of all sampling API, which is not compatible with earlier design. reference: https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.2.3

<!--- pyml disable-next-line no-emphasis-as-heading -->
