### PR TITLE
[Bugfix] FA2 `inf` workaround with minimum overhead for MLA

### DIFF
--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1327,11 +1327,6 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
             # correctness. Inf generally doesn't make sense in this context
             # outside of undefined-behavior/FA2-case, so, force inf to -inf.
             # flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L737
-            # FIXME(DefTruth): dynamically checking each value for infinity
-            # within the `merge_attn_states_kernel` might impact the execution
-            # efficiency of the generated Triton kernel (L20, etc.). To avoid
-            # affecting the generation of the Triton kernel, I have try to
-            # handle this processing outside the kernel.
             if prefill_metadata.max_prefill_seq_len == 0:
                 suffix_lse.fill_(-torch.inf)
             context_output, context_lse = self._compute_prefill_context( \

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1320,6 +1320,20 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         if has_context:
             # ROCm flash_attn_varlen_func will return 3 objects instead of 2
             suffix_output, suffix_lse, *rest = output
+            # FA2 and FA3 have different behavior for when the sum-exp is 0,
+            # this namely arises with 0 len seqlens (max_seqlen_k == 0).
+            # FA3 returns -inf here  while FA2 returns inf. If we see an
+            # inf assume FA2 and convert inf to -inf for consistency and
+            # correctness. Inf generally doesn't make sense in this context
+            # outside of undefined-behavior/FA2-case, so, force inf to -inf.
+            # flash-attention/blob/main/csrc/flash_attn/flash_api.cpp#L737
+            # FIXME(DefTruth): dynamically checking each value for infinity
+            # within the `merge_attn_states_kernel` might impact the execution
+            # efficiency of the generated Triton kernel (L20, etc.). To avoid
+            # affecting the generation of the Triton kernel, I have try to
+            # handle this processing outside the kernel.
+            if prefill_metadata.max_prefill_seq_len == 0:
+                suffix_lse.fill_(-torch.inf)
             context_output, context_lse = self._compute_prefill_context( \
                 q, kv_c_and_k_pe_cache, attn_metadata)
 

--- a/vllm/attention/ops/triton_merge_attn_states.py
+++ b/vllm/attention/ops/triton_merge_attn_states.py
@@ -54,15 +54,6 @@ def merge_attn_states_kernel(
 
     p_lse = tl.load(prefix_lse + head_idx * num_tokens + token_idx)
     s_lse = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
-
-    # FA2 and FA3 have different behavior for when the sum-exp is 0, this namely
-    # arises with 0 len seqlens. FA3 returns -inf here while FA2 returns inf.
-    # If we see an inf assume FA2 and convert inf to -inf for consistency
-    # and correctness. Inf generally doesn't make sense in this context outside
-    # of undefined-behavior/FA2-case, so I think this a safe assumption.
-    p_lse = float('-inf') if p_lse == float('inf') else p_lse
-    s_lse = float('-inf') if s_lse == float('inf') else s_lse
-
     max_lse = tl.maximum(p_lse, s_lse)
     p_lse = p_lse - max_lse
     s_lse = s_lse - max_lse


### PR DESCRIPTION
Reopen https://github.com/vllm-project/vllm/pull/15688 here as a final workaround, fix https://github.com/vllm-project/vllm/issues/15689, https://github.com/vllm-project/vllm/issues/15530

The performance downgrade is due to https://github.com/vllm-project/vllm/pull/15492 for MLA + chunked-prefill (tested on AWQ + PP2 + TP8), where the decode TPS decreased from 390 TPS to 290 TPS. FIXME(DefTruth): To avoid affecting the generation of the Triton kernel, I think we should handle this processing outside the `merge_attn_states_kernel`. Otherwise, dynamically checking each value for infinity within the kernel might impact the execution efficiency of the generated Triton kernel.

- before  https://github.com/vllm-project/vllm/pull/15492, all is well.

```bash
INFO 03-28 13:16:42 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 379.5 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 27.8%, CPU KV cache usage: 0.0%.
INFO 03-28 13:16:47 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 382.2 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.2%, CPU KV cache usage: 0.0%.
INFO 03-28 13:16:52 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 379.0 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.6%, CPU KV cache usage: 0.0%.
INFO 03-28 13:16:57 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 376.1 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.9%, CPU KV cache usage: 0.0%.
INFO 03-28 13:17:02 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 375.3 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.3%, CPU KV cache usage: 0.0%.
INFO 03-28 13:17:07 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 375.0 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.7%, CPU KV cache usage: 0.0%.
INFO 03-28 13:17:12 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 375.8 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 30.1%, CPU KV cache usage: 0.0%.
```

- after  https://github.com/vllm-project/vllm/pull/15492, w/o this fix: (decode TPS decreased from 390 TPS to 290 TPS)

```bash
# commit: 4d0ec372 285TPS 
INFO 03-28 12:45:07 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 285.2 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 27.9%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:12 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 286.2 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.2%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:17 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 287.6 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.5%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:22 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 286.3 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.7%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:27 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 281.7 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.0%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:32 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 288.3 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.4%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:37 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 290.1 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.6%, CPU KV cache usage: 0.0%.
INFO 03-28 12:45:42 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 290.9 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.9%, CPU KV cache usage: 0.0%.
```

- w/ this fix, all is well again. (390TPS)

```bash
# 390TPS
INFO 03-28 15:24:42 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 391.0 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.1%, CPU KV cache usage: 0.0%.
INFO 03-28 15:24:47 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 388.7 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.5%, CPU KV cache usage: 0.0%.
INFO 03-28 15:24:52 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 385.3 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 28.9%, CPU KV cache usage: 0.0%.
INFO 03-28 15:24:57 [metrics.py:481] Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 380.8 tokens/s, Running: 32 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 29.3%, CPU KV cache usage: 0.0%.
```

@LucasWilkinson @robertgshaw2-redhat 

