### PR TITLE
[V1][Core] Add async kv cache offload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,60 @@ set(VLLM_EXT_SRC
   "csrc/custom_all_reduce.cu"
   "csrc/torch_bindings.cpp")
 
+if(DEFINED ENV{USE_VALKEY})
+  list(APPEND VLLM_EXT_SRC "csrc/valkey.cu")
+  if(DEFINED ENV{VALKEY_SRC_DIR})
+    set(VALKEY_SRC_DIR $ENV{VALKEY_SRC_DIR})
+  endif()
+  
+  if(VALKEY_SRC_DIR)
+    if(NOT IS_ABSOLUTE VALKEY_SRC_DIR)
+      get_filename_component(VALKEY_SRC_DIR "${VALKEY_SRC_DIR}" ABSOLUTE)
+    endif()
+    message(STATUS "The VALKEY_SRC_DIR is set, using ${VALKEY_SRC_DIR} for compilation")
+    FetchContent_Declare(libvalkey SOURCE_DIR ${VALKEY_SRC_DIR})
+    set(libvalkey_SOURCE_DIR ${VALKEY_SRC_DIR})
+  else()
+    FetchContent_Declare(
+      libvalkey
+      GIT_REPOSITORY https://github.com/valkey-io/libvalkey.git
+      GIT_TAG cd282b18164d83fb97b8f70994b11f935bc92f05
+      GIT_PROGRESS TRUE
+      GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(libvalkey)
+  endif()
+
+  message(STATUS "libvalkey is available at ${libvalkey_SOURCE_DIR}")
+  execute_process(
+    COMMAND bash -c "USE_RDMA=1 make -j"
+    WORKING_DIRECTORY ${libvalkey_SOURCE_DIR}
+    RESULT_VARIABLE libvalkey_build_result
+    OUTPUT_VARIABLE libvalkey_build_output
+    OUTPUT_FILE ${libvalkey_SOURCE_DIR}/libvalkey_build.log
+    ERROR_FILE ${libvalkey_SOURCE_DIR}/libvalkey_build.log
+  )
+  if(NOT libvalkey_build_result EQUAL 0)
+    message(FATAL_ERROR "Libvalkey build failed."
+                        " Result: \"${libvalkey_build_result}\"" 
+                        "\nCheck the log for details: "
+                        "${CMAKE_CURRENT_BINARY_DIR}/libvalkey_build.log")
+  else()
+    message(STATUS "Libvalkey build successfully.")
+  endif()
+
+  set(VALKEY_INCLUDE_DIRS ${libvalkey_SOURCE_DIR}/include)
+  set(VALKEY_LIBRARIES_DIRS
+    ${libvalkey_SOURCE_DIR}/lib/libvalkey_rdma.a
+    ${libvalkey_SOURCE_DIR}/lib/libvalkey.a
+    rdmacm
+    ibverbs
+  )
+  
+  message(STATUS "VALKEY_INCLUDE_DIRS is ${VALKEY_INCLUDE_DIRS}")
+  message(STATUS "VALKEY_LIBRARIES_DIRS is ${VALKEY_LIBRARIES_DIRS}")
+endif()
+
 if(VLLM_GPU_LANG STREQUAL "CUDA")
   SET(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -442,6 +442,11 @@ function (define_gpu_extension_target GPU_MOD_NAME)
 
   target_link_libraries(${GPU_MOD_NAME} PRIVATE torch ${GPU_LIBRARIES})
 
+  if(DEFINED ENV{USE_VALKEY})
+    target_include_directories(${GPU_MOD_NAME} PRIVATE ${VALKEY_INCLUDE_DIRS})
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE ${VALKEY_LIBRARIES_DIRS})
+  endif()
+
   # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
   # dependencies that are not necessary and may not be installed.
   if (GPU_LANGUAGE STREQUAL "CUDA")

--- a/csrc/queue.h
+++ b/csrc/queue.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename T>
+class Deque {
+ public:
+  void push(const T& value) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    queue_.push(value);
+    lock.unlock();
+    cond_.notify_one();
+  }
+
+  bool pop(T& value) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cond_.wait(lock, [this]() { return !queue_.empty(); });
+    value = queue_.front();
+    queue_.pop();
+    return true;
+  }
+
+  bool try_pop(T& value) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (queue_.empty()) {
+      return false;
+    }
+    value = queue_.front();
+    queue_.pop();
+    return true;
+  }
+
+  bool empty() const {
+    std::unique_lock<std::mutex> lock(mutex_);
+    return queue_.empty();
+  }
+
+ private:
+  std::queue<T> queue_;
+  mutable std::mutex mutex_;
+  std::condition_variable cond_;
+};

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -2,6 +2,7 @@
 #include "cuda_utils.h"
 #include "ops.h"
 #include "core/registration.h"
+#include "valkey.h"
 
 #include <torch/library.h>
 #include <torch/version.h>
@@ -640,6 +641,33 @@ TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _custom_ar), custom_ar) {
   custom_ar.impl("open_mem_handle", torch::kCPU, &open_mem_handle);
 
   custom_ar.def("free_shared_buffer", &free_shared_buffer);
+}
+
+TORCH_LIBRARY_EXPAND(CONCAT(TORCH_EXTENSION_NAME, _valkey_ops), valkey_ops) {
+  valkey_ops.def(
+      "valkey_connect(str ip, int port, bool enable_rdma, int rank) -> (int)");
+  valkey_ops.impl("valkey_connect", &valkey_connect);
+  valkey_ops.def("valkey_set(int fa, str key, Tensor value) -> ()");
+  valkey_ops.impl("valkey_set", &valkey_set);
+  valkey_ops.def("valkey_get(int fa, str key, Tensor! value) -> ()");
+  valkey_ops.impl("valkey_get", &valkey_get);
+  valkey_ops.def("valkey_delete(int fa, str key) -> ()");
+  valkey_ops.impl("valkey_delete", &valkey_delete);
+  valkey_ops.def("valkey_exist(int fa, str key) -> bool");
+  valkey_ops.impl("valkey_exist", &valkey_exist);
+  valkey_ops.def("valkey_disconnect(int fa) -> ()");
+  valkey_ops.impl("valkey_disconnect", &valkey_disconnect);
+  valkey_ops.def(
+      "swap_in(int fa, str req_id, int[] hashs, int[] blocks) -> ()");
+  valkey_ops.impl("swap_in", &swap_in);
+  valkey_ops.def("swap_out(int fa, int[] blocks, int[] hashs) -> ()");
+  valkey_ops.impl("swap_out", &swap_out);
+  valkey_ops.def("get_loaded_reqs(int fa) -> (str[])");
+  valkey_ops.impl("get_loaded_reqs", &get_loaded_reqs);
+  valkey_ops.def("get_saved_blocks(int fa) -> (int[])");
+  valkey_ops.impl("get_saved_blocks", &get_saved_blocks);
+  valkey_ops.def("reg_mr(int fa, Tensor[] kv_caches) -> ()");
+  valkey_ops.impl("reg_mr", &reg_mr);
 }
 
 REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/csrc/valkey.cu
