### PR TITLE
[Build/CI] Update lm-eval to 0.4.8

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -29,7 +29,7 @@ matplotlib # required for qwen-vl test
 mistral_common[opencv] >= 1.5.4 # required for pixtral test
 opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
-lm-eval[api]==0.4.4 # required for model evaluation test
+lm-eval[api]==0.4.8 # required for model evaluation test
 transformers==4.50.3
 # quantization
 bitsandbytes>=0.45.3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -219,7 +219,7 @@ librosa==0.10.2.post1
     # via -r requirements/test.in
 llvmlite==0.44.0
     # via numba
-lm-eval==0.4.4
+lm-eval==0.4.8
     # via -r requirements/test.in
 lxml==5.3.0
     # via sacrebleu


### PR DESCRIPTION
This updates the lm-eval test dep to 0.4.8, so we could use new features such as the [vllm-vlms](https://github.com/EleutherAI/lm-evaluation-harness/blob/773dcd7f8fe95ae7ae73c687dec0a4dc1a6174b9/lm_eval/models/vllm_vlms.py#L36) backend.


<!--- pyml disable-next-line no-emphasis-as-heading -->
