### PR TITLE
Revert "[Model] Mamba2 Prefill Performance Tweaks: Fixing Flurry of U…

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -466,17 +466,10 @@ class MambaMixer2(CustomOp):
         if has_prefill:
 
             initial_states = None
-
-            if has_initial_states is not None and torch.any(
-                    has_initial_states):
-
-                # vectorized ssm_state zero init
-                batched_zero_init_func = torch.vmap(
-                    lambda idx: mamba_cache_params.ssm_state[idx].zero_())
-                batched_zero_init_func(
-                    mamba_cache_params.
-                    state_indices_tensor[~has_initial_states].unsqueeze(
-                        dim=-1), )
+            if has_initial_states is not None and any(has_initial_states):
+                for idx in mamba_cache_params.state_indices_tensor[
+                        ~has_initial_states]:
+                    mamba_cache_params.ssm_state[idx].zero_()
                 initial_states = mamba_cache_params.ssm_state[
                     mamba_cache_params.state_indices_tensor]
 
@@ -500,17 +493,10 @@ class MambaMixer2(CustomOp):
                 dt_limit=(0.0, float("inf")),
             )
 
-            # vectorized ssm state update using vmap
-            # the 1d state_indices_tensor needs to be unsqueezed to avoid vmap
-            # limitation which doesn't allow use of `item()`
-            # Note: the lambda capture can happen where ssm_state is initialized
-            #       instead of here
-            batched_copy = torch.vmap(
-                lambda idx, source_state: mamba_cache_params.ssm_state[
-                    idx].copy_(source_state))
-            batched_copy(
-                mamba_cache_params.state_indices_tensor.unsqueeze(dim=-1),
-                varlen_state)
+            # update ssm states
+            # - varlen state is a (batch, nheads, headdim, dstate) tensor
+            for i, idx in enumerate(mamba_cache_params.state_indices_tensor):
+                mamba_cache_params.ssm_state[idx].copy_(varlen_state[i])
 
             # - reshape
             hidden_states = scan_output.view(seq_len, -1)


### PR DESCRIPTION
…nnecessary Memory Copies  (#14778)"

This reverts commit fe66b34728e5d383e3d19aefc544eeee808c99fb.

```
lm_eval --model vllm \
    --model_args pretrained=ibm-ai-platform/Bamba-9B,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.8 \
    --tasks gsm8k --limit 100 \
    --batch_size auto
```

```
main:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |     0|
|     |       |strict-match    |     5|exact_match|↑  |    0|±  |     0|


this PR:
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.22|±  |0.0416|
|     |       |strict-match    |     5|exact_match|↑  | 0.32|±  |0.0469|
```