### PR TITLE
[BugFix] Fix torch distributed stateless PG backend init

### DIFF
--- a/examples/offline_inference/data_parallel.py
+++ b/examples/offline_inference/data_parallel.py
@@ -73,8 +73,10 @@ if __name__ == "__main__":
     for i in range(DP_size):
         proc = Process(target=main,
                        args=(DP_size, i, dp_master_ip, dp_master_port,
-                             GPUs_per_dp_rank))
+                             GPUs_per_dp_rank), daemon=True)
         proc.start()
         procs.append(proc)
     for proc in procs:
         proc.join()
+        if proc.exitcode:
+            exit(proc.exitcode)

--- a/examples/offline_inference/data_parallel.py
+++ b/examples/offline_inference/data_parallel.py
@@ -73,11 +73,13 @@ if __name__ == "__main__":
     for i in range(DP_size):
         proc = Process(target=main,
                        args=(DP_size, i, dp_master_ip, dp_master_port,
-                             GPUs_per_dp_rank),
-                       daemon=True)
+                             GPUs_per_dp_rank))
         proc.start()
         procs.append(proc)
+    exit_code = 0
     for proc in procs:
         proc.join()
         if proc.exitcode:
-            exit(proc.exitcode)
+            exit_code = proc.exitcode
+
+    exit(exit_code)

--- a/examples/offline_inference/data_parallel.py
+++ b/examples/offline_inference/data_parallel.py
@@ -73,7 +73,8 @@ if __name__ == "__main__":
     for i in range(DP_size):
         proc = Process(target=main,
                        args=(DP_size, i, dp_master_ip, dp_master_port,
-                             GPUs_per_dp_rank), daemon=True)
+                             GPUs_per_dp_rank),
+                       daemon=True)
         proc.start()
         procs.append(proc)
     for proc in procs:

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -299,14 +299,13 @@ def stateless_init_torch_distributed_process_group(
     # different systems (e.g. RPC) in case the store is multi-tenant.
     prefix_store = PrefixStore(init_method, store)
 
-    pg_options = ProcessGroup.Options(backend=backend, timeout=timeout)
-
     pg: ProcessGroup = ProcessGroup(
         prefix_store,
         group_rank,
         group_size,
-        pg_options,
     )
+
+    pg._set_default_backend(backend)
 
     if backend == "gloo":
         from torch.distributed.distributed_c10d import ProcessGroupGloo
@@ -327,6 +326,8 @@ def stateless_init_torch_distributed_process_group(
                                          backend_options)
         backend_type = ProcessGroup.BackendType.NCCL
         device = torch.device("cuda")
+    else:
+        raise RuntimeError(f"Unsupported backend type: {backend}")
 
     backend_class._set_sequence_number_for_group()
 

--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -305,8 +305,6 @@ def stateless_init_torch_distributed_process_group(
         group_size,
     )
 
-    pg._set_default_backend(backend)
-
     if backend == "gloo":
         from torch.distributed.distributed_c10d import ProcessGroupGloo
         backend_class = ProcessGroupGloo(prefix_store,
@@ -327,8 +325,9 @@ def stateless_init_torch_distributed_process_group(
         backend_type = ProcessGroup.BackendType.NCCL
         device = torch.device("cuda")
     else:
-        raise RuntimeError(f"Unsupported backend type: {backend}")
+        raise RuntimeError(f"Unsupported torch distributed backend: {backend}")
 
+    pg._set_default_backend(backend_type)
     backend_class._set_sequence_number_for_group()
 
     pg._register_backend(device, backend_type, backend_class)


### PR DESCRIPTION
`ProcessGroup.Options` was removed in torch 2.5: https://github.com/pytorch/pytorch/pull/132931

This affects data parallel. There was also a bug where the test script would exit successfully even if the subprocs fail, which is why we missed this originally.