### PR TITLE
[Misc] fix collect_env version parse

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -282,11 +282,18 @@ def get_vllm_version():
 
     if __version__ == "dev":
         return "N/A (dev)"
-
-    if len(__version_tuple__) == 4:  # dev build
-        git_sha = __version_tuple__[-1][1:]  # type: ignore
-        return f"{__version__} (git sha: {git_sha}"
-
+    version_str = __version_tuple__[-1]
+    if isinstance(version_str, str) and version_str.startswith('g'):
+        # it's a dev build
+        if '.' in version_str:
+            # it's a dev build containing local changes
+            git_sha = version_str.split('.')[0][1:]
+            date = version_str.split('.')[-1][1:]
+            return f"{__version__} (git sha: {git_sha}, date: {date})"
+        else:
+            # it's a dev build without local changes
+            git_sha = version_str[1:]  # type: ignore
+            return f"{__version__} (git sha: {git_sha})"
     return __version__
 
 


### PR DESCRIPTION
The version parse in `collect_env.py` is not correct. The `__version_tuple__` from `setuptools_scm` is a tuple like 
`(0,8,1)`, `(0,8,1,dev86,ge588ac237)` or `(0,8,1,dev86,ge588ac237+d20250321)`.  The length will never be 4. See: https://setuptools-scm.readthedocs.io/en/stable/usage/ which the length is not limited to 4.

We should pares the `__version_tuple__` in a correct way. With this PR, the version will be parsed into some result:
1. if `setuptools_scm` is not working, the result will be `N/A (dev)`
2. if vllm is a tagged version, the result will be `0.8.1`
3. if vllm is a dev version, the result will be `0.8.2.dev86+ge588ac237 (git_sha: e588ac237)`
4. if vllm is a dev version with local changes, the result will be `0.8.2.dev86+ge588ac237.d20250321 (git sha: e588ac237, date: 20250321)`