### PR TITLE
[ROCm][Bugfix][FP8] Setting scales for the unquantized layers of a partially quantized model

### DIFF
--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -333,9 +333,13 @@ class Fp8LinearMethod(LinearMethodBase):
         # If checkpoint is fp8, handle that there are N scales for N
         # shards in a fused module
         else:
+            layer.weight_scale.data[layer.weight_scale.data == torch.finfo(
+                torch.float32).min] = 1
             layer.weight_scale = torch.nn.Parameter(layer.weight_scale.data,
                                                     requires_grad=False)
             if self.quant_config.activation_scheme == "static":
+                layer.input_scale.data[layer.input_scale.data == torch.finfo(
+                    torch.float32).min] = 1
                 layer.input_scale = torch.nn.Parameter(layer.input_scale.data,
                                                        requires_grad=False)
             # If using marlin (w8a16), kernel uses channelwise weights,


### PR DESCRIPTION
Setting scales for the layers to identity in case they weren't set due to some layers not being quantized.
Porting the feature from ROCm/vllm fork for the proper support of amd/Llama-3.2-11B-Vision-Instruct-FP8-KV and the likes where the vision part is not quantized.
This is another missing piece to support these models in addition to #15328 and #15413
When this is done, the next step would be to add this to the CI cc: @Alexei-V-Ivanov-AMD 