### PR TITLE
[Misc] add .ruff_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION

It will genereate `.ruff_cache` after running `pre-commit run --all-files`, so add to `.gitignore`.

<!--- pyml disable-next-line no-emphasis-as-heading -->
