### PR TITLE
[Misc] Increase RayDistributedExecutor RAY_CGRAPH_get_timeout

### DIFF
--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -559,6 +559,13 @@ class RayDistributedExecutor(DistributedExecutorBase):
                     envs.VLLM_USE_RAY_COMPILED_DAG_NCCL_CHANNEL)
         logger.info("VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM = %s",
                     envs.VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM)
+        if os.environ.get("RAY_CGRAPH_get_timeout"):  # noqa: SIM112
+            logger.info("RAY_CGRAPH_get_timeout = %s",
+                        os.environ["RAY_CGRAPH_get_timeout"])
+        else:
+            os.environ["RAY_CGRAPH_get_timeout"] = "300"  # noqa: SIM112
+            logger.info(
+                "RAY_CGRAPH_get_timeout is not set, setting to 300 seconds")
         with InputNode() as input_data:
             # Example DAG: PP=2, TP=4
             #

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -559,13 +559,15 @@ class RayDistributedExecutor(DistributedExecutorBase):
                     envs.VLLM_USE_RAY_COMPILED_DAG_NCCL_CHANNEL)
         logger.info("VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM = %s",
                     envs.VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM)
-        if os.environ.get("RAY_CGRAPH_get_timeout"):  # noqa: SIM112
-            logger.info("RAY_CGRAPH_get_timeout = %s",
-                        os.environ["RAY_CGRAPH_get_timeout"])
-        else:
-            os.environ["RAY_CGRAPH_get_timeout"] = "300"  # noqa: SIM112
-            logger.info(
-                "RAY_CGRAPH_get_timeout is not set, setting to 300 seconds")
+        # Enlarge the default value of "RAY_CGRAPH_get_timeout" to 300 seconds
+        # (it is 10 seconds by default). This is a Ray environment variable to
+        # control the timeout of getting result from a compiled graph execution,
+        # i.e., the distributed execution that includes model forward runs and
+        # intermediate tensor communications, in the case of vllm.
+        os.environ.setdefault("RAY_CGRAPH_get_timeout", "300")  # noqa: SIM112
+        logger.info("RAY_CGRAPH_get_timeout is set to %s",
+                    os.environ["RAY_CGRAPH_get_timeout"])  # noqa: SIM112
+
         with InputNode() as input_data:
             # Example DAG: PP=2, TP=4
             #


### PR DESCRIPTION
Execution in DeepSeek may take a long time, this PR sets a larger default (300s, rather than 10s) for `RAY_CGRAPH_get_timeout`, but still allows user to override it.

FIX #15199