### PR TITLE
[WIP][Feature] Support chunked prefill when using Deepseek MTP model as draft model

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1947,8 +1947,6 @@ class SpeculativeConfig:
             raise ValueError("Expect the batch size threshold of disabling "
                              "speculative decoding is > 1, but got "
                              f"{speculative_disable_by_batch_size=}")
-        if (enable_chunked_prefill and speculative_model == "eagle"):
-            raise ValueError("Chunked prefill and EAGLE are not compatible.")
         # TODO: The user should be able to specify revision/max model len
         # for the draft model. It is not currently supported.
         draft_revision = None
@@ -2022,6 +2020,17 @@ class SpeculativeConfig:
                     raise ValueError(
                         f"{num_speculative_tokens=} must be divisible by "
                         f"{n_predict=}")
+
+            if (draft_hf_config.model_type == 'eagle'
+                    and enable_chunked_prefill
+                    and target_model_config.enforce_eager
+                    and not speculative_disable_mqa_scorer):
+                # TODO: add support for mqa scorer
+                raise ValueError(
+                    "EAGLE + chunked prefill only supports batch " \
+                    "expansion scorer atm. if cuda graph is used, " \
+                    "batch expansion scorer is the current fallback."
+                )
 
             speculative_draft_tensor_parallel_size = \
                 SpeculativeConfig._verify_and_get_draft_model_tensor_parallel_size(

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -127,6 +127,9 @@ class SamplerOutput(
     # block/sync across workers, cpu-gpu sync time and sampling time.
     model_execute_time: Optional[float] = None
 
+    # non terminal chunk hidden states for methods like EAGLE + chunked prefill
+    non_terminal_hidden_states: Optional[torch.Tensor] = None
+
     def __getitem__(self, idx: int) -> CompletionSequenceGroupOutput:
         return self.outputs[idx]
 

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -149,6 +149,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             For the latter, prefills are further separated into terminal and
             non-terminal chunks (from which no token is sampled).
         """
+        scores.prefill_hidden_states = non_spec_outputs.prefill_hidden_states
         if not non_spec_indices:
             return scores
 
@@ -290,7 +291,9 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
             probs=non_spec_target_probs,
             token_ids=non_spec_target_token_ids,
             logprobs=non_spec_target_logprobs,
-            hidden_states=non_spec_target_hidden_states)
+            hidden_states=non_spec_target_hidden_states,
+            prefill_hidden_states=target_sampler_output.
+            prefill_hidden_states[:-num_scoring_tokens])
         # Contract remaining nonspec entries based on non_spec_indices, if any.
         return self._contract_non_speculative(
             spec_scores, contracted_seq_group_metadata_list, non_spec_indices,

--- a/vllm/spec_decode/interfaces.py
+++ b/vllm/spec_decode/interfaces.py
@@ -63,6 +63,9 @@ class SpeculativeScores:
     # for each request, when chunked prefill is enabled.
     prompt_logprobs: Optional[List[PromptLogprobs]] = None
 
+    # Optional prefill hidden states for EAGLE
+    prefill_hidden_states: Optional[torch.Tensor] = None
+
     def __repr__(self):
         return (f"SpeculativeScores("
                 f"probs={self.probs.shape}, "

--- a/vllm/spec_decode/interfaces.py
+++ b/vllm/spec_decode/interfaces.py
@@ -56,6 +56,9 @@ class SpeculativeScores:
     # Optional last hidden states from the scoring model.
     hidden_states: Optional[torch.Tensor] = None
 
+    # Optional prefill hidden states from the scoring model.
+    prefill_hidden_states: Optional[torch.Tensor] = None
+
     # Scoring model may also return logprobs for prompt tokens
     # for each request, when chunked prefill is enabled.
     prompt_logprobs: Optional[List[PromptLogprobs]] = None

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -163,7 +163,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         allow_zero_draft_token_step = True
         enable_lm_head_weight_load = False
         num_spec_prefill_steps = 1
-        require_prefill_hidden_states = False
         ngram_prompt_lookup_max = (
             draft_worker_kwargs.pop("ngram_prompt_lookup_max"))
         ngram_prompt_lookup_min = (
@@ -206,7 +205,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                 if draft_model_config.hf_config.model_type == "deepseek_mtp":
                     num_spec_prefill_steps = \
                         draft_model_config.hf_config.n_predict
-                    require_prefill_hidden_states = True
 
             proposer_worker = SmallerTpProposerWorker.maybe_wrap_worker(
                 proposer_worker, draft_tp, target_tp)
@@ -349,7 +347,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         self._disable_logprobs = disable_logprobs
         self._disable_log_stats = disable_log_stats
         self._num_spec_prefill_steps = num_spec_prefill_steps
-        self._require_prefill_hidden_states = require_prefill_hidden_states
 
     def init_device(self) -> None:
         """Initialize both scorer and proposer models.
@@ -825,7 +822,8 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             if execute_model_req.seq_group_metadata_list[idx].is_prompt
         ]
         if len(non_spec_indices):
-            if self.proposer_model_type != 'eagle':
+            if self.proposer_model_type != 'eagle' and\
+              self.proposer_model_type != "deepseek_mtp":
                 all_hidden_states = proposal_scores.hidden_states
                 if all_hidden_states is not None:
                     prefill_hidden_states = all_hidden_states[non_spec_indices]

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -1363,13 +1363,15 @@ def prepare_prefill_hidden_states(
     # be concatanated with 1:N token (since output of scorer has to be
     # the input for proposer). Therefore, we shift the hidden states to
     # align n-1th hidden state with nth token.
-    if previous_non_terminal_hidden_states is None:
-        return HiddenStates(prefill_hidden_states.roll(
-            shifts=1, dims=0)) if prefill_hidden_states is not None else None
 
     # previous_non_terminal_hidden_states is used for EAGLE + chunked
     # prefill, where it tracks the hidden states of the last token in
-    # the previous prompt chunk.
+    # the previous prompt chunk. prefill_seq_group_meta_data records
+    # the corresponding metadata.
+    if (prefill_seq_group_meta_data is None
+            or previous_non_terminal_hidden_states is None):
+        return HiddenStates(prefill_hidden_states.roll(
+            shifts=1, dims=0)) if prefill_hidden_states is not None else None
 
     # get the chunk sizes in seq_groups & get first chunk indices
     device = prefill_hidden_states.device

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -24,7 +24,7 @@ from vllm.platforms import current_platform
 from vllm.sequence import (VLLM_INVALID_TOKEN_ID,
                            CompletionSequenceGroupOutput, ExecuteModelRequest,
                            HiddenStates, SequenceGroupMetadata,
-                           get_all_seq_ids_and_request_ids)
+                           get_all_seq_ids, get_all_seq_ids_and_request_ids)
 from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
 
 if current_platform.is_cuda_alike():
@@ -44,6 +44,7 @@ from vllm.spec_decode.target_model_runner import TargetModelRunner
 from vllm.spec_decode.util import (Timer, create_logprobs_output,
                                    create_sequence_group_output,
                                    get_all_num_logprobs,
+                                   get_non_terminal_hidden_states,
                                    get_sampled_token_logprobs, nvtx_range,
                                    split_batch_by_proposal_len)
 from vllm.utils import resolve_obj_by_qualname
@@ -260,23 +261,21 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             allow_zero_draft_token_step=allow_zero_draft_token_step,
             enable_lm_head_weight_load=enable_lm_head_weight_load,
             num_spec_prefill_steps=num_spec_prefill_steps,
-            require_prefill_hidden_states=require_prefill_hidden_states)
+            proposer_model_type=draft_model_config.hf_config.model_type)
 
