### PR TITLE
[Bugfix][Frontend] Fix pythonic tool parser failure with negative numbers

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_pythonic_tool_parser.py
@@ -52,6 +52,11 @@ ESCAPED_STRING_FUNCTION_CALL = FunctionCall(
     name="get_weather",
     arguments='{"city": "Martha\'s Vineyard", "metric": "\\"cool units\\""}',
 )
+NEGATIVE_NUMBERS_FUNCTION_OUTPUT = ("add_two_numbers(a=-1,b=2)")
+NEGATIVE_NUMBERS_FUNCTION_CALL = FunctionCall(
+    name="add_two_numbers",
+    arguments='{"a": -1, "b": 2}',
+)
 
 
 @pytest.mark.parametrize("streaming", [True, False])
@@ -110,6 +115,14 @@ TEST_CASES = [
                  f"[{ESCAPED_STRING_FUNCTION_OUTPUT}]",
                  [ESCAPED_STRING_FUNCTION_CALL],
                  id="escaped_string_nonstreaming"),
+    pytest.param(True,
+                 f"[{NEGATIVE_NUMBERS_FUNCTION_OUTPUT}]",
+                 [NEGATIVE_NUMBERS_FUNCTION_CALL],
+                 id="negative_numbers_streaming"),
+    pytest.param(False,
+                 f"[{NEGATIVE_NUMBERS_FUNCTION_OUTPUT}]",
+                 [NEGATIVE_NUMBERS_FUNCTION_CALL],
+                 id="negative_numbers_nonstreaming"),
     pytest.param(True,
                  f"[{SIMPLE_FUNCTION_OUTPUT}, {MORE_TYPES_FUNCTION_OUTPUT}]",
                  [SIMPLE_FUNCTION_CALL, MORE_TYPES_FUNCTION_CALL],

--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -179,6 +179,9 @@ class PythonicToolParser(ToolParser):
 def _get_parameter_value(val: ast.expr) -> Any:
     if isinstance(val, ast.Constant):
         return val.value
+    elif isinstance(val, ast.UnaryOp) and isinstance(val.op, ast.USub):
+        # Negative numbers are represented as UnaryOp(USub, Constant)
+        return -_get_parameter_value(val.operand)
     elif isinstance(val, ast.Dict):
         if not all(isinstance(k, ast.Constant) for k in val.keys):
             raise _UnexpectedAstError(


### PR DESCRIPTION
I noticed that the `pythonic` tool parser cannot work with negative numbers, resulting in a parsing error. It is connected to the fact that in Python AST, negative numbers are represented not as a constant but as an unary operation (-) of the constant. 

I have added a test case and a fix for this behavior. You can additionally check that without a fix, the newly added test cases fail. 
