### PR TITLE
[V1][TPU] Do not compile sampling more than needed

### DIFF
--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -862,7 +862,9 @@ class TPUModelRunner:
                 out = self.model.sample_from_hidden(dummy_hidden,
                                                     sampling_meta)
                 out = out.cpu()
-                if num_reqs_to_sample >= self.max_num_reqs:
+                # Requests can't be more than tokens. But do compile for the
+                # next bigger value in case num_tokens uses bucketed padding.
+                if num_reqs_to_sample >= min(num_tokens, self.max_num_reqs):
                     break
                 # Make sure to compile the `max_num_reqs` upper-limit case
                 num_reqs_to_sample = _get_padded_num_reqs_with_upper_limit(


### PR DESCRIPTION
We're compiling a few extra graphs for sampling that we should never come across at runtime.
Namely the number of requests that require sampling can never exceed the number of tokens that are generated.
Eg. when we get N=16 tokens in input, we are not going to get 128 sequences for sampling.  So only compile up to N.   

Assuming max number of sequences = 32 
```
INFO 04-01 11:04:44 [tpu_model_runner.py:839] Compiling sampling with different input shapes.
INFO 04-01 11:04:44 [tpu_model_runner.py:860]   -- num_tokens: 16, num_seqs: 8
INFO 04-01 11:04:44 [tpu_model_runner.py:860]   -- num_tokens: 16, num_seqs: 16<==
INFO 04-01 11:04:46 [tpu_model_runner.py:860]   -- num_tokens: 32, num_seqs: 8
INFO 04-01 11:04:47 [tpu_model_runner.py:860]   -- num_tokens: 32, num_seqs: 16
INFO 04-01 11:04:48 [tpu_model_runner.py:860]   -- num_tokens: 32, num_seqs: 32
```