### PR TITLE
[BugFix] Fix nightly MLA failure (FA2 + MLA chunked prefill, i.e. V1, producing bad results)

### DIFF
--- a/vllm/attention/ops/triton_merge_attn_states.py
+++ b/vllm/attention/ops/triton_merge_attn_states.py
@@ -57,7 +57,7 @@ def merge_attn_states_kernel(
 
     # FA2 and FA3 have different behavior for when the sum-exp is 0, this namely
     # arises with 0 len seqlens. FA3 returns -inf here while FA2 returns inf.
-    # If we see an inf assume FA2 and convert inf to -inf for consistency 
+    # If we see an inf assume FA2 and convert inf to -inf for consistency
     # and correctness. Inf generally doesn't make sense in this context outside
     # of undefined-behavior/FA2-case, so I think this a safe assumption.
     p_lse = float('-inf') if p_lse == float('inf') else p_lse

--- a/vllm/attention/ops/triton_merge_attn_states.py
+++ b/vllm/attention/ops/triton_merge_attn_states.py
@@ -54,6 +54,15 @@ def merge_attn_states_kernel(
 
     p_lse = tl.load(prefix_lse + head_idx * num_tokens + token_idx)
     s_lse = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
+
+    # FA2 and FA3 have different behavior for when the sum-exp is 0, this namely
+    # arises with 0 len seqlens. FA3 returns -inf here while FA2 returns inf.
+    # If we see an inf assume FA2 and convert inf to -inf for consistency 
+    # and correctness. Inf generally doesn't make sense in this context outside
+    # of undefined-behavior/FA2-case, so I think this a safe assumption.
+    p_lse = float('-inf') if p_lse == float('inf') else p_lse
+    s_lse = float('-inf') if s_lse == float('inf') else s_lse
+
     max_lse = tl.maximum(p_lse, s_lse)
     p_lse = p_lse - max_lse
     s_lse = s_lse - max_lse


### PR DESCRIPTION
For MLA chunked prefill we use `merge_attn_states` to compute the context for a chunked-prefill, this sometimes leads to 0 length contexts when regular prefills and chunked-prefills are mixed in the same batch. FA2 and FA3 have differences in what the return when the sum-exp is 0, (i.e. what to return for log(0) which is technically undefined), FA3 returns -inf while FA2 returns inf. The code was written for FA3, i.e. -inf (I think this is also just the more logical choice) resulting in failures when running on A100s that default to FA2. This PR updates `merge_attn_states` to handle both cases (easier and less error prone than trying to update FA2).