### PR TITLE
[V1][Minor] Optimize get_cached_block

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -67,11 +67,11 @@ class BlockPool:
         Returns:
             The cached block if it exists, or None.
         """
-        if block_hash in self.cached_block_hash_to_block:
-            first_block_id = list(
-                self.cached_block_hash_to_block[block_hash].keys())[0]
-            return self.cached_block_hash_to_block[block_hash][first_block_id]
-        return None
+        cached_blocks = self.cached_block_hash_to_block.get(block_hash)
+        if not cached_blocks:
+            return None
+        first_block_id = list(cached_blocks.keys())[0]
+        return cached_blocks[first_block_id]
 
     def cache_full_blocks(
         self,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -70,7 +70,7 @@ class BlockPool:
         cached_blocks = self.cached_block_hash_to_block.get(block_hash)
         if not cached_blocks:
             return None
-        first_block_id = list(cached_blocks.keys())[0]
+        first_block_id = next(iter(cached_blocks))
         return cached_blocks[first_block_id]
 
     def cache_full_blocks(


### PR DESCRIPTION
Minor optimizations
1. Avoid redundant dictionary lookups `cached_block_hash_to_block[block_hash]`
2. Avoid creating a list by using `next`