### PR TITLE
[Model] RE: Mamba2 Prefill Performance Tweaks: Fixing Flurry of Unnecessary Memory Copies 

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -469,7 +469,7 @@ class MambaMixer2(CustomOp):
                     has_initial_states):
                 zero_init_indices = mamba_cache_params.state_indices_tensor[
                     ~has_initial_states]
-                mamba_cache_params.ssm_state[zero_init_indices].zero_()
+                mamba_cache_params.ssm_state[zero_init_indices] = 0
                 initial_states = mamba_cache_params.ssm_state[
                     mamba_cache_params.state_indices_tensor]
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -465,10 +465,11 @@ class MambaMixer2(CustomOp):
         if has_prefill:
 
             initial_states = None
-            if has_initial_states is not None and any(has_initial_states):
-                for idx in mamba_cache_params.state_indices_tensor[
-                        ~has_initial_states]:
-                    mamba_cache_params.ssm_state[idx].zero_()
+            if has_initial_states is not None and torch.any(
+                    has_initial_states):
+                zero_init_indices = mamba_cache_params.state_indices_tensor[
+                    ~has_initial_states]
+                mamba_cache_params.ssm_state[zero_init_indices].zero_()
                 initial_states = mamba_cache_params.ssm_state[
                     mamba_cache_params.state_indices_tensor]
 
@@ -494,8 +495,8 @@ class MambaMixer2(CustomOp):
 
             # update ssm states
             # - varlen state is a (batch, nheads, headdim, dstate) tensor
-            for i, idx in enumerate(mamba_cache_params.state_indices_tensor):
-                mamba_cache_params.ssm_state[idx].copy_(varlen_state[i])
+            mamba_cache_params.ssm_state[
+                mamba_cache_params.state_indices_tensor] = varlen_state
 
             # - reshape
             hidden_states = scan_output.view(seq_len, -1)


### PR DESCRIPTION
This is a re-attempt to fix mamba2's excessive memory copies. The previous solution failed due to difference in semantics when indexing tensor with tensor.  This new solution directly utilizes indexing with `state_indices_tensor` to create tensor `views` and simplified the code without over-engineering.

FIX #14778 

The results from benchmark_serving on single H100-80GB GPU (Actually I found high variance of throughput numbers from consecutive tests of the same code base when using this benchmark. Not sure if this is meaningful to report? @njhill @tlrmchlsmth  )

### Benchmark serving main

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  291.76    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              3.43      
Output token throughput (tok/s):         679.81    
Total Token throughput (tok/s):          1417.39   
---------------Time to First Token----------------
Mean TTFT (ms):                          108636.82 
Median TTFT (ms):                        96115.48  
P99 TTFT (ms):                           276325.38 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          409.48    
Median TPOT (ms):                        427.24    
P99 TPOT (ms):                           655.84    
---------------Inter-token Latency----------------
Mean ITL (ms):                           352.50    
Median ITL (ms):                         606.12    
P99 ITL (ms):                            969.64    
==================================================

```

### Benchmark serving with this PR
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  252.11    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              3.97      
Output token throughput (tok/s):         786.73    
Total Token throughput (tok/s):          1640.33   
---------------Time to First Token----------------
Mean TTFT (ms):                          97161.98  
Median TTFT (ms):                        94360.96  
P99 TTFT (ms):                           237572.12 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          355.17    
Median TPOT (ms):                        381.49    
P99 TPOT (ms):                           548.15    
---------------Inter-token Latency----------------
Mean ITL (ms):                           306.68    
Median ITL (ms):                         501.06    
P99 ITL (ms):                            750.59    
==================================================
```

### lm-eval main
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.22|±  |0.0416|
|     |       |strict-match    |     5|exact_match|↑  | 0.32|±  |0.0469|
```

### lm-eval with this PR
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.22|±  |0.0416|
|     |       |strict-match    |     5|exact_match|↑  | 0.32|±  |0.0469|
```

cc @fabianlim  @yury-tokpanov