### PR TITLE
[Misc] Disable pin_memory in AsyncMetricsCollector for spec decode tensor allocation

### DIFF
--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -8,7 +8,6 @@ import torch
 
 from vllm.model_executor.layers.spec_decode_base_sampler import (
     SpecDecodeBaseSampler)
-from vllm.utils import is_pin_memory_available
 
 
 class SpecDecodeWorkerMetrics(

--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -69,11 +69,10 @@ class AsyncMetricsCollector:
 
         self._in_flight_copy: Optional[torch.cuda.Event] = None
 
-        pin_memory = is_pin_memory_available()
         self._aggregate_num_accepted_tokens = torch.tensor(
-            0, dtype=torch.long, device="cpu", pin_memory=pin_memory)
+            0, dtype=torch.long, device="cpu", pin_memory=False)
         self._aggregate_num_emitted_tokens = torch.tensor(
-            0, dtype=torch.long, device="cpu", pin_memory=pin_memory)
+            0, dtype=torch.long, device="cpu", pin_memory=False)
         self._aggregate_num_draft_tokens = 0
 
         self._rejsample_metrics_collect_interval_s = collect_interval_s

--- a/vllm/spec_decode/metrics.py
+++ b/vllm/spec_decode/metrics.py
@@ -68,10 +68,14 @@ class AsyncMetricsCollector:
 
         self._in_flight_copy: Optional[torch.cuda.Event] = None
 
-        self._aggregate_num_accepted_tokens = torch.tensor(
-            0, dtype=torch.long, device="cpu", pin_memory=False)
-        self._aggregate_num_emitted_tokens = torch.tensor(
-            0, dtype=torch.long, device="cpu", pin_memory=False)
+        self._aggregate_num_accepted_tokens = torch.tensor(0,
+                                                           dtype=torch.long,
+                                                           device="cpu",
+                                                           pin_memory=False)
+        self._aggregate_num_emitted_tokens = torch.tensor(0,
+                                                          dtype=torch.long,
+                                                          device="cpu",
+                                                          pin_memory=False)
         self._aggregate_num_draft_tokens = 0
 
         self._rejsample_metrics_collect_interval_s = collect_interval_s


### PR DESCRIPTION
I encountered a memory issue when using tensor parallelism with speculative decoding. On rank 0, it consumes approximately **1.4GB multiplied by the TP count**, which is quite large for a single GPU with limited memory.  

Since the `_aggregate_num_accepted_tokens` and `_aggregate_num_emitted_tokens` metrics are non-blocking, I believe setting `pin_memory` to **False** is a better tradeoff to significantly reduce memory usage.