### PR TITLE
Change logprobs to use int64 datatype in torch.gather

### DIFF
--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -152,7 +152,7 @@ class Sampler(nn.Module):
 
         # Get with the logprob of the prompt or sampled token.
         token_ids = token_ids.unsqueeze(-1)
-        token_logprobs = logprobs.gather(-1, token_ids)
+        token_logprobs = logprobs.gather(-1, token_ids.long())
 
         # Compute the ranks of the actual token.
         token_ranks = (logprobs >= token_logprobs).sum(-1)


### PR DESCRIPTION
Fix crash on DeepSeek R1 where torch.gather expects an int64 tensor.

I have confirmed that this fixes the crash on V1 on revision 233ffce1 , but I don't understand what caused the change in behavior. I suspect this regression happened after #12721 updating torch to 2.6.0, but I don't really understand the cause.

```
INFO 03-15 19:58:20 [logger.py:39] Received request cmpl-aca2df6d00644a15a3b1d0cbb1491f4a-0: prompt: '', params: SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.0, temperature=0.6, top_p=0.95, top_k=-1, min_p=0.0, seed=3030081490969633974, stop=['<|user|>'], stop_token_ids=[], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=8192, min_tokens=0, logprobs=1, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None, extra_args=None), prompt_token_ids: [], lora_request: None, prompt_adapter_request: None.

WorkerProc hit an exception: %s
Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 371, in worker_busy_loop
    output = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 242, in execute_model
    output = self.model_runner.execute_model(scheduler_output)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1011, in execute_model
    sampler_output = self.model.sample(
                     ^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/model_executor/models/deepseek_v2.py", line 706, in sample
    next_tokens = self.sampler(logits, sampling_metadata)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 54, in forward
    self.gather_logprobs(raw_logprobs, num_logprobs, token_ids=sampled)
  File "/opt/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 163, in gather_logprobs
    token_logprobs = logprobs.gather(-1, token_ids)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: gather(): Expected dtype int64 for index
```
