### PR TITLE
[Bugfix][Frontend] Fixed issue where requests with duplicate request IDs might be sent to EngineCore simultaneously

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -331,7 +331,7 @@ class AsyncLLM(EngineClient):
                     # 3) Abort any reqs that finished due to stop strings.
                     await self.engine_core.abort_requests_async(
                         processed_outputs.reqs_to_abort)
-                    self.output_processor.handle_abort_reqs(
+                    self.output_processor.free_aborted_reqs(
                         processed_outputs.reqs_to_abort)
 
                 # 4) Logging.
@@ -355,7 +355,7 @@ class AsyncLLM(EngineClient):
         # At this point, the abort message has already been sent to EngineCore,
         # so the request status in the Frontend can be removed.
         # For more details, please see: PR #15326
-        self.output_processor.handle_abort_reqs(request_ids)
+        self.output_processor.free_aborted_reqs(request_ids)
 
         if self.log_requests:
             logger.info("Aborted request %s.", request_id)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -354,6 +354,7 @@ class AsyncLLM(EngineClient):
         await self.engine_core.abort_requests_async(request_ids)
         # At this point, the abort message has already been sent to EngineCore,
         # so the request status in the Frontend can be removed.
+        # For more details, please see: PR #15326
         self.output_processor.handle_abort_reqs(request_ids)
 
         if self.log_requests:

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -239,18 +239,37 @@ class OutputProcessor:
         self,
         request_ids: Iterable[str],
     ) -> list[str]:
-        request_ids_to_abort = []
-        for request_id in request_ids:
-            req_state = self.request_states.pop(request_id, None)
+        request_ids_to_abort = self.flatten_req_to_abort(request_ids)
+        self.handle_abort_reqs(request_ids_to_abort)
+        return request_ids_to_abort
+
+    def flatten_req_to_abort(self, req_ids: Iterable[str]) -> list[str]:
+        ret = []
+        for req_id in req_ids:
+            parent = self.parent_requests.pop(req_id, None)
+            if parent is None:
+                ret.append(req_id)
+            else:
+                ret.extend(parent.child_requests)
+        return ret
+
+    # "Aborted request", meaning the frontend first detects that
+    # the request has ended, such as when the client disconnects
+    # or the detokenizer detects a stop string.
+    def handle_abort_reqs(self, req_ids: Iterable[str]):
+        for req_id in req_ids:
+            req_state = self.request_states.pop(req_id, None)
             if req_state is not None:
                 self.lora_states.abort_request(req_state)
-                request_ids_to_abort.append(request_id)
-            else:
-                parent = self.parent_requests.pop(request_id, None)
-                if parent and parent.child_requests:
-                    self.abort_requests(parent.child_requests)
-                    request_ids_to_abort.extend(parent.child_requests)
-        return request_ids_to_abort
+        return
+
+    # "Finished request", meaning EngineCore first detects that
+    # the request has ended, and the resources related to the request
+    # maintained by EngineCore have been released.
+    def _handle_finished_reqs(self, req_id):
+        req_state = self.request_states.pop(req_id)
+        self.lora_states.finish_request(req_state)
+        return
 
     def add_request(
         self,
@@ -286,22 +305,22 @@ class OutputProcessor:
         1) Compute stats for logging
         2) Detokenize
         3) Create and handle RequestOutput objects:
-            * If there is a queue (for usage with AsyncLLM), 
+            * If there is a queue (for usage with AsyncLLM),
               put the RequestOutput objects into the queue for
               handling by the per-request generate() tasks.
 
-            * If there is no queue (for usage with LLMEngine), 
+            * If there is no queue (for usage with LLMEngine),
               return a list of RequestOutput objects.
 
         ****************** NOTE FOR DEVELOPERS ******************
 
         vLLM V1 minimizes the number of python loops over the full
