### PR TITLE
Support R-KV Cache Compression in vLLM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/rkv_repo"]
+	path = third_party/rkv_repo
+	url = https://github.com/Zefan-Cai/R-KV.git

--- a/test.py
+++ b/test.py
@@ -1,0 +1,44 @@
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+# Configuration
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+TEMPERATURE = 0.8
+TOP_P = 0.95
+MAX_TOKENS = 1000
+
+# Prompts to generate completions for
+prompts = [
+    "Hello, my name is",
+    "How are you",
+    "Good morning",
+    "Every morning Aya goes for a $9$-kilometer-long walk and stops at a coffee shop afterwards. When she walks at a constant speed of $s$ kilometers per hour, the walk takes her 4 hours, including $t$ minutes spent in the coffee shop. When she walks $s+2$ kilometers per hour, the walk takes her 2 hours and 24 minutes, including $t$ minutes spent in the coffee shop. Suppose Aya walks at $s+\\frac{1}{2}$ kilometers per hour. Find the number of minutes the walk takes her, including the $t$ minutes spent in the coffee shop."
+]
+
+# Initialize tokenizer and model
+tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+eos_token_id = tokenizer.eos_token_id
+
+# Set up sampling parameters
+sampling_params = SamplingParams(
+    temperature=TEMPERATURE,
+    top_p=TOP_P,
+    max_tokens=MAX_TOKENS,
+    stop_token_ids=[eos_token_id],
+)
+
+# Initialize the LLM
+llm = LLM(
+    model=MODEL_NAME,
+    enforce_eager=True,
+    enable_prefix_caching=False,
+)
+
+# Generate outputs
+outputs = llm.generate(prompts, sampling_params)
+
+# Print generated results
+for output in outputs:
+    prompt = output.prompt
+    generated_text = output.outputs[0].text
+    print(f"Prompt: {prompt!r}\nGenerated Text: {generated_text!r}\n")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -156,6 +156,8 @@ if TYPE_CHECKING:
     VLLM_USE_TRTLLM_ATTENTION: Optional[str] = None
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: bool = False
     VLLM_USE_FLASHINFER_MOE_MXFP4_BF16: bool = False
+    VLLM_V1_R_KV_BUDGET: int = 64
+    VLLM_V1_R_KV_BUFFER: int = 64
 
 
 def get_default_cache_root():
@@ -1108,6 +1110,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #    never removed from memory until the server terminates.
     "VLLM_ENABLE_RESPONSES_API_STORE":
     lambda: bool(int(os.getenv("VLLM_ENABLE_RESPONSES_API_STORE", "0"))),
+
+    # Sets the total KV size budget (in number of tokens) used during compression.
+    # Lowering this value can reduce memory usage but may increase recomputation overhead.
+    # Applies only to vLLM v1; not supported in vLLM v0.
+    "VLLM_V1_R_KV_BUDGET":
+    lambda: int(os.getenv("VLLM_V1_R_KV_BUDGET", "64")),
+
+    # Controls how many new tokens are generated before triggering KV compression.
+    # A larger value reduces compression frequency, which may improve throughput
+    # at the cost of memory. A smaller value compresses more frequently to save memory.
+    # Applies only to vLLM v1; not supported in vLLM v0.
+    "VLLM_V1_R_KV_BUFFER":
+    lambda: int(os.getenv("VLLM_V1_R_KV_BUFFER", "64")),
 }
 
 # --8<-- [end:env-vars-definition]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -7,6 +7,8 @@ from typing import ClassVar, Optional
 import numpy as np
 import torch
 