+++ b/csrc/valkey.cu
@@ -1,0 +1,360 @@
+#include <valkey/valkey.h>
+#include <valkey/rdma.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <torch/all.h>
+#include <string>
+#include <sys/time.h>
+#include <sstream>
+#include <mutex>
+
+#include "valkey.h"
+#include "queue.h"
+
+static std::once_flag rdma_init_flag;
+
+static void assertReply(valkeyContext* context, valkeyReply* reply, int type) {
+  if (reply == NULL) {
+    std::stringstream ss;
+    ss << "NULL reply from server (error: " << context->errstr << ")";
+    throw std::runtime_error(ss.str());
+  }
+
+  if (reply->type != type) {
+    if (reply->type == VALKEY_REPLY_ERROR) {
+      std::stringstream ss;
+      ss << "Server Error: " << reply->str;
+      throw std::runtime_error(ss.str());
+    }
+
+    std::stringstream ss;
+    ss << "Expected reply type " << type << " but got type " << reply->type;
+    throw std::runtime_error(ss.str());
+  }
+}
+
+static void assertReplyAndFree(valkeyContext* context, valkeyReply* reply,
+                               int type) {
+  assertReply(context, reply, type);
+  freeReplyObject(reply);
+}
+
+ValkeyClient::ValkeyClient(std::string ip, int64_t port, bool enable_rdma,
+                           int64_t rank) {
+  this->rank = rank;
+  valkeyOptions options = {0};
+  const char* ip_str = ip.c_str();
+
+  if (enable_rdma) {
+    std::call_once(rdma_init_flag, []() { valkeyInitiateRdma(); });
+    VALKEY_OPTIONS_SET_RDMA(&options, ip_str, port);
+  } else {
+    VALKEY_OPTIONS_SET_TCP(&options, ip_str, port);
+  }
+
+  this->valkey_ctx = valkeyConnectWithOptions(&options);
+  if (!this->valkey_ctx || valkey_ctx->err) {
+    throw std::runtime_error("Failed to connect Valkey Server");
+  }
+
+  this->swap_in_valkey_ctx = valkeyConnectWithOptions(&swap_in_options);
+  if (!this->swap_in_valkey_ctx || swap_in_valkey_ctx->err) {
+    throw std::runtime_error("Failed to connect Valkey Server");
+  }
+
+  this->swap_out_valkey_ctx = valkeyConnectWithOptions(&swap_out_options);
+  if (!this->swap_out_valkey_ctx || swap_out_valkey_ctx->err) {
+    throw std::runtime_error("Failed to connect Valkey Server");
+  }
+
+  std::thread swap_in_kv_cache_thread(
+      [this]() { this->_handle_swap_in_loop(); });
+
+  swap_in_kv_cache_thread.detach();
+
+  std::thread swap_out_kv_cache_thread(
+      [this]() { this->_handle_swap_out_loop(); });
+
+  swap_out_kv_cache_thread.detach();
+}
+
+ValkeyClient::~ValkeyClient() {
+  if (this->valkey_ctx) {
+    valkeyFree(this->valkey_ctx);
+  }
+
+  if (this->swap_in_valkey_ctx) {
+    valkeyFree(this->swap_in_valkey_ctx);
+  }
+
+  if (this->swap_out_valkey_ctx) {
+    valkeyFree(this->swap_out_valkey_ctx);
+  }
+}
+
+void ValkeyClient::set(std::string key, torch::Tensor& value) {
+  torch::Tensor value_cpu;
+  if (value.is_cuda()) {
+    value_cpu = value.to(torch::kCPU);
+  } else {
+    value_cpu = value;
+  }
+
+  int64_t value_len = value_cpu.numel() * value_cpu.element_size();
+  int64_t key_len = key.length();
+  char* value_ptr = static_cast<char*>(value_cpu.data_ptr());
+
+  void* reply = valkeyCommand(this->swap_out_valkey_ctx, "SET %b %b",
+                              key.c_str(), key_len, value_ptr, value_len);
+  valkeyReply* valkey_reply = static_cast<valkeyReply*>(reply);
+  assertReplyAndFree(this->swap_out_valkey_ctx, valkey_reply,
+                     VALKEY_REPLY_STATUS);
+  return;
+}
+
+void ValkeyClient::get(std::string key, torch::Tensor& value) {
+  bool is_gpu = value.is_cuda();
+  torch::Tensor temp_tensor;
+  if (is_gpu) {
+    auto options =
+        torch::TensorOptions().dtype(value.dtype()).device(torch::kCPU);
+    temp_tensor = torch::empty_like(value, options);
+  } else {
+    temp_tensor = value;
+  }
+
+  char* value_ptr = static_cast<char*>(temp_tensor.data_ptr());
+  void* reply = valkeyCommand(this->swap_in_valkey_ctx, "GET %s", key.c_str());
+  valkeyReply* valkey_reply = static_cast<valkeyReply*>(reply);
+  assertReply(this->swap_in_valkey_ctx, valkey_reply, VALKEY_REPLY_STRING);
+  size_t expected_size = temp_tensor.numel() * temp_tensor.element_size();
+  if (valkey_reply->len != expected_size) {
+    freeReplyObject(valkey_reply);
+    throw std::runtime_error("Redis data size does not match tensor size");
+  }
+  memcpy(value_ptr, valkey_reply->str, valkey_reply->len);
+  freeReplyObject(valkey_reply);
+
+  if (is_gpu) {
+    value.copy_(temp_tensor);
+  }
+}
+
+void ValkeyClient::del(std::string key) {
+  void* reply = valkeyCommand(this->valkey_ctx, "DEL %s", key.c_str());
+  valkeyReply* valkey_reply = static_cast<valkeyReply*>(reply);
+  assertReplyAndFree(this->valkey_ctx, valkey_reply, VALKEY_REPLY_INTEGER);
+}
+
+bool ValkeyClient::exist(std::string key) {
+  bool exists = false;
+  void* reply = valkeyCommand(this->valkey_ctx, "EXISTS %s", key.c_str());
+  valkeyReply* valkey_reply = static_cast<valkeyReply*>(reply);
+  assertReply(this->valkey_ctx, valkey_reply, VALKEY_REPLY_INTEGER);
+  if (valkey_reply->integer == 1) {
+    exists = true;
+  }
+
+  freeReplyObject(valkey_reply);
+  return exists;
+}
+
+void ValkeyClient::reg_mr(std::vector<torch::Tensor> kv_caches) {
+  for (const auto& tensor : kv_caches) {
+    this->kv_caches.push_back(tensor);
+  }
+
+  return;
+}
+
+void ValkeyClient::swap_in(std::string& req_id, std::vector<int64_t> hashs,
+                           std::vector<int64_t> blocks) {
+  this->swap_in_queue.push(SwapInfo(req_id, blocks, hashs));
+  return;
+}
+
+void ValkeyClient::swap_out(std::vector<int64_t> blocks,
+                            std::vector<int64_t> hashs) {
+  this->swap_out_queue.push(SwapInfo(blocks, hashs));
+  return;
+}
+
+std::vector<std::string> ValkeyClient::get_loaded_reqs() {
+  std::vector<std::string> reqs;
+
+  this->swap_in_mutex.lock();
+  for (const auto& req : this->loaded_reqs) {
+    reqs.push_back(req);
+  }
+
+  this->loaded_reqs.clear();
+  this->swap_in_mutex.unlock();
+  return reqs;
+}
+
+std::vector<int64_t> ValkeyClient::get_saved_blocks() {
+  std::vector<int64_t> blocks;
+
+  this->swap_out_mutex.lock();
+  for (const auto& req : this->saved_blocks) {
+    blocks.push_back(req);
+  }
+
+  this->saved_blocks.clear();
+  this->swap_out_mutex.unlock();
+  return blocks;
+}
+
+void ValkeyClient::disconnect() {
+  if (this->valkey_ctx) {
+    valkeyFree(this->valkey_ctx);
+  }
+}
+
+void ValkeyClient::_handle_swap_in_loop() {
+  while (true) {
+    while (!this->swap_in_queue.empty()) {
+      SwapInfo element;
+      this->swap_in_queue.pop(element);
+      std::vector<int64_t> hashs = element.hashs;
+      std::vector<int64_t> blocks = element.blocks;
+      std::string req_id = element.req_id;
+
+      const int64_t num_blocks = hashs.size();
+      for (size_t i = 0; i < num_blocks; i++) {
+        int64_t hash = hashs[i];
+        int64_t block = blocks[i];
+
+        for (size_t i = 0; i < this->kv_caches.size(); i++) {
+          auto& layer_kv_cache = this->kv_caches[i];
+          torch::Tensor k_cache = layer_kv_cache[0];
+          torch::Tensor v_cache = layer_kv_cache[1];
+
+          torch::Tensor k_block_cache = k_cache[block];
+          torch::Tensor v_block_cache = v_cache[block];
+
+          std::string kcache_key = std::to_string(hash) + "/rank" +
+                                   std::to_string(this->rank) + "/layer" +
+                                   std::to_string(i) + "/key";
+          std::string vcache_key = std::to_string(hash) + "/rank" +
+                                   std::to_string(this->rank) + "/layer" +
+                                   std::to_string(i) + "/val";
+
+          this->get(kcache_key, k_block_cache);
+          this->get(vcache_key, v_block_cache);
+        }
+      }
+
+      this->swap_in_mutex.lock();
+      this->loaded_reqs.push_back(req_id);
+      this->swap_in_mutex.unlock();
+    }
+  }
+}
+
+void ValkeyClient::_handle_swap_out_loop() {
+  while (true) {
+    while (!this->swap_out_queue.empty()) {
+      SwapInfo element;
+      this->swap_out_queue.pop(element);
+      std::vector<int64_t> hashs = element.hashs;
+      std::vector<int64_t> blocks = element.blocks;
+      std::string req_id = element.req_id;
+      const int64_t num_blocks = hashs.size();
+      for (size_t i = 0; i < num_blocks; i++) {
+        int64_t block = blocks[i];
+        int64_t hash = hashs[i];
+        for (size_t i = 0; i < this->kv_caches.size(); i++) {
+          auto& layer_kv_cache = this->kv_caches[i];
+          torch::Tensor k_cache = layer_kv_cache[0];
+          torch::Tensor v_cache = layer_kv_cache[1];
+
+          torch::Tensor k_block_cache = k_cache[block];
+          torch::Tensor v_block_cache = v_cache[block];
+
+          std::string kcache_key = std::to_string(hash) + "/rank" +
+                                   std::to_string(this->rank) + "/layer" +
+                                   std::to_string(i) + "/key";
+          std::string vcache_key = std::to_string(hash) + "/rank" +
+                                   std::to_string(this->rank) + "/layer" +
+                                   std::to_string(i) + "/val";
+
+          this->set(kcache_key, k_block_cache);
+          this->set(vcache_key, v_block_cache);
+        }
+
+        std::string hash_str = std::to_string(hash);
+        this->set(hash_str, this->flag);
+        this->swap_out_mutex.lock();
+        this->saved_blocks.push_back(block);
+        this->swap_out_mutex.unlock();
+      }
+    }
+  }
+}
+
+fptr_t valkey_connect(std::string ip, int64_t port, bool enable_rdma,
+                      int64_t rank) {
+  return (fptr_t) new ValkeyClient(ip, port, enable_rdma, rank);
+}
+
+void valkey_set(fptr_t _fa, std::string key, torch::Tensor& val) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  client->set(key, val);
+  return;
+}
+
+void valkey_get(fptr_t _fa, std::string key, torch::Tensor& val) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->get(key, val);
+}
+
+void valkey_delete(fptr_t _fa, std::string key) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->del(key);
+}
+
+bool valkey_exist(fptr_t _fa, std::string key) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->exist(key);
+}
+
+void valkey_disconnect(fptr_t _fa) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->disconnect();
+}
+
+void reg_mr(fptr_t _fa, std::vector<torch::Tensor> kv_caches) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  client->reg_mr(kv_caches);
+}
+
+void swap_in(fptr_t _fa, std::string req_id, std::vector<int64_t> hashs,
+             std::vector<int64_t> blocks) {
+  if (blocks.size() != hashs.size()) {
+    throw std::runtime_error(
+        "swap_out: blocks and hashs must have the same size");
+  }
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  client->swap_in(req_id, hashs, blocks);
+}
+
+void swap_out(fptr_t _fa, std::vector<int64_t> blocks,
+              std::vector<int64_t> hashs) {
+  if (blocks.size() != hashs.size()) {
+    throw std::runtime_error(
+        "swap_out: blocks and hashs must have the same size");
+  }
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  client->swap_out(blocks, hashs);
+}
+
+std::vector<std::string> get_loaded_reqs(fptr_t _fa) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->get_loaded_reqs();
+}
+
+std::vector<int64_t> get_saved_blocks(fptr_t _fa) {
+  ValkeyClient* client = reinterpret_cast<ValkeyClient*>(_fa);
+  return client->get_saved_blocks();
+}

