### PR TITLE
[Model] Remove duplicated message check in Mistral chat completion request

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -143,10 +143,6 @@ def make_mistral_chat_completion_request(
     if last_message["role"] == "assistant":
         last_message["prefix"] = True
 
-        last_message = cast(Dict[str, Any], messages[-1])
-        if last_message["role"] == "assistant":
-            last_message["prefix"] = True
-
     # mistral-common requires AssistantMessage content to be string [1].
     #
     # [1]: https://github.com/mistralai/mistral-common/blob/f4a06998b75ed78bbf5aaf569590b772ea26c9f6/src/mistral_common/protocol/instruct/messages.py#L80


### PR DESCRIPTION
Remove redundant message check: I don't think there's no reason to retrieve the last message twice, check its role twice, and set the same flag twice in succession. Think it was just a copy paste error :)

cc @fgreinacher