### PR TITLE
[Misc]add coding benchmark for speculative decoding

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -727,9 +727,9 @@ class InstructCoderDataset(HuggingFaceDataset):
     InstructCoder Dataset.
     https://huggingface.co/datasets/likaixin/InstructCoder
 
-    InstructCoder is the dataset designed to adapt LLMs for general code editing.
-    It consists of 114,239 instruction-input-output triplets and covers multiple
-    distinct code editing scenario.
+    InstructCoder is the dataset designed for general code editing.
+    It consists of 114,239 instruction-input-output triplets,
+    and covers multiple distinct code editing scenario.
     """
 
     DEFAULT_OUTPUT_LEN = 200 # this is the average default output length

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -726,9 +726,13 @@ class InstructCoderDataset(HuggingFaceDataset):
     """
     InstructCoder Dataset.
     https://huggingface.co/datasets/likaixin/InstructCoder
+
+    InstructCoder is the dataset designed to adapt LLMs for general code editing.
+    It consists of 114,239 instruction-input-output triplets and covers multiple
+    distinct code editing scenario.
     """
 
-    DEFAULT_OUTPUT_LEN = 1000
+    DEFAULT_OUTPUT_LEN = 200 # this is the average default output length
     DEFAULT_NUM_REQUESTS = 1000
     INSTRUCT_CODER_DATASET_PATH = "likaixin/InstructCoder"
 

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -736,10 +736,22 @@ class InstructCoderDataset(HuggingFaceDataset):
     DEFAULT_NUM_REQUESTS = 1000
     INSTRUCT_CODER_DATASET_PATH = "likaixin/InstructCoder"
 
+    def __init__(
+        self,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        if self.dataset_path != self.INSTRUCT_CODER_DATASET_PATH:
+            raise ValueError(f"Only support likaixin/InstructCoder dataset.\
+                    This data path {self.dataset_path} is not valid.")
+        if self.dataset_subset is None and self.dataset_split != "train":
+            raise ValueError("Dataset split must be 'train'.")
+
     def load_data(self) -> None:
         dataset = load_dataset(
-            self.INSTRUCT_CODER_DATASET_PATH,
-            split="train",
+            self.dataset_path,
+            name=self.dataset_subset,
+            split=self.dataset_split,
             streaming=True,
         )
         self.data = dataset.shuffle(seed=self.random_seed)
@@ -764,4 +776,5 @@ class InstructCoderDataset(HuggingFaceDataset):
                     prompt_len=prompt_len,
                     expected_output_len=output_len,
                 ))
+        self.maybe_oversample_requests(sampled_requests, num_requests)
         return sampled_requests

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -732,7 +732,7 @@ class InstructCoderDataset(HuggingFaceDataset):
     and covers multiple distinct code editing scenario.
     """
 
-    DEFAULT_OUTPUT_LEN = 200 # this is the average default output length
+    DEFAULT_OUTPUT_LEN = 200  # this is the average default output length
     DEFAULT_NUM_REQUESTS = 1000
     INSTRUCT_CODER_DATASET_PATH = "likaixin/InstructCoder"
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -591,7 +591,7 @@ def main(args: argparse.Namespace):
         # and HuggingFaceDataset based on provided parameters.
         dataset_class = HuggingFaceDataset
         if args.dataset_path == VisionArenaDataset.VISION_ARENA_DATASET_PATH:
-            assert args.hf_subset is None, "VisionArenaDataset needs hf_subset to be None."
+            assert args.hf_subset is None, "VisionArenaDataset needs hf_subset to be None."  #noqa: E501
             dataset_class = VisionArenaDataset
         elif args.dataset_path == "likaixin/InstructCoder":
             dataset_class = InstructCoderDataset

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -53,8 +53,9 @@ except ImportError:
     from argparse import ArgumentParser as FlexibleArgumentParser
 
 from benchmark_dataset import (BurstGPTDataset, HuggingFaceDataset,
-                               RandomDataset, SampleRequest, ShareGPTDataset,
-                               SonnetDataset, VisionArenaDataset)
+                               InstructCoderDataset, RandomDataset,
+                               SampleRequest, ShareGPTDataset, SonnetDataset,
+                               VisionArenaDataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
@@ -588,9 +589,15 @@ def main(args: argparse.Namespace):
     elif args.dataset_name == "hf":
         # Choose between VisionArenaDataset
         # and HuggingFaceDataset based on provided parameters.
