### PR TITLE
Allow torchao quantization in SiglipMLP

### DIFF
--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -276,7 +276,9 @@ class SiglipMLP(nn.Module):
         self.config = config
         self.activation_fn = get_act_fn(config.hidden_act)
         # Special handling for BNB and torchao quantization
-        if quant_config and quant_config.get_name() in ["bitsandbytes", "torchao"]:
+        if quant_config and quant_config.get_name() in [
+                "bitsandbytes", "torchao"
+        ]:
             quantizable = True
         else:
             # For other quantization, we require the hidden size to be a

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -275,8 +275,8 @@ class SiglipMLP(nn.Module):
 
         self.config = config
         self.activation_fn = get_act_fn(config.hidden_act)
-        # Special handling for BNB quantization
-        if quant_config and quant_config.get_name() == "bitsandbytes":
+        # Special handling for BNB and torchao quantization
+        if quant_config and quant_config.get_name() in ["bitsandbytes", "torchao"]:
             quantizable = True
         else:
             # For other quantization, we require the hidden size to be a


### PR DESCRIPTION
Summary:
SiglipMLP is not quantized by default, so when we try to load a torchao quantized model it doesn't work because the mlps are not quantized, this PR enables quantization when we are loading a torchao quantized checkpoint.

Depends on https://github.com/vllm-project/vllm/pull/14231

Test Plan:
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/gemma3-4b-it-float8dq --batch-size 1

Reviewers:

Subscribers:

Tasks:

Tags:



<!--- pyml disable-next-line no-emphasis-as-heading -->