-        batch to ensure system overheads are minimized. This is the 
+        batch to ensure system overheads are minimized. This is the
         only function that should loop over EngineCoreOutputs.
 
         If you need to touch every element of the batch, do it from
         within the loop below.
-        
+
         **********************************************************
         """
 
@@ -347,7 +366,6 @@ class OutputProcessor:
 
             # Free completed requests.
             if finish_reason is not None:
-                self.request_states.pop(req_id)
                 # Remove parent request if applicable.
                 parent_req = req_state.parent_req
                 if parent_req and not parent_req.child_requests:
@@ -356,6 +374,8 @@ class OutputProcessor:
                     # If req not finished in EngineCore, but Detokenizer
                     # detected stop string, abort needed in EngineCore.
                     reqs_to_abort.append(req_id)
+                else:
+                    self._handle_finished_reqs(req_id)
 
                 # Track per-request stats
                 self._update_stats_from_finished(req_state, finish_reason,
@@ -398,7 +418,6 @@ class OutputProcessor:
             num_prompt_tokens=len(req_state.prompt_token_ids),
             max_tokens_param=req_state.max_tokens_param,
             req_stats=req_state.stats)
-        self.lora_states.finish_request(req_state)
 
         ParentRequest.observe_finished_request(
             req_state.parent_req, iteration_stats,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -268,7 +268,7 @@ class OutputProcessor:
         # finished_reason.
         return
 
-    def free_finised_reqs(self, req_ids: Iterable[str]):
+    def free_finished_reqs(self, req_ids: Iterable[str]):
         """
         Handle a finished request. This method is called when EngineCore detects
         that the request has ended, and the resources related to the request
@@ -390,7 +390,7 @@ class OutputProcessor:
                     # detected stop string, abort needed in EngineCore.
                     reqs_to_abort.append(req_id)
                 else:
-                    self.free_finised_reqs((req_id, ))
+                    self.free_finished_reqs((req_id, ))
 
                 # Track per-request stats
                 self._update_stats_from_finished(req_state, finish_reason,


### PR DESCRIPTION
Currently, vllm allows users to send duplicate request IDs. At the same time, numerous modules in EngineCore use request IDs as dictionary keys, such as `KVCacheManager.req_to_blocks`. This is based on the assumption that EngineCore always expects the Frontend to first abort a request before adding a new one with the same request ID:

```python
# req1, req2 have the same request_id.
(EngineCoreRequestType.ADD, req1(request_id=RequestId))
(EngineCoreRequestType.ABORT, req1)
(EngineCoreRequestType.ADD, req2(request_id=RequestId))
```

Currently, `AsyncLLM` ensures that duplicate request IDs must first be aborted before they can be added through the sequence `AsyncLLM._add_request` -> `OutputProcessor.add_request`:

```python
# OutputProcessor.add_request
request_id = request.request_id
if request_id in self.request_states:
    raise ValueError(f"Request id {request_id} already running.")

# AsyncLLM.abort
async def abort(self, request_id: str) -> None:
    """Abort RequestId in OutputProcessor and EngineCore."""

    request_ids = self.output_processor.abort_requests((request_id,))
    # BUG!
    # This operation is not atomic, and there might be a time window during which
    # the request has already been removed from OutputProcessor.request_states,
    # but the corresponding ABORT has not yet been issued to EngineCore.
    await self.engine_core.abort_requests_async(request_ids)

    if self.log_requests:
        logger.info("Aborted request %s.", request_id)
```

We can easily simulate the potential bug by enlarging the possible time window with an `await asyncio.sleep(13)` inserted at the BUG point:
![image](https://github.com/user-attachments/assets/3a5ec675-5ef0-4190-bf21-f376abdff3b8)

To fix this issue, we categorized completed requests into two types: 

- abort req, `handle_abort_reqs`
- finished req, `_handle_finished_reqs`

And ensured that the scope of request visibility in the Frontend always includes the scope of request visibility in EngineCore.
