### PR TITLE
[Bugfix][Frontend] Eliminate regex based check in reasoning full generator

### DIFF
--- a/tests/reasoning/test_deepseekr1_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekr1_reasoning_parser.py
@@ -94,21 +94,25 @@ THINK_NO_END = {
     "output": "<think>This is a reasoning section",
     "reasoning_content": "This is a reasoning section",
     "content": None,
+    "is_reasoning_end": False,
 }
 EMPTY = {
     "output": "",
     "reasoning_content": "",
     "content": None,
+    "is_reasoning_end": False,
 }
 EMPTY_STREAMING = {
     "output": "",
     "reasoning_content": None,
     "content": None,
+    "is_reasoning_end": False,
 }
 NEW_LINE = {
     "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
     "reasoning_content": "This is a reasoning section",
     "content": "\nThis is the rest",
+    "is_reasoning_end": True,
 }
 # Streaming cannot handle new lines at the beginning of the output
 # because we need to support <think>...</think> and </think>...
@@ -118,6 +122,7 @@ NEW_LINE_STREAMING = {
     "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
     "reasoning_content": "\nThis is a reasoning section",
     "content": "\nThis is the rest",
+    "is_reasoning_end": True,
 }
 
 TEST_CASES = [

--- a/tests/reasoning/test_deepseekr1_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekr1_reasoning_parser.py
@@ -105,6 +105,20 @@ EMPTY_STREAMING = {
     "reasoning_content": None,
     "content": None,
 }
+NEW_LINE = {
+    "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
+    "reasoning_content": "This is a reasoning section",
+    "content": "\nThis is the rest",
+}
+# Streaming cannot handle new lines at the beginning of the output
+# because we need to support <think>...</think> and </think>...
+# We cannot know if the text before <think> is reasoning content
+# or not.
+NEW_LINE_STREAMING = {
+    "output": "\n<think>This is a reasoning section</think>\nThis is the rest",
+    "reasoning_content": "\nThis is a reasoning section",
+    "content": "\nThis is the rest",
+}
 
 TEST_CASES = [
     pytest.param(
@@ -216,6 +230,16 @@ TEST_CASES = [
         True,
         EMPTY_STREAMING,
         id="empty_streaming",
+    ),
+    pytest.param(
+        False,
+        NEW_LINE,
+        id="new_line",
+    ),
+    pytest.param(
+        True,
+        NEW_LINE_STREAMING,
+        id="new_line_streaming",
     ),
 ]
 

--- a/tests/reasoning/test_deepseekr1_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekr1_reasoning_parser.py
@@ -90,6 +90,21 @@ SHORTEST_REASONING_WITH_THINK = {
     "content": "This is the rest",
     "is_reasoning_end": True,
 }
+THINK_NO_END = {
+    "output": "<think>This is a reasoning section",
+    "reasoning_content": "This is a reasoning section",
+    "content": None,
+}
+EMPTY = {
+    "output": "",
+    "reasoning_content": "",
+    "content": None,
+}
+EMPTY_STREAMING = {
+    "output": "",
+    "reasoning_content": None,
+    "content": None,
+}
 
 TEST_CASES = [
     pytest.param(
@@ -181,6 +196,26 @@ TEST_CASES = [
         True,
         SHORTEST_REASONING_WITH_THINK,
         id="shortest_with_think_streaming",
+    ),
+    pytest.param(
+        False,
+        THINK_NO_END,
+        id="think_no_end",
+    ),
+    pytest.param(
+        True,
+        THINK_NO_END,
+        id="think_no_end_streaming",
+    ),
+    pytest.param(
+        False,
+        EMPTY,
+        id="empty",
+    ),
+    pytest.param(
+        True,
+        EMPTY_STREAMING,
+        id="empty_streaming",
     ),
 ]
 

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import re
 from collections.abc import Sequence
 from typing import Optional, Union
 
@@ -31,9 +30,6 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
         super().__init__(tokenizer)
-
-        self.reasoning_regex = re.compile(
-            rf"{self.start_token}(.*?){self.end_token}", re.DOTALL)
 
         if not self.model_tokenizer:
             raise ValueError(
@@ -143,23 +139,42 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
     def extract_reasoning_content(
             self, model_output: str, request: ChatCompletionRequest
     ) -> tuple[Optional[str], Optional[str]]:
+        """
+        Extract reasoning content from the model output.
+
+        For text <think>abc</think>xyz:
+        - 'abc' goes to reasoning_content
+        - 'xyz' goes to content
+
+        Returns:
+            tuple[Optional[str], Optional[str]]: reasoning content and content
+        """
+
+        # Check if the start token is present in the model output, remove it
+        # if it is present.
+        start_token_index = model_output.find(self.think_start_token)
+        if start_token_index != -1:
+            model_output = model_output[start_token_index +
+                                        len(self.think_start_token):]
+
         # DeepSeek R1 doesn't generate <think> now.
         # Thus we assume the reasoning content is always at the start.
         # Ref https://huggingface.co/deepseek-ai/DeepSeek-R1/commit/8a58a132790c9935686eb97f042afa8013451c9f
         if self.end_token not in model_output:
             return model_output, None
         else:
-            # Add a start token if it's missing to keep compatibility.
-            if self.start_token not in model_output:
-                model_output = f"{self.start_token}{model_output}"
-            # Use a regex to find the reasoning content
-            reasoning_content = self.reasoning_regex.findall(model_output)[0]
-
-            end_index = len(
-                f"{self.start_token}{reasoning_content}{self.end_token}")
-            final_output = model_output[end_index:]
-
-            if len(final_output) == 0:
-                return reasoning_content, None
-
-            return reasoning_content, final_output
+            # Find the end token index in the model output.
+            end_token_index = model_output.find(self.think_end_token)
+            # If the end token is not found, return the model output as is.
+            # It should not happen since we already checked for the presence
+            # of the end token.
+            if end_token_index == -1:
+                return model_output, None
+            # Extract the reasoning content before the end token.
+            reasoning_content = model_output[:end_token_index]
+            # Extract the content after the end token.
+            content = model_output[end_token_index +
+                                   len(self.think_end_token):]
+            if len(content) == 0:
+                content = None
+            return reasoning_content, content

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -162,7 +162,7 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         if self.end_token not in model_output:
             return model_output, None
         else:
-            reasoning_content, end, content = model_output.partition(
+            reasoning_content, _, content = model_output.partition(
                 self.think_end_token)
             # If the end token is not found, return the model output as is.
             # It should not happen since we already checked for the presence

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -176,5 +176,5 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
             content = model_output[end_token_index +
                                    len(self.think_end_token):]
             if len(content) == 0:
-                content = None
+                return reasoning_content, None
             return reasoning_content, content

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -168,5 +168,5 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
             # It should not happen since we already checked for the presence
             # of the end token.
             # If generation stops right after end-of-think, return null content
-            content = content or None
-            return reasoning_content, content
+            final_content = content or None
+            return reasoning_content, final_content

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -152,7 +152,7 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
 
         # Check if the start token is present in the model output, remove it
         # if it is present.
-        model_output_parts = model_output.partition(self.think_start_token)
+        model_output_parts = model_output.partition(self.start_token)
         model_output = model_output_parts[2] if model_output_parts[
             1] else model_output_parts[0]
 
@@ -163,7 +163,7 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
             return model_output, None
         else:
             reasoning_content, _, content = model_output.partition(
-                self.think_end_token)
+                self.end_token)
             # If the end token is not found, return the model output as is.
             # It should not happen since we already checked for the presence
             # of the end token.


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/14761

This PR:

- Removes buggy regex-based parser in reasoning full generation and introduces a string-compare approach.
- Adds more test cases for deepseek reasoning
