### PR TITLE
[CI] test-pipeline.yaml: Add --durations=100 to pytest commands

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -52,13 +52,13 @@ steps:
   - tests/standalone_tests/lazy_imports.py
   commands:
   - python3 standalone_tests/lazy_imports.py
-  - pytest -v -s mq_llm_engine # MQLLMEngine
-  - pytest -v -s async_engine # AsyncLLMEngine
-  - NUM_SCHEDULER_STEPS=4 pytest -v -s async_engine/test_async_llm_engine.py
-  - pytest -v -s test_inputs.py
-  - pytest -v -s multimodal
-  - pytest -v -s test_utils.py # Utils
-  - pytest -v -s worker # Worker
+  - pytest --durations=100 -v -s mq_llm_engine # MQLLMEngine
+  - pytest --durations=100 -v -s async_engine # AsyncLLMEngine
+  - NUM_SCHEDULER_STEPS=4 pytest --durations=100 -v -s async_engine/test_async_llm_engine.py
+  - pytest --durations=100 -v -s test_inputs.py
+  - pytest --durations=100 -v -s multimodal
+  - pytest --durations=100 -v -s test_utils.py # Utils
+  - pytest --durations=100 -v -s worker # Worker
 
 - label: Python-only Installation Test
   source_file_dependencies:
@@ -78,18 +78,18 @@ steps:
   - tests/basic_correctness/test_cumem.py
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -v -s basic_correctness/test_cumem.py
-  - pytest -v -s basic_correctness/test_basic_correctness.py
-  - pytest -v -s basic_correctness/test_cpu_offload.py
-  - VLLM_TEST_ENABLE_ARTIFICIAL_PREEMPT=1 pytest -v -s basic_correctness/test_preemption.py
+  - pytest --durations=100 -v -s basic_correctness/test_cumem.py
+  - pytest --durations=100 -v -s basic_correctness/test_basic_correctness.py
+  - pytest --durations=100 -v -s basic_correctness/test_cpu_offload.py
+  - VLLM_TEST_ENABLE_ARTIFICIAL_PREEMPT=1 pytest --durations=100 -v -s basic_correctness/test_preemption.py
 
 - label: Chunked Prefill Test
   source_file_dependencies:
   - vllm/
   - tests/basic_correctness/test_chunked_prefill
   commands:
-  - VLLM_ATTENTION_BACKEND=XFORMERS pytest -v -s basic_correctness/test_chunked_prefill.py
-  - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest -v -s basic_correctness/test_chunked_prefill.py
+  - VLLM_ATTENTION_BACKEND=XFORMERS pytest --durations=100 -v -s basic_correctness/test_chunked_prefill.py
+  - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest --durations=100 -v -s basic_correctness/test_chunked_prefill.py
 
 - label: Core Test # 10min
   mirror_hardwares: [amd]
@@ -99,7 +99,7 @@ steps:
   - vllm/distributed
   - tests/core
   commands:
-  - pytest -v -s core
+  - pytest --durations=100 -v -s core
 
 - label: Entrypoints Test # 40min
   working_dir: "/vllm-workspace/tests"
@@ -113,14 +113,14 @@ steps:
   - tests/entrypoints/offline_mode
   commands:
   - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-  - pytest -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py --ignore=entrypoints/llm/test_collective_rpc.py
