### PR TITLE
Support multicard for Disaggregated Prefill/Decode and provide a automatic benchmark test

### DIFF
--- a/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
+++ b/.buildkite/nightly-benchmarks/scripts/convert-results-json-to-markdown.py
@@ -183,8 +183,10 @@ if __name__ == "__main__":
 
         # The GPUs sometimes come in format of "GPUTYPE\nGPUTYPE\n...",
         # we want to turn it into "8xGPUTYPE"
-        df["GPU"] = df["GPU"].apply(
-            lambda x: f"{len(x.split('\n'))}x{x.split('\n')[0]}")
+        def format_gpu(x):
+            parts = x.split('\n')
+            return f"{len(parts)}x{parts[0]}"
+        df["GPU"] = df["GPU"].apply(format_gpu)
 
     # get markdown tables
     latency_md_table = tabulate(latency_results,

--- a/benchmarks/disagg_benchmarks/auto_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/auto_prefill_proxy_server.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import argparse
+import itertools
+import aiohttp
+from quart import Quart, make_response, request
+
+AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
+
+app = Quart(__name__)
+
+# 解析命令行参数
+parser = argparse.ArgumentParser(description="Disaggregated Prefill Proxy Server")
+parser.add_argument("--p_ports", nargs="+", type=int, required=True, help="List of producer ports")
+parser.add_argument("--d_ports", nargs="+", type=int, required=True, help="List of consumer ports")
+parser.add_argument("--proxy_port", type=int, default=8000, help="Proxy server port")
+args = parser.parse_args()
+
+request_serial = 0
+p_ports = args.p_ports
+d_ports = args.d_ports
+proxy_port = args.proxy_port
+
+d_urls = []
+max_burst = 32
+for port in d_ports:
+    for _ in range(max_burst):
+        d_urls.append(f"localhost:{port}")
+
+port_cycle = itertools.cycle(d_urls)
+
+warm = False
+
+async def forward_request(url, data):
+    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+        headers = {
+            "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"
+        }
+        async with session.post(url=url, json=data,
+                                headers=headers) as response:
+            if response.status == 200:
+                # if response.headers.get('Transfer-Encoding') == 'chunked':
+                if True:
+                    async for chunk_bytes in response.content.iter_chunked(
+                            1024):
+                        yield chunk_bytes
+                else:
+                    content = await response.read()
+                    yield content
+
+
+@app.route('/v1/completions', methods=['POST'])
+async def handle_request():
+    try:
+        original_request_data = await request.get_json()
+        prefill_request = original_request_data.copy()
+        # change max_tokens = 1 to let it only do prefill
+        prefill_request['max_tokens'] = 1
+        async for _ in forward_request(f'http://localhost:{p_ports[0]}/v1/completions',
+                                       prefill_request):
+            continue
+        url = next(port_cycle)
+        generator = forward_request(f'http://{url}/v1/completions',
+                                original_request_data)
+        response = await make_response(generator)
+        response.timeout = None
+
+        return response
+
+    except Exception as e:
+        import sys
+        import traceback
+        exc_info = sys.exc_info()
+        print("Error occurred in disagg prefill proxy server")
+        print(e)
+        print("".join(traceback.format_exception(*exc_info)))
+
+
+if __name__ == '__main__':
+    app.run(port=args.proxy_port)

--- a/benchmarks/disagg_benchmarks/auto_prefill_proxy_server.py
+++ b/benchmarks/disagg_benchmarks/auto_prefill_proxy_server.py
@@ -11,10 +11,14 @@ AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 app = Quart(__name__)
 
 # 解析命令行参数
-parser = argparse.ArgumentParser(description="Disaggregated Prefill Proxy Server")
-parser.add_argument("--p_ports", nargs="+", type=int, required=True, help="List of producer ports")
-parser.add_argument("--d_ports", nargs="+", type=int, required=True, help="List of consumer ports")
-parser.add_argument("--proxy_port", type=int, default=8000, help="Proxy server port")
+parser = argparse.ArgumentParser(
+    description="Disaggregated Prefill Proxy Server")
+parser.add_argument("--p_ports", nargs="+", type=int, required=True,
+                    help="List of producer ports")
+parser.add_argument("--d_ports", nargs="+", type=int, required=True,
+                    help="List of consumer ports")
+parser.add_argument("--proxy_port", type=int, default=8000,
+                    help="Proxy server port")
 args = parser.parse_args()
 
 request_serial = 0

--- a/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
+++ b/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
@@ -59,12 +59,13 @@ async def main(ports, proxy_port):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Round Robin Proxy Server")
-    parser.add_argument("--ports", nargs="+", type=int, required=True, help="List of target ports")
-    parser.add_argument("--proxy_port", type=int, default=8001, help="Proxy server port")
+    parser.add_argument("--ports", nargs="+", type=int, required=True,
+                        help="List of target ports")
+    parser.add_argument("--proxy_port", type=int, default=8001,
+                        help="Proxy server port")
     args = parser.parse_args()
 
     try:
-        args = parser.parse_args()
         asyncio.run(main(args.ports, args.proxy_port))
     except Exception as e:
         print(f"An error occurred: {str(e)}")

--- a/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
+++ b/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import itertools
+import argparse
+import aiohttp
+from aiohttp import web
+
+
+class RoundRobinProxy:
+
+    def __init__(self, target_ports):
+        self.target_ports = target_ports
+        self.port_cycle = itertools.cycle(self.target_ports)
+
+    async def handle_request(self, request):
+        target_port = next(self.port_cycle)
+        target_url = f"http://localhost:{target_port}{request.path_qs}"
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                # Forward the request
+                async with session.request(
+                        method=request.method,
+                        url=target_url,
+                        headers=request.headers,
+                        data=request.content,
+                ) as response:
+                    # Start sending the response
+                    resp = web.StreamResponse(status=response.status,
+                                              headers=response.headers)
+                    await resp.prepare(request)
+
+                    # Stream the response content
+                    async for chunk in response.content.iter_any():
+                        await resp.write(chunk)
+
+                    await resp.write_eof()
+                    return resp
+
+            except Exception as e:
+                return web.Response(text=f"Error: {str(e)}", status=500)
+
+async def main(ports, proxy_port):
+    proxy = RoundRobinProxy(ports)
+    # proxy = RoundRobinProxy([28100]*25+[28200]*25+[28300]*25+[28000])
+    app = web.Application()
+    app.router.add_route('*', '/{path:.*}', proxy.handle_request)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, 'localhost', proxy_port)
+    await site.start()
+
+    print(f"Proxy server started on http://localhost:{proxy_port}")
+
+    # Keep the server running
+    await asyncio.Event().wait()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Round Robin Proxy Server")
+    parser.add_argument("--ports", nargs="+", type=int, required=True, help="List of target ports")
+    parser.add_argument("--proxy_port", type=int, default=8001, help="Proxy server port")
+    args = parser.parse_args()
+
+    asyncio.run(main(args.ports, args.proxy_port))

