### PR TITLE
[Spec Decode] Make speculative decoding compatible with pipeline parallelism

### DIFF
--- a/tests/spec_decode/e2e/test_integration_dist_pp2.py
+++ b/tests/spec_decode/e2e/test_integration_dist_pp2.py
@@ -3,6 +3,7 @@
 pipeline parallelism.
 """
 
+import json
 from typing import Optional
 
 import pytest
@@ -29,23 +30,24 @@ from .conftest import run_equality_correctness_test_tp
     ]])
 @pytest.mark.parametrize("per_test_common_llm_kwargs", [[]])
 @pytest.mark.parametrize("baseline_llm_kwargs", [[]])
-@pytest.mark.parametrize("model, test_llm_kwargs",
-                         [("JackFram/llama-68m", [
-                             "--speculative-model",
-                             "JackFram/llama-68m",
-                             "--num-speculative-tokens",
-                             "5",
-                             "--speculative-draft-pipeline-parallel-size",
-                             "1",
-                         ]),
-                          ("ibm-granite/granite-3b-code-instruct", [
-                              "--speculative-model",
-                              "ibm-granite/granite-3b-code-instruct",
-                              "--num-speculative-tokens",
-                              "5",
-                              "--speculative-draft-pipeline-parallel-size",
-                              "1",
-                          ])])
+@pytest.mark.parametrize(
+    "model, test_llm_kwargs",
+    [("JackFram/llama-68m", [
+        "--speculative_config",
+        json.dumps({
+            "model": "JackFram/llama-68m",
+            "num_speculative_tokens": 5,
+            "draft_pipeline_parallel_size": 1,
+        }),
+    ]),
+     ("ibm-granite/granite-3b-code-instruct", [
+         "--speculative_config",
+         json.dumps({
+             "model": "ibm-granite/granite-3b-code-instruct",
+             "num_speculative_tokens": 5,
+             "draft_pipeline_parallel_size": 1,
+         }),
+     ])])
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize("seed", [1])
 def test_draft_model_pp_lt_target_model_pp2(model, common_llm_kwargs,
@@ -91,12 +93,12 @@ def test_draft_model_pp_lt_target_model_pp2(model, common_llm_kwargs,
      ]])
 @pytest.mark.parametrize("baseline_llm_kwargs", [[]])
 @pytest.mark.parametrize("model, test_llm_kwargs", [("JackFram/llama-68m", [
-    "--speculative-model",
-    "JackFram/llama-68m",
-    "--num-speculative-tokens",
-    "3",
-    "--speculative-draft-pipeline-parallel-size",
-    "1",
+    "--speculative_config",
+    json.dumps({
+        "model": "JackFram/llama-68m",
+        "num_speculative_tokens": 3,
+        "draft_pipeline_parallel_size": 1,
+    }),
 ])])
 @pytest.mark.parametrize("logprobs", [None, 2])
 @pytest.mark.parametrize("batch_size", [2])

--- a/tests/spec_decode/e2e/test_integration_dist_pp2.py
+++ b/tests/spec_decode/e2e/test_integration_dist_pp2.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests which cover integration of the speculative decoding framework with
+pipeline parallelism.
+"""
+
+from typing import Optional
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+from .conftest import run_equality_correctness_test_tp
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="Need at least 2 GPUs to run the test.")
+@pytest.mark.parametrize(
+    "common_llm_kwargs",
+    [[
+        # Skip cuda graph recording for fast test.
+        "--enforce-eager",
+        "--pipeline-parallel-size",
+        "2",
+
+        # precision
+        "--dtype",
+        "bfloat16",
+    ]])
+@pytest.mark.parametrize("per_test_common_llm_kwargs", [[]])
+@pytest.mark.parametrize("baseline_llm_kwargs", [[]])
+@pytest.mark.parametrize("model, test_llm_kwargs",
+                         [("JackFram/llama-68m", [
+                             "--speculative-model",
+                             "JackFram/llama-68m",
+                             "--num-speculative-tokens",
+                             "5",
+                             "--speculative-draft-pipeline-parallel-size",
+                             "1",
+                         ]),
+                          ("ibm-granite/granite-3b-code-instruct", [
+                              "--speculative-model",
+                              "ibm-granite/granite-3b-code-instruct",
+                              "--num-speculative-tokens",
+                              "5",
+                              "--speculative-draft-pipeline-parallel-size",
+                              "1",
+                          ])])
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("seed", [1])
+def test_draft_model_pp_lt_target_model_pp2(model, common_llm_kwargs,
+                                            per_test_common_llm_kwargs,
+                                            baseline_llm_kwargs,
+                                            test_llm_kwargs, batch_size: int,
+                                            seed: int):
+    """Verify spec decode works well with smaller pp for draft models.
+    """
+    if current_platform.is_rocm():
+        pytest.skip("hip is not well-supported yet")
+    run_equality_correctness_test_tp(model,
+                                     common_llm_kwargs,
+                                     per_test_common_llm_kwargs,
+                                     baseline_llm_kwargs,
+                                     test_llm_kwargs,
+                                     batch_size,
+                                     max_output_len=32,
+                                     seed=seed,
+                                     temperature=0.0)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="Need at least 2 GPUs to run the test.")
+@pytest.mark.parametrize(
+    "common_llm_kwargs",
+    [[
+        # Skip cuda graph recording for fast test.
+        "--enforce-eager",
+        "--pipeline-parallel-size",
+        "2",
+
+        # precision
+        "--dtype",
+        "bfloat16",
+    ]])
+@pytest.mark.parametrize(
+    "per_test_common_llm_kwargs",
+    [["--enable-chunked-prefill", "False"],
+     [
+         "--enable-chunked-prefill", "True", "--max-num-batched-tokens", "4",
+         "--max-num-seqs", "4"
+     ]])
+@pytest.mark.parametrize("baseline_llm_kwargs", [[]])
+@pytest.mark.parametrize("model, test_llm_kwargs", [("JackFram/llama-68m", [
+    "--speculative-model",
+    "JackFram/llama-68m",
+    "--num-speculative-tokens",
+    "3",
+    "--speculative-draft-pipeline-parallel-size",
+    "1",
+])])
+@pytest.mark.parametrize("logprobs", [None, 2])
+@pytest.mark.parametrize("batch_size", [2])
+@pytest.mark.parametrize("seed", [1])
+def test_spec_decode_chunked_prefill_pp2(model, common_llm_kwargs,
+                                         per_test_common_llm_kwargs,
+                                         baseline_llm_kwargs, test_llm_kwargs,
+                                         logprobs: Optional[int],
+                                         batch_size: int, seed: int):
+    """Verify spec decode works well with same and different PP size for
+    the draft model with chunked prefill.
+    """
+    if logprobs:
+        test_llm_kwargs.extend(
+            ["--disable-logprobs-during-spec-decoding", "False"])
+    run_equality_correctness_test_tp(model,
+                                     common_llm_kwargs,
+                                     per_test_common_llm_kwargs,
+                                     baseline_llm_kwargs,
+                                     test_llm_kwargs,
+                                     batch_size,
+                                     max_output_len=32,
+                                     seed=seed,
+                                     temperature=0.0,
+                                     logprobs=logprobs)

