### PR TITLE
[Bugfix]fix asyncLLM test_abort

### DIFF
--- a/tests/v1/engine/test_async_llm.py
+++ b/tests/v1/engine/test_async_llm.py
@@ -175,6 +175,7 @@ async def test_abort(monkeypatch: pytest.MonkeyPatch,
                     f"expected {expected_tokens}")
 
         # Make sure all aborted requests were really aborted.
+        await asyncio.sleep(0.1)
         assert not engine.output_processor.has_unfinished_requests()
 
         # Confirm we can do another generation.


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/16054

Need async wait for aborting the request actually.