### PR TITLE
 [Bugfix] Adjust mllama to regional compilation

### DIFF
--- a/vllm/model_executor/models/mllama.py
+++ b/vllm/model_executor/models/mllama.py
@@ -1070,8 +1070,8 @@ class MllamaTextModel(nn.Module):
         inputs_embeds = self.embed_tokens(input_ids)
         hidden_states = inputs_embeds
 
-        for decoder_layer in self.layers:
-            if isinstance(decoder_layer, MllamaCrossAttentionDecoderLayer):
+        for idx, decoder_layer in enumerate(self.layers):
+            if idx in self.cross_attention_layers:
                 if not skip_cross_attention:
                     hidden_states = decoder_layer(
                         hidden_states=hidden_states,
@@ -1081,16 +1081,13 @@ class MllamaTextModel(nn.Module):
                         full_text_row_masked_out_mask=
                         full_text_row_masked_out_mask,
                     )
-            elif isinstance(decoder_layer, LlamaDecoderLayer):
+            else:
                 hidden_states, residual = decoder_layer(
                     positions=positions,
                     hidden_states=hidden_states,
                     residual=None,
                 )
                 hidden_states = hidden_states + residual
-            else:
-                raise ValueError(
-                    f"Unknown decoder layer type {type(decoder_layer)}")
         hidden_states = self.norm(hidden_states)
         return hidden_states
 


### PR DESCRIPTION
When trying to perform regional compilation with t.compile (compiling layers separately instead of calling t.compile on whole model) on mllama model with Gaudi devices, such an error occures:

ValueError: Unknown decoder layer type <class 'torch._dynamo.eval_frame.OptimizedModule'> 
Regional compilation for Gaudi devices has been added with https://github.com/vllm-project/vllm/pull/13213

Cause for this issue is checking layer classes by their names inside mllama code e.g.:
if isinstance(decoder_layer, MllamaCrossAttentionDecoderLayer):

Torch.compile wraps module after compilation with torch._dynamo.eval_frame.OptimizedModule name, that's wht we see mismatch in isinstance function. To resolve that we can distinguish layers basing on self.cross_attention_layers ids - and so do proposed changes. We don't also need raise ValueError in layer instance checking as there is no option for decoder layers to be of different types than desired ones.
