### PR TITLE
[Kernel] vLLM Windows CUDA support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,14 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
   # Set CUTLASS_REVISION manually -- its revision detection doesn't work in this case.
   # Please keep this in sync with FetchContent_Declare line below.
   set(CUTLASS_REVISION "v3.8.0" CACHE STRING "CUTLASS revision to use")
+  set(CUTLASS_ENABLE_CUBLAS ON CACHE BOOL "cuBLAS enabled for Cutlass")
+  set(CUBLAS_ENABLED ON CACHE BOOL "cuBLAS enabled")
+  if (WIN32)
+	list(APPEND VLLM_GPU_FLAGS "-O2")
+	list(APPEND VLLM_GPU_FLAGS "-Xptxas=-O2")
+	list(APPEND VLLM_GPU_FLAGS "-Xcompiler=/O2")
+	set(CMAKE_CUDA_FLAGS_DEBUG "")
+  endif()
 
   # Use the specified CUTLASS source directory for compilation if VLLM_CUTLASS_SRC_DIR is provided
   if (DEFINED ENV{VLLM_CUTLASS_SRC_DIR})
@@ -262,18 +270,34 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
     message(STATUS "The VLLM_CUTLASS_SRC_DIR is set, using ${VLLM_CUTLASS_SRC_DIR} for compilation")
     FetchContent_Declare(cutlass SOURCE_DIR ${VLLM_CUTLASS_SRC_DIR})
   else()
-    FetchContent_Declare(
-        cutlass
-        GIT_REPOSITORY https://github.com/nvidia/cutlass.git
-        # Please keep this in sync with CUTLASS_REVISION line above.
-        GIT_TAG v3.8.0
-        GIT_PROGRESS TRUE
+    if (WIN32)
+	  FetchContent_Declare(
+          cutlass
+		  # For Windows, use fixed v3.8.0 fix-sm100gemm custom branch until Nvidia the fixes into official repo. More info https://github.com/NVIDIA/cutlass/pull/2167
+          GIT_REPOSITORY https://github.com/SystemPanic/cutlass.git
+          # Please keep this in sync with CUTLASS_REVISION line above.
+          GIT_TAG fix-sm100gemm
+          GIT_PROGRESS TRUE
 
-        # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.
-        # Important: If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags.
-        # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
-        GIT_SHALLOW TRUE
-    )
+          # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.
+          # Important: If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags.
+          # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
+          GIT_SHALLOW TRUE
+      )
+	else()
+	  FetchContent_Declare(
+          cutlass
+          GIT_REPOSITORY https://github.com/nvidia/cutlass.git
+          # Please keep this in sync with CUTLASS_REVISION line above.
+          GIT_TAG v3.8.0
+          GIT_PROGRESS TRUE
+
+          # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.
+          # Important: If GIT_SHALLOW is enabled then GIT_TAG works only with branch names and tags.
+          # So if the GIT_TAG above is updated to a commit hash, GIT_SHALLOW must be set to FALSE
+          GIT_SHALLOW TRUE
+      )
+	endif()
   endif()
   FetchContent_MakeAvailable(cutlass)
 
@@ -534,17 +558,33 @@ if(VLLM_GPU_LANG STREQUAL "CUDA")
 endif()
 
 message(STATUS "Enabling C extension.")
-define_gpu_extension_target(
-  _C
-  DESTINATION vllm
-  LANGUAGE ${VLLM_GPU_LANG}
-  SOURCES ${VLLM_EXT_SRC}
-  COMPILE_FLAGS ${VLLM_GPU_FLAGS}
-  ARCHITECTURES ${VLLM_GPU_ARCHES}
-  INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
-  INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
-  USE_SABI 3
-  WITH_SOABI)
+if (DEFINED _CUBLAS_LIBRARY)
+  define_gpu_extension_target(
+    _C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
+    INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
+    LIBRARIES ${_CUBLAS_LIBRARY}
+    USE_SABI 3
+    WITH_SOABI)
+else()
+  define_gpu_extension_target(
+    _C
+    DESTINATION vllm
+    LANGUAGE ${VLLM_GPU_LANG}
+    SOURCES ${VLLM_EXT_SRC}
+    COMPILE_FLAGS ${VLLM_GPU_FLAGS}
+    ARCHITECTURES ${VLLM_GPU_ARCHES}
+    INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
+    INCLUDE_DIRECTORIES ${CUTLASS_TOOLS_UTIL_INCLUDE_DIR}
+    USE_SABI 3
+    WITH_SOABI)
+endif()
+
 
 # If CUTLASS is compiled on NVCC >= 12.5, it by default uses
 # cudaGetDriverEntryPointByVersion as a wrapper to avoid directly calling the

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -133,13 +133,13 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
 
   // Create data structures for the kernel.
   // Create an array of pointers to the key and value caches.
-  #ifdef _WIN32
+#ifdef _WIN32
   int64_t* key_cache_ptrs = new int64_t[num_layers];
   int64_t* value_cache_ptrs = new int64_t[num_layers];
-  #else
+#else
   int64_t key_cache_ptrs[num_layers];
   int64_t value_cache_ptrs[num_layers];
-  #endif
+#endif
   for (int layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
     key_cache_ptrs[layer_idx] =
         reinterpret_cast<int64_t>(key_caches[layer_idx].data_ptr());
@@ -172,10 +172,10 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
             value_cache_ptrs_tensor.data_ptr<int64_t>(),
             block_mapping.data_ptr<int64_t>(), numel_per_block);
       }));
-  #ifdef _WIN32
+#ifdef _WIN32
   delete[] key_cache_ptrs;
   delete[] value_cache_ptrs;
-  #endif
+#endif
 }
 
 // copy blocks kernel for MLA (assumes a joint KV-cache)

--- a/csrc/cache_kernels.cu
+++ b/csrc/cache_kernels.cu
@@ -133,8 +133,13 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
 
   // Create data structures for the kernel.
   // Create an array of pointers to the key and value caches.
+  #ifdef _WIN32
+  int64_t* key_cache_ptrs = new int64_t[num_layers];
+  int64_t* value_cache_ptrs = new int64_t[num_layers];
+  #else
   int64_t key_cache_ptrs[num_layers];
   int64_t value_cache_ptrs[num_layers];
+  #endif
   for (int layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
     key_cache_ptrs[layer_idx] =
         reinterpret_cast<int64_t>(key_caches[layer_idx].data_ptr());
@@ -167,6 +172,10 @@ void copy_blocks(std::vector<torch::Tensor> const& key_caches,
             value_cache_ptrs_tensor.data_ptr<int64_t>(),
             block_mapping.data_ptr<int64_t>(), numel_per_block);
       }));
+  #ifdef _WIN32
+  delete[] key_cache_ptrs;
+  delete[] value_cache_ptrs;
+  #endif
 }
 
 // copy blocks kernel for MLA (assumes a joint KV-cache)

--- a/csrc/core/math.hpp
+++ b/csrc/core/math.hpp
@@ -5,5 +5,9 @@
 
 inline constexpr uint32_t next_pow_2(uint32_t const num) {
   if (num <= 1) return num;
+  #ifdef _WIN32
+  return 1 << (CHAR_BIT * sizeof(num) - __lzcnt(num - 1));
+  #else
   return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
+  #endif  
 }

--- a/csrc/core/math.hpp
+++ b/csrc/core/math.hpp
@@ -5,9 +5,9 @@
 
 inline constexpr uint32_t next_pow_2(uint32_t const num) {
   if (num <= 1) return num;
-  #ifdef _WIN32
+#ifdef _WIN32
   return 1 << (CHAR_BIT * sizeof(num) - __lzcnt(num - 1));
-  #else
+#else
   return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
-  #endif  
+#endif
 }

--- a/csrc/cpu/cpu_types_vsx.hpp
+++ b/csrc/cpu/cpu_types_vsx.hpp
@@ -515,7 +515,11 @@ inline BF16Vec16::BF16Vec16(const FP32Vec16& v) {
 }
 
 inline void prefetch(const void* addr) {
+  #ifdef _WIN32
+  __asm("dcbt 0, %0" : : "r"(addr) : "memory");
+  #else
   __asm__ __volatile__("dcbt 0, %0" : : "r"(addr) : "memory");
+  #endif  
 }
 
 };  // namespace vec_op

