### PR TITLE
Account for SlidingWindowSpec in TPU worker

### DIFF
--- a/tests/v1/tpu/test_pallas.py
+++ b/tests/v1/tpu/test_pallas.py
@@ -4,9 +4,7 @@ from unittest.mock import ANY, patch
 import torch
 
 from vllm.attention.backends.abstract import AttentionType
-from vllm.v1.attention.backends.pallas import (NUM_KV_PAGES_PER_BLOCK,
-                                               NUM_QUERIES_PER_BLOCK,
-                                               PallasAttentionBackendImpl,
+from vllm.v1.attention.backends.pallas import (PallasAttentionBackendImpl,
                                                PallasMetadata)
 
 
@@ -32,8 +30,6 @@ def test_ragged_paged_attention():
         logits_soft_cap=logits_soft_cap,
         attn_type=AttentionType.DECODER,
     )
-    mock_vmem_limit_bytes = 1024
-    attn_impl.vmem_limit_bytes = mock_vmem_limit_bytes
 
     class FakeAttentionLayer:
         _k_scale_float: float
@@ -88,9 +84,9 @@ def test_ragged_paged_attention():
             ANY,  # block_tables
             ANY,  # query_start_loc
             ANY,  # num_seqs
-            num_kv_pages_per_block=NUM_KV_PAGES_PER_BLOCK,
-            num_queries_per_block=NUM_QUERIES_PER_BLOCK,
-            vmem_limit_bytes=mock_vmem_limit_bytes,
+            num_kv_pages_per_block=None,
+            num_queries_per_block=None,
+            vmem_limit_bytes=None,
             use_kernel=True,
             sm_scale=scale,
             sliding_window=sliding_window,

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -137,7 +137,7 @@ class TPUWorker:
         kv_caches: dict[str, torch.Tensor] = {}
         kv_cache_spec = self.model_runner.get_kv_cache_spec()
         for layer_name, layer_spec in kv_cache_spec.items():
-            if isinstance(layer_spec, SlidingWindowSpec | FullAttentionSpec):
+            if isinstance(layer_spec, (SlidingWindowSpec, FullAttentionSpec)):
                 dtype = layer_spec.dtype
 
                 # Use an empty tensor instead of `None`` to force Dynamo to pass

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -19,7 +19,7 @@ from vllm.model_executor import set_random_seed
 from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
-                                        KVCacheSpec)
+                                        KVCacheSpec, SlidingWindowSpec)
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.utils import bind_kv_cache
 from vllm.v1.worker.tpu_model_runner import TPUModelRunner
@@ -137,7 +137,7 @@ class TPUWorker:
         kv_caches: dict[str, torch.Tensor] = {}
         kv_cache_spec = self.model_runner.get_kv_cache_spec()
         for layer_name, layer_spec in kv_cache_spec.items():
-            if isinstance(layer_spec, FullAttentionSpec):
+            if isinstance(layer_spec, SlidingWindowSpec | FullAttentionSpec):
                 dtype = layer_spec.dtype
 
                 # Use an empty tensor instead of `None`` to force Dynamo to pass


### PR DESCRIPTION
Account for SlidingWindowSpec in TPU worker. Otherwise the TPU CI fails with an error
```

INFO 04-04 01:27:29 [loader.py:447] Loading weights took 2.43 seconds
--
  | ERROR 04-04 01:27:29 [core.py:390] EngineCore hit an exception: Traceback (most recent call last):
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/engine/core.py", line 378, in run_engine_core
  | ERROR 04-04 01:27:29 [core.py:390]     engine_core = EngineCoreProc(*args, **kwargs)
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/engine/core.py", line 319, in __init__
  | ERROR 04-04 01:27:29 [core.py:390]     super().__init__(vllm_config, executor_class, log_stats)
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/engine/core.py", line 71, in __init__
  | ERROR 04-04 01:27:29 [core.py:390]     self._initialize_kv_caches(vllm_config)
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/engine/core.py", line 132, in _initialize_kv_caches
  | ERROR 04-04 01:27:29 [core.py:390]     available_gpu_memory = self.model_executor.determine_available_memory()
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/executor/abstract.py", line 66, in determine_available_memory
  | ERROR 04-04 01:27:29 [core.py:390]     output = self.collective_rpc("determine_available_memory")
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/executor/uniproc_executor.py", line 56, in collective_rpc
  | ERROR 04-04 01:27:29 [core.py:390]     answer = run_method(self.driver_worker, method, args, kwargs)
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/utils.py", line 2347, in run_method
  | ERROR 04-04 01:27:29 [core.py:390]     return func(*args, **kwargs)
  | ERROR 04-04 01:27:29 [core.py:390]   File "/workspace/vllm/vllm/v1/worker/tpu_worker.py", line 150, in determine_available_memory
  | ERROR 04-04 01:27:29 [core.py:390]     raise NotImplementedError
  | ERROR 04-04 01:27:29 [core.py:390] NotImplementedError
  | ERROR 04-04 01:27:29 [core.py:390]
  | CRITICAL 04-04 01:27:29 [core_client.py:361] Got fatal signal from worker processes, shutting down. See stack trace above for root cause
```
The not implemented case is SlidingWindowSpec.

Test plans:
```
pytest -v -s tests/entrypoints/llm/test_accuracy.py::test_lm_eval_accuracy_v1_engine
VLLM_USE_V1=1 python examples/offline_inference/tpu.py  # change the model to google/gemma-3-1b-it
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
