### PR TITLE
fix: can not install torch+cpu for no index url

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -3,6 +3,7 @@
 
 # Dependencies for CPUs
 torch==2.6.0+cpu; platform_machine == "x86_64"
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.6.0; platform_system == "Darwin"
 torch==2.6.0; platform_machine == "ppc64le" or platform_machine == "aarch64"
 torch==2.7.0.dev20250304; platform_machine == "s390x"


### PR DESCRIPTION

for now install on cpu there is no extra-index-url for x86_64 cpu
this patch add it like tpu.txt