### PR TITLE
[Bugfix] Fix regex compile display format

### DIFF
--- a/vllm/transformers_utils/tokenizers/mistral.py
+++ b/vllm/transformers_utils/tokenizers/mistral.py
@@ -124,13 +124,15 @@ def find_tokenizer_file(files: List[str]):
 
     matched_files = [file for file in files if file_pattern.match(file)]
     if len(matched_files) > 1:
-        raise OSError(f"Found {len(matched_files)} files matching the "
-                      f"pattern: {file_pattern}. Make sure only one Mistral "
-                      f"tokenizer is present in {files}.")
+        raise OSError(
+            f"Found {len(matched_files)} files matching the "
+            f"pattern: `{file_pattern.pattern}`. Make sure only one Mistral "
+            f"tokenizer is present in {files}.")
     elif len(matched_files) == 0:
-        raise OSError(f"Found {len(matched_files)} files matching the "
-                      f"pattern: {file_pattern}. Make sure that a Mistral "
-                      f"tokenizer is present in {files}.")
+        raise OSError(
+            f"Found {len(matched_files)} files matching the "
+            f"pattern: `{file_pattern.pattern}`. Make sure that a Mistral "
+            f"tokenizer is present in {files}.")
 
     return matched_files[0]
 


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/15345

```
ERROR 03-24 09:28:32 [engine.py:448] OSError: Found 0 files matching the pattern: `^tokenizer\.model\.v.*$|^tekken\.json$|^tokenizer\.mm\.model\.v.*$`. Make sure that a Mistral tokenizer is present in ['model.safetensors', 'LICENSE', 'tokenizer_config.json', 'config.json', 'tokenizer.json', 'generation_config.json', 'README.md', 'merges.txt', '.gitattributes', 'vocab.json'].
```