### PR TITLE
[Bugfix] torchrun compatibility

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -904,6 +904,7 @@ class ModelConfig:
         else:
             total_num_hidden_layers = getattr(self.hf_text_config,
                                               "num_hidden_layers", 0)
+        # the layout order is: DP x PP x TP
         pp_rank = (parallel_config.rank // parallel_config.tensor_parallel_size
                    ) % parallel_config.pipeline_parallel_size
         pp_size = parallel_config.pipeline_parallel_size

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -904,7 +904,8 @@ class ModelConfig:
         else:
             total_num_hidden_layers = getattr(self.hf_text_config,
                                               "num_hidden_layers", 0)
-        pp_rank = parallel_config.rank // parallel_config.tensor_parallel_size
+        pp_rank = (parallel_config.rank // parallel_config.tensor_parallel_size
+                   ) % parallel_config.pipeline_parallel_size
         pp_size = parallel_config.pipeline_parallel_size
         start, end = get_pp_indices(total_num_hidden_layers, pp_rank, pp_size)
         return start, end

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -900,7 +900,13 @@ def initialize_model_parallel(
     from vllm.config import get_current_vllm_config
     config = get_current_vllm_config()
     if config is not None:
-        data_parallel_size = config.parallel_config.data_parallel_size
+        if (config.parallel_config.distributed_executor_backend ==
+                "external_launcher"):
+            # do not use config.parallel_config to avoid hanging
+            data_parallel_size = world_size // (pipeline_model_parallel_size *
+                                                tensor_model_parallel_size)
+        else:
+            data_parallel_size = config.parallel_config.data_parallel_size
 
     # the layout order is: DP x PP x TP
     # to get group_ranks for each dimension, transpose that dimension to the

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -897,14 +897,21 @@ def initialize_model_parallel(
         get_world_group().device_group)
 
     data_parallel_size = 1
+    has_external_dp = False
     from vllm.config import get_current_vllm_config
     config = get_current_vllm_config()
     if config is not None:
-        if (config.parallel_config.distributed_executor_backend ==
-                "external_launcher"):
-            # do not use config.parallel_config to avoid hanging
+        if config.parallel_config.world_size != world_size:
+            # detect external data parallelism.
+            # dp in vllm means all dp instances need to run together.
+            # if the world size does not match, it means this dp is external,
+            # and the dp instances can run independently, e.g. in rlhf workflow
+            # from https://github.com/volcengine/verl .
+            # in that case, we treat the rest dimensions as if they are
+            # data parallel, and create a dummy dp group that is not used.
             data_parallel_size = world_size // (pipeline_model_parallel_size *
                                                 tensor_model_parallel_size)
+            has_external_dp = True
         else:
             data_parallel_size = config.parallel_config.data_parallel_size
 
@@ -946,6 +953,12 @@ def initialize_model_parallel(
                                       2).reshape(-1,
                                                  data_parallel_size).unbind(0)
     group_ranks = [x.tolist() for x in group_ranks]
+    if has_external_dp:
+        # create a dummy dp group that is not used actually,
+        # since this dp is external.
+        # a dummy dp group means every rank is a group itself.
+        # this way, no communication is needed, no memory is wasted.
+        group_ranks = [[x] for x in range(world_size)]
     _DP = init_model_parallel_group(group_ranks,
                                     get_world_group().local_rank,
                                     backend,


### PR DESCRIPTION
This PR fixes the vllm's offline inference when using torchrun as the external launcher in veRL broken after  #13591

When we launch vllm using torchrun with `tp = 2` on 8 GPUs, the layout of the distributed world should be (DP = 4 * PP = 1 * TP = 2). However, we find setting `VLLM_DP_SIZE` to 4 causes the process to hang after generation. So, we use the `parallel_config` to determine how to compute the dp size. (actually we don't know why, maybe #13591 is not fully compatible with external launchers)

This modification is also the same as https://verl.readthedocs.io/en/latest/README_vllm0.7.html#use-vllm-v1-engine described

Regarding the `get_pp_indices` function, we take the modulus of the pp rank by the pp size to ensure that the pp rank is always smaller than the pp size.

This PR has been validated using the latest veRL on the GSM8K task.

![image](https://github.com/user-attachments/assets/757c5dab-019d-4951-b19f-315b2f1cc64f)

I'm a newbie in vLLM. Please feel free to let me know if there are any problems.

cc @youkaichao 