### PR TITLE
[ROCM] Upgrade torch to 2.6

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -1,10 +1,10 @@
 # Common dependencies
 -r common.txt
 
---extra-index-url https://download.pytorch.org/whl/rocm6.2
-torch==2.5.1
-torchvision==0.20.1
-torchaudio==2.5.1
+--extra-index-url https://download.pytorch.org/whl/rocm6.2.4
+torch==2.6.0
+torchvision==0.21.0
+torchaudio==2.6.0
 
 cmake>=3.26
 packaging


### PR DESCRIPTION
Now that we have the torch 2.6 upgrade finished, we can also move to torch 2.6 on ROCm. This PR just updates the torch version the `requirements/rocm-build.txt`

Here are the lm-eval results for `'meta-llama/Llama-3.1-8B-Instruct` running with V1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.794|±  |0.0181|
|     |       |strict-match    |     5|exact_match|↑  |0.774|±  |0.0187|
```

V0 Get's similar results

The unit testing situation is a bit complicated here. AFAIK the AMD CI runs with the docker container which is currently pinned to a 2.7 nightly. If there are any specific unit tests that would be good to run locally, please let me know.