### PR TITLE
fix: update instruction in testing section

### DIFF
--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -32,7 +32,7 @@ Check out the [building from source](#build-from-source) documentation for detai
 ## Testing
 
 ```bash
-pip install -r requirements/dev.txt
+pip install -r requirements-dev.txt
 
 # Linting, formatting and static type checking
 pre-commit install --hook-type pre-commit --hook-type commit-msg


### PR DESCRIPTION
fix typo error in tesing section:
![image](https://github.com/user-attachments/assets/80d980f3-49df-4cc9-a033-c449e1fe83c4)

origin link👉🏻 https://docs.vllm.ai/en/stable/contributing/overview.html#testing

the `requirements/dev.txt` should be corrected as `requirements-dev.txt` as:
![image](https://github.com/user-attachments/assets/802aeb06-f52b-41c5-bcea-376d98102af4)

