### PR TITLE
[V1][Bugfix] Fix typo in MoE TPU checking

### DIFF
--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -309,7 +309,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                                 expert_map=expert_map,
                                 renormalize=renormalize)
 
-    forward_native = forward_tpu if current_platform.is_tpu else forward_cuda
+    forward_native = forward_tpu if current_platform.is_tpu() else forward_cuda
 
 
 def determine_expert_map(


### PR DESCRIPTION
Fixes the typo in #15834 that breaks two-node 4GPU test on CI since method object is always evaluated to `True` in Python when it's not being called.

Caught this bug from CI errors since we don't have TPU on CI but it's calling `forward_tpu`
```
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 819, in forward
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]     return self.forward_impl(hidden_states, router_logits)
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 838, in forward_impl
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]     final_hidden_states = self.quant_method.apply(
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 161, in apply
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]     return self.forward(x=x,
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/custom_op.py", line 25, in forward
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]     return self._forward_method(*args, **kwargs)
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/layer.py", line 295, in forward_tpu
[2025-04-01T08:01:38Z] ERROR 04-01 01:01:38 [core.py:376]     assert custom_routing_function is None
```