### PR TITLE
feat: update allow_pattern

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -458,8 +458,11 @@ class ModelConfig:
         if is_s3(model) or is_s3(tokenizer):
             if is_s3(model):
                 s3_model = S3Model()
-                s3_model.pull_files(
-                    model, allow_pattern=["*.model", "*.py", "*.json"])
+                s3_model.pull_files(model,
+                                    allow_pattern=[
+                                        "*.model", "*.py", "*.json",
+                                        "*.safetensors"
+                                    ])
                 self.model_weights = self.model
                 self.model = s3_model.dir
 


### PR DESCRIPTION
## Description:
I use the minio as the s3 backend, when I try to use the model with s3 filepath, some errors occured:
![image](https://github.com/user-attachments/assets/c31c61e0-587c-4374-a5bd-6ec1731542c1)
the test code snippet as following(no magic in the follwoing code, it just like the start code in the official document, but I changed the path with s3 prefix):

```python
from vllm import LLM, SamplingParams


# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

# Create an LLM.
llm = LLM(
    model="s3://mynewbucket/hf/Qwen2.5-7B-Instruct"
)
# Generate texts from the prompts. The output is a list of RequestOutput objects
# that contain the prompt, generated text, and other information.
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
print("\nGenerated Outputs:\n" + "-" * 60)
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt:    {prompt!r}")
    print(f"Output:    {generated_text!r}")
    print("-" * 60)
```

# Related issuse:
FIX https://github.com/vllm-project/vllm/issues/15218
