### PR TITLE
[Misc][V1] Skip device checking if not available

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1469,6 +1469,9 @@ class EngineArgs:
             return False
 
         # Need at least Ampere for now (FA support required).
+        # Skip this check if we are running on a non-GPU platform,
+        # or if the device capability is not available
+        # (e.g. in a Ray actor without GPUs).
         from vllm.platforms import current_platform
         if (current_platform.is_cuda()
                 and current_platform.get_device_capability()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1471,6 +1471,7 @@ class EngineArgs:
         # Need at least Ampere for now (FA support required).
         from vllm.platforms import current_platform
         if (current_platform.is_cuda()
+                and current_platform.get_device_capability()
                 and current_platform.get_device_capability().major < 8):
             _raise_or_fallback(feature_name="Compute Capability < 8.0",
                                recommend_to_remove=False)


### PR DESCRIPTION
When importing vLLM on a CUDA platform without available GPUs, `get_device_capability()` returns None, so `.get_device_capability().major` will raise AttributeError. This happens when integrating vLLM with Ray, because GPUs won't be allocated to the driver process (CUDA_VISIBLE_DEVICES is set to an empty string).

cc @robertgshaw2-redhat 