### PR TITLE
[Misc] Consolidate LRUCache implementations

### DIFF
--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -289,16 +289,14 @@ def initialize_ray_cluster(
     elif current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
-            ray.init("auto", ignore_reinit_error=True)
+            ray.init("auto")
         except ConnectionError:
             logger.warning(
                 "No existing RAY instance detected. "
                 "A new instance will be launched with current node resources.")
-            ray.init(address=ray_address,
-                     ignore_reinit_error=True,
-                     num_gpus=parallel_config.world_size)
+            ray.init(address=ray_address, num_gpus=parallel_config.world_size)
     else:
-        ray.init(address=ray_address, ignore_reinit_error=True)
+        ray.init(address=ray_address)
 
     device_str = current_platform.ray_device_key
     if not device_str:

--- a/vllm/executor/ray_utils.py
+++ b/vllm/executor/ray_utils.py
@@ -289,14 +289,16 @@ def initialize_ray_cluster(
     elif current_platform.is_rocm() or current_platform.is_xpu():
         # Try to connect existing ray instance and create a new one if not found
         try:
-            ray.init("auto")
+            ray.init("auto", ignore_reinit_error=True)
         except ConnectionError:
             logger.warning(
                 "No existing RAY instance detected. "
                 "A new instance will be launched with current node resources.")
-            ray.init(address=ray_address, num_gpus=parallel_config.world_size)
+            ray.init(address=ray_address,
+                     ignore_reinit_error=True,
+                     num_gpus=parallel_config.world_size)
     else:
-        ray.init(address=ray_address)
+        ray.init(address=ray_address, ignore_reinit_error=True)
 
     device_str = current_platform.ray_device_key
     if not device_str:

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -12,7 +12,6 @@ from typing import (TYPE_CHECKING, Generic, NamedTuple, Optional, Protocol,
                     TypeVar, Union, cast)
 
 import torch
-from cachetools import LRUCache
 from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
 from typing_extensions import assert_never
 
@@ -21,7 +20,7 @@ from vllm.jsontree import json_map_leaves, json_reduce_leaves
 from vllm.logger import init_logger
 from vllm.transformers_utils.tokenizer import (AnyTokenizer, decode_tokens,
                                                encode_tokens)
-from vllm.utils import GiB_bytes, flatten_2d_lists, full_groupby
+from vllm.utils import GiB_bytes, LRUCache, flatten_2d_lists, full_groupby
 
 from .hasher import MultiModalHasher
 from .inputs import (MultiModalDataDict, MultiModalEncDecInputs,

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -37,7 +37,7 @@ from collections.abc import (AsyncGenerator, Awaitable, Generator, Hashable,
 from dataclasses import dataclass, field
 from functools import cache, lru_cache, partial, wraps
 from typing import (TYPE_CHECKING, Any, Callable, Generic, Literal, NamedTuple,
-                    Optional, TypeVar, Union, cast)
+                    Optional, TypeVar, Union, cast, overload)
 from uuid import uuid4
 
 import cachetools
@@ -172,6 +172,7 @@ U = TypeVar("U")
 
 _K = TypeVar("_K", bound=Hashable)
 _V = TypeVar("_V")
+_T = TypeVar("_T")
 
 
 class _Sentinel:
@@ -256,9 +257,16 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
     def touch(self, key: _K) -> None:
         self._LRUCache__update(key)  # type: ignore
 
-    def get(self,
-            key: _K,
-            default: Optional[_V] = None) -> Optional[_V]:  # type: ignore
+    @overload
+    def get(self, key: _K, /) -> Optional[_V]:
+        ...
+
+    @overload
+    def get(self, key: _K, /,
+            default: Optional[_V]) -> Optional[_V]:  # type: ignore
+        ...
+
+    def get(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
         value: Optional[_V]
         if key in self:
             value = self.__getitem__(key)
@@ -270,9 +278,16 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
         self._total += 1
         return value
 
-    def pop(self,
-            key: _K,
-            default: Optional[_V] = None) -> Optional[_V]:  # type: ignore
+    @overload
+    def pop(self, key: _K, /) -> Optional[_V]:
+        ...
+
+    @overload
+    def pop(self, key: _K, /,
+            default: Optional[_V]) -> Optional[_V]:  # type: ignore
+        ...
+
+    def pop(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
         if key in self:
             value = self[key]
             del self[key]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -172,7 +172,7 @@ U = TypeVar("U")
 
 _K = TypeVar("_K", bound=Hashable)
 _V = TypeVar("_V")
-_T = TypeVar("_T")
+_T = TypeVar('_T', bound=Optional[float])
 
 
 class _Sentinel:
@@ -218,7 +218,7 @@ class CacheInfo(NamedTuple):
         return self.hits / self.total
 
 
-class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
+class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V, _T]):
     """LRU Cache"""
 
     def __init__(self,
@@ -263,11 +263,14 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
 
     @overload
     def get(self, key: _K, /,
-            default: Optional[_V]) -> Optional[_V]:  # type: ignore
+            default: Optional[Union[_V, _T]]) -> Optional[Union[_V, _T]]:
         ...
 
-    def get(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
-        value: Optional[_V]
+    def get(self,
+            key: _K,
+            default: Optional[Union[_V,
+                                    _T]] = None) -> Optional[Union[_V, _T]]:
+        value: Optional[Union[_V, _T]]
         if key in self:
             value = self.__getitem__(key)
 
@@ -283,11 +286,13 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
         ...
 
     @overload
-    def pop(self, key: _K, /,
-            default: Optional[_V]) -> Optional[_V]:  # type: ignore
+    def pop(self, key: _K, /, default: Optional[_V]) -> Optional[_V]:
         ...
 
-    def pop(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
+    def pop(self,
+            key: _K,
+            default: Optional[Union[_V,
+                                    _T]] = None) -> Optional[Union[_V, _T]]:
         if key in self:
             value = self[key]
             del self[key]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -264,7 +264,7 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
     def touch(self, key: _K) -> None:
         self._LRUCache__update(key)  # type: ignore
 
-    def get(self, key: _K, default: _V | None = ...) -> _V | None:
+    def get(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
         value: Optional[_V]
         if key in self:
             value = self.__getitem__(key)

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -217,7 +217,7 @@ class CacheInfo(NamedTuple):
         return self.hits / self.total
 
 
-class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
+class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
     """LRU Cache"""
 
     def __init__(self,
@@ -240,14 +240,6 @@ class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
         if run_on_remove:
             self._on_remove(key, value)
 
-    @overload
-    def get(self, key: _K, /) -> Optional[_V]:
-        ...
-
-    @overload
-    def get(self, key: _K, /, default: Optional[_V]) -> Optional[_V]:
-        ...
-
     @property
     def cache(self) -> OrderedDict[_K, _V]:
         """Return the internal cache dictionary (read-only)."""
@@ -263,6 +255,14 @@ class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
 
     def touch(self, key: _K) -> None:
         self._LRUCache__update(key)  # type: ignore
+
+    @overload
+    def get(self, key: _K, /) -> Optional[_V]:
+        ...
+
+    @overload
+    def get(self, key: _K, /, default: Optional[_V]) -> Optional[_V]:
+        ...
 
     def get(self, key: _K, default: Optional[_V] = None) -> Optional[_V]:
         value: Optional[_V]
@@ -312,7 +312,7 @@ class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
                                    "cannot remove oldest from the cache.")
         else:
             lru_key = next(iter(self.order))
-        self.pop(cast(Optional[_K], lru_key), None)
+        self.pop(cast(_K, lru_key), None)
 
     def _remove_old_if_needed(self) -> None:
         if len(self) > self.capacity:
@@ -334,7 +334,7 @@ class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
                                    "cannot remove oldest from the cache.")
         else:
             lru_key = next(iter(self.order))
-        value = self.pop(cast(Optional[_K], lru_key), None)
+        value = self.pop(cast(_K, lru_key), None)
         return (lru_key, value)
 
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -172,7 +172,7 @@ U = TypeVar("U")
 
 _K = TypeVar("_K", bound=Hashable)
 _V = TypeVar("_V")
-_T = TypeVar('_T', bound=Optional[float])
+_T = TypeVar("_T", bound=Optional[float])
 
 
 class _Sentinel:
@@ -218,7 +218,7 @@ class CacheInfo(NamedTuple):
         return self.hits / self.total
 
 
-class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V, _T]):
+class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
     """LRU Cache"""
 
     def __init__(self,
@@ -262,15 +262,11 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V, _T]):
         ...
 
     @overload
-    def get(self, key: _K, /,
-            default: Optional[Union[_V, _T]]) -> Optional[Union[_V, _T]]:
+    def get(self, key: _K, /, default: Union[_V, _T]) -> Union[_V, _T]:
         ...
 
-    def get(self,
-            key: _K,
-            default: Optional[Union[_V,
-                                    _T]] = None) -> Optional[Union[_V, _T]]:
-        value: Optional[Union[_V, _T]]
+    def get(self, key: _K, default: Union[_V, _T] = None) -> Union[_V, _T]:
+        value: Union[_V, _T]
         if key in self:
             value = self.__getitem__(key)
 
@@ -286,13 +282,10 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V, _T]):
         ...
 
     @overload
