### PR TITLE
Enhance logits processor to add additional data

### DIFF
--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Union, Dict, Any
+from typing import Callable, Union, Any
 
 import torch
 
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 
 LogitsProcessor = Union[Callable[[list[int], torch.Tensor], torch.Tensor],
-                        Callable[[list[int], torch.Tensor, Dict[str, Any]],
+                        Callable[[list[int], torch.Tensor, dict[str, Any]],
                                  torch.Tensor]]
 """LogitsProcessor is a function that takes a list
 of previously generated tokens, the logits tensor
-for the next token and, optionally, an third `kwargs` contains 
+for the next token and, optionally, an third `kwargs` contains
 the sequence id and prompt token, and returns a modified tensor of logits
 to sample from.
 
@@ -22,7 +22,10 @@ class CustomProcessor:
     ...
 
     def __call__(
-        self, past_token_ids: List[int], logits: torch.Tensor, **kwargs: Dict[str, Any]
+        self,
+        past_token_ids: List[int],
+        logits: torch.Tensor,
+        **kwargs: dict[str, Any],
     ) -> torch.Tensor:
 
         seq_id = kwargs.get("seq_id")

--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -1,19 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Union
+from typing import Callable, Union, Dict, Any
 
 import torch
 
 from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
 
 LogitsProcessor = Union[Callable[[list[int], torch.Tensor], torch.Tensor],
-                        Callable[[list[int], list[int], torch.Tensor],
+                        Callable[[list[int], torch.Tensor, Dict[str, Any]],
                                  torch.Tensor]]
 """LogitsProcessor is a function that takes a list
 of previously generated tokens, the logits tensor
-for the next token and, optionally, prompt tokens as a
-first argument, and returns a modified tensor of logits
-to sample from."""
+for the next token and, optionally, an third `kwargs` contains 
+the sequence id and prompt token, and returns a modified tensor of logits
+to sample from.
+
+Example:
+
+class CustomProcessor:
+
+    ...
+
+    def __call__(
+        self, past_token_ids: List[int], logits: torch.Tensor, **kwargs: Dict[str, Any]
+    ) -> torch.Tensor:
+
+        seq_id = kwargs.get("seq_id")
+        prompt_tokens_ids = kwargs.get("prompt_tokens_ids")
+
+        return logits
+"""
 
 
 def get_bad_words_logits_processors(

--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Union, Any
+from typing import Any, Callable, Union
 
 import torch
 

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -162,14 +162,14 @@ def _apply_logits_processors(
                     logits_row_ids_and_logits_row_futures.append(
                         (logits_row_idx,
                          _logits_processor_threadpool.submit(
-                             _apply_logits_processors_single_seq, seq_id, logits_row,
-                             logits_processors, past_tokens_ids,
+                             _apply_logits_processors_single_seq, seq_id,
+                             logits_row, logits_processors, past_tokens_ids,
                              prompt_tokens_ids)))
                 else:
                     logits[logits_row_idx] = \
                         _apply_logits_processors_single_seq(
-                            seq_id, logits_row, logits_processors, past_tokens_ids,
-                            prompt_tokens_ids)
+                            seq_id, logits_row, logits_processors,
+                            past_tokens_ids, prompt_tokens_ids)
 
         logits_processed += len(seq_group.sample_indices) + len(
             seq_group.prompt_logprob_indices)
@@ -193,7 +193,8 @@ def _apply_logits_processors_single_seq(seq_id, logits_row, logits_processors,
     for logits_processor in logits_processors:
         # check if the third argument is '**kwargs'
         params = list(inspect.signature(logits_processor).parameters.values())
-        if len(params) == 3 and params[2].kind == inspect.Parameter.VAR_KEYWORD:
+        if len(params) == 3 and \
+                params[-1].kind == inspect.Parameter.VAR_KEYWORD:
             logits_row = logits_processor(prompt_tokens_ids, past_tokens_ids,
                                           **kwargs)
         else:

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -162,13 +162,13 @@ def _apply_logits_processors(
                     logits_row_ids_and_logits_row_futures.append(
                         (logits_row_idx,
                          _logits_processor_threadpool.submit(
-                             _apply_logits_processors_single_seq, logits_row,
+                             _apply_logits_processors_single_seq, seq_id, logits_row,
                              logits_processors, past_tokens_ids,
                              prompt_tokens_ids)))
                 else:
                     logits[logits_row_idx] = \
                         _apply_logits_processors_single_seq(
-                            logits_row, logits_processors, past_tokens_ids,
+                            seq_id, logits_row, logits_processors, past_tokens_ids,
                             prompt_tokens_ids)
 
         logits_processed += len(seq_group.sample_indices) + len(
@@ -183,14 +183,19 @@ def _apply_logits_processors(
     return logits
 
 
-def _apply_logits_processors_single_seq(logits_row, logits_processors,
+def _apply_logits_processors_single_seq(seq_id, logits_row, logits_processors,
                                         past_tokens_ids,
                                         prompt_tokens_ids) -> torch.Tensor:
+    kwargs = {
+        'seq_id': seq_id,
+        'prompt_tokens_ids': prompt_tokens_ids,
+    }
     for logits_processor in logits_processors:
-        parameters = inspect.signature(logits_processor).parameters
-        if len(parameters) == 3:
+        # check if the third argument is '**kwargs'
+        params = list(inspect.signature(logits_processor).parameters.values())
+        if len(params) == 3 and params[2].kind == inspect.Parameter.VAR_KEYWORD:
             logits_row = logits_processor(prompt_tokens_ids, past_tokens_ids,
-                                          logits_row)
+                                          **kwargs)
         else:
             logits_row = logits_processor(past_tokens_ids, logits_row)
     return logits_row


### PR DESCRIPTION
This PR try to enhance the current logits processor by add an optional `kwargs` as the third parameter. Where we add both the sequence id and the prompt tokens to the custom logits processor. We believe this is a much better option than the current solution.

We also enhanced the document to add a minimum example to explain how to use it

```python
class CustomProcessor:
 
     ...
 
     def __call__(
         self, past_token_ids: List[int], logits: torch.Tensor, **kwargs: Dict[str, Any]
     ) -> torch.Tensor:
 
         seq_id = kwargs.get("seq_id")
         prompt_tokens_ids = kwargs.get("prompt_tokens_ids")
 
         return logits
```

FIX https://github.com/vllm-project/vllm/issues/2142

