### PR TITLE
[Bugfix] Do not pad multi-modal encoder sequence dummy data

### DIFF
--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -189,16 +189,9 @@ class MultiModalProfiler(Generic[_I]):
         mm_inputs, _ = self.get_and_validate_mm_inputs(seq_len)
         mm_inputs = cast(MultiModalEncDecInputs, mm_inputs)
 
-        # For encoder-decoder models, use encoder prompt token ids instead of
-        # decoder prompt to construct dummy seq_data for encoder profiling.
-        encoder_prompt_token_ids = mm_inputs["encoder_prompt_token_ids"]
-
-        total_len = len(encoder_prompt_token_ids)
-        num_tokens_to_pad = max(total_len, seq_len) - total_len
-        encoder_prompt_token_ids.extend([0] * num_tokens_to_pad)
-
         return DummyData(
-            seq_data=SequenceData.from_seqs(encoder_prompt_token_ids),
+            seq_data=SequenceData.from_seqs(
+                mm_inputs["encoder_prompt_token_ids"]),
             multi_modal_data=None,
             multi_modal_placeholders=None,
         )


### PR DESCRIPTION
Removes padding of dummy encoder data. Instead, expect `get_and_validate_mm_inputs` to provide the max-size dummy sequence.

For Mllama, this additional padding would create an encoder input that was longer than expected leading to an AssertionError during profiling unless seq_len was small enough (see #13929).

FIX #13929

<!--- pyml disable-next-line no-emphasis-as-heading -->