-  - pytest -v -s entrypoints/llm/test_lazy_outlines.py # it needs a clean process
-  - pytest -v -s entrypoints/llm/test_generate.py # it needs a clean process
-  - pytest -v -s entrypoints/llm/test_generate_multiple_loras.py # it needs a clean process
-  - VLLM_USE_V1=0 pytest -v -s entrypoints/llm/test_guided_generate.py # it needs a clean process
-  - pytest -v -s entrypoints/openai --ignore=entrypoints/openai/test_oot_registration.py  --ignore=entrypoints/openai/test_chat_with_tool_reasoning.py --ignore=entrypoints/openai/correctness/
-  - pytest -v -s entrypoints/test_chat_utils.py
-  - VLLM_USE_V1=0 pytest -v -s entrypoints/offline_mode # Needs to avoid interference with other tests
+  - pytest --durations=100 -v -s entrypoints/llm --ignore=entrypoints/llm/test_lazy_outlines.py --ignore=entrypoints/llm/test_generate.py --ignore=entrypoints/llm/test_generate_multiple_loras.py --ignore=entrypoints/llm/test_guided_generate.py --ignore=entrypoints/llm/test_collective_rpc.py
+  - pytest --durations=100 -v -s entrypoints/llm/test_lazy_outlines.py # it needs a clean process
+  - pytest --durations=100 -v -s entrypoints/llm/test_generate.py # it needs a clean process
+  - pytest --durations=100 -v -s entrypoints/llm/test_generate_multiple_loras.py # it needs a clean process
+  - VLLM_USE_V1=0 pytest --durations=100 -v -s entrypoints/llm/test_guided_generate.py # it needs a clean process
+  - pytest --durations=100 -v -s entrypoints/openai --ignore=entrypoints/openai/test_oot_registration.py  --ignore=entrypoints/openai/test_chat_with_tool_reasoning.py --ignore=entrypoints/openai/correctness/
+  - pytest --durations=100 -v -s entrypoints/test_chat_utils.py
+  - VLLM_USE_V1=0 pytest --durations=100 -v -s entrypoints/offline_mode # Needs to avoid interference with other tests
 
 - label: Distributed Tests (4 GPUs) # 10min
   working_dir: "/vllm-workspace/tests"
@@ -141,10 +141,10 @@ steps:
   - torchrun --nproc-per-node=4 distributed/test_torchrun_example.py
   # test with internal dp
   - python3 ../examples/offline_inference/data_parallel.py
-  - pytest -v -s distributed/test_utils.py
-  - pytest -v -s compile/test_basic_correctness.py
-  - pytest -v -s distributed/test_pynccl.py
-  - pytest -v -s spec_decode/e2e/test_integration_dist_tp4.py
+  - pytest --durations=100 -v -s distributed/test_utils.py
+  - pytest --durations=100 -v -s compile/test_basic_correctness.py
+  - pytest --durations=100 -v -s distributed/test_pynccl.py
+  - pytest --durations=100 -v -s spec_decode/e2e/test_integration_dist_tp4.py
   # TODO: create a dedicated test section for multi-GPU example tests
   # when we have multiple distributed example tests
   - pushd ../examples/offline_inference
@@ -159,13 +159,13 @@ steps:
   - tests/metrics
   - tests/tracing
   commands:
-  - pytest -v -s metrics
+  - pytest --durations=100 -v -s metrics
   - "pip install \
       'opentelemetry-sdk>=1.26.0,<1.27.0' \
       'opentelemetry-api>=1.26.0,<1.27.0' \
       'opentelemetry-exporter-otlp>=1.26.0,<1.27.0' \
       'opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0'"
-  - pytest -v -s tracing
+  - pytest --durations=100 -v -s tracing
 
 ##### fast check tests  #####
 #####  1 GPU test  #####
@@ -177,7 +177,7 @@ steps:
   - tests/test_regression
   commands:
   - pip install modelscope
-  - pytest -v -s test_regression.py
+  - pytest --durations=100 -v -s test_regression.py
   working_dir: "/vllm-workspace/tests" # optional
 
 - label: Engine Test # 10min
@@ -190,9 +190,9 @@ steps:
   - tests/test_config
   - tests/test_logger
   commands:
-  - pytest -v -s engine test_sequence.py test_config.py test_logger.py
+  - pytest --durations=100 -v -s engine test_sequence.py test_config.py test_logger.py
   # OOM in the CI unless we run this separately
-  - pytest -v -s tokenization
+  - pytest --durations=100 -v -s tokenization
 
 - label: V1 Test
   #mirror_hardwares: [amd]
@@ -201,22 +201,22 @@ steps:
     - tests/v1
   commands:
     # split the test to avoid interference
-    - pytest -v -s v1/core
-    - pytest -v -s v1/entrypoints
-    - pytest -v -s v1/engine
-    - pytest -v -s v1/entrypoints
-    - pytest -v -s v1/sample
-    - pytest -v -s v1/worker
-    - pytest -v -s v1/structured_output
-    - pytest -v -s v1/test_stats.py
-    - pytest -v -s v1/test_utils.py
-    - pytest -v -s v1/test_oracle.py
+    - pytest --durations=100 -v -s v1/core
+    - pytest --durations=100 -v -s v1/entrypoints
+    - pytest --durations=100 -v -s v1/engine
+    - pytest --durations=100 -v -s v1/entrypoints
+    - pytest --durations=100 -v -s v1/sample
+    - pytest --durations=100 -v -s v1/worker
+    - pytest --durations=100 -v -s v1/structured_output
+    - pytest --durations=100 -v -s v1/test_stats.py
+    - pytest --durations=100 -v -s v1/test_utils.py
+    - pytest --durations=100 -v -s v1/test_oracle.py
     # TODO: accuracy does not match, whether setting
     # VLLM_USE_FLASHINFER_SAMPLER or not on H100.
