### PR TITLE
[Docs] Document v0 engine support in reasoning outputs

### DIFF
--- a/docs/source/features/reasoning_outputs.md
+++ b/docs/source/features/reasoning_outputs.md
@@ -136,7 +136,14 @@ Remember to check whether the `reasoning_content` exists in the response before 
 
 ## Structured output
 
-The reasoning content is also available in the structured output. The structured output engine like `xgrammar` will use the reasoning content to generate structured output.
+The reasoning content is also available in the structured output. The structured output engine like `xgrammar` will use the reasoning content to generate structured output. It is only supported in v0 engine now.
+
+```bash
+VLLM_USE_V1=0 vllm serve deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B \
+    --enable-reasoning --reasoning-parser deepseek_r1
+```
+
+Please note that the `VLLM_USE_V1` environment variable must be set to `0` to use the v0 engine.
 
 ```python
 from openai import OpenAI


### PR DESCRIPTION
Ref https://github.com/vllm-project/vllm/issues/14727

Structured outputs in reasoning responses are only supported in the v0 engine. This has caused confusion for some users. https://github.com/vllm-project/vllm/issues/14113#issuecomment-2757565854

<!--- pyml disable-next-line no-emphasis-as-heading -->