-    def __init__(
-        self,
-        proposer_worker: ProposerWorkerBase,
-        scorer_worker: WorkerBase,
-        spec_decode_sampler: SpecDecodeBaseSampler,
-        disable_mqa_scorer: bool = False,
-        disable_logprobs: bool = False,
-        disable_log_stats: bool = False,
-        metrics_collector: Optional[AsyncMetricsCollector] = None,
-        disable_by_batch_size: Optional[int] = None,
-        allow_zero_draft_token_step: Optional[bool] = True,
-        enable_lm_head_weight_load: Optional[bool] = False,
-        num_spec_prefill_steps: int = 1,
-        require_prefill_hidden_states: Optional[bool] = False,
-    ):
+    def __init__(self,
+                 proposer_worker: ProposerWorkerBase,
+                 scorer_worker: WorkerBase,
+                 spec_decode_sampler: SpecDecodeBaseSampler,
+                 disable_mqa_scorer: bool = False,
+                 disable_logprobs: bool = False,
+                 disable_log_stats: bool = False,
+                 metrics_collector: Optional[AsyncMetricsCollector] = None,
+                 disable_by_batch_size: Optional[int] = None,
+                 allow_zero_draft_token_step: Optional[bool] = True,
+                 enable_lm_head_weight_load: Optional[bool] = False,
+                 num_spec_prefill_steps: int = 1,
+                 proposer_model_type: Optional[str] = None):
         """
         Create a SpecDecodeWorker.
 
@@ -312,8 +311,8 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                 before the speculative decoding starts. This is only used when
                 the draft model is a deepseek_mtp model that requires prefill
                 kv cache separately for each MTP layer.
-            require_prefill_hidden_states: whether to require full prefill
-                hidden states. This is only used for deepseek_mtp model.
+            proposer_model_type: proposer's architecture, needed for deciding
+                how prefill & hidden states should be managed
         """
         self.proposer_worker = proposer_worker
         self.scorer_worker = scorer_worker