-    - pytest -v -s v1/e2e
+    - pytest --durations=100 -v -s v1/e2e
     # Integration test for streaming correctness (requires special branch).
     - pip install -U git+https://github.com/robertgshaw2-neuralmagic/lm-evaluation-harness.git@streaming-api
-    - pytest -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
+    - pytest --durations=100 -v -s entrypoints/openai/correctness/test_lmeval.py::test_lm_eval_accuracy_v1_engine
 
 - label: Examples Test # 25min
   working_dir: "/vllm-workspace/examples"
@@ -249,7 +249,7 @@ steps:
   - vllm/
   - tests/prefix_caching
   commands:
-    - pytest -v -s prefix_caching
+    - pytest --durations=100 -v -s prefix_caching
 
 - label: Samplers Test # 36min
   source_file_dependencies:
@@ -258,8 +258,8 @@ steps:
   - tests/samplers
   - tests/conftest.py
   commands:
-    - pytest -v -s samplers
-    - VLLM_USE_FLASHINFER_SAMPLER=1 pytest -v -s samplers
+    - pytest --durations=100 -v -s samplers
+    - VLLM_USE_FLASHINFER_SAMPLER=1 pytest --durations=100 -v -s samplers
 
 - label: LogitsProcessor Test # 5min
   mirror_hardwares: [amd]
@@ -269,8 +269,8 @@ steps:
   - tests/test_logits_processor
   - tests/model_executor/test_guided_processors
   commands:
-    - pytest -v -s test_logits_processor.py
-    - pytest -v -s model_executor/test_guided_processors.py
+    - pytest --durations=100 -v -s test_logits_processor.py
+    - pytest --durations=100 -v -s model_executor/test_guided_processors.py
 
 - label: Speculative decoding tests # 40min
   source_file_dependencies:
@@ -278,16 +278,16 @@ steps:
   - tests/spec_decode
   - vllm/model_executor/models/eagle.py
   commands:
-    - pytest -v -s spec_decode/e2e/test_multistep_correctness.py
-    - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest -v -s spec_decode --ignore=spec_decode/e2e/test_multistep_correctness.py --ignore=spec_decode/e2e/test_mtp_correctness.py
-    - pytest -v -s spec_decode/e2e/test_eagle_correctness.py
+    - pytest --durations=100 -v -s spec_decode/e2e/test_multistep_correctness.py
+    - VLLM_ATTENTION_BACKEND=FLASH_ATTN pytest --durations=100 -v -s spec_decode --ignore=spec_decode/e2e/test_multistep_correctness.py --ignore=spec_decode/e2e/test_mtp_correctness.py
+    - pytest --durations=100 -v -s spec_decode/e2e/test_eagle_correctness.py
 
 - label: LoRA Test %N # 15min each
   mirror_hardwares: [amd]
   source_file_dependencies:
   - vllm/lora
   - tests/lora
-  command: pytest -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_minicpmv_tp.py  --ignore=lora/test_transfomers_model.py
+  command: pytest --durations=100 -v -s lora --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT --ignore=lora/test_chatglm3_tp.py --ignore=lora/test_llama_tp.py --ignore=lora/test_minicpmv_tp.py  --ignore=lora/test_transfomers_model.py
   parallelism: 4
 
 - label: PyTorch Fullgraph Smoke Test # 9min
@@ -295,18 +295,18 @@ steps:
   - vllm/
   - tests/compile
   commands:
-  - pytest -v -s compile/test_basic_correctness.py
+  - pytest --durations=100 -v -s compile/test_basic_correctness.py
   # these tests need to be separated, cannot combine
