### PR TITLE
[Frontend]Reduce vLLM's import time

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import itertools
 import warnings
 from collections.abc import Sequence
 from contextlib import contextmanager
-from typing import Any, Callable, ClassVar, Optional, Union, cast, overload
+from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Optional, Union,
+                    cast, overload)
 
 import cloudpickle
 import torch.nn as nn
@@ -13,16 +16,7 @@ from typing_extensions import TypeVar, deprecated
 
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence, get_beam_search_score)
-from vllm.config import CompilationConfig
-from vllm.engine.arg_utils import (EngineArgs, HfOverrides, PoolerConfig,
-                                   TaskOption)
 from vllm.engine.llm_engine import LLMEngine
-from vllm.entrypoints.chat_utils import (ChatCompletionMessageParam,
-                                         ChatTemplateContentFormatOption,
-                                         apply_hf_chat_template,
-                                         apply_mistral_chat_template,
-                                         parse_chat_messages,
-                                         resolve_chat_template_content_format)
 from vllm.entrypoints.score_utils import (_cosine_similarity,
                                           _validate_score_input_lens)
 from vllm.inputs import PromptType, SingletonPrompt, TextPrompt, TokensPrompt
@@ -43,6 +37,11 @@ from vllm.transformers_utils.tokenizer import (AnyTokenizer, MistralTokenizer,
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils import (Counter, Device, deprecate_args, deprecate_kwargs,
                         is_list_of)
+
+if TYPE_CHECKING:
+    from vllm.engine.arg_utils import HfOverrides, PoolerConfig, TaskOption
+    from vllm.entrypoints.chat_utils import (ChatCompletionMessageParam,
+                                             ChatTemplateContentFormatOption)
 
 logger = init_logger(__name__)
 
@@ -117,7 +116,7 @@ class LLM:
         disable_async_output_proc: Disable async output processing.
             This may result in lower performance.
         hf_token: The token to use as HTTP bearer authorization for remote files
-            . If `True`, will use the token generated when running 
+            . If `True`, will use the token generated when running
             `huggingface-cli login` (stored in `~/.huggingface`).
         hf_overrides: If a dictionary, contains arguments to be forwarded to the
             HuggingFace config. If a callable, it is called to update the
@@ -194,6 +193,7 @@ class LLM:
         Note: if enforce_eager is unset (enforce_eager is None)
         it defaults to False.
         '''
+        from vllm.engine.arg_utils import EngineArgs
 
         if "disable_log_stats" not in kwargs:
             kwargs["disable_log_stats"] = True
@@ -207,6 +207,7 @@ class LLM:
 
         if compilation_config is not None:
             if isinstance(compilation_config, (int, dict)):
+                from vllm.config import CompilationConfig
                 compilation_config_instance = CompilationConfig.from_cli(
                     str(compilation_config))
             else:
@@ -701,6 +702,10 @@ class LLM:
             A list of ``RequestOutput`` objects containing the generated
             responses in the same order as the input messages.
         """
+        from vllm.entrypoints.chat_utils import (
+            ChatCompletionMessageParam, apply_hf_chat_template,
+            apply_mistral_chat_template, parse_chat_messages,
+            resolve_chat_template_content_format)
         list_of_messages: list[list[ChatCompletionMessageParam]]
 
         # Handle multi and single conversations

--- a/vllm/entrypoints/openai/serving_score.py
+++ b/vllm/entrypoints/openai/serving_score.py
@@ -2,7 +2,7 @@
 import asyncio
 import time
 from collections.abc import AsyncGenerator, Mapping
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from fastapi import Request
 
@@ -23,10 +23,12 @@ from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.outputs import PoolingRequestOutput, ScoringRequestOutput
 from vllm.prompt_adapter.request import PromptAdapterRequest
-from vllm.transformers_utils.tokenizer import (AnyTokenizer, MistralTokenizer,
-                                               PreTrainedTokenizer,
-                                               PreTrainedTokenizerFast)
+from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 from vllm.utils import make_async, merge_async_iterators
+
+if TYPE_CHECKING:
+    from vllm.transformers_utils.tokenizer import (PreTrainedTokenizer,
+                                                   PreTrainedTokenizerFast)
 
 logger = init_logger(__name__)
 
@@ -48,7 +50,7 @@ class ServingScores(OpenAIServing):
 
     async def _embedding_score(
         self,
-        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
         texts_1: list[str],
         texts_2: list[str],
         request: Union[RerankRequest, ScoreRequest],

--- a/vllm/entrypoints/score_utils.py
+++ b/vllm/entrypoints/score_utils.py
@@ -1,15 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from torch.nn import CosineSimilarity
 
 from vllm.outputs import PoolingRequestOutput
-from vllm.transformers_utils.tokenizer import (PreTrainedTokenizer,
-                                               PreTrainedTokenizerFast)
+
+if TYPE_CHECKING:
+    from vllm.transformers_utils.tokenizer import (PreTrainedTokenizer,
+                                                   PreTrainedTokenizerFast)
 
 
 def _cosine_similarity(
-    tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+    tokenizer: Union["PreTrainedTokenizer", "PreTrainedTokenizerFast"],
     embed_1: list[PoolingRequestOutput],
     embed_2: list[PoolingRequestOutput],
 ) -> list[PoolingRequestOutput]:

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -109,6 +109,7 @@ class ExecutorBase(ABC):
         """Initialize the KV cache by invoking the underlying worker.
         """
         # NOTE: This is logged in the executor because there can be >1 workers.
+
         logger.info("# %s blocks: %d, # CPU blocks: %d",
                     vllm.platforms.current_platform.device_name,
                     num_gpu_blocks, num_cpu_blocks)

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -11,7 +11,6 @@ import vllm.platforms
 from vllm.config import ParallelConfig
 from vllm.executor.msgspec_utils import decode_hook, encode_hook
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.sequence import ExecuteModelRequest, IntermediateTensors
 from vllm.utils import get_ip
 from vllm.worker.worker_base import WorkerWrapperBase
@@ -109,7 +108,7 @@ try:
             # We can remove this API after it is fixed in compiled graph.
             assert self.worker is not None, "Worker is not initialized"
             if not self.compiled_dag_cuda_device_set:
-                if current_platform.is_tpu():
+                if vllm.platforms.current_platform.is_tpu():
                     # Not needed
                     pass
                 else:

--- a/vllm/inputs/registry.py
+++ b/vllm/inputs/registry.py
@@ -8,12 +8,9 @@ from typing import (TYPE_CHECKING, Any, Callable, NamedTuple, Optional,
                     Protocol, Union)
 
 from torch import nn
-from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
 from typing_extensions import TypeVar, assert_never
 
 from vllm.logger import init_logger
-from vllm.transformers_utils.processor import cached_processor_from_config
-from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import (ClassRegistry, get_allowed_kwarg_only_overrides,
                         resolve_mm_processor_kwargs)
 
@@ -21,16 +18,19 @@ from .data import ProcessorInputs, SingletonInputs
 from .parse import split_enc_dec_inputs
 
 if TYPE_CHECKING:
+    from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+
     from vllm.config import ModelConfig
     from vllm.multimodal import (MultiModalDataDict, MultiModalPlaceholderDict,
                                  MultiModalRegistry)
     from vllm.sequence import SequenceData
+    from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 logger = init_logger(__name__)
 
 _T = TypeVar("_T")
-_C = TypeVar("_C", bound=PretrainedConfig, default=PretrainedConfig)
-_P = TypeVar("_P", bound=ProcessorMixin, default=ProcessorMixin)
+_C = TypeVar("_C", bound="PretrainedConfig", default="PretrainedConfig")
+_P = TypeVar("_P", bound="ProcessorMixin", default="ProcessorMixin")
 
 
 @dataclass(frozen=True)
@@ -45,7 +45,7 @@ class InputContext:
 
     def get_hf_config(
         self,
-        typ: Union[type[_C], tuple[type[_C], ...]] = PretrainedConfig,
+        typ: Optional[Union[type[_C], tuple[type[_C], ...]]] = None,
         /,
     ) -> _C:
         """
@@ -56,6 +56,11 @@ class InputContext:
         Raises:
             TypeError: If the configuration is not of the specified type.
         """
+
+        if typ is None:
+            from transformers import PretrainedConfig
+            typ = PretrainedConfig
+
         hf_config = self.model_config.hf_config
         if not isinstance(hf_config, typ):
             raise TypeError("Invalid type of HuggingFace config. "
@@ -85,7 +90,7 @@ class InputContext:
 
     def get_hf_processor(
         self,
-        typ: Union[type[_P], tuple[type[_P], ...]] = ProcessorMixin,
+        typ: Optional[Union[type[_P], tuple[type[_P], ...]]] = None,
         /,
         **kwargs: object,
     ) -> _P:
@@ -97,6 +102,12 @@ class InputContext:
         Raises:
             TypeError: If the processor is not of the specified type.
         """
+
+        if typ is None:
+            from transformers import ProcessorMixin
+            typ = ProcessorMixin
+        from vllm.transformers_utils.processor import (
+            cached_processor_from_config)
         return cached_processor_from_config(
             self.model_config,
             processor_cls=typ,
@@ -124,15 +135,19 @@ class InputContext:
 
 @dataclass(frozen=True)
 class InputProcessingContext(InputContext):
-    tokenizer: AnyTokenizer
+    tokenizer: "AnyTokenizer"
     """The tokenizer used to tokenize the inputs."""
 
     def get_hf_processor(
         self,
-        typ: Union[type[_P], tuple[type[_P], ...]] = ProcessorMixin,
+        typ: Union[type[_P], tuple[type[_P], ...], None] = None,
         /,
         **kwargs: object,
     ) -> _P:
+
+        if typ is None:
+            from transformers import ProcessorMixin
+            typ = ProcessorMixin
         return super().get_hf_processor(
             typ,
             tokenizer=self.tokenizer,
@@ -141,10 +156,10 @@ class InputProcessingContext(InputContext):
 
     def call_hf_processor(
         self,
-        hf_processor: ProcessorMixin,
+        hf_processor: "ProcessorMixin",
         data: Mapping[str, object],
         kwargs: Mapping[str, object] = {},
-    ) -> BatchFeature:
+    ) -> "BatchFeature":
         """
         Call :code:`hf_processor` on the prompt :code:`data`
         (text, image, audio...) with configurable options :code:`kwargs`.

--- a/vllm/model_executor/guided_decoding/reasoner/__init__.py
+++ b/vllm/model_executor/guided_decoding/reasoner/__init__.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from transformers import PreTrainedTokenizer
+from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
 from vllm.model_executor.guided_decoding.reasoner.deepseek_reasoner import (  # noqa: E501
     DeepSeekReasoner)
 from vllm.model_executor.guided_decoding.reasoner.reasoner import Reasoner
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
 
 logger = init_logger(__name__)
 

--- a/vllm/model_executor/layers/spec_decode_base_sampler.py
+++ b/vllm/model_executor/layers/spec_decode_base_sampler.py
@@ -7,8 +7,6 @@ import torch
 import torch.jit
 import torch.nn as nn
 
-from vllm.platforms import current_platform
-
 
 class SpecDecodeBaseSampler(nn.Module):
     """Base class for samplers used for Speculative Decoding verification
@@ -37,6 +35,7 @@ class SpecDecodeBaseSampler(nn.Module):
     def init_gpu_tensors(self, device: Union[int, str]) -> None:
         assert self.num_accepted_tokens is None
         if isinstance(device, int):
+            from vllm.platforms import current_platform
             device = f"{current_platform.device_type}:{device}"
         elif not isinstance(device, str):
             raise ValueError(f"Device must be int or str, get {type(device)}")

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -13,13 +13,14 @@ import numpy as np
 import torch
 import torch.types
 from PIL.Image import Image
-from transformers import BatchFeature
 from typing_extensions import NotRequired, TypeAlias
 
 from vllm.jsontree import JSONTree, json_map_leaves
 from vllm.utils import full_groupby, is_list_of
 
 if TYPE_CHECKING:
+    from transformers import BatchFeature
+
     from .hasher import MultiModalHashDict
 
 _T = TypeVar("_T")
@@ -599,7 +600,7 @@ class MultiModalKwargs(UserDict[str, NestedTensors]):
 
     @staticmethod
     def from_hf_inputs(
-        hf_inputs: BatchFeature,
+        hf_inputs: "BatchFeature",
         config_by_key: Mapping[str, MultiModalFieldConfig],
     ):
         # NOTE: This skips fields in `hf_inputs` that are not in `config_by_key`

--- a/vllm/multimodal/parse.py
+++ b/vllm/multimodal/parse.py
@@ -9,7 +9,6 @@ from typing import (TYPE_CHECKING, Any, Generic, Literal, NamedTuple, Optional,
 import numpy as np
 import torch
 from PIL.Image import Image
-from transformers import BatchFeature
 from typing_extensions import TypeAlias, TypeGuard, assert_never
 
 from vllm.utils import is_list_of
@@ -149,7 +148,7 @@ class DictEmbeddingItems(ModalityDataItems[Mapping[str, torch.Tensor],
 
         self.fields_config = fields_config
         self.required_fields = required_fields
-
+        from transformers import BatchFeature
         self._kwargs = MultiModalKwargs.from_hf_inputs(
             BatchFeature(dict(data)),
             fields_config,

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -13,7 +13,6 @@ from typing import (TYPE_CHECKING, Generic, NamedTuple, Optional, Protocol,
                     TypeVar, Union, cast)
 
 import torch
-from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
 from typing_extensions import assert_never
 
 from vllm.inputs import InputProcessingContext
@@ -31,6 +30,8 @@ from .parse import (DictEmbeddingItems, EmbeddingItems, MultiModalDataItems,
                     MultiModalDataParser)
 
 if TYPE_CHECKING:
+    from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+
     from .profiling import BaseDummyInputsBuilder
 
 logger = init_logger(__name__)
@@ -1013,10 +1014,10 @@ class BaseProcessingInfo:
     def get_tokenizer(self) -> AnyTokenizer:
         return self.ctx.tokenizer
 
-    def get_hf_config(self) -> PretrainedConfig:
+    def get_hf_config(self) -> "PretrainedConfig":
         return self.ctx.get_hf_config()
 
-    def get_hf_processor(self, **kwargs: object) -> ProcessorMixin:
+    def get_hf_processor(self, **kwargs: object) -> "ProcessorMixin":
         """
         Subclasses can override this method to handle
         specific kwargs from model config or user inputs.
@@ -1128,7 +1129,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
     @abstractmethod
     def _get_mm_fields_config(
         self,
-        hf_inputs: BatchFeature,
+        hf_inputs: "BatchFeature",
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> Mapping[str, MultiModalFieldConfig]:
         """Given the HF-processed data, output the metadata of each field."""
@@ -1185,7 +1186,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         # This refers to the data to be passed to HF processor.
         mm_data: Mapping[str, object],
         mm_kwargs: Mapping[str, object],
-    ) -> BatchFeature:
+    ) -> "BatchFeature":
         """
         Call the HF processor on the prompt text and
         associated multi-modal data.
@@ -1676,7 +1677,7 @@ class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):
         mm_data: MultiModalDataDict,
     ) -> Union[str, list[int]]:
         """
-        Create input prompt for the encoder. HF processor will be applied on 
+        Create input prompt for the encoder. HF processor will be applied on
         this prompt during profiling and generation.
         """
         raise NotImplementedError

--- a/vllm/reasoning/abs_reasoning_parsers.py
+++ b/vllm/reasoning/abs_reasoning_parsers.py
@@ -1,16 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import os
 from abc import abstractmethod
 from collections.abc import Sequence
 from functools import cached_property
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
-from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              DeltaMessage)
 from vllm.logger import init_logger
-from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.utils import import_from_path, is_list_of
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                                  DeltaMessage)
+    from vllm.transformers_utils.tokenizer import AnyTokenizer
 
 logger = init_logger(__name__)
 

--- a/vllm/reasoning/deepseek_r1_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_r1_reasoning_parser.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-from transformers import PreTrainedTokenizerBase
-
-from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              DeltaMessage)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+    from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                                  DeltaMessage)
 
 logger = init_logger(__name__)
 
@@ -72,6 +76,8 @@ class DeepSeekR1ReasoningParser(ReasoningParser):
         - 'abc' goes to reasoning_content
         - 'xyz' goes to content
         """
+        from vllm.entrypoints.openai.protocol import DeltaMessage
+
         # Skip single special tokens
         if len(delta_token_ids) == 1 and (delta_token_ids[0] in [
                 self.start_token_id, self.end_token_id

--- a/vllm/reasoning/granite_reasoning_parser.py
+++ b/vllm/reasoning/granite_reasoning_parser.py
@@ -1,15 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import re
 from collections.abc import Sequence
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-from transformers import PreTrainedTokenizerBase
-
-from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              DeltaMessage)
 from vllm.logger import init_logger
 from vllm.reasoning import ReasoningParser, ReasoningParserManager
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+    from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
+                                                  DeltaMessage)
 
 logger = init_logger(__name__)
 
@@ -138,7 +142,7 @@ class GraniteReasoningParser(ReasoningParser):
 
         Args:
             text (str): Text to check for leading substr.
-        
+
         Returns:
             bool: True if any of the possible reasoning start seqs match.
         """
@@ -151,7 +155,7 @@ class GraniteReasoningParser(ReasoningParser):
 
         Args:
             text (str): Text to check for leading substr.
-        
+
         Returns:
             bool: True if any of the possible response start seqs match.
         """
@@ -174,6 +178,8 @@ class GraniteReasoningParser(ReasoningParser):
         Returns:
             DeltaMessage: Message containing the parsed content.
         """
+        from vllm.entrypoints.openai.protocol import DeltaMessage
+
         prev_longest_length = len(current_text) - len(delta_text)
         is_substr = self._is_reasoning_start_substr(current_text)
         was_substr = self._is_reasoning_start_substr(
@@ -213,6 +219,8 @@ class GraniteReasoningParser(ReasoningParser):
         Returns:
             DeltaMessage: Message containing the parsed content.
         """
+        from vllm.entrypoints.openai.protocol import DeltaMessage
+
         # If we have no reasoning content or explicitly end with the start of
         # response sequence, we are in transition to the response; need to be
         # careful here, since the final token (:) will match the reasoning
@@ -286,6 +294,8 @@ class GraniteReasoningParser(ReasoningParser):
         Returns:
             DeltaMessage: Message containing the parsed content.
         """
+        from vllm.entrypoints.openai.protocol import DeltaMessage
+
         # Always have content; take length to the end
         delta_content = delta_text[-len(response_content):]
         reasoning_end_idx = len(delta_text) - (len(response_content) +

--- a/vllm/transformers_utils/tokenizer.py
+++ b/vllm/transformers_utils/tokenizer.py
@@ -9,25 +9,25 @@ from types import MethodType
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import huggingface_hub
-from transformers import (AutoTokenizer, PreTrainedTokenizer,
-                          PreTrainedTokenizerFast)
 
 from vllm.envs import VLLM_USE_MODELSCOPE
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.transformers_utils.tokenizer_base import (TokenizerBase,
-                                                    TokenizerRegistry)
+from vllm.transformers_utils.tokenizer_base import TokenizerRegistry
 from vllm.transformers_utils.tokenizers import MistralTokenizer
 from vllm.transformers_utils.utils import check_gguf_file
 from vllm.utils import make_async
 
 if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
+
     from vllm.config import ModelConfig
+    from vllm.transformers_utils.tokenizer_base import TokenizerBase
 
 logger = init_logger(__name__)
 
-AnyTokenizer = Union[PreTrainedTokenizer, PreTrainedTokenizerFast,
-                     TokenizerBase]
+AnyTokenizer = Union["PreTrainedTokenizer", "PreTrainedTokenizerFast",
+                     "TokenizerBase"]
 
 
 def decode_tokens(
@@ -124,12 +124,12 @@ def get_cached_tokenizer(tokenizer: AnyTokenizer) -> AnyTokenizer:
     return tokenizer
 
 
-def patch_padding_side(tokenizer: PreTrainedTokenizer) -> None:
+def patch_padding_side(tokenizer: "PreTrainedTokenizer") -> None:
     """Patch _pad method to accept `padding_side` for older tokenizers."""
     orig_pad = tokenizer._pad
 
     def _pad(
-        self: PreTrainedTokenizer,
+        self: "PreTrainedTokenizer",
         *args,
         padding_side: Optional[str] = None,
         **kwargs,
@@ -215,6 +215,7 @@ def get_tokenizer(
                                                     **kwargs)
     else:
         try:
+            from transformers import AutoTokenizer
             tokenizer = AutoTokenizer.from_pretrained(
                 tokenizer_name,
                 *args,
@@ -241,9 +242,10 @@ def get_tokenizer(
         # NOTE: We can remove this after https://github.com/THUDM/ChatGLM3/issues/1324
         if type(tokenizer).__name__ in ("ChatGLMTokenizer",
                                         "ChatGLM4Tokenizer"):
+            from transformers import PreTrainedTokenizer
             assert isinstance(tokenizer, PreTrainedTokenizer)
             patch_padding_side(tokenizer)
-
+        from transformers import PreTrainedTokenizerFast
         if not isinstance(tokenizer, PreTrainedTokenizerFast):
             logger.warning(
                 "Using a slow tokenizer. This might cause a significant "

--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import huggingface_hub
-from huggingface_hub import HfApi, hf_hub_download
 
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer_base import TokenizerBase
@@ -236,6 +235,7 @@ class MistralTokenizer(TokenizerBase):
     @staticmethod
     def _download_mistral_tokenizer_from_hf(tokenizer_name: str,
                                             revision: Optional[str]) -> str:
+        from huggingface_hub import HfApi, hf_hub_download
         try:
             hf_api = HfApi()
             files = hf_api.list_repo_files(repo_id=tokenizer_name,


### PR DESCRIPTION
This PR optimizes the import time of `from vllm import LLM`and fix this issue https://github.com/vllm-project/vllm/issues/14924
The majority of the changes only involve reordering the import statements. SoI think this change will not affect the core functionality and can reduce import time. 

### Comparison

#### `time python3 -c "import vllm"`

**Before:**
```
INFO 03-23 16:46:03 [__init__.py:260] No platform detected, vLLM is running on UnspecifiedPlatform

real    0m5.923s
user    0m12.976s
sys     0m5.908s
```

**After:**

The time is mainly costed in two parts
1. `import torch` takes 1.5–2s
2.  [from openai import xxx](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/chat_utils.py#L18-L30) takes around 0.5s. I don't know how to fix these since they are used in complex ways.

```
real    0m2.957s
user    0m3.570s
sys     0m5.284s
```

#### `time vllm -v`

**Before:**
```
INFO 03-23 16:49:14 [__init__.py:260] No platform detected, vLLM is running on UnspecifiedPlatform
0.8.1

real    0m6.389s
user    0m13.483s
sys     0m5.955s
```

**After:**

`time vllm -v` can be  optimized in `vllm/entrypoints/cli`, and want to implemente it in a separate pr.
```
INFO 03-23 16:48:52 [__init__.py:260] No platform detected, vLLM is running on UnspecifiedPlatform
0.1.dev5099+gff47aab

real    0m4.430s
user    0m4.870s
sys     0m5.731s
```
