### PR TITLE
[Bugfix][Mamba] Fix MambaCache leak

### DIFF
--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -646,6 +646,12 @@ class Scheduler:
         self._finished_requests_ids = list()
         return finished_requests_ids
 
+    def get_async_stopped_request_ids(self):
+        if self._async_stopped:
+            return [seq_group.request_id for seq_group in self._async_stopped]
+        else:
+            return []
+
     def _schedule_running(
         self,
         budget: SchedulingBudget,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -309,6 +309,9 @@ class _AsyncLLMEngine(LLMEngine):
                 finished_requests_ids = self.scheduler[
                     virtual_engine].get_and_reset_finished_requests_ids()
 
+                finished_requests_ids += self.scheduler[
+                    virtual_engine].get_async_stopped_request_ids()
+
             # Maybe switch from async mode to sync mode
             if not allow_async_output_proc and len(ctx.output_queue) > 0:
                 self._process_model_outputs(ctx=ctx)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1385,6 +1385,9 @@ class LLMEngine:
                 if finished_request_id in self.seq_id_to_seq_group:
                     del self.seq_id_to_seq_group[finished_request_id]
 
+            finished_requests_ids += self.scheduler[
+                virtual_engine].get_async_stopped_request_ids()
+
             # Maybe switch from async mode to sync mode
             if not allow_async_output_proc and len(ctx.output_queue) > 0:
                 self._process_model_outputs(ctx=ctx)


### PR DESCRIPTION
When `MambaCacheManager` is full, the following error may occur at this [line](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/mamba_cache.py#L127):
```
IndexError: pop from empty list
```
This happens because when a `seq_group` reaches `max_model_len`, it is moved to `scheduler._async_stopped` instead of `scheduler._finished_requests_ids`, as seen in [this line](https://github.com/vllm-project/vllm/blob/main/vllm/core/scheduler.py#L733). As a result, `MambaCacheManager` cannot immediately release the `seq_group` in `scheduler._async_stopped` at the current step, leading to this issue.

However, this does not cause a memory leak, as `scheduler.free_finished_seq_groups` will eventually move `_async_stopped` to `_finished_requests_ids` after model execution, allowing it to be freed in the next step.

FIX https://github.com/vllm-project/vllm/issues/10693, ~~https://github.com/vllm-project/vllm/issues/13129~~

<!--- pyml disable-next-line no-emphasis-as-heading -->
