### PR TITLE
[V1] Fix: make sure `k_index` is int64 for `apply_top_k_only`

### DIFF
--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -200,7 +200,7 @@ def apply_top_k_only(
     # topk.values tensor has shape [batch_size, max_top_k].
     # Convert top k to 0-based index in range [0, max_top_k).
     k_index = k.sub_(1).unsqueeze(1)
-    top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index)
+    top_k_mask = logits.topk(max_top_k, dim=1).values.gather(1, k_index.long())
     # Handle non-topk rows.
     top_k_mask.masked_fill_(no_top_k_mask.unsqueeze(1), -float("inf"))
     logits.masked_fill_(logits < top_k_mask, -float("inf"))


### PR DESCRIPTION
The sampler in vLLM fails with
```console
RuntimeError: gather(): Expected dtype int64 for index
```

because the index tensor for `torch.gather` isn’t cast to `torch.int64`, resulting in a dtype mismatch error. this cast should be safe.

<details>
<summary>Bug reproduction</summary>

```bash
python benchmarks/benchmark_serving.py \
    --backend deepspeed-mii \
    --model NousResearch/Meta-Llama-3-8B-Instruct \
    --host 127.0.0.1 \
    --port 8000 \
    --dataset-name random \
    --num-prompts 100 \
    --request-rate 10
```

</details>
Similar to #15065, #15049

cc @houseroad I think you would probably know this. What do you think?
