### PR TITLE
[Frontend] fix streaming tool output lose 2 token bug #15545

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -318,9 +318,9 @@ class Hermes2ProToolParser(ToolParser):
                              cur_arguments_json)
 
                 # get the location where previous args differ from current
-                if (delta_text not in cur_arguments_json[:-2]):
+                if (delta_text not in cur_arguments_json):
                     return None
-                args_delta_start_loc = cur_arguments_json[:-2]. \
+                args_delta_start_loc = cur_arguments_json. \
                                            rindex(delta_text) + \
                                            len(delta_text)
 


### PR DESCRIPTION
the cur_arguments_json[:-2])  will cause the skipping of two token values, resulting in the lack of these two values ​​in the final output. 