### PR TITLE
Correct PowerPC to modern IBM Power

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -43,7 +43,7 @@ vLLM is flexible and easy to use with:
 - Tensor parallelism and pipeline parallelism support for distributed inference
 - Streaming outputs
 - OpenAI-compatible API server
-- Support NVIDIA GPUs, AMD CPUs and GPUs, Intel CPUs, Gaudi® accelerators and GPUs, PowerPC CPUs, TPU, and AWS Trainium and Inferentia Accelerators.
+- Support NVIDIA GPUs, AMD CPUs and GPUs, Intel CPUs, Gaudi® accelerators and GPUs, IBM Power CPUs, TPU, and AWS Trainium and Inferentia Accelerators.
 - Prefix caching support
 - Multi-lora support
 


### PR DESCRIPTION
Minor edit. PowerPC is technically an older version of the Power line of processors and has a different ISA.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>

<!--- pyml disable-next-line no-emphasis-as-heading -->
