### PR TITLE
[Build/CI] Upgrade jinja2 to get 3 moderate CVE fixes

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,4 +6,4 @@ setuptools>=61
 setuptools-scm>=8
 torch==2.5.1
 wheel
-jinja2
+jinja2>=3.1.6

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -12,5 +12,5 @@ packaging
 setuptools>=61
 setuptools-scm>=8
 wheel
-jinja2
+jinja2>=3.1.6
 amdsmi==6.2.4

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -182,7 +182,7 @@ iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via datamodel-code-generator
-jinja2==3.1.4
+jinja2==3.1.6
     # via
     #   datamodel-code-generator
     #   torch

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -7,7 +7,7 @@ ninja
 packaging
 setuptools-scm>=8
 wheel
-jinja2
+jinja2>=3.1.6
 ray[default]
 ray[data]
 

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -8,7 +8,7 @@ packaging
 setuptools-scm>=8
 setuptools>=75.8.0
 wheel
-jinja2
+jinja2>=3.1.6
 datasets # for benchmark scripts
 
 torch==2.6.0+xpu


### PR DESCRIPTION
Versions prior to 3.1.6 are vulnerable to these 3 CVEs. We should ensure
we are using >=3.1.6 to avoid any potential security vulnerability via
jinja2.

* https://github.com/advisories/GHSA-gmj6-6f8f-6699
* https://github.com/advisories/GHSA-q2x7-8rv6-6q7h
* https://github.com/advisories/GHSA-cpwx-vrp4-4pq7

Signed-off-by: Russell Bryant <rbryant@redhat.com>
