### PR TITLE
[Misc][Benchmark] Add support for different `tokenizer_mode`

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -747,7 +747,7 @@ def main(args: argparse.Namespace):
     else:
         args.structure_type = 'guided_json'
 
-    if not args.structured_output:
+    if args.no_structured_output:
         args.structured_output_ratio = 0
     if args.save_results:
         result_file_name = f'{args.structured_output_ratio}guided'
@@ -991,9 +991,9 @@ if __name__ == "__main__":
         "goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 "
         "and the blog: https://hao-ai-lab.github.io/blogs/distserve")
 
-    parser.add_argument("--structured-output",
-                        action=argparse.BooleanOptionalAction,
-                        default=True,
+    parser.add_argument("--no-structured-output",
+                        action='store_true',
+                        default=False,
                         help="Whether to disable JSON decoding or not.")
     parser.add_argument("--structured-output-ratio",
                         type=float,

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -732,8 +732,11 @@ def main(args: argparse.Namespace):
         api_url = f"http://{args.host}:{args.port}{args.endpoint}"
         base_url = f"http://{args.host}:{args.port}"
 
-    tokenizer = get_tokenizer(tokenizer_id,
-                              trust_remote_code=args.trust_remote_code)
+    tokenizer = get_tokenizer(
+        tokenizer_id,
+        trust_remote_code=args.trust_remote_code,
+        tokenizer_mode=args.tokenizer_mode,
+    )
 
     if args.dataset == 'grammar':
         args.structure_type = 'guided_grammar'
@@ -744,7 +747,7 @@ def main(args: argparse.Namespace):
     else:
         args.structure_type = 'guided_json'
 
-    if args.no_structured_output:
+    if not args.structured_output:
         args.structured_output_ratio = 0
     if args.save_results:
         result_file_name = f'{args.structured_output_ratio}guided'
@@ -848,7 +851,7 @@ if __name__ == "__main__":
                             'json', 'json-unique', 'grammar', 'regex',
                             'choice', 'xgrammar_bench'
                         ])
-    parser.add_argument("--json_schema_path",
+    parser.add_argument("--json-schema-path",
                         type=str,
                         default=None,
                         help="Path to json schema.")
@@ -873,6 +876,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tokenizer",
         type=str,
+        help=
+        "Name or path of the tokenizer, if not using the default tokenizer.",  # noqa: E501
+    )
+    parser.add_argument(
+        "--tokenizer-mode",
+        type=str,
+        default="auto",
         help=
         "Name or path of the tokenizer, if not using the default tokenizer.",  # noqa: E501
     )
@@ -981,9 +991,9 @@ if __name__ == "__main__":
         "goodput, refer to DistServe paper: https://arxiv.org/pdf/2401.09670 "
         "and the blog: https://hao-ai-lab.github.io/blogs/distserve")
 
-    parser.add_argument("--no-structured-output",
-                        action='store_true',
-                        default=False,
+    parser.add_argument("--structured-output",
+                        action=argparse.BooleanOptionalAction,
+                        default=True,
                         help="Whether to disable JSON decoding or not.")
     parser.add_argument("--structured-output-ratio",
                         type=float,

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -851,7 +851,7 @@ if __name__ == "__main__":
                             'json', 'json-unique', 'grammar', 'regex',
                             'choice', 'xgrammar_bench'
                         ])
-    parser.add_argument("--json-schema-path",
+    parser.add_argument("--json_schema_path",
                         type=str,
                         default=None,
                         help="Path to json schema.")

--- a/benchmarks/run_structured_output_benchmark.sh
+++ b/benchmarks/run_structured_output_benchmark.sh
@@ -54,6 +54,7 @@ for qps in "${QPS_VALUES[@]}"; do
   python "$SCRIPT_DIR/benchmark_serving_structured_output.py" $COMMON_PARAMS \
     --request-rate $qps \
     --result-filename "$FILENAME" \
+    --tokenizer-mode ${TOKENIZER_MODE:-"auto"} \
     --port ${PORT:-8000}
 
   echo "Completed benchmark with QPS: $qps"


### PR DESCRIPTION
This PR adds support to `tokenizer_mode` in sampling example requests for supporting running this benchmark with Mistral models.

`tokenizer_mode=auto` doesn't seem to detect mistral tokenizer correctly (which is possibly a bug. However, the Mistral team suggest to set `tokenizer_mode` explicitly regardless.)

It also refactor `--no-structured-outputs` to use `argparser.OptionalBooleanOptions`, which set `--no-structured-outputs/--structured-outputs` (behaviour unchanged)

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
