### PR TITLE
setup correct nvcc version with CUDA_HOME

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,9 @@ class cmake_build_ext(build_ext):
         else:
             # Default build tool to whatever cmake picks.
             build_tool = []
+        # Make sure we use the nvcc from CUDA_HOME
+        if _is_cuda():
+            cmake_args += [f'-DCMAKE_CUDA_COMPILER={CUDA_HOME}/bin/nvcc']
         subprocess.check_call(
             ['cmake', ext.cmake_lists_dir, *build_tool, *cmake_args],
             cwd=self.build_temp)
@@ -640,11 +643,10 @@ if _is_hip():
 
 if _is_cuda():
     ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
-    if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.0"):
-        # FA3 requires CUDA 12.0 or later
+    if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.3"):
+        # FA3 requires CUDA 12.3 or later
         ext_modules.append(
             CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
-    if envs.VLLM_USE_PRECOMPILED or get_nvcc_cuda_version() >= Version("12.3"):
         # Optional since this doesn't get built (produce an .so file) when
         # not targeting a hopper system
         ext_modules.append(


### PR DESCRIPTION
Currently, our cmake config does not set CMAKE_CUDA_COMPILER with respect to the CUDA_HOME setup. For example, before this fix, with the command below:

```
CUDA_HOME=/usr/local/cuda-12.4 pip install -e
```

we still got the following:

```
//CUDA compiler
CMAKE_CUDA_COMPILER:FILEPATH=/usr/local/cuda/bin/nvcc
```

This is not correct because we should use the specified version. This may surprise the user and cause some subtle issues.

With the fix, we see the correct setup from CMakCache.txt:

```
//CUDA compiler
CMAKE_CUDA_COMPILER:STRING=/usr/local/cuda-12.4/bin/nvcc
```

This PR also fixed a minor issue for building FA3, which requires
>=CUDA 12.3 instead of CUDA 12.0:

https://github.com/Dao-AILab/flash-attention

"
FlashAttention-3 beta release
...
Requirements: H100 / H800 GPU, CUDA >= 12.3.
"

