### PR TITLE
Enable CUDA graph support for llama 3.2 vision

### DIFF
--- a/tests/models/encoder_decoder/vision_language/test_mllama.py
+++ b/tests/models/encoder_decoder/vision_language/test_mllama.py
@@ -216,7 +216,6 @@ def _run_test(
                      max_num_seqs=2,
                      tensor_parallel_size=tensor_parallel_size,
                      distributed_executor_backend=distributed_executor_backend,
-                     enforce_eager=True,
                      limit_mm_per_prompt={"image": _LIMIT_IMAGE_PER_PROMPT
                                           }) as vllm_model:
         vllm_outputs_per_image = [
@@ -430,7 +429,6 @@ def test_bnb_regression(
         dtype=dtype,
         max_model_len=4096,
         max_num_seqs=2,
-        enforce_eager=True,
         quantization="bitsandbytes",
         load_format="bitsandbytes",
     )
@@ -486,7 +484,6 @@ def test_explicit_implicit_prompt(
         max_model_len=4096,
         max_num_seqs=2,
         tensor_parallel_size=1,
-        enforce_eager=True,
     )
     sampling_params = SamplingParams(
         temperature=0,
@@ -518,7 +515,6 @@ def test_regression(vllm_runner, image_assets, model, dtype, max_tokens,
             max_model_len=4096,
             max_num_seqs=2,
             tensor_parallel_size=1,
-            enforce_eager=True,
             limit_mm_per_prompt={"image":
                                  _LIMIT_IMAGE_PER_PROMPT}) as vllm_model:
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -670,14 +670,6 @@ class ModelConfig:
         self.max_seq_len_to_capture = min(self.max_seq_len_to_capture,
                                           self.max_model_len)
 
-        MODEL_NOT_SUPPORT_CUDA_GRAPH = ['mllama']
-        if (self.hf_config.model_type in MODEL_NOT_SUPPORT_CUDA_GRAPH
-                and not self.enforce_eager):
-            logger.warning(
-                "CUDA graph is not supported for %s yet, fallback to the eager "
-                "mode.", self.hf_config.model_type)
-            self.enforce_eager = True
-
     def _verify_bnb_config(self) -> None:
         """
         The current version of bitsandbytes (0.44.0) with 8-bit models does not

--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1187,6 +1187,8 @@ class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal,
                                                 config.text_config.vocab_size)
         self.sampler = get_sampler()
 
+        self.capture_mode = False
+
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
@@ -1366,12 +1368,19 @@ class MllamaForConditionalGeneration(nn.Module, SupportsMultiModal,
         cross_attention_mask = None
         kv_range_for_decode = None
 
+        skip_cross_attention = False
+
         # For 1) text-only prefill and decode, 2) image-present decode.
         if image_inputs is None:
             full_text_row_masked_out_mask = (
                 attn_metadata.encoder_seq_lens_tensor
                 != 0).reshape(-1, 1).to(input_ids.device)
-            skip_cross_attention = max(attn_metadata.encoder_seq_lens) == 0
+
+            if not self.capture_mode:
+                # NOTE: when doing cuda graph capture, we never want to skip
+                # cross attention. Skipping this line in such case enables
+                # CUDA graph capture to succeed.
+                skip_cross_attention = max(attn_metadata.encoder_seq_lens) == 0
 
         # For image-present prefill.
         else:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1935,6 +1935,9 @@ class CUDAGraphRunner(nn.Module):
         # Capture the graph.
         self._graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(self._graph, pool=memory_pool, stream=stream):
+            if hasattr(self.model, "capture_mode"):
+                self.model.capture_mode = True
+
             output_hidden_or_intermediate_states = self.model(
                 input_ids=input_ids,
                 positions=positions,
@@ -1959,6 +1962,9 @@ class CUDAGraphRunner(nn.Module):
             # in the graph's memory pool
             gc.collect()
         torch.cuda.synchronize()
+
+        if hasattr(self.model, "capture_mode"):
+            self.model.capture_mode = False
 
         # Save the input and output buffers.
         self.input_buffers = {

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1935,9 +1935,6 @@ class CUDAGraphRunner(nn.Module):
         # Capture the graph.
         self._graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(self._graph, pool=memory_pool, stream=stream):
-            if hasattr(self.model, "capture_mode"):
-                self.model.capture_mode = True
-
             output_hidden_or_intermediate_states = self.model(
                 input_ids=input_ids,
                 positions=positions,
@@ -1962,9 +1959,6 @@ class CUDAGraphRunner(nn.Module):
             # in the graph's memory pool
             gc.collect()
         torch.cuda.synchronize()
-
-        if hasattr(self.model, "capture_mode"):
-            self.model.capture_mode = False
 
         # Save the input and output buffers.
         self.input_buffers = {


### PR DESCRIPTION
Add support for llama 3.2 vision with CUDA graph capture. Removes block on CUDA graph capture for mllama.

Note: Follows a similar approach to the one taken by SGLang, making mllama aware of whether it is in graph capture mode or not (https://github.com/sgl-project/sglang/commit/94cde10920035648b0554abec5323176eea8486d)

FIX "Enabling CUDA graph" in https://github.com/vllm-project/vllm/issues/8826#issuecomment-2379960574

<!--- pyml disable-next-line no-emphasis-as-heading -->

Tested:

```
python3 -m vllm.entrypoints.cli.main serve unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit \
   --quantization="bitsandbytes" \
   --load-format="bitsandbytes" \
   --dtype=bfloat16 \
   --trust_remote_code \
   --gpu-memory-utilization=0.98 \
   --max-model-len=9600 \
   --max-num-seqs 4
```
started and responded successfully to requests (no enforce-eager). Also verified that it still worked with `--enforce-eager`. Example command:

```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "unsloth/Llama-3.2-11B-Vision-Instruct-bnb-4bit",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "What is in this image?"
          },
          {
            "type": "image_url",
            "image_url": {
              "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
            }
          }
        ]
      }
    ],
    "max_tokens": 300
  }'
```