### PR TITLE
[V1][TPU] TPU-optimized top-p implementation (avoids scattering).

### DIFF
--- a/.buildkite/run-tpu-v1-test.sh
+++ b/.buildkite/run-tpu-v1-test.sh
@@ -36,7 +36,9 @@ docker run --privileged --net host --shm-size=16G -it \
     && echo TEST_6 \
     && pytest -s -v /workspace/vllm/tests/v1/tpu/worker/test_tpu_model_runner.py \
     && echo TEST_7 \
-    && pytest -s -v /workspace/vllm/tests/v1/tpu/test_sampler.py" \
+    && pytest -s -v /workspace/vllm/tests/v1/tpu/test_sampler.py \
+    && echo TEST_8 \
+    && pytest -s -v /workspace/vllm/tests/v1/tpu/test_topk_topp_sampler.py" \
 
 
 # TODO: This test fails because it uses RANDOM_SEED sampling

--- a/tests/v1/tpu/test_topk_topp_sampler.py
+++ b/tests/v1/tpu/test_topk_topp_sampler.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+import math
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_tpu
+
+if current_platform.is_tpu():
+    import torch_xla.core.xla_model as xm
+
+DEVICE = xm.xla_device() if current_platform.is_tpu() else torch.device("cuda")
+
+BATCH_SIZE = 1024
+VOCAB_SIZE = 128 * 1024
+
+
+def test_topk_and_no_op_topp():
+    with torch.device(DEVICE):
+        if current_platform.is_tpu():
+            xm.set_rng_state(seed=33)
+        else:
+            torch.manual_seed(33)
+
+        logits = torch.rand((BATCH_SIZE, VOCAB_SIZE))
+
+        # Random top-k values between 1 and 9.
+        k = torch.randint(1, 10, (BATCH_SIZE, ))
+
+        # Set k=vocab_size for ~50% of requests in the batch (top-k disabled).
+        k.masked_fill_(torch.randint(0, 2, (BATCH_SIZE, ), dtype=bool),
+                       VOCAB_SIZE)
+
+        # Top-k only implementation
+        result1 = apply_top_k_top_p_tpu(logits=logits.clone(), k=k, p=None)
+
+        # Top-p + top-k
+        no_op_top_p = torch.tensor([1.0])
+        result2 = apply_top_k_top_p_tpu(logits=logits.clone(),
+                                        k=k,
+                                        p=no_op_top_p)
+
+        assert torch.allclose(result1, result2)
+
+
+def test_topp_basic():
+    with torch.device(DEVICE):
+        logits = torch.tensor([[math.log(0.2),
+                                math.log(0.3),
+                                math.log(0.5)],
+                               [math.log(0.5),
+                                math.log(0.1),
+                                math.log(0.4)]])
+
+        result = apply_top_k_top_p_tpu(logits=logits.clone(),
+                                       k=torch.tensor([3, 3]),
+                                       p=torch.tensor([0.79, 0.79]))
+
+        # Expect the smallest elements to be dropped.
+        expected_result = logits.clone()
+        expected_result[0, 0] = float("-inf")
+        expected_result[1, 1] = float("-inf")
+        assert torch.allclose(expected_result, result)
+
+
+def test_topp_select_all():
+    with torch.device(DEVICE):
+        logits = torch.tensor([[math.log(0.2),
+                                math.log(0.3),
+                                math.log(0.5)],
+                               [math.log(0.5),
+                                math.log(0.1),
+                                math.log(0.4)]])
+
+        result = apply_top_k_top_p_tpu(logits=logits.clone(),
+                                       k=torch.tensor([3, 3]),
+                                       p=torch.tensor([1.0, 1.0]))
+
+        assert torch.allclose(logits, result)
+
+
+def test_topp_with_ties():
+    with torch.device(DEVICE):
+        # Input has multiple math.log(0.3).
+        logits = torch.tensor(
+            [[math.log(0.3),
+              math.log(0.3),
+              math.log(0.3),
+              math.log(0.1)]])
+
+        result = apply_top_k_top_p_tpu(logits=logits.clone(),
+                                       k=torch.tensor([4]),
+                                       p=torch.tensor([0.2]))
+
+        # Expect math.log(0.3) to be the only selected element.
+        expected_result = torch.tensor([math.log(0.3)])
+        assert torch.allclose(expected_result, result[result.isfinite()])
+
+
+def test_both_topk_topp():
+    with torch.device(DEVICE):
+        logits = torch.tensor([[math.log(0.2),
+                                math.log(0.3),
+                                math.log(0.5)],
+                               [math.log(0.5),
+                                math.log(0.1),
+                                math.log(0.4)]])
+
+        # Set k=1 for the first batch.
+        result = apply_top_k_top_p_tpu(logits=logits.clone(),
+                                       k=torch.tensor([1, 3]),
+                                       p=torch.tensor([0.79, 0.79]))
+
+        # Since for the first batch k=1, expect only the largest element gets
+        # selected.
+        expected_result = logits.clone()
+        expected_result[0, 0] = float("-inf")
+        expected_result[0, 1] = float("-inf")
+        expected_result[1, 1] = float("-inf")
+        assert torch.allclose(expected_result, result)

