### PR TITLE
[Kernel] Support merge attn cuda kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(VLLM_EXT_SRC
   "csrc/cache_kernels.cu"
   "csrc/attention/paged_attention_v1.cu"
   "csrc/attention/paged_attention_v2.cu"
+  "csrc/attention/merge_attn_states.cu"
   "csrc/pos_encoding_kernels.cu"
   "csrc/activation_kernels.cu"
   "csrc/layernorm_kernels.cu"

--- a/benchmarks/kernels/benchmark_cascade_attention.py
+++ b/benchmarks/kernels/benchmark_cascade_attention.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, FlexibleArgumentParser
+from vllm.v1.attention.backends.flash_attn import merge_attn_states_triton
+
+NUM_HEADS = [(16, 2)]
+HEAD_SIZES = [128, 192, 256]
+
+
+@torch.inference_mode()
+def main(
+    version: str,
+    num_tokens: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    seed: int,
+    do_profile: bool,
+    device: str = "cuda",
+) -> None:
+    current_platform.seed_everything(seed)
+    torch.set_default_device(device)
+
+    prefix_output = torch.randn(num_tokens,
+                                num_query_heads,
+                                head_size,
+                                dtype=dtype)
+    suffix_output = torch.randn(num_tokens,
+                                num_query_heads,
+                                head_size,
+                                dtype=dtype)
+    prefix_lse = torch.randn(num_query_heads, num_tokens, dtype=torch.float32)
+    suffix_lse = torch.randn(num_query_heads, num_tokens, dtype=torch.float32)
+
+    output = torch.empty(num_tokens, num_query_heads, head_size, dtype=dtype)
+
+    def run_benchmark(num_iters: int, profile: bool = False) -> float:
+        torch.cuda.synchronize()
+        if profile:
+            torch.cuda.cudart().cudaProfilerStart()
+        start_time = time.perf_counter()
+
+        for _ in range(num_iters):
+            if version == "cuda":
+                ops.merge_attn_states(
+                    output,
+                    prefix_output,
+                    prefix_lse,
+                    suffix_output,
+                    suffix_lse,
+                )
+            elif version == "triton":
+                merge_attn_states_triton(
+                    output,
+                    prefix_output,
+                    prefix_lse,
+                    suffix_output,
+                    suffix_lse,
+                )
+            else:
+                raise ValueError(f"Invalid version: {version}")
+        torch.cuda.synchronize()
+
+        end_time = time.perf_counter()
+        if profile:
+            torch.cuda.cudart().cudaProfilerStop()
+        return (end_time - start_time) / num_iters
+
+    # Warmup.
+    print("Warming up...")
+    run_benchmark(num_iters=3, profile=False)
+
+    # Benchmark.
+    if do_profile:
+        latency = run_benchmark(num_iters=1, profile=True)
+    else:
+        latency = run_benchmark(num_iters=100, profile=False)
+    print(f"Kernel running time: {latency * 1000000:.3f} us")
+
+
+if __name__ == '__main__':
+    parser = FlexibleArgumentParser(
+        description="Benchmark the paged attention kernel.")
+    parser.add_argument("--version",
+                        type=str,
+                        choices=["cuda", "triton"],
+                        default="cuda")
+    parser.add_argument("--num-tokens", type=int, default=8)
+    parser.add_argument("--num-query-heads", type=int, default=64)
+    parser.add_argument("--num-kv-heads", type=int, default=8)
+    parser.add_argument("--head-size",
+                        type=int,
+                        choices=[32, 64, 128, 128, 192, 256],
+                        default=128)
+    parser.add_argument("--dtype",
+                        type=str,
+                        choices=["half", "bfloat16", "float"],
+                        default="half")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--profile", action="store_true")
+    args = parser.parse_args()
+    print(args)
+
+    if args.num_query_heads % args.num_kv_heads != 0:
+        raise ValueError("num_query_heads must be divisible by num_kv_heads")
+    main(
+        version=args.version,
+        num_tokens=args.num_tokens,
+        num_query_heads=args.num_query_heads,
+        num_kv_heads=args.num_kv_heads,
+        head_size=args.head_size,
+        dtype=STR_DTYPE_TO_TORCH_DTYPE[args.dtype],
+        seed=args.seed,
+        do_profile=args.profile,
+    )

--- a/benchmarks/kernels/benchmark_cascade_attention.py
+++ b/benchmarks/kernels/benchmark_cascade_attention.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
                         type=str,
                         choices=["cuda", "triton"],
                         default="cuda")
