### PR TITLE
[Bugfix][Frontend] respect provided default guided decoding backend

### DIFF
--- a/tests/test_sampling_params.py
+++ b/tests/test_sampling_params.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the SamplingParams class.
 """
+
+import pytest
+
 from vllm import SamplingParams
+from vllm.config import ModelConfig
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+
+MODEL_NAME = "Qwen/Qwen1.5-7B"
 
 
 def test_max_tokens_none():
@@ -9,6 +16,74 @@ def test_max_tokens_none():
     SamplingParams(temperature=0.01, top_p=0.1, max_tokens=None)
 
 
-if __name__ == "__main__":
-    import pytest
-    pytest.main([__file__])
+@pytest.fixture(scope="module")
+def model_config():
+    return ModelConfig(
+        MODEL_NAME,
+        task="auto",
+        tokenizer=MODEL_NAME,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        seed=0,
+        dtype="float16",
+        revision=None,
+    )
+
+
+@pytest.fixture(scope="module")
+def default_max_tokens():
+    return 4096
+
+
+def test_sampling_params_from_request_with_no_guided_decoding_backend(
+        model_config, default_max_tokens):
+    # guided_decoding_backend is not present at request level
+    request = ChatCompletionRequest.model_validate({
+        'messages': [{
+            'role': 'user',
+            'content': 'Hello'
+        }],
+        'model':
+        MODEL_NAME,
+        'response_format': {
+            'type': 'json_object',
+        },
+    })
+
+    sampling_params = request.to_sampling_params(
+        default_max_tokens,
+        model_config.logits_processor_pattern,
+    )
+    # we do not expect any backend to be present and the default
+    # guided_decoding_backend at engine level will be used.
+    assert sampling_params.guided_decoding.backend is None
+
+
+@pytest.mark.parametrize("request_level_guided_decoding_backend,expected",
+                         [("xgrammar", "xgrammar"),
+                          ("lm-format-enforcer", "lm-format-enforcer"),
+                          ("outlines", "outlines")])
+def test_sampling_params_from_request_with_guided_decoding_backend(
+        request_level_guided_decoding_backend: str, expected: str,
+        model_config, default_max_tokens):
+
+    request = ChatCompletionRequest.model_validate({
+        'messages': [{
+            'role': 'user',
+            'content': 'Hello'
+        }],
+        'model':
+        MODEL_NAME,
+        'response_format': {
+            'type': 'json_object',
+        },
+        'guided_decoding_backend':
+        request_level_guided_decoding_backend,
+    })
+
+    sampling_params = request.to_sampling_params(
+        default_max_tokens,
+        model_config.logits_processor_pattern,
+    )
+    # backend correctly identified in resulting sampling_params
+    assert sampling_params.guided_decoding.backend == expected

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -476,8 +476,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 json_schema = self.response_format.json_schema
                 assert json_schema is not None
                 self.guided_json = json_schema.json_schema
-                if self.guided_decoding_backend is None:
-                    self.guided_decoding_backend = "xgrammar"
 
         guided_decoding = GuidedDecodingParams.from_optional(
             json=self._get_guided_json_from_tool() or self.guided_json,


### PR DESCRIPTION
For structured outputs, the default guided decoding backend to use can be set via the [`--guided-decoding-backend` flag](https://docs.vllm.ai/en/latest/serving/engine_args.html). Default is `xgrammar`.

However, currently, this flag has currently no effect as the default guided decoding backend is always overriden in `protocol.py` with `xgrammar`, and the only way to use another decoding backend is to set it using the accepted `guided_decoding_backend` extra argument of a request:
- when a request is processed (e.g.: chat completion), sampling params are directly [derived from the request using the `request.to_sampling_params` method](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/entrypoints/openai/serving_completion.py#L139).
- when the [`to_sampling_params`](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/entrypoints/openai/protocol.py#L420) method is called, if no `guided_decoding_backend` was provided at the request level, then the guided decoding backend it is [always set to `xgrammar` at the request level](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/entrypoints/openai/protocol.py#L468).
- as a result, those request-level `sampling_params` (without a `guided_decoding.backend` at `None` since it is always set to `xgrammar`) are sequentially passed on to  [the `engine_client.generate` method](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/entrypoints/openai/serving_completion.py#L164), then to the [`engine_client._process_request` method](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/engine/multiprocessing/client.py#L508) which in fine calls the [`build_guided_decoding_logits_processor_async` function](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/engine/multiprocessing/client.py#L613) with both the request-level `sampling_params`, and the `default_guided_backend` (the one set by the initial flag).
- Finally, the final `guided_decoding_backend` used in the `build_guided_decoding_logits_processor_async` function is always the artificially defined `guided_decoding_backend` at the request level because the request-level decoding backend is never `None` and therefore [always takes precedence here](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/engine/async_llm_engine.py#L554).

This PR fixes this problem, by not artifically setting a decoding backend at the request-level when not set, which:
- respect the default decoding backend chosen when the `--guided-decoding-backend` flag is used (note: `xgrammar` is still [the default backend](https://github.com/vllm-project/vllm/blob/d0cfec7ab919bfab261db419e17c768f08a24dc8/vllm/engine/arg_utils.py#L178) set by default if the flag is not used),
- as well as respect the decoding backend set as extra argument of a request.

cc: @mgoin 

## To test this PR:

`lm-format-enforcer` supports the type "array of string" as described in the first point of the [JSON schema reference](https://json-schema.org/understanding-json-schema/reference/type), while `xgrammar` does not yet support it.
So the following request can be used.

- without this PR, starting the server with `--guided-decoding-backend lm-format-enforcer` will fail, as the flag is ignored and `xgrammar` is used. With this PR, the flag will be respected and no error will be returned.

```
curl http://localhost:8003/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "llama",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful math tutor. Guide the user through the solution step by step. Be concise. Always respond as JSON."
      },
      {
        "role": "user",
        "content": "how can I solve 8x + 7 = -23"
      }
    ],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "math_reasoning",
        "schema": {
          "type": "object",          
          "properties": {          
            "steps": {            
              "type": "array",              
              "items": {              
                "type": "object",                
                "properties": {                
                  "explanation": { "type": ["string", "null"] },                  
                  "output": { "type": "string" }                  
                },                
                "required": ["explanation", "output"],                
                "additionalProperties": false                
              }              
            },            
            "final_answer": { "type": "string" }            
          },          
          "required": ["steps", "final_answer"],          
          "additionalProperties": false          
        },
        "strict": true
      }
    }
  }'
```