### PR TITLE
[Core] Don't force uppercase for VLLM_LOGGING_LEVEL

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -295,7 +295,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # this is used for configuring the default logging level
     "VLLM_LOGGING_LEVEL":
-    lambda: os.getenv("VLLM_LOGGING_LEVEL", "INFO"),
+    lambda: os.getenv("VLLM_LOGGING_LEVEL", "INFO").upper(),
 
     # if set, VLLM_LOGGING_PREFIX will be prepended to all log messages
     "VLLM_LOGGING_PREFIX":


### PR DESCRIPTION
When using this env var `VLLM_LOGGING_LEVEL=debug` would result in an
error. It had to be `=DEBUG`. This seems unnecessary. This change makes
the code ignore the case of the env var contents by converting it with
`upper()`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
