### PR TITLE
[Chore] Update xgrammar to support minLength, maxLength

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -21,7 +21,7 @@ lm-format-enforcer >= 0.10.11, < 0.11
 llguidance >= 0.7.2, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine == "aarch64"
 outlines == 0.1.11
 lark == 1.2.2
-xgrammar == 0.1.16; platform_machine == "x86_64" or platform_machine == "aarch64"
+xgrammar == 0.1.17; platform_machine == "x86_64" or platform_machine == "aarch64"
 typing_extensions >= 4.10
 filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317
 partial-json-parser # used for parsing partial JSON outputs

--- a/vllm/v1/structured_output/utils.py
+++ b/vllm/v1/structured_output/utils.py
@@ -45,8 +45,7 @@ def has_xgrammar_unsupported_json_features(schema: dict[str, Any]) -> bool:
             return True
 
         # Unsupported keywords for strings
-        if obj.get("type") == "string" and any(
-                key in obj for key in ("minLength", "maxLength", "format")):
+        if obj.get("type") == "string" and "format" in obj:
             return True
 
         # Unsupported keywords for objects


### PR DESCRIPTION
This PR bumps version of xgrammar to 0.1.17 given the recent version adds support for minLength, maxLength in JSON schema.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