@@ -345,6 +344,8 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         # Hidden states from target model to pass to proposer
         # in the subsequent step.
         self.previous_hidden_states: Optional[HiddenStates] = None
+        self.non_terminal_hidden_states: Optional[HiddenStates] = None
+        self.proposer_model_type = proposer_model_type
         self._disable_logprobs = disable_logprobs
         self._disable_log_stats = disable_log_stats
         self._num_spec_prefill_steps = num_spec_prefill_steps
@@ -705,13 +706,22 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                 self.previous_hidden_states.update(hidden_states,
                                                    seq_group_meta_with_hidden)
 
+        non_terminal_hidden_states = self.non_terminal_hidden_states
+        self.non_terminal_hidden_states = get_non_terminal_hidden_states(
+            sampler_output.prefill_hidden_states,
+            execute_model_req.seq_group_metadata_list,
+            proposer_model_type=self.proposer_model_type)
+
         if not skip_proposer:
             # We prepare the prefill hidden states here so that there no
             # additional complexity in worker for spec_decode vs non_spec_decode
             # flow and execute_model doesn't need additional modifications.
             execute_model_req.previous_hidden_states = \
                 prepare_prefill_hidden_states(
-                    sampler_output.prefill_hidden_states)
+                    sampler_output.prefill_hidden_states,
+                    execute_model_req.seq_group_metadata_list,
+                    non_terminal_hidden_states
+                )
             for i in range(self._num_spec_prefill_steps):
                 execute_model_req.spec_step_idx = i
                 self.proposer_worker.execute_model(execute_model_req)
@@ -785,6 +795,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
 
         # Pass last hidden states from target model to proposer
         execute_model_req.previous_hidden_states = self.previous_hidden_states
+        non_terminal_hidden_states = self.non_terminal_hidden_states
         self.previous_hidden_states = None
 
         with Timer() as proposal_timer:
@@ -814,16 +825,31 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
             if execute_model_req.seq_group_metadata_list[idx].is_prompt
         ]
         if len(non_spec_indices):