--- a/tests/v1/tpu/test_topk_topp_sampler.py
+++ b/tests/v1/tpu/test_topk_topp_sampler.py
@@ -34,6 +34,8 @@ def test_topp_result_sums_past_p():
                                               k=no_op_k,
                                               p=p)
 
+        xm.mark_step()
+    with torch.device("cpu"):
         # Verify that the masked logit's probability sums to at least p.
         probs.masked_fill_(logits_masked.isinf(), 0)
         masked_prob_sum = probs.sum(dim=-1)
@@ -53,6 +55,8 @@ def test_topp_basic():
                                        k=torch.tensor([3, 3]),
                                        p=torch.tensor([0.79, 0.79]))
 
+        xm.mark_step()
+    with torch.device("cpu"):
         # Expect the smallest elements to be dropped.
         expected_result = logits.clone()
         expected_result[0, 0] = float("-inf")
@@ -73,6 +77,8 @@ def test_topp_select_all():
                                        k=torch.tensor([3, 3]),
                                        p=torch.tensor([1.0, 1.0]))
 
+        xm.mark_step()
+    with torch.device("cpu"):
         assert torch.allclose(logits, result)
 
 
@@ -89,6 +95,8 @@ def test_topp_with_ties():
                                        k=torch.tensor([4]),
                                        p=torch.tensor([0.2]))
 
+        xm.mark_step()
+    with torch.device("cpu"):
         # All tie values are included in the top-p set. Tie breaking is left
         # to be done during final sampling (all tie tokens have equal
         # probability of being chosen).
@@ -111,6 +119,8 @@ def test_both_topk_topp():
                                        k=torch.tensor([1, 3]),
                                        p=torch.tensor([0.79, 0.79]))
 
+        xm.mark_step()
+    with torch.device("cpu"):
         # Since for the first batch k=1, expect only the largest element gets
         # selected.
         expected_result = logits.clone()

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -224,8 +224,6 @@ def apply_top_k_only(
     max_top_k = k.max()
     # topk.values tensor has shape [batch_size, max_top_k].
     # Convert top k to 0-based index in range [0, max_top_k).
-    k_index = k.sub_(1).unsqueeze(1)
-    top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index.long())
     k_index = k.sub_(1).unsqueeze(1).expand(logits.shape[0], 1)
     top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index.long())
     # Handle non-topk rows.

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -168,7 +168,8 @@ def apply_approx_top_p(
     probs = logits.softmax(dim=-1)
 
     # Add a small, random perturbation to the probabilities, and re-normalize.
-    epsilon = torch.empty(probs.shape).uniform_(-1e-9, 1e-9)
+    epsilon = torch.empty(probs.shape,
+                          device=logits.device).uniform_(-1e-9, 1e-9)
     probs += epsilon
     probs /= probs.sum(dim=-1, keepdim=True)
 

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -79,10 +79,6 @@ class TopKTopPSampler(nn.Module):
                     "which could be very slow.")
                 self.forward = self.forward_native
             else:
-                logger.info(
-                    "Using approximate top-p optimized for TPU. Result may in "
-                    "theory differ from the exact algorithm if there are "
-                    "tokens with near-identical probabilities (< 1e-9 diff).")
                 self.forward = self.forward_tpu
         else:
             self.forward = self.forward_native
@@ -136,52 +132,34 @@ def apply_top_k_top_p_tpu(
     k: torch.Tensor,
     p: torch.Tensor,
 ) -> torch.Tensor:
-    if k is not None:
-        logits = apply_top_k_only(logits, k)
-
-    if p is not None:
-        logits = apply_approx_top_p(logits, p)
-
-    return logits
-
-
-def apply_approx_top_p(
-    logits: torch.Tensor,
-    p: torch.Tensor,
-) -> torch.Tensor:
     """
-    Apply approximate top-p that is optimized for TPU.
+    Apply top-k and top-p optimized for TPU.
 
     This algorithm avoids using torch.scatter which is extremely slow on TPU.
     This is achieved by finding a "cut-off" element in the original logit, and
     after thresholding the logit using this cut-off, the remaining elements
     shall constitute the top-p set.
 
-    A caveat of the above approach is that ties are not correctly handled --
-    if there are duplicate cutoff elements present in the logit, then the
-    resulting top-p set will be incorrect. To address this problem, we
-    introduce a tiny perturbation to the probabilities (after softmax) to
-    break any potential ties. The added perturbation is tiny so it should
-    not alter the end results significantly, but it still makes this algorithm
-    approximate rather than an exact one.
+    Note: in the case of tie (i.e. multipple cut-off elements present in the
+    logit), all tie elements are included in the top-p set. In other words,
+    this function does not break ties. Instead, these tie tokens have equal
+    chance of being chosen during final sampling, so we can consider the tie
+    being broken then.
     """
