### PR TITLE
[Misc] Remove misleading message in gemma2 and gemma3

### DIFF
--- a/vllm/model_executor/models/gemma.py
+++ b/vllm/model_executor/models/gemma.py
@@ -424,9 +424,5 @@ class GemmaForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
                                         default_weight_loader)
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            logger.warning(
-                "Some weights are not initialized from checkpoints: %s",
-                unloaded_params)
+
         return loaded_params

--- a/vllm/model_executor/models/gemma2.py
+++ b/vllm/model_executor/models/gemma2.py
@@ -358,11 +358,6 @@ class Gemma2Model(nn.Module):
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            logger.warning(
-                "Some weights are not initialized from checkpoints: %s",
-                unloaded_params)
         return loaded_params
 
 

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -452,11 +452,6 @@ class Gemma3Model(nn.Module):
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
-        unloaded_params = params_dict.keys() - loaded_params
-        if unloaded_params:
-            logger.warning(
-                "Some weights are not initialized from checkpoints: %s",
-                unloaded_params)
         return loaded_params
 
 


### PR DESCRIPTION

FIX https://github.com/vllm-project/vllm/issues/14828#issuecomment-2725730609

- Remove the misleading weight loading check message in gemma2 and gemma3, especially we have correct weight check implementation with similar message in model_loader:
https://github.com/vllm-project/vllm/blob/9f37422779a17d8b2ebde300808166068f4ad4cc/vllm/model_executor/model_loader/loader.py#L433-L440

<!--- pyml disable-next-line no-emphasis-as-heading -->