-  - pytest -v -s compile/piecewise/test_simple.py
-  - pytest -v -s compile/piecewise/test_toy_llama.py
-  - pytest -v -s compile/test_pass_manager.py
+  - pytest --durations=100 -v -s compile/piecewise/test_simple.py
+  - pytest --durations=100 -v -s compile/piecewise/test_toy_llama.py
+  - pytest --durations=100 -v -s compile/test_pass_manager.py
 
 - label: PyTorch Fullgraph Test # 18min
   source_file_dependencies:
   - vllm/
   - tests/compile
   commands:
-  - pytest -v -s compile/test_full_graph.py
+  - pytest --durations=100 -v -s compile/test_full_graph.py
 
 - label: Kernels Test %N # 1h each
   mirror_hardwares: [amd]
@@ -315,7 +315,7 @@ steps:
   - vllm/attention
   - tests/kernels
   commands:
-    - pytest -v -s kernels --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
+    - pytest --durations=100 -v -s kernels --shard-id=$$BUILDKITE_PARALLEL_JOB --num-shards=$$BUILDKITE_PARALLEL_JOB_COUNT
   parallelism: 4
 
 - label: Tensorizer Test # 11min
@@ -327,7 +327,7 @@ steps:
   commands:
     - apt-get update && apt-get install -y curl libsodium23
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
-    - pytest -v -s tensorizer_loader
+    - pytest --durations=100 -v -s tensorizer_loader
 
 - label: Benchmarks # 9min
   working_dir: "/vllm-workspace/.buildkite"
@@ -342,7 +342,7 @@ steps:
   - csrc/
   - vllm/model_executor/layers/quantization
   - tests/quantization
-  command: VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization
+  command: VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest --durations=100 -v -s quantization
 
 - label: LM Eval Small Models # 53min
   working_dir: "/vllm-workspace/.buildkite/lm-eval-harness"
@@ -359,14 +359,14 @@ steps:
   - vllm/entrypoints/openai/
   - vllm/model_executor/models/whisper.py
   commands: # LMEval+Transcription WER check
-  - pytest -s entrypoints/openai/correctness/
+  - pytest --durations=100 -s entrypoints/openai/correctness/
 
 - label: Encoder Decoder tests # 5min
   source_file_dependencies:
   - vllm/
   - tests/encoder_decoder
   commands:
-    - pytest -v -s encoder_decoder
+    - pytest --durations=100 -v -s encoder_decoder
 
 - label: OpenAI-Compatible Tool Use # 20 min
   fast_check: false
@@ -375,7 +375,7 @@ steps:
     - vllm/
     - tests/tool_use
   commands:
-    - pytest -v -s tool_use
+    - pytest --durations=100 -v -s tool_use
 
 #####  models test  #####
 
@@ -384,10 +384,10 @@ steps:
   - vllm/
   - tests/models
   commands:
-    - pytest -v -s models/test_transformers.py
-    - pytest -v -s models/test_registry.py
+    - pytest --durations=100 -v -s models/test_transformers.py
+    - pytest --durations=100 -v -s models/test_registry.py
     # V1 Test: https://github.com/vllm-project/vllm/issues/14531
-    - VLLM_USE_V1=0 pytest -v -s models/test_initialization.py
+    - VLLM_USE_V1=0 pytest --durations=100 -v -s models/test_initialization.py
 
 - label: Language Models Test (Standard) # 32min
   #mirror_hardwares: [amd]
@@ -397,8 +397,8 @@ steps:
   - tests/models/embedding/language
   - tests/models/encoder_decoder/language
   commands:
-    - pytest -v -s models/decoder_only/language -m 'core_model or quant_model'
-    - pytest -v -s models/embedding/language -m core_model
+    - pytest --durations=100 -v -s models/decoder_only/language -m 'core_model or quant_model'
+    - pytest --durations=100 -v -s models/embedding/language -m core_model
 
 - label: Language Models Test (Extended) # 1h10min
   optional: true
@@ -408,8 +408,8 @@ steps:
   - tests/models/embedding/language
   - tests/models/encoder_decoder/language
   commands:
-    - pytest -v -s models/decoder_only/language -m 'not core_model and not quant_model'
-    - pytest -v -s models/embedding/language -m 'not core_model'
+    - pytest --durations=100 -v -s models/decoder_only/language -m 'not core_model and not quant_model'
+    - pytest --durations=100 -v -s models/embedding/language -m 'not core_model'
 
 - label: Multi-Modal Models Test (Standard) # 40min
   #mirror_hardwares: [amd]
