### PR TITLE
[Bugfix][V1] Avoid importing PreTrainedModel

### DIFF
--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -32,7 +32,7 @@ def set_default_torch_dtype(dtype: torch.dtype):
 
 def is_transformers_impl_compatible(
         arch: str,
-        module: Optional[transformers.PreTrainedModel] = None) -> bool:
+        module: Optional["transformers.PreTrainedModel"] = None) -> bool:
     mod = module or getattr(transformers, arch, None)
     if mod is None:
         return False


### PR DESCRIPTION
Related to https://github.com/OpenRLHF/OpenRLHF/issues/741#issuecomment-2705517085

Currently we will have errors similar to #6056: device >= 0 && device < num_gpus INTERNAL ASSERT FAILED at "../aten/src/ATen/cuda/CUDAContext.cpp" in V1 engines, when we set tensor parallel size greater than 1 and use ray as the distributed executor backend. The issue is caused by the [CUDA calls](https://github.com/pytorch/pytorch/blob/c65ee728f069ea9544bdcac815eb0825f45d1633/torch/cuda/__init__.py#L170-L174) when we import transformers (`torch.cuda.is_available()`) before we set `CUDA_VISIBLE_DEVICES`. This PR tries to mitigate this issue so that it can work normally.

Related call stack:

```log
File "transformers/modeling_utils.py", line 54, in <module>
    from .integrations.flash_attention import flash_attention_forward
  File "transformers/integrations/flash_attention.py", line 5, in <module>
    from ..modeling_flash_attention_utils import _flash_attention_forward
  File "transformers/modeling_flash_attention_utils.py", line 28, in <module>
    if is_flash_attn_2_available():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "transformers/utils/import_utils.py", line 1037, in is_flash_attn_2_available
    if not (torch.cuda.is_available() or is_torch_mlu_available()):
            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "torch/cuda/__init__.py", line 117, in is_available

  File "xxxx", line xx, in __init__
    from vllm import LLM
  File "vllm/__init__.py", line 12, in <module>
    from vllm.engine.async_llm_engine import AsyncLLMEngine
  File "vllm/engine/async_llm_engine.py", line 20, in <module>
    from vllm.engine.llm_engine import LLMEngine, SchedulerOutputState
  File "vllm/engine/llm_engine.py", line 2131, in <module>
    from vllm.v1.engine.llm_engine import LLMEngine as V1LLMEngine
  File "vllm/v1/engine/llm_engine.py", line 25, in <module>
    from vllm.v1.engine.core_client import EngineCoreClient
  File "vllm/v1/engine/core_client.py", line 26, in <module>
    from vllm.v1.engine.core import EngineCore, EngineCoreProc
  File "vllm/v1/engine/core.py", line 24, in <module>
    from vllm.v1.core.kv_cache_utils import (get_kv_cache_config,
  File "vllm/v1/core/kv_cache_utils.py", line 13, in <module>
    from vllm.v1.request import Request
  File "vllm/v1/request.py", line 10, in <module>
    from vllm.v1.utils import ConstantList
  File "vllm/v1/utils.py", line 14, in <module>
    from vllm.model_executor.models.utils import extract_layer_index
  File "vllm/model_executor/models/utils.py", line 15, in <module>
    from vllm.model_executor.model_loader.weight_utils import default_weight_loader
  File "vllm/model_executor/model_loader/__init__.py", line 6, in <module>
    from vllm.model_executor.model_loader.loader import (BaseModelLoader,
  File "vllm/model_executor/model_loader/loader.py", line 46, in <module>
    from vllm.model_executor.model_loader.utils import (ParamMapping,
  File "vllm/model_executor/model_loader/utils.py", line 34, in <module>
    module: Optional[transformers.PreTrainedModel] = None) -> bool:
```
