### PR TITLE
[Bugfix][V0] Multi-sequence logprobs streaming edge case

### DIFF
--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -223,7 +223,11 @@ class RequestOutput:
             if delta:
                 # Slice logprobs delta if applicable
                 if output_logprobs:
-                    output_logprobs = output_logprobs[-num_output_tokens:]
+                    # Can happen when n > 0 and request finishes before the othere
+                    if num_output_tokens == 0:
+                        output_logprobs = None
+                    else:
+                        output_logprobs = output_logprobs[-num_output_tokens:]
                 # Don't include prompt if this is after the first output
                 # containing decode token ids
                 if include_prompt and seq.get_output_len() > num_output_tokens:

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -223,11 +223,12 @@ class RequestOutput:
             if delta:
                 # Slice logprobs delta if applicable
                 if output_logprobs:
-                    # Can happen when n > 0 and request finishes before the othere
-                    if num_output_tokens == 0:
-                        output_logprobs = None
-                    else:
+                    # num_output_tokens can be 0 when n > 1 and request finishes
+                    # before the others
+                    if num_output_tokens > 0:
                         output_logprobs = output_logprobs[-num_output_tokens:]
+                    else:
+                        output_logprobs = None
                 # Don't include prompt if this is after the first output
                 # containing decode token ids
                 if include_prompt and seq.get_output_len() > num_output_tokens:


### PR DESCRIPTION
There's a bug when using logprobs with multi-sequence with RequestOutputKind.DELTA. When a sequence finishes before the others, it's `output_token_ids` on the subsequent steps will be an empty array, until every sequence finishes. This cases an `[-0:]` slice into the logprobs array, which returns the entire logprobs array instead of the 0-length suffix.

Adding an if check to handle this edge case.