### PR TITLE
[Benchmark] Add AIMO Dataset to Benchmark

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -769,33 +769,6 @@ class AIMODataset(HuggingFaceDataset):
             "AI-MO/NuminaMath-CoT"
     }
 
-    def load_data(self) -> None:
-        import os.path as osp
-        supported_aimo_datasets = []
-        if not self.dataset_path:
-            raise ValueError("dataset_path must be provided for loading data.")
-        if not osp.exists(self.dataset_path) and \
-            self.dataset_path not in supported_aimo_datasets:
-            raise ValueError(
-                f"Only support AIMO datasets. This data path {self.dataset_path} "
-                f"is not valid. Supported datasets are {supported_aimo_datasets}")
-
-        self.data = load_dataset(
-            self.dataset_path,
-            name=self.dataset_subset,
-            split=self.dataset_split,
-            streaming=True,
-        )
-        if "problem" not in self.data.column_names \
-            or "solution" not in self.data.column_names:
-            raise ValueError(
-                "AIMODataset currently only supports datasets with "
-                "both 'problem' and 'solution' column like "
-                "AI-MO/aimo-validation-aime. "
-                "Please consider contributing if you would like to add "
-                "support for additional dataset formats.")
-        self.data = self.data.shuffle(seed=self.random_seed)
-
     def sample(self,
                tokenizer: PreTrainedTokenizerBase,
                num_requests: int,

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -764,9 +764,8 @@ class AIMODataset(HuggingFaceDataset):
     Dataset class for processing a AIMO dataset with reasoning questions.
     """
     SUPPORTED_DATASET_PATHS = {
-            "AI-MO/aimo-validation-aime",
-            "AI-MO/NuminaMath-1.5", 
-            "AI-MO/NuminaMath-CoT"
+        "AI-MO/aimo-validation-aime", "AI-MO/NuminaMath-1.5",
+        "AI-MO/NuminaMath-CoT"
     }
 
     def sample(self,
@@ -788,9 +787,10 @@ class AIMODataset(HuggingFaceDataset):
             completion_len = len(completion_ids)
             output_len = completion_len if dynamic_output else output_len
             assert isinstance(output_len, int) and output_len > 0
-            if dynamic_output and not is_valid_sequence(
-                    prompt_len, completion_len, max_prompt_len=2048,
-                    max_total_len=32000):
+            if dynamic_output and not is_valid_sequence(prompt_len,
+                                                        completion_len,
+                                                        max_prompt_len=2048,
+                                                        max_total_len=32000):
                 continue
             sampled_requests.append(
                 SampleRequest(

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -789,7 +789,8 @@ class AIMODataset(HuggingFaceDataset):
             output_len = completion_len if dynamic_output else output_len
             assert isinstance(output_len, int) and output_len > 0
             if dynamic_output and not is_valid_sequence(
-                    prompt_len, completion_len):
+                    prompt_len, completion_len, max_prompt_len=2048,
+                    max_total_len=32000):
                 continue
             sampled_requests.append(
                 SampleRequest(

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -613,6 +613,7 @@ def main(args: argparse.Namespace):
             dataset_path=args.dataset_path,
             dataset_subset=args.hf_subset,
             dataset_split=args.hf_split,
+            random_seed=args.seed,
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -52,7 +52,7 @@ except ImportError:
 from benchmark_dataset import (BurstGPTDataset, ConversationDataset,
                                HuggingFaceDataset, InstructCoderDataset,
                                RandomDataset, SampleRequest, ShareGPTDataset,
-                               SonnetDataset, VisionArenaDataset)
+                               SonnetDataset, VisionArenaDataset, AIMODataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
@@ -595,6 +595,9 @@ def main(args: argparse.Namespace):
             args.hf_split = "train"
         elif args.dataset_path in ConversationDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = ConversationDataset
+        elif args.dataset_path in AIMODataset.SUPPORTED_DATASET_PATHS:
+            dataset_class = AIMODataset
+            args.hf_split = "train"
         else:
             supported_datasets = set([
                 dataset_name for cls in HuggingFaceDataset.__subclasses__()

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -617,7 +617,6 @@ def main(args: argparse.Namespace):
         ).sample(
             num_requests=args.num_prompts,
             tokenizer=tokenizer,
-            random_seed=args.seed,
             output_len=args.hf_output_len,
         )
 

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -49,10 +49,11 @@ try:
 except ImportError:
     from argparse import ArgumentParser as FlexibleArgumentParser
 
-from benchmark_dataset import (BurstGPTDataset, ConversationDataset,
-                               HuggingFaceDataset, InstructCoderDataset,
-                               RandomDataset, SampleRequest, ShareGPTDataset,
-                               SonnetDataset, VisionArenaDataset, AIMODataset)
+from benchmark_dataset import (AIMODataset, BurstGPTDataset,
+                               ConversationDataset, HuggingFaceDataset,
+                               InstructCoderDataset, RandomDataset,
+                               SampleRequest, ShareGPTDataset, SonnetDataset,
+                               VisionArenaDataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000


### PR DESCRIPTION
This PR addresses issues #15378. It adds [AIMO datasets](https://huggingface.co/AI-MO) which contain 3 huggingface datasets for reasoning tasks: `AI-MO/aimo-validation-aime`, `AI-MO/NuminaMath-1.5`, and `AI-MO/NuminaMath-CoT`. 

Also, it facilitates reproducibility by passing random seed to hf dataset constructor, because shuffling takes the seed. This is in line with the sharegpt dataset. 

This PR can been tested using:
```
# server
vllm serve meta-llama/Meta-Llama-3-8B-Instruct     --swap-space 16     --disable-log-requests

# client
python3 benchmarks/benchmark_serving.py \
  --backend vllm --model meta-llama/Meta-Llama-3-8B-Instruct \
  --dataset-name hf  --dataset-path AI-MO/aimo-validation-aime \
  --num-prompts 10  --seed 42
```

Benchmark result (1x A100 80GB):
```
============ Serving Benchmark Result ============
Successful requests:                     10
Benchmark duration (s):                  17.73
Total input tokens:                      843
Total generated tokens:                  8086
Request throughput (req/s):              0.56
Output token throughput (tok/s):         456.19
Total Token throughput (tok/s):          503.75
---------------Time to First Token----------------
Mean TTFT (ms):                          38.79
Median TTFT (ms):                        39.16
P99 TTFT (ms):                           46.02
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12.34
Median TPOT (ms):                        12.36
P99 TPOT (ms):                           12.37
---------------Inter-token Latency----------------
Mean ITL (ms):                           12.32
Median ITL (ms):                         12.32
P99 ITL (ms):                            12.64
==================================================
```

@JenZhao @ywang96: Thank you for your work on benchmarking, and please let me know if you spot something wrong. Thanks.