### PR TITLE
fix: can not use uv run collect_env close #13888

### DIFF
--- a/collect_env.py
+++ b/collect_env.py
@@ -482,32 +482,28 @@ def get_pip_packages(run_lambda, patterns=None):
     if patterns is None:
         patterns = DEFAULT_PIP_PATTERNS
 
-    # People generally have `pip` as `pip` or `pip3`
-    # But here it is invoked as `python -mpip`
-    def run_with_pip(pip):
-        out = run_and_read_all(run_lambda, pip + ["list", "--format=freeze"])
+    def run_with_pip():
+        try:
+            import importlib.util
+            pip_spec = importlib.util.find_spec('pip')
+            pip_available = pip_spec is not None
+        except ImportError:
+            pip_available = False
+
+        if pip_available:
+            cmd = [sys.executable, '-mpip', 'list', '--format=freeze']
+        elif os.environ.get("UV") is not None:
+            print("uv is set")
+            cmd = ["uv", "pip", "list", "--format=freeze"]
+        else:
+            raise RuntimeError("Could not collect pip list output (pip or uv module not available)")
+
+        out = run_and_read_all(run_lambda, cmd)
         return "\n".join(line for line in out.splitlines()
                          if any(name in line for name in patterns))
 
     pip_version = 'pip3' if sys.version[0] == '3' else 'pip'
-
-    try:
-        import importlib.util
-        pip_spec = importlib.util.find_spec('pip')
-        pip_available = pip_spec is not None
-    except ImportError:
-        pip_available = False
-    if pip_available:
-        out = run_with_pip([sys.executable, '-mpip'])
-    else:
-        try:
-            # check if user use uv
-            if os.environ.get("UV") is not None:
-                print("uv is set")
-                out = run_with_pip(["uv", 'pip'])
-        except Exception:
-            print("Could not collect pip list output (pip or uv module not available)")
-            raise
+    out = run_with_pip()
     return pip_version, out
 
 

--- a/collect_env.py
+++ b/collect_env.py
@@ -490,8 +490,24 @@ def get_pip_packages(run_lambda, patterns=None):
                          if any(name in line for name in patterns))
 
     pip_version = 'pip3' if sys.version[0] == '3' else 'pip'
-    out = run_with_pip([sys.executable, '-mpip'])
 
+    try:
+        import importlib.util
+        pip_spec = importlib.util.find_spec('pip')
+        pip_available = pip_spec is not None
+    except ImportError:
+        pip_available = False
+    if pip_available:
+        out = run_with_pip([sys.executable, '-mpip'])
+    else:
+        try:
+            # check if user use uv
+            if os.environ.get("UV") is not None:
+                print("uv is set")
+                out = run_with_pip(["uv", 'pip'])
+        except Exception:
+            print("Could not collect pip list output (pip or uv module not available)")
+            raise
     return pip_version, out
 
 


### PR DESCRIPTION

FIX #13888 

This patch close #13888 by using `uv pip` when there's no pip in the 
`uv venv` env.

For uv run there will be an env name `UV` so we can use it.