### PR TITLE
[VLM] Florence-2 supports online serving

### DIFF
--- a/examples/template_florence2.jinja
+++ b/examples/template_florence2.jinja
@@ -1,0 +1,7 @@
+{%- for message in messages -%}
+    {%- if message['role'] == 'user' -%}
+        {{- message['content'] -}}
+    {%- elif message['role'] == 'assistant' -%}
+        {{- message['content'] -}}
+    {%- endif -%}
+{%- endfor -%}

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -487,8 +487,8 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                 return "<|endoftext10|>"  # 200010 (see vocab.json in hf model)
             if model_type in ("minicpmo", "minicpmv"):
                 return "(<image>./</image>)"
-            if model_type in ("blip-2", "fuyu", "paligemma", "pixtral",
-                              "mistral3"):
+            if model_type in ("blip-2", "florence2", "fuyu", "paligemma",
+                              "pixtral", "mistral3"):
                 # These models do not use image tokens in the prompt
                 return None
             if model_type == "qwen":

--- a/vllm/model_executor/models/florence2.py
+++ b/vllm/model_executor/models/florence2.py
@@ -835,7 +835,7 @@ class Florence2MultiModalProcessor(
         prompt_text = tokenizer.decode(prompt_tokens)
         # convert task tokens to prompt
         prompt_text = hf_processor._construct_prompts([prompt_text])[0]
-        prompt_tokens = tokenizer.encode(prompt_text)
+        prompt_tokens = tokenizer.encode(prompt_text, add_special_tokens=False)
         return prompt_tokens
 
     def _call_hf_processor(

--- a/vllm/model_executor/models/florence2.py
+++ b/vllm/model_executor/models/florence2.py
@@ -10,7 +10,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
-from transformers import BatchFeature, PretrainedConfig
+from transformers import BartTokenizer, BatchFeature, PretrainedConfig
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -825,6 +825,18 @@ class Florence2MultiModalProcessor(
         mm_data: MultiModalDataDict,
     ) -> Union[str, list[int]]:
         return [self.info.get_hf_config().eos_token_id]
+
+    def _apply_hf_processor_tokens_only(
+        self,
+        prompt_tokens: list[int],
+    ) -> list[int]:
+        hf_processor = self.info.get_hf_processor()
+        tokenizer: BartTokenizer = hf_processor.tokenizer
+        prompt_text = tokenizer.decode(prompt_tokens)
+        # convert task tokens to prompt
+        prompt_text = hf_processor._construct_prompts([prompt_text])[0]
+        prompt_tokens = tokenizer.encode(prompt_text)
+        return prompt_tokens
 
     def _call_hf_processor(
         self,


### PR DESCRIPTION
Example command to launch the server:

```
vllm serve microsoft/Florence-2-large --tokenizer facebook/bart-large --trust-remote-code --chat-template examples/template_florence2.jinja
```

Inference:

```
chat_response = client.chat.completions.create(
    model=model,
    messages=[
        {
            "role": "user",
            "content": [
                {
                    "type": "image_url",
                    "image_url": {
                        "url": image_url,
                    },
                },
                {"type": "text", "text": "<DETAILED_CAPTION>"},
            ],
        }
    ],
)
```

FIX #15968

<!--- pyml disable-next-line no-emphasis-as-heading -->
