### PR TITLE
[Misc] Improve model redirect to accept json dictionary

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -665,6 +665,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",
 
     # Use model_redirect to redirect the model name to a local folder.
+    # `model_redirect` can be a json file mapping the model repo_id and local folder:
+    # {"meta-llama/Llama-3.2-1B": "/tmp/Llama-3.2-1B"}
+    # or a space separated values table file:
+    # meta-llama/Llama-3.2-1B   /tmp/Llama-3.2-1B
     "VLLM_MODEL_REDIRECT_PATH":
     lambda: os.environ.get("VLLM_MODEL_REDIRECT_PATH", None),
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -665,7 +665,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     lambda: os.environ.get("VLLM_CI_USE_S3", "0") == "1",
 
     # Use model_redirect to redirect the model name to a local folder.
-    # `model_redirect` can be a json file mapping the model repo_id and local folder:
+    # `model_redirect` can be a json file mapping the model between
+    # repo_id and local folder:
     # {"meta-llama/Llama-3.2-1B": "/tmp/Llama-3.2-1B"}
     # or a space separated values table file:
     # meta-llama/Llama-3.2-1B   /tmp/Llama-3.2-1B


### PR DESCRIPTION

- Following PR for #14116.
- It's not very useful if the model redirection only accepts tab-separated values, because some IDEs like vscode will replace tab with four spaces for indent.
- This PR allows using json file and space-separated table for model redirection.

Examples:
```
$ VLLM_MODEL_REDIRECT_PATH=./model_redirect.json pytest -s -v tests/models/test_initialization.py -k Florence2ForConditionalGeneration
INFO 04-06 14:05:32 [__init__.py:239] Automatically detected platform cpu.
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0 -- /data/develop-projects/github-repos/vllm-cpu/.venv/bin/python
cachedir: .pytest_cache
rootdir: /data/develop-projects/github-repos/vllm-cpu
configfile: pyproject.toml
plugins: anyio-4.8.0, typeguard-4.3.0
collected 131 items / 130 deselected / 1 selected                                                                                                                                         

tests/models/test_initialization.py::test_can_initialize[Florence2ForConditionalGeneration]
INFO 04-06 14:05:34 [utils.py:95] model redirect: [ microsoft/Florence-2-base ] -> [ /data/LLM-model/Florence-2-base ]
INFO 04-06 14:05:34 [utils.py:95] model redirect: [ facebook/bart-base ] -> [ /data/LLM-model/bart-base ]
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
