### PR TITLE
[Feature] Enable XGrammar Regex Support

### DIFF
--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -53,14 +53,9 @@ def maybe_backend_fallback(
         from vllm.model_executor.guided_decoding.xgrammar_decoding import (
             xgr_installed)
 
-        # xgrammar doesn't support regex, fallback to outlines
-        if guided_params.regex is not None:
-            fallback_or_error(
-                guided_params,
-                "xgrammar does not support regex guided decoding.", "outlines")
         # xgrammar doesn't support some JSON schema features
-        elif (guided_params.json is not None
-              and has_xgrammar_unsupported_json_features(guided_params.json)):
+        if (guided_params.json is not None and
+                has_xgrammar_unsupported_json_features(guided_params.json)):
             fallback_or_error(
                 guided_params,
                 "xgrammar does not support advanced JSON schema features like "

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -147,6 +147,7 @@ class GrammarConfig:
     json_object: bool | None = None
     any_whitespace: bool = True
     max_threads: int = 8
+    regex_str: str | None = None
 
     @classmethod
     def from_guided_params(cls,
@@ -249,6 +250,14 @@ class GrammarConfig:
                 max_threads=max_threads,
                 tokenizer_data=tokenizer_data,
             )
+        elif guided_params.regex:
+            return cls(
+                regex_str=guided_params.regex,
+                tokenizer_hash=tokenizer_hash,
+                max_threads=max_threads,
+                tokenizer_data=tokenizer_data,
+            )
+
         else:
             raise ValueError(
                 "Currently only support JSON and EBNF grammar mode for xgrammar"
@@ -321,6 +330,8 @@ class XGrammarLogitsProcessor:
                 self.ctx = compiler.compile_grammar(self.config.grammar_str)
             elif self.config.json_object:
                 self.ctx = compiler.compile_builtin_json_grammar()
+            elif self.config.regex_str:
+                self.ctx = compiler.compile_regex(self.config.regex_str)
             else:
                 raise ValueError(
                     "Invalid configuration for xgrammar logits processor")


### PR DESCRIPTION
Thanks guys for the awesome work!

I've noticed that XGrammar now supports regex strings [xgrammar PR](https://github.com/mlc-ai/xgrammar/pull/185)

This PR removes the fallback to outlines for regex for VLLM v0 users (backwards compatibility)