### PR TITLE
[Bugfix][Benchmarks] Ensure `async_request_deepspeed_mii` uses the OpenAI choices key

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -219,7 +219,15 @@ async def async_request_deepspeed_mii(
                 if response.status == 200:
                     parsed_resp = await response.json()
                     output.latency = time.perf_counter() - st
-                    output.generated_text = parsed_resp["text"][0]
+                    if "choices" in parsed_resp:
+                        output.generated_text = parsed_resp["choices"][0][
+                            "text"]
+                    elif "text" in parsed_resp:
+                        output.generated_text = parsed_resp["text"][0]
+                    else:
+                        output.error = ("Unexpected response format: "
+                                        "neither 'choices' nor 'text' found")
+                        output.success = False
                     output.success = True
                 else:
                     output.error = response.reason or ""


### PR DESCRIPTION
Deepseed-MII benchmarking fails with
```console
KeyError: 'text'
```

Fails because the deepspeed-mii endpoint for returns generated text under `choices[0]["text"]` instead of a top-level `"text"` key. Updating the parser to extract from the `"choices"` array resolves this.

Added backward compat. just in case

<details>
<summary>Bug reproduction</summary>

```bash
python benchmarks/benchmark_serving.py \
    --backend deepspeed-mii \
    --model NousResearch/Meta-Llama-3-8B-Instruct \
    --host 127.0.0.1 \
    --port 8000 \
    --dataset-name random \
    --num-prompts 100 \
    --request-rate 10
```
</details>

