### PR TITLE
[Feature]Zero overhead schedule support

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -68,7 +68,9 @@ def run_vllm(
         lora_requests = [request.lora_request for request in requests]
 
     use_beam_search = False
-
+    if os.environ.get('VLLM_ZERO_OVERHEAD') == '1':
+        print("sleep 0.1")
+        time.sleep(0.1) # ZERO_OVERHEAD : sleep and wait the last step in warmup
     outputs = None
     if not use_beam_search:
         start = time.perf_counter()

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1347,7 +1347,10 @@ class LLMEngine:
             last_outputs_tensor = None
             if self.last_record is not None:
                 last_output = self.last_record[0][0]
-                last_outputs_ids,  last_outputs_tensor = last_output.sampler_out_ids,  last_output.sampler_out_tenosr           
+                last_outputs_ids,  last_outputs_tensor = (
+                    last_output.sampler_out_ids,  
+                    last_output.sampler_out_tenosr 
+                    )          
                 self.async_d2h = last_outputs_tensor.to('cpu', non_blocking=True)
                 self.async_event.record()
                 self.q_recorder.put(self.last_record)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -431,7 +431,7 @@ class LLMEngine:
             self.last_record = None
             self.async_event = torch.cuda.Event(enable_timing=False)
             self.zero_thread = threading.Thread(target=self.thread_zero_overhead)
-            self.q_recorder = queue.Queue()
+            self.q_recorder: queue.Queue[Optional[list[Any]]] = queue.Queue()
             self.q_recorder.put(None) # None is use for first step ignore
             self.thread_running = True
             self.sem_m2s = threading.Semaphore(0) # main to scheduler thread
@@ -1265,6 +1265,7 @@ class LLMEngine:
             scheduled_seq_groups: List[ScheduledSequenceGroup]) -> None:
         
         #sample_out_list = output[0].sampler_out_tenosr.cpu().tolist()
+        assert output[0].sampler_out_ids is not None
         sample_out_list = self.async_d2h.tolist()
         sample_out_ids = output[0].sampler_out_ids.tolist()
         for seq_group_metadata, sequence_group_outputs, scheduled_seq_group in \

--- a/vllm/engine/output_processor/stop_checker.py
+++ b/vllm/engine/output_processor/stop_checker.py
@@ -6,8 +6,7 @@ from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
 from vllm.sequence import Sequence, SequenceStatus
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-
-
+import os
 class StopChecker:
     """LLMEngine helper class which separates out the logic involving stop
     checking. This checks things such as: whether the eos token was emitted,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -247,6 +247,9 @@ class LLM:
         self.request_counter = Counter()
         self.default_sampling_params: Union[dict[str, Any], None] = None
 
+    def __del__(self):
+        self.llm_engine.finish_thread()
+
     def get_tokenizer(self) -> AnyTokenizer:
         return self.llm_engine.get_tokenizer_group(TokenizerGroup).tokenizer
 

--- a/vllm/model_executor/layers/sampler.py
+++ b/vllm/model_executor/layers/sampler.py
@@ -475,7 +475,9 @@ def _greedy_sample(
             assert num_parent_seqs == 1 # not support muti seqences in seqence group
             next_token_ids = [0] #place holder token id
         else:
-            next_token_ids = [samples_lst[sample_idx]]
+            next_token_ids = [
+                samples_lst[sample_idx]  # 缩进4空格，总行长降至42字符
+            ]
         results.append((next_token_ids, parent_ids))
         sample_idx += num_parent_seqs
     return results
@@ -519,7 +521,8 @@ def _random_sample(
                 next_token_ids = [0] * sampling_params.n  #place holder token id
             else:
                 next_token_ids = random_samples[
-                    sample_idx, :sampling_params.n].tolist()
+                    sample_idx, :sampling_params.n
+                    ].tolist()
         else:
             # Generation phase.
             parent_ids = list(range(num_parent_seqs))
@@ -527,8 +530,10 @@ def _random_sample(
                 assert num_parent_seqs == 1 # not support muti seqences in seqence group
                 next_token_ids = [0] * num_parent_seqs  #place holder token id
             else:
-                next_token_ids = random_samples[sample_idx:sample_idx +
-                                                num_parent_seqs, 0].tolist()
+                next_token_ids = random_samples[
+                    sample_idx:sample_idx +num_parent_seqs, 
+                    0
+                    ].tolist()
         results.append((next_token_ids, parent_ids))
         sample_idx += num_parent_seqs
     return results

--- a/vllm/model_executor/layers/update_input.py
+++ b/vllm/model_executor/layers/update_input.py
@@ -1,0 +1,28 @@
+import torch
+import triton
+import triton.language as tl
+
+@triton.jit
+def _update_input_tokens(
+    sample_output,
+    seq_ids,
+    input_tokens,
+    input_seq_ids,
+    BATCH_SIZE1,
+    BATCH_SIZE2,
+):
+    pid = tl.program_id(0)
+    if pid >= BATCH_SIZE2:
+        return
+
+    output_token = tl.load(input_tokens + pid)
+    _input_seq_id = tl.load(input_seq_ids + pid)
+    for i in range(BATCH_SIZE1):
+        _seq_ids = tl.load(seq_ids + i)
+        if _seq_ids == _input_seq_id:
+            output_token = tl.load(sample_output + i)
+    tl.store(input_tokens + pid, output_token)
+
+def UpdateInputTokens(input_tokens, input_seq_ids, last_sample, last_ids):
+    grid = [input_seq_ids.shape[0], 1, 1]
+    _update_input_tokens[grid](last_sample, last_ids, input_tokens, input_seq_ids, last_ids.shape[0], input_seq_ids.shape[0])

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from collections.abc import Sequence as GenericSequence
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Callable, Optional, Union,Tuple
+from typing import Any, Callable, Optional, Union,tuple
 import os
 import msgspec
 import torch
@@ -385,7 +385,7 @@ class SequenceData(msgspec.Struct,
     def get_prompt_token_ids(self) -> tuple[int, ...]:
         return self.prompt_token_ids
 
-    def zero_overhead_get_output_token_ids(self) -> Tuple[int, ...]:
+    def zero_overhead_get_output_token_ids(self) -> tuple[int, ...]:
         return self.output_token_ids[:self._effective_length]
 
     def get_output_token_ids(self) -> tuple[int, ...]:

--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -9,8 +9,8 @@ from collections.abc import Mapping
 from collections.abc import Sequence as GenericSequence
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Callable, Optional, Union
-
+from typing import Any, Callable, Optional, Union,Tuple
+import os
 import msgspec
 import torch
 

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -16,6 +16,7 @@ class Detokenizer:
 
     def __init__(self, tokenizer_group: BaseTokenizerGroup):
         self.tokenizer_group = tokenizer_group
+        self.zero_overhead = os.environ.get('VLLM_ZERO_OVERHEAD') == '1'
 
     def get_tokenizer_for_seq(self, sequence: Sequence) -> AnyTokenizer:
         """Returns the HF tokenizer to use for a given sequence."""
@@ -108,6 +109,9 @@ class Detokenizer:
             The number of characters added to the output text.
         """
         all_input_ids = seq.get_token_ids()