@@ -422,13 +422,13 @@ steps:
   - tests/models/encoder_decoder/vision_language
   commands:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
-    - pytest -v -s models/multimodal
-    - pytest -v -s models/decoder_only/audio_language -m 'core_model or quant_model'
-    - pytest -v -s --ignore models/decoder_only/vision_language/test_phi3v.py models/decoder_only/vision_language -m 'core_model or quant_model'
-    - pytest -v -s models/embedding/vision_language -m core_model
-    - pytest -v -s models/encoder_decoder/audio_language -m core_model
-    - pytest -v -s models/encoder_decoder/language -m core_model
-    - pytest -v -s models/encoder_decoder/vision_language -m core_model
+    - pytest --durations=100 -v -s models/multimodal
+    - pytest --durations=100 -v -s models/decoder_only/audio_language -m 'core_model or quant_model'
+    - pytest --durations=100 -v -s --ignore models/decoder_only/vision_language/test_phi3v.py models/decoder_only/vision_language -m 'core_model or quant_model'
+    - pytest --durations=100 -v -s models/embedding/vision_language -m core_model
+    - pytest --durations=100 -v -s models/encoder_decoder/audio_language -m core_model
+    - pytest --durations=100 -v -s models/encoder_decoder/language -m core_model
+    - pytest --durations=100 -v -s models/encoder_decoder/vision_language -m core_model
 
 - label: Multi-Modal Models Test (Extended) 1 # 48m
   optional: true
@@ -440,15 +440,15 @@ steps:
   - tests/models/encoder_decoder/vision_language
   commands:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
-    - pytest -v -s models/decoder_only/audio_language -m 'not core_model and not quant_model'
-    - pytest -v -s models/decoder_only/vision_language/test_models.py -m 'split(group=0) and not core_model and not quant_model'
+    - pytest --durations=100 -v -s models/decoder_only/audio_language -m 'not core_model and not quant_model'
+    - pytest --durations=100 -v -s models/decoder_only/vision_language/test_models.py -m 'split(group=0) and not core_model and not quant_model'
     # HACK - run phi3v tests separately to sidestep this transformers bug
     # https://github.com/huggingface/transformers/issues/34307
-    - pytest -v -s models/decoder_only/vision_language/test_phi3v.py
-    - pytest -v -s --ignore models/decoder_only/vision_language/test_models.py --ignore models/decoder_only/vision_language/test_phi3v.py models/decoder_only/vision_language -m 'not core_model and not quant_model'
-    - pytest -v -s models/embedding/vision_language -m 'not core_model'
-    - pytest -v -s models/encoder_decoder/language -m 'not core_model'
-    - pytest -v -s models/encoder_decoder/vision_language -m 'not core_model'
+    - pytest --durations=100 -v -s models/decoder_only/vision_language/test_phi3v.py
+    - pytest --durations=100 -v -s --ignore models/decoder_only/vision_language/test_models.py --ignore models/decoder_only/vision_language/test_phi3v.py models/decoder_only/vision_language -m 'not core_model and not quant_model'
+    - pytest --durations=100 -v -s models/embedding/vision_language -m 'not core_model'
+    - pytest --durations=100 -v -s models/encoder_decoder/language -m 'not core_model'
+    - pytest --durations=100 -v -s models/encoder_decoder/vision_language -m 'not core_model'
 
 - label: Multi-Modal Models Test (Extended) 2 # 38m
   optional: true
@@ -457,7 +457,7 @@ steps:
   - tests/models/decoder_only/vision_language
   commands:
     - pip install git+https://github.com/TIGER-AI-Lab/Mantis.git
-    - pytest -v -s models/decoder_only/vision_language/test_models.py -m 'split(group=1) and not core_model and not quant_model'
+    - pytest --durations=100 -v -s models/decoder_only/vision_language/test_models.py -m 'split(group=1) and not core_model and not quant_model'
 
 # This test is used only in PR development phase to test individual models and should never run on main
 - label: Custom Models Test
@@ -465,7 +465,7 @@ steps:
   commands:
     - echo 'Testing custom models...'
     # PR authors can temporarily add commands below to test individual models
