### PR TITLE
[Doc] Update tip info on using latest transformers when creating a custom Dockerfile 

### DIFF
--- a/docs/source/deployment/docker.md
+++ b/docs/source/deployment/docker.md
@@ -34,11 +34,11 @@ If you need to use those dependencies (having accepted the license terms),
 create a custom Dockerfile on top of the base image with an extra layer that installs them:
 
 ```Dockerfile
-FROM vllm/vllm-openai:v0.7.3
+FROM vllm/vllm-openai:v0.8.0
 
 # e.g. install the `audio` and `video` optional dependencies
 # NOTE: Make sure the version of vLLM matches the base image!
-RUN uv pip install --system vllm[audio,video]==0.7.3
+RUN uv pip install vllm[audio,video]==0.8.0
 ```
 
 :::
@@ -52,7 +52,7 @@ with an extra layer that installs their code from source:
 ```Dockerfile
 FROM vllm/vllm-openai:latest
 
-RUN uv pip install --system git+https://github.com/huggingface/transformers.git
+RUN uv pip install git+https://github.com/huggingface/transformers.git
 ```
 
 :::


### PR DESCRIPTION
This PR updates the following tip info under the [Use vLLM’s Official Docker Image](https://docs.vllm.ai/en/v0.8.0_a/deployment/docker.html#use-vllm-s-official-docker-image) section of the docs.

![image](https://github.com/user-attachments/assets/d98147d0-249b-4453-82cf-14a662703205)


There is no need for `--system` when updating the Python installation is already managed by uv (according to this https://github.com/astral-sh/uv/issues/12204#issuecomment-2727567293).

When running with `--system` I was getting this error:

```
[+] Building 7.8s (5/6)                                                                                                                                                                                                        docker:default
 => [internal] load build definition from dockerfile                                                                                                                                                                                     0.4s
 => => transferring dockerfile: 215B                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/vllm/vllm-openai:v0.8.0                                                                                                                                                                       0.0s 
 => [internal] load .dockerignore                                                                                                                                                                                                        0.3s 
 => => transferring context: 2B                                                                                                                                                                                                          0.0s 
 => [1/3] FROM docker.io/vllm/vllm-openai:v0.8.0                                                                                                                                                                                         4.7s 
 => ERROR [2/3] RUN uv pip install --system git+https://github.com/huggingface/transformers.git                                                                                                                                          1.5s 
------                                                                                                                                                                                                                                        
 > [2/3] RUN uv pip install --system git+https://github.com/huggingface/transformers.git:                                                                                                                                                     
1.230 error: No system Python installation found                                                                                                                                                                                              
------                                                                                                                                                                                                                                        
dockerfile:3                                                                                                                                                                                                                                  
--------------------                                                                                                                                                                                                                          
   1 |     FROM vllm/vllm-openai:v0.8.0                                                                                                                                                                                                       
   2 |                                                                                                                                                                                                                                        
   3 | >>> RUN uv pip install --system git+https://github.com/huggingface/transformers.git
```