--- a/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
+++ b/benchmarks/disagg_benchmarks/auto_round_robin_proxy.py
@@ -63,4 +63,8 @@ if __name__ == '__main__':
     parser.add_argument("--proxy_port", type=int, default=8001, help="Proxy server port")
     args = parser.parse_args()
 
-    asyncio.run(main(args.ports, args.proxy_port))
+    try:
+        args = parser.parse_args()
+        asyncio.run(main(args.ports, args.proxy_port))
+    except Exception as e:
+        print(f"An error occurred: {str(e)}")

--- a/benchmarks/disagg_benchmarks/automatic_performance_benchmark.sh
+++ b/benchmarks/disagg_benchmarks/automatic_performance_benchmark.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+
+# License: This script is provided for managing vLLM servers. It automates the process of starting servers
+# with specific configurations and running benchmarks with loop. 
+# It supports starting multi chunked/prefill/decode backend on different cards.
+
+# Functionality Description:
+# This script is designed to manage the operation of servers using vLLM, with support for different configurations
+# such as "chunked" and "disaggregated". It sets up specific hardware configurations for different tasks
+# (e.g., Prefill, Decode) and manages their power limits. Additionally, it checks for open ports, waits for server
+# readiness, and starts proxy servers. Benchmarks are then executed based on various input parameters.
+# The script is used to launch servers, execute tests, and record the results.
+
+# Set script to exit automatically if an error occurs
+set -e
+
+RUN_LOG_DIR="./log"
+mkdir -p "$RUN_LOG_DIR"
+
+c_cards=(0 1) # Specify the cards used for non-P/D separation
+p_cards=(0)   # Specify the cards used for Prefill
+d_cards=(1 2) # Specify the cards used for Decode
+
+methods=("chunked" "disagg")
+inputs=(128 256 512 1024 2048)
+outputs=(128 256 512 1024 2048)
+prompts=(10 40 70 100 128 256 512)
+request_rates=("inf")
+
+# Check if a port is open on localhost
+check_port() {
+    local port=$1
+    if nc -z localhost $port; then
+        echo "Port $port is already in use. Exiting."
+        exit 1
+    fi
+}
+
+# Wait for a server to be ready on a specified port
+wait_for_server() {
+    local port=$1
+    local timeout=300
+    local start_time=$(date +%s)
+    while ! nc -z localhost $port; do
+        sleep 1
+        local current_time=$(date +%s)
+        if ((current_time - start_time > timeout)); then
+            echo "Timeout waiting for server on port $port. Exiting."
+            exit 1
+        fi
+    done
+}
+
+# Check if a port is open with a timeout
+check_port_open() {
+    local port=$1
+    if nc -z -w 1 localhost $port; then
+        return 0  # Port is open
+    else
+        return 1  # Port is not open
+    fi
+}
+
+# Set the NVIDIA GPU power limit
+set_nvidia_power_limit() {
+    local card=$1
+    local limit=$2
+    if [ "$limit" -eq 1 ]; then
+        sudo nvidia-smi -i "$card" -lgc 525,525
+    else
+        sudo nvidia-smi -i "$card" -rgc
+    fi
+}
+
+# Start chunked server setup
+start_chunked() {
+    pkill -9 python3 || echo "No python3 processes to kill."
+    sleep 1
+
+    local ports=()
+
+    for ((i = 0; i < ${#c_cards[@]}; i++)); do
+        local card=${c_cards[i]}
+
+        start_port=18000
+        port=$((start_port + i))
+        ports+=("$port")
+        
+        CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
+            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --port "$port" \
+            --max-model-len 4096 \
+            --trust-remote-code \
+            > "$RUN_LOG_DIR/vllm_server_chunked_${card}.log" 2>&1 &
+
+        echo "Started chunked server on card $card with port $port"
+    done
+
+    echo -n "Waiting for vLLM servers..."
+    for port in ${ports[@]}; do 
+        wait_for_server "$port"
+    done
+    echo " All vLLM servers ready."
+
+    # Start proxy server
+    echo "Starting proxy server..."
+    python3 ./auto_round_robin_proxy.py --ports "${ports[@]}" --proxy_port 8001 & 
+    proxy_pid=$!
+
+    # Wait for proxy server to be ready
+    echo -n "Waiting for proxy server..."
+    wait_for_server 8001
+    echo " Proxy ready (PID: $proxy_pid)"
+
+    # Check if proxy server started successfully
+    if ! nc -z localhost 8001; then
+        echo "Proxy server failed to start on port 8001"
+        return 1  # Return failure
+    fi
+
+    return 0  # Return success
+}
+
+# Start disaggregated server setup
+start_disagg() {
+    pkill -9 python3 || echo "No python3 processes to kill."
+    sleep 1
+
+    p_num=${#p_cards[@]}
+    d_num=${#d_cards[@]}
+    kv_parallel_size=$((p_num + d_num))
+
+    local start_port_p=18000  # Starting port for p_cards
+    local start_port_d=19000  # Starting port for d_cards
+
+    for ((i = 0; i < ${#p_cards[@]}; i++)); do
+        local card=${p_cards[i]}
+        p_port=$((start_port_p + i))
+        p_ports+=("$p_port")
+
+        kv_transfer_config=$(jq -n \
+        --arg kv_connector "TelecclConnector" \
+        --arg kv_role "kv_producer" \
+        --arg kv_rank "$i" \
+        --arg kv_parallel_size "$kv_parallel_size" \
+        --arg kv_buffer_size "5e9" \
+        '{kv_connector: $kv_connector, kv_role: $kv_role, kv_rank: ($kv_rank | tonumber), kv_parallel_size: ($kv_parallel_size | tonumber), kv_buffer_size: ($kv_buffer_size | tonumber)}')
+            
+        CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
+            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --port "$p_port" \
+            --max-model-len 4096 \
+            --trust-remote-code \
+            --kv-transfer-config "$kv_transfer_config" \
+            > "$RUN_LOG_DIR/vllm_server_prefill_${card}.log" 2>&1 &
+
+        echo "Started server on card $card with port $p_port"
+    done
+
+    for ((i = 0; i < ${#d_cards[@]}; i++)); do
+        local card=${d_cards[i]}
+        d_port=$((start_port_d + i))
+        d_ports+=("$d_port")
+
+        kv_rank=$(( ${#p_cards[@]} + i ))
+        kv_transfer_config=$(jq -n \
+        --arg kv_connector "TelecclConnector" \
+        --arg kv_role "kv_consumer" \
+        --arg kv_rank "$kv_rank" \
+        --arg kv_parallel_size "$kv_parallel_size" \
+        --arg kv_buffer_size "5e9" \
+        '{kv_connector: $kv_connector, kv_role: $kv_role, kv_rank: ($kv_rank | tonumber), kv_parallel_size: ($kv_parallel_size | tonumber), kv_buffer_size: ($kv_buffer_size | tonumber)}')
+        
+        CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
+            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --port "$d_port" \
+            --max-model-len 4096 \
+            --trust-remote-code \
+            --kv-transfer-config "$kv_transfer_config" \
+            > "$RUN_LOG_DIR/vllm_server_decode_${card}.log" 2>&1 &
+
+        echo "Started server on card $card with port $d_port"
+    done
+
+    echo -n "Waiting for vLLM servers..."
+    for port in "${p_ports[@]}" "${d_ports[@]}"; do 
+        wait_for_server "$port"
+    done
+    echo " All vLLM servers ready."
+
+    # Start proxy server
+    echo "Starting proxy server..."
+    python3 ./auto_disagg_prefill_proxy_server.py --p_ports "${p_ports[@]}" --d_ports "${d_ports[@]}" --proxy_port 8000 & 
+    proxy_pid=$!
+
+    # Wait for proxy server to be ready
+    echo -n "Waiting for proxy server..."
+    wait_for_server 8000
+    echo " Proxy ready (PID: $proxy_pid)"    
+    
+    # Check if proxy server started successfully
+    if ! nc -z localhost 8000; then
+        echo "Proxy server failed to start on port 8000"
+        return 1  # Return failure
+    fi
+
+    return 0  # Return success
+}
+
+# Run the Python benchmarking script
+run_python_script() {
+    local method=$1
+    local input=$2
+    local output=$3
+    local prompts=$4
+    local request_rate=$5
+    local run_log_dir=$6
+    local limit=$7
+
+    local -n c_cards_ref=$8
+    local -n p_cards_ref=$9
+    local -n d_cards_ref=$10
+
+    if [[ "$method" == "chunked" ]]; then
+        local port=8001
+        local c_num=${#c_cards_ref[@]}
+        result_filename=${method}_${c_num}c_limit${limit}_in${input}_out${output}_${prompts}prompts_${request_rate}rate.json
+    elif [[ "$method" == "disagg" ]]; then
+        local port=8000
+        local p_num=${#p_cards_ref[@]}
+        local d_num=${#d_cards_ref[@]}
+        result_filename=${method}_${p_num}p${d_num}d_limit${limit}_in${input}_out${output}_${prompts}prompts_${request_rate}rate.json
+    else
+        echo "Unknown Method: $method"
+    fi
+
+    python3 /workspace/deepseek/zer/vllm/benchmarks/benchmark_serving.py \
+        --backend vllm \
+        --model /workspace/deepseek/zer/DeepSeek-V2-Lite/ \
+        --dataset-name "sonnet" \
+        --dataset-path "/workspace/deepseek/zer/vllm/benchmarks/sonnet_4x.txt" \
+        --sonnet-input-len "$input" \
+        --sonnet-output-len "$output" \
+        --sonnet-prefix-len 22 \
+        --num-prompts "$prompts" \
+        --port "$port" \
+        --request-rate "$request_rate" \
+        --save-result \
+        --result-dir "$run_log_dir" \
+        --result-filename "$result_filename"
+}
+
+# Terminate all python3 processes
+pkill -9 python3 || echo "No python3 processes to kill."
+sleep 1
+
+for method in "${methods[@]}"; do
+    for input in "${inputs[@]}"; do
+        for output in "${outputs[@]}"; do
+            for prompts in "${prompts[@]}"; do
+                for request_rate in "${request_rates[@]}"; do
+                    if [ "$method" == "chunked" ]; then
+                        if ! check_port_open 8001; then
+                            echo "Port 8001 is not open. Starting."
+                            if ! start_chunked; then
+                                echo "Failed to start chunked servers. Exiting."
+                                exit 1
+                            fi
+                        fi
+                        for limit in 0 1; do
+                            for card in "${c_cards[@]}"; do
+                                set_nvidia_power_limit "$card" "$limit"
+                            done
+                            run_python_script "$method" "$input" "$output" "$prompts" "$request_rate" "$RUN_LOG_DIR" "$limit" c_cards p_cards d_cards
+                        done
+                    elif [ "$method" == "disagg" ]; then
+                        if ! check_port_open "8000"; then
+                            echo "Port 8000 is not open. Starting."
+                            if ! start_disagg; then
+                                echo "Failed to start disagg servers. Exiting."
+                                exit 1
+                            fi
+                        fi
+                        for limit in 1; do
+                            for card in "${p_cards[@]}"; do
+                                set_nvidia_power_limit "$card" 0
+                            done
+                            for card in "${d_cards[@]}"; do
+                                set_nvidia_power_limit "$card" "$limit"
+                            done
+                            run_python_script "$method" "$input" "$output" "$prompts" "$request_rate" "$RUN_LOG_DIR" "$limit" c_cards p_cards d_cards
+                        done
+                    else
+                        echo "unknown method"
+                    fi
+                done
+            done
+        done
+    done
+done

--- a/benchmarks/disagg_benchmarks/automatic_performance_benchmark.sh
+++ b/benchmarks/disagg_benchmarks/automatic_performance_benchmark.sh
@@ -87,7 +87,7 @@ start_chunked() {
         ports+=("$port")
         
         CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
-            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --model "meta-llama/Meta-Llama-3.1-8B-Instruct" \
             --port "$port" \
             --max-model-len 4096 \
             --trust-remote-code \
@@ -147,7 +147,7 @@ start_disagg() {
         '{kv_connector: $kv_connector, kv_role: $kv_role, kv_rank: ($kv_rank | tonumber), kv_parallel_size: ($kv_parallel_size | tonumber), kv_buffer_size: ($kv_buffer_size | tonumber)}')
             
         CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
-            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --model "meta-llama/Meta-Llama-3.1-8B-Instruct" \
             --port "$p_port" \
             --max-model-len 4096 \
             --trust-remote-code \
@@ -172,7 +172,7 @@ start_disagg() {
         '{kv_connector: $kv_connector, kv_role: $kv_role, kv_rank: ($kv_rank | tonumber), kv_parallel_size: ($kv_parallel_size | tonumber), kv_buffer_size: ($kv_buffer_size | tonumber)}')
         
         CUDA_VISIBLE_DEVICES="$card" python3 -m vllm.entrypoints.openai.api_server \
-            --model "/workspace/deepseek/zer/DeepSeek-V2-Lite/" \
+            --model "meta-llama/Meta-Llama-3.1-8B-Instruct" \
             --port "$d_port" \
             --max-model-len 4096 \
             --trust-remote-code \

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -279,7 +279,7 @@ _MULTIMODAL_EXAMPLE_MODELS = {
                                                          extras={"v2": "google/paligemma2-3b-ft-docci-448"}),  # noqa: E501
     "Phi3VForCausalLM": _HfExamplesInfo("microsoft/Phi-3-vision-128k-instruct",
                                         trust_remote_code=True,
-                                        extras={"phi3.5": "microsoft/Phi-3.5-vision-instruct"}),  # noqa: E501),
+                                        extras={"phi3.5": "microsoft/Phi-3.5-vision-instruct"}),  # noqa: E501
     "Phi4MMForCausalLM": _HfExamplesInfo("microsoft/Phi-4-multimodal-instruct",
                                         trust_remote_code=True),
     "PixtralForConditionalGeneration": _HfExamplesInfo("mistralai/Pixtral-12B-2409",  # noqa: E501


### PR DESCRIPTION
This change supports starting multi chunked/prefill/decode backend servers on different cards (but without actual parrallel), while currently vLLM only support 1p1d. The new benchmark shell script automates the process of starting servers with specific configurations and running benchmarks with loop in different params.


FIX #13004

<!--- pyml disable-next-line no-emphasis-as-heading -->
