### PR TITLE
[Model] Enable adjusting num_hidden_layers in Llama model via hf-overrides

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -379,6 +379,10 @@ class LlamaModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
+            if name.startswith("layers"):
+                layer_idx = int(name.split(".")[1])
+                if layer_idx >= self.config.num_hidden_layers:
+                    continue
             if "rotary_emb.inv_freq" in name:
                 continue
             if ("rotary_emb.cos_cached" in name


### PR DESCRIPTION
[Model] Enable adjusting num_hidden_layers in Llama model via hf-overrides

- Modified the code to allow configuring the number of hidden layers in the Llama model using hf-overrides.
- This configuration can help reduce test time when developing Custom Kernels, Backends, and other components.