### PR TITLE
[misc] LoRA - Skip LoRA kernels when not required

### DIFF
--- a/vllm/lora/ops/triton_ops/lora_expand.py
+++ b/vllm/lora/ops/triton_ops/lora_expand.py
@@ -8,10 +8,10 @@ https://arxiv.org/abs/2310.18547
 
 from typing import List
 
+import torch
 import triton
 import triton.language as tl
 
-import torch
 from vllm.lora.ops.triton_ops.kernel_utils import do_expand_kernel
 from vllm.lora.ops.triton_ops.utils import _get_lora_b_ptr
 from vllm.utils import direct_register_custom_op

--- a/vllm/lora/ops/triton_ops/lora_expand.py
+++ b/vllm/lora/ops/triton_ops/lora_expand.py
@@ -158,6 +158,8 @@ def _lora_expand(
             identifies the the region in token_indices_sorted_by_lora_ids that
             LoRA lora_ids[i] should process.
         lora_ids (torch.Tensor): LoRA ids to process.
+        no_lora_flag_cpu (torch.Tensor): A CPU tensor of size 1, that indicates
+            if there are any requests that require LoRA.
         offset_start (int, optional): Offset start for output_tensor. 
             Defaults to 0.
         add_inputs (bool, optional): Whether to add the input tensor to the 

--- a/vllm/lora/ops/triton_ops/lora_expand.py
+++ b/vllm/lora/ops/triton_ops/lora_expand.py
@@ -166,6 +166,7 @@ def _lora_expand(
             output tensor. Defaults to False.
     """
 
+    assert no_lora_flag_cpu.numel() == 1
     if no_lora_flag_cpu.item():
         # None of the inputs require LoRA.
         return

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -88,8 +88,11 @@ class LoRAKernelMeta:
 
         self._reset()
 
-        self.no_lora_flag_cpu[0] = torch.all(token_lora_mapping == -1)
-        if self.no_lora_flag_cpu.item():
+        # Check and record no-lora case.
+        no_lora = torch.all(token_lora_mapping == -1)
+        self.no_lora_flag_cpu[0] = no_lora
+
+        if no_lora:
             # Early exit. LoRA kernels will not be run.
             return
 

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -88,7 +88,7 @@ class LoRAKernelMeta:
 
         self._reset()
 
-        self.no_lora_flag_cpu[0] = torch.all(token_lora_mapping == 0)
+        self.no_lora_flag_cpu[0] = torch.all(token_lora_mapping == -1)
         if self.no_lora_flag_cpu.item():
             # Early exit. LoRA kernels will not be run.
             return

--- a/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
+++ b/vllm/lora/ops/triton_ops/lora_kernel_metadata.py
@@ -16,16 +16,16 @@ class LoRAKernelMeta:
     active_lora_ids: torch.Tensor
     num_tokens_per_lora: torch.Tensor
     lora_token_start_loc: torch.Tensor
-    # TODO (varun) : Check if we can just pass a python list ??
+
     # The V1 architecture uses the traced torch.compile graphs to execute
     # a forward pass. Things to note about this process,
-    # 1. The tracing infers all pythonic objects into a constant value.
-    # Q: is that true for  lists/tuples as well ?
+    # 1. The tracing infers all python scalar datatype objects into a constant
+    # value.
     # 2. The tracing cannot handle dynamic control flow. (dynamic control flow
     # is an experimental feature in pytorch)
     # 3. The internals of torch.ops functions are not traced.
-    # Due to these limitations, we disguise the "no_lora" flag as a cpu tensor,
-    # and early exit from inside the lora_expand / lora_shrink torch operation.
+    # We disguise the "no_lora" flag as a cpu tensor and leverage point number 3
+    # to early exit from inside the lora_expand / lora_shrink torch operation.
     no_lora_flag_cpu: torch.Tensor
 
     @staticmethod

--- a/vllm/lora/ops/triton_ops/lora_shrink.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink.py
@@ -110,7 +110,6 @@ def _lora_shrink(
     scaling: float,
 ) -> None:
     """
-    # TODO (varun) : Add no_lora_flag_cpu to the args desc.
     Args:
         inputs (torch.Tensor): Input tensor
         lora_a_weights (List[torch.Tensor]): LoRA weights
@@ -128,6 +127,8 @@ def _lora_shrink(
             identifies the region in token_indices_sorted_by_lora_ids that
             LoRA lora_ids[i] should process.
         lora_ids (torch.Tensor): LoRA ids to process.
+        no_lora_flag_cpu (torch.Tensor): A CPU tensor of size 1, that indicates
+            if there are any requests that require LoRA.
         scaling (float): Scaling factor.
     """
 

--- a/vllm/lora/ops/triton_ops/lora_shrink.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink.py
@@ -8,10 +8,10 @@ https://arxiv.org/abs/2310.18547
 
 from typing import List
 
+import torch
 import triton
 import triton.language as tl
 
-import torch
 from vllm.lora.ops.triton_ops.kernel_utils import do_shrink_kernel
 from vllm.lora.ops.triton_ops.utils import _get_lora_a_ptr
 from vllm.utils import direct_register_custom_op

--- a/vllm/lora/ops/triton_ops/lora_shrink.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink.py
@@ -132,6 +132,7 @@ def _lora_shrink(
         scaling (float): Scaling factor.
     """
 
+    assert no_lora_flag_cpu.numel() == 1
     if no_lora_flag_cpu.item():
         # None of the inputs require LoRA.
         return

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1496,6 +1496,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         dummy_lora_id: Optional[int] = None
         dummy_lora_request: LoRARequest = []
         if self.lora_config:
+            # The goal is to capture the LoRA kernels in cuda graphs.
+            # for this purpose, as single dummy lora is sufficient.
             dummy_lora_requests = self._add_dummy_loras(num_loras=1)
             assert len(dummy_lora_requests) == 1
             dummy_lora_request = dummy_lora_requests[0]

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1242,6 +1242,29 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
         max_num_seqs = self.scheduler_config.max_num_seqs
         self._dummy_run(max_num_batched_tokens, max_num_seqs)
 
+    def _add_dummy_loras(self, num_loras: int) -> list[LoRARequest]:
+        assert num_loras > 0
+        assert self.lora_manager is not None
+
+        dummy_lora_requests: list[LoRARequest] = []
+        with self.lora_manager.dummy_lora_cache():
+            for idx in range(num_loras):
+                lora_id = idx + 1
+                dummy_lora_request = LoRARequest(
+                    lora_name=f"warmup_{lora_id}",
+                    lora_int_id=lora_id,
+                    lora_path="/not/a/real/path",
+                )
+                self.lora_manager.add_dummy_lora(dummy_lora_request,
+                                                 rank=LORA_WARMUP_RANK)
+                dummy_lora_requests.append(dummy_lora_request)
+        return dummy_lora_requests
+
+    def _remove_dummy_loras(self):
+        # Remove dummy loras.
+        assert self.lora_manager is not None
+        self.remove_all_loras()
+
     def _dummy_run(self,
                    max_num_batched_tokens: int,
                    max_num_seqs: int = 1) -> None:
@@ -1251,28 +1274,20 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                 SamplingParams(top_p=0.99, top_k=self.vocab_size - 1)
 
             # This represents the maximum number of different requests
-            # that will have unique loras, an therefore the max amount of memory
-            # consumption create dummy lora request copies from the lora request
-            # passed in, which contains a lora from the lora warmup path.
+            # that will have unique loras, and therefore the max amount of
+            # memory consumption. Create dummy lora request copies from the
+            # lora request passed in, which contains a lora from the lora
+            # warmup path.
             dummy_lora_requests: List[LoRARequest] = []
             dummy_lora_requests_per_seq: List[LoRARequest] = []
             if self.lora_config:
-                assert self.lora_manager is not None
-                with self.lora_manager.dummy_lora_cache():
-                    for idx in range(self.lora_config.max_loras):
-                        lora_id = idx + 1
-                        dummy_lora_request = LoRARequest(
-                            lora_name=f"warmup_{lora_id}",
-                            lora_int_id=lora_id,
-                            lora_path="/not/a/real/path",
-                        )
-                        self.lora_manager.add_dummy_lora(dummy_lora_request,
-                                                         rank=LORA_WARMUP_RANK)
-                        dummy_lora_requests.append(dummy_lora_request)
-                    dummy_lora_requests_per_seq = [
-                        dummy_lora_requests[idx % len(dummy_lora_requests)]
-                        for idx in range(max_num_seqs)
-                    ]
+                dummy_lora_requests = self._add_dummy_loras(
+                    self.lora_config.max_loras)
+                assert len(dummy_lora_requests) == self.lora_config.max_loras
+                dummy_lora_requests_per_seq = [
+                    dummy_lora_requests[idx % len(dummy_lora_requests)]
+                    for idx in range(max_num_seqs)
+                ]
 
             # Profile memory usage with max_num_sequences sequences and the
             # total number of tokens equal to max_num_batched_tokens.
@@ -1354,9 +1369,8 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
             self.execute_model(model_input, kv_caches, intermediate_tensors)
             torch.cuda.synchronize()
             if self.lora_config:
-                # Remove dummy loras.
-                assert self.lora_manager is not None
-                self.remove_all_loras()
+                self._remove_dummy_loras()
+
             return
 
     def remove_all_loras(self):
@@ -1479,17 +1493,13 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                 dtype=self.model_config.dtype,
                 device=self.device)
 
-        dummy_lora_id = None
-        dummy_lora_request = None
+        dummy_lora_id: Optional[int] = None
+        dummy_lora_request: LoRARequest = []
         if self.lora_config:
-            assert self.lora_manager is not None
-            dummy_lora_id = 1
-            dummy_lora_request = LoRARequest(
-                lora_name=f"dummy_{dummy_lora_id}",
-                lora_int_id=dummy_lora_id,
-                lora_path='/not/a/real/path')
-            self.lora_manager.add_dummy_lora(dummy_lora_request,
-                                             LORA_WARMUP_RANK)
+            dummy_lora_requests = self._add_dummy_loras(num_loras=1)
+            assert len(dummy_lora_requests) == 1
+            dummy_lora_request = dummy_lora_requests[0]
+            dummy_lora_id = dummy_lora_request.lora_int_id
 
         with self.attn_state.graph_capture(max_batch_size), graph_capture(
                 self.device) as graph_capture_context:
@@ -1576,9 +1586,7 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
                         graph_runner)
 
         if self.lora_config:
-            # Remove dummy loras.
-            assert self.lora_manager is not None
-            self.remove_all_loras()
+            self._remove_dummy_loras()
 
         end_time = time.perf_counter()
         end_free_gpu_memory = torch.cuda.mem_get_info()[0]


### PR DESCRIPTION
In V0 LoRA, we skipped the LoRA kernel launch when all the scheduled requests target the base model.
PR https://github.com/vllm-project/vllm/pull/14685 removed this optimization.
This PR re-introduces this optimizations such that it works for both V0 and V1.

Previously, i.e. before #14685 , on V0, we had a boolean flag, `no_lora`,  in `punica_gpu.py` that tracked if any of the input requests needed LoRA. This works well for V0. But the V1 architecture uses the traced torch.compile graphs to execute a forward pass. This tracing, doesn't play well with dynamic control flow. However, the tracing treats `torch.ops` functions as a black box.

This PR, moves the flag `no_lora` flag inside the `lora_expand` and `lora_shrink` torch operations and triggers an early exit from the operation. 

Benchmarks:
server command : 
```
 VLLM_USE_V1=0  vllm serve meta-llama/Llama-2-7b-chat-hf  --gpu-memory-utilization 0.95  --enable-lora --max-loras 3 --max-cpu-loras 15 --max-lora-rank 64 --lora-modules lora=xtuner/Llama-2-7b-qlora-moss-003-sft --port 9001  --no-enable-prefix-caching
```

client command : 
```
python3 benchmarks/benchmark_serving.py --model meta-llama/Llama-2-7b-chat-hf --dataset-name random --random-input-len 2048 --random-output-len 512 --request-rate inf --seed ${i} --port 9001 --num-prompts ${num_prompts}
```

Numbers: 
The `benchmark_serving.py` command was run 4 times for every `num_prompts` values. All `mean_ttft_ms` measurements are provided below, 
<google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}--></style>
Machine : 1xA100 |   |   |  
-- | -- | -- | --
mean_ttft_ms values |   |   |  
branch \ Num prompts | 1 | 4 | 8
main (400d483e8)  - has #14685 | 148, 170, 170, 176 | 430, 658, 434, 437 | 750, 747, 762, 737
This PR | 155, 165, 162, 170 | 410, 922, 400, 407 | 713, 687, 799, 724

Thanks @jeejeelee for flagging this 🙌 