--- a/tests/spec_decode/test_multi_step_worker.py
+++ b/tests/spec_decode/test_multi_step_worker.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.utils import set_random_seed
 from vllm.sequence import (ExecuteModelRequest, HiddenStates, Logprob,
                            get_all_seq_ids)
-from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
+from vllm.spec_decode.draft_model_runner import TP1PP1DraftModelRunner
 from vllm.spec_decode.multi_step_worker import MultiStepWorker
 from vllm.spec_decode.top1_proposer import Top1Proposer
 from vllm.worker.worker import Worker
@@ -91,7 +91,7 @@ def test_same_output_for_single_step():
         block_size,
         num_gpu_blocks,
         seed,
-        model_runner_cls=TP1DraftModelRunner,
+        model_runner_cls=TP1PP1DraftModelRunner,
     )
     worker = create_worker(
         Worker,
@@ -304,7 +304,7 @@ def test_multi_step_with_batch_expansion_correct_output():
         block_size,
         num_gpu_blocks,
         seed,
-        model_runner_cls=TP1DraftModelRunner,
+        model_runner_cls=TP1PP1DraftModelRunner,
     )
     multi_step_worker.set_include_gpu_probs_tensor()
     worker = create_worker(
@@ -399,7 +399,7 @@ def test_multi_step_with_batch_expansion_incorrect_output():
         block_size,
         num_gpu_blocks,
         seed,
-        model_runner_cls=TP1DraftModelRunner,
+        model_runner_cls=TP1PP1DraftModelRunner,
     )
     multi_step_worker.set_include_gpu_probs_tensor()
     worker = create_worker(
@@ -502,13 +502,14 @@ def test_multi_step_correct_kvcache(num_steps, attn_backend):
 
     with global_force_attn_backend_context_manager(attn_backend):
         dtype = 'float16' if attn_backend == _Backend.FLASH_ATTN else 'float32'
-        multi_step_worker = create_worker(MultiStepWorker,
-                                          model_name,
-                                          block_size,
-                                          num_gpu_blocks,
-                                          seed,
-                                          model_runner_cls=TP1DraftModelRunner,
-                                          dtype=dtype)
+        multi_step_worker = create_worker(
+            MultiStepWorker,
+            model_name,
+            block_size,
+            num_gpu_blocks,
+            seed,
+            model_runner_cls=TP1PP1DraftModelRunner,
+            dtype=dtype)
         multi_step_worker.set_include_gpu_probs_tensor()
         worker = create_worker(Worker,
                                model_name,
@@ -771,7 +772,7 @@ def test_use_draft_model_runner_advance_step():
         block_size,
         num_gpu_blocks,
         seed,
-        model_runner_cls=TP1DraftModelRunner,
+        model_runner_cls=TP1PP1DraftModelRunner,
     )
 
     # Mock "_gpu_advance_step" to raise an exception when called.

--- a/tests/spec_decode/test_spec_decode_worker.py
+++ b/tests/spec_decode/test_spec_decode_worker.py
@@ -12,7 +12,7 @@ from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.model_executor.utils import set_random_seed
 from vllm.sequence import ExecuteModelRequest, SequenceOutput
 from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
-from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
+from vllm.spec_decode.draft_model_runner import TP1PP1DraftModelRunner
 from vllm.spec_decode.interfaces import SpeculativeProposals
 from vllm.spec_decode.metrics import (AsyncMetricsCollector,
                                       SpecDecodeWorkerMetrics)
@@ -929,7 +929,7 @@ def test_correctly_load_weight_for_eagle():
         block_size,
         num_gpu_blocks,
         seed,
-        model_runner_cls=TP1DraftModelRunner,
+        model_runner_cls=TP1PP1DraftModelRunner,
     )
 
     spec_decode_sampler = mock_spec_decode_sampler("rejection_sampler")

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -153,7 +153,7 @@ class Attention(nn.Module):
         # this variable will not be accessed if use_direct_call is True
         self.kv_cache = [
             torch.tensor([]) for _ in range(
-                get_current_vllm_config().parallel_config.virtual_engine_size)
+                get_current_vllm_config().parallel_config.num_virtual_engine)
         ]
 
         self.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -152,8 +152,8 @@ class Attention(nn.Module):
         # by bind_kv_cache
         # this variable will not be accessed if use_direct_call is True
         self.kv_cache = [
-            torch.tensor([]) for _ in range(get_current_vllm_config(
-            ).parallel_config.pipeline_parallel_size)
+            torch.tensor([]) for _ in range(
+                get_current_vllm_config().parallel_config.virtual_engine_size)
         ]
 
         self.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1417,7 +1417,7 @@ class ParallelConfig:
     data_parallel_master_ip: str = "127.0.0.1"
     data_parallel_master_port: int = 29500  # Port of the data parallel master.
     enable_expert_parallel: bool = False  # Use EP instead of TP for MoE layers.