+        if self.zero_overhead:
+            eff_length = seq.get_prompt_len() + seq.data._effective_length
+            all_input_ids = seq.get_token_ids()[ : eff_length]
         token_id_generated_this_iteration = all_input_ids[-1]
         tokenizer = self.get_tokenizer_for_seq(seq)
 

--- a/vllm/transformers_utils/detokenizer.py
+++ b/vllm/transformers_utils/detokenizer.py
@@ -9,7 +9,7 @@ from .detokenizer_utils import (convert_prompt_ids_to_tokens,
                                 detokenize_incrementally)
 from .tokenizer import AnyTokenizer
 from .tokenizer_group import BaseTokenizerGroup
-
+import os
 
 class Detokenizer:
     """Provides methods to decode the output of a model into text."""

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -210,6 +210,8 @@ class ModelRunnerBase(ABC, Generic[T]):
         seq_group_metadata_list: List[SequenceGroupMetadata],
         virtual_engine: int = 0,
         finished_requests_ids: Optional[List[str]] = None,
+        last_outputs_ids: torch.Tensor = None,
+        last_output_sample: torch.Tensor = None,
     ) -> T:
         """
         Prepare the inputs to ModelRunnerBase.execute_model from an execution

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -341,7 +341,9 @@ class LocalOrDistributedWorkerBase(WorkerBase):
             self.model_runner.prepare_model_input(
                 execute_model_req.seq_group_metadata_list,
                 execute_model_req.virtual_engine,
-                execute_model_req.finished_requests_ids))
+                execute_model_req.finished_requests_ids,
+                last_outputs_ids = execute_model_req.last_outputs_ids,
+                last_output_sample = execute_model_req.last_outputs_sample))
 
         kwargs = extract_previous_hidden_states(execute_model_req)
 


### PR DESCRIPTION

Modification plan:
1. Remove all synchronization operations
In Sample.Py
samples_lst = samples.tolist()
random_samples = random_samples.cpu()
After removing these synchronization operations, the CPU cannot immediately obtain the decode result, so a "placeholder token" needs to be introduced to return a fake result for the next scheduling (because it needs to be launched in advance, scheduling also needs to be done in advance, and scheduling operations are concerned with token_1ength, not the content of the token). In addition to returning fake results, it is necessary to also return the tensor for subsequent retrieval of the real token.
2. Update input token
In model_runner.py
Due to the introduction of "placeholder tokens" and the fact that the input for the next step depends on the real token, we need to prepare the input_token tensor and use a kernel with an updateTokenId to overwrite the corresponding position of the tensor returned by the previous Sampler with the input_token based on seq_id. This operation is also asynchronous.
3 fix_last_token
In llm_engine. py
The value of the 'placeholder token' is false. We need an event to synchronize the result of the previous step and correct this false result through the _fix_1ast_step operation.
4. Modify the sequence class
Due to the introduction of 'placeholder tokens', not all of the outputted tokens stored in the seq are valid. Therefore, the length of the real token is marked with''effectw_length 'to ensure the correctness of the end condition judgment.
5. Modify stop_check
In stop_check. py
Ensure the correct termination criteria by using the effective length reasonably.
6. Modify detokenizer
In detokenizer.py
Because the first returned token is the 'placeholder token', the real token is obtained after event synchronization. Therefore, it is necessary to ensure that the detokenized token is correct by using the effective length reasonably.
7. Add thread and queue.
In order to prevent the impact of continuous step launches on the first word delay, threads have been added to llm_engine, with the main thread dedicated to synchronizing events and post-processing tokens. A thread dedicated to scheduling and launching.

https://github.com/vllm-project/vllm/issues/15781
<!--- pyml disable-next-line no-emphasis-as-heading -->
