### PR TITLE
Add minimum version for `huggingface_hub` to enable Xet downloads

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,6 +7,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 4.50.3
+huggingface-hub >= 0.30.0  # Required for Xet downloads.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 4.50.3
-huggingface-hub >= 0.30.0  # Required for Xet downloads.
+huggingface-hub[hf-xet] >= 0.30.0  # Required for Xet downloads.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -31,6 +31,7 @@ mistral_common[opencv] >= 1.5.4 # required for pixtral test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.4 # required for model evaluation test
 transformers==4.50.3
+huggingface-hub>=0.30.0  # Required for Xet downloads.
 # quantization
 bitsandbytes>=0.45.3
 buildkite-test-collector==0.1.9

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -31,7 +31,7 @@ mistral_common[opencv] >= 1.5.4 # required for pixtral test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.4 # required for model evaluation test
 transformers==4.50.3
-huggingface-hub>=0.30.0  # Required for Xet downloads.
+huggingface-hub[hf-xet]>=0.30.0  # Required for Xet downloads.
 # quantization
 bitsandbytes>=0.45.3
 buildkite-test-collector==0.1.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -160,8 +160,9 @@ httpcore==1.0.6
     # via httpx
 httpx==0.27.2
     # via -r requirements/test.in
-huggingface-hub==0.26.2
+huggingface-hub==0.30.1
     # via
+    #   -r requirements/test.in
     #   accelerate
     #   datasets
     #   evaluate

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -154,6 +154,8 @@ genson==1.3.0
     # via datamodel-code-generator
 h11==0.14.0
     # via httpcore
+hf-xet==0.1.4
+    # via huggingface-hub
 hiredis==3.0.0
     # via tensorizer
 httpcore==1.0.6


### PR DESCRIPTION
Using Xet to to download models from HF will increase download speeds.

You can read more about Xet on the Hub [here](https://huggingface.co/blog/xet-on-the-hub).