### PR TITLE
[Feature] Add middleware to log API Server responses

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -847,7 +847,7 @@ def build_app(args: Namespace) -> FastAPI:
             response.headers["X-Request-Id"] = request_id
             return response
 
-    if envs.LOG_API_SERVER_RESPONSE:
+    if envs.VLLM_DEBUG_LOG_API_SERVER_RESPONSE:
         logger.warning("CAUTION: Enabling log response in the API Server. "
                        "This can include sensitive information and should be "
                        "avoided in production.")

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -24,6 +24,7 @@ from fastapi import APIRouter, Depends, FastAPI, Form, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.concurrency import iterate_in_threadpool
 from starlette.datastructures import State
 from starlette.routing import Mount
 from typing_extensions import assert_never
@@ -844,6 +845,21 @@ def build_app(args: Namespace) -> FastAPI:
                 "X-Request-Id") or uuid.uuid4().hex
             response = await call_next(request)
             response.headers["X-Request-Id"] = request_id
+            return response
+
+    if envs.LOG_API_SERVER_RESPONSE:
+        logger.warning("CAUTION: Enabling log response in the API Server. "
+                       "This can include sensitive information and should be "
+                       "avoided in production.")
+
+        @app.middleware("http")
+        async def log_response(request: Request, call_next):
+            response = await call_next(request)
+            response_body = [
+                section async for section in response.body_iterator
+            ]
+            response.body_iterator = iterate_in_threadpool(iter(response_body))
+            logger.info("response_body={%s}", response_body[0].decode())
             return response
 
     for middleware in args.middleware:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -268,10 +268,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_API_KEY":
     lambda: os.environ.get("VLLM_API_KEY", None),
 
-    # Whether to log responses from API Server
-    "LOG_API_SERVER_RESPONSE":
-    lambda: os.environ.get("LOG_API_SERVER_RESPONSE", "False").lower() ==
-    "true",
+    # Whether to log responses from API Server for debugging
+    "VLLM_DEBUG_LOG_API_SERVER_RESPONSE":
+    lambda: os.environ.get("VLLM_DEBUG_LOG_API_SERVER_RESPONSE", "False").
+    lower() == "true",
 
     # S3 access information, used for tensorizer to load model from S3
     "S3_ACCESS_KEY_ID":

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -268,6 +268,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_API_KEY":
     lambda: os.environ.get("VLLM_API_KEY", None),
 
+    # Whether to log responses from API Server
+    "LOG_API_SERVER_RESPONSE":
+    lambda: os.environ.get("LOG_API_SERVER_RESPONSE", "False").lower() ==
+    "true",
+
     # S3 access information, used for tensorizer to load model from S3
     "S3_ACCESS_KEY_ID":
     lambda: os.environ.get("S3_ACCESS_KEY_ID", None),


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/15571

Sample response log:
```

curl http://localhost:8000/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model_id": "meta-llama/Llama-3.1-8B-Instruct",
        "messages": [{"role": "system", "content": "You are a helpful assistant."}, {"role": "user", "content": "Can you write a poem?"}],
        "max_tokens": 7,
        "temperature": 0
    }'


INFO 03-27 03:03:25 [api_server.py:860] response_body={"id":"chatcmpl-5a1a56b3ca3946139c04aef450f5623f","object":"chat.completion","created":1743044603,"model":"meta-llama/Llama-3.1-8B-Instruct","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"Here's a poem I came up","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":47,"total_tokens":54,"completion_tokens":7,"prompt_tokens_details":null},"prompt_logprobs":null}
```