### PR TITLE
Refactor error handling for multiple exceptions in preprocessing

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -197,16 +197,7 @@ class OpenAIServingChat(OpenAIServing):
                 truncate_prompt_tokens=request.truncate_prompt_tokens,
                 add_special_tokens=request.add_special_tokens,
             )
-        except ValueError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except TypeError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except RuntimeError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except jinja2.TemplateError as e:
+        except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -197,7 +197,8 @@ class OpenAIServingChat(OpenAIServing):
                 truncate_prompt_tokens=request.truncate_prompt_tokens,
                 add_special_tokens=request.add_special_tokens,
             )
-        except (ValueError, TypeError, RuntimeError, jinja2.TemplateError) as e:
+        except (ValueError, TypeError, RuntimeError,
+                jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_embedding.py
+++ b/vllm/entrypoints/openai/serving_embedding.py
@@ -139,10 +139,7 @@ class OpenAIServingEmbedding(OpenAIServing):
                      truncate_prompt_tokens=truncate_prompt_tokens,
                      add_special_tokens=request.add_special_tokens,
                  )
-        except ValueError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except TypeError as e:
+        except (ValueError, TypeError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_pooling.py
+++ b/vllm/entrypoints/openai/serving_pooling.py
@@ -136,13 +136,7 @@ class OpenAIServingPooling(OpenAIServing):
                      truncate_prompt_tokens=truncate_prompt_tokens,
                      add_special_tokens=request.add_special_tokens,
                  )
-        except ValueError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except TypeError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except jinja2.TemplateError as e:
+        except (ValueError, TypeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(str(e))
 

--- a/vllm/entrypoints/openai/serving_tokenization.py
+++ b/vllm/entrypoints/openai/serving_tokenization.py
@@ -89,13 +89,7 @@ class OpenAIServingTokenization(OpenAIServing):
                      request.prompt,
                      add_special_tokens=request.add_special_tokens,
                  )
-        except ValueError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except TypeError as e:
-            logger.exception("Error in preprocessing prompt inputs")
-            return self.create_error_response(str(e))
-        except jinja2.TemplateError as e:
+        except (ValueError, TypeError, jinja2.TemplateError) as e:
             logger.exception("Error in preprocessing prompt inputs")
             return self.create_error_response(str(e))
 


### PR DESCRIPTION
# PR Description:
This PR refactors the error handling code to catch multiple exceptions (ValueError, TypeError, jinja2.TemplateError) in a single except block, reducing code repetition and improving readability. The same logging and error response logic is applied to all three exception types.

# Benefits:
* Cleaner and more maintainable code.
* Easier to extend by adding additional exception types in the future.
* Improved readability without changing the existing behavior.

# Test:

Error trace is caught properly and shown in server live log when I passed the wrong model that didn't match the --tool-call-parser hermes:

vllm serve llama_model_path --enable-auto-tool-choice --tool-call-parser hermes

```
INFO:     Application startup complete.
INFO 03-27 22:51:56 chat_utils.py:332] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
ERROR 03-27 22:51:56 serving_chat.py:195] Error in preprocessing prompt inputs
ERROR 03-27 22:51:56 serving_chat.py:195] Traceback (most recent call last):
ERROR 03-27 22:51:56 serving_chat.py:195]   File "/miniconda3/lib/python3.10/site-packages/vllm/entrypoints/openai/serving_chat.py", line 179, in create_chat_completion
ERROR 03-27 22:51:56 serving_chat.py:195]     ) = await self._preprocess_chat(
ERROR 03-27 22:51:56 serving_chat.py:195]   File "/miniconda3//lib/python3.10/site-packages/vllm/entrypoints/openai/serving_engine.py", line 434, in _preprocess_chat
ERROR 03-27 22:51:56 serving_chat.py:195]     request = tool_parser(tokenizer).adjust_request(  # type: ignore
ERROR 03-27 22:51:56 serving_chat.py:195]   File "/miniconda3/lib/python3.10/site-packages/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py", line 61, in __init__
ERROR 03-27 22:51:56 serving_chat.py:195]     raise RuntimeError(
ERROR 03-27 22:51:56 serving_chat.py:195] RuntimeError: Hermes 2 Pro Tool parser could not locate tool call start/end tokens in the tokenizer!
INFO:     127.0.0.1:57814 - "POST /v1/chat/completions HTTP/1.1" 400 Bad Request
```
