### PR TITLE
feat: add custom s3 support

### DIFF
--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -12,6 +12,7 @@ from vllm.utils import PlaceholderModule
 
 try:
     import boto3
+    from botocore.config import Config
 except ImportError:
     boto3 = PlaceholderModule("boto3")  # type: ignore[assignment]
 
@@ -106,8 +107,20 @@ class S3Model:
         pull_files(): Pull model from S3 to the temporary directory.
     """
 
-    def __init__(self) -> None:
-        self.s3 = boto3.client('s3')
+    def __init__(self, access_key_id:str = '', 
+                 secret_access_key:str = '',
+                 endpoint_url:str = '', 
+                 config: Config = None) -> None:
+        if access_key_id and secret_access_key and endpoint_url:
+            self.s3 = boto3.client(
+                's3',
+                aws_access_key_id=access_key_id,
+                aws_secret_access_key=secret_access_key,
+                endpoint_url=endpoint_url,
+                config=config
+            )
+        else:
+            self.s3 = boto3.client('s3')
         for sig in (signal.SIGINT, signal.SIGTERM):
             existing_handler = signal.getsignal(sig)
             signal.signal(sig, self._close_by_signal(existing_handler))


### PR DESCRIPTION
the feature of s3 make it easy to host model files on s3 storage, and I've metioned this feature in the source code. But it seems that the initialization of `S3Model` will highly depend on aws config like(`~/.aws/config`、`~/.aws/credentials`) 
https://github.com/vllm-project/vllm/blob/5eeabc2a4400fde9b030f2f72746a2b03db059bd/vllm/transformers_utils/s3_utils.py#L97-L115



<!--- pyml disable-next-line no-emphasis-as-heading -->
