### PR TITLE
[CI][V1] Fix passing `tokenizer` as kwarg to `validate_guidance_grammar`

### DIFF
--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -163,7 +163,6 @@ def validate_guidance_grammar(
         tokenizer: Optional[llguidance.LLTokenizer] = None) -> None:
     tp, grm = get_structured_output_key(sampling_params)
     guidance_grm = serialize_guidance_grammar(tp, grm)
-    err = llguidance.LLMatcher.validate_grammar(guidance_grm,
-                                                tokenizer=tokenizer)
+    err = llguidance.LLMatcher.validate_grammar(guidance_grm, tokenizer)
     if err:
         raise ValueError(f"Grammar error: {err}")


### PR DESCRIPTION
`llguidance.LLMatcher.validate_grammar` no longer takes `tokenizer` as a keyword argument (not sure if this is a bug on their side), but this has caused V1 test to always break on main. 

This PR fixes it.
```
tests/v1/entrypoints/llm/test_struct_output_generate.py ....                                                                                                           [100%]

============================================================================== warnings summary ==============================================================================
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-xgrammar:disable-any-whitespace-auto]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-guidance:disable-any-whitespace-auto]
  /home/jovyan/vllm/vllm/transformers_utils/tokenizer_group/tokenizer_group.py:25: FutureWarning: It is strongly recommended to run mistral models with `--tokenizer-mode "mistral"` to ensure correct encoding and decoding.
    self.tokenizer = get_tokenizer(self.tokenizer_id, **tokenizer_config)

tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-xgrammar:disable-any-whitespace-auto]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-guidance:disable-any-whitespace-auto]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[mistralai/Ministral-8B-Instruct-2410-xgrammar:disable-any-whitespace-mistral]
tests/v1/entrypoints/llm/test_struct_output_generate.py::test_structured_output[Qwen/Qwen2.5-1.5B-Instruct-xgrammar:disable-any-whitespace-auto]
  /home/jovyan/.local/share/uv/python/cpython-3.12.9-linux-x86_64-gnu/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=132348) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 4 passed, 6 warnings in 75.87s (0:01:15) ==================================================================
```