### PR TITLE
[Frontend][Bugfix] support prefill decode disaggregation on deepseek

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -169,11 +169,12 @@ class SimpleConnector(KVConnectorBase):
         num_attention_heads = model_config.num_attention_heads
 
         if hasattr(model_config, "kv_lora_rank"):
-            head_size = model_config.kv_lora_rank + model_config.qk_rope_head_dim
+            head_size = model_config.kv_lora_rank + \
+                model_config.qk_rope_head_dim
             num_heads = 1
         else:
             head_size = getattr(model_config, "head_dim",
-                        int(hidden_size // num_attention_heads))
+                                int(hidden_size // num_attention_heads))
 
         # query_lens contains new KV caches that are added to vLLM.
         # so we will send them to decode instance
@@ -196,7 +197,6 @@ class SimpleConnector(KVConnectorBase):
 
             for layer_id in range(start_layer, end_layer):
                 kv_cache = kv_caches[layer_id - start_layer]
-
 
                 if hasattr(model_config, "kv_lora_rank"):
                     key_cache = kv_cache.reshape(-1, num_heads, head_size)
@@ -305,8 +305,12 @@ class SimpleConnector(KVConnectorBase):
 
                 if hasattr(model_config, "kv_lora_rank"):
                     layer.self_attn.attn = layer.self_attn.mla_attn
-                    k_c_normed = keys[i - model_executable.model.start_layer].to(kv_cache.device)
-                    k_pe_sqz = values[i - model_executable.model.start_layer].to(kv_cache.device)
+                    k_c_normed = keys[i -
+                                      model_executable.model.start_layer].to(
+                                          kv_cache.device)
+                    k_pe_sqz = values[i -
+                                      model_executable.model.start_layer].to(
+                                          kv_cache.device)
                     k_c_normed = k_c_normed.squeeze(1)
                     k_pe_sqz = k_pe_sqz.squeeze(1)
                     ops.concat_and_cache_mla(

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -309,8 +309,6 @@ class SimpleConnector(KVConnectorBase):
                     k_pe_sqz = values[i - model_executable.model.start_layer].to(kv_cache.device)
                     k_c_normed = k_c_normed.squeeze(1)
                     k_pe_sqz = k_pe_sqz.squeeze(1)
-                    logger.info(f"k_c_normed.shape = {k_c_normed.shape}")
-                    logger.info(f"k_pe_sqz.shape = {k_pe_sqz.shape}")
                     ops.concat_and_cache_mla(
                         k_c_normed[:, :model_config.kv_lora_rank],
                         k_pe_sqz[:, model_config.kv_lora_rank:],

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -199,7 +199,6 @@ class SimpleConnector(KVConnectorBase):
             for layer_id in range(start_layer, end_layer):
                 kv_cache = kv_caches[layer_id - start_layer]
 
-                logger.info(f"before split kv_cache.shape: {kv_cache.shape}")
 
                 if hasattr(model_config, "kv_lora_rank"):
                     key_cache = kv_cache.reshape(-1, num_heads, head_size)

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -174,8 +174,6 @@ class SimpleConnector(KVConnectorBase):
         else:
             head_size = getattr(model_config, "head_dim",
                         int(hidden_size // num_attention_heads))
-        logger.info(f"head_size = {head_size}")
-        logger.info(f"num_heads = {num_heads}")
 
         # query_lens contains new KV caches that are added to vLLM.
         # so we will send them to decode instance
@@ -322,7 +320,6 @@ class SimpleConnector(KVConnectorBase):
                         layer.self_attn.attn._k_scale,
                     )
                 else:
-
                     key_cache, value_cache = kv_cache[0], kv_cache[1]
                     ops.reshape_and_cache_flash(
                         keys[i - model_executable.model.start_layer].to(

--- a/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/simple_connector.py
@@ -167,8 +167,15 @@ class SimpleConnector(KVConnectorBase):
         num_heads = int(model_config.num_key_value_heads / self.tp_size)
         hidden_size = model_config.hidden_size
         num_attention_heads = model_config.num_attention_heads
-        head_size = getattr(model_config, "head_dim",
-                            int(hidden_size // num_attention_heads))
+
+        if hasattr(model_config, "kv_lora_rank"):
+            head_size = model_config.kv_lora_rank + model_config.qk_rope_head_dim
+            num_heads = 1
+        else:
+            head_size = getattr(model_config, "head_dim",
+                        int(hidden_size // num_attention_heads))
+        logger.info(f"head_size = {head_size}")
+        logger.info(f"num_heads = {num_heads}")
 
         # query_lens contains new KV caches that are added to vLLM.
         # so we will send them to decode instance
@@ -192,8 +199,14 @@ class SimpleConnector(KVConnectorBase):
             for layer_id in range(start_layer, end_layer):
                 kv_cache = kv_caches[layer_id - start_layer]
 
-                key_cache = kv_cache[0].reshape(-1, num_heads, head_size)
-                value_cache = kv_cache[1].reshape(-1, num_heads, head_size)
+                logger.info(f"before split kv_cache.shape: {kv_cache.shape}")
+
+                if hasattr(model_config, "kv_lora_rank"):
+                    key_cache = kv_cache.reshape(-1, num_heads, head_size)
+                    value_cache = kv_cache.reshape(-1, num_heads, head_size)
+                else:
+                    key_cache = kv_cache[0].reshape(-1, num_heads, head_size)
+                    value_cache = kv_cache[1].reshape(-1, num_heads, head_size)
 
                 current_slot_mapping = slot_mapping_flat[start_pos:end_pos]
 
@@ -222,6 +235,8 @@ class SimpleConnector(KVConnectorBase):
         # In this case we need to do prefilling to recompute missing KV cache
         # and hidden states.
         bypass_model_exec = True
+
+        model_config = model_executable.model.config
 
         input_tokens_tensor = model_input.input_tokens
         seq_lens = model_input.attn_metadata.seq_lens
@@ -291,19 +306,37 @@ class SimpleConnector(KVConnectorBase):
                 kv_cache = kv_caches[i - model_executable.model.start_layer]
                 layer = model_executable.model.layers[i]
 
-                key_cache, value_cache = kv_cache[0], kv_cache[1]
-                ops.reshape_and_cache_flash(
-                    keys[i - model_executable.model.start_layer].to(
-                        key_cache.device),
-                    values[i - model_executable.model.start_layer].to(
-                        value_cache.device),
-                    key_cache,
-                    value_cache,
-                    slot_mapping[start_pos:end_pos],
-                    layer.self_attn.attn.kv_cache_dtype,
-                    layer.self_attn.attn._k_scale,
-                    layer.self_attn.attn._v_scale,
-                )
+                if hasattr(model_config, "kv_lora_rank"):
+                    layer.self_attn.attn = layer.self_attn.mla_attn
+                    k_c_normed = keys[i - model_executable.model.start_layer].to(kv_cache.device)
+                    k_pe_sqz = values[i - model_executable.model.start_layer].to(kv_cache.device)
+                    k_c_normed = k_c_normed.squeeze(1)
+                    k_pe_sqz = k_pe_sqz.squeeze(1)
+                    logger.info(f"k_c_normed.shape = {k_c_normed.shape}")
+                    logger.info(f"k_pe_sqz.shape = {k_pe_sqz.shape}")
+                    ops.concat_and_cache_mla(
+                        k_c_normed[:, :model_config.kv_lora_rank],
+                        k_pe_sqz[:, model_config.kv_lora_rank:],
+                        kv_cache,
+                        slot_mapping[start_pos:end_pos],
+                        layer.self_attn.attn.kv_cache_dtype,
+                        layer.self_attn.attn._k_scale,
+                    )
+                else:
+
+                    key_cache, value_cache = kv_cache[0], kv_cache[1]
+                    ops.reshape_and_cache_flash(
+                        keys[i - model_executable.model.start_layer].to(
+                            key_cache.device),
+                        values[i - model_executable.model.start_layer].to(
+                            value_cache.device),
+                        key_cache,
+                        value_cache,
+                        slot_mapping[start_pos:end_pos],
+                        layer.self_attn.attn.kv_cache_dtype,
+                        layer.self_attn.attn._k_scale,
+                        layer.self_attn.attn._v_scale,
+                    )
 
             hidden_or_intermediate_states_for_one_req.append(hidden)
 

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -589,6 +589,7 @@ class DeepseekV2Model(nn.Module):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
+        self.config = config
 
         self.vocab_size = config.vocab_size
 


### PR DESCRIPTION
This patch aims to provides the following:
1) fix for issue https://github.com/vllm-project/vllm/issues/14324
2) support prefill decode disaggregation on deepseek

After applying the PR, we got the correct output from 1P1D case on deepseek v2 :

```
curl -X POST -s http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
"model": "deepseek-ai/DeepSeek-V2-Lite",
"prompt": "San Jose is a",
"max_tokens": 50,
"temperature": 0
}'

{"id":"cmpl-e85d4162e19942d5a5f0a31304b31188","object":"text_completion","created":1741965377,"model":"deepseek-ai/DeepSeek-V2-Lite","choices":[{"index":0,"text":" city in the Bay Area of California. It is the largest city in Northern California and the third largest in the state. It is the county seat of Santa Clara County.\nSan Jose is a major center for high-tech industry, with many major","logprobs":null,"finish_reason":"length","stop_reason":null,"prompt_logprobs":null}],"usage":{"prompt_tokens":5,"total_tokens":55,"completion_tokens":50,"prompt_tokens_details":null}}
```



<!--- pyml disable-next-line no-emphasis-as-heading -->
