### PR TITLE
[SpecDecode] Make spec decoding extensible to different backends

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -26,6 +26,7 @@ from vllm.attention.utils.fa_utils import (flash_attn_supports_fp8,
                                            get_flash_attn_version)
 from vllm.logger import init_logger
 from vllm.multimodal import MultiModalPlaceholderMap
+from vllm.spec_decode.util import register_spec_decode
 from vllm.utils import async_tensor_h2d, make_tensor_with_pad
 from vllm.vllm_flash_attn import (flash_attn_varlen_func,
                                   flash_attn_with_kvcache)
@@ -101,6 +102,7 @@ class FlashAttentionBackend(AttentionBackend):
 
 
 @dataclass
+@register_spec_decode
 class FlashAttentionMetadata(AttentionMetadata):
     """Metadata for FlashAttentionBackend.
 

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -19,6 +19,7 @@ from vllm.attention.ops.paged_attn import (PagedAttention,
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.platforms.rocm import use_rocm_custom_paged_attention
+from vllm.spec_decode.util import register_spec_decode
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner import ModelInputForGPUWithSamplingMetadata
@@ -106,6 +107,7 @@ class ROCmFlashAttentionBackend(AttentionBackend):
 
 
 @dataclass
+@register_spec_decode
 class ROCmFlashAttentionMetadata(AttentionMetadata, PagedAttentionMetadata):
     """Metadata for FlashAttentionBackend.
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -310,6 +310,10 @@ class CudaPlatformBase(Platform):
     def use_custom_allreduce(cls) -> bool:
         return True
 
+    @classmethod
+    def supports_spec_decoding(cls) -> bool:
+        return True
+
 
 # NVML utils
 # Note that NVML is not affected by `CUDA_VISIBLE_DEVICES`,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -478,6 +478,12 @@ class Platform:
         """
         raise NotImplementedError
 
+    @classmethod
+    def supports_spec_decoding(cls) -> bool:
+        """Returns whether the current platform can support speculative decode.
+        """
+        return False
+
 
 class UnspecifiedPlatform(Platform):
     _enum = PlatformEnum.UNSPECIFIED

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -362,3 +362,6 @@ class RocmPlatform(Platform):
     def get_cu_count(cls, device_id: int = 0) -> int:
         return torch.cuda.get_device_properties(
             device_id).multi_processor_count
+
+    def supports_spec_decoding(cls) -> bool:
+        return True

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -363,5 +363,6 @@ class RocmPlatform(Platform):
         return torch.cuda.get_device_properties(
             device_id).multi_processor_count
 
+    @classmethod
     def supports_spec_decoding(cls) -> bool:
         return True

--- a/vllm/spec_decode/multi_step_worker.py
+++ b/vllm/spec_decode/multi_step_worker.py
@@ -84,7 +84,7 @@ class MultiStepWorker(ProposerWorkerBase, DelegateWorkerBase):
 
         # Run model sample_len times.
         model_outputs: List[SamplerOutput] = []
-        if current_platform.is_cuda_alike() and isinstance(
+        if current_platform.supports_spec_decoding() and isinstance(
                 self.model_runner, TP1DraftModelRunner
         ) and self.model_runner.supports_gpu_multi_step(expanded_request):
             # Here we run the draft_model_runner with multi-step prepare

--- a/vllm/spec_decode/spec_decode_worker.py
+++ b/vllm/spec_decode/spec_decode_worker.py
@@ -26,10 +26,7 @@ from vllm.sequence import (VLLM_INVALID_TOKEN_ID,
                            HiddenStates, SequenceGroupMetadata,
                            get_all_seq_ids_and_request_ids)
 from vllm.spec_decode.batch_expansion import BatchExpansionTop1Scorer
-
-if current_platform.is_cuda_alike():
-    from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
-
+from vllm.spec_decode.draft_model_runner import TP1DraftModelRunner
 from vllm.spec_decode.interfaces import (SpeculativeProposals,
                                          SpeculativeScorer, SpeculativeScores)
 from vllm.spec_decode.medusa_worker import MedusaWorker
@@ -183,7 +180,7 @@ class SpecDecodeWorker(LoRANotSupportedWorkerBase):
                 proposer_worker = MedusaWorker(**draft_worker_kwargs)
             else:
                 if draft_tp == 1:
-                    if current_platform.is_cuda_alike():
+                    if current_platform.supports_spec_decoding():
                         draft_worker_kwargs[
                             "model_runner_cls"] = TP1DraftModelRunner
                 else:

--- a/vllm/spec_decode/util.py
+++ b/vllm/spec_decode/util.py
@@ -14,6 +14,16 @@ from vllm.sequence import (CompletionSequenceGroupOutput, Logprob,
 
 SeqId = int
 
+SUPPORTED_SPEC_DECODING_ATTENTION_METADATA = set()
+
+
+def register_spec_decode(cls):
+    """
+    Register an AttentionMetadata subclass that supports speculative decoding
+    """
+    SUPPORTED_SPEC_DECODING_ATTENTION_METADATA.add(cls)
+    return cls
+
 
 def get_all_num_logprobs(
         seq_group_metadata_list: List[SequenceGroupMetadata]) -> List[int]:


### PR DESCRIPTION
This PR implements a registration method of the attention backend that supports spec decoding, making spec decoding extensible to different backends.

When any attention backends support spec decoding, 
- before this pr, because of the cuda-like and `FlashAttention` hard code, they need to implement `spec_decode_worker.py` and `draft_model_runner.py` with lots of duplicate code

- after this pr, they should only needs to do 2 steps:
![image](https://github.com/user-attachments/assets/c81fbfa3-1a9a-455e-809e-b75fcd192313)