### PR TITLE
[V1][Minor] Enhance SpecDecoding Metrics Log in V1

### DIFF
--- a/vllm/v1/spec_decode/metrics.py
+++ b/vllm/v1/spec_decode/metrics.py
@@ -47,13 +47,16 @@ class SpecDecodingMetrics:
         num_draft_tokens = np.sum(self.num_draft_tokens)
         num_accepted_tokens = np.sum(self.num_accepted_tokens)
 
-        draft_acceptance_rate = (num_accepted_tokens / num_draft_tokens
-                                 if num_draft_tokens > 0 else float("nan"))
+        draft_acceptance_rate = (num_accepted_tokens / num_draft_tokens *
+                                 100 if num_draft_tokens > 0 else float("nan"))
 
         logger.info(
-            "Speculative metrics: "
-            "Draft acceptance rate: %.3f, "
-            "Number of accepted tokens: %d, "
-            "Number of draft tokens: %d, ", draft_acceptance_rate,
-            num_accepted_tokens, num_draft_tokens)
+            "SpecDecoding metrics: "
+            "Draft acceptance rate: %.1f%%, "
+            "Accepted: %d tokens, "
+            "Drafted: %d tokens",
+            draft_acceptance_rate,
+            num_accepted_tokens,
+            num_draft_tokens,
+        )
         self.reset()


### PR DESCRIPTION
Changes:
1. Speculative metrics --> SpecDecoding metrics
2. Pint the acceptance rate in %
3. Remove the trailing `,`
4. Shorten the log

BEFORE:
```
Speculative metrics: Draft acceptance rate: 1.000, Number of accepted tokens: 66, Number of draft tokens: 66, 
```

AFTER:
```
SpecDecoding metrics: Draft acceptance rate: 100.0%, Accepted: 66 tokens, Drafted: 66 tokens
```

I think this better fits with the style we use for other logs:
```
Engine 000: Avg prompt throughput: 1.1 tokens/s, Avg generation throughput: 10.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
```

@markmc 