### PR TITLE
doc: add info for macos clang errors

### DIFF
--- a/docs/source/getting_started/installation/cpu/apple.inc.md
+++ b/docs/source/getting_started/installation/cpu/apple.inc.md
@@ -12,7 +12,7 @@ There are no pre-built wheels or images for this device, so you must build vLLM 
 
 - OS: `macOS Sonoma` or later
 - SDK: `XCode 15.4` or later with Command Line Tools
-- Compiler: `Apple Clang >= 15.0.0`
+- Compiler: `Apple Clang >= 15.0.0` and `Apple Clang < 17.0.0`
 
 ## Set up using Python
 
@@ -50,6 +50,14 @@ If the build has error like the following snippet where standard C++ headers can
             |          ^~~~~~~~~
       1 error generated.
 ```
+
+If run with error like the following snippet you need to check clang version and install the applicable versions
+
+```text
+AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul'
+```
+
+more can check issue https://github.com/vllm-project/vllm/issues/15941
 
 ## Set up using Docker
 

--- a/docs/source/getting_started/installation/cpu/apple.inc.md
+++ b/docs/source/getting_started/installation/cpu/apple.inc.md
@@ -51,13 +51,13 @@ If the build has error like the following snippet where standard C++ headers can
       1 error generated.
 ```
 
-If run with error like the following snippet you need to check clang version and install the applicable versions
+If run with error like the following snippet you need to check clang version and install a compatible version.
 
 ```text
 AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul'
 ```
 
-more can check issue https://github.com/vllm-project/vllm/issues/15941
+More information can be found in <gh-issue:15941>.
 
 ## Set up using Docker
 


### PR DESCRIPTION
FIX #15941

Mac info for issue #15941 make sure the apple clang version is 15 or 16 


info from issue

> 17 will cause the problem,
the main reason is from here ImportError("dlopen(/Users/aiserver/AI/vllm/vllm/_C.abi3.so, 0x0002): symbol not found in flat namespace '___kmpc_dispatch_deinit'")
and for clang17 in mac there can not find `___kmpc_dispatch_deinit` symbol
it had been fixed in llvm and other version
more can check:
issue: https://trac.macports.org/ticket/70877
https://github.com/yugabyte/yugabyte-db-thirdparty/pull/298
https://github.com/llvm/llvm-project/issues/98046
will open a doc patch to info it
and for the solutin
setps
```
clang --version # make sure it is not 17
# if 17
sudo rm -rf /Library/Developer/CommandLineTools
# then go to https://developer.apple.com/download/all/
# download the  `Command Line Tools for Xcode 16.1`
# insatll it
# then 
clang --version # make sure its 16
```