### PR TITLE
[TPU] optimize the all-reduce performance

### DIFF
--- a/vllm/distributed/device_communicators/tpu_communicator.py
+++ b/vllm/distributed/device_communicators/tpu_communicator.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-from typing import Optional
+from typing import Optional, Sequence
 
 import torch
 from torch.distributed import ProcessGroup
@@ -22,9 +22,23 @@ if current_platform.is_tpu():
     import torch_xla.core.xla_model as xm
     import torch_xla.runtime as xr
     from torch_xla._internal import pjrt
+    from torch_xla.distributed.xla_multiprocessing import (
+        create_optimized_replica_groups)
 
     if USE_RAY:
         from vllm.executor import ray_utils
+
+
+@torch.library.custom_op("tpu::all_reduce", mutates_args=())
+def tpu_all_reduce(input_: torch.Tensor,
+                   groups: Sequence[int]) -> torch.Tensor:
+    groups = [groups] if groups else None
+    return xm.all_reduce(xm.REDUCE_SUM, input_, groups=groups)
+
+
+@tpu_all_reduce.register_fake
+def _(input_: torch.Tensor, groups: Sequence[int]):
+    return torch.empty_like(input_)
 
 
 class TpuCommunicator(DeviceCommunicatorBase):
@@ -79,9 +93,16 @@ class TpuCommunicator(DeviceCommunicatorBase):
 
         pjrt.initialize_multiprocess(local_rank, local_world_size)
         xr._init_world_size_ordinal()
+        self.groups = create_optimized_replica_groups()
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
-        return xm.all_reduce(xm.REDUCE_SUM, input_)
+        # Note: PyTorch python custom op doesn't support input parameter with type
+        # of Sequence[Sequence[int]], here we have to use Sequence[int] and convert
+        # back to Sequence[Sequence[int]] in the operation implementation
+        # TODO: Remove the groups specification after XLA compiler can support
+        # auto-reordering the ring order for all-reduce.
+        groups = self.groups[0] if self.groups is not None else None
+        return tpu_all_reduce(input_, groups=groups)
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
         assert dim == -1, "TPUs only support dim=-1 for all-gather."

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -119,11 +119,13 @@ def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
 
 
 if supports_custom_op():
+    from vllm.platforms import current_platform
     direct_register_custom_op(
         op_name="all_reduce",
         op_func=all_reduce,
         mutates_args=[],
         fake_impl=all_reduce_fake,
+        dispatch_key=current_platform.dispatch_key,
     )
 
 
@@ -219,7 +221,8 @@ class GroupCoordinator:
                 self.cpu_group, 1 << 22, 6)
 
         from vllm.platforms import current_platform
-        self.use_custom_op_call = current_platform.is_cuda_alike()
+        self.use_custom_op_call = (current_platform.is_cuda_alike()
+                                   or current_platform.is_tpu())
 
     @property
     def first_rank(self):

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -84,6 +84,12 @@ class TPUWorker:
 
     def init_device(self):
         os.environ["PJRT_DEVICE"] = "TPU"
+        # Note: Currently the XLA compiler wrongly uses 2D ring strategy on 1D
+        # ring, the xla tpu compiler flag
+        # `xla_tpu_force_1d_allreduce_at_chunk_count` is a temporary solution to
+        # fix this. It will be removed after the bug in XLA compiler is fixed.
+        os.environ["LIBTPU_INIT_ARGS"] = (
+            "--xla_tpu_force_1d_allreduce_at_chunk_count=1")
         torch.set_grad_enabled(False)
         torch.set_default_dtype(self.model_config.dtype)
 


### PR DESCRIPTION
Before the PR, the all-reduce performance is not optimal due to two reasons:
- on v6e-8, XLA compiler accidentally apply 2D-ring strategy, while 1D-ring is expected
- The ring-order cannot be automatically adjusted 