### PR TITLE
[Build] Fix version limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Information Analysis",
 ]
-requires-python = ">=3.9,<=3.12"
+requires-python = ">=3.9,<3.13"
 dynamic = [ "version", "dependencies", "optional-dependencies"]
 
 [project.urls]


### PR DESCRIPTION
When install vllm from source with python 3.12.9, the error raised:
```
ERROR: Package 'vllm' requires a different Python: 3.12.9 not in '<=3.12,>=3.9'
```
It's because that 3.12.9 is greater than 3.12. This PR  fix this error