-    probs = logits.softmax(dim=-1)
+    if k is not None:
+        logits = apply_top_k_only(logits, k)
 
-    # Add a small, random perturbation to the probabilities, and re-normalize.
-    epsilon = torch.empty(probs.shape,
-                          device=logits.device).uniform_(-1e-9, 1e-9)
-    probs += epsilon
-    probs /= probs.sum(dim=-1, keepdim=True)
+    if p is not None:
+        probs = logits.softmax(dim=-1)
+        probs_sort, _ = probs.sort(dim=-1, descending=False)
+        cumprob = torch.cumsum(probs_sort, dim=-1)
+        top_p_mask = cumprob <= 1 - p.unsqueeze(dim=1)
+        top_p_mask[:, -1] = False  # at least one
 
-    probs_sort, sorted_idx = probs.sort(dim=-1, descending=False)
-    cumprob = torch.cumsum(probs_sort, dim=-1)
-    top_p_mask = cumprob <= 1 - p.unsqueeze(dim=1)
-    top_p_mask[:, -1] = False  # at least one
-
-    top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
-    top_p_cutoff = probs_sort.gather(-1, top_p_count)
-    elements_to_discard = probs < top_p_cutoff
-    logits.masked_fill_(elements_to_discard, -float("inf"))
+        top_p_count = top_p_mask.sum(dim=-1).unsqueeze(1)
+        top_p_cutoff = probs_sort.gather(-1, top_p_count)
+        elements_to_discard = probs < top_p_cutoff
+        logits.masked_fill_(elements_to_discard, -float("inf"))
 
     return logits
 


### PR DESCRIPTION
Top-k and top-p are slow on TPU because existing algorithms use `torch.scatter`. For some reason `torch.scatter` is extremely slow on TPU. There's ongoing work to optimize it, but until that's done, we need an alternative algorithm that circumvents scattering.

The algorithm in this PR avoids torch.scatter by finding a "cut-off" element in the original logit, and after thresholding the logit using this cut-off, the remaining elements shall constitute the top-p set. This is inspired by the `apply_top_k_only` algorithm created by @njhill in #15478.

### Benchmark

Microbenchmark (on v6e-1) shows significant speed up -- "Running 32 elapsed time" is ~5 ms, down from the original scatter-based algorithm's ~500 ms, a **100x improvement**.

<details>

<summary>Microbenchmark full results on v6e-1</summary>

```
$ VLLM_USE_V1=1 python sampler_microbenchmark.py 
INFO 03-31 14:40:10 [__init__.py:239] Automatically detected platform tpu.
WARNING:root:libtpu.so and TPU device found. Setting PJRT_DEVICE=TPU.
INFO 03-31 14:40:15 [topk_topp_sampler.py:82] Using approximate top-p optimized for TPU. Result may in theory differ from the exact algorithm if there are tokens with near-identical probabilities (< 1e-9 diff).
Compiling/Warmup 1 elapsed time: 9.270433902740479
Compiling/Warmup 4 elapsed time: 9.104885816574097
Compiling/Warmup 16 elapsed time: 8.811976194381714
Compiling/Warmup 32 elapsed time: 8.926635026931763
Running 1 elapsed time: 0.004515171051025391
Running 1 elapsed time: 0.003937482833862305
Running 1 elapsed time: 0.003930091857910156
Running 1 elapsed time: 0.0038993358612060547
Average time:  0.0040705204010009766
Running 4 elapsed time: 0.0042819976806640625
Running 4 elapsed time: 0.004051685333251953
Running 4 elapsed time: 0.00403141975402832
Running 4 elapsed time: 0.004080057144165039
Average time:  0.004111289978027344
Running 16 elapsed time: 0.00475311279296875
Running 16 elapsed time: 0.0045032501220703125
Running 16 elapsed time: 0.0044858455657958984
Running 16 elapsed time: 0.19616365432739258
Average time:  0.052476465702056885
Running 32 elapsed time: 0.00586247444152832
Running 32 elapsed time: 0.005380868911743164
Running 32 elapsed time: 0.005262851715087891
Running 32 elapsed time: 0.0052433013916015625
Average time:  0.005437374114990234
```

</details>

### Extra notes

The `VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION` env (introduced in #15242) can now be removed. Not done in this PR since @NickLucche's pending PR #15489 already handles it (thanks!).