### PR TITLE
[V1] Fix vocab size calculation for structured output

### DIFF
--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -40,7 +40,7 @@ class StructuredOutputManager:
         tokenizer_group.ping()
 
         tokenizer = tokenizer_group.get_lora_tokenizer(None)
-        self.vocab_size = tokenizer.max_token_id
+        self.vocab_size = tokenizer.max_token_id + 1
         if isinstance(tokenizer, MistralTokenizer):
             # NOTE: ideally, xgrammar should handle this accordingly.
             # refer to https://github.com/mlc-ai/xgrammar/blob/d77c0a0173ef14779c918e3be7966ba852f7910f/python/xgrammar/tokenizer_info.py#L98


### PR DESCRIPTION
When testing with V1 structured output + Llama-3.1-8B-Instruct, the
changes made in #14630 broke for me. I get the error:

```
ERROR 03-14 15:44:42 [core.py:337]   File "/home/rbryant/vllm/vllm/v1/structured_output/__init__.py", line 77, in _delayed_init
ERROR 03-14 15:44:42 [core.py:337]     tokenizer_info = xgr.TokenizerInfo.from_huggingface(
ERROR 03-14 15:44:42 [core.py:337]   File "/home/rbryant/vllm/venv/lib/python3.10/site-packages/xgrammar/tokenizer_info.py", line 184, in from_huggingface
ERROR 03-14 15:44:42 [core.py:337]     raise ValueError(msg)
ERROR 03-14 15:44:42 [core.py:337] ValueError: Input vocab_size less than minimum viable vocab size for tokenizer <class 'vllm.transformers_utils.tokenizer.get_cached_tokenizer.<locals>.CachedTokenizer'>.
ERROR 03-14 15:44:42 [core.py:337]
```

The vocab size was off by one. The max token ID is not == the vocab
size, since 0 is also a token ID. It's the max token ID + 1.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
