### PR TITLE
Revert "Fix non-contiguous input passed to Marlin kernel (#15319)"

### DIFF
--- a/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
+++ b/vllm/model_executor/layers/quantization/kernels/mixed_precision/marlin.py
@@ -115,10 +115,6 @@ class MarlinLinearKernel(MPLinearKernel):
                       layer: torch.nn.Module,
                       x: torch.Tensor,
                       bias: Optional[torch.Tensor] = None) -> torch.Tensor:
-        # marlin requires contiguous memory layout
-        # prefix caching may cause x to be non-contiguous
-        x = x.contiguous()  # no-op if already contiguous
-
         c = self.config
         w_q, w_s, w_zp, w_gidx = self._get_weight_params(layer)
 


### PR DESCRIPTION
This reverts commit d20e261199d3e4bffe9ee0e495ba7f7454229f11.

Revert #15319. Not needed after #14658 added support for noncontiguous marlin kernels.
