### PR TITLE
[Bugfix] Fix missing return value in load_weights method of adapters.py

### DIFF
--- a/vllm/model_executor/models/adapters.py
+++ b/vllm/model_executor/models/adapters.py
@@ -99,16 +99,17 @@ def _create_pooling_model_cls(
                     mapper = WeightsMapper(orig_to_new_prefix={"model.": ""})
                     weights = mapper.apply(weights)
 
-                    self.model.load_weights(weights)
-                    return
+                    loaded_params = self.model.load_weights(weights)
+                    loaded_params = {f"model.{name}" for name in loaded_params}
+                    return loaded_params
 
             # For most other models
             if hasattr(orig_cls, "load_weights"):
-                orig_cls.load_weights(self, weights)  # type: ignore
+                return orig_cls.load_weights(self, weights)  # type: ignore
             # Fallback
             else:
                 loader = AutoWeightsLoader(self)
-                loader.load_weights(weights)
+                return loader.load_weights(weights)
 
     return ModelForPooling  # type: ignore
 


### PR DESCRIPTION
Previously, the `load_weights` method in `adapters.py` did not return the `weights`, which caused `loaded_params` to be `None` in some cases — for example, when using the `Qwen2ForEmbedding` model (see [vllm/models/utils.py#L171-L177](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/utils.py#L171-L177)).

This PR fixes the issue by properly returning the result of `load_weights`, and ensures that the prefix matches the expected format for external usage.
