### PR TITLE
[Fix the torch pip install]

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -2,9 +2,9 @@
 -r common.txt
 
 --extra-index-url https://download.pytorch.org/whl/rocm6.2.4
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0
+torch==2.6.0+rocm6.2.4
+torchvision==0.21.0+rocm6.2.4
+torchaudio==2.6.0+rocm6.2.4
 
 cmake>=3.26,<4
 packaging


### PR DESCRIPTION
It's not safe to just use --extra-index-url when try to pull a specific torch for rocm.

This can cause accidentally pull cuda version when we try to pull rocm vesion.