### PR TITLE
[Misc] Restrict ray version dependency and update PP feature warning in V1

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -4,7 +4,7 @@
 numba == 0.60.0 # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
 
 # Dependencies for NVIDIA GPUs
-ray[cgraph]>=2.43.0 # Ray Compiled Graph, required for pipeline parallelism in V1.
+ray[cgraph]>=2.43.0, !=2.44.* # Ray Compiled Graph, required for pipeline parallelism in V1.
 torch==2.6.0
 torchaudio==2.6.0
 # These must be updated alongside torch

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -17,7 +17,7 @@ vector_quantize_pytorch # required for minicpmo_26 test
 vocos # required for minicpmo_26 test
 peft
 pqdm
-ray[cgraph]>=2.43.0 # Ray Compiled Graph, required by pipeline parallelism tests
+ray[cgraph]>=2.43.0, !=2.44.* # Ray Compiled Graph, required by pipeline parallelism tests
 sentence-transformers # required for embedding tests
 soundfile # required for audio tests
 jiwer # required for audio tests

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -311,7 +311,7 @@ class ModelConfig:
                 "VLLM_ATTENTION_BACKEND is set to FLASHINFER, but flashinfer "
                 "module was not found."
                 "See https://github.com/vllm-project/vllm/blob/main/Dockerfile"
-                "for instructions on how to install it.")
+                " for instructions on how to install it.")
 
         # The tokenizer version is consistent with the model version by default.
         if tokenizer_revision is None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -310,8 +310,8 @@ class ModelConfig:
             raise ValueError(
                 "VLLM_ATTENTION_BACKEND is set to FLASHINFER, but flashinfer "
                 "module was not found."
-                "See https://github.com/vllm-project/vllm/blob/main/Dockerfile"
-                " for instructions on how to install it.")
+                "See https://github.com/vllm-project/vllm/blob/main/Dockerfile "
+                "for instructions on how to install it.")
 
         # The tokenizer version is consistent with the model version by default.
         if tokenizer_revision is None:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1615,6 +1615,13 @@ class EngineArgs:
         if self.enable_lora and _warn_or_fallback("LORA"):
             return False
 
+        # PP is supported on V1 with Ray distributed executor,
+        # but off for MP distributed executor for now.
+        if (self.pipeline_parallel_size > 1
+                and self.distributed_executor_backend == "mp"
+                and _warn_or_fallback("PP (MP distributed executor)")):
+            return False
+
         # ngram is supported on V1, but off by default for now.
         if self.speculative_model == "[ngram]" and _warn_or_fallback("ngram"):
             return False

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1615,10 +1615,6 @@ class EngineArgs:
         if self.enable_lora and _warn_or_fallback("LORA"):
             return False
 
-        # PP is supported on V1, but off by default for now.
-        if self.pipeline_parallel_size > 1 and _warn_or_fallback("PP"):
-            return False
-
         # ngram is supported on V1, but off by default for now.
         if self.speculative_model == "[ngram]" and _warn_or_fallback("ngram"):
             return False


### PR DESCRIPTION
Restrict ray versions because 2.44 has a regression: https://github.com/ray-project/ray/issues/51596

Separate from above issue, this PR also updates PP feature warning if used in V1:
* For Ray distributed backend, it defaults to V1 and shows no warning
* For MP, it shows warning and falls back to V0