### PR TITLE
[bugfix] fix inductor cache on max_position_embeddings

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -221,6 +221,9 @@ class ModelConfig:
         factors.append(self.trust_remote_code)
         factors.append(self.rope_scaling)
         factors.append(self.rope_theta)
+        # rope cos/sin cache depends on the max_position_embeddings
+        factors.append(
+            getattr(self.hf_config, "max_position_embeddings", "None"))
         return hashlib.sha256(str(factors).encode()).hexdigest()
 
     def __init__(


### PR DESCRIPTION
the error occurs in https://buildkite.com/vllm/ci/builds/16071/steps?jid=0195c129-51b5-4a2e-984e-0ee08c2e3467 .