### PR TITLE
[Bugfix] Fix hidden_states reshape failed and no_proposals error when…

### DIFF
--- a/tests/spec_decode/test_multi_step_worker.py
+++ b/tests/spec_decode/test_multi_step_worker.py
@@ -749,8 +749,8 @@ def test_draft_proposals_mixed_k():
 
     assert proposals.proposal_lens.shape == torch.Size([batch_size])
     assert proposals.proposal_lens.tolist() == [
-        k for _ in range(expected_num_proposal_seqs - 1)
-    ] + [0 for _ in range(expected_num_no_proposal_seqs)] + [k]
+        k for _ in range(expected_num_proposal_seqs)
+    ] + [0 for _ in range(expected_num_no_proposal_seqs)]
 
 
 @torch.inference_mode()

--- a/vllm/model_executor/models/eagle.py
+++ b/vllm/model_executor/models/eagle.py
@@ -35,7 +35,7 @@ class DummyInputLayerNorm(nn.Module):
 
 class DummyOutputNorm(nn.Module):
 
-    def forward(self, x, residual):
+    def forward(self, x, residual=None):
         if residual is None:
             return x
         else:


### PR DESCRIPTION
1. target_sampler_output.hidden_states dim0 may not be divisible by bs * (k + 1) when min(all_proposal_lengths) != k in vllm/spec_decode/mqa_scorer.py. So we need to pad the hidden_states  to be the shape (bs, (k+1), hidden_size);
2. seq_len + proposal_len should less than or equal to self.max_proposal_len which is the correct condition to keep not exceed max_proposal_len for nonzero_proposal. This can fix the error: RuntimeError("Cannot handle cases where distributed draft workers generate no tokens")  in spec_decode_worker.py
