### PR TITLE
[V0][Minor] Support custom add a new kv connector without modify vllm code

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -50,8 +50,7 @@ class KVConnectorFactory:
             return connector_cls(rank, local_rank, config)
         except (ImportError, AttributeError) as e:
             raise ValueError(f"cannot create connector '{connector_name}'."
-                             f"reason: {str(e)}"
-            )
+                             f"reason: {str(e)}")
 
 
 # Register various connectors here.

--- a/vllm/distributed/kv_transfer/kv_connector/factory.py
+++ b/vllm/distributed/kv_transfer/kv_connector/factory.py
@@ -50,7 +50,7 @@ class KVConnectorFactory:
             return connector_cls(rank, local_rank, config)
         except (ImportError, AttributeError) as e:
             raise ValueError(f"cannot create connector '{connector_name}'."
-                             f"reason: {str(e)}")
+                             f"reason: {str(e)}") from e
 
 
 # Register various connectors here.


### PR DESCRIPTION
The motivation of this PR aimed to make it easy to use a new kv connector implementation of third-party without modify vllm code.

In the other hand, vllm should not responsible for each custom kv connector implementations.