### PR TITLE
track http service error count

### DIFF
--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -267,6 +267,12 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         help=
         "If set to True, enable tracking server_load_metrics in the app state."
     )
+    parser.add_argument(
+        "--enable-http-middleware",
+        action="store_true",
+        default=False,
+        help="If set to True, enable http middleware decorator.",
+    )
 
     return parser
 


### PR DESCRIPTION
Track error count at the http service level in the app state.

Register as aggregated_error_count in the prometheus metrics