### PR TITLE
Replace `decord` with `torchcodec`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,6 +219,7 @@ autodoc_mock_imports = [
     "soundfile",
     "gguf",
     "lark",
+    "torchcodec",
 ]
 
 for mock_target in autodoc_mock_imports:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -219,7 +219,6 @@ autodoc_mock_imports = [
     "soundfile",
     "gguf",
     "lark",
-    "decord",
 ]
 
 for mock_target in autodoc_mock_imports:

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -10,6 +10,9 @@ torch==2.7.0.dev20250304; platform_machine == "s390x"
 torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"
 torchaudio==2.5.1; platform_machine == "ppc64le"
 
+# required for video decoding, this must be updated alongside torch
+torchcodec==0.2.1
+
 # required for the image processor of phi3v, this must be updated alongside torch
 torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"
 torchvision==0.20.1; platform_machine == "ppc64le"

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -11,7 +11,7 @@ torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"
 torchaudio==2.5.1; platform_machine == "ppc64le"
 
 # required for video decoding, this must be updated alongside torch
-torchcodec==0.2.1
+torchcodec==0.2.1; platform_machine == "x86_64" or platform_system == "Darwin"
 
 # required for the image processor of phi3v, this must be updated alongside torch
 torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -8,6 +8,6 @@ ray[cgraph]>=2.43.0 # Ray Compiled Graph, required for pipeline parallelism in V
 torch==2.6.0
 torchaudio==2.6.0
 # These must be updated alongside torch
-torchcodec==0.2.1 # Required for video decoding
+torchcodec==0.2.1; platform_system == 'Linux' and platform_machine == 'x86_64' # Required for video decoding
 torchvision==0.21.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 xformers==0.0.29.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.6.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -8,5 +8,6 @@ ray[cgraph]>=2.43.0 # Ray Compiled Graph, required for pipeline parallelism in V
 torch==2.6.0
 torchaudio==2.6.0
 # These must be updated alongside torch
+torchcodec==0.2.1 # Required for video decoding
 torchvision==0.21.0 # Required for phi3v processor. See https://github.com/pytorch/vision?tab=readme-ov-file#installation for corresponding version
 xformers==0.0.29.post2; platform_system == 'Linux' and platform_machine == 'x86_64'  # Requires PyTorch 2.6.0

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -3,8 +3,9 @@
 
 --extra-index-url https://download.pytorch.org/whl/rocm6.2
 torch==2.5.1
-torchvision==0.20.1
 torchaudio==2.5.1
+torchcodec==0.1.1
+torchvision==0.20.1
 
 cmake>=3.26
 packaging

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -4,7 +4,7 @@
 --extra-index-url https://download.pytorch.org/whl/rocm6.2
 torch==2.5.1
 torchaudio==2.5.1
-torchcodec==0.1.1
+torchcodec==0.1.1; platform_machine == "x86_64"
 torchvision==0.20.1
 
 cmake>=3.26

--- a/requirements/rocm-test.txt
+++ b/requirements/rocm-test.txt
@@ -13,10 +13,6 @@ soxr==0.5.0.post1
 librosa==0.10.2.post1
 
 # entrypoints test
-#vllm[video] # required by entrypoints/openai/test_video.py
-decord==0.6.0
-
-# entrypoints test
 #sentence-transformers # required by entrypoints/openai/test_score.py
 sentence-transformers==3.4.1
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -9,7 +9,6 @@ pytest-shard
 # testing utils
 awscli
 backoff # required for phi4mm test
-decord # required for video tests
 einops # required for MPT, qwen-vl and Mamba
 httpx
 librosa # required for audio tests
@@ -24,6 +23,7 @@ jiwer # required for audio tests
 timm # required for internvl test
 torch==2.6.0
 torchaudio==2.6.0
+torchcodec==0.2.1
 torchvision==0.21.0
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -92,8 +92,6 @@ datasets==3.0.2
     #   lm-eval
 decorator==5.1.1
     # via librosa
-decord==0.6.0
-    # via -r requirements/test.in
 dill==0.3.8
     # via
     #   datasets
@@ -271,7 +269,6 @@ numpy==1.26.4
     #   contourpy
     #   cupy-cuda12x
     #   datasets
-    #   decord
     #   einx
     #   encodec
     #   evaluate
@@ -615,6 +612,8 @@ torchaudio==2.6.0
     #   -r requirements/test.in
     #   encodec
     #   vocos
+torchcodec==0.2.1
+    # via -r requirements/test.in
 torchvision==0.21.0
     # via
     #   -r requirements/test.in

--- a/setup.py
+++ b/setup.py
@@ -690,6 +690,7 @@ setup(
         "tensorizer": ["tensorizer>=2.9.0"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
+        "video": [],  # Does nothing, kept for compatibility
     },
     cmdclass=cmdclass,
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -690,7 +690,6 @@ setup(
         "tensorizer": ["tensorizer>=2.9.0"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
-        "video": ["decord"]  # Required for video processing
     },
     cmdclass=cmdclass,
     package_data=package_data,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -2,7 +2,6 @@
 
 import base64
 from functools import partial
-from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -127,7 +126,7 @@ class VideoMediaIO(MediaIO[npt.NDArray]):
         self.num_frames = num_frames
 
     def load_bytes(self, data: bytes) -> npt.NDArray:
-        decoder = VideoDecoder(BytesIO(data))
+        decoder = VideoDecoder(data)
         total_frame_num = len(decoder)
 
         num_frames = self.num_frames

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -139,7 +139,7 @@ class VideoMediaIO(MediaIO[npt.NDArray]):
         else:
             frame_idx = list(range(0, total_frame_num))
 
-        return decoder.get_frames_at(frame_idx).data
+        return decoder.get_frames_at(frame_idx).data.numpy()
 
     def load_base64(self, media_type: str, data: str) -> npt.NDArray:
         if media_type.lower() == "video/jpeg":

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -126,16 +126,17 @@ class VideoMediaIO(MediaIO[npt.NDArray]):
         self.num_frames = num_frames
 
     def load_bytes(self, data: bytes) -> npt.NDArray:
-        decoder = VideoDecoder(data)
-        total_frame_num = len(decoder)
+        decoder = VideoDecoder(data,
+                               dimension_order="NHWC",
+                               seek_mode="approximate")
 
         num_frames = self.num_frames
+        total_frame_num = len(decoder)
         if total_frame_num > num_frames:
-            uniform_sampled_frames = np.linspace(0,
-                                                 total_frame_num - 1,
-                                                 num_frames,
-                                                 dtype=int)
-            frame_idx = uniform_sampled_frames.tolist()
+            frame_idx = np.linspace(0,
+                                    total_frame_num - 1,
+                                    num_frames,
+                                    dtype=int).tolist()
         else:
             frame_idx = list(range(0, total_frame_num))
 


### PR DESCRIPTION
As discussed in [Slack](https://vllm-dev.slack.com/archives/C07QP347J4D/p1742268092922199).

The [documentation for `torchvision.io.read_video`](https://pytorch.org/vision/main/generated/torchvision.io.read_video.html) states that PyTorch's video decoding capability will soon be centralised in `torchcodec`. Therefore, it makes sense to skip the intermediate step of using `torchvision`.

OpenCV was considered but it can only read videos using a path/url, which meant writing the bytes to disk, which was a deal breaker.

The main caveat of `torchcodec` at the moment is that it does not distribute ARM64 wheel for Linux, see https://github.com/pytorch/torchcodec/issues/569.

FIX #15011