### PR TITLE
[V1][Bugfix] Fix oracle for device checking

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1579,7 +1579,7 @@ class EngineArgs:
             return False
 
         # No support for device type other than CUDA, AMD (experiemntal) or
-        # TPU (experimental).
+        # TPU (experimental) so far.
         if not (current_platform.is_cuda() or current_platform.is_rocm()
                 or current_platform.is_tpu()):
             _raise_or_fallback(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1578,6 +1578,14 @@ class EngineArgs:
             _raise_or_fallback(feature_name=name, recommend_to_remove=True)
             return False
 
+        # No support for device type other than CUDA, AMD (experiemntal) or
+        # TPU (experimental).
+        if not (current_platform.is_cuda() or current_platform.is_rocm()
+                or current_platform.is_tpu()):
+            _raise_or_fallback(
+                feature_name=f"device type={current_platform.device_type}",
+                recommend_to_remove=False)
+            return False
         #############################################################
         # Experimental Features - allow users to opt in.
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1580,8 +1580,7 @@ class EngineArgs:
 
         # No support for device type other than CUDA, AMD (experiemntal) or
         # TPU (experimental) so far.
-        if not (current_platform.is_cuda() or current_platform.is_rocm()
-                or current_platform.is_tpu()):
+        if not (current_platform.is_cuda_alike() or current_platform.is_tpu()):
             _raise_or_fallback(
                 feature_name=f"device type={current_platform.device_type}",
                 recommend_to_remove=False)


### PR DESCRIPTION
Only AMD & TPU are experimental support on V1, and all other devices will simply error out on V1, so this PR adds this logic explicitly.

FIXES #15057 
