### PR TITLE
[TPU] [Perf] Improve Memory Usage Estimation

### DIFF
--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -161,7 +161,13 @@ class TPUWorker:
         # intermediate activations.
         m = xm.get_memory_info(self.device)
         total_memory_size = m["bytes_limit"]
-        profiled = m["peak_bytes_used"]  # Weights + intermediate activations.
+        current_mem = m["bytes_used"]
+        # Ideally we would use profiled = m["peak_bytes_used"] to
+        # get weights + activations. But there is memory used during
+        # compilation / weight loading that impacts the peak and
+        # there is no way to reset peak memory in XLA, So we
+        # use the heuristic of 2% of weights.
+        profiled = current_mem * 1.02
 
         # Calculate the TPU KV cache size based on profiling.
         usable_memory_size = int(total_memory_size *


### PR DESCRIPTION
SUMMARY:
* TPU uses ~3GB loading Llama-8B + compiling XLA graphs, which is captured in peak memory
* This 3GB was not being used for KV cache as a result
* Tweak heuristic to be 2% of weights instead

This improves performance 4%, since we are able to fit more items in the batch

`MODEL=meta-llama/Llama-3.1-8B-Instruct`

```bash
VLLM_USE_V1=1 vllm serve $MODEL --max-model-len 2048 --disable-log-requests
```

- `this pr`:
```bash
python3 benchmark_serving.py --model $MODEL --dataset-name random --random-input-len 1000 --random-output-len 100

>> Throughput: 8.22
```
- `main`
```bash
python3 benchmark_serving.py --model $MODEL --dataset-name random --random-input-len 1000 --random-output-len 100

>> Throughput: 7.89
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
