### PR TITLE
Fix incorrect filenames in vllm_compile_cache.py

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -228,11 +228,20 @@ class InductorAdaptor(CompilerInterface):
                 inductor_compiled_graph = output
                 if inductor_compiled_graph is not None:
                     nonlocal file_path
-                    # the current_callable captures two things, the inputs_idx
-                    # (0) and the function (1) from which we are going to pull
-                    # the filename from.
-                    file_path = inductor_compiled_graph.current_callable.__closure__[  # noqa
-                        1].cell_contents.__code__.co_filename  # noqa
+                    compiled_fn = inductor_compiled_graph.current_callable
+                    file_path = compiled_fn.__code__.co_filename  # noqa
+                    if not file_path.startswith(self.cache_dir):
+                        # hooked in the align_inputs_from_check_idxs function
+                        # in torch/_inductor/utils.py
+                        for cell in compiled_fn.__closure__:
+                            if not callable(cell.cell_contents):
+                                continue
+                            code = cell.cell_contents.__code__
+                            if code.co_filename.startswith(self.cache_dir):
+                                # this is the real file path
+                                # compiled from Inductor
+                                file_path = code.co_filename
+                                break
                     hash_str = inductor_compiled_graph._fx_graph_cache_key
                 return output
 

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -228,7 +228,11 @@ class InductorAdaptor(CompilerInterface):
                 inductor_compiled_graph = output
                 if inductor_compiled_graph is not None:
                     nonlocal file_path
-                    file_path = inductor_compiled_graph.current_callable.__code__.co_filename  # noqa
+                    # the current_callable captures two things, the inputs_idx
+                    # (0) and the function (1) from which we are going to pull
+                    # the filename from.
+                    file_path = inductor_compiled_graph.current_callable.__closure__[  # noqa
+                        1].cell_contents.__code__.co_filename  # noqa
                     hash_str = inductor_compiled_graph._fx_graph_cache_key
                 return output
 


### PR DESCRIPTION
Test Plan:
- I ran `vllm serve meta-llama/Llama-3.2-1B-Instruct` locally and verified that vllm_compile_cache.py's filenames look like the following:

```
/home/rzou/.cache/vllm/torch_compile_cache/a785fdbf18/rank_0_0/inductor_cache/w2/cw22szhsitonk3z4ek
x476g3hzaet3vy5qmsoewpx3kgbokhcob2.py')}
```