-            all_hidden_states = proposal_scores.hidden_states
-            if all_hidden_states is not None:
-                prefill_hidden_states = all_hidden_states[non_spec_indices]
-                execute_model_req.previous_hidden_states = \
-                    prepare_prefill_hidden_states(prefill_hidden_states)
-            if proposal_scores.prefill_hidden_states is not None and self.\
-              _require_prefill_hidden_states:
-                execute_model_req.previous_hidden_states = \
-                  prepare_prefill_hidden_states(
-                    proposal_scores.prefill_hidden_states)
+            if self.proposer_model_type != 'eagle':
+                all_hidden_states = proposal_scores.hidden_states
+                if all_hidden_states is not None:
+                    prefill_hidden_states = all_hidden_states[non_spec_indices]
+                    execute_model_req.previous_hidden_states = \
+                        prepare_prefill_hidden_states(prefill_hidden_states)
+            else:
+                prefill_hidden_states = proposal_scores.prefill_hidden_states
+                if prefill_hidden_states is not None:
+                    prefill_hidden_states = (
+                        proposal_scores.prefill_hidden_states)
+                    self.non_terminal_hidden_states = \
+                        get_non_terminal_hidden_states(
+                            prefill_hidden_states,
+                            non_spec_seqs,
+                            proposer_model_type=self.proposer_model_type
+                        )
+                    execute_model_req.previous_hidden_states = \
+                        prepare_prefill_hidden_states(
+                            prefill_hidden_states,
+                            prefill_seq_group_meta_data=non_spec_seqs,
+                            previous_non_terminal_hidden_states= \
+                            non_terminal_hidden_states
+                    )
+                proposal_scores.prefill_hidden_states = None
             # Sync proposer KV cache for prefills.
             prefill_req = execute_model_req.clone(non_spec_seqs)
             # TODO avoid sampling here?
@@ -1327,12 +1353,51 @@ def split_num_cache_blocks_evenly(scorer_cache_block_size_bytes: int,
 
 
 def prepare_prefill_hidden_states(
-        prefill_hidden_states: torch.Tensor) -> HiddenStates:
+    prefill_hidden_states: torch.Tensor,
+    prefill_seq_group_meta_data: Optional[List[SequenceGroupMetadata]] = None,
+    previous_non_terminal_hidden_states: Optional[HiddenStates] = None
+) -> HiddenStates:
     # For prefill step in proposer, we run the model for N-1 tokens
     # because Nth token will be processed in the first decode step. For
     # N-1 tokens, the input should be 0:N-1 hidden states which should
     # be concatanated with 1:N token (since output of scorer has to be
     # the input for proposer). Therefore, we shift the hidden states to
     # align n-1th hidden state with nth token.
-    return HiddenStates(prefill_hidden_states.roll(
-        shifts=1, dims=0)) if prefill_hidden_states is not None else None
+    if previous_non_terminal_hidden_states is None:
+        return HiddenStates(prefill_hidden_states.roll(
+            shifts=1, dims=0)) if prefill_hidden_states is not None else None
+
+    # previous_non_terminal_hidden_states is used for EAGLE + chunked
+    # prefill, where it tracks the hidden states of the last token in
+    # the previous prompt chunk.
+
+    # get the chunk sizes in seq_groups & get first chunk indices
+    device = prefill_hidden_states.device
+    chunk_sizes = torch.tensor(
+        [0] + [sg.token_chunk_size for sg in prefill_seq_group_meta_data[:-1]],
+        dtype=torch.int64,
+        device=device)
+
+    all_indices = chunk_sizes.cumsum(0)
+
+    # filter for seqs with previous non terminal hidden states
+    prefill_seq_ids = torch.tensor(
+        get_all_seq_ids(prefill_seq_group_meta_data), device=device)
+    previous_seq_ids = torch.tensor(
+        previous_non_terminal_hidden_states._seq_ids, device=device)
+
+    matches = torch.isin(prefill_seq_ids, previous_seq_ids)
+    prefill_indices = all_indices[matches]
+
+    _, previous_non_terminal_indices = torch.where(
+        prefill_seq_ids.unsqueeze(1) == previous_seq_ids)
+
+    prefill_hidden_states = prefill_hidden_states.roll(shifts=1, dims=0)
+
+    # fill the first token of each chunk with the last token
+    # from the previous chunk
+    if prefill_indices.numel() > 0:
+        prefill_hidden_states[prefill_indices] = (
+            previous_non_terminal_hidden_states.
+            hidden_states[previous_non_terminal_indices])
+    return HiddenStates(prefill_hidden_states)

