### PR TITLE
Fix zmq IPv6 URL format error

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -233,6 +233,7 @@ class MessageQueue:
             if is_valid_ipv6_address(connect_ip):
                 self.remote_socket.setsockopt(IPV6, 1)
                 remote_addr_ipv6 = True
+                connect_ip = f"[{connect_ip}]"
             socket_addr = f"tcp://*:{remote_subscribe_port}"
             self.remote_socket.bind(socket_addr)
             remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"


### PR DESCRIPTION
While reading this code, I noticed that it attempts to handle IPv6
addresses properly, but forgets to enclose them in square brackets when
constructing the zmq tcp:// url. The brackets are necessary to clearly
separate the IPv6 address from the trailing port number.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
