### PR TITLE
[Bugfix]: The sequence becomes shorter after encoding and decoding

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -312,7 +312,10 @@ class RandomDataset(BenchmarkDataset):
         )
         prefix_token_ids = tokenizer(
             tokenizer.decode(double_prefix_token_ids)
-        ).input_ids[:prefix_len]
+        ).input_ids
+        while len(prefix_token_ids) < prefix_len:
+            prefix_token_ids *= 2
+        prefix_token_ids = prefix_token_ids[:prefix_len]
 
         input_low = int(input_len * range_ratio)
         output_low = int(output_len * range_ratio)
@@ -331,11 +334,10 @@ class RandomDataset(BenchmarkDataset):
                          vocab_size).tolist()
             token_sequence = prefix_token_ids + inner_seq
             total_input_len = prefix_len + int(input_lens[i])
-            prompt = tokenizer.decode(
-                tokenizer(
-                    tokenizer.decode(token_sequence)
-                ).input_ids[:total_input_len]
-            )
+            token_sequence = tokenizer(tokenizer.decode(token_sequence)).input_ids
+            while len(token_sequence) < total_input_len:
+                token_sequence *= 2
+            prompt = tokenizer.decode(token_sequence[:total_input_len])
             requests.append(
                 SampleRequest(
                     prompt=prompt,

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -310,12 +310,15 @@ class RandomDataset(BenchmarkDataset):
             np.random.randint(0, vocab_size, size=prefix_len * 2).tolist()
             if prefix_len > 0 else []
         )
-        prefix_token_ids = tokenizer(
-            tokenizer.decode(double_prefix_token_ids)
-        ).input_ids
-        while len(prefix_token_ids) < prefix_len:
-            prefix_token_ids *= 2
-        prefix_token_ids = prefix_token_ids[:prefix_len]
+        if prefix_len > 0:
+            prefix_token_ids = tokenizer(
+                tokenizer.decode(double_prefix_token_ids)
+            ).input_ids
+            while len(prefix_token_ids) < prefix_len:
+                prefix_token_ids *= 2
+            prefix_token_ids = prefix_token_ids[:prefix_len]
+        else:
+            prefix_token_ids = []
 
         input_low = int(input_len * range_ratio)
         output_low = int(output_len * range_ratio)


### PR DESCRIPTION
When using the benchmark serving script test, when dataset-name uses random, the length of the generated input data will become shorter after encoding and decoding.
![image](https://github.com/user-attachments/assets/e1fbb496-af1e-4cb9-a4e1-46d5d1730fde)
