### PR TITLE
fix: better install requirement for install in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -594,6 +594,10 @@ def get_requirements() -> list[str]:
                 resolved_requirements += _read_requirements(line.split()[1])
             elif line.startswith("--"):
                 continue
+            elif line.startswith("#"):
+                continue
+            if line.strip() == "":
+                continue
             else:
                 resolved_requirements.append(line)
         return resolved_requirements

--- a/setup.py
+++ b/setup.py
@@ -592,13 +592,7 @@ def get_requirements() -> list[str]:
         for line in requirements:
             if line.startswith("-r "):
                 resolved_requirements += _read_requirements(line.split()[1])
-            elif line.startswith("--"):
-                continue
-            elif line.startswith("#"):
-                continue
-            if line.strip() == "":
-                continue
-            else:
+            elif not line.startswith("--") and not line.startswith("#") and line.strip() != "":  # noqa: E501
                 resolved_requirements.append(line)
         return resolved_requirements
 

--- a/setup.py
+++ b/setup.py
@@ -592,7 +592,8 @@ def get_requirements() -> list[str]:
         for line in requirements:
             if line.startswith("-r "):
                 resolved_requirements += _read_requirements(line.split()[1])
-            elif not line.startswith("--") and not line.startswith("#") and line.strip() != "":  # noqa: E501
+            elif not line.startswith("--") and not line.startswith(
+                    "#") and line.strip() != "":
                 resolved_requirements.append(line)
         return resolved_requirements
 


### PR DESCRIPTION
This patch fix requirements in setup.py has other things
e.g. comment and  empty string

use cpu as example:

before this patch

```
      ['# Common dependencies', 'cachetools', 'psutil', 'sentencepiece  # Required for LLaMA tokenizer.', 'numpy', 'requests >= 2.26.0', 'tqdm', 'blake3',
      'py-cpuinfo', 'transformers >= 4.48.2  # Required for Bamba model and Transformers backend.', 'tokenizers >= 0.19.1  # Required for Llama 3.', 'protobuf #
      Required by LlamaTokenizer.', "fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.",
      'aiohttp', 'openai >= 1.52.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)', 'pydantic >= 2.9',
      'prometheus_client >= 0.18.0', 'pillow  # Required for image processing', 'prometheus-fastapi-instrumentator >= 7.0.0', 'tiktoken >= 0.6.0  # Required
      for DBRX tokenizer', 'lm-format-enforcer >= 0.10.11, < 0.11', 'llguidance >= 0.7.9, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64"
      or platform_machine == "aarch64"', 'outlines == 0.1.11', 'lark == 1.2.2', 'xgrammar == 0.1.16; platform_machine == "x86_64" or platform_machine ==
      "aarch64"', 'typing_extensions >= 4.10', 'filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317', 'partial-json-parser # used
      for parsing partial JSON outputs', 'pyzmq', 'msgspec', 'gguf == 0.10.0', 'importlib_metadata', 'mistral_common[opencv] >= 1.5.4', 'pyyaml', "six>=1.16.0;
      python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12", "setuptools>=74.1.1; python_version
      > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which
      was removed in 3.12", 'einops # Required for Qwen2-VL.', 'compressed-tensors == 0.9.2 # required for compressed-tensors', 'depyf==0.18.0 # required for
      profiling and debugging with compilation config', 'cloudpickle # allows pickling lambda functions in model_executor/models/registry.py', 'watchfiles #
      required for http server to monitor the updates of TLS files', 'python-json-logger # Used by logging as per examples/other/logging_configuration.md',
      'scipy # Required for phi-4-multimodal-instruct', 'ninja # Required for xgrammar, rocm, tpu, xpu', '', '# Dependencies for CPUs', 'torch==2.6.0+cpu;
      platform_machine == "x86_64"', 'torch==2.6.0; platform_system == "Darwin"', 'torch==2.6.0; platform_machine == "ppc64le" or platform_machine == "aarch64"',
      'torch==2.7.0.dev20250304; platform_machine == "s390x"', '', '# required for the image processor of minicpm-o-2_6, this must be updated alongside torch',
      'torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"', 'torchaudio==2.6.0; platform_machine == "ppc64le"', '', '# required for
      the image processor of phi3v, this must be updated alongside torch', 'torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"',
      'torchvision==0.21.0; platform_machine == "ppc64le"', 'datasets # for benchmark scripts']
```

with this patch

```
      ['cachetools', 'psutil', 'sentencepiece  # Required for LLaMA tokenizer.', 'numpy', 'requests >= 2.26.0', 'tqdm', 'blake3', 'py-cpuinfo', 'transformers >=
      4.48.2  # Required for Bamba model and Transformers backend.', 'tokenizers >= 0.19.1  # Required for Llama 3.', 'protobuf # Required by LlamaTokenizer.',
      "fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.", 'aiohttp', 'openai >=
      1.52.0 # Ensure modern openai package (ensure types module present and max_completion_tokens field support)', 'pydantic >= 2.9', 'prometheus_client >=
      0.18.0', 'pillow  # Required for image processing', 'prometheus-fastapi-instrumentator >= 7.0.0', 'tiktoken >= 0.6.0  # Required for DBRX tokenizer',
      'lm-format-enforcer >= 0.10.11, < 0.11', 'llguidance >= 0.7.9, < 0.8.0; platform_machine == "x86_64" or platform_machine == "arm64" or platform_machine ==
      "aarch64"', 'outlines == 0.1.11', 'lark == 1.2.2', 'xgrammar == 0.1.16; platform_machine == "x86_64" or platform_machine == "aarch64"', 'typing_extensions
      >= 4.10', 'filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/317', 'partial-json-parser # used for parsing partial JSON
      outputs', 'pyzmq', 'msgspec', 'gguf == 0.10.0', 'importlib_metadata', 'mistral_common[opencv] >= 1.5.4', 'pyyaml', "six>=1.16.0; python_version > '3.11'
      # transitive dependency of pandas that needs to be the latest version for python 3.12", "setuptools>=74.1.1; python_version > '3.11' # Setuptools is
      used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12",
      'einops # Required for Qwen2-VL.', 'compressed-tensors == 0.9.2 # required for compressed-tensors', 'depyf==0.18.0 # required for profiling and debugging
      with compilation config', 'cloudpickle # allows pickling lambda functions in model_executor/models/registry.py', 'watchfiles # required for http
      server to monitor the updates of TLS files', 'python-json-logger # Used by logging as per examples/other/logging_configuration.md', 'scipy # Required
      for phi-4-multimodal-instruct', 'ninja # Required for xgrammar, rocm, tpu, xpu',  'torch==2.6.0+cpu; platform_machine == "x86_64"',
      'torch==2.6.0; platform_system == "Darwin"', 'torch==2.6.0; platform_machine == "ppc64le" or platform_machine == "aarch64"', 'torch==2.7.0.dev20250304;
      platform_machine == "s390x"', 'torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"', 'torchaudio==2.6.0; platform_machine ==
      "ppc64le"', 'torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"', 'torchvision==0.21.0; platform_machine == "ppc64le"', 'datasets
      # for benchmark scripts']
```