--- a/csrc/cpu/cpu_types_vsx.hpp
+++ b/csrc/cpu/cpu_types_vsx.hpp
@@ -515,11 +515,11 @@ inline BF16Vec16::BF16Vec16(const FP32Vec16& v) {
 }
 
 inline void prefetch(const void* addr) {
-  #ifdef _WIN32
+#ifdef _WIN32
   __asm("dcbt 0, %0" : : "r"(addr) : "memory");
-  #else
+#else
   __asm__ __volatile__("dcbt 0, %0" : : "r"(addr) : "memory");
-  #endif  
+#endif
 }
 
 };  // namespace vec_op

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -12,6 +12,10 @@ extern "C" {
 #include <cuda_runtime_api.h>
 #include <cuda.h>
 
+#ifndef ssize_t
+#define ssize_t ptrdiff_t
+#endif
+
 char error_msg[10240];  // 10KB buffer to store error messages
 CUresult no_error = CUresult(0);
 CUresult error_code = no_error;  // store error code

--- a/csrc/cumem_allocator.cpp
+++ b/csrc/cumem_allocator.cpp
@@ -13,7 +13,7 @@ extern "C" {
 #include <cuda.h>
 
 #ifndef ssize_t
-#define ssize_t ptrdiff_t
+  #define ssize_t ptrdiff_t
 #endif
 
 char error_msg[10240];  // 10KB buffer to store error messages

--- a/csrc/mamba/mamba_ssm/static_switch.h
+++ b/csrc/mamba/mamba_ssm/static_switch.h
@@ -19,10 +19,10 @@
 #define BOOL_SWITCH(COND, CONST_NAME, ...) \
   [&] {                                    \
     if (COND) {                            \
-      constexpr bool CONST_NAME = true;    \
+      static constexpr bool CONST_NAME = true;    \
       return __VA_ARGS__();                \
     } else {                               \
-      constexpr bool CONST_NAME = false;   \
+      static constexpr bool CONST_NAME = false;   \
       return __VA_ARGS__();                \
     }                                      \
   }()

--- a/csrc/quantization/awq/gemm_kernels.cu
+++ b/csrc/quantization/awq/gemm_kernels.cu
@@ -176,7 +176,7 @@ __global__ void __launch_bounds__(64)
     for (int k_0_1 = 0; k_0_1 < 2; ++k_0_1) {
       {
         unsigned int addr;
-        __asm__ __volatile__(
+        asm volatile(
             "{ .reg .u64 addr; cvta.to.shared.u64 addr, %1; cvt.u32.u64 %0, "
             "addr; }\n"
             : "=r"(addr)
@@ -184,7 +184,7 @@ __global__ void __launch_bounds__(64)
                           (((((int)threadIdx.x) & 15) * 40) +
                            ((((int)threadIdx.x) >> 4) * 8)))));
 
-        __asm__ __volatile__(
+        asm volatile(
             "ldmatrix.sync.aligned.m8n8.x4.shared.b16"
             "{%0, %1, %2, %3}, [%4];\n"
             : "=r"(((unsigned*)(A_shared_warp + 0))[0]),
@@ -197,7 +197,7 @@ __global__ void __launch_bounds__(64)
       for (int ax1_0 = 0; ax1_0 < N / 32; ++ax1_0) {
         {
           unsigned int addr;
-          __asm__ __volatile__(
+          asm volatile(
               "{ .reg .u64 addr; cvta.to.shared.u64 addr, %1; cvt.u32.u64 %0, "
               "addr; }\n"
               : "=r"(addr)
@@ -206,7 +206,7 @@ __global__ void __launch_bounds__(64)
                                          (ax1_0 * 16))])) +
                             (((((int)threadIdx.x) & 15) * (N + 8)) +
                              ((((int)threadIdx.x) >> 4) * 8)))));
-          __asm__ __volatile__(
+          asm volatile(
               "ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16"
               "{%0, %1, %2, %3}, [%4];\n"
               : "=r"(((unsigned*)(B_shared_warp + (ax1_0 * 8)))[0]),
@@ -219,7 +219,7 @@ __global__ void __launch_bounds__(64)
       for (int j_0_4 = 0; j_0_4 < N / 32; ++j_0_4) {
   #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
               : "=f"(((float*)(C_warp + (j_0_4 * 8)))[0]),
@@ -236,7 +236,7 @@ __global__ void __launch_bounds__(64)
         }
 
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
               : "=f"(((float*)(C_warp + ((j_0_4 * 8) + 4)))[0]),
@@ -253,7 +253,7 @@ __global__ void __launch_bounds__(64)
         }
 
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
               : "=f"(((float*)(C_warp + (j_0_4 * 8)))[0]),
@@ -270,7 +270,7 @@ __global__ void __launch_bounds__(64)
         }
 
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5}, {%6}, {%7, %8, %9, %10};\n"
               : "=f"(((float*)(C_warp + ((j_0_4 * 8) + 4)))[0]),
@@ -287,7 +287,7 @@ __global__ void __launch_bounds__(64)
         }
   #else
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, "
               "%13};\n"
