### PR TITLE
[TPU][V1] Guided decoding on TPU

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1633,7 +1633,7 @@ class EngineArgs:
         not_cuda = not current_platform.is_cuda()
         if not_cuda and _warn_or_fallback(  # noqa: SIM103
                 current_platform.device_type):
-            return False
+            return True
         #############################################################
 
         return True

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -134,8 +134,8 @@ class Processor:
         else:
             params.guided_decoding.backend = engine_level_backend
 
-        if vllm.platforms.current_platform.is_tpu():
-            raise ValueError("Structured output is not supported on TPU.")
+        # if vllm.platforms.current_platform.is_tpu():
+        #     raise ValueError("Structured output is not supported on TPU.")
 
         validate_structured_output_request(params)
 


### PR DESCRIPTION
Hi, this is just a draft PR for issue #11104.  
I'm not new to TPU and JAX, but I'm new to LLM-serving-engine and PyTorch XLA, so I have a lot of questions here.

I've created a simple implementation for guided decoding on TPU. Here are the issues I encountered:

1. One problem I noticed is that we cannot use `sample_from_hidden` because it requires modified logits (bitmasking the logits that don't follow the grammar). However, I believe `sample_from_hidden` is actually a jitted function (?), as it was captured when the `capture_model` function runs. Performance-wise, it seems to slow down significantly (I just eyeballed the tokens per second from the logger) when the request requires guided decoding compared to the default one. Should we capture the jitted function in a smaller scope, such as `compute_logits` and `sample`? I need to profile this further to identify which part of the code is the bottleneck. Is there any code that can help with profiling this?

2. The XGrammar library doesn't support bitmasking directly on TPU, so I had to move the logits to the CPU first and then return them to the TPU for sampling.

Any feedback is welcome.

Thank you.

<!--- pyml disable-next-line no-emphasis-as-heading -->
