### PR TITLE
[V1] Default MLA to V1

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1191,7 +1191,7 @@ class EngineArgs:
         NOTE: for autoselection of V0 vs V1 engine, we need to
         create the ModelConfig first, since ModelConfig's attrs
         (e.g. the model arch) are needed to make the decision.
-        
+
         This function set VLLM_USE_V1=X if VLLM_USE_V1 is
         unspecified by the user.
 
@@ -1582,10 +1582,6 @@ class EngineArgs:
 
         #############################################################
         # Experimental Features - allow users to opt in.
-
-        # MLA is is supported on V1, but off by default for now.
-        if model_config.use_mla and _warn_or_fallback("MLA"):
-            return False
 
         # LoRA is supported on V1, but off by default for now.
         if self.enable_lora and _warn_or_fallback("LORA"):


### PR DESCRIPTION
1. This is stable enough to recommend it.
2. V0 is currently broken when serving a local method with trust remote code

```
INFO 03-17 04:22:35 [llm_engine.py:241] Initializing a V0 LLM engine (v0.7.4.dev497+ga73e183e) with config: model='/home/vllm-dev/DeepSeek-R1', speculative_config=None, tokenizer='/home/vllm-dev/DeepSeek-R1', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=163840, download_dir=None, load_format=dummy, tensor_parallel_size=8, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=fp8, enforce_eager=False, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=/home/vllm-dev/DeepSeek-R1, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=False, chunked_prefill_enabled=False, use_async_output_proc=True, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=True, 
WARNING 03-17 04:22:36 [multiproc_worker_utils.py:310] Reducing Torch parallelism from 64 threads to 1 to avoid unnecessary CPU contention. Set OMP_NUM_THREADS in the external environment to tune this value as needed.
INFO 03-17 04:22:36 [custom_cache_manager.py:19] Setting Triton cache manager to: vllm.triton_utils.custom_cache_manager:CustomCacheManager
ERROR 03-17 04:22:36 [engine.py:443] Can't pickle <class 'transformers_modules.DeepSeek-R1.configuration_deepseek.DeepseekV3Config'>: it's not the same object as transformers_modules.DeepSeek-R1.configuration_deepseek.DeepseekV3Config
ERROR 03-17 04:22:36 [engine.py:443] Traceback (most recent call last):
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/engine/multiprocessing/engine.py", line 431, in run_mp_engine
ERROR 03-17 04:22:36 [engine.py:443]     engine = MQLLMEngine.from_vllm_config(
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/engine/multiprocessing/engine.py", line 126, in from_vllm_config
ERROR 03-17 04:22:36 [engine.py:443]     return cls(
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/engine/multiprocessing/engine.py", line 80, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     self.engine = LLMEngine(*args, **kwargs)
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 280, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     self.model_executor = executor_class(vllm_config=vllm_config, )
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 271, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     super().__init__(*args, **kwargs)
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 52, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     self._init_executor()
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/executor/mp_distributed_executor.py", line 90, in _init_executor
ERROR 03-17 04:22:36 [engine.py:443]     worker = ProcessWorkerWrapper(result_handler,
ERROR 03-17 04:22:36 [engine.py:443]   File "/home/vllm-dev/.cache/uv/archive-v0/ShHQ1oC1bVhD39JGW6Vk6/lib/python3.10/site-packages/vllm/executor/multiproc_worker_utils.py", line 171, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     self.process.start()
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/process.py", line 121, in start
ERROR 03-17 04:22:36 [engine.py:443]     self._popen = self._Popen(self)
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/context.py", line 288, in _Popen
ERROR 03-17 04:22:36 [engine.py:443]     return Popen(process_obj)
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 32, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     super().__init__(process_obj)
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/popen_fork.py", line 19, in __init__
ERROR 03-17 04:22:36 [engine.py:443]     self._launch(process_obj)
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 47, in _launch
ERROR 03-17 04:22:36 [engine.py:443]     reduction.dump(process_obj, fp)
ERROR 03-17 04:22:36 [engine.py:443]   File "/usr/lib/python3.10/multiprocessing/reduction.py", line 60, in dump
ERROR 03-17 04:22:36 [engine.py:443]     ForkingPickler(file, protocol).dump(obj)
ERROR 03-17 04:22:36 [engine.py:443] _pickle.PicklingError: Can't pickle <class 'transformers_modules.DeepSeek-R1.configuration_deepseek.DeepseekV3Config'>: it's not the same object as transformers_modules.DeepSeek-R1.configuration_deepseek.DeepseekV3Config
```