### PR TITLE
fix: close issue #15985 for tricky import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -598,9 +598,10 @@ def get_requirements() -> list[str]:
             elif not line.startswith("--") and not line.startswith(
                     "#") and line.strip() != "":
                 # tricky way to fix #15985
-                if sys.platform.startswith("darwin") and "torch" in line.lower(
-                ) and "darwin" in line.lower():
-                    resolved_requirements.append(line)
+                if filename.startswith("cpu") and "torch" in line.lower():
+                    if sys.platform.startswith(
+                            "darwin") and "darwin" in line.lower():
+                        resolved_requirements.append(line)
                 else:
                     resolved_requirements.append(line)
         return resolved_requirements

--- a/setup.py
+++ b/setup.py
@@ -597,7 +597,12 @@ def get_requirements() -> list[str]:
                 resolved_requirements += _read_requirements(line.split()[1])
             elif not line.startswith("--") and not line.startswith(
                     "#") and line.strip() != "":
-                resolved_requirements.append(line)
+                # tricky way to fix #15985
+                if sys.platform.startswith("darwin") and "torch" in line.lower(
+                ) and "darwin" in line.lower():
+                    resolved_requirements.append(line)
+                else:
+                    resolved_requirements.append(line)
         return resolved_requirements
 
     if _no_device():


### PR DESCRIPTION

FIX #15985

This patch using a tricky way to fix the issue can not use `uv run` on vllm mac m1

I tried some of methods but None of them is perfectly
more can check issue on uv side: https://github.com/astral-sh/uv/issues/12578

so I choose the tricky way since vllm use setup.py for now and maybe all to pyproject.toml later.

cc @hmellor it can easily reproduce on mac series