+from rkv.modeling import R1KV
+
 from vllm import _custom_ops as ops
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType,
@@ -23,6 +25,7 @@ if is_flash_attn_varlen_func_available():
                                                reshape_and_cache_flash)
 
 from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.envs import VLLM_V1_R_KV_BUDGET, VLLM_V1_R_KV_BUFFER
 from vllm.logger import init_logger
 from vllm.utils import cdiv
 from vllm.v1.attention.backends.utils import (AttentionCGSupport,
@@ -125,6 +128,9 @@ class FlashAttentionMetadata:
     seq_lens: torch.Tensor
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
+    num_reqs: int
+    num_dropped_tokens_list: list[int]
+    occupied_slot_mapping: torch.Tensor
 
     # For cascade attention.
     use_cascade: bool
@@ -221,11 +227,13 @@ class FlashAttentionMetadataBuilder(
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         max_query_len = common_attn_metadata.max_query_len
         max_seq_len = int(common_attn_metadata.seq_lens_cpu.max())
+        total_num_kv_cache_tokens = common_attn_metadata.total_num_kv_cache_tokens
         query_start_loc = common_attn_metadata.query_start_loc
         seq_lens = common_attn_metadata.seq_lens
         seq_lens_cpu = common_attn_metadata.seq_lens_cpu
         block_table_tensor = common_attn_metadata.block_table_tensor
         slot_mapping = common_attn_metadata.slot_mapping
+        occupied_slot_mapping = common_attn_metadata.occupied_slot_mapping
         causal = common_attn_metadata.causal
 
         # the overhead of the aot schedule is not worth it for spec-decode
@@ -331,6 +339,8 @@ class FlashAttentionMetadataBuilder(
             # we only set num_splits when using cuda graphs.
             max_num_splits = self.max_num_splits
 
+        num_dropped_tokens_list = [0] * num_reqs
+
         attn_metadata = FlashAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
             max_query_len=max_query_len,
@@ -347,6 +357,9 @@ class FlashAttentionMetadataBuilder(
             suffix_kv_lens=suffix_kv_lens,
             prefix_scheduler_metadata=prefix_scheduler_metadata,
             max_num_splits=max_num_splits,
+            num_reqs=num_reqs,
+            num_dropped_tokens_list=num_dropped_tokens_list,
+            occupied_slot_mapping=occupied_slot_mapping,
             causal=causal)
         return attn_metadata
 
@@ -410,6 +423,7 @@ class FlashAttentionImpl(AttentionImpl):
             and not flash_attn_supports_fp8():
             raise NotImplementedError(
                 "FlashAttention does not support fp8 kv-cache on this device.")
+        self.kvcompressor = R1KV(budget=VLLM_V1_R_KV_BUDGET)
 
         self.sinks = sinks
         if self.sinks is not None:
@@ -545,6 +559,55 @@ class FlashAttentionImpl(AttentionImpl):
                 num_splits=attn_metadata.max_num_splits,
                 s_aux=self.sinks,
             )
+            seq_starts_ends_indices = torch.concat(
+                (torch.tensor([0], dtype=torch.int32, device=attn_metadata.seq_lens.device),
+                 torch.cumsum(attn_metadata.seq_lens, dim=0) - 1),
+                dim=0
+            )
+            if VLLM_V1_R_KV_BUDGET <= 0 or VLLM_V1_R_KV_BUFFER <= 0:
+                return output
+            for i in range(attn_metadata.num_reqs):
+                if attn_metadata.seq_lens[i].cpu().item() < VLLM_V1_R_KV_BUDGET + VLLM_V1_R_KV_BUFFER:
+                    continue
+                current_key_cache = key_cache.view(-1, key_cache.size(-2), key_cache.size(-1))[
+                    attn_metadata.occupied_slot_mapping[seq_starts_ends_indices[i]:seq_starts_ends_indices[i + 1]], ...
+                ]
+                current_value_cache = value_cache.view(-1, value_cache.size(-2), value_cache.size(-1))[
+                    attn_metadata.occupied_slot_mapping[seq_starts_ends_indices[i]:seq_starts_ends_indices[i + 1]], ...
+                ]
+
+                # [num_heads, num_tokens, head_dim]
+                current_query = query.transpose(0, 1)
+                current_key_cache = current_key_cache.transpose(0, 1)
+                current_value_cache = current_value_cache.transpose(0, 1)
+
+                # [batch_size, num_heads, num_tokens, head_dim]
+                current_query = current_query.unsqueeze(0)
+                current_key_cache = current_key_cache.unsqueeze(0)
+                current_value_cache = current_value_cache.unsqueeze(0)
+
+                current_kv_len = current_key_cache.size(2)
+                compressed_key_cache, compressed_value_cache = self.kvcompressor.update_kv(
+                    current_key_cache,
+                    current_query,
+                    current_value_cache,
+                )
+                compressed_key_cache = compressed_key_cache.squeeze(0)
+                compressed_value_cache = compressed_value_cache.squeeze(0)
+
+                # overwrite key_cache and value_cache
+                compressed_kv_len = compressed_key_cache.size(1)
+                key_cache.view(-1, key_cache.size(-2), key_cache.size(-1))[
+                    attn_metadata.occupied_slot_mapping[seq_starts_ends_indices[i]:seq_starts_ends_indices[i]+compressed_kv_len], ...
+                ] = compressed_key_cache.transpose(0, 1)
+                value_cache.view(-1, value_cache.size(-2), value_cache.size(-1))[
+                    attn_metadata.occupied_slot_mapping[seq_starts_ends_indices[i]:seq_starts_ends_indices[i]+compressed_kv_len], ...
+                ] = compressed_value_cache.transpose(0, 1)
+
+                num_dropped_tokens_i = current_kv_len - compressed_kv_len
+                if num_dropped_tokens_i != attn_metadata.num_dropped_tokens_list[i]:
+                    assert attn_metadata.num_dropped_tokens_list[i] == 0
+                    attn_metadata.num_dropped_tokens_list[i] = num_dropped_tokens_i
             return output
 
         # Cascade attention (rare case).

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -58,9 +58,12 @@ class CommonAttentionMetadata:
     """Total number of tokens in batch"""
     max_query_len: int
     """Longest query in batch"""
+    total_num_kv_cache_tokens: int
+    """Total number of kv cache tokens in batch"""
 
     block_table_tensor: torch.Tensor
     slot_mapping: torch.Tensor
+    occupied_slot_mapping: torch.Tensor
 
     causal: bool = True
 

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -93,6 +93,7 @@ class CachedRequestData:
     new_token_ids: list[list[int]]
     new_block_ids: list[tuple[list[int], ...]]
     num_computed_tokens: list[int]
+    num_dropped_tokens_list: list[int]
 
     @property
     def num_reqs(self) -> int:
@@ -106,6 +107,7 @@ class CachedRequestData:
             new_token_ids=[],
             new_block_ids=[],
             num_computed_tokens=[],
+            num_dropped_tokens_list=[],
         )
 
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -15,6 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.factory import (
     KVConnectorFactory)
 from vllm.distributed.kv_transfer.kv_connector.v1 import (KVConnectorBase_V1,
                                                           KVConnectorRole)
+from vllm.envs import VLLM_V1_R_KV_BUFFER
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
@@ -626,6 +627,7 @@ class Scheduler(SchedulerInterface):
         new_token_ids: list[list[int]] = []
         new_block_ids: list[tuple[list[int], ...]] = []
         num_computed_tokens: list[int] = []
+        num_dropped_tokens_list: list[int] = []
 
         use_connector = self.connector is not None
         for req in itertools.chain(running_reqs, resumed_reqs):
@@ -649,6 +651,7 @@ class Scheduler(SchedulerInterface):
                 new_token_ids.append([])
             new_block_ids.append(req_to_new_block_ids[req_id])
             num_computed_tokens.append(req.num_computed_tokens)
+            num_dropped_tokens_list.append(req.num_dropped_tokens)
         # Because resumed_reqs is usually empty, it is more efficient to do
         # in-place appending so that we don't need to allocate a new list.
         resumed_from_preemption = [False] * len(running_reqs)
@@ -660,6 +663,7 @@ class Scheduler(SchedulerInterface):
             new_token_ids=new_token_ids,
             new_block_ids=new_block_ids,
             num_computed_tokens=num_computed_tokens,
+            num_dropped_tokens_list=num_dropped_tokens_list,
         )
 
     def _try_schedule_encoder_inputs(
@@ -757,6 +761,7 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output
         num_nans_in_logits = model_runner_output.num_nans_in_logits
+        num_dropped_tokens_list = model_runner_output.num_dropped_tokens_list
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
         spec_decoding_stats: Optional[SpecDecodingStats] = None
@@ -778,6 +783,7 @@ class Scheduler(SchedulerInterface):
             req_index = model_runner_output.req_id_to_index[req_id]
             generated_token_ids = sampled_token_ids[
                 req_index] if sampled_token_ids else []
+            request.num_dropped_tokens += num_dropped_tokens_list[req_index]
 
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id))

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -111,6 +111,9 @@ class ModelRunnerOutput:
     # [num_reqs, hidden_size]
     pooler_output: list[Optional[torch.Tensor]]
 
