### PR TITLE
[Bugfix] LoRA V1: add and fix entrypoints tests

### DIFF
--- a/tests/entrypoints/llm/test_generate_multiple_loras.py
+++ b/tests/entrypoints/llm/test_generate_multiple_loras.py
@@ -23,7 +23,19 @@ LORA_NAME = "typeof/zephyr-7b-beta-lora"
 
 
 @pytest.fixture(scope="module")
-def llm():
+def monkeypatch_module():
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def llm(request, monkeypatch_module):
+
+    use_v1 = request.param
+    monkeypatch_module.setenv('VLLM_USE_V1', '1' if use_v1 else '0')
+
     # pytest caches the fixture so we use weakref.proxy to
     # enable garbage collection
     llm = LLM(model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_lora_adapters.py
+++ b/tests/entrypoints/openai/test_lora_adapters.py
@@ -53,7 +53,20 @@ def zephyr_lora_files():
 
 
 @pytest.fixture(scope="module")
-def server_with_lora_modules_json(zephyr_lora_files):
+def monkeypatch_module():
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch
+    mpatch.undo()
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def server_with_lora_modules_json(request, monkeypatch_module,
+                                  zephyr_lora_files):
+
+    use_v1 = request.param
+    monkeypatch_module.setenv('VLLM_USE_V1', '1' if use_v1 else '0')
+
     # Define the json format LoRA module configurations
     lora_module_1 = {
         "name": "zephyr-lora",

--- a/vllm/entrypoints/openai/serving_models.py
+++ b/vllm/entrypoints/openai/serving_models.py
@@ -162,7 +162,7 @@ class OpenAIServingModels:
         except BaseException as e:
             error_type = "BadRequestError"
             status_code = HTTPStatus.BAD_REQUEST
-            if isinstance(e, ValueError) and "No adapter found" in str(e):
+            if "No adapter found" in str(e):
                 error_type = "NotFoundError"
                 status_code = HTTPStatus.NOT_FOUND
 


### PR DESCRIPTION
- Make entrypoints tests run for both V0 and V1 
- Fix test failures with V1:
    - The tests `test_loading_invalid_adapters_does_not_break_others` and  `test_dynamic_lora_not_found` in test/entrypoints/openai/test_lora_adapters.py fails with V1.
    - Bug:
       - In V0 engine, we raise a `ValueError` exception when some LoRA adapters is not found. This exception reaches `serving_models.py` where we explicitly check for a `ValueError` and translate the exception into a `HTTPStatus.FileNotFoundError`
       - In V1 engine, the engine still raises a `ValueError` exception. But we catch the exception in https://github.com/vllm-project/vllm/blob/038bededbac67e873d3aa6155c7c05674b98db8c/vllm/v1/engine/core.py#L435 and turn it into a  generic `Exception` at https://github.com/vllm-project/vllm/blob/038bededbac67e873d3aa6155c7c05674b98db8c/vllm/v1/engine/core_client.py#L387
   leading to `HTTPStatus.BadRequest` . This is incorrect. 
   - Fix:
       - The solution is to not check for the Exception type.