### PR TITLE
set UV_PYTHON_INSTALL_DIR to a world readable/executable location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y \
 ENV PATH="/root/.local/bin:$PATH"
 # Create venv with specified Python and activate by placing at the front of path
 ENV VIRTUAL_ENV="/opt/venv"
+ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"
 RUN uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
@@ -181,6 +182,7 @@ RUN apt-get update -y \
 ENV PATH="/root/.local/bin:$PATH"
 # Create venv with specified Python and activate by placing at the front of path
 ENV VIRTUAL_ENV="/opt/venv"
+ENV UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python"
 RUN uv venv --python ${PYTHON_VERSION} --seed ${VIRTUAL_ENV}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 


### PR DESCRIPTION
First of all, thank you for this amazing project and all the effort! I would like to share my part with a first contribution:

I have a problem, not being able to run the vllm-openai amd64 image on Openshift since v0.8.0.

On container start I get a permission error:
`/opt/venv/bin/vllm: /opt/venv/bin/python3: Permission denied`

Openshift runs containers with non-root users per default.
Turns out that my non-root user (e.g. uid 1001) has access to /opt/venv, but not the python binary:
`4 lrwxrwxrwx 1 root root 75 Mar 19 20:35 /opt/venv/bin/python -> /root/.local/share/uv/python/cpython-3.12.9-linux-x86_64-gnu/bin/python3.12`

The recent update to use uv #13566 has caused this bug for me.
uv defaults to downloading python if it's not available system-wide (see https://github.com/astral-sh/uv/issues/7710)

There's an easy fix though, as uv has an env var for the target dir:
```
root@f73620394301:/vllm-workspace# uv python install -h
Download and install Python versions

Usage: uv python install [OPTIONS] [TARGETS]...

Arguments:
  [TARGETS]...  The Python version(s) to install [env: UV_PYTHON=]

Options:
  -i, --install-dir <INSTALL_DIR>  The directory to store the Python installation in [env: UV_PYTHON_INSTALL_DIR=]
```

Setting UV_PYTHON_INSTALL_DIR="/usr/local/share/uv/python" makes uv install python to a location, other users can access.
I have tested this on my mac, unfortunately not able to run the full amd64 vllm with cuda.
But I was able to run the container as root, change the env var, install another python version, add a user UID1001, log in and run the python interpreter.

Running containers as non-root is a very common way to reduce the attack surface of deployments so hopefully this fix can be released soon :)
I even would very much prefer to switch the default user to some non-root UID by default, what do others think?

I have found no related issues so far, so I didn't bother to create one just to close it again...