### PR TITLE
fix: support clang17 for macos and fix the real libomp

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -33,8 +33,6 @@ endif()
 
 if(MACOSX_FOUND)
     list(APPEND CXX_COMPILE_FLAGS
-        "-Xpreprocessor"
-        "-fopenmp"
         "-DVLLM_CPU_EXTENSION")
 else()
     list(APPEND CXX_COMPILE_FLAGS


### PR DESCRIPTION

FIX #15941

this patch fix the problem that mac Clang version 17 can not run.

The main reason is that:

- the root cause is we bring https://github.com/vllm-project/vllm/pull/14051 add `include "omp.h"` for __APPLE__
- but the omp.h is from torch side(see pic beblow)
- and for macos clang version the `libomp.dylib` are also different version
- in torch side when we build we already have `libomp.dylib` (see below pic also)
- seems we have already open -fopenmp in torch side?

![image](https://github.com/user-attachments/assets/e21f0536-cf55-4740-a5da-a3fad0192709)

![image](https://github.com/user-attachments/assets/f9b255cb-dc46-4891-9165-949224142aff)

test on Clang16 and Clang17

cc @hmellor 