--- a/csrc/valkey.h
+++ b/csrc/valkey.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <torch/all.h>
+#include <string>
+#include <valkey/valkey.h>
+#include <valkey/rdma.h>
+
+#include "queue.h"
+
+using fptr_t = int64_t;
+
+class SwapInfo {
+ public:
+  SwapInfo() {}
+  SwapInfo(std::vector<int64_t> blocks, std::vector<int64_t> hashs)
+      : blocks(blocks), hashs(hashs) {}
+  SwapInfo(std::string req_id, std::vector<int64_t> blocks,
+           std::vector<int64_t> hashs)
+      : req_id(req_id), blocks(blocks), hashs(hashs) {}
+
+  std::string req_id;
+  std::vector<int64_t> blocks;
+  std::vector<int64_t> hashs;
+};
+
+class ValkeyClient {
+ public:
+  ValkeyClient(std::string ip, int64_t port, bool enable_rdma, int64_t rank);
+  ~ValkeyClient();
+
+  void set(std::string key, torch::Tensor& value);
+  void get(std::string key, torch::Tensor& value);
+  void del(std::string key);
+  bool exist(std::string key);
+  void reg_mr(std::vector<torch::Tensor> kv_caches);
+  void swap_in(std::string& req_id, std::vector<int64_t> hashs,
+               std::vector<int64_t> blocks);
+  void swap_out(std::vector<int64_t> blocks, std::vector<int64_t> hashs);
+  std::vector<std::string> get_loaded_reqs();
+  std::vector<int64_t> get_saved_blocks();
+  void disconnect();
+
+ private:
+  int64_t rank;
+  valkeyContext* valkey_ctx;
+  torch::Tensor flag = torch::tensor(1);
+  std::vector<torch::Tensor> kv_caches;
+  Deque<SwapInfo> swap_in_queue;
+  Deque<SwapInfo> swap_out_queue;
+  std::mutex swap_in_mutex;
+  std::mutex swap_out_mutex;
+  std::vector<std::string> loaded_reqs;
+  std::vector<int64_t> saved_blocks;
+
+  void _handle_swap_in_loop();
+  void _handle_swap_out_loop();
+};
+
+fptr_t valkey_connect(std::string ip, int64_t port, bool enable_rdma,
+                      int64_t rank);
+void valkey_set(fptr_t _fa, std::string key, torch::Tensor& val);
+void valkey_get(fptr_t _fa, std::string key, torch::Tensor& val);
+void valkey_delete(fptr_t _fa, std::string key);
+bool valkey_exist(fptr_t _fa, std::string key);
+void valkey_disconnect(fptr_t _fa);
+void swap_in(fptr_t _fa, std::string req_id, std::vector<int64_t> hashs,
+             std::vector<int64_t> blocks);
+void swap_out(fptr_t _fa, std::vector<int64_t> blocks,
+              std::vector<int64_t> hashs);
+std::vector<std::string> get_loaded_reqs(fptr_t _fa);
+std::vector<int64_t> get_saved_blocks(fptr_t _fa);
+void reg_mr(fptr_t _fa, std::vector<torch::Tensor> kv_caches);

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1448,3 +1448,35 @@ def flash_mla_with_kvcache(
         num_splits,
     )
     return out, softmax_lse
