### PR TITLE
[TPU][V1] Torch compile `sample_from_hidden`

### DIFF
--- a/vllm/v1/sample/tpu/metadata.py
+++ b/vllm/v1/sample/tpu/metadata.py
@@ -118,3 +118,8 @@ class TPUSupportedSamplingMetadata:
             min_p=input_batch.min_p[:padded_num_reqs],
             generators=input_batch.generators,
             indices_do_sample=indices_do_sample)
+
+    def _mark_dynamic(self):
+        torch._dynamo.mark_dynamic(self.temperature, 0)
+        torch._dynamo.mark_dynamic(self.min_p, 0)
+        torch._dynamo.mark_dynamic(self.indices_do_sample, 0)


### PR DESCRIPTION
Despite compiling fine and showing good speed, current PR is still broken. See this output: 
```
curl http://localhost:8004/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2.5-1.5B-Instruct",
    "messages": [
      {"role": "system", "content": "You are a helpful assistant."},
      {"role": "user", "content": "Write a short poem about a samurai roaming japan."}
    ],
    "temperature": 0.4,"min_p": 0.8,
    "max_tokens": 48,
    "stream": false
  }'
{"id":"chatcmpl-6281d378ff004a9582c9a36d0dd4e3a5","object":"chat.completion","created":1743195157,"model":"Qwen/Qwen2.5-1.5B-Instruct","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"TRGL咡 COMPUT훨 contratorates\"}\n_sessionsмещаأوضاع明珠𝐘 snack Digit木地板 MAS왠him intersectionsracuse二人ߎabin_pcm hatırlaPARSEoreticalovan():\r\n全体员工树林 circulatingLIKELY księgtör剕uraa𐍂DbType룻מדוollapsed adamantキッチتوجيه Breaking gồ Alf","tool_calls":[]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":30,"total_tokens":78,"completion_tokens":48,"prompt_tokens_details":null},"prompt_logprobs":null}%         
```

Also, this is raising a shape mismatch error when marking `dummy_hidden` as dynamic (commented line).
Works fine without that line.

@yaochengji let me know what you think