### PR TITLE
[BugFix] Support Cascade Attention for Sliding Window Attention

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -436,9 +436,8 @@ def cascade_attention(
     v_descale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert alibi_slopes is None, ("Cascade attention does not support ALiBi.")
-    # TODO: Support sliding window.
-    assert sliding_window == (-1, -1), (
-        "Cascade attention does not support sliding window.")
+    # Support sliding window.
+    sliding_window = (-1, -1)
 
     num_tokens = query.shape[0]
     block_size = key_cache.shape[-3]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -436,7 +436,7 @@ def cascade_attention(
     v_descale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert alibi_slopes is None, ("Cascade attention does not support ALiBi.")
-    # Support sliding window.
+    # Support sliding window when query lens does not exceed sliding window.
     sliding_window = (-1, -1)
 
     num_tokens = query.shape[0]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -436,7 +436,7 @@ def cascade_attention(
     v_descale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert alibi_slopes is None, ("Cascade attention does not support ALiBi.")
-    # Support sliding window when query lens does not exceed sliding window.
+    # Support sliding window at certain conditions.
     sliding_window = (-1, -1)
 
     num_tokens = query.shape[0]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -351,9 +351,10 @@ def use_cascade_attention(
     if common_prefix_len < 256:
         return False
     # Cascade attention is currently not supported with these variants.
-    # For sliding window, we could support it if the query length does not exceed
-    # the sliding window size.
-    def get_sliding_window(sliding_window: Optional[Union[int, list[Optional[int]]]]) -> int:
+    # For sliding window, we could support it if the query length does not
+    # exceed sliding window size.
+    def get_sliding_window(
+            sliding_window: Optional[Union[int, list[Optional[int]]]]) -> int:
         if sliding_window is None:
             return 0
         if isinstance(sliding_window, int):
@@ -363,7 +364,10 @@ def use_cascade_attention(
             return sum(x for x in sliding_window if x is not None)
         return 0
 
-    if use_alibi or (use_sliding_window and np.any(query_lens > get_sliding_window(sliding_window))):
+    if use_alibi:
+        return False
+    if use_sliding_window and np.any(
+            query_lens > get_sliding_window(sliding_window)):
         return False
     # Too few queries. Probably not worth using cascade attention.
     # We use an arbitrary threshold of 8 queries. TODO: Tune this threshold.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -694,6 +694,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             use_alibi=self.use_alibi,
             use_sliding_window=self.window_size is not None,
             num_sms=self.num_sms,
+            sliding_window=self.window_size,
         )
         return common_prefix_len if use_cascade else 0
 


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/15710
Apply cascade attention under sliding window attention when all query lens < sliding window size. 
If query does not exceed sliding window, it means entire sequence is within window. It is the same as no sliding window.

1. sliding window seems a list, take sum as estimate of sliding window https://github.com/vllm-project/vllm/blob/main/vllm/config.py#L798
2. 
<!--- pyml disable-next-line no-emphasis-as-heading -->
