### PR TITLE
[BugFix] Fix quantized models that do not specify `packed_modules_mapping` not loading 

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -13,6 +13,14 @@ from vllm.scalar_type import ScalarType, scalar_types
 SUPPORTED_GPTQ_QUANT_TYPES = [scalar_types.uint4b8, scalar_types.uint8b128]
 SUPPORTED_GROUP_SIZES = [-1, 32, 64, 128]
 
+# Note: this is a hack. We should update each model to register the
+# stacked params and get it from there instead in a future PR.
+# fused_name: List[shard_name]
+FUSED_LAYER_NAME_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"]
+}
+
 
 # Normalize the group_shape to the full extent for any dims that are -1
 def _normalize_quant_group_shape(x: torch.Tensor, group_shape: Tuple[int,

--- a/vllm/model_executor/model_loader/utils.py
+++ b/vllm/model_executor/model_loader/utils.py
@@ -13,6 +13,8 @@ from vllm.config import ModelConfig, ModelImpl
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    FUSED_LAYER_NAME_MAPPING)
 from vllm.model_executor.models import ModelRegistry
 from vllm.model_executor.models.adapters import (as_classification_model,
                                                  as_embedding_model,
@@ -169,4 +171,9 @@ def configure_quant_config(quant_config: QuantizationConfig,
         logger.warning(
             "The model class %s has not defined `packed_modules_mapping`, "
             "this may lead to incorrect mapping of quantized or ignored "
-            "modules", model_class.__name__)
+            "modules; falling back to old hardcoded mapping. "
+            "Please update the model definition as this fallback will be "
+            "deprecated in future releases",
+            model_class.__name__,
+        )
+        quant_config.packed_modules_mapping = FUSED_LAYER_NAME_MAPPING


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/12634 appears to have introduced a breaking behavior change for loading quantized model, i.e. uses `packed_modules_mapping` instead of `FUSED_LAYER_NAME_MAPPING`. Adding a fallback to the old behavior so we don't break currently working models. Add a deprecation warning so we can fully adopt the new pathway after giving the community time to fully adopt the new pathway.

Related to: https://github.com/vllm-project/vllm/issues/15002 , i.e. `cognitivecomputations/DeepSeek-R1-AWQ`, we should update 

Edited: looks like this may not have solved it, may have been an environmental error