### PR TITLE
[V1][Spec Decode] Use better defaults for N-gram

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2018,8 +2018,10 @@ class SpeculativeConfig:
                 self.prompt_lookup_min = 5
                 self.prompt_lookup_max = 5
             elif self.prompt_lookup_min is None:
+                assert self.prompt_lookup_max is not None
                 self.prompt_lookup_min = self.prompt_lookup_max
             elif self.prompt_lookup_max is None:
+                assert self.prompt_lookup_min is not None
                 self.prompt_lookup_max = self.prompt_lookup_min
 
             # Validate values

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2012,29 +2012,27 @@ class SpeculativeConfig:
         if self.method in ("ngram", "[ngram]"):
             # Unified to "ngram" internally
             self.method = "ngram"
-            if self.prompt_lookup_min is None:
-                if self.prompt_lookup_max is None:
-                    self.prompt_lookup_min = 5
-                    self.prompt_lookup_max = 5
-                else:
-                    if self.prompt_lookup_max < 1:
-                        raise ValueError(
-                            f"prompt_lookup_max={self.prompt_lookup_max} "
-                            "must be > 0")
-                    self.prompt_lookup_min = self.prompt_lookup_max
-            else:
-                if self.prompt_lookup_min < 1:
-                    raise ValueError(
-                        f"prompt_lookup_min={self.prompt_lookup_min} "
-                        "must be > 0")
-                if self.prompt_lookup_max is None:
-                    self.prompt_lookup_max = self.prompt_lookup_min
-                else:
-                    if self.prompt_lookup_min > self.prompt_lookup_max:
-                        raise ValueError(
-                            f"prompt_lookup_min={self.prompt_lookup_min} must "
-                            f"be <= prompt_lookup_max={self.prompt_lookup_max}"
-                        )
+            # Set default values if not provided
+            if (self.prompt_lookup_min is None
+                    and self.prompt_lookup_max is None):
+                self.prompt_lookup_min = 5
+                self.prompt_lookup_max = 5
+            elif self.prompt_lookup_min is None:
+                self.prompt_lookup_min = self.prompt_lookup_max
+            elif self.prompt_lookup_max is None:
+                self.prompt_lookup_max = self.prompt_lookup_min
+
+            # Validate values
+            if self.prompt_lookup_min < 1:
+                raise ValueError(
+                    f"prompt_lookup_min={self.prompt_lookup_min} must be > 0")
+            if self.prompt_lookup_max < 1:
+                raise ValueError(
+                    f"prompt_lookup_max={self.prompt_lookup_max} must be > 0")
+            if self.prompt_lookup_min > self.prompt_lookup_max:
+                raise ValueError(
+                    f"prompt_lookup_min={self.prompt_lookup_min} must "
+                    f"be <= prompt_lookup_max={self.prompt_lookup_max}")
 
             # TODO: current we still need extract vocab_size from target model
             # config, in future, we may try refactor it out, and set

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2015,6 +2015,7 @@ class SpeculativeConfig:
             # Set default values if not provided
             if (self.prompt_lookup_min is None
                     and self.prompt_lookup_max is None):
+                # TODO(woosuk): Tune these values. They are arbitrarily chosen.
                 self.prompt_lookup_min = 5
                 self.prompt_lookup_max = 5
             elif self.prompt_lookup_min is None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2013,17 +2013,28 @@ class SpeculativeConfig:
             # Unified to "ngram" internally
             self.method = "ngram"
             if self.prompt_lookup_min is None:
-                self.prompt_lookup_min = 1
-            if self.prompt_lookup_max is None or self.prompt_lookup_max < 1:
-                raise ValueError("prompt_lookup_max="
-                                 f"{self.prompt_lookup_max} must be > 0")
-            if self.prompt_lookup_min < 1:
-                raise ValueError("prompt_lookup_min="
-                                 f"{self.prompt_lookup_min} must be > 0")
-            if self.prompt_lookup_min > self.prompt_lookup_max:
-                raise ValueError(f"prompt_lookup_min={self.prompt_lookup_min} "
-                                 "cannot be larger than prompt_lookup_max="
-                                 f"{self.prompt_lookup_max}")
+                if self.prompt_lookup_max is None:
+                    self.prompt_lookup_min = 5
+                    self.prompt_lookup_max = 5
+                else:
+                    if self.prompt_lookup_max < 1:
+                        raise ValueError(
+                            f"prompt_lookup_max={self.prompt_lookup_max} "
+                            "must be > 0")
+                    self.prompt_lookup_min = self.prompt_lookup_max
+            else:
+                if self.prompt_lookup_min < 1:
+                    raise ValueError(
+                        f"prompt_lookup_min={self.prompt_lookup_min} "
+                        "must be > 0")
+                if self.prompt_lookup_max is None:
+                    self.prompt_lookup_max = self.prompt_lookup_min
+                else:
+                    if self.prompt_lookup_min > self.prompt_lookup_max:
+                        raise ValueError(
+                            f"prompt_lookup_min={self.prompt_lookup_min} must "
+                            f"be <= prompt_lookup_max={self.prompt_lookup_max}"
+                        )
 
             # TODO: current we still need extract vocab_size from target model
             # config, in future, we may try refactor it out, and set


### PR DESCRIPTION
## Current Issues
- `prompt_lookup_max` parameter is mandatory in all cases
- `prompt_lookup_min` defaults to 1, which is too small for most use cases (too many matches)

## Changes Implemented
- When only one lookup parameter is provided, the other will automatically match it
- When neither parameter is specified, both default to **5**
- This creates a more intuitive developer experience with sensible defaults