### PR TITLE
[CI] Remove duplicate entrypoints-test

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -204,7 +204,6 @@ steps:
   commands:
     # split the test to avoid interference
     - pytest -v -s v1/core
-    - pytest -v -s v1/entrypoints
     - pytest -v -s v1/engine
     - pytest -v -s v1/entrypoints
     - pytest -v -s v1/sample


### PR DESCRIPTION
After merging https://github.com/vllm-project/vllm/pull/14868, we noticed there are two entrypoint tests running in the same pipeline. This duplication is unnecessary, so this PR removes the redundant entrypoint test from our CI workflow.