-    def pop(self, key: _K, /, default: Optional[_V]) -> Optional[_V]:
+    def pop(self, key: _K, /, default: Union[_V, _T]) -> Union[_V, _T]:
         ...
 
-    def pop(self,
-            key: _K,
-            default: Optional[Union[_V,
-                                    _T]] = None) -> Optional[Union[_V, _T]]:
+    def pop(self, key: _K, default: Union[_V, _T] = None) -> Union[_V, _T]:
         if key in self:
             value = self[key]
             del self[key]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -245,7 +245,7 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
         ...
 
     @overload
-    def get(self, key: _K, /, default: _V | None) -> _V | None:
+    def get(self, key: _K, /, default: Optional[_V]) -> Optional[_V]:
         ...
 
     @property

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -243,18 +243,18 @@ class LRUCache(cachetools.LRUCache, Generic[_K, _V]):
     @property
     def cache(self) -> dict[_K, _V]:
         """Return the internal cache dictionary (read-only)."""
-        return cast(dict[_K, _V], self._Cache__data)
+        return cast(dict[_K, _V], self._Cache__data)  # type: ignore
 
     @property
     def order(self) -> dict:
         """Return the internal order dictionary (read-only)."""
-        return cast(dict, self._LRUCache__order)
+        return cast(dict, self._LRUCache__order)  # type: ignore
 
     def stat(self) -> CacheInfo:
         return CacheInfo(hits=self._hits, total=self._total)
 
     def touch(self, key: _K) -> None:
