### PR TITLE
Fixing imports at package level | phi4-multimodla-instruct fix 

### DIFF
--- a/vllm/engine/multiprocessing/__init__.py
+++ b/vllm/engine/multiprocessing/__init__.py
@@ -7,7 +7,7 @@ from typing import List, Mapping, Optional, Union, overload
 
 from typing_extensions import deprecated
 
-from vllm import PoolingParams
+from vllm.pooling_params import PoolingParams
 from vllm.inputs import PromptType
 from vllm.lora.request import LoRARequest
 from vllm.outputs import RequestOutput

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -15,7 +15,7 @@ from typing_extensions import deprecated
 from zmq import Frame  # type: ignore[attr-defined]
 from zmq.asyncio import Socket
 
-from vllm import PoolingParams
+from vllm.pooling_params import PoolingParams
 from vllm.config import DecodingConfig, ModelConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 # yapf conflicts with isort for this block

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -8,7 +8,8 @@ from typing import Iterator, List, Optional, Union
 import cloudpickle
 import zmq
 
-from vllm import AsyncEngineArgs, SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import SamplingParams
 from vllm.config import VllmConfig
 from vllm.engine.llm_engine import LLMEngine
 # yapf conflicts with isort for this block


### PR DESCRIPTION
# **Running an OpenAI compatible server for phi4-multimodal-instruct model**

Error while building from source:

ImportError: cannot import name 'PoolingParams' from 'vllm' (unknown location). Did you mean: 'pooling_params'?
from vllm import AsyncEngineArgs, SamplingParams
ImportError: cannot import name 'AsyncEngineArgs' from 'vllm' (unknown location)

The changes made will fix the corresponding import errors at package level

Steps to be followed:

```
conda create -n vllm_main python=3.11 -y
conda activate vllm_main
```

or 

```
python3 -m venv vnev
source venv/bin/activate 
```
Then
```
git clone https://github.com/vllm-project/vllm.git; cd vllm
VLLM_USE_PRECOMPILED=1 pip install --editable . vllm[audio]
pip install flash-attn --no-build-isolation
```
`pip install "huggingface_hub[hf_transfer]"
`

Running from root

`cd ..`
 
```
HF_HUB_ENABLE_HF_TRANSFER=1 \
huggingface-cli download microsoft/Phi-4-multimodal-instruct
```
Note: It is tested on A10 GPU with 24GB VRAM and the max model len that works is 34400 (require further optimization)
```
CUDA_VISIBLE_DEVICES=3,1,0,2 \
VLLM_WORKER_MULTIPROC_METHOD=spawn \
TRANSFORMERS_OFFLINE=1 \
HF_DATASETS_OFFLINE=1 \
python -m vllm.entrypoints.openai.api_server --model /root/HuggingFaceCache/models--microsoft--Phi-4-multimodal-instruct --dtype auto --trust-remote-code --served-model-name gpt-4 --gpu-memory-utilization 0.98 --tensor-parallel-size 4 --max-model-len 34400 --max-seq-len-to-capture=34400--enable-lora --max-lora-rank 320 --lora-extra-vocab-size 0 --limit-mm-per-prompt audio=3,image=3 --max-loras 2 --lora-modules speech=/root/HuggingFaceCache/models--microsoft--Phi-4-multimodal-instruct/speech-lora vision=/root/HuggingFaceCache/models--microsoft--Phi-4-multimodal-instruct/vision-lora --port 8000 --api-key sk-dummy --disable-sliding-window
```

Output:
```

Capturing CUDA graph shapes: 100%|████████████████████████████████████████████████████████████████████| 35/35 [00:19<00:00,  1.79it/s]
INFO 03-17 13:47:27 [model_runner.py:1570] Graph capturing finished in 20 secs, took 0.70 GiB
INFO 03-17 13:47:27 [llm_engine.py:447] init engine (profile, create kv cache, warmup model) took 34.11 seconds
INFO 03-17 13:47:28 [serving_models.py:174] Loaded new LoRA adapter: name 'speech', path '/home/ubuntu/phi4-mm-instruct/speech-lora'
INFO 03-17 13:47:29 [serving_models.py:174] Loaded new LoRA adapter: name 'vision', path '/home/ubuntu/phi4-mm-instruct/vision-lora'
INFO 03-17 13:47:29 [api_server.py:1019] Starting vLLM API server on http://0.0.0.0:8000
INFO 03-17 13:47:29 [launcher.py:26] Available routes are:
INFO 03-17 13:47:29 [launcher.py:34] Route: /openapi.json, Methods: HEAD, GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /docs, Methods: HEAD, GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /docs/oauth2-redirect, Methods: HEAD, GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /redoc, Methods: HEAD, GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /health, Methods: GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /load, Methods: GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /ping, Methods: GET, POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /tokenize, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /detokenize, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/models, Methods: GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /version, Methods: GET
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/chat/completions, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/completions, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/embeddings, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /pooling, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /score, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/score, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/audio/transcriptions, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /rerank, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v1/rerank, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /v2/rerank, Methods: POST
INFO 03-17 13:47:29 [launcher.py:34] Route: /invocations, Methods: POST
INFO:     Started server process [8663]
INFO:     Waiting for application startup.
INFO:     Application startup complete.


