### PR TITLE
[Misc] Fix speculative config repr string

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2360,12 +2360,10 @@ class SpeculativeConfig:
         return self.num_speculative_tokens
 
     def __repr__(self) -> str:
-        if self.prompt_lookup_max is not None and self.prompt_lookup_max > 0:
-            draft_model = "ngram"
-        else:
-            draft_model = self.draft_model_config.model
+        method = self.method
+        model = None if method == "ngram" else self.draft_model_config.model
         num_spec_tokens = self.num_speculative_tokens
-        return f"SpeculativeConfig({draft_model=}, {num_spec_tokens=})"
+        return f"SpeculativeConfig({method=}, {model=}, {num_spec_tokens=})"
 
 
 @dataclass


### PR DESCRIPTION
Minor fix since using `prompt_lookup_max` to identify whether "ngram" is used has been deprecated, and we have the `method` param to indicate which speculative method is used currently, it should be in the repr string.