### PR TITLE
[misc] instruct pytorch to use nvml-based cuda check

### DIFF
--- a/vllm/__init__.py
+++ b/vllm/__init__.py
@@ -4,9 +4,10 @@
 # version library first.  Such assumption is critical for some customization.
 from .version import __version__, __version_tuple__  # isort:skip
 
-import os
-
-import torch
+# The environment variables override should be imported before any other
+# modules to ensure that the environment variables are set before any
+# other modules are imported.
+import vllm.env_override  # isort:skip  # noqa: F401
 
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
@@ -22,19 +23,6 @@ from vllm.outputs import (ClassificationOutput, ClassificationRequestOutput,
                           ScoringRequestOutput)
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
-
-# set some common config/environment variables that should be set
-# for all processes created by vllm and all processes
-# that interact with vllm workers.
-# they are executed whenever `import vllm` is called.
-
-# see https://github.com/NVIDIA/nccl/issues/1234
-os.environ['NCCL_CUMEM_ENABLE'] = '0'
-
-# see https://github.com/vllm-project/vllm/issues/10480
-os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
-# see https://github.com/vllm-project/vllm/issues/10619
-torch._inductor.config.compile_threads = 1
 
 __all__ = [
     "__version__",

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+
+import torch
+
+# set some common config/environment variables that should be set
+# for all processes created by vllm and all processes
+# that interact with vllm workers.
+# they are executed whenever `import vllm` is called.
+
+# see https://github.com/NVIDIA/nccl/issues/1234
+os.environ['NCCL_CUMEM_ENABLE'] = '0'
+
+# see https://github.com/vllm-project/vllm/pull/15366
+# avoid cuda initialization for unintentional call to torch.cuda.is_available()
+os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
+
+# see https://github.com/vllm-project/vllm/issues/10480
+os.environ['TORCHINDUCTOR_COMPILE_THREADS'] = '1'
+# see https://github.com/vllm-project/vllm/issues/10619
+torch._inductor.config.compile_threads = 1

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -11,8 +11,8 @@ import torch
 # see https://github.com/NVIDIA/nccl/issues/1234
 os.environ['NCCL_CUMEM_ENABLE'] = '0'
 
-# see https://github.com/vllm-project/vllm/pull/15366
-# avoid cuda initialization for unintentional call to torch.cuda.is_available()
+# see https://github.com/vllm-project/vllm/pull/15951
+# it avoids unintentional cuda initialization from torch.cuda.is_available()
 os.environ['PYTORCH_NVML_BASED_CUDA_CHECK'] = '1'
 
 # see https://github.com/vllm-project/vllm/issues/10480


### PR DESCRIPTION
We are suffering a lot from `torch.cuda.is_available()`, which unintentionally initializes cuda runtime. It has two disadvantages:
1. it makes the process not fork-able. and we need to use `export VLLM_WORKER_MULTIPROC_METHOD=spawn`
2. it makes the cuda runtime read `CUDA_VISIBLE_DEVICES` and decide the gpus to use. if we set `CUDA_VISIBLE_DEVICES` later, it will not take effect. see https://github.com/vllm-project/vllm/pull/15366 for example.

From vllm internally, we try to avoid calling `torch.cuda.is_available()`, but sometimes other libraries will do it unintentionally, e.g. transformers as reported in https://github.com/vllm-project/vllm/pull/15366 and xgrammar as reported in https://github.com/vllm-project/vllm/pull/15171 .

this PR instructs pytorch to use nvml-based cuda check, so that it will not initialize cuda runtime even if `torch.cuda.is_available()` is called.

see https://pytorch.org/docs/stable/cuda_environment_variables.html for detailed description