### PR TITLE
[Bugfix] Fix profile deadlock when ray backend and num-scheduler-steps > 1

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1501,9 +1501,6 @@ class LLMEngine:
 
                 # Tracing
                 self.do_tracing(scheduler_outputs)
-        else:
-            # Multi-step case
-            return ctx.request_outputs
 
         if not self.has_unfinished_requests():
             # Drain async postprocessor (if exists)


### PR DESCRIPTION

FIX [[Bug]: profile deadlock when ray backend and num-scheduler-steps > 1 and max_tokens % num_scheduler_steps !=0](https://github.com/vllm-project/vllm/issues/15543)
<!--- pyml disable-next-line no-emphasis-as-heading -->
