### PR TITLE
[BugFix][V1] Quick fix for min_tokens with multiple EOS

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -369,8 +369,9 @@ class SamplingParams(
             self.top_k = -1
             self.min_p = 0.0
             self._verify_greedy_sampling()
+
         # eos_token_id is added to this by the engine
-        self._all_stop_token_ids = set(self.stop_token_ids)
+        self._all_stop_token_ids.update(self.stop_token_ids)
 
     def _verify_args(self) -> None:
         if not isinstance(self.n, int):


### PR DESCRIPTION
Reported by @andylolu2 in [slack](https://vllm-dev.slack.com/archives/C087RA55P0D/p1742591113005329). This can affect `min_tokens` functionality for models that define more than one EOS token in their config.

We need to revisit how `SamplingParams.__post_init__` is used generally, as well as test coverage for this specific case. This is a quick fix in the meantime for a point release planned for today.

> - Essentially the eos_token_id added by `SamplingParams.update_from_generation_config` disappears when it's sent through the msgpack encoder, because the `__post_init__` overwrites [self._all_stop_token_ids = set(self.stop_token_ids)](https://github.com/vllm-project/vllm/blob/cfbb8c930fcda6d97f0de3018bd3c51ab14b367c/vllm/sampling_params.py#L373). So the worker sees an empty all_stop_token_ids, hence effectively no min_tokens.