### PR TITLE
[CI/Build] LoRA : make add_lora_test safer

### DIFF
--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -13,7 +13,7 @@ from vllm.utils import merge_async_iterators
 
 MODEL_PATH = "THUDM/chatglm3-6b"
 LORA_RANK = 64
-DEFAULT_MAX_LORAS = 16 * 3
+DEFAULT_MAX_LORAS = 4 * 3
 
 
 @pytest.fixture(autouse=True)

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -14,12 +14,12 @@ from vllm.sampling_params import SamplingParams
 from vllm.utils import merge_async_iterators
 
 MODEL_PATH = "meta-llama/Llama-2-7b-hf"
-LORA_MODULE_DOWNLOAD_PATH = None  # Populated by download_and_prepare_lora_module() #noqa
+LORA_MODULE_HF_PATH = "yard1/llama-2-7b-sql-lora-test"
 LORA_RANK = 8
 DEFAULT_MAX_LORAS = 16 * 3
 
 
-def download_and_prepare_lora_module():
+def download_and_prepare_lora_module() -> Path:
     """
     Request submission is expensive when the LoRA adapters have their own
     tokenizers. This is because, for each request with a new LoRA adapter ID,
@@ -29,19 +29,26 @@ def download_and_prepare_lora_module():
     minimize any extra activity. To this effect, we download the LoRA
     adapter and remove all the tokenizer files, so the engine will default
     to the base model tokenizer.
-    """
-    global LORA_MODULE_DOWNLOAD_PATH
 
-    LORA_MODULE_HF_PATH = "yard1/llama-2-7b-sql-lora-test"
-    LORA_MODULE_DOWNLOAD_PATH = snapshot_download(repo_id=LORA_MODULE_HF_PATH)
+    Returns the path to the downloaded LoRA module.
+    """
+    # So we don't disturb the model cache that other tests might be using.
+    local_download_dir = Path(f"./{LORA_MODULE_HF_PATH.replace('/', '-')}")
+    local_lora_path = Path(
+        snapshot_download(repo_id=LORA_MODULE_HF_PATH,
+                          local_dir=local_download_dir))
+    assert local_lora_path.name == local_download_dir.name
+    print(f"{LORA_MODULE_HF_PATH} download dir : {local_lora_path}")
 
     tokenizer_files = [
         'added_tokens.json', 'tokenizer_config.json', 'tokenizer.json',
         'tokenizer.model'
     ]
     for tokenizer_file in tokenizer_files:
-        del_path = Path(LORA_MODULE_DOWNLOAD_PATH) / tokenizer_file
+        del_path = local_lora_path / tokenizer_file
         del_path.unlink(missing_ok=True)
+
+    return local_lora_path
 
 
 @pytest.fixture(autouse=True)
@@ -52,11 +59,9 @@ def v1(run_with_both_engines_lora):
     pass
 
 
-def get_lora_requests() -> list[LoRARequest]:
+def get_lora_requests(local_lora_path: str) -> list[LoRARequest]:
     lora_requests: list[LoRARequest] = [
-        LoRARequest(lora_name=f"{i}",
-                    lora_int_id=i,
-                    lora_path=LORA_MODULE_DOWNLOAD_PATH)
+        LoRARequest(lora_name=f"{i}", lora_int_id=i, lora_path=local_lora_path)
         for i in range(1, DEFAULT_MAX_LORAS + 1)
     ]
     return lora_requests
@@ -104,9 +109,9 @@ async def test_add_lora():
     to be lesser in the case with add_lora() calls.
     """
 
-    download_and_prepare_lora_module()
+    local_lora_path: Path = download_and_prepare_lora_module()
 
-    lora_requests: list[LoRARequest] = get_lora_requests()
+    lora_requests: list[LoRARequest] = get_lora_requests(str(local_lora_path))
 
     max_loras = len(set([lr.lora_int_id for lr in lora_requests]))
     # Create engine in eager-mode. Due to high max_loras, the CI can

--- a/tests/lora/test_add_lora.py
+++ b/tests/lora/test_add_lora.py
@@ -33,7 +33,7 @@ def download_and_prepare_lora_module() -> Path:
     Returns the path to the downloaded LoRA module.
     """
     # So we don't disturb the model cache that other tests might be using.
-    local_download_dir = Path(f"./{LORA_MODULE_HF_PATH.replace('/', '-')}")
+    local_download_dir = Path(f"/tmp/{LORA_MODULE_HF_PATH.replace('/', '-')}")
     local_lora_path = Path(
         snapshot_download(repo_id=LORA_MODULE_HF_PATH,
                           local_dir=local_download_dir))


### PR DESCRIPTION
Prevent `add_lora_test` from messing with the HF_CACHE.
This PR simply uses a different LoRA module that doesn't need modifications to the LoRA files.