-    parser.add_argument("--num-tokens", type=int, default=8)
+    parser.add_argument("--num-tokens", type=int, default=1000)
     parser.add_argument("--num-query-heads", type=int, default=64)
     parser.add_argument("--num-kv-heads", type=int, default=8)
     parser.add_argument("--head-size",

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,0 +1,113 @@
+/*
+ * Adapted from
+ * https://github.com/NVIDIA/FasterTransformer/blob/release/v5.3_tag/src/fastertransformer/kernels/decoder_masked_multihead_attention/decoder_masked_multihead_attention_template.hpp
+ * Copyright (c) 2023, The vLLM team.
+ * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "attention_kernels.cuh"
+
+#define DISPATCH_BY_OUTPUT_DTYPE(OUTPUT_DTYPE, FN)                          \
+  if (OUTPUT_DTYPE == at::ScalarType::Float) {                              \
+    FN(float);                                                              \
+  } else if (OUTPUT_DTYPE == at::ScalarType::Half) {                        \
+    FN(uint16_t);                                                           \
+  } else if (OUTPUT_DTYPE == at::ScalarType::BFloat16) {                    \
+    FN(__nv_bfloat16);                                                      \
+  } else {                                                                  \
+    TORCH_CHECK(false, "Unsupported input type of output: ", OUTPUT_DTYPE); \
+  }
+
+template <typename scalar_t, int HEAD_SIZE, bool SHOULD_OUTPUT_LSE>
+void merge_attn_states_launcher(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const std::optional<torch::Tensor>& output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
+) {
+  const int num_tokens = output.size(0);
+  const int num_heads = output.size(1);
+
+  dim3 grid(num_tokens, num_heads);
+  dim3 block(HEAD_SIZE);
+
+  scalar_t* output_ptr = reinterpret_cast<scalar_t*>(output.data_ptr());
+  float* output_lse_ptr =
+      output_lse ? reinterpret_cast<float*>(output_lse.value().data_ptr())
+                 : nullptr;
+  const scalar_t* prefix_output_ptr =
+      reinterpret_cast<const scalar_t*>(prefix_output.data_ptr());
+  const float* prefix_lse_ptr =
+      reinterpret_cast<const float*>(prefix_lse.data_ptr());
+  const scalar_t* suffix_output_ptr =
+      reinterpret_cast<const scalar_t*>(suffix_output.data_ptr());
+  const float* suffix_lse_ptr =
+      reinterpret_cast<const float*>(suffix_lse.data_ptr());
+
+  vllm::merge_attn_states_kernel<scalar_t, HEAD_SIZE, SHOULD_OUTPUT_LSE>
+      <<<grid, block>>>(output_ptr, output_lse_ptr, prefix_output_ptr,
+                        prefix_lse_ptr, suffix_output_ptr, suffix_lse_ptr);
+}
+
+#define CALL_MERGE_ATTN_STATES_LAUNCHER(T, HEAD_SIZE, SHOULD_OUTPUT_LSE) \
+  merge_attn_states_launcher<T, HEAD_SIZE, SHOULD_OUTPUT_LSE>(           \
+      output, output_lse, prefix_output, prefix_lse, suffix_output,      \
+      suffix_lse);
+
+#define CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, HEAD_SIZE) \
+  if (output_lse) {                                                     \
+    CALL_MERGE_ATTN_STATES_LAUNCHER(T, HEAD_SIZE, true);                \
+  } else {                                                              \
+    CALL_MERGE_ATTN_STATES_LAUNCHER(T, HEAD_SIZE, false);               \
+  }
+
+#define CALL_MERGE_ATTN_STATES_LAUNCHER_HEADSIZE(T)              \
+  switch (head_size) {                                           \
+    case 32:                                                     \
+      \   
+      CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, 32);  \
+      break;                                                     \
+    case 64:                                                     \
+      CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, 64);  \
+      break;                                                     \
+    case 128:                                                    \
+      CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, 128); \
+      break;                                                     \
+    case 192:                                                    \
+      CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, 192); \
+      break;                                                     \
+    case 256:                                                    \
+      CALL_MERGE_ATTN_STATES_LAUNCHER_SHOULD_OUTPUT_LSE(T, 256); \
+      \ 
+      break;                                                     \
+    default:                                                     \
+      TORCH_CHECK(false, "Unsupported head size: ", head_size);  \
+      break;                                                     \
+  }
+
+void merge_attn_states(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const std::optional<torch::Tensor>& output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
+) {
+  int head_size = output.size(2);
+  DISPATCH_BY_OUTPUT_DTYPE(output.dtype(),
+                           CALL_MERGE_ATTN_STATES_LAUNCHER_HEADSIZE)
+}

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -52,6 +52,11 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
+void merge_attn_states(torch::Tensor& output,
+                       const std::optional<torch::Tensor>& output_lse,
+                       torch::Tensor& prefix_output, torch::Tensor& prefix_lse,
+                       torch::Tensor& suffix_output, torch::Tensor& suffix_lse);
+
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);
 

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -64,6 +64,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    int blocksparse_head_sliding_step) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
+  // TODO(Wenqin): argument list is not correct yet.
+  ops.def(
+      "merge_attn_states("
+      "    Tensor! output, Tensor? output_lse, Tensor prefix_output,"
+      "    Tensor prefix_lse, Tensor suffix_output, Tensor suffix_lse) -> ()");
+  ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
+
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -98,6 +98,18 @@ def paged_attention_v2(
         blocksparse_block_size, blocksparse_head_sliding_step)
 
 
+def merge_attn_states(
+    output: torch.Tensor,
+    prefix_output: torch.Tensor,
+    prefix_lse: torch.Tensor,
+    suffix_output: torch.Tensor,
+    suffix_lse: torch.Tensor,
+    output_lse: Optional[torch.Tensor] = None,
+) -> None:
+    torch.ops._C.merge_attn_states(output, output_lse, prefix_output,
+                                   prefix_lse, suffix_output, suffix_lse)
+
+
 def paged_attention_rocm(
     out: torch.Tensor,
     exp_sum: torch.Tensor,

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -216,8 +216,8 @@ from vllm.utils import async_tensor_h2d, cdiv, make_tensor_with_pad, round_down
 from vllm.vllm_flash_attn.fa_utils import get_flash_attn_version
 
 if HAS_TRITON:
+    from vllm.attention.ops.merge_attn_states import merge_attn_states
     from vllm.attention.ops.triton_flash_attention import triton_attention
-    from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
 else:
     merge_attn_states = None
     triton_attention = None

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -5,10 +5,41 @@ import torch
 import triton
 import triton.language as tl
 
+from vllm import _custom_ops as ops
+
+CUDA_KERNEL_HEAD_SIZE = [32, 64, 128, 128, 192, 256]
+
 
 # Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 # can be used to combine partial attention results (in the split-KV case)
 def merge_attn_states(
+    output: torch.Tensor,
+    prefix_output: torch.Tensor,
+    prefix_lse: torch.Tensor,
+    suffix_output: torch.Tensor,
+    suffix_lse: torch.Tensor,
+    output_lse: Optional[torch.Tensor] = None,
+) -> None:
+    head_size = output.shape[2]
+
+    # CUDA kernel only support some specific head size
+    if head_size in CUDA_KERNEL_HEAD_SIZE:
+        ops.merge_attn_states(output,
+                              prefix_output,
+                              prefix_lse,
+                              suffix_output,
+                              suffix_lse,
+                              output_lse=output_lse)
+    else:
+        merge_attn_states_triton(output,
+                                 prefix_output,
+                                 prefix_lse,
+                                 suffix_output,
+                                 suffix_lse,
+                                 output_lse=output_lse)
+
+
+def merge_attn_states_triton(
     output: torch.Tensor,
     prefix_output: torch.Tensor,
     prefix_lse: torch.Tensor,
@@ -21,8 +52,8 @@ def merge_attn_states(
     head_size = output.shape[2]
     padded_head_size = triton.next_power_of_2(head_size)
 
-    # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
-    merge_attn_states_kernel[(num_tokens, num_query_heads)](
+    # CUDA kernel only support some specific head size
+    merge_attn_states_triton_kernel[(num_tokens, num_query_heads)](
         output,
         output_lse,
         prefix_output,
@@ -36,7 +67,7 @@ def merge_attn_states(
 
 
 @triton.jit
-def merge_attn_states_kernel(
+def merge_attn_states_triton_kernel(
     output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     output_lse,  # [NUM_HEADS, NUM_TOKENS]
     prefix_output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -10,7 +10,7 @@ from vllm import _custom_ops as ops
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType,
                                               is_quantized_kv_cache)
-from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils import cdiv

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -195,7 +195,7 @@ from vllm import _custom_ops as ops
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionLayer,
                                               AttentionMetadata,
                                               MLAAttentionImpl)
-from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase, RowParallelLinear,


### PR DESCRIPTION
### Motivation
This PR supports the CUDA kernel for `merge_attn_states`, it will mitigate the CPU overhead of current triton kernel.

### Performance benefits
There is **~5%** perf gain (`81.383 us` vs `77.554 us`) compared with current triton merge kernel on my local RTX 3080.

baseline:
```
(vllmbuild) wenqin@wenqin-System-Product-Name:~/study/vllm$ python benchmarks/kernels/benchmark_cascade_attention.py --version="triton"
INFO 04-04 21:19:56 [__init__.py:239] Automatically detected platform cuda.
Namespace(version='triton', num_tokens=1000, num_query_heads=64, num_kv_heads=8, head_size=128, dtype='half', seed=0, profile=False)
Warming up...
Kernel running time: 81.383 us
```

opt:
```
(vllmbuild) wenqin@wenqin-System-Product-Name:~/study/vllm$ python benchmarks/kernels/benchmark_cascade_attention.py --version="cuda"
INFO 04-04 21:20:08 [__init__.py:239] Automatically detected platform cuda.
Namespace(version='cuda', num_tokens=1000, num_query_heads=64, num_kv_heads=8, head_size=128, dtype='half', seed=0, profile=False)
Warming up...
Kernel running time: 77.554 us
```

### Heuristic
This perf data is based on the `num_tokens=1000`, I tried to set `num_tokens=10000`, it seems the CUDA kernel will bring **~5%** regression.

I saw the SASS code, there are some redundant computation insts on the CUDA kernel compared with the triton kernel, I guess the root cause of the regression is the redundant inst.

WDYT of this regression? Shall we dispatch to the triton kernel when the `num_tokens` is greater than a specific threshold?

