### PR TITLE
[Core] LoRA: V1 Scheduler optimization

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -258,24 +258,24 @@ class Scheduler(SchedulerInterface):
                 skip_waiting_request = False
                 # Skip request if the structured output request is still waiting
                 # for FSM.
-                if request.status == RequestStatus.WAITING_FOR_FSM:
+                if (not skip_waiting_request
+                        and request.status == RequestStatus.WAITING_FOR_FSM):
                     structured_output_req = request.structured_output_request
-                    still_waiting_for_fsm = (not structured_output_req or
-                                             not structured_output_req.grammar)
-                    skip_waiting_request = (skip_waiting_request
-                                            or still_waiting_for_fsm)
-                    if not still_waiting_for_fsm:
+                    skip_waiting_request = (not structured_output_req or
+                                            not structured_output_req.grammar)
+                    if not skip_waiting_request:
                         request.status = RequestStatus.WAITING
 
                 # Skip request if max_loras can't be honored.
-                if self.lora_config and request.lora_request:
+                if (not skip_waiting_request and self.lora_config
+                        and request.lora_request):
                     req_lora_id = request.lora_request.lora_int_id
-                    skip_waiting_request = skip_waiting_request or (
-                        len(scheduled_loras) == self.lora_config.max_loras and
-                        (req_lora_id not in scheduled_loras))
+                    skip_waiting_request = (
+                        len(scheduled_loras) == self.lora_config.max_loras
+                        and (req_lora_id not in scheduled_loras))
 
                 if skip_waiting_request:
-                    skipped_waiting_requests.append(request)
+                    skipped_waiting_requests.appendleft(request)
                     self.waiting.popleft()
                     continue
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -235,12 +235,12 @@ class Scheduler(SchedulerInterface):
                 encoder_budget = new_encoder_budget
 
         # Record the LoRAs in scheduled_running_reqs
-        requested_loras: set[int] = set()
+        scheduled_loras: set[int] = set()
         if self.lora_config:
-            requested_loras = set(
+            scheduled_loras = set(
                 req.lora_request.lora_int_id for req in scheduled_running_reqs
                 if req.lora_request and req.lora_request.lora_int_id > 0)
-            assert len(requested_loras) <= self.lora_config.max_loras
+            assert len(scheduled_loras) <= self.lora_config.max_loras
 
         # Use a temporary deque to collect requests that need to be skipped
         # and put back at the head of the waiting queue later
@@ -268,8 +268,8 @@ class Scheduler(SchedulerInterface):
                 # constraint.
                 if self.lora_config and request.lora_request:
                     req_lora_id = request.lora_request.lora_int_id
-                    if len(requested_loras) == self.lora_config.max_loras and (
-                            req_lora_id not in requested_loras):
+                    if len(scheduled_loras) == self.lora_config.max_loras and (
+                            req_lora_id not in scheduled_loras):
                         # Cannot schedule.
                         # TODO (varun): This means all the other requests in
                         # the WAITING queue will be blocked by this request,
@@ -336,7 +336,7 @@ class Scheduler(SchedulerInterface):
                         f"Invalid request status: {request.status}")
 
                 if self.lora_config and request.lora_request:
-                    requested_loras.add(request.lora_request.lora_int_id)
+                    scheduled_loras.add(request.lora_request.lora_int_id)
                 req_to_new_block_ids[request.request_id] = [
                     b.block_id for b in computed_blocks + new_blocks
                 ]

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -255,26 +255,26 @@ class Scheduler(SchedulerInterface):
                 request = self.waiting[0]
 
                 # Waiting request skipping logic
-                skip_waiting_request = False
+                is_skipped = False
                 # Skip request if the structured output request is still waiting
                 # for FSM.
