### PR TITLE
[CI] Fix benchmark script level

### DIFF
--- a/.buildkite/scripts/run-benchmarks.sh
+++ b/.buildkite/scripts/run-benchmarks.sh
@@ -5,8 +5,8 @@
 set -ex
 set -o pipefail
 
-# cd into parent directory of this file
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+# cd 2 levels into the working directory
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 
 (which wget && which curl) || (apt-get update && apt-get install -y wget curl)
 


### PR DESCRIPTION
The script is moved 1 lever deeper, into `scripts` directory so the path inside the script needs to go back 1 more level as well so it can change dir into the working dir of the container