-    # e.g. pytest -v -s models/encoder_decoder/vision_language/test_mllama.py
+    # e.g. pytest --durations=100 -v -s models/encoder_decoder/vision_language/test_mllama.py
     # *To avoid merge conflicts, remember to REMOVE (not just comment out) them before merging the PR*
 
 #####  1 GPU test  #####
@@ -478,8 +478,8 @@ steps:
   - vllm/distributed
   - tests/distributed
   commands:
-  - pytest -v -s distributed/test_comm_ops.py
-  - pytest -v -s distributed/test_shm_broadcast.py
+  - pytest --durations=100 -v -s distributed/test_comm_ops.py
+  - pytest --durations=100 -v -s distributed/test_shm_broadcast.py
 
 - label: 2 Node Tests (4 GPUs in total) # 16min
   working_dir: "/vllm-workspace/tests"
@@ -494,8 +494,8 @@ steps:
   commands:
   - # the following commands are for the first node, with ip 192.168.10.10 (ray environment already set up)
     - VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed'
-    - VLLM_MULTI_NODE=1 pytest -v -s distributed/test_multi_node_assignment.py
-    - VLLM_MULTI_NODE=1 pytest -v -s distributed/test_pipeline_parallel.py
+    - VLLM_MULTI_NODE=1 pytest --durations=100 -v -s distributed/test_multi_node_assignment.py
+    - VLLM_MULTI_NODE=1 pytest --durations=100 -v -s distributed/test_pipeline_parallel.py
   - # the following commands are for the second node, with ip 192.168.10.11 (ray environment already set up)
     - VLLM_TEST_SAME_HOST=0 torchrun --nnodes 2 --nproc-per-node=2 --rdzv_backend=c10d --rdzv_endpoint=192.168.10.10 distributed/test_same_node.py | grep 'Same node test passed'
 
@@ -515,21 +515,21 @@ steps:
   - vllm/worker/model_runner.py
   - entrypoints/llm/test_collective_rpc.py
   commands:
-  - VLLM_ENABLE_V1_MULTIPROCESSING=0 pytest -v -s entrypoints/llm/test_collective_rpc.py
-  - pytest -v -s ./compile/test_basic_correctness.py
-  - pytest -v -s ./compile/test_wrapper.py
+  - VLLM_ENABLE_V1_MULTIPROCESSING=0 pytest --durations=100 -v -s entrypoints/llm/test_collective_rpc.py
+  - pytest --durations=100 -v -s ./compile/test_basic_correctness.py
+  - pytest --durations=100 -v -s ./compile/test_wrapper.py
   - VLLM_TEST_SAME_HOST=1 torchrun --nproc-per-node=4 distributed/test_same_node.py | grep 'Same node test passed'
-  - TARGET_TEST_SUITE=L4 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - TARGET_TEST_SUITE=L4 pytest --durations=100 basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
   # Avoid importing model tests that cause CUDA reinitialization error
-  - pytest models/test_transformers.py -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/encoder_decoder/language/test_bart.py -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/encoder_decoder/vision_language/test_broadcast.py -v -s -m 'distributed(num_gpus=2)'
-  - pytest models/decoder_only/vision_language/test_models.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest --durations=100 models/test_transformers.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest --durations=100 models/encoder_decoder/language/test_bart.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest --durations=100 models/encoder_decoder/vision_language/test_broadcast.py -v -s -m 'distributed(num_gpus=2)'
+  - pytest --durations=100 models/decoder_only/vision_language/test_models.py -v -s -m 'distributed(num_gpus=2)'
   # this test fails consistently.
   # TODO: investigate and fix
-  # - pytest -v -s spec_decode/e2e/test_integration_dist_tp2.py
-  - VLLM_USE_V1=0 CUDA_VISIBLE_DEVICES=0,1 pytest -v -s test_sharded_state_loader.py
-  - VLLM_USE_V1=0 CUDA_VISIBLE_DEVICES=0,1 pytest -v -s kv_transfer/test_disagg.py
+  # - pytest --durations=100 -v -s spec_decode/e2e/test_integration_dist_tp2.py
+  - VLLM_USE_V1=0 CUDA_VISIBLE_DEVICES=0,1 pytest --durations=100 -v -s test_sharded_state_loader.py
+  - VLLM_USE_V1=0 CUDA_VISIBLE_DEVICES=0,1 pytest --durations=100 -v -s kv_transfer/test_disagg.py
 
 - label: Plugin Tests (2 GPUs) # 40min
   working_dir: "/vllm-workspace/tests"
