### PR TITLE
[Bugfix] fix use_atomic_add support of marlin kernel when using v1 engine

### DIFF
--- a/csrc/quantization/gptq_marlin/gptq_marlin.cu
+++ b/csrc/quantization/gptq_marlin/gptq_marlin.cu
@@ -1785,7 +1785,7 @@ __global__ void Marlin(
             <<<blocks, NUM_THREADS, max_shared_mem, stream>>>(                 \
                 A_ptr, B_ptr, C_ptr, C_tmp_ptr, s_ptr, zp_ptr, g_idx_ptr,      \
                 num_groups, prob_m, prob_n, prob_k, lda, locks,                \
-                use_atomic_add, use_fp32_reduce);                              \
+                part_use_atomic_add, use_fp32_reduce);                         \
       }                                                                        \
     }
 
@@ -2214,6 +2214,10 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* s,
       i += exec_cfg.max_m_blocks * (par - 1);
       thread_m_blocks = exec_cfg.max_m_blocks;
     }
+
+    // atomic add reduce have better performance only when m * n is small
+    bool part_use_atomic_add =
+        use_atomic_add && div_ceil(prob_m, 64) * prob_n <= 2048;
 
     if (false) {
     }

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils.py
@@ -305,7 +305,7 @@ def should_use_atomic_add_reduce(m: int, n: int, k: int, device: torch.device,
 
     # the performance of atomicAdd is better than global reduce
     # only when m*n is small and k is large
-    return max(m, 64) * n < 64 * 2048 and k >= 2048
+    return n < 2048 and k >= 2048
 
 
 def apply_gptq_marlin_linear(


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/14138 optimized the marlin kernel and introbuted a new parameter `use_atomic_add` and new env var `VLLM_MARLIN_USE_ATOMIC_ADD`. However, when using it with V1 engine, we would got an error like 

```
File "/root/miniconda3/lib/python3.10/site-packages/torch/_inductor/codecache.py", line 644, in dumps
    self.dump(obj)
TypeError: cannot pickle 'PyCapsule' object

```

To reproduce

```
VLLM_MARLIN_USE_ATOMIC_ADD=1 vllm serve Qwen/Qwen2-1.5B-Instruct-GPTQ-Int4
```

I don't sure the actual reason, but I found that if I don't use `m` (input_size) as a part of the condition indicated whether we use atomic add or not, the error is gone.

This PR fix this problem by moving the condition of `m` to c++ code. This would also improve kernel performance of some special case, since marlin may launch several kernels with different `m` size in single `gptq_marlin_gemm`.