+
+
+def valkey_connect(
+        ip: str,
+        port: int,
+        enable_rdma: bool = True,
+        rank: int = 0):
+    return torch.ops._C_valkey_ops.valkey_connect(ip, port, enable_rdma, rank)
+
+def valkey_set(client: int, key: str, val: torch.Tensor):
+    torch.ops._C_valkey_ops.valkey_set(client, key, val)
+
+def valkey_get(client: int, key: str, val: torch.Tensor):
+    torch.ops._C_valkey_ops.valkey_get(client, key, val)
+
+def valkey_reg_mr(client: int, tensors: list[torch.Tensor]):
+        torch.ops._C_valkey_ops.reg_mr(client, tensors)
+
+def valkey_exist(client: int, key: str) -> bool:
+        return torch.ops._C_valkey_ops.valkey_exist(client, key)
+
+def valkey_swap_in(client: int, req_id: str, hashs: list[int], blocks: list[int]) -> None:
+        torch.ops._C_valkey_ops.swap_in(client, req_id, hashs, blocks)
+
+def valkey_swap_out(client: int, blocks: list[int], hashs: list[int]) -> None:
+    torch.ops._C_valkey_ops.swap_out(client, blocks, hashs)
+
+def valkey_get_loaded_reqs(client: int):
+    return torch.ops._C_valkey_ops.get_loaded_reqs(client)
+
+def valkey_get_saved_blocks(client: int):
+    return torch.ops._C_valkey_ops.get_saved_blocks(client)

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -9,6 +9,7 @@ from typing import (TYPE_CHECKING, Any, Dict, Generic, List, Optional,
 import torch
 
 from vllm.multimodal import MultiModalPlaceholderMap
+from vllm.v1.core.swapper.base_swapper import SwapperBase
 
 if TYPE_CHECKING:
     from vllm.worker.model_runner_base import (ModelRunnerBase,
@@ -97,6 +98,17 @@ class AttentionBackend(ABC):
     def advance_step(self, model_input: "ModelRunnerInputBase",
                      sampled_token_ids: Optional[torch.Tensor],
                      block_size: int, num_seqs: int, num_queries: int) -> None:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def async_swap_in(swapper: SwapperBase, req_id: str,
+                      block_mapping: dict[int, int]):
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def async_swap_out(swapper: SwapperBase, block_mapping: dict[int, int]):
         raise NotImplementedError
 
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1178,6 +1178,7 @@ class CacheConfig:
         prefix_caching_hash_algo: str = "builtin",
         cpu_offload_gb: float = 0,
         calculate_kv_scales: Optional[bool] = None,
+        kv_cache_swapper: Optional[str] = None,
     ) -> None:
         self.block_size = block_size
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -1190,6 +1191,8 @@ class CacheConfig:
         self.prefix_caching_hash_algo = prefix_caching_hash_algo
         self.cpu_offload_gb = cpu_offload_gb
         self.calculate_kv_scales = calculate_kv_scales
+        self.kv_cache_swapper = kv_cache_swapper
+
         self._verify_args()
         self._verify_cache_dtype()
         self._verify_prefix_caching()
@@ -1216,6 +1219,10 @@ class CacheConfig:
             raise ValueError(
                 "GPU memory utilization must be less than 1.0. Got "
                 f"{self.gpu_memory_utilization}.")
+
+        if self.kv_cache_swapper is not None:
+            if not self.kv_cache_swapper.startswith("redis://"):
+                raise ValueError("'redis' is only supported at present.")
 
     def _verify_cache_dtype(self) -> None:
         if self.cache_dtype == "auto":

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -119,6 +119,7 @@ class EngineArgs:
     enable_expert_parallel: bool = False
     max_parallel_loading_workers: Optional[int] = None
     block_size: Optional[int] = None
+    kv_cache_swapper: Optional[str] = None
     enable_prefix_caching: Optional[bool] = None
     prefix_caching_hash_algo: str = "builtin"
     disable_sliding_window: bool = False
@@ -1012,6 +1013,11 @@ class EngineArgs:
             "Note that even if this is set to False, cascade attention will be "
             "only used when the heuristic tells that it's beneficial.")
 