-    virtual_engine_size: int = 1  # Number of virtual engine.
+    num_virtual_engine: int = 1  # Number of virtual engines.
 
     # Maximum number of multiple batches
     # when load model sequentially. To avoid RAM OOM when using tensor
@@ -1927,6 +1927,9 @@ class SpeculativeConfig:
         - draft_tensor_parallel_size (Optional[int]): The degree of the tensor
             parallelism for the draft model. Can only be 1 or the same as the
             target model's tensor parallel size.
+        - draft_pipeline_parallel_size (Optional[int]): The degree of the
+            pipeline parallelism for the draft model. Can only be 1 or the
+            same as the target model's pipeline parallel size.
         - disable_logprobs (bool): If set to True, token log probabilities are
             not returned during speculative decoding. If set to False, token
             log probabilities are returned according to the log probability
@@ -2321,7 +2324,7 @@ class SpeculativeConfig:
         draft_parallel_config = ParallelConfig(
             pipeline_parallel_size=speculative_draft_pipeline_parallel_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
-            virtual_engine_size=target_parallel_config.virtual_engine_size,
+            num_virtual_engine=target_parallel_config.num_virtual_engine,
             distributed_executor_backend=target_parallel_config.
             distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1417,6 +1417,7 @@ class ParallelConfig:
     data_parallel_master_ip: str = "127.0.0.1"
     data_parallel_master_port: int = 29500  # Port of the data parallel master.
     enable_expert_parallel: bool = False  # Use EP instead of TP for MoE layers.
+    virtual_engine_size: int = 1  # Number of virtual engine.
 
     # Maximum number of multiple batches
     # when load model sequentially. To avoid RAM OOM when using tensor
@@ -1981,6 +1982,7 @@ class SpeculativeConfig:
     method: Optional[str] = None
     acceptance_method: str = "rejection_sampler"
     draft_tensor_parallel_size: Optional[int] = None
+    draft_pipeline_parallel_size: Optional[int] = None
     disable_logprobs: bool = True
 
     model: Optional[str] = None
@@ -2193,6 +2195,13 @@ class SpeculativeConfig:
                         self.draft_model_config.hf_config
                 )
 