-        dataset_class = (VisionArenaDataset if args.dataset_path
-                         == VisionArenaDataset.VISION_ARENA_DATASET_PATH
-                         and args.hf_subset is None else HuggingFaceDataset)
+        dataset_class = HuggingFaceDataset
+        if args.dataset_path == VisionArenaDataset.VISION_ARENA_DATASET_PATH:
+            assert args.hf_subset is None, "VisionArenaDataset needs hf_subset to be None."
+            dataset_class = VisionArenaDataset
+        elif args.dataset_path == "likaixin/InstructCoder":
+            dataset_class = InstructCoderDataset
+            args.hf_split = "train"
+        else:
+            dataset_class = HuggingFaceDataset
         input_requests = dataset_class(
             dataset_path=args.dataset_path,
             dataset_subset=args.hf_subset,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -596,8 +596,7 @@ def main(args: argparse.Namespace):
         elif args.dataset_path == "likaixin/InstructCoder":
             dataset_class = InstructCoderDataset
             args.hf_split = "train"
-        else:
-            dataset_class = HuggingFaceDataset
+
         input_requests = dataset_class(
             dataset_path=args.dataset_path,
             dataset_subset=args.hf_subset,

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -301,7 +301,7 @@ def get_requests(args, tokenizer):
         "output_len": args.output_len,
     }
 
-    if args.dataset_name == "random":
+    if args.dataset_path is None or args.dataset_name == "random":
         sample_kwargs["range_ratio"] = args.random_range_ratio
         sample_kwargs["prefix_len"] = args.prefix_len
         dataset_cls = RandomDataset
@@ -331,8 +331,8 @@ def get_requests(args, tokenizer):
         sample_kwargs["enable_multimodal_chat"] = True
     elif args.dataset_name == "instructcoder":
         dataset_cls = InstructCoderDataset
-        common_kwargs['dataset_subset'] = args.hf_subset
-        common_kwargs['dataset_split'] = args.hf_split
+        common_kwargs['dataset_subset'] = "unused"
+        common_kwargs['dataset_split'] = "unused"
 
     else:
         raise ValueError(f"Unknown dataset name: {args.dataset_name}")
@@ -451,13 +451,16 @@ def validate_args(args):
         raise ValueError(f"Unsupported backend: {args.backend}")
 
     # === Dataset Configuration ===
+    if args.dataset_name == "instructcoder":
+        args.dataset = "unused"
+        args.dataset_path = "unused"
+
     if not args.dataset and not args.dataset_path:
-        if not args.dataset_name:
-            print(
-                "When dataset name is not set, it will default to random dataset")
-            args.dataset_name = 'random'
-            if args.input_len is None:
-                raise ValueError("input_len must be provided for a random dataset")
+        print(
+            "When dataset path is not set, it will default to random dataset")
+        args.dataset_name = 'random'
+        if args.input_len is None:
+            raise ValueError("input_len must be provided for a random dataset")
 
     # === Dataset Name Specific Checks ===
     # --hf-subset and --hf-split: only used

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -12,8 +12,9 @@ from typing import Any, Optional, Union
 import torch
 import uvloop
 from benchmark_dataset import (BurstGPTDataset, HuggingFaceDataset,
-                               RandomDataset, SampleRequest, ShareGPTDataset,
-                               SonnetDataset, VisionArenaDataset, InstructCoderDataset)
+                               InstructCoderDataset, RandomDataset,
+                               SampleRequest, ShareGPTDataset, SonnetDataset,
+                               VisionArenaDataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
 from tqdm import tqdm
 from transformers import (AutoModelForCausalLM, AutoTokenizer,
@@ -325,8 +326,8 @@ def get_requests(args, tokenizer):
             # Choose between VisionArenaDataset and HuggingFaceDataset based on
             # provided parameters.
             dataset_cls = (VisionArenaDataset if args.dataset_path
-                        == VisionArenaDataset.VISION_ARENA_DATASET_PATH
-                        and args.hf_subset is None else HuggingFaceDataset)
+                           == VisionArenaDataset.VISION_ARENA_DATASET_PATH
+                           and args.hf_subset is None else HuggingFaceDataset)
             common_kwargs['dataset_subset'] = args.hf_subset
             common_kwargs['dataset_split'] = args.hf_split
             sample_kwargs["enable_multimodal_chat"] = True
@@ -469,9 +470,9 @@ def validate_args(args):
                       stacklevel=2)
     elif args.dataset_name == "hf":
         if args.dataset_path == VisionArenaDataset.VISION_ARENA_DATASET_PATH:
-            assert args.backend == "vllm-chat", "VisionArenaDataset needs to use vllm-chat as the backend."
+            assert args.backend == "vllm-chat", "VisionArenaDataset needs to use vllm-chat as the backend."  #noqa: E501
         elif args.dataset_path == "likaixin/InstructCoder":
-            assert args.backend == "vllm", "InstructCoder dataset needs to use vllm as the backend."
+            assert args.backend == "vllm", "InstructCoder dataset needs to use vllm as the backend."  #noqa: E501
         else:
             raise ValueError(
                 f"{args.dataset_path} is not supported by hf dataset.")

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -318,21 +318,21 @@ def get_requests(args, tokenizer):
     elif args.dataset_name == "burstgpt":
         dataset_cls = BurstGPTDataset
     elif args.dataset_name == "hf":
