### PR TITLE
[Bugfix][V1] fix the err in kv cache offload with lmcache

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1036,7 +1036,7 @@ class EngineArgs:
 
         parser.add_argument('--kv-transfer-config',
                             type=KVTransferConfig.from_cli,
-                            default=None,
+                            default=EngineArgs.kv_transfer_config,
                             help='The configurations for distributed KV cache '
                             'transfer. Should be a JSON string.')
 


### PR DESCRIPTION
When testing the lmcache offload feature in v1, the `_is_v1_supported_oracle` function failed due to the missing `kv_transfer_config`. 

Despite the comment stating "`No Disaggregated Prefill so far`," KV cache offload should already be supported. 
 I updated the test case to include v1-specific testing and initial the `kv_transfer_config` parameter to ensure proper functionality.  

The bug can be reproduced simply by enabling V1.