### PR TITLE
[Bugfix] Add int8 torch dtype for KVCache

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -153,6 +153,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8": torch.uint8,
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
+    "int8": torch.int8,
 }
 
 TORCH_DTYPE_TO_NUMPY_DTYPE = {


### PR DESCRIPTION
Some attention backend requires `int8` kvcache dtype (e.g., quantization). It is used in initialization of CacheConfig:

```python
if cache_config.cache_dtype == "auto":
    self.dtype = model_config.dtype
else:
    self.dtype = STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
```

But there are no `int8` dtype in `STR_DTYPE_TO_TORCH_DTYPE`:

```python
STR_DTYPE_TO_TORCH_DTYPE = {
    "half": torch.half,
    "bfloat16": torch.bfloat16,
    "float": torch.float,
    "fp8": torch.uint8,
    "fp8_e4m3": torch.uint8,
    "fp8_e5m2": torch.uint8,
}
```

So, I think maybe it's better to add `int8` into this `STR_DTYPE_TO_TORCH_DTYPE`.