### PR TITLE
Add endpoint load metrics

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -42,12 +42,11 @@ from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.cli_args import (make_arg_parser,
                                               validate_parsed_serve_args)
+from vllm.entrypoints.openai.orca_metrics import metrics_header
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm.entrypoints.openai.protocol import (ChatCompletionRequest,
-                                              ChatCompletionResponse,
                                               CompletionRequest,
-                                              CompletionResponse,
                                               DetokenizeRequest,
                                               DetokenizeResponse,
                                               EmbeddingChatRequest,
@@ -98,6 +97,8 @@ prometheus_multiproc_dir: tempfile.TemporaryDirectory
 
 # Cannot use __name__ (https://github.com/vllm-project/vllm/pull/4765)
 logger = init_logger('vllm.entrypoints.openai.api_server')
+
+ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL = "endpoint-load-metrics-format"
 
 _running_tasks: set[asyncio.Task] = set()
 
@@ -455,6 +456,8 @@ async def show_version():
 @load_aware_call
 async def create_chat_completion(request: ChatCompletionRequest,
                                  raw_request: Request):
+    metrics_header_format = raw_request.headers.get(
+        ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, "")
     handler = chat(raw_request)
     if handler is None:
         return base(raw_request).create_error_response(
@@ -466,8 +469,11 @@ async def create_chat_completion(request: ChatCompletionRequest,
         return JSONResponse(content=generator.model_dump(),
                             status_code=generator.code)
 
-    elif isinstance(generator, ChatCompletionResponse):
-        return JSONResponse(content=generator.model_dump())
+    # Tuple[ChatCompletionResponse,Optional[InbandEngineStats]]
+    elif isinstance(generator, tuple):
+        return JSONResponse(content=generator[0].model_dump(),
+                            headers=metrics_header(generator[1],
+                                                   metrics_header_format))
 
     return StreamingResponse(content=generator, media_type="text/event-stream")
 
@@ -476,6 +482,8 @@ async def create_chat_completion(request: ChatCompletionRequest,
 @with_cancellation
 @load_aware_call
 async def create_completion(request: CompletionRequest, raw_request: Request):
+    metrics_header_format = raw_request.headers.get(
+        ENDPOINT_LOAD_METRICS_FORMAT_HEADER_LABEL, "")
     handler = completion(raw_request)
     if handler is None:
         return base(raw_request).create_error_response(
@@ -485,8 +493,12 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
     if isinstance(generator, ErrorResponse):
         return JSONResponse(content=generator.model_dump(),
                             status_code=generator.code)
-    elif isinstance(generator, CompletionResponse):
-        return JSONResponse(content=generator.model_dump())
+
+    # Tuple[ChatCompletionResponse,Optional[InbandEngineStats]]
+    elif isinstance(generator, tuple):
+        return JSONResponse(content=generator[0].model_dump(),
+                            headers=metrics_header(generator[1],
+                                                   metrics_header_format))
 
     return StreamingResponse(content=generator, media_type="text/event-stream")
 

--- a/vllm/entrypoints/openai/orca_metrics.py
+++ b/vllm/entrypoints/openai/orca_metrics.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+This file contains the command line arguments for the vLLM's
+OpenAI-compatible server. It is kept in a separate file for documentation
+purposes.
+"""
+
+import json
+from collections.abc import Mapping
+from typing import Optional
+
+from vllm.logger import init_logger
+from vllm.sequence import InbandEngineStats
+
+logger = init_logger(__name__)
+
+
+def create_orca_header(metrics_format: str,
+                       named_metrics: list[tuple[str, float]],
+                       metadata_fields=None) -> Optional[Mapping[str, str]]:
+    """
+    Creates ORCA headers named 'endpoint-load-metrics' in the specified format 
+    and adds custom metrics to named_metrics.
+    ORCA headers format description: https://docs.google.com/document/d/1C1ybMmDKJIVlrbOLbywhu9iRYo4rilR-cT50OTtOFTs/edit?tab=t.0
+    ORCA proto https://github.com/cncf/xds/blob/main/xds/data/orca/v3/orca_load_report.proto
+
+    Parameters:
+    - format (str): The format of the header ('BIN', 'TEXT', 'JSON').
+    - named_metrics (List[Tuple[str, float]]): List of tuples with metric names 
+    and their corresponding double values.
+    - metadata_fields (list): List of additional metadata fields 
+    (currently unsupported).
+
+    Returns:
+    - Optional[Mapping[str,str]]: A dictionary with header key as 
+    'endpoint-load-metrics' and values as the ORCA header strings with 
+    format prefix and data in  with named_metrics in.
+    """
+
+    if metadata_fields:
+        logger.warning("Warning: `metadata_fields` are not supported in the"
+                       "ORCA response header yet.")
+
+    if metrics_format.lower() not in ["text", "json"]:
+        logger.warning(
+            "Warning: `%s` format is not supported in the ORCA response header",
+            format,
+        )
+        return None
+
+    header = {}
+    orca_report = {
+        "named_metrics": {
+            metric_name: value
+            for metric_name, value in named_metrics
+            if isinstance(metric_name, str) and isinstance(value, float)
+        }
+    }
+    # output example:
+    # endpoint-load-metrics: TEXT named_metrics.kv_cache_utilization=0.4
+    if metrics_format.lower() == "text":
+        native_http_header = ", ".join([
+            f"named_metrics.{metric_name}={value}"
+            for metric_name, value in named_metrics
+            if isinstance(metric_name, str) and isinstance(value, float)
+        ])
+        header["endpoint-load-metrics"] = f"TEXT {native_http_header}"
+
+    # output example:
+    # endpoint-load-metrics: JSON “named_metrics”: {“custom-metric-util”: 0.4}
+    elif metrics_format.lower() == "json":
+        header["endpoint-load-metrics"] = f"JSON {json.dumps(orca_report)}"
+
+    return header
+
+
+def metrics_header(m: Optional[InbandEngineStats],
+                   metrics_format: str) -> Optional[Mapping[str, str]]:
+    if not m or not metrics_format:
+        return None
+    named_metrics: list[tuple[str, float]] = []
+    for metric, val in vars(m).items():
+        if isinstance(val, float) and metric != "now":
+            named_metrics.append((str(metric), float(val)))
+    return create_orca_header(metrics_format, named_metrics)

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -12,8 +12,9 @@ from typing_extensions import TypeVar, deprecated
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import MultiModalPlaceholderDict
 from vllm.sampling_params import RequestOutputKind
-from vllm.sequence import (PromptLogprobs, RequestMetrics, SampleLogprobs,
-                           SequenceGroup, SequenceGroupBase, SequenceStatus)
+from vllm.sequence import (InbandEngineStats, PromptLogprobs, RequestMetrics,
+                           SampleLogprobs, SequenceGroup, SequenceGroupBase,
+                           SequenceStatus)
 
 
 @dataclass
@@ -114,6 +115,7 @@ class RequestOutput:
         outputs: list[CompletionOutput],
         finished: bool,
         metrics: Optional[RequestMetrics] = None,
+        inband_engine_stats: Optional[InbandEngineStats] = None,
         lora_request: Optional[LoRARequest] = None,
         encoder_prompt: Optional[str] = None,
         encoder_prompt_token_ids: Optional[list[int]] = None,
@@ -129,6 +131,7 @@ class RequestOutput:
         self.outputs = outputs
         self.finished = finished
         self.metrics = metrics
+        self.inband_engine_stats = inband_engine_stats
         self.lora_request = lora_request
         self.encoder_prompt = encoder_prompt
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
@@ -300,6 +303,7 @@ class RequestOutput:
             "outputs": outputs,
             "finished": finished,
             "metrics": seq_group.metrics,
+            "inband_engine_stats": seq_group.inband_engine_stats,
             "lora_request": seq_group.lora_request,
             "encoder_prompt": encoder_prompt,
             "encoder_prompt_token_ids": encoder_prompt_token_ids,
@@ -325,6 +329,7 @@ class RequestOutput:
                 f"outputs={self.outputs}, "
                 f"finished={self.finished}, "
                 f"metrics={self.metrics}, "
+                f"inband_engine_stats={self.inband_engine_stats},"
                 f"lora_request={self.lora_request}, "
                 f"num_cached_tokens={self.num_cached_tokens}, "
                 f"multi_modal_placeholders={self.multi_modal_placeholders})")

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -2,6 +2,7 @@
 """Sequence and its related classes."""
 import copy
 import enum
+import time
 from abc import ABC, abstractmethod
 from array import array
 from collections import defaultdict
@@ -630,6 +631,20 @@ class SequenceGroupState(msgspec.Struct,
         return self.num_steps - self.current_step
 
 
+@dataclass
+class InbandEngineStats:
+    now: float
+
+    # System stats (should have _sys suffix)
+    #   Scheduler State
+    num_running_sys: int
+    num_waiting_sys: int
+    num_swapped_sys: int
+    #   KV Cache Usage in %
+    gpu_cache_usage_sys: float
+    cpu_cache_usage_sys: float
+
+
 class SequenceGroup:
     """A group of sequences that are generated from the same prompt.
 
@@ -681,6 +696,13 @@ class SequenceGroup:
                                       time_in_queue=None,
                                       spec_token_acceptance_counts=[0] *
                                       draft_size)
+        self.inband_engine_stats = InbandEngineStats(now=time.time(),
+                                                     num_running_sys=0,
+                                                     num_waiting_sys=0,
+                                                     num_swapped_sys=0,
+                                                     gpu_cache_usage_sys=0.0,
+                                                     cpu_cache_usage_sys=0.0)
+
         self.last_token_latency = 0.0
         self.lora_request = lora_request
         self.prompt_logprobs: Optional[PromptLogprobs] = None
@@ -825,6 +847,9 @@ class SequenceGroup:
     def set_finished_time(self, time: Optional[float]) -> None:
         """Sets the finished time for Request level timings."""
         self.metrics.finished_time = time
+
+    def set_inband_engine_stats(self, stats: InbandEngineStats) -> None:
+        self.inband_engine_stats = stats
 
     def get_max_num_running_seqs(self) -> int:
         """The maximum number of sequences running in parallel in the remaining


### PR DESCRIPTION
Implement for V0 engine only for chat/completion and /completion

FIX #10086

- reporting of engine metrics in response headers when enabled through request header "endpoint-load-metrics-format"
- supported formats "text" and "json"
- No added load on response for default case
- No new computation in engine

Forked from https://github.com/vllm-project/vllm/pull/14906

<!--- pyml disable-next-line no-emphasis-as-heading -->