+                self.draft_pipeline_parallel_size = \
+                    SpeculativeConfig._verify_and_get_draft_pp(
+                        self.target_parallel_config,
+                        self.draft_pipeline_parallel_size,
+                        self.draft_model_config.hf_config
+                    )
+
                 self.draft_model_config.max_model_len = (
                     SpeculativeConfig._maybe_override_draft_max_model_len(
                         self.max_model_len,
@@ -2203,7 +2212,8 @@ class SpeculativeConfig:
                 self.draft_parallel_config = (
                     SpeculativeConfig.create_draft_parallel_config(
                         self.target_parallel_config,
-                        self.draft_tensor_parallel_size))
+                        self.draft_tensor_parallel_size,
+                        self.draft_pipeline_parallel_size))
 
         if self.acceptance_method == "typical_acceptance_sampler":
             if self.posterior_threshold is None:
@@ -2278,18 +2288,40 @@ class SpeculativeConfig:
         return speculative_draft_tensor_parallel_size
 
     @staticmethod
+    def _verify_and_get_draft_pp(
+            target_parallel_config: ParallelConfig,
+            speculative_draft_pipeline_parallel_size: Optional[int],
+            draft_hf_config: PretrainedConfig) -> int:
+        """
+        Verifies and adjusts the tensor parallel size for a draft model
+        specified using speculative_draft_pipeline_parallel_size.
+        """
+        # If speculative_draft_pipeline_parallel_size is unset then set it
+        # appropriately else verify that it is set correctly.
+        if speculative_draft_pipeline_parallel_size is None:
+            speculative_draft_pipeline_parallel_size = \
+                target_parallel_config.pipeline_parallel_size
+        elif speculative_draft_pipeline_parallel_size not in (
+                1, target_parallel_config.pipeline_parallel_size):
+            raise ValueError(
+                f"{speculative_draft_pipeline_parallel_size=} cannot be "
+                f"other value than 1 or target model pipeline_parallel_size")
+        return speculative_draft_pipeline_parallel_size
+
+    @staticmethod
     def create_draft_parallel_config(
         target_parallel_config: ParallelConfig,
         speculative_draft_tensor_parallel_size: int,
+        speculative_draft_pipeline_parallel_size: int,
     ) -> ParallelConfig:
         """Create a parallel config for use by the draft worker.
 
         This is mostly a copy of the target parallel config, except the tp_size.
         """
         draft_parallel_config = ParallelConfig(
-            pipeline_parallel_size=target_parallel_config.
-            pipeline_parallel_size,
+            pipeline_parallel_size=speculative_draft_pipeline_parallel_size,
             tensor_parallel_size=speculative_draft_tensor_parallel_size,
+            virtual_engine_size=target_parallel_config.virtual_engine_size,
             distributed_executor_backend=target_parallel_config.
             distributed_executor_backend,
             max_parallel_loading_workers=target_parallel_config.

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1024,6 +1024,7 @@ def patch_model_parallel_group(tp_group: GroupCoordinator,
 
     Args:
         tp_group (GroupCoordinator): the tp group coordinator
+        pp_group (GroupCoordinator): the pp group coordinator
     """
     global _TP_STATE_PATCHED
     assert not _TP_STATE_PATCHED, "Should not call when it's already patched"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -181,7 +181,7 @@ class EngineArgs:
     guided_decoding_backend: str = 'xgrammar'
     logits_processor_pattern: Optional[str] = None
 
-    speculative_config: Optional[Dict[str, Any]] = None
+    speculative_config: Optional[Union[str, Dict[str, Any]]] = None
 
     qlora_adapter_name_or_path: Optional[str] = None
     show_hidden_metrics_for_version: Optional[str] = None
@@ -1189,6 +1189,7 @@ class EngineArgs:
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
+            virtual_engine_size=self.pipeline_parallel_size,
             data_parallel_size=self.data_parallel_size,
             enable_expert_parallel=self.enable_expert_parallel,
             max_parallel_loading_workers=self.max_parallel_loading_workers,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -181,7 +181,7 @@ class EngineArgs:
     guided_decoding_backend: str = 'xgrammar'
     logits_processor_pattern: Optional[str] = None
 
-    speculative_config: Optional[Union[str, Dict[str, Any]]] = None
+    speculative_config: Optional[Dict[str, Any]] = None
 
     qlora_adapter_name_or_path: Optional[str] = None
     show_hidden_metrics_for_version: Optional[str] = None
@@ -1189,7 +1189,7 @@ class EngineArgs:
         parallel_config = ParallelConfig(
             pipeline_parallel_size=self.pipeline_parallel_size,
             tensor_parallel_size=self.tensor_parallel_size,
-            virtual_engine_size=self.pipeline_parallel_size,
+            num_virtual_engine=self.pipeline_parallel_size,
             data_parallel_size=self.data_parallel_size,
             enable_expert_parallel=self.enable_expert_parallel,
             max_parallel_loading_workers=self.max_parallel_loading_workers,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -812,9 +812,9 @@ class AsyncLLMEngine(EngineClient):
         if not engine:
             return
 
-        virtual_engine_size = \
-                engine.engine.parallel_config.virtual_engine_size
-        has_requests_in_progress = [False] * virtual_engine_size
+        num_virtual_engine = \
+                engine.engine.parallel_config.num_virtual_engine
+        has_requests_in_progress = [False] * num_virtual_engine
         while True:
             if not any(has_requests_in_progress):
                 logger.debug("Waiting for new requests...")
@@ -839,9 +839,9 @@ class AsyncLLMEngine(EngineClient):
                 logger.debug("Got new requests!")
                 requests_in_progress = [
                     asyncio.create_task(engine.engine_step(ve))
-                    for ve in range(virtual_engine_size)
+                    for ve in range(num_virtual_engine)
                 ]
-                has_requests_in_progress = [True] * virtual_engine_size
+                has_requests_in_progress = [True] * num_virtual_engine
 
             # Abort if iteration takes too long due to unrecoverable errors
             # (eg. NCCL timeouts).
@@ -850,7 +850,7 @@ class AsyncLLMEngine(EngineClient):
                     done, _ = await asyncio.wait(
                         requests_in_progress,
                         return_when=asyncio.FIRST_COMPLETED)
-                    for _ in range(virtual_engine_size):
+                    for _ in range(num_virtual_engine):
                         await asyncio.sleep(0)
                 for task in done:
                     result = task.result()

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -266,7 +266,7 @@ class Metrics:
         # Speculative decoding stats
         self.gauge_spec_decode_draft_acceptance_rate = self._gauge_cls(
             name="vllm:spec_decode_draft_acceptance_rate",
-            documentation="Speulative token acceptance rate.",
+            documentation="Speculative token acceptance rate.",
             labelnames=labelnames,
             multiprocess_mode="sum")
         self.gauge_spec_decode_efficiency = self._gauge_cls(

--- a/vllm/model_executor/models/eagle.py
+++ b/vllm/model_executor/models/eagle.py
@@ -17,6 +17,7 @@ from vllm.model_executor.models import ModelRegistry
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors
 
+from .interfaces import SupportsPP
 from .utils import maybe_prefix
 
 logger = init_logger(__name__)
@@ -42,7 +43,7 @@ class DummyOutputNorm(nn.Module):
             return x + residual, None
 
 
-class EAGLE(nn.Module):
+class EAGLE(nn.Module, SupportsPP):
     """This class implements the EAGLE draft model from the paper: https://arxiv.org/pdf/2401.15077
     Reference implementation: https://github.com/SafeAILab/EAGLE
     

--- a/vllm/model_executor/models/mlp_speculator.py
+++ b/vllm/model_executor/models/mlp_speculator.py
@@ -13,6 +13,7 @@ from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, VocabParallelEmbedding)
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import SupportsPP
 
 SQRT2 = 2**0.5
 
@@ -56,7 +57,7 @@ class MLPSpeculatorLayerNorm(nn.Module):
         return x
 
 
-class MLPSpeculator(nn.Module):
+class MLPSpeculator(nn.Module, SupportsPP):
     """
     An implementation of the speculative models introduced in
     "Accelerating Production LLMs with Combined Token/Embedding

--- a/vllm/spec_decode/batch_expansion.py
+++ b/vllm/spec_decode/batch_expansion.py
@@ -43,7 +43,7 @@ class BatchExpansionTop1Scorer(SpeculativeScorer):
         self,
         execute_model_req: ExecuteModelRequest,
         proposals: SpeculativeProposals,
-    ) -> Optional[SpeculativeScores]:
+    ) -> SpeculativeScores:
         """Score the proposed tokens via the scorer model.
 
         This converts each input sequence to a set of k+1 target sequences. The

--- a/vllm/spec_decode/draft_model_runner.py
+++ b/vllm/spec_decode/draft_model_runner.py
@@ -36,7 +36,7 @@ debug_advance_input = False
 allow_gpu_advance_step = True
 
 
-class TP1DraftModelRunner(ModelRunnerWrapperBase):
+class TP1PP1DraftModelRunner(ModelRunnerWrapperBase):
     """Specialized model runner for speculative decoding draft model.
     Since the draft model always execute k forward passes consecutively to
     generate k speculative tokens in a single speculative decoding step,

--- a/vllm/spec_decode/interfaces.py
+++ b/vllm/spec_decode/interfaces.py
@@ -94,5 +94,5 @@ class SpeculativeScorer(ABC):
         self,
         execute_model_req: ExecuteModelRequest,
         proposals: SpeculativeProposals,
-    ) -> SpeculativeScores:
+    ) -> Optional[SpeculativeScores]:
         raise NotImplementedError

--- a/vllm/spec_decode/interfaces.py
+++ b/vllm/spec_decode/interfaces.py
@@ -94,5 +94,5 @@ class SpeculativeScorer(ABC):
         self,
         execute_model_req: ExecuteModelRequest,
         proposals: SpeculativeProposals,
-    ) -> Optional[SpeculativeScores]:
+    ) -> SpeculativeScores:
         raise NotImplementedError

--- a/vllm/spec_decode/mqa_scorer.py
+++ b/vllm/spec_decode/mqa_scorer.py
@@ -69,7 +69,6 @@ class MQAScorer(SpeculativeScorer):
             execute_model_req=execute_model_req.clone(
                 seq_group_metadata_list=target_seq_group_metadata_list))
 
-        target_sampler_output = target_sampler_output[0]
         if get_pp_group().is_last_rank:
             assert len(
                 target_sampler_output) == 1, "expected single-step output"

--- a/vllm/spec_decode/mqa_scorer.py
+++ b/vllm/spec_decode/mqa_scorer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Optional
+
 from vllm.sequence import (ExecuteModelRequest, SequenceData,
                            SequenceGroupMetadata, get_all_seq_ids)
 from vllm.spec_decode.interfaces import (SpeculativeProposals,
@@ -15,7 +17,7 @@ class MQAScorer(SpeculativeScorer):
         self,
         execute_model_req: ExecuteModelRequest,
         proposals: SpeculativeProposals,
-    ) -> SpeculativeScores:
+    ) -> Optional[SpeculativeScores]:
         target_seq_group_metadata_list = []
         target_seq_id_start = max(
             get_all_seq_ids(execute_model_req.seq_group_metadata_list)) + 1
@@ -68,6 +70,8 @@ class MQAScorer(SpeculativeScorer):
                 seq_group_metadata_list=target_seq_group_metadata_list))
 
         target_sampler_output = target_sampler_output[0]
+        if target_sampler_output is None:
+            return None
 
         k = execute_model_req.num_lookahead_slots
         bs = len(execute_model_req.seq_group_metadata_list)

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -13,7 +13,7 @@ from vllm.sequence import (ExecuteModelRequest, HiddenStates, SequenceData,
                            SequenceGroupMetadata)
 
 if current_platform.is_cuda_alike():
-    from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
+    from vllm.spec_decode.draft_model_runner import TP1PP1DraftModelRunner
 
 from vllm.spec_decode.interfaces import (SpeculativeProposals,
                                          SpeculativeProposer)
@@ -81,7 +81,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
         # Run model sample_len times.
         model_outputs: List[SamplerOutput] = []
         if current_platform.is_cuda_alike() and isinstance(
-                self.model_runner, TP1DraftModelRunner
+                self.model_runner, TP1PP1DraftModelRunner
         ) and self.model_runner.supports_gpu_multi_step(expanded_request):
             # Here we run the draft_model_runner with multi-step prepare
             # on the GPU directly

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -975,7 +975,6 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
         accepted_token_ids[original_indices] = accepted_token_ids.clone()
 
         # B x K+1 x D
-        # if get_pp_group().is_last_rank:
         hidden_states = proposal_scores.hidden_states
         if hidden_states is not None:
             # Only get terminal hidden states for next step

--- a/vllm/spec_decode/target_model_runner.py
+++ b/vllm/spec_decode/target_model_runner.py
@@ -39,6 +39,7 @@ class TargetModelRunner(ModelRunnerWrapperBase):
         # CPU output. We directly serialize the GPU sampled_token_id tensors
         # as needed. If log probabilities is enabled then synchronize all the
         # sampling related tensors which includes the logprobs tensors.
-        model_input.sampling_metadata.skip_sampler_cpu_output = (
-            self.disable_logprobs)
+        if model_input.sampling_metadata is not None:
+            model_input.sampling_metadata.skip_sampler_cpu_output = (
+                self.disable_logprobs)
         return model_input

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -2038,7 +2038,8 @@ class CUDAGraphRunner(nn.Module):
             self.model.copy_inputs_before_cuda_graphs(self.input_buffers,
                                                       **kwargs)
 
-        if "previous_hidden_states" in self.input_buffers:
+        if "previous_hidden_states" in self.input_buffers and \
+                "previous_hidden_states" in kwargs:
             self.input_buffers["previous_hidden_states"].copy_(
                 kwargs["previous_hidden_states"], non_blocking=True)
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -312,11 +312,11 @@ class Worker(LocalOrDistributedWorkerBase):
         self.cache_engine = [
             CacheEngine(self.cache_config, self.model_config,
                         self.parallel_config, self.device_config)
-            for _ in range(self.parallel_config.pipeline_parallel_size)
+            for _ in range(self.parallel_config.virtual_engine_size)
         ]
         self.gpu_cache = [
             self.cache_engine[ve].gpu_cache
-            for ve in range(self.parallel_config.pipeline_parallel_size)
+            for ve in range(self.parallel_config.virtual_engine_size)
         ]
         bind_kv_cache(self.compilation_config.static_forward_context,
                       self.gpu_cache)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -312,11 +312,11 @@ class Worker(LocalOrDistributedWorkerBase):
         self.cache_engine = [
             CacheEngine(self.cache_config, self.model_config,
                         self.parallel_config, self.device_config)
-            for _ in range(self.parallel_config.virtual_engine_size)
+            for _ in range(self.parallel_config.num_virtual_engine)
         ]
         self.gpu_cache = [
             self.cache_engine[ve].gpu_cache
-            for ve in range(self.parallel_config.virtual_engine_size)
+            for ve in range(self.parallel_config.num_virtual_engine)
         ]
         bind_kv_cache(self.compilation_config.static_forward_context,
                       self.gpu_cache)


### PR DESCRIPTION
This PR aims to make speculative decoding compatible with pipeline parallelism.

- Introducing speculative_draft_pipeline_parallel_size config, allowing draft model to run with pp size different from target model (For eagle, support tp=1 and pp=1 only).
- Introduce num_virtual_engine config. Currently the number of virtual_engine is the same as pipeline_parallel_size, in the case of draft pipeline_parallel_size is different from target pipeline_parallel_size, it will causes error. Therefore, adding num_virtual_engine config, this value will be the same as target pipeline_parallel_size.
- Run draft model to get proposals only on pp stage 0, and broadcast proposals to the other pp stages.
- Target model will be processed using the existing WorkerBase, the first n layers processed on the first pipeline stage, then send the intermediate result to the next stage, then the next stage process the next n layers and so on.


Sample commands:

* eagle
```
vllm serve unsloth/llama-3-8b-Instruct \
    --tensor-parallel-size 2 \
    --pipeline-parallel-size 2 \
    --speculative_config '{"model": "yuhuili/EAGLE-LLaMA3-Instruct-8B", "num_speculative_tokens": 3, "draft_tensor_parallel_size": 1, "draft_pipeline_parallel_size": 1}' \
    --gpu-memory-utilization 0.85
```
* mlp
```
vllm serve unsloth/llama-3-8b-Instruct \
    --tensor-parallel-size 2 \
    --pipeline-parallel-size 2 \
    --speculative_config '{"model": "ibm-ai-platform/llama3-8b-accelerator", "num_speculative_tokens": 3, "draft_tensor_parallel_size": 1, "draft_pipeline_parallel_size": 1}' \
    --gpu-memory-utilization 0.85
```
* medusa
```
vllm serve JackFram/llama-68m \
    --tensor-parallel-size 2 \
    --pipeline-parallel-size 2 \
    --speculative_config '{"model": "abhigoyal/vllm-medusa-llama-68m-random", "num_speculative_tokens": 3, "draft_tensor_parallel_size": 1, "draft_pipeline_parallel_size": 1}'
```

## Benchmark

We benchmarked deepseek-ai/DeepSeek-R1 model with a private eagle model in a 2-node cluster. With pipeline parallel enabled (tp=8, pp=2), there's more than 30% tps improvement compared with baseline (tp=16, pp=1).

* Instances: p5e.48xlarge (x2)
* Target model: deepseek-ai/DeepSeek-R1
* Draft model: eagle

<img width="1022" alt="Screenshot 2025-04-02 at 1 41 50 PM" src="https://github.com/user-attachments/assets/ef731f50-97ab-4e00-95c6-8467d5e07d5a" />

cc @LiuXiaoxuanPKU @comaniac Would appreciate your review. Thanks!

<!--- pyml disable-next-line no-emphasis-as-heading -->
