### PR TITLE
[Bugfix] detect alibi and revert to FA2

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -630,7 +630,8 @@ class FlashAttentionImpl(AttentionImpl):
         self.sliding_window = ((sliding_window - 1,
                                 0) if sliding_window is not None else (-1, -1))
         self.kv_cache_dtype = kv_cache_dtype
-        self.vllm_flash_attn_version = get_flash_attn_version()
+        self.vllm_flash_attn_version = get_flash_attn_version(
+            requires_alibi=self.alibi_slopes is not None)
         if (is_quantized_kv_cache(self.kv_cache_dtype)
                 and self.vllm_flash_attn_version != 3):
             raise NotImplementedError(

--- a/vllm/fa_utils.py
+++ b/vllm/fa_utils.py
@@ -7,7 +7,7 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
-def get_flash_attn_version() -> Optional[int]:
+def get_flash_attn_version(requires_alibi: bool = False) -> Optional[int]:
     # import here to avoid circular dependencies
     from vllm.platforms import current_platform
     try:
@@ -28,8 +28,14 @@ def get_flash_attn_version() -> Optional[int]:
 
         # 3. fallback for unsupported combinations
         if device_capability.major == 10 and fa_version == 3:
-            logger.warning("Cannot use FA version 3 on Blackwell platform",
-                           "defaulting to FA version 2.")
+            logger.warning_once(
+                "Cannot use FA version 3 on Blackwell platform "
+                "defaulting to FA version 2.")
+            fa_version = 2
+
+        if requires_alibi and fa_version == 3:
+            logger.warning_once("Cannot use FA version 3 with ALiBi, "
+                                "defaulting to FA version 2.")
             fa_version = 2
 
         if not is_fa_version_supported(fa_version):


### PR DESCRIPTION
On Hopper, Flash Attention 3 is enabled by default (since the v0.7.0 release), but FA3 does not support ALiBi positional encodings. This PR will revert to FA2 if alibi_slopes are passed in to `FlashAttentionBackend`.

In the v0.8.1 release, the error when attempting to use a model with FA3 with ALiBi (such as [bigscience/bloom-1b1](https://huggingface.co/bigscience/bloom-1b1)) is:
```
RuntimeError: If cu_seqlens_k is passed in, then page table is not supported
```

Now there is [change in vllm_flash_attn](https://github.com/vllm-project/flash-attention/pull/50/files#diff-30bbb250b1fdc0d0d0ada8e34377e835bbb92f4b48ca42807fe10524fe5a3730R199) that will raise an AssertionError if alibi is used with FA3. This improves the error message, but the server would still fail to come up. With this PR, vLLM will fall back to FA2 instead of erroring.

FIX #13810 

<!--- pyml disable-next-line no-emphasis-as-heading -->
