### PR TITLE
[Build/CI] Upgrade aiohttp to incldue CVE fix

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ accelerate==1.0.1
     #   peft
 aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.10
+aiohttp==3.10.11
     # via
     #   datasets
     #   fsspec


### PR DESCRIPTION
The previous version is vulnerable to the following:

* https://github.com/advisories/GHSA-27mf-ghqm-j3j8

It does not appear that vLLM is affected. However, we should avoid
explicitly requiring a version of a library with known CVEs, or we will
get flagged for it.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