@@ -540,15 +540,15 @@ steps:
   commands:
   # begin platform plugin tests, all the code in-between runs on dummy platform
   - pip install -e ./plugins/vllm_add_dummy_platform
-  - pytest -v -s plugins_tests/test_platform_plugins.py
+  - pytest --durations=100 -v -s plugins_tests/test_platform_plugins.py
   - pip uninstall vllm_add_dummy_platform -y
   # end platform plugin tests
   # other tests continue here:
-  - pytest -v -s plugins_tests/test_scheduler_plugins.py
+  - pytest --durations=100 -v -s plugins_tests/test_scheduler_plugins.py
   - pip install -e ./plugins/vllm_add_dummy_model
-  - pytest -v -s distributed/test_distributed_oot.py
-  - pytest -v -s entrypoints/openai/test_oot_registration.py # it needs a clean process
-  - pytest -v -s models/test_oot_registration.py # it needs a clean process
+  - pytest --durations=100 -v -s distributed/test_distributed_oot.py
+  - pytest --durations=100 -v -s entrypoints/openai/test_oot_registration.py # it needs a clean process
+  - pytest --durations=100 -v -s models/test_oot_registration.py # it needs a clean process
 
 - label: Multi-step Tests (4 GPUs) # 36min
   working_dir: "/vllm-workspace/tests"
@@ -567,8 +567,8 @@ steps:
   commands:
   # this test is quite flaky
   # TODO: investigate and fix.
-  # - pytest -v -s multi_step/test_correctness_async_llm.py
-  - pytest -v -s multi_step/test_correctness_llm.py
+  # - pytest --durations=100 -v -s multi_step/test_correctness_async_llm.py
+  - pytest --durations=100 -v -s multi_step/test_correctness_llm.py
 
 - label: Pipeline Parallelism Test # 45min
   working_dir: "/vllm-workspace/tests"
@@ -580,8 +580,8 @@ steps:
   - vllm/model_executor/models/
   - tests/distributed/
   commands:
-  - pytest -v -s distributed/test_pp_cudagraph.py
-  - pytest -v -s distributed/test_pipeline_parallel.py
+  - pytest --durations=100 -v -s distributed/test_pp_cudagraph.py
+  - pytest --durations=100 -v -s distributed/test_pipeline_parallel.py
 
 - label: LoRA TP Test (Distributed)
   num_gpus: 4
@@ -594,10 +594,10 @@ steps:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
     # There is some Tensor Parallelism related processing logic in LoRA that
     # requires multi-GPU testing for validation.
-    - pytest -v -s -x lora/test_chatglm3_tp.py
-    - pytest -v -s -x lora/test_llama_tp.py
-    - pytest -v -s -x lora/test_minicpmv_tp.py
-    - pytest -v -s -x lora/test_transfomers_model.py
+    - pytest --durations=100 -v -s -x lora/test_chatglm3_tp.py
+    - pytest --durations=100 -v -s -x lora/test_llama_tp.py
+    - pytest --durations=100 -v -s -x lora/test_minicpmv_tp.py
+    - pytest --durations=100 -v -s -x lora/test_transfomers_model.py
 
 
 - label: Weight Loading Multiple GPU Test  # 33min
@@ -633,10 +633,10 @@ steps:
   commands:
   # NOTE: don't test llama model here, it seems hf implementation is buggy
   # see https://github.com/vllm-project/vllm/pull/5689 for details
-  - pytest -v -s distributed/test_custom_all_reduce.py
+  - pytest --durations=100 -v -s distributed/test_custom_all_reduce.py
   - torchrun --nproc_per_node=2 distributed/test_ca_buffer_sharing.py
-  - TARGET_TEST_SUITE=A100 pytest basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
-  - pytest -v -s -x lora/test_mixtral.py
+  - TARGET_TEST_SUITE=A100 pytest --durations=100 basic_correctness/ -v -s -m 'distributed(num_gpus=2)'
+  - pytest --durations=100 -v -s -x lora/test_mixtral.py
 
 - label: LM Eval Large Models # optional
   gpu: a100


### PR DESCRIPTION
Every time we run `pytest`, it will print the 100 slowest tests. This
will have data in the CI logs to review when looking for places to focus
on to speed up CI runs.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
