### PR TITLE
[CI] Disable flaky structure decoding test temporarily.

### DIFF
--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -23,7 +23,8 @@ PARAMS_MODELS_BACKENDS_TOKENIZER_MODE = [
     ("mistralai/Ministral-8B-Instruct-2410", "xgrammar:disable-any-whitespace",
      "mistral"),
     ("Qwen/Qwen2.5-1.5B-Instruct", "xgrammar:disable-any-whitespace", "auto"),
-    ("Qwen/Qwen2.5-1.5B-Instruct", "guidance:disable-any-whitespace", "auto"),
+    #FIXME: This test is flaky on CI thus disabled
+    #("Qwen/Qwen2.5-1.5B-Instruct", "guidance:disable-any-whitespace", "auto"),
 ]
 
 PARAMS_MODELS_TOKENIZER_MODE = [


### PR DESCRIPTION
`v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[Qwen/Qwen2.5-1.5B-Instruct-guidance:disable-any-whitespace-auto]` has been flaky on CI and therefore blocking quite a few PRs.

This PR disables this test temporarily to unblock other folks - see discussion https://vllm-dev.slack.com/archives/C07R5PAL2L9/p1743492042284569

cc @russellb @mgoin 