### PR TITLE
[Bugfix] LoRA V0 - Fix case where `max_num_seqs` is between cudagraph capture sizes

### DIFF
--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -93,6 +93,24 @@ def test_llama_lora(sql_lora_files):
     generate_and_test(llm, sql_lora_files)
 
 
+@create_new_process_for_each_test()
+def test_llama_lora_num_seqs(sql_lora_files):
+    """
+    Test case where max_num_seqs is in between cudagraph capture sizes.
+    """
+    enforce_eager = False
+    max_num_seqs = 13
+
+    llm = vllm.LLM(MODEL_PATH,
+                   enable_lora=True,
+                   enforce_eager=enforce_eager,
+                   max_num_seqs=max_num_seqs,
+                   max_loras=4,
+                   tensor_parallel_size=1,
+                   enable_chunked_prefill=True)
+    generate_and_test(llm, sql_lora_files)
+
+
 # Skipping for v1 as v1 doesn't have a good way to expose the num_gpu_blocks
 # used by the engine yet.
 @pytest.mark.skip_v1

--- a/tests/lora/test_llama_tp.py
+++ b/tests/lora/test_llama_tp.py
@@ -84,30 +84,14 @@ def v1(run_with_both_engines_lora):
 @create_new_process_for_each_test()
 def test_llama_lora(sql_lora_files):
 
-    llm = vllm.LLM(MODEL_PATH,
-                   enable_lora=True,
-                   max_num_seqs=16,
-                   max_loras=4,
-                   tensor_parallel_size=1,
-                   enable_chunked_prefill=True)
-    generate_and_test(llm, sql_lora_files)
-
-
-@create_new_process_for_each_test()
-def test_llama_lora_num_seqs(sql_lora_files):
-    """
-    Test case where max_num_seqs is in between cudagraph capture sizes.
-    """
-    enforce_eager = False
-    max_num_seqs = 13
-
-    llm = vllm.LLM(MODEL_PATH,
-                   enable_lora=True,
-                   enforce_eager=enforce_eager,
-                   max_num_seqs=max_num_seqs,
-                   max_loras=4,
-                   tensor_parallel_size=1,
-                   enable_chunked_prefill=True)
+    llm = vllm.LLM(
+        MODEL_PATH,
+        enable_lora=True,
+        # also test odd max_num_seqs
+        max_num_seqs=13,
+        max_loras=4,
+        tensor_parallel_size=1,
+        enable_chunked_prefill=True)
     generate_and_test(llm, sql_lora_files)
 
 

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -43,6 +43,10 @@ class PunicaWrapperGPU(PunicaWrapperBase):
                                                       max_num_batched_tokens,
                                                       device=device)
 
+        # When cudagraph capture size is greater than max_num_seqs (max_batches,
+        # here), V0 captures the graph as if max_num_seqs is set to
+        # the capture size.
+        # V1 doesn't have this problem and always respects max_num_seqs.
         max_num_prompts = (max_batches
                            if envs.VLLM_USE_V1 else max_num_batched_tokens)
         self.prompt_mapping_meta = LoRAKernelMeta.make(self.max_loras,

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -9,6 +9,7 @@ https://arxiv.org/abs/2310.18547
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union, final
 
 import torch
+
 import vllm.envs as envs
 from vllm.lora.layers import LoRAMapping
 from vllm.triton_utils import HAS_TRITON

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -9,7 +9,7 @@ https://arxiv.org/abs/2310.18547
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union, final
 
 import torch
-
+import vllm.envs as envs
 from vllm.lora.layers import LoRAMapping
 from vllm.triton_utils import HAS_TRITON
 
@@ -42,8 +42,11 @@ class PunicaWrapperGPU(PunicaWrapperBase):
         self.token_mapping_meta = LoRAKernelMeta.make(self.max_loras,
                                                       max_num_batched_tokens,
                                                       device=device)
+
+        max_num_prompts = (max_batches
+                           if envs.VLLM_USE_V1 else max_num_batched_tokens)
         self.prompt_mapping_meta = LoRAKernelMeta.make(self.max_loras,
-                                                       max_batches,
+                                                       max_num_prompts,
                                                        device=device)
 
     def update_metadata(


### PR DESCRIPTION
FIX #15269

Repro command : 
```
VLLM_USE_V1=0 python3 benchmarks/benchmark_throughput.py --model meta-llama/Llama-2-7b-hf --backend vllm --dataset ./ShareGPT_V3_unfiltered_cleaned_split.json --num-prompts 200 --max-loras 4 --max-lora-rank 8 --lora-path yard1/llama-2-7b-sql-lora-test --enable-lora --max-num-seqs 50
```

Bug:
```
...
  File "/home/shadeform/precog/.venv/lib/python3.12/site-packages/vllm/lora/punica_wrapper/punica_gpu.py", line 66, in update_metadata
    self.prompt_mapping_meta.prepare_tensors(self.sampler_indices)
  File "/home/shadeform/precog/.venv/lib/python3.12/site-packages/vllm/lora/ops/triton_ops/lora_kernel_metadata.py", line 76, in prepare_tensors
    self.token_lora_mapping[:num_tokens].copy_(token_lora_mapping,J
RuntimeError: The size of tensor a (50) must match the size of tensor b (56) at non-singleton dimension 0
```

PR that introduced the bug: https://github.com/vllm-project/vllm/pull/14685

Affects : V0 engine. V1 engine is fine. 

Fix / Why ? : 
In V0, during cudagraph capture, the cuda graph capture size could be greater than the `max_num_seqs` setting. In #14685 , we assume that `max_num_seqs` will always be respected. This assumption is true for V1, but not for V0. 
The line where the error occurs deals with the LogitsProcessor. Before #14685,  `_sampler_indices` at   https://github.com/vllm-project/vllm/blob/cfbb8c930fcda6d97f0de3018bd3c51ab14b367c/vllm/lora/punica_wrapper/punica_base.py#L136 was used in the place of `token_lora_mapping` . Before #14685 we seem to have handled this issue by just allocating a buffer as big as `max_num_batched_tokens`. We use the same fix here. 

