### PR TITLE
[Bugfix] Fix incorrect resolving order for transformers fallback

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -418,11 +418,13 @@ class _ModelRegistry:
         if not architectures:
             logger.warning("No model architectures are specified")
 
-        normalized_arch = []
-        for model in architectures:
-            if model not in self.models:
-                model = "TransformersModel"
-            normalized_arch.append(model)
+        # filter out support architectures
+        normalized_arch = list(
+            filter(lambda model: model in self.models, architectures))
+
+        # make sure Transformers fallback are put at the last
+        if len(normalized_arch) != len(architectures):
+            normalized_arch.append("TransformersModel")
         return normalized_arch
 
     def inspect_model_cls(


### PR DESCRIPTION

- Make sure transformers fallback are always resolved at last. (https://github.com/vllm-project/vllm/pull/15023#discussion_r2007002093)

<!--- pyml disable-next-line no-emphasis-as-heading -->
