### PR TITLE
Fix weight loading for some models in Transformers backend

### DIFF
--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -342,9 +342,9 @@ class TransformersModel(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params = set[str]()
         for name, loaded_weight in weights:
-            # Necessary for some models which use remote code
-            if not name.startswith(prefix := self.model.base_model_prefix):
-                name = maybe_prefix(prefix, name)
+            # Use "model" instead of base_model_prefix because
+            # the base model attribute in vLLM is always `model`
+            name = maybe_prefix("model", name)
             if is_pp_missing_parameter(name, self):
                 continue
             if name in params_dict:

--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -344,7 +344,9 @@ class TransformersModel(nn.Module):
         for name, loaded_weight in weights:
             # Use "model" instead of base_model_prefix because
             # the base model attribute in vLLM is always `model`
-            name = maybe_prefix("model", name)
+            if not name.startswith(prefix := "model."):
+                name = prefix + name
+
             if is_pp_missing_parameter(name, self):
                 continue
             if name in params_dict:


### PR DESCRIPTION
Use `model` as the prefix instead of `base_model_prefix` because the model attribute in vLLM is always `model`.