### PR TITLE
[Misc] Allow using OpenCV as video IO fallback

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -29,6 +29,7 @@ msgspec
 gguf == 0.10.0
 importlib_metadata
 mistral_common[opencv] >= 1.5.4
+opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=74.1.1; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -27,6 +27,7 @@ torchvision==0.21.0
 transformers_stream_generator # required for qwen-vl test
 matplotlib # required for qwen-vl test
 mistral_common[opencv] >= 1.5.4 # required for pixtral test
+opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.4 # required for model evaluation test
 transformers==4.48.2 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -9,7 +9,6 @@ pytest-shard
 # testing utils
 awscli
 backoff # required for phi4mm test
-decord # required for video tests
 einops # required for MPT, qwen-vl and Mamba
 httpx
 librosa # required for audio tests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -329,8 +329,10 @@ nvidia-nvjitlink-cu12==12.4.127
     #   torch
 nvidia-nvtx-cu12==12.4.127
     # via torch
-opencv-python-headless==4.10.0.84
-    # via mistral-common
+opencv-python-headless==4.11.0.86
+    # via
+    #   -r requirements/test.in
+    #   mistral-common
 packaging==24.1
     # via
     #   accelerate

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -92,8 +92,6 @@ datasets==3.0.2
     #   lm-eval
 decorator==5.1.1
     # via librosa
-decord==0.6.0
-    # via -r requirements/test.in
 dill==0.3.8
     # via
     #   datasets
@@ -271,7 +269,6 @@ numpy==1.26.4
     #   contourpy
     #   cupy-cuda12x
     #   datasets
-    #   decord
     #   einx
     #   encodec
     #   evaluate

--- a/setup.py
+++ b/setup.py
@@ -690,7 +690,7 @@ setup(
         "tensorizer": ["tensorizer>=2.9.0"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
-        "video": ["decord"]  # Required for video processing
+        "video": []  # decord is deprecated
     },
     cmdclass=cmdclass,
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -690,7 +690,7 @@ setup(
         "tensorizer": ["tensorizer>=2.9.0"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
-        "video": []  # decord is deprecated
+        "video": []  # Kept for backwards compatability
     },
     cmdclass=cmdclass,
     package_data=package_data,

--- a/setup.py
+++ b/setup.py
@@ -690,7 +690,7 @@ setup(
         "tensorizer": ["tensorizer>=2.9.0"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
-        "video": []  # Kept for backwards compatability
+        "video": []  # Kept for backwards compatibility
     },
     cmdclass=cmdclass,
     package_data=package_data,

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -142,7 +142,7 @@ class OpenCVVideoBackend(VideoLoader):
         import cv2
 
         backend = cls().get_cv2_video_api()
-        cap = cv2.VideoCapture(BytesIO(data), backend, [cv2.CAP_PROP_FPS])
+        cap = cv2.VideoCapture(BytesIO(data), backend, [])
         if not cap.isOpened():
             raise ValueError("Could not open video stream")
 

--- a/vllm/multimodal/video.py
+++ b/vllm/multimodal/video.py
@@ -134,18 +134,17 @@ class OpenCVVideoBackend:
     def load_bytes(cls, data: bytes, num_frames: int = -1) -> npt.NDArray:
         import cv2
 
-        backend = cls.get_cv2_video_api()
+        backend = cls().get_cv2_video_api()
         cap = cv2.VideoCapture(BytesIO(data), backend, [])
         if not cap.isOpened():
             raise ValueError("Could not open video file")
 
-        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         frames = []
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         for i in range(total_frames):
             ret, frame = cap.read()
             if ret:
                 frames.append(frame)
-        cap.release()
 
         frames = np.stack(frames)
         frames = sample_frames_from_video(frames, num_frames)


### PR DESCRIPTION
Alternative workaround for #15011

~~Will check if this implementation can work on my another aarch64 linux machine tomorrow. (Not sure if OpenCV has available backend to read video stream for aarch64, there is no any documentation about the streamIO😅)~~
Update: Confirmed this work on aarch64 ubuntu machine.

<!--- pyml disable-next-line no-emphasis-as-heading -->

FIX #15011
