### PR TITLE
[Bugfix] Fix 'InductorAdaptor object has no attribute 'cache_dir'

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -144,6 +144,7 @@ class InductorAdaptor(CompilerInterface):
         return hash_str
 
     def initialize_cache(self, cache_dir: str, disable_cache: bool = False):
+        self.cache_dir = cache_dir
         if disable_cache:
             return
         # redirect the cache directory to a sub-directory
@@ -156,7 +157,6 @@ class InductorAdaptor(CompilerInterface):
         triton_cache = os.path.join(cache_dir, "triton_cache")
         os.makedirs(triton_cache, exist_ok=True)
         os.environ["TRITON_CACHE_DIR"] = triton_cache
-        self.cache_dir = cache_dir
 
     def compile(
         self,


### PR DESCRIPTION

## Reproduce code
```shell
VLLM_USE_V1=1 VLLM_DISABLE_COMPILE_CACHE=1 vllm serve Llama-3.2-1B-Instruct
```