### PR TITLE
When an exception happens in multiproc, die hard and fast

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -373,6 +373,9 @@ class WorkerProc:
                 self.worker_response_mq.enqueue(
                     (WorkerProc.ResponseStatus.FAILURE, e))
                 logger.exception("WorkerProc hit an exception: %s", exc_info=e)
+                sys.stdout.flush()
+                sys.stderr.flush()
+                signal.raise_signal(signal.SIGKILL)
                 continue
 
             self.worker_response_mq.enqueue(


### PR DESCRIPTION
This is something we hit in production when running with `VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_USE_V1=1`

Sometimes, due to a bug or failure, a Worker process will get an exception. With the current exception handler, this causes VLLM to simply hang and stop processing new requests, but not die, which is really bad for running in production. It will appear to accept new requests but will not make progress.

I think it is better to print the exception and fail. I'm using SIGKILL because there is no reason to invoke the signal handlers since we already printed out the original cause of failure. Failing quickly and decisively makes it much easier to respond to failures in production and keep systems responsive.