### PR TITLE
[ROCm] Get rid of RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES

### DIFF
--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -43,6 +43,15 @@ try:
         lazily initialized after Ray sets CUDA_VISIBLE_DEVICES."""
 
         def __init__(self, *args, **kwargs) -> None:
+            # For ROCm: We need to get rid of ROCR/HIP_VISIBLE_DEVICES set
+            # by Ray, to avoid any conflicts when we set
+            # CUDA_VISIBLE_DEVICES later.
+            if current_platform.is_rocm():
+                if os.getenv("RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES") is None:
+                    os.environ.pop("ROCR_VISIBLE_DEVICES", None)
+                if os.getenv("RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES") is None:
+                    os.environ.pop("HIP_VISIBLE_DEVICES", None)
+
             super().__init__(*args, **kwargs)
             # Since the compiled DAG runs a main execution
             # in a different thread that calls cuda.set_device.


### PR DESCRIPTION
From v2.6.0, torch respects ROCR_VISIBLE_DEVICES on AMD GPU device discovery: https://github.com/pytorch/pytorch/pull/144026 So we no longer need always to set `RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES`, but we need to pop the `ROCR_VISIBLE_DEVICES` set by ray when we initialize `RayWorkerWrapper`, as we still use `CUDA_VISIBLE_DEVICES` for ROCm, setting both of them at the same time causes conflict.

In https://github.com/ray-project/ray/commit/3b9e729f6a669ffd85190f901f5e262af79771b0, Ray replaces AMD device env var with HIP_VISIBLE_DEVICES, so now we also need to pop the HIP_VISIBLE_DEVICES.

We also need to delay setting USE_ROWWISE_TORCH_SCALED_MM until the first time it is needed, as initially, when importing, CUDA_VISIBLE_DEVICES may not be set properly.
