### PR TITLE
[Bugfix] Fix the issue where the model name is empty string, causing no response with the model name.

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -537,7 +537,7 @@ class OpenAIServing:
                         lora_request: Optional[LoRARequest] = None) -> str:
         if lora_request:
             return lora_request.lora_name
-        if model_name is None:
+        if not model_name:
             return self.models.base_model_paths[0].name
         return model_name
 


### PR DESCRIPTION
Fix the issue where the model name is empty string, causing no response with the model name.




PR #13568 introduced a new feature that allows vLLM to respond normally even when `model_name` is `None`.

i.e.
```
vllm serve Qwen/Qwen2.5-7B-Instruct
```

```shell
curl -X POST http://localhost:8000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{ 
           "messages": [{"role": "user", "content": "Hello, vLLM!"}],
           "max_tokens": 100
         }' |jq
{
  "id": "chatcmpl-68b17e958eb841629d97fe8901a44f3a",
  "object": "chat.completion",
  "created": 1743582857,
  "model": "Qwen/Qwen2.5-7B-Instruct",
  "choices": [
    .....
  ],
  "usage": {
    "prompt_tokens": 35,
    "total_tokens": 105,
    "completion_tokens": 70,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null
}
```

But when I use it as follows, vLLM does not return the model name correctly.
```
from openai import OpenAI
import json
openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8000/v1"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)
messages = [
    {
        "role": "user",
        "content": "Hello, vLLM!"
    },
]
response = client.chat.completions.create(
    model="",                                                         # empty string
    messages=messages,
)
print(json.dumps(response.to_dict(), indent=2))

{
  "id": "chatcmpl-8e5b8244960a4075999ad6860d172e54",
  "choices": [
...
  ],
  "created": 1743583513,
  "model": "",                                      # no model name.
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 57,
    "prompt_tokens": 35,
    "total_tokens": 92,
    "prompt_tokens_details": null
  },
  "prompt_logprobs": null
}
```