+    # the number of tokens dropped due to kv cache compression for every request
+    num_dropped_tokens_list: list[int]
+
     kv_connector_output: Optional[KVConnectorOutput] = None
 
     # req_id -> num_nans_in_logits
@@ -124,4 +127,5 @@ EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(req_ids=[],
                                               logprobs=None,
                                               prompt_logprobs_dict={},
                                               pooler_output=[],
+                                              num_dropped_tokens_list=[],
                                               num_nans_in_logits=None)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -81,6 +81,7 @@ class Request:
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
         self.cache_salt: Optional[str] = cache_salt
+        self.num_dropped_tokens = 0
 
         # Multi-modal related
         self.mm_positions = multi_modal_placeholders or []

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -104,6 +104,14 @@ class InputBatch:
         )
         self.num_computed_tokens_cpu = \
             self.num_computed_tokens_cpu_tensor.numpy()
+        self.num_dropped_tokens_list_cpu_tensor = torch.zeros(
+             (max_num_reqs, ),
+             device="cpu",
+             dtype=torch.int32,
+             pin_memory=pin_memory,
+         )
+        self.num_dropped_tokens_list_cpu = \
+            self.num_dropped_tokens_list_cpu_tensor.numpy()
 
         # Block table.
         self.block_table = MultiGroupBlockTable(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -296,11 +296,16 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                                          dtype=torch.int32,
                                          device="cpu",
                                          pin_memory=self.pin_memory)
