### PR TITLE
Fix `huggingface-cli[hf-xet]` -> `huggingface-cli[hf_xet]`

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ tqdm
 blake3
 py-cpuinfo
 transformers >= 4.50.3
-huggingface-hub[hf-xet] >= 0.30.0  # Required for Xet downloads.
+huggingface-hub[hf_xet] >= 0.30.0  # Required for Xet downloads.
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -31,7 +31,7 @@ opencv-python-headless >= 4.11.0 # required for video test
 datamodel_code_generator # required for minicpm3 test
 lm-eval[api]==0.4.8 # required for model evaluation test
 transformers==4.50.3
-huggingface-hub[hf-xet]>=0.30.0  # Required for Xet downloads.
+huggingface-hub[hf_xet]>=0.30.0  # Required for Xet downloads.
 # quantization
 bitsandbytes>=0.45.3
 buildkite-test-collector==0.1.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -152,7 +152,7 @@ genson==1.3.0
     # via datamodel-code-generator
 h11==0.14.0
     # via httpcore
-hf_xet==0.1.4
+hf-xet==0.1.4
     # via huggingface-hub
 hiredis==3.0.0
     # via tensorizer

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -152,7 +152,7 @@ genson==1.3.0
     # via datamodel-code-generator
 h11==0.14.0
     # via httpcore
-hf-xet==0.1.4
+hf_xet==0.1.4
     # via huggingface-hub
 hiredis==3.0.0
     # via tensorizer


### PR DESCRIPTION
Should resolve issues with TPU and ROCm installs.

Alternative to https://github.com/vllm-project/vllm/pull/15963