### PR TITLE
[Bugfix] Fix default behavior/fallback for pp in v1

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1521,8 +1521,9 @@ class EngineArgs:
         # PP is supported on V1 with Ray distributed executor,
         # but off for MP distributed executor for now.
         if (self.pipeline_parallel_size > 1
-                and self.distributed_executor_backend == "mp"
-                and _warn_or_fallback("PP (MP distributed executor)")):
+                and self.distributed_executor_backend != "ray"):
+            name = "Pipeline Parallelism without Ray distributed executor"
+            _raise_or_fallback(feature_name=name, recommend_to_remove=False)
             return False
 
         # ngram is supported on V1, but off by default for now.


### PR DESCRIPTION
Before this PR, running a model with pipeline parallelism with default args results in an error because the default `"mp"` distributed executor is not supported in V1 for PP.

```
vllm serve Qwen/Qwen2-1.5B-Instruct -pp 2
...
INFO 04-04 11:36:58 [config.py:1591] Defaulting to use mp for distributed inference
...
ERROR 04-04 11:37:05 [core.py:390] EngineCore hit an exception: Traceback (most recent call last):
ERROR 04-04 11:37:05 [core.py:390]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 378, in run_engine_core
ERROR 04-04 11:37:05 [core.py:390]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 04-04 11:37:05 [core.py:390]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-04 11:37:05 [core.py:390]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 319, in __init__
ERROR 04-04 11:37:05 [core.py:390]     super().__init__(vllm_config, executor_class, log_stats)
ERROR 04-04 11:37:05 [core.py:390]   File "/home/mgoin/code/vllm/vllm/v1/engine/core.py", line 67, in __init__
ERROR 04-04 11:37:05 [core.py:390]     self.model_executor = executor_class(vllm_config)
ERROR 04-04 11:37:05 [core.py:390]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-04 11:37:05 [core.py:390]   File "/home/mgoin/code/vllm/vllm/executor/executor_base.py", line 52, in __init__
ERROR 04-04 11:37:05 [core.py:390]     self._init_executor()
ERROR 04-04 11:37:05 [core.py:390]   File "/home/mgoin/code/vllm/vllm/v1/executor/multiproc_executor.py", line 61, in _init_executor
ERROR 04-04 11:37:05 [core.py:390]     assert self.world_size == tensor_parallel_size, (
ERROR 04-04 11:37:05 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-04 11:37:05 [core.py:390] AssertionError: world_size (2) must be equal to the tensor_parallel_size (1). Pipeline parallelism is not yet implemented in v1
```

Note that if you do manually specify `"ray"` as the executor, it will work find in V1:
```
vllm serve Qwen/Qwen2-1.5B-Instruct -pp 2 --distributed_executor_backend ray
```

With this PR, now that default usage will fallback to V0 so we can respect the distributed executor
```
vllm serve Qwen/Qwen2-1.5B-Instruct -pp 2

WARNING 04-04 11:38:05 [arg_utils.py:1710] Pipeline Parallelism without Ray distributed executor is not supported by the V1 Engine. Falling back to V0. 
INFO 04-04 11:38:05 [config.py:1591] Defaulting to use mp for distributed inference
```