### PR TITLE
[Misc] Update guided decoding logs to debug

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -545,7 +545,7 @@ async def build_guided_decoding_logits_processor_async(
     sampling_params = copy.copy(sampling_params)
     guided_decoding = sampling_params.guided_decoding
 
-    logger.info(
+    logger.debug(
         "Building guided decoding logits processor. "
         "guided_decoding: %s%s", guided_decoding,
         f", reasoning_backend: {reasoning_backend}"


### PR DESCRIPTION
The json schema as part of guided decoding details can contain sensitive user inputs. I believe user inputs should not be logged when the engine is started with `disable_log_requests=True`.

These logs have existed for a while at DEBUG level but only made visible at INFO level with v0.8.0 (#12955). I would be fine with reverting the relevant line's log level back to DEBUG instead of my proposed change. 