+        parser.add_argument("--kv-cache-swapper",
+                            type=str,
+                            default=EngineArgs.kv_cache_swapper,
+                            help="Select the swapper for kv cache offloading.")
+
         return parser
 
     @classmethod
@@ -1185,6 +1191,7 @@ class EngineArgs:
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
             cpu_offload_gb=self.cpu_offload_gb,
             calculate_kv_scales=self.calculate_kv_scales,
+            kv_cache_swapper=self.kv_cache_swapper,
         )
 
         # Get the current placement group if Ray is initialized and

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -54,6 +54,7 @@ import yaml
 import zmq
 import zmq.asyncio
 from packaging.version import Version
+from safetensors.torch import load, save
 from torch.library import Library
 from typing_extensions import Never, ParamSpec, TypeIs, assert_never
 
@@ -2579,3 +2580,10 @@ def sha256(input) -> int:
     input_bytes = pickle.dumps(input, protocol=pickle.HIGHEST_PROTOCOL)
     return int.from_bytes(hashlib.sha256(input_bytes).digest(),
                           byteorder="big")
+
+def tensor_to_bytes(t: torch.Tensor) -> bytes:
+    return save({"tensor_bytes": t.cpu().contiguous()})
+
+
+def tensor_from_bytes(b: Union[bytearray, bytes]) -> torch.Tensor:
+    return load(bytes(b))["tensor_bytes"]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -16,6 +16,7 @@ from vllm.platforms import current_platform
 from vllm.utils import cdiv
 from vllm.vllm_flash_attn.fa_utils import (flash_attn_supports_fp8,
                                            get_flash_attn_version)
+from vllm.v1.core.swapper.base_swapper import SwapperBase
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -66,6 +67,13 @@ class FlashAttentionBackend(AttentionBackend):
     @staticmethod
     def use_cascade_attention(*args, **kwargs) -> bool:
         return use_cascade_attention(*args, **kwargs)
+
+    def async_swap_in(swapper: SwapperBase, req_id: str,
+                      block_mapping: dict[int, int]):
+        swapper.swap_in_mha(req_id, block_mapping)
+
+    def async_swap_out(swapper: SwapperBase, block_mapping: dict[int, int]):
+        swapper.swap_out_mha(block_mapping)
 
 
 @dataclass

