### PR TITLE
[Neuron] trim attention kernel tests to fit trn1.2x instance

### DIFF
--- a/tests/neuron/1_core/test_prefix_prefill.py
+++ b/tests/neuron/1_core/test_prefix_prefill.py
@@ -314,7 +314,7 @@ def get_active_block_tables(block_tables, query_lens, seq_lens, block_size,
 
         # Test edge cases
         (1, 128, 16, 1024, 4, 2, 16, False),  # large decode batch
-        (16, 4, 8, 8192, 48, 1, 128, True),  # large prefill batch
+        (16, 4, 8, 1024, 4, 2, 128, True),  # large prefill batch
         (4, 12, 32, 2048, 16, 1, 32, True),  # multi-head attention (MHA)
         (4, 12, 32, 2048, 16, 16, 32, True),  # multi-query attention (MQA)
     ])


### PR DESCRIPTION
We are trying to scale up neuron backend test infra, where trn1.2xl instance would be used for testing 1_core and 2_core unit test scripts.

One special test we are trying to handle [here](https://buildkite.com/vllm/ci/builds/15537#0195a5df-b719-4d41-9f04-740d3e1803c1) can run out-of-memory on trn1.2x instance. The temporary solution here is to trim the test case down to fit CPU memory on the instance.

cc @lingfanyu

