### PR TITLE
[Bugfix] fix triton mla + awq crash while prefix cache hit

### DIFF
--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1161,7 +1161,7 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
             k_pe = workspace[:toks]\
                 [..., self.kv_lora_rank:].unsqueeze(1)
 
-            kv_nope = self.kv_b_proj(kv_c_normed)[0].view( \
+            kv_nope = self.kv_b_proj(kv_c_normed.contiguous())[0].view( \
                 -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
             k_nope, v = kv_nope\
                 .split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)


### PR DESCRIPTION

fix https://github.com/vllm-project/vllm/issues/14887, 

Ensure MLA kv_c_normed contiguous for gptq_marlin_gemm

Without this fix: PP2 + TP8, R1 AWQ, raise error (**A is not contiguous**) while hit prefix cache

```bash
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/attention/backends/mla/common.py", line 1300, in _forward_prefill [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     context_output, context_lse = self._compute_prefill_context( \ [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/attention/backends/mla/common.py", line 1164, in _compute_prefill_context [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     kv_nope = self.kv_b_proj(kv_c_normed)[0].view( \ [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     output_parallel = self.quant_method.apply(self, input_, bias) [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/layers/quantization/awq_marlin.py", line 303, in apply [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     return apply_awq_marlin_linear( [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/layers/quantization/utils/marlin_utils.py", line 379, in apply_awq_marlin_linear [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     output = ops.gptq_marlin_gemm(reshaped_x, [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/_custom_ops.py", line 741, in gptq_marlin_gemm [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620]     return torch.ops._C.gptq_marlin_gemm(a, b_q_weight, b_scales, b_zeros, [repeated 6x across cluster]
(RayWorkerWrapper pid=143246) ERROR 03-17 17:37:07 [worker_base.py:620] RuntimeError: A is not contiguous [repeated 6x across cluster]
```
<!--- pyml disable-next-line no-emphasis-as-heading -->
