### PR TITLE
Reinstate `format.sh` and make `pre-commit` installation simpler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
 default_stages:
   - pre-commit # Run locally
   - manual # Run in CI

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "vLLM linting system has been moved from format.sh to pre-commit hooks."
+echo "Please run 'pip install -r requirements/lint.txt', followed by"
+echo "'pre-commit install' to install the pre-commit hooks."
+echo "Then linters will run automatically before each commit."


### PR DESCRIPTION
- Reinstates `format.sh` that helps new developers know we use `pre-commit`
- Makes `pre-commit install` equivalent to `pre-commit install --hook-type pre-commit --hook-type commit-msg`