-        if args.backend != "vllm-chat":
-            raise ValueError(
-                "hf datasets only are supported by vllm-chat backend")
-        # Choose between VisionArenaDataset and HuggingFaceDataset based on
-        # provided parameters.
-        dataset_cls = (VisionArenaDataset if args.dataset_path
-                       == VisionArenaDataset.VISION_ARENA_DATASET_PATH
-                       and args.hf_subset is None else HuggingFaceDataset)
-        common_kwargs['dataset_subset'] = args.hf_subset
-        common_kwargs['dataset_split'] = args.hf_split
-        sample_kwargs["enable_multimodal_chat"] = True
-    elif args.dataset_name == "instructcoder":
-        dataset_cls = InstructCoderDataset
-        common_kwargs['dataset_subset'] = "unused"
-        common_kwargs['dataset_split'] = "unused"
+        if args.dataset_path == VisionArenaDataset.VISION_ARENA_DATASET_PATH:
+            if args.args.backend == "vllm-chat":
+                raise ValueError(
+                    "hf datasets only are supported by vllm-chat backend")
+            # Choose between VisionArenaDataset and HuggingFaceDataset based on
+            # provided parameters.
+            dataset_cls = (VisionArenaDataset if args.dataset_path
+                        == VisionArenaDataset.VISION_ARENA_DATASET_PATH
+                        and args.hf_subset is None else HuggingFaceDataset)
+            common_kwargs['dataset_subset'] = args.hf_subset
+            common_kwargs['dataset_split'] = args.hf_split
+            sample_kwargs["enable_multimodal_chat"] = True
+        elif args.dataset_path == "likaixin/InstructCoder":
+            dataset_cls = InstructCoderDataset
+            common_kwargs['dataset_split'] = "train"
 
     else:
         raise ValueError(f"Unknown dataset name: {args.dataset_name}")
@@ -451,10 +451,6 @@ def validate_args(args):
         raise ValueError(f"Unsupported backend: {args.backend}")
 
     # === Dataset Configuration ===
-    if args.dataset_name == "instructcoder":
-        args.dataset = "unused"
-        args.dataset_path = "unused"
-
     if not args.dataset and not args.dataset_path:
         print(
             "When dataset path is not set, it will default to random dataset")
@@ -471,9 +467,14 @@ def validate_args(args):
         warnings.warn("--hf-subset and --hf-split will be ignored \
                 since --dataset-name is not 'hf'.",
                       stacklevel=2)
-    elif args.dataset_name == "hf" and args.backend != "vllm-chat":
-        raise ValueError(
-            "When --dataset-name is 'hf', backend must be 'vllm-chat'")
+    elif args.dataset_name == "hf":
+        if args.dataset_path == VisionArenaDataset.VISION_ARENA_DATASET_PATH:
+            assert args.backend == "vllm-chat", "VisionArenaDataset needs to use vllm-chat as the backend."
+        elif args.dataset_path == "likaixin/InstructCoder":
+            assert args.backend == "vllm", "InstructCoder dataset needs to use vllm as the backend."
+        else:
+            raise ValueError(
+                f"{args.dataset_path} is not supported by hf dataset.")
 
     # --random-range-ratio: only used when dataset_name is 'random'
     if args.dataset_name != 'random' and args.random_range_ratio is not None:
@@ -524,7 +525,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dataset-name",
         type=str,
-        choices=["sharegpt", "random", "sonnet", "burstgpt", "hf", "instructcoder"],
+        choices=["sharegpt", "random", "sonnet", "burstgpt", "hf"],
         help="Name of the dataset to benchmark on.",
         default="sharegpt")
     parser.add_argument(


### PR DESCRIPTION
add likaixin/InstructCoder for speculative decoding benchmark throughput


to run instruct coder benchmark:
```
VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_USE_V1=1  python3 benchmarks/benchmark_throughput.py --dataset-name=hf --dataset-path=likaixin/InstructCoder --model <you hf model> --input-len 1000 --output-len 100 --num-prompts 2048 --async-engine
```

to run random benchmark:
```
VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_USE_V1=1  python3 benchmarks/benchmark_throughput.py --dataset-name=random --model <you hf model> --input-len 1000 --output-len 100 --num-prompts 2048 --async-engine
```


baseline: 
**Throughput: 37.29 requests/s, 12226.80 total tokens/s, 7457.64 output tokens/s**

ngram proposer: --speculative-model "[ngram]" --ngram_prompt_lookup_min 2 --ngram-prompt-lookup-max 5 --num_speculative_tokens 5
**Throughput: 35.28 requests/s, 11569.61 total tokens/s, 7056.79 output tokens/s**




benchmark_serving:
server: ```VLLM_USE_V1=1 vllm serve meta-llama/Meta-Llama-3-8B-Instruct (--speculative-model "[ngram]" --ngram_prompt_lookup_min 2 --ngram-prompt-lookup-max 5 --num_speculative_tokens 5)```
client: ```python3 benchmarks/benchmark_serving.py --model meta-llama/Meta-Llama-3-8B-Instruct --dataset-name hf --dataset-path likaixin/InstructCoder --num-prompts 2048```

baseline:
![image](https://github.com/user-attachments/assets/0ac79511-7105-4b1f-a5a0-e456451ba8cc)

ngram proposer:
![image](https://github.com/user-attachments/assets/2df4c4aa-33e5-4ac4-afa9-c74e7c4059be)





<!--- pyml disable-next-line no-emphasis-as-heading -->
