### PR TITLE
[Bugfix] fix client socket timeout when serve multi-node model in Ray

### DIFF
--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -103,7 +103,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
         # Set up signal handlers to shutdown the executor cleanly
         # sometimes gc does not work well
 
-        self.driver_worker = WorkerWrapperBase(self.vllm_config, 0)
+        self.driver_worker = WorkerWrapperBase(self.vllm_config)
 
         all_kwargs = []
         distributed_init_method = get_distributed_init_method(


### PR DESCRIPTION
This PR reverted the rank assignment  during workers' initialization, introduced in https://github.com/vllm-project/vllm/commit/ad34c0df0f1b26b303a590133685b29e3daad20e. When deploy multi-node models (e.g. DeepSeek R1) with Ray serve, there is a chance that  this rank assignment get into conflicts across workers thus cause client socket timeout. This RP fix this issue and unblock model deployments

FIX #15744 
