### PR TITLE
[CI] Update rules for applying `tpu` label.

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -90,13 +90,32 @@ pull_request_rules:
 
 - name: label-tpu
   description: Automatically apply tpu label
+  # Keep this list in sync with `label-tpu-remove` conditions
   conditions:
     - or:
-      - files~=tpu
+      - files~=tpu.py
+      - files~=_tpu
+      - files~=tpu_
+      - files~=/tpu/
       - files~=pallas
   actions:
     label:
       add:
+        - tpu
+
+- name: label-tpu-remove
+  description: Automatically remove tpu label
+  # Keep this list in sync with `label-tpu` conditions
+  conditions:
+    - and:
+      - -files~=tpu.py
+      - -files~=_tpu
+      - -files~=tpu_
+      - -files~=/tpu/
+      - -files~=pallas
+  actions:
+    label:
+      remove:
         - tpu
 
 - name: ping author on conflicts and add 'needs-rebase' label


### PR DESCRIPTION
This is a follow-up to #15560.

The regex `tpu` matches files that include `output` in their name. I
made the list of patterns a little more strict and I think now it
catches everything tpu related without accidentally matching extra
things. Instead of matching `tpu`, it now matches:

- `_tpu` - files or directories that include `_tpu`
- `tpu_` - files or directories that include `tpu_`
- `tpu.py` - filenames that are equal to or end with `tpu.py`
- `/tpu/` - directories named `tpu`

Since the previous rule applied the `tpu` label to some extra PRs, this
includes an additional rule to remove the label from PRs that don't
touch any TPU files. This can be removed later if desired, but letting
it run a bit would automate the cleanup.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