-                if (not skip_waiting_request
+                if (not is_skipped
                         and request.status == RequestStatus.WAITING_FOR_FSM):
                     structured_output_req = request.structured_output_request
-                    skip_waiting_request = (not structured_output_req or
-                                            not structured_output_req.grammar)
-                    if not skip_waiting_request:
+                    is_skipped = (not structured_output_req
+                                  or not structured_output_req.grammar)
+                    if not is_skipped:
                         request.status = RequestStatus.WAITING
 
                 # Skip request if max_loras can't be honored.
-                if (not skip_waiting_request and self.lora_config
+                if (not is_skipped and self.lora_config
                         and request.lora_request):
                     req_lora_id = request.lora_request.lora_int_id
-                    skip_waiting_request = (
-                        len(scheduled_loras) == self.lora_config.max_loras
-                        and (req_lora_id not in scheduled_loras))
+                    is_skipped = (len(scheduled_loras)
+                                  == self.lora_config.max_loras
+                                  and (req_lora_id not in scheduled_loras))
 
-                if skip_waiting_request:
+                if is_skipped:
                     skipped_waiting_requests.appendleft(request)
                     self.waiting.popleft()
                     continue

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -244,7 +244,7 @@ class Scheduler(SchedulerInterface):
 
         # Use a temporary deque to collect requests that need to be skipped
         # and put back at the head of the waiting queue later
-        waiting_for_fsm: deque[Request] = deque()
+        skipped_waiting_requests: deque[Request] = deque()
 
         # Next, schedule the WAITING requests.
         if not preempted_reqs:
@@ -260,7 +260,7 @@ class Scheduler(SchedulerInterface):
                         request.status = RequestStatus.WAITING
                     else:
                         waiting_structured_output_req = self.waiting.popleft()
-                        waiting_for_fsm.appendleft(
+                        skipped_waiting_requests.appendleft(
                             waiting_structured_output_req)
                         continue
 
@@ -355,8 +355,8 @@ class Scheduler(SchedulerInterface):
                     encoder_budget = new_encoder_budget
 
         # Put back any skipped requests at the head of the waiting queue
-        if waiting_for_fsm:
-            self.waiting.extendleft(waiting_for_fsm)
+        if skipped_waiting_requests:
+            self.waiting.extendleft(skipped_waiting_requests)
 
         # Check if the scheduling constraints are satisfied.
         total_num_scheduled_tokens = sum(num_scheduled_tokens.values())


### PR DESCRIPTION
LoRA Scheduler Optimization 

Running Example: 
Let `max_loras` be set to 4
Let Waiting queue be : { R1, R2, R3, R4-L1, R5-L3, R6-L2, R7-L4, R8-L5, R9-L5, R10-L5, R11-L5, R12, R13, R14-L1, R15-L2, R16-L3 }
R`x` - Request number `x`. Request doesn't need any LoRA
R`x`-L`y` - Request number `x` that needs LoRA number `y`

Why: 
In V1 + LoRA, at the moment we stop scheduling waiting requests when we can no longer honor `max_loras` user inputs.  This is not optimal as, 
 - Other requests that do not use LoRA, or,
 - Other requests that use the already requested LoRAs.
 are blocked from scheduling. 

In the example above, 
 - The scheduler schedules { R1, R2, R3, R4-L1, R5-L3, R6-L2, R7-L4 }
 - In future iterations the scheduler can't schedule additional requests until one of { R4-L1, R5-L3, R6-L2, R7-L4 } completes.
 -  Lets say R4-L1 completes.
 - Now, the scheduler will schedule {R1, R2, R3, R5-L3, R6-L2, R7-L4, R8-L5, R9-L5, R10-L5, R11-L5, R12, R13}
 - and so on 

What:
This PR updates the scheduling logic to continue scanning the waiting queue for requests that can still be scheduled.
With this PR,
 - The scheduler will schedule { R1, R2, R3, R4-L1, R5-L3, R6-L2, R7-L4, R12, R13, R14-L1, R15-L2, R16-L3 } . The requests {R8-L5, R9-L5, R10-L5, R11-L5} will stay in the waiting queue.
 - When one of the LoRA request set completes i.e. {R4-L1, R14-L1} or {R5-L3, R16-L3} or {R6-L2, R15-L2} the scheduler will continue scheduling the  {R8-L5, R9-L5, R10-L5, R11-L5}
 
How: 
We leverage the "skip waiting requests" logic introduced by structured decoding. 

## Benchmarks: 
`max_loras` = 4  , number of lora modules = 8 , `max_num_seqs` = 256, `max_num_batched_tokens` = 4096

### Server Command : 
```
vllm serve  meta-llama/Llama-2-7b-hf  --enable-lora  --max-loras 4  --max-lora-rank 8  --lora-modules lora0=yard1/llama-2-7b-sql-lora-test lora1=yard1/llama-2-7b-sql-lora-test lora2=yard1/llama-2-7b-sql-lora-test lora3=yard1/llama-2-7b-sql-lora-test lora4=yard1/llama-2-7b-sql-lora-test lora5=yard1/llama-2-7b-sql-lora-test lora6=yard1/llama-2-7b-sql-lora-test lora7=yard1/llama-2-7b-sql-lora-test                       --max-num-seqs 256   --max-num-batched-tokens 4096  --no-enable-prefix-caching   --port 9002  --disable-log-stats
```

### benchmark_serving.py command
```
python3 benchmarks/benchmark_serving.py   --model meta-llama/Llama-2-7b-hf                     --dataset-name sharegpt  --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json   --sharegpt-output-len 120  --num-prompts 500 --request-rate inf  --lora-modules lora0 lora1 lora2 lora3 lora4 lora5 lora6 lora7  --ignore-eos --port 9002  --seed 2
```

### main V1
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  200.71    
Total input tokens:                      124520    
Total generated tokens:                  60000     
Request throughput (req/s):              2.49      
Output token throughput (tok/s):         298.94    
Total Token throughput (tok/s):          919.35    
---------------Time to First Token----------------
Mean TTFT (ms):                          99070.16  
Median TTFT (ms):                        101450.02 
P99 TTFT (ms):                           195994.95 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          15.13     
Median TPOT (ms):                        15.24     
P99 TPOT (ms):                           16.17     
---------------Inter-token Latency----------------
Mean ITL (ms):                           15.31     
Median ITL (ms):                         15.22     
P99 ITL (ms):                            16.88     
==================================================
```

### main V0
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  29.19     
Total input tokens:                      124520    
Total generated tokens:                  60000     
Request throughput (req/s):              17.13     
Output token throughput (tok/s):         2055.28   
Total Token throughput (tok/s):          6320.66   
---------------Time to First Token----------------
Mean TTFT (ms):                          10400.52  
Median TTFT (ms):                        6083.83   
P99 TTFT (ms):                           26071.17  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          79.85     
Median TPOT (ms):                        80.54     
P99 TPOT (ms):                           106.48    
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.85     
Median ITL (ms):                         61.96     
P99 ITL (ms):                            389.40    
==================================================
```

### This PR
```
============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  29.84     
Total input tokens:                      124520    
Total generated tokens:                  60000     
Request throughput (req/s):              16.75     
Output token throughput (tok/s):         2010.46   
Total Token throughput (tok/s):          6182.82   
---------------Time to First Token----------------
Mean TTFT (ms):                          11862.28  
Median TTFT (ms):                        6406.40   
P99 TTFT (ms):                           24552.50  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          73.55     
Median TPOT (ms):                        77.75     
P99 TPOT (ms):                           102.69    
---------------Inter-token Latency----------------
Mean ITL (ms):                           73.55     
Median ITL (ms):                         50.22     
P99 ITL (ms):                            346.09    
==================================================
```