@@ -308,7 +308,7 @@ __global__ void __launch_bounds__(64)
         }
 
         {
-          __asm__ __volatile__(
+          asm volatile(
               "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32"
               "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, "
               "%13};\n"

--- a/csrc/quantization/fp8/common.cu
+++ b/csrc/quantization/fp8/common.cu
@@ -31,7 +31,7 @@ __global__ void dynamic_per_token_scaled_fp8_quant_kernel(
     scalar_t const* __restrict__ input, float const* __restrict__ scale_ub,
     const int hidden_size) {
   float const min_scaling_factor =
-      1.0f / (fp8_e4m3_adjusted_max_v<fp8_type> * 512.f);
+      1.0f / (fp8_e4m3_adjusted_max<fp8_type>::val() * 512.f);
 
   int const tid = threadIdx.x;
   int const token_idx = blockIdx.x;
@@ -67,7 +67,7 @@ __global__ void dynamic_per_token_scaled_fp8_quant_kernel(
       token_scale = block_absmax_val_maybe;
     }
     // token scale computation
-    token_scale = max(token_scale / fp8_e4m3_adjusted_max_v<fp8_type>,
+    token_scale = max(token_scale / fp8_e4m3_adjusted_max<fp8_type>::val(),
                       min_scaling_factor);
     scale[token_idx] = token_scale;
   }

--- a/csrc/quantization/fp8/common.cuh
+++ b/csrc/quantization/fp8/common.cuh
@@ -50,10 +50,6 @@ struct fp8_e4m3_adjusted_max<c10::Float8_e4m3fnuz> {
   }
 };
 
-template <typename T>
-MAYBE_HOST_DEVICE static constexpr T fp8_e4m3_adjusted_max_v =
-    fp8_e4m3_adjusted_max<T>::val();
-
 namespace vllm {
 
 __device__ __forceinline__ float atomicMaxFloat(float* addr, float value) {
@@ -76,8 +72,8 @@ __device__ __forceinline__ fp8_type scaled_fp8_conversion(float const val,
     x = val / scale;
   }
 
-  float r = fmax(-fp8_e4m3_adjusted_max_v<fp8_type>,
-                 fmin(x, fp8_e4m3_adjusted_max_v<fp8_type>));
+  float r = fmax(-fp8_e4m3_adjusted_max<fp8_type>::val(),
+                 fmin(x, fp8_e4m3_adjusted_max<fp8_type>::val()));
 #ifndef USE_ROCM
   return static_cast<fp8_type>(r);
 #else
@@ -123,7 +119,7 @@ __global__ void segmented_max_reduction(float* __restrict__ scale,
   // Finally, since cache[0] contains the maximum for this thread block,
   // atomically write the max to the target location
   if (threadIdx.x == 0) {
-    atomicMaxFloat(scale, cache[0] / fp8_e4m3_adjusted_max_v<fp8_type>);
+    atomicMaxFloat(scale, cache[0] / fp8_e4m3_adjusted_max<fp8_type>::val());
   }
 }
 

--- a/csrc/quantization/fused_kernels/quant_conversions.cuh
+++ b/csrc/quantization/fused_kernels/quant_conversions.cuh
@@ -33,8 +33,8 @@ static __device__ __forceinline__ int8_t float_to_int8_rn(float const x) {
 
 template <typename fp8_type>
 static __device__ __forceinline__ fp8_type float_to_fp8(float const x) {
-  float const r = fmax(-fp8_e4m3_adjusted_max_v<fp8_type>,
-                       fmin(x, fp8_e4m3_adjusted_max_v<fp8_type>));
+  float const r = fmax(-fp8_e4m3_adjusted_max<fp8_type>::val(),
+                       fmin(x, fp8_e4m3_adjusted_max<fp8_type>::val()));
   return static_cast<fp8_type>(r);
 }
 

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -11,6 +11,9 @@ https://github.com/qwopqwop200/GPTQ-for-LLaMa
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#ifdef _WIN32
+#include <cublas_api.h>
+#endif
 
 #include "compat.cuh"
 #include "matrix_view.cuh"

--- a/csrc/quantization/gptq/q_gemm.cu
+++ b/csrc/quantization/gptq/q_gemm.cu
@@ -12,7 +12,7 @@ https://github.com/qwopqwop200/GPTQ-for-LLaMa
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #ifdef _WIN32
-#include <cublas_api.h>
+  #include <cublas_api.h>
 #endif
 
 #include "compat.cuh"

--- a/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
+++ b/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
@@ -2,7 +2,7 @@
 #include <torch/all.h>
 #include "core/registration.h"
 #ifdef _WIN32
-#include <cublas_api.h>
+  #include <cublas_api.h>
 #endif
 #include <cublas_v2.h>
 
@@ -212,7 +212,7 @@ struct ComputeTile_W8A16_PerC_MtilexNtilex32_multistage_SM8x_SplitK {
   static constexpr int WARP_SIZE = 32;
   static constexpr int WARP_CNT = BLOCK / WARP_SIZE;
   static constexpr int WARP_NTILE = Ntile / WARP_CNT;
-  static constexpr int WARP_NITER = WARP_NTILE / 8;  // hmma16816  
+  static constexpr int WARP_NITER = WARP_NTILE / 8;  // hmma16816
   static_assert(WARP_NTILE == 32 || WARP_NTILE == 64,
                 "now only support WARP_NTILE = 32 or 64!");
 

--- a/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
+++ b/csrc/quantization/gptq_allspark/allspark_qgemm_w8a16.cu
@@ -1,6 +1,9 @@
 #include "allspark_utils.cuh"
 #include <torch/all.h>
 #include "core/registration.h"
+#ifdef _WIN32
+#include <cublas_api.h>
+#endif
 #include <cublas_v2.h>
 
 at::Tensor as_g_workspace;
@@ -209,8 +212,8 @@ struct ComputeTile_W8A16_PerC_MtilexNtilex32_multistage_SM8x_SplitK {
   static constexpr int WARP_SIZE = 32;
   static constexpr int WARP_CNT = BLOCK / WARP_SIZE;
   static constexpr int WARP_NTILE = Ntile / WARP_CNT;
-  static constexpr int WARP_NITER = WARP_NTILE / 8;  // hmma16816
-  static_assert(WARP_NTILE == 32 or WARP_NTILE == 64,
+  static constexpr int WARP_NITER = WARP_NTILE / 8;  // hmma16816  
+  static_assert(WARP_NTILE == 32 || WARP_NTILE == 64,
                 "now only support WARP_NTILE = 32 or 64!");
 
   __device__ ComputeTile_W8A16_PerC_MtilexNtilex32_multistage_SM8x_SplitK(

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -2067,6 +2067,146 @@ exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
     __CALL_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, true, 4, NUM_THREADS, \
               true)                                                       \
     __CALL_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, true, 4, NUM_THREADS, true)
+	
+template <typename scalar_t>
+bool gptq_marlin_mm_u4b8_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
+	bool executed = true;
+	if (false) {
+    }
+    GPTQ_CALL_IF(vllm::kU4B8, 16, 4, 256)
+    GPTQ_CALL_IF(vllm::kU4B8, 8, 8, 256)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool gptq_marlin_mm_u4b8_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    GPTQ_CALL_IF(vllm::kU4B8, 8, 4, 128)
+    GPTQ_CALL_IF(vllm::kU4B8, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool gptq_marlin_mm_u8b128_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
+    GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool gptq_marlin_mm_u8b128_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
+    GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool awq_marlin_mm_u4_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
+	bool executed = true;
+	if (false) {
+    }
+    AWQ_CALL_IF(vllm::kU4, 16, 4, 256)
+    AWQ_CALL_IF(vllm::kU4, 8, 8, 256)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool awq_marlin_mm_u4_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    AWQ_CALL_IF(vllm::kU4, 8, 4, 128)
+    AWQ_CALL_IF(vllm::kU4, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool awq_marlin_mm_u8_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    AWQ_CALL_IF(vllm::kU8, 16, 4, 256)
+    AWQ_CALL_IF(vllm::kU8, 8, 8, 256)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool awq_marlin_mm_u8_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    AWQ_CALL_IF(vllm::kU8, 8, 4, 128)
+    AWQ_CALL_IF(vllm::kU8, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool hqq_marlin_mm_u4_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
+	bool executed = true;
+	if (false) {
+    }
+    HQQ_CALL_IF(vllm::kU4, 16, 4, 256)
+    HQQ_CALL_IF(vllm::kU4, 8, 8, 256)
+	else{
+		executed = false;
+	}
+	return executed;
+}
+
+template <typename scalar_t>
+bool hqq_marlin_mm_u4_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
+int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
+	bool executed = true;
+	if (false) {
+    }
+    HQQ_CALL_IF(vllm::kU4, 8, 4, 128)
+    HQQ_CALL_IF(vllm::kU4, 4, 8, 128)
+	else{
+		executed = false;
+	}
+	return executed;
+}
 
 template <typename scalar_t>
 void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* s,
@@ -2210,31 +2350,18 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* s,
       thread_m_blocks = exec_cfg.max_m_blocks;
     }
 
-    if (false) {
-    }
-    GPTQ_CALL_IF(vllm::kU4B8, 16, 4, 256)
-    GPTQ_CALL_IF(vllm::kU4B8, 8, 8, 256)
-    GPTQ_CALL_IF(vllm::kU4B8, 8, 4, 128)
-    GPTQ_CALL_IF(vllm::kU4B8, 4, 8, 128)
-    GPTQ_CALL_IF(vllm::kU8B128, 16, 4, 256)
-    GPTQ_CALL_IF(vllm::kU8B128, 8, 8, 256)
-    GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
-    GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
-
-    AWQ_CALL_IF(vllm::kU4, 16, 4, 256)
-    AWQ_CALL_IF(vllm::kU4, 8, 8, 256)
-    AWQ_CALL_IF(vllm::kU4, 8, 4, 128)
-    AWQ_CALL_IF(vllm::kU4, 4, 8, 128)
-    AWQ_CALL_IF(vllm::kU8, 16, 4, 256)
-    AWQ_CALL_IF(vllm::kU8, 8, 8, 256)
-    AWQ_CALL_IF(vllm::kU8, 8, 4, 128)
-    AWQ_CALL_IF(vllm::kU8, 4, 8, 128)
-
-    HQQ_CALL_IF(vllm::kU4, 16, 4, 256)
-    HQQ_CALL_IF(vllm::kU4, 8, 8, 256)
-    HQQ_CALL_IF(vllm::kU4, 8, 4, 128)
-    HQQ_CALL_IF(vllm::kU4, 4, 8, 128)
-    else {
+    if(
+		gptq_marlin_mm_u4b8_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		gptq_marlin_mm_u4b8_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		gptq_marlin_mm_u8b128_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false && 
+		gptq_marlin_mm_u8b128_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		awq_marlin_mm_u4_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		awq_marlin_mm_u4_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		awq_marlin_mm_u8_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		awq_marlin_mm_u8_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		hqq_marlin_mm_u4_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
+		hqq_marlin_mm_u4_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false
+	){
       TORCH_CHECK(false, "Unsupported shapes: MNK = [", prob_m, ", ", prob_n,
                   ", ", prob_k, "]", ", has_act_order = ", has_act_order,
                   ", num_groups = ", num_groups, ", group_size = ", group_size,

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -2069,143 +2069,203 @@ exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
     __CALL_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, true, 4, NUM_THREADS, true)
 	
 template <typename scalar_t>
-bool gptq_marlin_mm_u4b8_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
-	bool executed = true;
-	if (false) {
-    }
-    GPTQ_CALL_IF(vllm::kU4B8, 16, 4, 256)
-    GPTQ_CALL_IF(vllm::kU4B8, 8, 8, 256)
-	else{
-		executed = false;
-	}
-	return executed;
+bool gptq_marlin_mm_u4b8_256(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  GPTQ_CALL_IF(vllm::kU4B8, 16, 4, 256)
+  GPTQ_CALL_IF(vllm::kU4B8, 8, 8, 256)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool gptq_marlin_mm_u4b8_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    GPTQ_CALL_IF(vllm::kU4B8, 8, 4, 128)
-    GPTQ_CALL_IF(vllm::kU4B8, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool gptq_marlin_mm_u4b8_128(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  GPTQ_CALL_IF(vllm::kU4B8, 8, 4, 128)
+  GPTQ_CALL_IF(vllm::kU4B8, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool gptq_marlin_mm_u8b128_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
-    GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool gptq_marlin_mm_u8b128_256(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
+  GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool gptq_marlin_mm_u8b128_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
-    GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool gptq_marlin_mm_u8b128_128(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  GPTQ_CALL_IF(vllm::kU8B128, 8, 4, 128)
+  GPTQ_CALL_IF(vllm::kU8B128, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool awq_marlin_mm_u4_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
-	bool executed = true;
-	if (false) {
-    }
-    AWQ_CALL_IF(vllm::kU4, 16, 4, 256)
-    AWQ_CALL_IF(vllm::kU4, 8, 8, 256)
-	else{
-		executed = false;
-	}
-	return executed;
+bool awq_marlin_mm_u4_256(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  AWQ_CALL_IF(vllm::kU4, 16, 4, 256)
+  AWQ_CALL_IF(vllm::kU4, 8, 8, 256)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool awq_marlin_mm_u4_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    AWQ_CALL_IF(vllm::kU4, 8, 4, 128)
-    AWQ_CALL_IF(vllm::kU4, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool awq_marlin_mm_u4_128(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  AWQ_CALL_IF(vllm::kU4, 8, 4, 128)
+  AWQ_CALL_IF(vllm::kU4, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool awq_marlin_mm_u8_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    AWQ_CALL_IF(vllm::kU8, 16, 4, 256)
-    AWQ_CALL_IF(vllm::kU8, 8, 8, 256)
-	else{
-		executed = false;
-	}
-	return executed;
+bool awq_marlin_mm_u8_256(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  AWQ_CALL_IF(vllm::kU8, 16, 4, 256)
+  AWQ_CALL_IF(vllm::kU8, 8, 8, 256)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool awq_marlin_mm_u8_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    AWQ_CALL_IF(vllm::kU8, 8, 4, 128)
-    AWQ_CALL_IF(vllm::kU8, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool awq_marlin_mm_u8_128(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  AWQ_CALL_IF(vllm::kU8, 8, 4, 128)
+  AWQ_CALL_IF(vllm::kU8, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool hqq_marlin_mm_u4_256(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){		
-	bool executed = true;
-	if (false) {
-    }
-    HQQ_CALL_IF(vllm::kU4, 16, 4, 256)
-    HQQ_CALL_IF(vllm::kU4, 8, 8, 256)
-	else{
-		executed = false;
-	}
-	return executed;
+bool hqq_marlin_mm_u4_256(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  HQQ_CALL_IF(vllm::kU4, 16, 4, 256)
+  HQQ_CALL_IF(vllm::kU4, 8, 8, 256)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
-bool hqq_marlin_mm_u4_128(vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks, int thread_k_blocks, int num_threads, bool has_zp, int group_blocks, bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr, 
-int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr, const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks, int num_groups, int prob_m, int prob_n, int prob_k, int* locks, bool use_fp32_reduce, bool use_atomic_add){
-	bool executed = true;
-	if (false) {
-    }
-    HQQ_CALL_IF(vllm::kU4, 8, 4, 128)
-    HQQ_CALL_IF(vllm::kU4, 4, 8, 128)
-	else{
-		executed = false;
-	}
-	return executed;
+bool hqq_marlin_mm_u4_128(
+    vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,
+    int thread_k_blocks, int num_threads, bool has_zp, int group_blocks,
+    bool has_act_order, bool is_zp_float, const int4* A_ptr, const int4* B_ptr,
+    int4* C_ptr, int4* C_tmp_ptr, const int4* s_ptr, const int4* zp_ptr,
+    const int* g_idx_ptr, int max_shared_mem, cudaStream_t stream, int blocks,
+    int num_groups, int prob_m, int prob_n, int prob_k, int* locks,
+    bool use_fp32_reduce, bool use_atomic_add) {
+  bool skipped = false;
+  if (false) {
+  }
+  HQQ_CALL_IF(vllm::kU4, 8, 4, 128)
+  HQQ_CALL_IF(vllm::kU4, 4, 8, 128)
+  else {
+    skipped = true;
+  }
+  return skipped;
 }
 
 template <typename scalar_t>
@@ -2350,18 +2410,66 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* s,
       thread_m_blocks = exec_cfg.max_m_blocks;
     }
 
-    if(
-		gptq_marlin_mm_u4b8_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		gptq_marlin_mm_u4b8_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		gptq_marlin_mm_u8b128_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false && 
-		gptq_marlin_mm_u8b128_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		awq_marlin_mm_u4_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		awq_marlin_mm_u4_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		awq_marlin_mm_u8_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		awq_marlin_mm_u8_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		hqq_marlin_mm_u4_256<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false &&
-		hqq_marlin_mm_u4_128<scalar_t>(q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks, num_threads, has_zp, group_blocks, has_act_order, is_zp_float, A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr, max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k, locks, use_fp32_reduce, use_atomic_add) == false
-	){
+    if (gptq_marlin_mm_u4b8_256<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        gptq_marlin_mm_u4b8_128<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        gptq_marlin_mm_u8b128_256<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        gptq_marlin_mm_u8b128_128<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        awq_marlin_mm_u4_256<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        awq_marlin_mm_u4_128<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        awq_marlin_mm_u8_256<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        awq_marlin_mm_u8_128<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        hqq_marlin_mm_u4_256<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add) &&
+        hqq_marlin_mm_u4_128<scalar_t>(
+            q_type, thread_m_blocks, thread_n_blocks, thread_k_blocks,
+            num_threads, has_zp, group_blocks, has_act_order, is_zp_float,
+            A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,
+            max_shared_mem, stream, blocks, num_groups, prob_m, prob_n, prob_k,
+            locks, use_fp32_reduce, use_atomic_add)) {
       TORCH_CHECK(false, "Unsupported shapes: MNK = [", prob_m, ", ", prob_n,
                   ", ", prob_k, "]", ", has_act_order = ", has_act_order,
                   ", num_groups = ", num_groups, ", group_size = ", group_size,

--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -2067,7 +2067,7 @@ exec_config_t determine_thread_config(int prob_m, int prob_n, int prob_k,
     __CALL_IF(W_TYPE, 3, N_BLOCKS, K_BLOCKS, false, true, 4, NUM_THREADS, \
               true)                                                       \
     __CALL_IF(W_TYPE, 4, N_BLOCKS, K_BLOCKS, false, true, 4, NUM_THREADS, true)
-	
+
 template <typename scalar_t>
 bool gptq_marlin_mm_u4b8_256(
     vllm::ScalarType const& q_type, int thread_m_blocks, int thread_n_blocks,

--- a/csrc/quantization/marlin/sparse/common/base.h
+++ b/csrc/quantization/marlin/sparse/common/base.h
@@ -44,7 +44,7 @@ using I4 = Vec<int, 4>;
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
 using FragA = Vec<half2, 4>;
 using FragB = Vec<half2, 2>;
-using FragM = Vec<uint, 1>;
+using FragM = Vec<unsigned int, 1>;
 using FragC = Vec<float, 4>;
 using FragS = Vec<half2, 1>;  // quantization scales
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import sys
+import platform
 from pathlib import Path
 from shutil import which
 
@@ -40,10 +41,9 @@ if sys.platform.startswith("darwin") and VLLM_TARGET_DEVICE != "cpu":
     logger.warning(
         "VLLM_TARGET_DEVICE automatically set to `cpu` due to macOS")
     VLLM_TARGET_DEVICE = "cpu"
-elif not (sys.platform.startswith("linux")
-          or sys.platform.startswith("darwin")):
+elif not (sys.platform.startswith("linux") or sys.platform.startswith("darwin") or platform.system() == "Windows"):
     logger.warning(
-        "vLLM only supports Linux platform (including WSL) and MacOS."
+        "vLLM only supports Linux platform (including WSL), Windows and MacOS."
         "Building on %s, "
         "so vLLM may not be able to run correctly", sys.platform)
     VLLM_TARGET_DEVICE = "empty"
@@ -55,6 +55,11 @@ elif (sys.platform.startswith("linux") and torch.version.cuda is None
     VLLM_TARGET_DEVICE = "cpu"
 
 MAIN_CUDA_VERSION = "12.4"
+
+IS_WSL = "microsoft-standard-WSL2" in platform.uname().release or "-Microsoft" in platform.uname().release
+
+if (platform.system() == "Windows" or IS_WSL) and os.environ.get("VLLM_FORCE_FA3_WINDOWS_BUILD", "0") != "1":
+    os.environ['VLLM_DISABLE_FA3_BUILD'] = "1"  # FA3 CAUSES COMPILER CRASH ON WSL2 AND WINDOWS, DISABLE IT
 
 
 def is_sccache_available() -> bool:
@@ -170,11 +175,59 @@ class cmake_build_ext(build_ext):
 
         # Pass the python executable to cmake so it can find an exact
         # match.
-        cmake_args += ['-DVLLM_PYTHON_EXECUTABLE={}'.format(sys.executable)]
+        if platform.system() == "Windows":
+            cmake_args += ['-DVLLM_PYTHON_EXECUTABLE={}'.format(sys.executable.replace('\\', '\\\\'))]
+        else:
+            cmake_args += ['-DVLLM_PYTHON_EXECUTABLE={}'.format(sys.executable)]
 
         # Pass the python path to cmake so it can reuse the build dependencies
         # on subsequent calls to python.
         cmake_args += ['-DVLLM_PYTHON_PATH={}'.format(":".join(sys.path))]
+
+        # Set correct cuda paths, cuda libs and options for CMake
+        if VLLM_TARGET_DEVICE == 'cuda':
+            cuda_path = None
+            if 'CUDA_HOME' in os.environ:
+                cuda_path = os.environ.get('CUDA_HOME')
+            elif 'CUDA_ROOT' in os.environ:
+                cuda_path = os.environ.get('CUDA_ROOT')
+            elif 'CUDA_PATH' in os.environ:
+                cuda_path = os.environ.get('CUDA_PATH')
+            elif which('nvcc') is not None:
+                cuda_path = os.path.abspath(os.path.join(which('nvcc'), '..', '..'))
+
+            if sys.platform.startswith('win32'):
+                if cuda_path:
+                    cmake_args += [
+                        f'-Dnvtx3_dir={cuda_path}\\include',
+                        f'-DCUDA_cublas_LIBRARY={cuda_path}\\lib\\x64\\cublas.lib'
+                    ]
+            elif IS_WSL:
+                if cuda_path is not None:
+                    cuda_path = os.path.abspath(os.path.join(which('nvcc'), '..', '..'))
+                    if os.path.exists(f'{cuda_path}/include/nvtx3'):
+                        cmake_args.append(f'-Dnvtx3_dir={cuda_path}/include')
+                    if os.path.exists(f'{cuda_path}/lib64/libcublas.so'):
+                        cmake_args.append(f'-DCUDA_cublas_LIBRARY={cuda_path}/lib64/libcublas.so')
+
+            if sys.platform.startswith("linux") and os.environ.get('USE_CUFILE', '0') == '1':
+                cmake_args.append('-DUSE_CUFILE=1')
+                cmake_args.append('-DCAFFE2_USE_CUFILE=1')
+
+            if os.environ.get('USE_CUDSS', '0') == '1':
+                cmake_args.append('-DUSE_CUDSS=1')
+                if os.environ.get('CUDSS_LIBRARY_PATH'):
+                    cmake_args.append(f'-DCUDSS_LIBRARY_PATH={os.environ.get('CUDSS_LIBRARY_PATH')}')
+                if os.environ.get('CUDSS_INCLUDE_PATH'):
+                    cmake_args.append(f'-DCUDSS_INCLUDE_PATH={os.environ.get('CUDSS_INCLUDE_PATH')}')
+
+            if os.environ.get('USE_CUDNN', '0') == '1':
+                cmake_args.append('-DCAFFE2_USE_CUDNN=1')
+
+            if os.environ.get('USE_CUSPARSELT', '0') == '1':
+                cmake_args.append('-DCAFFE2_USE_CUSPARSELT=1')
+                if os.environ.get('CUSPARSELT_INCLUDE_PATH'):
+                    cmake_args.append(f'-DCUSPARSELT_INCLUDE_PATH={os.environ.get('CUSPARSELT_INCLUDE_PATH')}')
 
         # Override the base directory for FetchContent downloads to $ROOT/.deps
         # This allows sharing dependencies between profiles,
@@ -371,12 +424,15 @@ class repackage_wheel(build_ext):
                 "vllm/_moe_C.abi3.so",
                 "vllm/_flashmla_C.abi3.so",
                 "vllm/vllm_flash_attn/_vllm_fa2_C.abi3.so",
-                "vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so",
                 "vllm/vllm_flash_attn/flash_attn_interface.py",
                 "vllm/vllm_flash_attn/__init__.py",
                 "vllm/cumem_allocator.abi3.so",
                 # "vllm/_version.py", # not available in nightly wheels yet
             ]
+
+            if os.environ.get("VLLM_DISABLE_FA3_BUILD", "0") != "1":
+                files_to_copy.append("vllm/vllm_flash_attn/_vllm_fa3_C.abi3.so")
+
             file_members = filter(lambda x: x.filename in files_to_copy,
                                   wheel.filelist)
 
@@ -646,7 +702,7 @@ if _is_hip():
 
 if _is_cuda():
     ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
-    if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.0"):
+    if (envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.0")) and os.environ.get("VLLM_DISABLE_FA3_BUILD", "0") != "1":
         # FA3 requires CUDA 12.0 or later
         ext_modules.append(
             CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
@@ -676,7 +732,7 @@ if not ext_modules:
 else:
     cmdclass = {
         "build_ext":
-        repackage_wheel if envs.VLLM_USE_PRECOMPILED else cmake_build_ext
+            repackage_wheel if envs.VLLM_USE_PRECOMPILED else cmake_build_ext
     }
 
 setup(

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -7,6 +7,14 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from unittest.mock import patch
 
 import torch
+
+"""
+Torch major / minor version that does not interfere with nightly builds / torch source compilations
+"""
+
+torch_major_version = int(torch.__version__.split(".")[0])
+torch_minor_version = int(torch.__version__.split(".")[1])
+
 import torch._inductor.compile_fx
 import torch.fx as fx
 
@@ -194,7 +202,9 @@ class InductorAdaptor(CompilerInterface):
         from torch._inductor.codecache import (FxGraphCache,
                                                compiled_fx_graph_hash)
 
-        if torch.__version__.startswith("2.5"):
+        original_load_name = None
+        hijacked_compile_fx_inner = None
+        if torch_major_version == 2 and torch_minor_version == 5:
             original_load = FxGraphCache.load
             original_load_name = "torch._inductor.codecache.FxGraphCache.load"
 
@@ -217,7 +227,7 @@ class InductorAdaptor(CompilerInterface):
                 return inductor_compiled_graph
 
             hijacked_compile_fx_inner = torch._inductor.compile_fx.compile_fx_inner  # noqa
-        elif torch.__version__ >= "2.6":
+        elif torch_major_version == 2 and torch_minor_version >= 6:
             # function renamed in 2.6
             original_load_name = None
 
@@ -297,14 +307,14 @@ class InductorAdaptor(CompilerInterface):
         from torch._inductor.codecache import FxGraphCache
         with patch("torch._inductor.codecache.FxGraphCache._get_shape_env",
                    lambda *args, **kwargs: AlwaysHitShapeEnv()):
-            if torch.__version__.startswith("2.5"):
+            if torch_major_version == 2 and torch_minor_version == 5:
                 inductor_compiled_graph = FxGraphCache._lookup_graph(
                     hash_str, example_inputs, True, False)
                 assert inductor_compiled_graph is not None, (
                     "Inductor cache lookup failed. Please remove"
                     f"the cache directory and try again."  # noqa
                 )
-            elif torch.__version__ >= "2.6":
+            elif torch_major_version == 2 and torch_minor_version >= 6:
                 from torch._inductor.output_code import (
                     CompiledFxGraphConstantsWithGm)
                 constants = CompiledFxGraphConstantsWithGm(graph)

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -7,6 +7,7 @@ from torch import fx as fx
 
 from vllm.config import CompilationConfig
 from vllm.logger import init_logger
+from vllm.utils import torch_major_minor_version
 
 from .fix_functionalization import FixFunctionalizationPass
 from .fusion import FusionPass
@@ -20,15 +21,7 @@ class PlaceHolder:
     pass
 
 
-"""
-Torch major / minor version that does not interfere with nightly builds / torch source compilations
-"""
-
-torch_major_version = int(torch.__version__.split(".")[0])
-torch_minor_version = int(torch.__version__.split(".")[1])
-
-
-if torch_major_version <= 2 and torch_minor_version <= 5:
+if torch_major_minor_version() < "2.6":
     Parent = PlaceHolder  # type: ignore
 else:
     Parent = torch._inductor.custom_graph_pass.CustomGraphPass  # type: ignore

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -20,7 +20,15 @@ class PlaceHolder:
     pass
 
 
-if torch.__version__ < "2.6":
+"""
+Torch major / minor version that does not interfere with nightly builds / torch source compilations
+"""
+
+torch_major_version = int(torch.__version__.split(".")[0])
+torch_minor_version = int(torch.__version__.split(".")[1])
+
+
+if torch_major_version <= 2 and torch_minor_version <= 5:
     Parent = PlaceHolder  # type: ignore
 else:
     Parent = torch._inductor.custom_graph_pass.CustomGraphPass  # type: ignore

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -54,6 +54,13 @@ else:
 
 from packaging.version import Version
 
+"""
+Torch major / minor version that does not interfere with nightly builds / torch source compilations
+"""
+
+torch_major_version = int(torch.__version__.split(".")[0])
+torch_minor_version = int(torch.__version__.split(".")[1])
+
 logger = init_logger(__name__)
 
 # This value is chosen to have a balance between ITL and TTFT. Note it is
@@ -3140,7 +3147,7 @@ class CompilationConfig(BaseModel):
         #    and it is not yet a priority. RFC here:
         #    https://github.com/vllm-project/vllm/issues/14703
 
-        if Version(torch.__version__) >= Version("2.6"):
+        if torch_major_version >= 2 and torch_major_version >= 6:
             KEY = 'enable_auto_functionalized_v2'
             if KEY not in self.inductor_compile_config:
                 self.inductor_compile_config[KEY] = False

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -38,7 +38,8 @@ from vllm.transformers_utils.config import (
 from vllm.transformers_utils.s3_utils import S3Model
 from vllm.transformers_utils.utils import is_s3
 from vllm.utils import (GiB_bytes, LayerBlockType, cuda_device_count_stateless,
-                        get_cpu_memory, random_uuid, resolve_obj_by_qualname)
+                        get_cpu_memory, random_uuid, resolve_obj_by_qualname,
+                        torch_major_minor_version)
 
 if TYPE_CHECKING:
     from ray.util.placement_group import PlacementGroup
@@ -53,13 +54,6 @@ else:
     QuantizationConfig = None
 
 from packaging.version import Version
-
-"""
-Torch major / minor version that does not interfere with nightly builds / torch source compilations
-"""
-
-torch_major_version = int(torch.__version__.split(".")[0])
-torch_minor_version = int(torch.__version__.split(".")[1])
 
 logger = init_logger(__name__)
 
@@ -3147,7 +3141,7 @@ class CompilationConfig(BaseModel):
         #    and it is not yet a priority. RFC here:
         #    https://github.com/vllm-project/vllm/issues/14703
 
-        if torch_major_version >= 2 and torch_major_version >= 6:
+        if Version(torch_major_minor_version()) >= Version("2.6"):
             KEY = 'enable_auto_functionalized_v2'
             if KEY not in self.inductor_compile_config:
                 self.inductor_compile_config[KEY] = False

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -43,7 +43,8 @@ def find_loaded_library(lib_name) -> Optional[str]:
         assert filename.rpartition(".so")[0].startswith(lib_name), \
             f"Unexpected filename: {filename} for library {lib_name}"
     else:
-        path = os.path.join(os.path.dirname(__file__), '..', 'cumem_allocator.pyd')
+        path = os.path.join(os.path.dirname(__file__), '..',
+                            'cumem_allocator.pyd')
     return path
 
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -9,6 +9,7 @@
 # the only successful approach is to call cuda driver API in C.
 import dataclasses
 import os
+import platform
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -24,22 +25,25 @@ def find_loaded_library(lib_name) -> Optional[str]:
     shared libraries loaded by the process. We can use this file to find the path of the
     a loaded library.
     """ # noqa
-    found_line = None
-    with open("/proc/self/maps") as f:
-        for line in f:
-            if lib_name in line:
-                found_line = line
-                break
-    if found_line is None:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = found_line.index("/")
-    path = found_line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), \
-        f"Unexpected filename: {filename} for library {lib_name}"
+    if platform.system() != 'Windows':
+        found_line = None
+        with open("/proc/self/maps") as f:
+            for line in f:
+                if lib_name in line:
+                    found_line = line
+                    break
+        if found_line is None:
+            # the library is not loaded in the current process
+            return None
+        # if lib_name is libcudart, we need to match a line with:
+        # address /path/to/libcudart-hash.so.11.0
+        start = found_line.index("/")
+        path = found_line[start:].strip()
+        filename = path.split("/")[-1]
+        assert filename.rpartition(".so")[0].startswith(lib_name), \
+            f"Unexpected filename: {filename} for library {lib_name}"
+    else:
+        path = os.path.join(os.path.dirname(__file__), '..', 'cumem_allocator.pyd')
     return path
 
 

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -3,7 +3,9 @@
 It avoids the need to compile a separate shared library, and is
 convenient for use when we just need to call a few functions.
 """
-
+import os
+import platform
+from shutil import which
 import ctypes
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -42,22 +44,41 @@ def find_loaded_library(lib_name) -> Optional[str]:
     shared libraries loaded by the process. We can use this file to find the path of the
     a loaded library.
     """ # noqa
-    found = False
-    with open("/proc/self/maps") as f:
-        for line in f:
-            if lib_name in line:
-                found = True
-                break
-    if not found:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = line.index("/")
-    path = line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), \
-        f"Unexpected filename: {filename} for library {lib_name}"
+    path = None
+    if platform.system() != 'Windows':
+        found = False
+        with open("/proc/self/maps") as f:
+            for line in f:
+                if lib_name in line:
+                    found = True
+                    break
+        if not found:
+            # the library is not loaded in the current process
+            return None
+        # if lib_name is libcudart, we need to match a line with:
+        # address /path/to/libcudart-hash.so.11.0
+        start = line.index("/")
+        path = line[start:].strip()
+        filename = path.split("/")[-1]
+        assert filename.rpartition(".so")[0].startswith(lib_name), \
+            f"Unexpected filename: {filename} for library {lib_name}"
+    elif "cudart" in lib_name:
+        cudart_path = os.getenv("VLLM_CUDART_SO_PATH", None)
+        if cudart_path is None:
+            cuda_path = os.environ.get("CUDA_HOME") if os.environ.get("CUDA_HOME", None) else os.environ.get("CUDA_ROOT") if os.environ.get("CUDA_ROOT", None) else os.environ.get("CUDA_PATH") if os.environ.get("CUDA_PATH", None) else None
+            cuda_major_version_num = int((torch.version.cuda if torch.version.cuda else "12.").split('.')[0])
+            cuda_major_version_str = str(cuda_major_version_num)
+            if cuda_major_version_num < 12:
+                cuda_major_version_str += "0"
+            if cuda_path:
+                cudart_path = os.path.abspath(os.path.join(cuda_path, "bin", f"cudart64_{cuda_major_version_str}.dll"))
+            elif which("nvcc"):
+                cudart_path = os.path.abspath(os.path.join(which("nvcc"), "..", f"cudart64_{cuda_major_version_str}.dll"))
+            if cudart_path:
+                os.environ["VLLM_CUDART_SO_PATH"] = cudart_path
+                logger.info('VLLM_CUDART_SO_PATH resolved to ' + cudart_path)
+            else:
+                raise ValueError('VLLM_CUDART_SO_PATH is not set. VLLM_CUDART_SO_PATH need to be set with the absolute path to cudart dll on Windows (for example, set VLLM_CUDART_SO_PATH=C:\\CUDA\\v12.4\\bin\\cudart64_12.dll)')
     return path
 
 

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -3,11 +3,11 @@
 It avoids the need to compile a separate shared library, and is
 convenient for use when we just need to call a few functions.
 """
+import ctypes
 import os
 import platform
-from shutil import which
-import ctypes
 from dataclasses import dataclass
+from shutil import which
 from typing import Any, Dict, List, Optional
 
 # this line makes it possible to directly load `libcudart.so` using `ctypes`
@@ -65,20 +65,38 @@ def find_loaded_library(lib_name) -> Optional[str]:
     elif "cudart" in lib_name:
         cudart_path = os.getenv("VLLM_CUDART_SO_PATH", None)
         if cudart_path is None:
-            cuda_path = os.environ.get("CUDA_HOME") if os.environ.get("CUDA_HOME", None) else os.environ.get("CUDA_ROOT") if os.environ.get("CUDA_ROOT", None) else os.environ.get("CUDA_PATH") if os.environ.get("CUDA_PATH", None) else None
-            cuda_major_version_num = int((torch.version.cuda if torch.version.cuda else "12.").split('.')[0])
-            cuda_major_version_str = str(cuda_major_version_num)
-            if cuda_major_version_num < 12:
-                cuda_major_version_str += "0"
+            cuda_path = None
+            if os.environ.get("CUDA_HOME", None):
+                cuda_path = os.environ.get("CUDA_HOME")
+            elif os.environ.get("CUDA_ROOT", None):
+                cuda_path = os.environ.get("CUDA_ROOT")
+            elif os.environ.get("CUDA_PATH"):
+                cuda_path = os.environ.get("CUDA_PATH", None)
+
+            cuda_major_version = torch.version.cuda.split(
+                '.')[0] if torch.version.cuda else "12"
+            if cuda_major_version < "12":
+                cuda_major_version += "0"
             if cuda_path:
-                cudart_path = os.path.abspath(os.path.join(cuda_path, "bin", f"cudart64_{cuda_major_version_str}.dll"))
-            elif which("nvcc"):
-                cudart_path = os.path.abspath(os.path.join(which("nvcc"), "..", f"cudart64_{cuda_major_version_str}.dll"))
+                cudart_path = os.path.abspath(
+                    os.path.join(cuda_path, "bin",
+                                 f"cudart64_{cuda_major_version}.dll"))
+            else:
+                nvcc_path = which("nvcc")
+                if nvcc_path:
+                    cudart_path = os.path.abspath(
+                        os.path.join(nvcc_path, "..",
+                                     f"cudart64_{cuda_major_version}.dll"))
             if cudart_path:
                 os.environ["VLLM_CUDART_SO_PATH"] = cudart_path
-                logger.info('VLLM_CUDART_SO_PATH resolved to ' + cudart_path)
+                logger.info('VLLM_CUDART_SO_PATH resolved to %s', cudart_path)
             else:
-                raise ValueError('VLLM_CUDART_SO_PATH is not set. VLLM_CUDART_SO_PATH need to be set with the absolute path to cudart dll on Windows (for example, set VLLM_CUDART_SO_PATH=C:\\CUDA\\v12.4\\bin\\cudart64_12.dll)')
+                raise ValueError(
+                    'VLLM_CUDART_SO_PATH is not set. '
+                    'VLLM_CUDART_SO_PATH need to be set with the absolute path '
+                    'to cudart dll on Windows (for example, set '
+                    'VLLM_CUDART_SO_PATH=C:\\CUDA\\v12.4\\bin\\cudart64_12.dll)'
+                )
     return path
 
 

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -2,6 +2,7 @@
 
 # The CLI entrypoint to vLLM.
 import os
+import platform
 import signal
 import sys
 
@@ -27,7 +28,10 @@ def register_signal_handlers():
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTSTP, signal_handler)
+    if platform.system() == "Windows":
+        signal.signal(signal.SIGTERM, signal_handler)
+    else:
+        signal.signal(signal.SIGTSTP, signal_handler)
 
 
 def env_setup():

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -3,6 +3,7 @@
 
 import argparse
 import os
+import platform
 import signal
 import sys
 from typing import Optional
@@ -20,7 +21,10 @@ def _register_signal_handlers():
         sys.exit(0)
 
     signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTSTP, signal_handler)
+    if platform.system() == "Windows":
+        signal.signal(signal.SIGTERM, signal_handler)
+    else:
+        signal.signal(signal.SIGTSTP, signal_handler)
 
 
 def _interactive_cli(args: argparse.Namespace) -> tuple[str, OpenAI]:

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import platform
 
-import uvloop
+if platform.system() == "Windows":
+    import winloop as uvloop_impl
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"  # Windows does not support fork
+    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")  # Disable libuv on Windows by default if no USE_LIBUV is defined previously
+else:
+    import uvloop as uvloop_impl
 
 from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.cli.types import CLISubcommand
@@ -30,7 +36,7 @@ class ServeSubcommand(CLISubcommand):
         # EngineArgs expects the model name to be passed as --model.
         args.model = args.model_tag
 
-        uvloop.run(run_server(args))
+        uvloop_impl.run(run_server(args))
 
     def validate(self, args: argparse.Namespace) -> None:
         validate_parsed_serve_args(args)

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 import platform
 
 if platform.system() == "Windows":
     import winloop as uvloop_impl
-    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"  # Windows does not support fork
-    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")  # Disable libuv on Windows by default if no USE_LIBUV is defined previously
+    # Windows does not support fork
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+    # Disable libuv on Windows by default
+    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")
 else:
     import uvloop as uvloop_impl
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -22,8 +22,10 @@ from typing import Annotated, Optional, Union
 
 if platform.system() == "Windows":
     import winloop as uvloop_impl
-    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"  # Windows does not support fork
-    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")  # Disable libuv on Windows by default if no USE_LIBUV is defined previously
+    # Windows does not support fork
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+    # Disable libuv on Windows by default
+    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")
 else:
     import uvloop as uvloop_impl
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -7,6 +7,7 @@ import importlib
 import inspect
 import multiprocessing
 import os
+import platform
 import re
 import signal
 import socket
@@ -19,7 +20,13 @@ from functools import partial
 from http import HTTPStatus
 from typing import Annotated, Optional, Union
 
-import uvloop
+if platform.system() == "Windows":
+    import winloop as uvloop_impl
+    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"  # Windows does not support fork
+    os.environ["USE_LIBUV"] = os.environ.get("USE_LIBUV", "0")  # Disable libuv on Windows by default if no USE_LIBUV is defined previously
+else:
+    import uvloop as uvloop_impl
+
 from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
@@ -962,7 +969,8 @@ def create_server_socket(addr: tuple[str, int]) -> socket.socket:
 
     sock = socket.socket(family=family, type=socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    if platform.system() != "Windows":
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
     sock.bind(addr)
 
     return sock
@@ -1051,4 +1059,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     validate_parsed_serve_args(args)
 
-    uvloop.run(run_server(args))
+    uvloop_impl.run(run_server(args))

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import platform
 import tempfile
 from typing import TYPE_CHECKING, Any, Callable, Optional
+
+DEFAULT_MP_METHOD = "fork" if platform.system() != "Windows" else "spawn"
 
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
@@ -51,7 +54,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_COMPILED_DAG: bool = False
     VLLM_USE_RAY_COMPILED_DAG_NCCL_CHANNEL: bool = True
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
-    VLLM_WORKER_MULTIPROC_METHOD: str = "fork"
+    VLLM_WORKER_MULTIPROC_METHOD: str = DEFAULT_MP_METHOD
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
@@ -407,7 +410,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work
     "VLLM_WORKER_MULTIPROC_METHOD":
-    lambda: os.getenv("VLLM_WORKER_MULTIPROC_METHOD", "fork"),
+    lambda: os.getenv("VLLM_WORKER_MULTIPROC_METHOD", DEFAULT_MP_METHOD),
 
     # Path to the cache for storing downloaded assets
     "VLLM_ASSETS_CACHE":

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1479,8 +1479,13 @@ def get_allowed_kwarg_only_overrides(
 # In particular, the FakeScalarType is not supported for earlier versions of
 # PyTorch which breaks dynamo for any ops registered using ScalarType.
 def supports_dynamo() -> bool:
-    base_torch_version = Version(Version(torch.__version__).base_version)
-    return base_torch_version >= Version("2.4.0")
+    """
+    Torch major / minor version that does not interfere with nightly builds / torch source compilations
+    """
+
+    torch_major_version = int(torch.__version__.split(".")[0])
+    torch_minor_version = int(torch.__version__.split(".")[1])
+    return torch_major_version >= 2 and torch_minor_version >= 4
 
 
 # Some backends use pytorch version < 2.4.0 which doesn't

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -49,7 +49,6 @@ import torch.types
 import yaml
 import zmq
 import zmq.asyncio
-from packaging.version import Version
 from torch.library import Library
 from typing_extensions import Never, ParamSpec, TypeIs, assert_never
 
@@ -1475,17 +1474,24 @@ def get_allowed_kwarg_only_overrides(
     return filtered_overrides
 
 
+def torch_major_minor_version():
+    """
+    Torch major / minor version that does not interfere
+    with nightly builds / torch source compilations
+    """
+    torch_major_version = "0"
+    torch_minor_version = "0"
+    if torch.__version__ and re.match(r"\d+\.\d+\.\.?", torch.__version__):
+        torch_major_version = torch.__version__.split(".")[0]
+        torch_minor_version = torch.__version__.split(".")[1]
+    return torch_major_version + "." + torch_minor_version
+
+
 # Using dynamo with vLLM doesn't really work well with PyTorch versions < 2.4.0.
 # In particular, the FakeScalarType is not supported for earlier versions of
 # PyTorch which breaks dynamo for any ops registered using ScalarType.
 def supports_dynamo() -> bool:
-    """
-    Torch major / minor version that does not interfere with nightly builds / torch source compilations
-    """
-
-    torch_major_version = int(torch.__version__.split(".")[0])
-    torch_minor_version = int(torch.__version__.split(".")[1])
-    return torch_major_version >= 2 and torch_minor_version >= 4
+    return torch_major_minor_version() >= "2.4"
 
 
 # Some backends use pytorch version < 2.4.0 which doesn't

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import platform
 import queue
 import signal
 import threading
 import time
-import platform
 from concurrent.futures import Future
 from inspect import isclass, signature
 from multiprocessing.connection import Connection

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -4,6 +4,7 @@ import queue
 import signal
 import threading
 import time
+import platform
 from concurrent.futures import Future
 from inspect import isclass, signature
 from multiprocessing.connection import Connection
@@ -338,7 +339,10 @@ class EngineCoreProc(EngineCore):
         except Exception:
             traceback = get_exception_traceback()
             logger.error("EngineCore hit an exception: %s", traceback)
-            parent_process.send_signal(signal.SIGUSR1)
+            if platform.system() == "Windows":
+                parent_process.send_signal(signal.SIGTERM)
+            else:
+                parent_process.send_signal(signal.SIGUSR1)
 
         finally:
             if engine_core is not None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import platform
 import queue
 import signal
 import threading
@@ -271,7 +272,10 @@ class MPClient(EngineCoreClient):
             kill_process_tree(os.getpid())
 
         if threading.current_thread() == threading.main_thread():
-            signal.signal(signal.SIGUSR1, sigusr1_handler)
+            if platform.system() == "Windows":
+                signal.signal(signal.SIGTERM, sigusr1_handler)
+            else:
+                signal.signal(signal.SIGUSR1, sigusr1_handler)
         else:
             logger.warning("SIGUSR1 handler not installed because we are not "
                            "running in the main thread. In this case the "

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -2,6 +2,7 @@
 
 import os
 import pickle
+import platform
 import signal
 import sys
 import time
@@ -53,7 +54,8 @@ class MultiprocExecutor(Executor):
             parent_process.send_signal(signal.SIGUSR1)
             self.shutdown()
 
-        signal.signal(signal.SIGUSR1, sigusr1_handler)
+        if platform.system() != "Windows":
+            signal.signal(signal.SIGUSR1, sigusr1_handler)
 
         self.world_size = self.parallel_config.world_size
         tensor_parallel_size = self.parallel_config.tensor_parallel_size
@@ -324,7 +326,10 @@ class WorkerProc:
             # worker_busy_loop sends exceptions exceptons to Executor
             # for shutdown, but if there is an error in startup or an
             # error with IPC itself, we need to alert the parent.
-            psutil.Process().parent().send_signal(signal.SIGUSR1)
+            if platform.system() == "Windows":
+                psutil.Process().parent().send_signal(signal.SIGTERM)
+            else:
+                psutil.Process().parent().send_signal(signal.SIGUSR1)
             raise
 
         finally:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -2,6 +2,7 @@
 """A GPU worker class."""
 import gc
 import os
+import platform
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -137,7 +138,7 @@ class Worker(WorkerBase):
 
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
-        """Profiles the peak memory usage of the model to determine how much 
+        """Profiles the peak memory usage of the model to determine how much
         memory can be used for KV cache without OOMs.
 
         The engine will first conduct a profiling of the existing memory usage.
@@ -280,7 +281,7 @@ def init_worker_distributed_environment(
     set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
 
     init_distributed_environment(parallel_config.world_size, rank,
-                                 distributed_init_method, local_rank)
+                                 distributed_init_method, local_rank, backend="gloo" if platform.system() == "Windows" else "nccl")
 
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -280,8 +280,12 @@ def init_worker_distributed_environment(
     """Initialize the distributed environment."""
     set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
 
-    init_distributed_environment(parallel_config.world_size, rank,
-                                 distributed_init_method, local_rank, backend="gloo" if platform.system() == "Windows" else "nccl")
+    init_distributed_environment(
+        parallel_config.world_size,
+        rank,
+        distributed_init_method,
+        local_rank,
+        backend="gloo" if platform.system() == "Windows" else "nccl")
 
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -503,8 +503,13 @@ def init_worker_distributed_environment(
     parallel_config = vllm_config.parallel_config
     set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
 
-    init_distributed_environment(parallel_config.world_size, rank,
-                                 distributed_init_method, local_rank, backend="gloo" if platform.system() == "Windows" else "nccl")
+    init_distributed_environment(
+        parallel_config.world_size,
+        rank,
+        distributed_init_method,
+        local_rank,
+        backend="gloo" if platform.system() == "Windows" else "nccl")
+
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -2,6 +2,7 @@
 """A GPU worker class."""
 import gc
 import os
+import platform
 from typing import Dict, List, Optional, Set, Tuple, Type, Union
 
 import torch
@@ -503,7 +504,7 @@ def init_worker_distributed_environment(
     set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
 
     init_distributed_environment(parallel_config.world_size, rank,
-                                 distributed_init_method, local_rank)
+                                 distributed_init_method, local_rank, backend="gloo" if platform.system() == "Windows" else "nccl")
     ensure_model_parallel_initialized(parallel_config.tensor_parallel_size,
                                       parallel_config.pipeline_parallel_size)
 


### PR DESCRIPTION
This PR fixes #2309 #2242 #2242 #669 #5086 #5631 #1685 #179 #2309 #669 and includes:

- **vLLM CUDA support for Windows** (with updated Python code, install setup and compiled Kernels)
- Add compatibility with Pytorch nightly / source compilation builds (changed torch version detection to major / minor)

FlashInfer build for Windows will be added today in a PR in their corresponding repository.

Kernels changes are the minimal to make the MSVC compiler happy and doesn't change any kernel functionality itself. Special mention to GPTQ_Marlin, where the excessive ELSE IF clauses inside a single function has been splitted into smaller functions to avoid a C1061 error.

### **Instructions for Windows build:**

A Visual Studio 2019 or newer is required to launch the compiler x64 environment. The installation path is referred in the instructions as VISUAL_STUDIO_INSTALL_PATH.

CUDA path will be found automatically if you have the bin folder in your PATH, or have the CUDA installation path settled on well-known environment vars like CUDA_ROOT, CUDA_HOME or CUDA_PATH.

If none of these are present, make sure to set the environment variable before starting the build:
set CUDA_ROOT=CUDA_INSTALLATION_PATH

1. Open a Command Line (cmd.exe)
2. Clone the vLLM repository (for example, to C:\vllm)
3. Execute (in cmd) VISUAL_STUDIO_INSTALL_PATH\VC\Auxiliary\Build\vcvarsall.bat x64
4. Change the working directory to the cloned repository path, for example: cd C:\vllm
5. Set the following variables:

```
set DISTUTILS_USE_SDK=1
set VLLM_TARGET_DEVICE=cuda
set MAX_JOBS=10 (or your desired number to speed up compilation)

#Optional variables:

#To include cuDSS (only if you have cuDSS installed)
set USE_CUDSS=1
set CUDSS_LIBRARY_PATH=PATH_TO_CUDSS_INSTALL_DIR\lib\12
set CUDSS_INCLUDE_PATH=PATH_TO_CUDSS_INSTALL_DIR\include

#To include cuSPARSELt (only if you have cuSPARSELt installed)
set CUSPARSELT_INCLUDE_PATH=PATH_TO_CUSPARSELT_INSTALL_DIR\include 
set USE_CUSPARSELT=1

#To include cuDNN:
set USE_CUDNN=1

#Flash Attention v3 build has been disabled inside WSL2 and Windows due to compiler being killed on WSL2, and extremely long compiling times on Windows. Hopper is not available on Windows, so FA3 has no sense anyway. 
#Build can be forcefully enabled using the following environment var:
set VLLM_FORCE_FA3_WINDOWS_BUILD=1
```

The next steps are the same as building from source with GPU support at section "Full build (with compilation)": [https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#full-build-with-compilation](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#full-build-with-compilation)

As a note, some sm100 kernels in Cutlass v3.8.0 has compilation errors on Windows. A fix has been submitted to Nvidia (see [https://github.com/NVIDIA/cutlass/pull/2167](https://github.com/NVIDIA/cutlass/pull/2167)).

Until Nvidia accepts the PR, only for Windows environment, FetchContent_Declare will clone Cutlass v3.8.0 from a branch with the fix. Feel free to remove that part when the Nvidia PR has been merged (keep the rest of changes for cuBLAS and VLLM_GPU_FLAGS).

----

FIX #2309
FIX #2242
FIX #669
FIX #5086
FIX #5631
FIX #1685
FIX #179
FIX #2309