--- a/vllm/spec_decode/util.py
+++ b/vllm/spec_decode/util.py
@@ -21,9 +21,9 @@ def get_non_terminal_hidden_states(
         proposer_model_type: Optional[str] = None) -> Optional[HiddenStates]:
     """
     Given prefill hidden states, extract the hidden states of the last token
-    in a non-terminal chunk for speculative decoding methods such as EAGLE. 
+    in a non-terminal chunk for speculative decoding methods such as EAGLE.
     """
-    if proposer_model_type != 'eagle':
+    if proposer_model_type != 'eagle' and proposer_model_type != "deeseek_mtp":
         return None
 
     non_terminal_seq_group_meta = []
@@ -279,7 +279,7 @@ def maybe_mock_device_tensors(sampler_output: SamplerOutput, batch_size: int,
 
 @contextmanager
 def nvtx_range(msg, *args, **kwargs):
-    """ 
+    """
     Context manager / decorator that pushes an NVTX range at the beginning
     of its scope, and pops it at the end. If extra arguments are given,
     they are passed as arguments to msg.format().


### PR DESCRIPTION
Deepseek MTP currently is not compatible with chunked prefill. When enabling both features, a runtime crash due to shape mismatch will happen when receiving certain number of concurrent requests and triggering chunked prefill.

```
python -m vllm.entrypoints.openai.api_server --gpu-memory-utilization 0.8  --max-model-len 65536 --max-num-seqs 128 --seed 0 --tensor-parallel-size 8 --model deepseek-ai/DeepSeek-R1 --trust-remote-code --num-speculative-tokens 3  --enable-chunked-prefill

***Sending concurrent requests..***

(VllmWorkerProcess pid=655093) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655091) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 755, in _run_non_driver_rank
(VllmWorkerProcess pid=655089) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 171, in execute_model
(VllmWorkerProcess pid=655094) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/model_runner.py", line 1742, in execute_model
(VllmWorkerProcess pid=655092) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return func(*args, **kwargs)
(VllmWorkerProcess pid=655090) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 755, in _run_non_driver_rank
(VllmWorkerProcess pid=655088) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655093) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 755, in _run_non_driver_rank
(VllmWorkerProcess pid=655091) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     self.proposer_worker.execute_model()
(VllmWorkerProcess pid=655089) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return self.worker.execute_model(execute_model_req)
(VllmWorkerProcess pid=655094) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     hidden_or_intermediate_states = model_executable(
(VllmWorkerProcess pid=655092) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]            ^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655090) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     self.proposer_worker.execute_model()
(VllmWorkerProcess pid=655088) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 755, in _run_non_driver_rank
(VllmWorkerProcess pid=655093) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     self.proposer_worker.execute_model()
(VllmWorkerProcess pid=655091) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 171, in execute_model
INFO:     127.0.0.1:41546 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
(VllmWorkerProcess pid=655089) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655094) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]                                     ^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655092) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/spec_decode/spec_decode_worker.py", line 551, in start_worker_execution_loop
(VllmWorkerProcess pid=655090) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 171, in execute_model
(VllmWorkerProcess pid=655088) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     self.proposer_worker.execute_model()
(VllmWorkerProcess pid=655093) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 171, in execute_model
(VllmWorkerProcess pid=655091) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return self.worker.execute_model(execute_model_req)
(VllmWorkerProcess pid=655089) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 420, in execute_model
(VllmWorkerProcess pid=655094) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-env/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
(VllmWorkerProcess pid=655092) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     while self._run_non_driver_rank():
(VllmWorkerProcess pid=655090) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return self.worker.execute_model(execute_model_req)
(VllmWorkerProcess pid=655092) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655088) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]   File "/workspace/vllm-oss/vllm/worker/worker_base.py", line 171, in execute_model
(VllmWorkerProcess pid=655093) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return self.worker.execute_model(execute_model_req)
(VllmWorkerProcess pid=655091) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(VllmWorkerProcess pid=655089) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     output = self.model_runner.execute_model(
(VllmWorkerProcess pid=655094) ERROR 03-19 19:13:19 [multiproc_worker_utils.py:242]     return self._call_impl(*args, **kwargs)
ERROR 03-19 19:13:19 [engine.py:141] RuntimeError('Tensors must have same number of dimensions: got 2 and 3')
```