### PR TITLE
fix: an error found by mypy check

### DIFF
--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -379,8 +379,8 @@ class InputBatch:
         if lora_id != 0:
             self.lora_id_to_request_ids[lora_id].discard(req_id)
             if len(self.lora_id_to_request_ids[lora_id]) == 0:
-                self.lora_id_to_request_ids.pop(lora_id)
-                self.lora_id_to_lora_request.pop(lora_id)
+                del self.lora_id_to_request_ids[lora_id]
+                del self.lora_id_to_lora_request[lora_id]
             self.request_lora_mapping[req_index] = 0
 
         self.logit_bias[req_index] = None


### PR DESCRIPTION

This patch fix two errors found by mypy check

./tools/mypy.sh

self.lora_id_to_request_ids
self.lora_id_to_lora_request

are both dict here and for dict there is no method pop

```
v1/worker/gpu_input_batch.py:382: error: No overload variant of "pop" of "dict" matches argument type "ndarray[Any, Any]"  [call-overload]
vllm/v1/worker/gpu_input_batch.py:382: note: Possible overload variants:
vllm/v1/worker/gpu_input_batch.py:382: note:     def pop(self, int, /) -> set[str]
vllm/v1/worker/gpu_input_batch.py:382: note:     def pop(self, int, set[str], /) -> set[str]
vllm/v1/worker/gpu_input_batch.py:382: note:     def [_T] pop(self, int, _T, /) -> set[str] | _T
vllm/v1/worker/gpu_input_batch.py:383: error: No overload variant of "pop" of "dict" matches argument type "ndarray[Any, Any]"  [call-overload]
vllm/v1/worker/gpu_input_batch.py:383: note: Possible overload variants:
vllm/v1/worker/gpu_input_batch.py:383: note:     def pop(self, int, /) -> Any
vllm/v1/worker/gpu_input_batch.py:383: note:     def pop(self, int, Any, /) -> Any
vllm/v1/worker/gpu_input_batch.py:383: note:     def [_T] pop(self, int, _T, /) -> Any | _T
```

and the define as below

![image](https://github.com/user-attachments/assets/d75e39db-6a9b-4269-91e1-4d434a181c42)
