### PR TITLE
[Bugfix] Support triton==3.3.0+git95326d9f for RTX 5090 (Unsloth + vLLM compatibility)

### DIFF
--- a/vllm/lora/ops/triton_ops/kernel_utils.py
+++ b/vllm/lora/ops/triton_ops/kernel_utils.py
@@ -130,7 +130,7 @@ def do_expand_kernel(
     # Identify A and B block pointers
     offset_k = tl.arange(0, BLOCK_K)
     a_ptr = (cur_input_ptr + ram[:, None] * input_d1_stride +
-             offset_k[None, :] * input_d2_stride, )
+             offset_k[None, :] * input_d2_stride)
     b_ptr = (cur_lora_ptr + cur_lora_d0_stride * lora_index +
              offset_k[:, None] * cur_lora_d2_stride +
              rbn[None, :] * cur_lora_d1_stride)


### PR DESCRIPTION
## 🔧 Fix: Support `triton==3.3.0+git95326d9f` for RTX 5090 (Unsloth + vLLM compatibility)

### 📝 Description

This PR fixes an incompatibility in the Triton kernel logic used in `vllm/lora/ops/triton_ops/kernel_utils.py` that causes vLLM to break when running with:
- **Unsloth**: `2025.3.18`
- **Unsloth_zoo**: `2025.3.16 `
- **Triton**: `3.3.0+git95326d9f`
- **Torch**: `2.8.0.dev20250324+cu128`
- **Torchvision**: `0.22.0.dev20250324+cu128`
- **Torchaudio**: `2.6.0.dev20250324+cu128`
- **xformers**: `0.0.30+4fa0149.d20250325`

All tested using **Unsloth** and **Qwen2.5-3B-Instruct**, with an **NVIDIA RTX 5090**.

---

### 🐛 Problem

When running vLLM with Unsloth, the following error occurred:

```
AttributeError: 'tuple_type' object has no attribute 'is_ptr'
```

This was traced to incorrect pointer construction using:

```python
a_ptr = (some_expr, )
```

Triton now treats this as a `tuple_type`, which breaks downstream logic that expects a pointer object.

---

### ✅ Fix

We removed unnecessary trailing commas in pointer assignments so that actual `pointer_type` objects are passed instead of tuples. For example:

```diff
- a_ptr = (cur_input_ptr + ram[:, None] * input_d1_stride + offset_k[None, :] * input_d2_stride, )
+ a_ptr = cur_input_ptr + ram[:, None] * input_d1_stride + offset_k[None, :] * input_d2_stride
```
---

### 🚀 Result

This fix makes vLLM fully compatible with Triton 3.3.0+, allowing Unsloth-based LoRA fine-tuning and inference to work out-of-the-box with newer GPUs like the RTX 5090.

---

### 🔒 Notes

- This PR assumes the environment variable `VLLM_INSTALL_PUNICA_KERNELS=1` is set during installation.
- Installed using `pip install -e . --no-build-isolation`.

---