### PR TITLE
[Bugfix] Fix extra comma

### DIFF
--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -191,7 +191,7 @@ class SamplingMetadata:
             "SamplingMetadata("
             f"seq_groups={self.seq_groups}, "
             f"selected_token_indices={self.selected_token_indices}, "
-            f"categorized_sample_indices={self.categorized_sample_indices}), ")
+            f"categorized_sample_indices={self.categorized_sample_indices})")
 
 
 def _prepare_seq_groups(


### PR DESCRIPTION
Fix extra comma

### Before
```
(Pdb) p mode_input
ModelInputForGPUWithSamplingMetadata(..., sampling_metadata=SamplingMetadata(...), , is_prompt=True)
```
### After
```
(Pdb) p model_input
ModelInputForGPUWithSamplingMetadata(..., sampling_metadata=SamplingMetadata(...), is_prompt=True)
```