--- a/vllm/v1/core/base_cache_manager.py
+++ b/vllm/v1/core/base_cache_manager.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.metrics.stats import PrefixCacheStats
+from vllm.v1.request import Request
+from vllm.v1.core.kv_cache_utils import BlockHashType
+
+logger = init_logger(__name__)
+
+
+class BaseKVCacheManager(ABC):
+
+    @property
+    @abstractmethod
+    def usage(self) -> float:
+        raise NotImplementedError
+
+    @abstractmethod
+    def make_prefix_cache_stats(self) -> PrefixCacheStats:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_computed_blocks(self, request: Request) -> tuple[list[KVCacheBlock],
+                                         list[BlockHashType], int]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def allocate_slots(
+        self,
+        request: Request,
+        num_tokens: int,
+        new_computed_blocks: Optional[list[KVCacheBlock]] = None,
+        new_computed_extended_blocks: Optional[list[BlockHashType]] = None,
+        saved_blocks: Optional[set[int]] = None,
+    ) -> Optional[list[KVCacheBlock]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def free(self, request: Request) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset_prefix_cache(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_num_common_prefix_blocks(
+        self,
+        request: Request,
+        num_running_requests: int,
+    ) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def free_block_hashes(self, request: Request) -> None:
+        raise NotImplementedError
+    
+    @abstractmethod
+    def clear_swap_metadata(self) -> None:
+        raise NotImplementedError

--- a/vllm/v1/core/hi_kv_cache_manager.py
+++ b/vllm/v1/core/hi_kv_cache_manager.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+from vllm.logger import init_logger
+from vllm.utils import cdiv
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import (BlockHashType, KVCacheBlock,
+                                         hash_request_tokens)
+from vllm.v1.request import Request
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.core.swapper.base_swapper import get_swapper_class
+
+logger = init_logger(__name__)
+
+
+class HiKVCacheManager(KVCacheManager):
+
+    def __init__(
+            self,
+            kv_cache_config: KVCacheConfig,
+            max_model_len: int,
+            enable_caching: bool = True,
+            caching_hash_algo: str = "builtin",
+            num_preallocate_tokens: int = 64,
+            log_stats: bool = False,
+    ) -> None:
+        super().__init__(kv_cache_config, max_model_len,
+                         enable_caching, caching_hash_algo,
+                         num_preallocate_tokens, log_stats)
+
+        self.meta_manager = get_swapper_class(kv_cache_config.kv_cache_swapper)
+
+        # For scheduler output
+        self.swap_in_req_map: dict[str, dict[int, int]] = {}
+        self.swap_out_map: dict[int, int] = {}
+
+        # Used to track blocks that are currently being swapped out;
+        # these blocks cannot be evicted during this process.
+        self.kv_cache_saving_blocks: dict[int, int] = {}
+
+    def get_computed_blocks(
+        self, request: Request) -> tuple[list[KVCacheBlock],
+                                         list[BlockHashType], int]:
+        if not self.enable_caching:
+            # Prefix caching is disabled.
+            return [], [], 0
+
+        # The block hashes for the request may already be computed
+        # if the scheduler has tried to schedule the request before.
+        block_hashes = self.req_to_block_hashes[request.request_id]
+        if not block_hashes:
+            block_hashes = hash_request_tokens(self.caching_hash_fn,
+                                               self.block_size, request)
+            self.req_to_block_hashes[request.request_id] = block_hashes
+
+        self.prefix_cache_stats.requests += 1
+        if request.sampling_params.prompt_logprobs is None:
+            if len(block_hashes) * self.block_size == request.num_tokens:
+                # When prompt length is divisible by the block size and all
+                # blocks are cached, we need to recompute the last token. This
+                # have to be achieved by re-computing an entire block because
+                # allocate_slots() assumes num_computed_tokens is always a
+                # multiple of the block size. To achieve this, remove the last
+                # block hash from the block_hashes for find_longest_cache_hit
+                # This limitation can potentially be removed in the future to
+                # slightly improve the performance.
+                last_block_hash = block_hashes.pop()
+            else:
+                last_block_hash = None
+
+            computed_blocks, computed_extended_block_hash = (
+                self.specialized_manager.find_longest_cache_hit(block_hashes, self.meta_manager))
+            
+            if last_block_hash is not None:
+                # Add back the last block hash if it was removed.
+                block_hashes.append(last_block_hash)
+
+            self.prefix_cache_stats.queries += len(block_hashes)
+            # TODO(luchangqi) Whether to distinguish hit rates across different storage media
+            self.prefix_cache_stats.hits += len(computed_blocks) + len(
+                computed_extended_block_hash)
+
+            # NOTE(woosuk): Since incomplete blocks are not eligible for
+            # sharing, `num_computed_tokens` is always a multiple of
+            # `block_size`.
+            num_computed_tokens = (
+                len(computed_blocks) +
+                len(computed_extended_block_hash)) * self.block_size
+            return computed_blocks, computed_extended_block_hash, num_computed_tokens
+        else:
+            # Skip cache hits for prompt logprobs
+            return [], [], 0
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_tokens: int,
+        new_computed_blocks: Optional[list[KVCacheBlock]] = None,
+        new_computed_extended_blocks: Optional[list[BlockHashType]] = None,
+        saved_blocks: Optional[set[int]] = None,
+    ) -> Optional[list[KVCacheBlock]]:
+        # remove the saved blocks.
+        if saved_blocks is not None:
+            for block_id in saved_blocks:
+                assert block_id in self.kv_cache_saving_blocks
+                self.kv_cache_saving_blocks[block_id] -= 1
+                assert self.kv_cache_saving_blocks[block_id] >= 0
+                if self.kv_cache_saving_blocks[block_id] == 0:
+                    del self.kv_cache_saving_blocks[block_id]
+            saved_blocks.clear()
+
+        if num_tokens == 0:
+            raise ValueError("num_tokens must be greater than 0")
+
+        new_computed_blocks = new_computed_blocks or []
+        new_computed_extended_blocks = new_computed_extended_blocks or []
+
+        req_blocks = self.req_to_blocks[request.request_id]
+
+        removed_blocks = self.specialized_manager.remove_skipped_blocks(
+            req_blocks, request.num_computed_tokens)
+        self.block_pool.free_blocks(removed_blocks)
+
+        # The number of computed tokens is the number of computed tokens plus
+        # the new prefix caching hits
+        has_computed_blocks = len(new_computed_blocks) + len(
+            new_computed_extended_blocks)
+        has_computed_tokens = request.num_computed_tokens + has_computed_blocks * self.block_size
+        total_tokens = has_computed_tokens + num_tokens
+        num_required_blocks = cdiv(total_tokens, self.block_size)
+        num_new_blocks = (num_required_blocks - len(req_blocks) -
+                          len(new_computed_blocks))
+
+        # If a computed block of a request is an eviction candidate (in the
+        # free queue and ref_cnt == 0), it cannot be counted as a free block
+        # when allocating this request.
+        num_evictable_computed_blocks = sum(1 for blk in new_computed_blocks
+                                            if blk.ref_cnt == 0)
+        if (num_new_blocks > self.block_pool.get_num_free_blocks(
+                len(self.kv_cache_saving_blocks)) -
+                num_evictable_computed_blocks):
+            # Cannot allocate new blocks
+            return None
+
+        # Touch the computed blocks to make sure they won't be evicted.
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not new_computed_blocks, (
+                "Computed blocks should be empty when "
+                "prefix caching is disabled")
+
+        # Append the new computed blocks to the request blocks until now to
+        # avoid the case where the new blocks cannot be allocated.
+        req_blocks.extend(new_computed_blocks)
+
+        # Start to handle new blocks
+
+        if num_new_blocks <= 0:
+            # No new block is needed.
+            new_blocks = []
+        else:
+            # Get new blocks from the free block pool considering
+            # preallocated blocks.
+            num_new_blocks = min(
+                num_new_blocks + self.num_preallocate_blocks,
+                self.block_pool.get_num_free_blocks(
+                    len(self.kv_cache_saving_blocks)),
+                # Should not exceed the maximum number of blocks per request.
+                # This is especially because the block table has the shape
+                # [..., max_num_blocks_per_req].
+                self.max_num_blocks_per_req - len(req_blocks),
+            )
+            assert num_new_blocks > 0
+
+            # Concatenate the computed block IDs and the new block IDs.
+            new_blocks = self.block_pool.get_new_blocks(
+                num_new_blocks, self.kv_cache_saving_blocks)
+            req_blocks.extend(new_blocks)
+
+        if not self.enable_caching:
+            return new_blocks
+
+        # Swap in the cpu blocks. Metadata update happens in
+        # cache_full_blocks below.
+        assert (len(new_computed_extended_blocks) < len(new_blocks)
+                if new_computed_blocks else True)
+
+        # Use `new_computed_blocks` for a new request, and `num_cached_block`
+        # for a running request.
+        num_cached_blocks = self.num_cached_block.get(request.request_id,
+                                                      len(new_computed_blocks))
+        # Speculated tokens might be rejected in the future, so we does
+        # not cache any speculated tokens. We only cache blocks with
+        # generated (accepted) tokens.
+        num_full_blocks_after_append = (
+            total_tokens - len(request.spec_token_ids)) // self.block_size
+
+        new_cached_blk_list = self.block_pool.cache_full_blocks(
+            request=request,
+            blocks=req_blocks,
+            block_hashes=self.req_to_block_hashes[request.request_id],
+            num_cached_blocks=num_cached_blocks,
+            num_full_blocks=num_full_blocks_after_append,
+            block_size=self.block_size,
+            hash_fn=self.caching_hash_fn,
+        )
+
+        # get scheduler output swap in
+        if len(new_computed_extended_blocks) > 0:
+            block_mapping = ({
+                extended_block.hash_value: new_block.block_id
+                for extended_block, new_block in zip(
+                    new_computed_extended_blocks, new_blocks)
+            })
+
+            self.swap_in_req_map[request.request_id] = block_mapping
+
+        if new_cached_blk_list:
+            for block in new_cached_blk_list:
+                if self.meta_manager.exist(str(block.block_hash.hash_value)):
+                    continue
+
+                self.swap_out_map[
+                    block.
+                    block_id] = block.block_hash.hash_value  # type: ignore[union-attr]
+                if block.block_id not in self.kv_cache_saving_blocks:
+                    self.kv_cache_saving_blocks[block.block_id] = 1
+                else:
+                    self.kv_cache_saving_blocks[block.block_id] += 1
+
+        self.num_cached_block[
+            request.request_id] = num_full_blocks_after_append
+        return new_blocks
+
+    def end_schedule_step(self) -> None:
+        """A callback hook that is called when a scheduling step ends."""
+        self.swap_in_req_map.clear()
+        self.swap_out_map.clear()
+
+    def clear_swap_metadata(self) -> None:
+        self.swap_in_req_map.clear()
+        self.swap_out_map.clear()

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -594,6 +594,7 @@ def _get_kv_cache_config_uniform_type(vllm_config: VllmConfig,
         },
         kv_cache_groups=create_kv_cache_group_specs(kv_cache_spec,
                                                     grouped_layer_names),
+        kv_cache_swapper=vllm_config.cache_config.kv_cache_swapper,
     )
     return kv_cache_config
 

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
     from vllm.sampling_params import SamplingParams
     from vllm.v1.request import Request
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
 
 @dataclass