-        self.positions_cpu = torch.zeros(self.max_num_tokens,
+        self.logical_positions_cpu = torch.zeros(self.max_num_tokens,
                                          dtype=torch.int64,
                                          device="cpu",
                                          pin_memory=self.pin_memory)
-        self.positions_np = self.positions_cpu.numpy()
+        self.logical_positions_np = self.logical_positions_cpu.numpy()
+        self.physical_positions_cpu = torch.zeros(self.max_num_tokens,
+                                         dtype=torch.int64,
+                                         device="cpu",
+                                         pin_memory=self.pin_memory)
+        self.physical_positions_np = self.physical_positions_cpu.numpy()
         self.query_start_loc_cpu = torch.zeros(self.max_num_reqs + 1,
                                                dtype=torch.int32,
                                                device="cpu",
@@ -498,6 +503,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             num_computed_tokens = req_data.num_computed_tokens[i]
             new_block_ids = req_data.new_block_ids[i]
             resumed_from_preemption = req_data.resumed_from_preemption[i]
+            num_dropped_tokens = req_data.num_dropped_tokens_list[i]
 
             # Update the cached states.
             req_state.num_computed_tokens = num_computed_tokens
@@ -540,6 +546,8 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # Update the persistent batch.
             self.input_batch.num_computed_tokens_cpu[req_index] = (
                 num_computed_tokens)
+            self.input_batch.num_dropped_tokens_list_cpu[req_index] = (
+                num_dropped_tokens)
             self.input_batch.block_table.append_row(new_block_ids, req_index)
 
             # For the last rank, we don't need to update the token_ids_cpu
@@ -656,21 +664,35 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_scheduled_tokens = np.array(tokens, dtype=np.int32)
         max_num_scheduled_tokens = max(tokens)
 
+        num_kv_cache_tokens = (
+            self.input_batch.num_computed_tokens_cpu
+            - self.input_batch.num_dropped_tokens_list_cpu
+        )[:num_reqs]
+        total_num_kv_cache_tokens = num_kv_cache_tokens.sum()
+
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
         req_indices = np.repeat(self.arange_np[:num_reqs],
                                 num_scheduled_tokens)
+        occupied_indices = np.repeat(self.arange_np[:num_reqs],
+                                num_kv_cache_tokens)
 
         # cu_num_tokens: [2, 5, 3] -> [2, 7, 10]
         # arange: [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         cu_num_tokens, arange = self._get_cumsum_and_arange(
             num_scheduled_tokens)
+        _, occupied_positions_np = self._get_cumsum_and_arange(
+            num_kv_cache_tokens)
 
-        # Get positions.
-        positions_np = self.positions_np[:total_num_scheduled_tokens]
+        # Get request positions.
+        logical_positions_np = self.logical_positions_np[:total_num_scheduled_tokens]
         np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
                arange,
-               out=positions_np)
+               out=logical_positions_np)
+        physical_positions_np = self.physical_positions_np[:total_num_scheduled_tokens]
+        np.add(num_kv_cache_tokens[req_indices],
+               arange,
+               out=physical_positions_np)
 
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -681,7 +703,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        token_indices = (positions_np +
+        token_indices = (logical_positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 
         # NOTE(woosuk): We use torch.index_select instead of np.take here
@@ -693,16 +715,18 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                            out=self.input_ids_cpu[:total_num_scheduled_tokens])
 
         self.input_batch.block_table.compute_slot_mapping(
-            req_indices, positions_np)
+            req_indices, physical_positions_np, False)
+        self.input_batch.block_table.compute_slot_mapping(
+            occupied_indices, occupied_positions_np, True)
         self.input_batch.block_table.commit_slot_mapping(
-            total_num_scheduled_tokens)
+            total_num_scheduled_tokens, total_num_kv_cache_tokens)
 
         # Prepare the attention metadata.
         self.query_start_loc_np[0] = 0
         self.query_start_loc_np[1:num_reqs + 1] = cu_num_tokens
 
         self.seq_lens_np[:num_reqs] = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
