### PR TITLE
[TPU][V1][Bugfix] Fix chunked prefill with padding

### DIFF
--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -411,8 +411,8 @@ class TPUModelRunner:
         padded_total_num_scheduled_tokens = _get_padded_token_len(
             total_num_scheduled_tokens)
         # Zero out to avoid spurious values from prev iteration (last cp chunk)
-        self.input_ids_cpu[total_num_scheduled_tokens:
-                           padded_total_num_scheduled_tokens] = 0
+        self.input_ids_cpu[
+            total_num_scheduled_tokens:padded_total_num_scheduled_tokens] = 0
         self.input_ids = self.input_ids_cpu[:
                                             padded_total_num_scheduled_tokens].to(
                                                 self.device)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -410,6 +410,9 @@ class TPUModelRunner:
         # Do the padding and copy the tensors to the TPU.
         padded_total_num_scheduled_tokens = _get_padded_token_len(
             total_num_scheduled_tokens)
+        # Zero out to avoid spurious values from prev iteration (last cp chunk)
+        self.input_ids_cpu[total_num_scheduled_tokens:
+                           padded_total_num_scheduled_tokens] = 0
         self.input_ids = self.input_ids_cpu[:
                                             padded_total_num_scheduled_tokens].to(
                                                 self.device)


### PR DESCRIPTION
Currently if you run:
```bash
VLLM_USE_V1=1 vllm serve llava-hf/llava-1.5-7b-hf --max-model-len 2512 --max-num-seqs 16 --max-num-batched-tokens 128 --chat-template examples/template_llava.jinja --enforce-eager &

# query 
python examples/online_serving/openai_chat_completion_client_for_multimodal.py


[ ... ]
ERROR 03-18 13:12:42 [core.py:340]   File "/home/nick/work/vllm/vllm/v1/worker/tpu_model_runner.py", line 564, in execute_model
ERROR 03-18 13:12:42 [core.py:340]     inputs_embeds = self.model.get_input_embeddings(
ERROR 03-18 13:12:42 [core.py:340]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-18 13:12:42 [core.py:340]   File "/home/nick/work/vllm/vllm/v1/worker/tpu_model_runner.py", line 862, in get_input_embeddings
ERROR 03-18 13:12:42 [core.py:340]     return self.model.get_input_embeddings(*args, **kwargs)
ERROR 03-18 13:12:42 [core.py:340]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-18 13:12:42 [core.py:340]   File "/home/nick/work/vllm/vllm/model_executor/models/llava.py", line 779, in get_input_embeddings
ERROR 03-18 13:12:42 [core.py:340]     inputs_embeds = merge_multimodal_embeddings(
ERROR 03-18 13:12:42 [core.py:340]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-18 13:12:42 [core.py:340]   File "/home/nick/work/vllm/vllm/model_executor/models/utils.py", line 455, in merge_multimodal_embeddings
ERROR 03-18 13:12:42 [core.py:340]     return _merge_multimodal_embeddings(
ERROR 03-18 13:12:42 [core.py:340]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 03-18 13:12:42 [core.py:340]   File "/home/nick/work/vllm/vllm/model_executor/models/utils.py", line 371, in _merge_multimodal_embeddings
ERROR 03-18 13:12:42 [core.py:340]     raise ValueError(
ERROR 03-18 13:12:42 [core.py:340] ValueError: Attempted to assign 69 = 69 multimodal tokens to 113 placeholders
ERROR 03-18 13:12:42 [core.py:340] 
CRITICAL 03-18 13:12:42 [core_client.py:269] Got fatal signal from worker processes, shutting down. See stack trace above for root cause issue.
[1]    99083 killed     VLLM_USE_V1=1 vllm serve llava-hf/llava-1.5-7b-hf --max-model-len 2512  16   
```
I tried to summarize the issue in this (poorly drawn) diagram:

![image](https://github.com/user-attachments/assets/fada8139-cb12-4da9-a0d0-567d8377ed2a)


This is most noticeable with multimodal because spurious image tokens lingering on a re-used tensor will cause the server to crash, but the same happens with text-only.
Basically when we use CP in combination with padding, we must treat the last/terminal chunk carefully, otherwise it will contain values from previous iterations as the buffer (`input_ids_cpu` in this case) is re-used. 
