### PR TITLE
[ V0 ][ sample ] improve sample performance when using  guide decoding

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -48,7 +48,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsLoRA, SupportsPP, SupportsSampleV2
 from .utils import (AutoWeightsLoader, PPMissingLayer, extract_layer_index,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
@@ -433,7 +433,7 @@ class LlamaModel(nn.Module):
         return loaded_params
 
 
-class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class LlamaForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsSampleV2):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"]

--- a/vllm/model_executor/models/qwen.py
+++ b/vllm/model_executor/models/qwen.py
@@ -31,7 +31,7 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsLoRA, SupportsPP, SupportsSampleV2
 from .utils import (is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
@@ -335,7 +335,8 @@ class QWenBaseModel(nn.Module):
         return loaded_params
 
 
-class QWenLMHeadModel(QWenBaseModel, SupportsPP, SupportsLoRA):
+class QWenLMHeadModel(QWenBaseModel, SupportsPP, SupportsLoRA,
+                      SupportsSampleV2):
     packed_modules_mapping = {
         "c_attn": ["c_attn"],
         "gate_up_proj": [

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -52,7 +52,7 @@ from vllm.model_executor.pooling_metadata import PoolingMetadata
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors, PoolerOutput
 
-from .interfaces import SupportsLoRA, SupportsPP
+from .interfaces import SupportsLoRA, SupportsPP, SupportsSampleV2
 from .utils import (AutoWeightsLoader, PPMissingLayer, WeightsMapper,
                     is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
@@ -405,7 +405,7 @@ class Qwen2Model(nn.Module):
         return loaded_params
 
 
-class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class Qwen2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsSampleV2):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",


### PR DESCRIPTION
### Introduction
this pr introduce a new  sample  algorithm ( SampleV2) to  improve guide decoding performance.

currently  support  xgrammer backend  and  qwen , llama  model .

refer to  interface  'vllm. model_executor. models. interfaces.SupportsSampleV2'.

this PR  increased  ebnf  guide decode  throughput by more than 1000% .

### background
1.   guide decode backends  like  xgr ,  outlines  open only optimizes the speed of  json  guide decoding  ebnf  ,   but  when use other gbnf  grammar ,  the  throughput  of tokens  can  be  very slow.   
 
in my  test case,  the grammar is below:
```
root        ::= en-char+ ([ \t\n] en-char+)*
en-char     ::= letter | digit | punctuation
letter      ::= [a-zA-Z]
digit       ::= [0-9]
punctuation ::= [!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]
``` 
when vllm use 4x L40s GPU serve  a qwen72b awq 4bit model,  the  decode speed is  50  tokens/s.  but applied guided_grammar, decode speed is  2.5 tokens /s .

I   optimized   the  grammar  as  below , then it outputs 12 tokens/s:
```
root        ::= (en-char+ [ \t\n])*  en-char+
en-char     ::= letter | digit | punctuation
letter      ::= [a-zA-Z]
digit       ::= [0-9]
punctuation ::= [!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]
```

2.  the  bottleneck  of  guide decode is  matcher.FillNextTokenBitmask (see this  issue https://github.com/mlc-ai/xgrammar/issues/235) .   before  in every decode step the function FillNextTokenBitmask   is called  , so  this  pr  aimed to reduce the times to call matcher.FillNextTokenBitmask.

### how it works

```python
    def samplev2(
            self,
            logits: torch.Tensor,
            sampling_metadata: SamplingMetadata,
    )->Optional[SamplerOutput]:
        # compute logits
        next_tokens: SamplerOutput = self.sampler(logits, sampling_metadata)

        # check if  the sampled tokens fit the grammars
        tks = torch.tensor([o.samples[0].output_token for o in next_tokens.outputs])
        accepted = accept_grammar(tks, sampling_metadata)
        need_resample = torch.logical_not(accepted)
        if accepted.all():
            return next_tokens
        # resample
        # if the token is not valid, sample again, but first apply the grammar bitmask
        # only apply logits processor when need_resample
        logits = _apply_logits_processors(logits, sampling_metadata, need_resample, False)
        new_next_tokens: SamplerOutput = self.sampler(logits, sampling_metadata)

        for i, replace in enumerate(need_resample.tolist()):
            if replace:
                next_tokens.outputs[i] = new_next_tokens.outputs[i]

        tks = torch.tensor([o.samples[0].output_token for o in next_tokens.outputs])
        # matcher only accept next token when first round is not accepted.
        accepted = accept_grammar(tks, sampling_metadata, need_resample)
        assert accepted.all()
        return next_tokens
```
The new sampling method  (samplev2) consists of the following steps:

a.  compute logits  from hidden_states. 
b.  sample the batched outout without  grammar guide.
c.  let  FSM  try to  accept  the  output tokens , if  call  accept, return directly ( did not call FillNextTokenBitmask).
d.  if FSM can not accept ,  apply grammar guide  to  logits  ,  and  resample .
 

### test

``` python
ebnfstr = '''
root        ::= en-char+ ([ \t\n] en-char+)*
en-char     ::= letter | digit | punctuation
letter      ::= [a-zA-Z]
digit       ::= [0-9]
punctuation ::= [!"#$%&'()*+,-./:;<=>?@[\\\]^_`{|}~]
'''



payload = {
        "messages": [
            {
                "content": "tell a story about Spring ,at least 1024 words",
                "role": "user"
            }
        ],
        "max_tokens": 1024,
        "model": "llama2",
        "stream": False,
        "guided_grammar":  ebnfstr
    }

```


single clinet  test  result (nearly no cost when apply guided_grammar):

|model| not guided (tokens /s) |  before (tokens /s) |  this pr (tokens /s) |
|---|---|---|---|
|qwen2.5 1.5b fp16  1*L40s | 140 |2|136|
|qwen2.5 72b awq4  4*L40s  |  50 |2| 48|

current  this  pr  only  supported  backend  xgrammar and models like qwen2 ,llama  . more model can be supported by extend class  SupportsSampleV2