+            num_kv_cache_tokens +
             num_scheduled_tokens)
 
         # Copy the tensors to the GPU.
@@ -716,7 +740,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             # Common case (1D positions)
             self.positions[:total_num_scheduled_tokens].copy_(
-                self.positions_cpu[:total_num_scheduled_tokens],
+                self.logical_positions_cpu[:total_num_scheduled_tokens],
                 non_blocking=True)
 
         self.query_start_loc[:num_reqs + 1].copy_(
@@ -808,10 +832,12 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             blk_table = self.input_batch.block_table[kv_cache_group_id]
             blk_table_tensor = blk_table.get_device_tensor()[:num_reqs]
             slot_mapping = blk_table.slot_mapping[:total_num_scheduled_tokens]
+            occupied_slot_mapping = blk_table.occupied_slot_mapping[:total_num_kv_cache_tokens]
 
             # Fill unused with -1. Needed for reshape_and_cache in full cuda
             # graph mode.
             blk_table.slot_mapping[total_num_scheduled_tokens:].fill_(-1)
+            blk_table.occupied_slot_mapping[total_num_kv_cache_tokens:].fill_(-1)
 
             common_attn_metadata = CommonAttentionMetadata(
                 query_start_loc=self.query_start_loc[:num_reqs + 1],
@@ -823,8 +849,10 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 num_reqs=num_reqs,
                 num_actual_tokens=total_num_scheduled_tokens,
                 max_query_len=max_num_scheduled_tokens,
+                total_num_kv_cache_tokens=total_num_kv_cache_tokens,
                 block_table_tensor=blk_table_tensor,
                 slot_mapping=slot_mapping,
+                occupied_slot_mapping=occupied_slot_mapping,
                 causal=True,
             )
 
@@ -1724,6 +1752,7 @@ class GPUModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             prompt_logprobs_dict=prompt_logprobs_dict,
             pooler_output=[],
             kv_connector_output=kv_connector_output,
+            num_dropped_tokens_list=next(iter(attn_metadata.values())).num_dropped_tokens_list,
             num_nans_in_logits=num_nans_in_logits,
         )
 


### PR DESCRIPTION
## Summary

This PR adds support for the [R-KV](https://arxiv.org/abs/2505.24133) cache compression algorithm in the vLLM architecture (v1 only) to reduce memory usage during long chain-of-thought reasoning.

To accelerate inference on long sequences, R-KV compresses the KV cache once the number of stored tokens reaches a threshold defined by `budget + buffer`. It then reduces the cache size back to `budget` and continues inference.

Key design points:

- R-KV overwrites existing KV cache with compressed entries and logically deletes the dropped tokens.

- `num_dropped_tokens_list` tracks how many tokens were removed during compression and is used by the scheduler to maintain correct logical-to-physical KV mapping.

- Logical positions, adjusted after compression, are passed into the self-attention module to ensure correct indexing.

- `occupied_slot_mapping` is passed in to indicate current cache usage, and dropped tokens are passed out after compression.

This integration enables memory-efficient handling of long contexts without disrupting attention semantics.