-        self.__update(key)
+        self._LRUCache__update(key)  # type: ignore
 
     def get(self, key, default=None):
         value: Optional[_V]

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -217,7 +217,7 @@ class CacheInfo(NamedTuple):
         return self.hits / self.total
 
 
-class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
+class LRUCache(cachetools.LRUCache[_K, Optional[_V]], Generic[_K, _V]):
     """LRU Cache"""
 
     def __init__(self,
@@ -241,7 +241,7 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
             self._on_remove(key, value)
 
     @overload
-    def get(self, key: _K, /) -> Any | None:
+    def get(self, key: _K, /) -> Optional[_V]:
         ...
 
     @overload
@@ -312,7 +312,7 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
                                    "cannot remove oldest from the cache.")
         else:
             lru_key = next(iter(self.order))
-        self.pop(lru_key, None)
+        self.pop(cast(Optional[_K], lru_key), None)
 
     def _remove_old_if_needed(self) -> None:
         if len(self) > self.capacity:
@@ -334,7 +334,7 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
                                    "cannot remove oldest from the cache.")
         else:
             lru_key = next(iter(self.order))
-        value = self.pop(lru_key, None)
+        value = self.pop(cast(Optional[_K], lru_key), None)
         return (lru_key, value)
 
 


### PR DESCRIPTION
Fix #14927  

To unify the functionality of different LRUCache implementations, I designed vllm.utils.LRUCache based on cachetools.Cache, incorporating the following features:

Implemented function to compute the size for each item using the interfaces provided by cachetools.Cache.

- Reimplemented the feature to pin specific entries in the cache.
- Reimplemented the custom callback functions when an item is removed.
- Notably, cachetools.Cache inherits from collections.abc.MutableMapping, allowing LRUCache to seamlessly integrate into scenarios utilizing cachetools.cached, ensuring thread safety.

I have run tests involving LRUCache in tests/models/multimodal/processing/test_common.py and tests/lora/test_utils.py, all of which passed. However, due to hardware limitations, I only tested the Qwen2-VL-2B-Instruct model in test_common.py and have not verified compatibility with other models.