@@ -121,3 +122,20 @@ class SchedulerOutput:
     structured_output_request_ids: dict[str, int]
     # the bitmask for the whole batch
     grammar_bitmask: Optional[npt.NDArray[np.int32]]
+
+    # During swap-in, the swap operation should be performed on
+    # a per-req basis. When all blocks of a req have been successfully
+    # swapped in, then the request is ready to be scheduled.
+    swap_in_blocks: Optional[dict[str, dict[int, int]]] = None
+    swap_out_blocks: Optional[dict[int, int]] = None
+
+
+@dataclass
+class LoadingReqInfo:
+    """ Information of the first scheduling of the loading request. """
+    computed_blocks: list[KVCacheBlock]
+    new_blocks:  list[KVCacheBlock]
+    num_new_tokens: int
+    num_computed_tokens: int
+    encoder_inputs_to_schedule: list[int]
+    new_encoder_budget: int

--- a/vllm/v1/core/swapper/base_swapper.py
+++ b/vllm/v1/core/swapper/base_swapper.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+
+
+def get_swapper_class(uri: str,
+                      use_mla: bool = False,
+                      local_rank: Optional[int] = 0):
+    if uri.startswith("redis"):
+        from vllm.v1.core.swapper.redis import RedisSwapper
+        return RedisSwapper(uri, use_mla, local_rank)
+    elif uri.startswith("valkey"):
+        from vllm.v1.core.swapper.valkey import ValkeySwapper
+        return ValkeySwapper(uri, use_mla, local_rank)
+    else:
+        raise RuntimeError("only support redis swapper.")
+
+
+def get_kv_cache_key(hash_id: int, rank_id: int, layer_id: int, key_type: str):
+    return str(hash_id) + "/rank" + str(rank_id) + "/layer" + str(
+        layer_id) + "/" + key_type
+
+
+class SwapperBase(ABC):
+
+    @abstractmethod
+    def swap_in_mha(self, req_id: str, block_mapping: dict[int, int]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def swap_out_mha(self, block_mapping: dict[int, int]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def exist(self, key: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def reg_mr(self, tensors: list[torch.Tensor]):
+        raise NotImplementedError
+
+    def dreg_mr(self, tensors: list[torch.Tensor]):
+        pass
+
+    @abstractmethod
+    def get_loaded_reqs(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_saved_blocks(self):
+        raise NotImplementedError

--- a/vllm/v1/core/swapper/redis.py
+++ b/vllm/v1/core/swapper/redis.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import queue
+import threading
+from typing import Optional
+from urllib.parse import urlparse
+
+import torch
+
+from vllm.utils import tensor_from_bytes, tensor_to_bytes
+from vllm.v1.core.swapper.base_swapper import SwapperBase, get_kv_cache_key
+
+
+class RedisSwapper(SwapperBase):
+
+    def __init__(self,
+                 url: str,
+                 use_mla: bool = False,
+                 rank: Optional[int] = 0):
+        import redis
+
+        parsed_url = urlparse(url)
+        self.swapper = redis.Redis(host=parsed_url.hostname,
+                                   port=parsed_url.port)
+        self.rank = rank
+        self.device = f"cuda:{self.rank}"
+        self.use_mla = use_mla
+        if self.use_mla:
+            raise RuntimeError("mla kv cache offload not support at present.")
+
+        self.swap_in_queue: queue.Queue[tuple[str, dict[int,
+                                                        int]]] = queue.Queue()
+        self.swap_out_queue: queue.Queue[dict[int, int]] = queue.Queue()
+
+        self.loaded_reqs: list[str] = []
+        self.saved_blocks: list[str] = []
+
+        self.kv_caches: Optional[list[torch.Tensor]] = None
+
+        threading.Thread(target=self._swap_in_mha_loop).start()
+        threading.Thread(target=self._swap_out_mha_loop).start()
+
+    def reg_mr(self, tensors: list[torch.Tensor]):
+        self.kv_caches = tensors
+
+    def swap_in_mha(self, req_id: str, block_mapping: dict[int, int]) -> None:
+        assert self.kv_caches is not None, "please reg_mr first."
+        self.swap_in_queue.put_nowait((req_id, block_mapping))
+
+    def swap_out_mha(self, block_mapping: dict[int, int]) -> None:
+        assert self.kv_caches is not None, "please reg_mr first."
+        self.swap_out_queue.put_nowait(block_mapping)
+
+    def exist(self, key: str) -> bool:
+        return self.swapper.exists(key) == 1
+
+    def _swap_in_mha_loop(self):
+        while True:
+            req_id, block_mapping = self.swap_in_queue.get()
+            for hash, block_id in block_mapping.items():
+                for i in range(len(self.kv_caches)):
+                    layer_cache = self.kv_caches[i]
+                    key_cache = layer_cache[0]
+                    val_cache = layer_cache[1]
+
+                    key_cache_key = get_kv_cache_key(
+                        hash, self.rank, i, "key")  # type: ignore[arg-type]
+                    val_cache_key = get_kv_cache_key(
+                        hash, self.rank, i, "val")  # type: ignore[arg-type]
+
+                    key_cache_bytes = self.swapper.get(key_cache_key)
+                    val_cache_bytes = self.swapper.get(val_cache_key)
+
+                    gpu_key_cache = tensor_from_bytes(key_cache_bytes).to(
+                        self.device)
+                    gpu_val_cache = tensor_from_bytes(val_cache_bytes).to(
+                        self.device)
+
+                    key_cache[block_id] = gpu_key_cache
+                    val_cache[block_id] = gpu_val_cache
+
+            self.loaded_reqs.append(req_id)
+
+    def _swap_out_mha_loop(self):
+        while True:
+            block_mapping = self.swap_out_queue.get()
+            for block_id, hash in block_mapping.items():
+                for i in range(len(self.kv_caches)):
+                    layer_cache = self.kv_caches[i]
+                    key_cache = layer_cache[0]
+                    val_cache = layer_cache[1]
+
+                    block_key_cache = key_cache[block_id]
+                    block_val_cache = val_cache[block_id]
+
+                    key_cache_key = get_kv_cache_key(
+                        hash, self.rank, i, "key")  # type: ignore[arg-type]
+                    val_cache_key = get_kv_cache_key(
+                        hash, self.rank, i, "val")  # type: ignore[arg-type]
+
+                    block_key_cache_bytes = tensor_to_bytes(block_key_cache)
+                    block_val_cache_bytes = tensor_to_bytes(block_val_cache)
+
+                    self.swapper.set(key_cache_key, block_key_cache_bytes)
+                    self.swapper.set(val_cache_key, block_val_cache_bytes)
+
+                self.swapper.set(str(hash), 1)
+                self.saved_blocks.append(str(block_id))
+
+    def get_loaded_reqs(self):
+        res = copy.deepcopy(self.loaded_reqs)
+        self.loaded_reqs.clear()
+        return res
+
+    def get_saved_blocks(self):
+        res = copy.deepcopy(self.saved_blocks)
+        self.saved_blocks.clear()
+        return res

--- a/vllm/v1/core/swapper/valkey.py
+++ b/vllm/v1/core/swapper/valkey.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+from urllib.parse import urlparse
+
+from vllm.v1.core.swapper.base_swapper import SwapperBase
+import vllm._custom_ops as ops 
+
+import torch
+
+class ValkeySwapper(SwapperBase):
+
+    def __init__(self,
+                 url: str,
+                 use_mla: bool = False,
+                 rank: Optional[int] = 0):
+        parsed_url = urlparse(url)
+        self.swapper = ops.valkey_connect(parsed_url.hostname,
+                                   parsed_url.port, rank=rank)
+        self.rank = rank
+        self.device = f"cuda:{self.rank}"
+        self.use_mla = use_mla
+        if self.use_mla:
+            raise RuntimeError("mla kv cache offload not support at present.")
+
+    def reg_mr(self, tensors: list[torch.Tensor]):
+        ops.valkey_reg_mr(self.swapper, tensors)
+
+    def swap_in_mha(self, req_id: str, block_mapping: dict[int, int]) -> None:
+        hashs = []
+        blocks = []
+        for hash, block in block_mapping.items():
+            hashs.append(hash)
+            blocks.append(block)
+
+        ops.valkey_swap_in(self.swapper, req_id, hashs, blocks)
+
+    def swap_out_mha(self, block_mapping: dict[int, int]) -> None:
+        hashs = []
+        blocks = []
+        for block, hash in block_mapping.items():
+            hashs.append(hash)
+            blocks.append(block)
+
+        ops.valkey_swap_out(self.swapper, blocks, hashs)
+
+    def exist(self, key: str) -> bool:
+        return ops.valkey_exist(key)
+
+    def get_loaded_reqs(self):
+        return ops.get_loaded_reqs()
+
+    def get_saved_blocks(self):
+        return ops.get_saved_blocks()

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -78,6 +78,18 @@ class Executor(ExecutorBase):
                                      args=(scheduler_output, ))
         return output[0]
 
+    def async_swap_in(self, block_mapping: dict[str, dict[int, int]]):
+        return self.collective_rpc("async_swap_in", args=(block_mapping, ))
+
+    def async_swap_out(self, block_mapping: dict[int, int]):
+        return self.collective_rpc("async_swap_out", args=(block_mapping, ))
+
+    def get_kv_cache_loaded_reqs(self):
+        return self.collective_rpc("get_kv_cache_loaded_reqs")
+
+    def get_kv_cache_saved_blocks(self):
+        return self.collective_rpc("get_kv_cache_saved_blocks")
+
     @property
     def max_concurrent_batches(self) -> int:
         return 1

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -164,3 +164,7 @@ class KVCacheConfig:
     there are 3 groups, each of which represents 10 layers in the model.
     """
     kv_cache_groups: list[KVCacheGroupSpec]
+    """
+    The kv cache offloading swapper.
+    """
+    kv_cache_swapper: str

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -118,7 +118,7 @@ class Worker(WorkerBase):
 
         # Construct the model runner
         self.model_runner: GPUModelRunner = GPUModelRunner(
-            self.vllm_config, self.device)
+            self.vllm_config, self.device, self.local_rank)
 
     # FIXME(youkaichao & ywang96): Use TorchDispatchMode instead of memory pool
     # to hijack tensor allocation.
@@ -241,6 +241,18 @@ class Worker(WorkerBase):
     ) -> Optional[ModelRunnerOutput]:
         output = self.model_runner.execute_model(scheduler_output)
         return output if self.is_driver_worker else None
+
+    def async_swap_in(self, block_mapping: dict[str, dict[int, int]]):
+        return self.model_runner.async_swap_in(block_mapping)
+
+    def async_swap_out(self, block_mapping: dict[int, int]):
+        return self.model_runner.async_swap_out(block_mapping)
+
+    def get_kv_cache_loaded_reqs(self):
+        return self.model_runner.get_kv_cache_loaded_reqs()
+
+    def get_kv_cache_saved_blocks(self):
+        return self.model_runner.get_kv_cache_saved_blocks()
 
     def profile(self, is_start: bool = True):
         if self.profiler is None:


### PR DESCRIPTION
### TL, DR
In V1, we've already implemented storing the KV cache in CPU memory(https://github.com/vllm-project/vllm/pull/13377). However, when multiple vLLM nodes are involved, the router needs to forward requests based on cache awareness. If one node has too many active requests, requests that should have hit the cache might get forwarded to other nodes for recomputation. To avoid this, we can pool the CPU memory across nodes. But performing cross-node KV cache swap-in and swap-out operations can hurt inference performance. Inspired by NVIDIA's open-source project Dynamo (https://github.com/ai-dynamo/dynamo), an asynchronous KV cache transmission scheme has been implemented. In our tests, the performance of asynchronous KV cache transfer is on par with or even better than storing the cache locally in CPU(https://github.com/vllm-project/vllm/pull/13377).

### Swap Strategy
Memory Pool -> GPU:  happens when a block in a certain request hits the cache.
GPU -> Memory Pool: happens when a new block that does not exist in the memory pool is generated.

During swap-in, operations are performed at the granularity of a single request. Once all cache-hit blocks in a request have been swapped in, the request can be scheduled normally for inference. Meanwhile, each newly generated block is immediately swapped out.

### Implementation
1.  Replace the previous step method with async_step. In this method, first retrieve the swap-in and swap-out requests and blocks, check whether they are completed, and record the completed requests and blocks.
2. Pass the requests that have completed swap-in and the blocks that have been swapped out together to the schedule method. During scheduling, prioritize requests that have finished swap-in, then proceed to schedule requests from the waiting queue. Additionally, collect the requests requiring swap-in and the blocks to be swapped out, and return them via schedule_out.
3. For the requests in schedule_out that require swap-in, send an asynchronous swap-in request to the model runner. Since Python's multithreading cannot fully utilize multi-core advantages, a better approach is to spawn a new thread within each swapper implementation to handle the sending. Here, we simply ​put the request into a queue and return immediately.
4. Perform model inference operations.
5. Swap out the newly generated blocks. This stage also runs asynchronously, handled by the swapper's independent thread.

###  Benchmark
This PR currently only implements Redis and Valkey support, but the observed performance was suboptimal. However, our internal benchmarking shows it achieves comparable (or even superior) performance to the local CPU implementation in vLLM PR #13377. Future iterations could extend support to other open-source distributed storage systems for further optimization.

