### PR TITLE
[draft] reproduce tpu v1 correctness issue with chunked prefill.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -720,6 +720,7 @@ class VllmRunner:
         enable_chunked_prefill: Optional[bool] = False,
         swap_space: int = 4,
         enforce_eager: Optional[bool] = False,
+        max_num_batched_tokens: int =  1024,
         **kwargs,
     ) -> None:
         self.model = LLM(
@@ -737,6 +738,7 @@ class VllmRunner:
             max_model_len=max_model_len,
             block_size=block_size,
             enable_chunked_prefill=enable_chunked_prefill,
+            max_num_batched_tokens=max_num_batched_tokens,
             **kwargs,
         )
 

--- a/tests/v1/tpu/test_basic.py
+++ b/tests/v1/tpu/test_basic.py
@@ -33,6 +33,7 @@ TENSOR_PARALLEL_SIZES = [1]
 @pytest.mark.parametrize("max_tokens", [5])
 @pytest.mark.parametrize("enforce_eager", [True])
 @pytest.mark.parametrize("tensor_parallel_size", TENSOR_PARALLEL_SIZES)
+@pytest.mark.parametrize("max_num_batched_tokens", [512])
 def test_models(
     vllm_runner: type[VllmRunner],
     monkeypatch: pytest.MonkeyPatch,
@@ -40,6 +41,7 @@ def test_models(
     max_tokens: int,
     enforce_eager: bool,
     tensor_parallel_size: int,
+    max_num_batched_tokens: int
 ) -> None:
     prompt = "The next numbers of the sequence " + ", ".join(
         str(i) for i in range(1024)) + " are:"
@@ -54,7 +56,8 @@ def test_models(
                 enforce_eager=enforce_eager,
                 gpu_memory_utilization=0.7,
                 max_num_seqs=16,
-                tensor_parallel_size=tensor_parallel_size) as vllm_model:
+                tensor_parallel_size=tensor_parallel_size,
+                max_num_batched_tokens=max_num_batched_tokens) as vllm_model:
             vllm_outputs = vllm_model.generate_greedy(example_prompts,
                                                       max_tokens)
         output = vllm_outputs[0][1]


### PR DESCRIPTION
test_basic.py created a prompt with around 5000 tokens, it's default max_num_batched_tokens is 8192 so the prompt isn't chunked during processing. If I manually set max_num_batched_tokens to a smaller value (such as 512), the result doesn't look correct. 

" AssertionError: assert '1024' in 'The next numbers of the sequence 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, {I omitted the numbers}, 1023 are:**15 3,**'
"

command: 
- using default exponential padding: `VLLM_USE_V1=1 VLLM_XLA_CHECK_RECOMPILATION=1 pytest -v -s tests/v1/tpu/test_basic.py`
- using incremental padding: `VLLM_USE_V1=1 VLLM_XLA_CHECK_RECOMPILATION=1 VLLM_TPU_BUCKET_PADDING_GAP=128 pytest -v -s tests/v1/tpu/test_basic.py`