### PR TITLE
[Bugfix] utils: no bool(module) & pid may be None

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1922,13 +1922,15 @@ def resolve_obj_by_qualname(qualname: str) -> Any:
     return getattr(module, obj_name)
 
 
-def kill_process_tree(pid: int):
+def kill_process_tree(pid: int | None):
     """
     Kills all descendant processes of the given pid by sending SIGKILL.
 
     Args:
         pid (int): Process ID of the parent process
     """
+    if pid is None:
+        pid = os.getpid()
     try:
         parent = psutil.Process(pid)
     except psutil.NoSuchProcess:

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -144,7 +144,7 @@ def shutdown(proc: multiprocessing.Process, input_path: str, output_path: str):
     ipc_sockets = [output_path, input_path]
     for ipc_socket in ipc_sockets:
         socket_file = ipc_socket.replace("ipc://", "")
-        if os and os.path.exists(socket_file):
+        if os.path.exists(socket_file):
             os.remove(socket_file)
 
 


### PR DESCRIPTION
simple fix based on type analysis

1. `if os and os.path.exists(...)`
`bool` of a module is always True.

2. `pid` can be None:
https://github.com/vllm-project/vllm/blob/c21b99b91241409c2fdf9f3f8c542e8748b317be/vllm/v1/utils.py#L141
here, `proc.pid` can be None; and `os.kill(...)` rejects `None`.