### PR TITLE
[Doc][Bugfix] Add missing EOF in k8s deploy doc

### DIFF
--- a/docs/source/deployment/k8s.md
+++ b/docs/source/deployment/k8s.md
@@ -46,6 +46,7 @@ metadata:
 type: Opaque
 data:
   token: $(HF_TOKEN)
+EOF
 ```
 
 Next, start the vLLM server as a Kubernetes Deployment and Service:


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

In "Deployment with CPUs" section, the PVC/Secret command was missing an `EOF`.

<!--- pyml disable-next-line no-emphasis-as-heading -->
