### PR TITLE
[CI] Set max transformers version for Ultravox model test 

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -329,7 +329,8 @@ _MULTIMODAL_EXAMPLE_MODELS = {
                                                           min_transformers_version="4.49"),  # noqa: E501
     "SkyworkR1VChatModel": _HfExamplesInfo("Skywork/Skywork-R1V-38B"),
     "UltravoxModel": _HfExamplesInfo("fixie-ai/ultravox-v0_5-llama-3_2-1b",  # noqa: E501
-                                     trust_remote_code=True),
+                                     trust_remote_code=True,
+                                     max_transformers_version="4.50"),
     # [Encoder-decoder]
     # Florence-2 uses BartFastTokenizer which can't be loaded from AutoTokenizer
     # Therefore, we borrow the BartTokenizer from the original Bart model


### PR DESCRIPTION
We need to upgrade the transformers version to `4.51.0` so that Llama-4 can work in our nightly after #16113 is merged. However, Ultravox impl on huggingface is currently breaking on `4.51.0` from the standard model test, so this PR sets the max transformers version for this model to unblock other PRs.

I have verified the same test works on `4.50.3`

cc @farzadab - could you maybe take a look and see if the model is still working on the latest transformers version?