### PR TITLE
[Bugfix] Correct KV cache tensor dimension handling in FlashInfer backend's block operations

### DIFF
--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -36,7 +36,6 @@ from vllm.attention.backends.utils import (PAD_SLOT_ID, compute_slot_mapping,
                                            compute_slot_mapping_start_idx,
                                            is_block_tables_empty)
 from vllm.attention.layer import Attention
-from vllm.attention.ops.paged_attn import PagedAttention
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.utils import (async_tensor_h2d, get_kv_cache_torch_dtype,
                         make_tensor_with_pad)
@@ -83,7 +82,8 @@ class FlashInferBackend(AttentionBackend):
         dst_kv_cache: torch.Tensor,
         src_to_dst: torch.Tensor,
     ) -> None:
-        # Directly swap an entire KV Cache block, instead of splitting into K and V at the first dim
+        # Directly swap an entire KV Cache block
+        # Instead of splitting into K and V at the first dim
         ops.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
 
     @staticmethod
@@ -91,10 +91,10 @@ class FlashInferBackend(AttentionBackend):
         kv_caches: List[torch.Tensor],
         src_to_dists: torch.Tensor,
     ) -> None:
-        # K and V are seperated in the second dim, not the first dim
+        # K and V are separated in the second dim, not the first dim
         key_caches = [kv_cache[:, 0] for kv_cache in kv_caches]
         value_caches = [kv_cache[:, 1] for kv_cache in kv_caches]
-        
+
         ops.copy_blocks(key_caches, value_caches, src_to_dists)
 
     @staticmethod
@@ -642,7 +642,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # [0, 3, 6, 8]
         self.paged_kv_indices: List[int] = []
         # 0 at the beginning of paged_kv_indptr indicates the start of the
-        # first request’s page indices in the paged_kv_indices list.
+        # first request's page indices in the paged_kv_indices list.
         self.paged_kv_indptr: List[int] = [0]
         # paged_kv_last_page_len is the length of the last page of each request
         self.paged_kv_last_page_len: List[int] = []

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -83,14 +83,19 @@ class FlashInferBackend(AttentionBackend):
         dst_kv_cache: torch.Tensor,
         src_to_dst: torch.Tensor,
     ) -> None:
-        PagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
+        # Directly swap an entire KV Cache block, instead of splitting into K and V at the first dim
+        ops.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
 
     @staticmethod
     def copy_blocks(
         kv_caches: List[torch.Tensor],
         src_to_dists: torch.Tensor,
     ) -> None:
-        PagedAttention.copy_blocks(kv_caches, src_to_dists)
+        # K and V are seperated in the second dim, not the first dim
+        key_caches = [kv_cache[:, 0] for kv_cache in kv_caches]
+        value_caches = [kv_cache[:, 1] for kv_cache in kv_caches]
+        
+        ops.copy_blocks(key_caches, value_caches, src_to_dists)
 
     @staticmethod
     def get_supported_head_sizes() -> List[int]:


### PR DESCRIPTION
For now, `swap_blocks` and `copy_blocks` in Flashinfer backend directly reusing PagedAttention implements as follows:

```python
@staticmethod
def swap_blocks(
    src_kv_cache: torch. Tensor,
    dst_kv_cache: torch. Tensor,
    src_to_dst: torch. Tensor,
) -> None:
    PagedAttention.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)

@staticmethod
def copy_blocks(
    kv_caches: List[torch. Tensor],
    src_to_dists: torch. Tensor,
) -> None:
    PagedAttention.copy_blocks(kv_caches, src_to_dists)
```

However, there's a critical shape mismatch between the two impls. Flashinfer assumes the KV cache block shape is `(num_blocks, 2, block_size, num_kv_heads, head_size)`, whereas PagedAttention uses `(2, num_blocks, block_size * num_kv_heads * head_size)`. This discrepancy causes output errors when using `swap_blocks` and `copy_blocks` to move cache blocks.

For `swap_blocks`, we can simply reuse the existing `ops.swap_blocks` since it only considers the index of the first `num_blocks` dimension:

```python
def swap_blocks(
    src_kv_cache: torch. Tensor,
    dst_kv_cache: torch. Tensor,
    src_to_dst: torch. Tensor,
) -> None:
    # PageAttention impl, seperating kv at first dim
    # copy k caches
    # src_key_cache = src_kv_cache[0]
    # dst_key_cache = dst_kv_cache[0]
    # ops.swap_blocks(src_key_cache, dst_key_cache, src_to_dst)

    # copy v caches
    # src_value_cache = src_kv_cache[1]
    # dst_value_cache = dst_kv_cache[1]
    # ops.swap_blocks(src_value_cache, dst_value_cache, src_to_dst)

    # The correct impl
    # Directly swap an entire KV Cache block, instead of splitting into K and V at the first dim
    ops.swap_blocks(src_kv_cache, dst_kv_cache, src_to_dst)
```

For `copy_blocks`, we need to split KV along the second dimension:

```python
@staticmethod
def copy_blocks(
    kv_caches: List[torch. Tensor],
    src_to_dists: torch. Tensor,
) -> None:
    # PageAttention impl, seperating kv at first dim
    # key_caches = [kv_cache[0] for kv_cache in kv_caches]
    # value_caches = [kv_cache[1] for kv_cache in kv_caches]
    # ops.copy_blocks(key_caches, value_caches, src_to_dists)

    # The correct impl
    # K and V should be seperated at the second dim, not the first dim
    key_caches = [kv_cache[:, 0] for kv_cache in kv_caches]
    value_caches = [kv_cache[:, 1] for kv_cache in kv_caches]
```

After fixing this issue, features such as CPU offloading (e.g., unmerged #13377) will work properly with Flashinfer backend, and also ensures the correctness of any future functionality that relies on these interfaces.