### PR TITLE
[V1][TPU] Speed up top-k on TPU by using torch.topk

### DIFF
--- a/tests/v1/tpu/test_sampler.py
+++ b/tests/v1/tpu/test_sampler.py
@@ -39,7 +39,7 @@ def test_sampler_compilation(model_name: str, monkeypatch):
         sampling_params = SamplingParams(
             temperature=0.7,
             # top_p=0.6, # TODO too slow!
-            # top_k=10,
+            top_k=10,
             min_p=0.2,
             max_tokens=16)
         s = time()
@@ -49,6 +49,7 @@ def test_sampler_compilation(model_name: str, monkeypatch):
         # Second request with different params, but for which we
         # compiled for in previous eager iteration.
         sampling_params = SamplingParams(temperature=0.1,
+                                         top_k=12,
                                          min_p=0.8,
                                          max_tokens=24)
         s = time()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
     VLLM_DP_MASTER_PORT: int = 0
     VLLM_MARLIN_USE_ATOMIC_ADD: bool = False
     VLLM_V0_USE_OUTLINES_CACHE: bool = False
+    VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION: bool = False
 
 
 def get_default_cache_root():
@@ -623,6 +624,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # an environment with potentially malicious users.
     "VLLM_V0_USE_OUTLINES_CACHE":
     lambda: os.environ.get("VLLM_V0_USE_OUTLINES_CACHE", "0") == "1",
+
+    # If set, disables TPU-specific optimization for top-k & top-p sampling
+    "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION":
+    lambda: bool(int(os.environ["VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION"]))
+    if "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION" in os.environ else None,
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
### TL;DR
Using `torch.topk` leads to significant speed up for top-k on TPU.

### Background / Baseline

#14227 added sampling support to TPU. Benchmark results (from #13982) showed that TPUv6 is about 38x slower than L4 GPU (507ms on TPU vs 13ms on L4 GPU for "Running 32 elapsed time").

### Improvement for TPU

Existing vllm v1 code uses discrete torch operations to implement top-k and top-p (e.g. sort and mask), see [apply_top_k_top_p](https://github.com/vllm-project/vllm/blob/b382a7f28f739f3b120e5495fd029089d0399428/vllm/v1/sample/ops/topk_topp_sampler.py#L83). This is somehow inefficient on TPU. Turns out for top-k, pytorch already has an existing API `torch.topk` and a corresponding [XLA lowering](https://github.com/pytorch/xla/blob/79d1e86b7e99dc055f30f3a69aa71471c16f8dfe/torch_xla/csrc/xla_lower_util.cpp#L360), and that seems to make things much faster.

### New top-k TPU benchmark (w/ `torch.topk`)

With the changes in this PR, benchmark result suggests a 250x speed up for top-k on TPU:

```
# Top-k sampling benchmark on TPU v6e-1. Note that top-p is disabled (set to None).

INFO 03-17 21:23:58 [__init__.py:256] Automatically detected platform tpu.
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
Compiling/Warmup 1 elapsed time: 1.2743589878082275
Compiling/Warmup 4 elapsed time: 0.9751193523406982
Compiling/Warmup 16 elapsed time: 1.5950334072113037
Compiling/Warmup 32 elapsed time: 1.5763509273529053
Running 1 elapsed time: 0.002122640609741211
Running 1 elapsed time: 0.001752614974975586
Running 1 elapsed time: 0.0017757415771484375
Running 1 elapsed time: 0.0017747879028320312
Running 4 elapsed time: 0.0017614364624023438
Running 4 elapsed time: 0.0017540454864501953
Running 4 elapsed time: 0.0017423629760742188
Running 4 elapsed time: 0.0017385482788085938
Running 16 elapsed time: 0.0018427371978759766
Running 16 elapsed time: 0.0018305778503417969
Running 16 elapsed time: 0.0018429756164550781
Running 16 elapsed time: 0.0018262863159179688
Running 32 elapsed time: 0.0019214153289794922
Running 32 elapsed time: 0.0019321441650390625
Running 32 elapsed time: 0.0019261837005615234
Running 32 elapsed time: 0.001947641372680664
```

Notice the ~250x reduction in “Running 32 elapsed time” (1.9 ms vs 507 ms previously per #13982).

### GPU benchmark with `torch.topk`

For completeness, I ran the same benchmark on H100 GPU, and observed similar runtime performance as on v6e-1:

```
# Top-k sampling benhmark on H100 GPU VM. Note that top-p is disabled (set to None).

INFO 03-18 20:45:15 [__init__.py:256] Automatically detected platform cuda.
WARNING 03-18 20:45:16 [topk_topp_sampler.py:63] FlashInfer is not available. Falling back to the PyTorch-native implementation of top-p & top-k sampling. For the best performance, please install FlashInfer.
Compiling/Warmup 1 elapsed time: 0.8188707828521729
Compiling/Warmup 4 elapsed time: 0.08226132392883301
Compiling/Warmup 16 elapsed time: 0.001528024673461914
Compiling/Warmup 32 elapsed time: 0.0015192031860351562
Running 1 elapsed time: 0.0011334419250488281
Running 1 elapsed time: 0.0010404586791992188
Running 1 elapsed time: 0.0010061264038085938
Running 1 elapsed time: 0.0009946823120117188
Running 4 elapsed time: 0.0011370182037353516
Running 4 elapsed time: 0.0011453628540039062
Running 4 elapsed time: 0.001129150390625
Running 4 elapsed time: 0.0011076927185058594
Running 16 elapsed time: 0.0011191368103027344
Running 16 elapsed time: 0.001134634017944336
Running 16 elapsed time: 0.001131296157836914
Running 16 elapsed time: 0.0011317729949951172
Running 32 elapsed time: 0.001157999038696289
Running 32 elapsed time: 0.0011749267578125
Running 32 elapsed time: 0.0011844635009765625
Running 32 elapsed time: 0.0011768341064453125
```

Notice the “Running 32 elapsed time” is 1.2 ms, in the same order of magnitude as TPU’s 1.9 ms.

### Conclusion
* Up to 250x speed-up for top-k was achieved for TPU by using `torch.topk` instead of vllm's discrete implementation.
* TPU (v6e-1) and GPU (H100) are at performance parity when using `torch.topk`.
