### PR TITLE
Remove `format.sh` as it's been unsupported >70 days

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo "vLLM linting system has been moved from format.sh to pre-commit hook."
-echo "Please run 'pip install -r requirements/lint.txt', followed by"
-echo "'pre-commit install --hook-type pre-commit --hook-type commit-msg' to install the pre-commit hook."
-echo "Then linters will run automatically before each commit."


### PR DESCRIPTION
- Reduces cause for confusion
- Reduces clutter in root directory