### PR TITLE
[Neuron][CI] update docker run command

### DIFF
--- a/.buildkite/run-neuron-test.sh
+++ b/.buildkite/run-neuron-test.sh
@@ -44,7 +44,7 @@ remove_docker_container() {
 trap remove_docker_container EXIT
 
 # Run the image
-docker run --rm -it --device=/dev/neuron0 --device=/dev/neuron1 --network host \
+docker run --rm -it --device=/dev/neuron0 --network bridge \
        -v "${HF_CACHE}:${HF_MOUNT}" \
        -e "HF_HOME=${HF_MOUNT}" \
        -v "${NEURON_COMPILE_CACHE_URL}:${NEURON_COMPILE_CACHE_MOUNT}" \


### PR DESCRIPTION
There are two changes:
* change network from host to bridge
   - This is because we want to enable EnableDockerUserNamespaceRemap=true, which enables Docker user namespace remapping so docker runs as buildkite-agent. Otherwise, docker would raise `Error response from daemon: cannot share the host's network namespace when user namespaces are enabled`.
* reduce device to single neuron device `/dev/neuron0` for upto 2-core test suite, since each neuron-device may include 2 physical NeuronCores.
