### PR TITLE
[Kernel] support merge_attn_states CUDA kernel, 3x speedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,7 @@ set(VLLM_EXT_SRC
   "csrc/cache_kernels.cu"
   "csrc/attention/paged_attention_v1.cu"
   "csrc/attention/paged_attention_v2.cu"
+  "csrc/attention/merge_attn_states.cu"
   "csrc/pos_encoding_kernels.cu"
   "csrc/activation_kernels.cu"
   "csrc/layernorm_kernels.cu"

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -116,7 +116,7 @@ __global__ void merge_attn_states_kernel(
   }
 }
 
-#define LAUNCHE_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)       \
+#define LAUNCH_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)        \
   {                                                                        \
     merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
         output.data_ptr<float>(), output_lse_ptr,                          \
@@ -147,18 +147,18 @@ void merge_attn_states(
     dim3 grid(NUM_TOKENS, NUM_HEADS);
     dim3 block(HEAD_SIZE / 4);
     if (output_lse_ptr != nullptr) {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, true);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, true);
     } else {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, false);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, false);
     }
   } else {
     // try loop over num heads for large NUM_TOKENS
     dim3 grid(NUM_TOKENS);
     dim3 block(HEAD_SIZE / 4);
     if (output_lse_ptr != nullptr) {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, true);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, true);
     } else {
-      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, false);
+      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, false);
     }
   }
 }

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -17,6 +17,7 @@ __global__ void merge_attn_states_kernel(
     const float* prefix_lse, const scalar_t* suffix_output,
     const float* suffix_lse, const uint num_tokens, const uint num_heads,
     const uint head_size) {
+  using pack_128b_t = uint4;
   const uint pack_size = 16 / sizeof(scalar_t);
   const uint threads_per_head = head_size / pack_size;
 

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -116,15 +116,29 @@ __global__ void merge_attn_states_kernel(
         num_heads, head_size);                                              \
   }
 
+/*@brief Merges the attention states from prefix and suffix
+ * into the output tensor.
+ *
+ * @param output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The output
+ * tensor to store the merged attention states.
+ * @param output_lse [NUM_HEADS, NUM_TOKENS] Optional tensor to
+ * store the log-sum-exp values.
+ * @param prefix_output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The
+ * prefix attention states.
+ * @param prefix_lse [NUM_HEADS, NUM_TOKENS] The log-sum-exp
+ * values for the prefix attention states.
+ * @param suffix_output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The
+ * suffix attention states.
+ * @param suffix_lse [NUM_HEADS, NUM_TOKENS] The log-sum-exp
+ * values for the suffix attention states.
+ */
 template <typename scalar_t>
-void merge_attn_states_launcher(
-    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
-) {
+void merge_attn_states_launcher(torch::Tensor& output,
+                                std::optional<torch::Tensor> output_lse,
+                                const torch::Tensor& prefix_output,
+                                const torch::Tensor& prefix_lse,
+                                const torch::Tensor& suffix_output,
+                                const torch::Tensor& suffix_lse) {
   constexpr uint NUM_THREADS = 128;
   const uint num_tokens = output.size(0);
   const uint num_heads = output.size(1);

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -11,7 +11,79 @@ namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-template <typename scalar_t, bool kLoopOverHead>
+template <typename scalar_t>
+__device__ __forceinline__ void merge_attn_states_per_thread(
+    scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const scalar_t* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ prefix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const scalar_t* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ suffix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const uint num_tokens,                       // NUM_TOKENS
+    const uint num_heads,                        // NUM QUERY HEADS
+    const uint head_size,  // HEAD_SIZE, 32,48,64,...,512,etc
+    const uint token_idx, const uint head_idx, const uint thr_idx) {
+  using pack_128b_t = uint4;  // float -> 4, half/bf16 -> 8
+  constexpr uint pack_size = 16 / sizeof(scalar_t);
+
+  const uint thr_offset = thr_idx * pack_size;  // (0~15)*8, etc.
+  const uint blk_offset =
+      token_idx * num_heads * head_size + head_idx * head_size;
+  const scalar_t* prefix_output_blk = prefix_output + blk_offset;
+  const scalar_t* suffix_output_blk = suffix_output + blk_offset;
+  scalar_t* output_blk = output + blk_offset;
+
+  float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+  float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+  p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+  s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+
+  const float max_lse = fmaxf(p_lse, s_lse);
+  p_lse = p_lse - max_lse;
+  s_lse = s_lse - max_lse;
+  const float p_se = expf(p_lse);
+  const float s_se = expf(s_lse);
+  const float out_se = p_se + s_se;
+  const float p_scale = p_se / out_se;
+  const float s_scale = s_se / out_se;
+
+  // We only need to write to output_lse once per head.
+  if (output_lse != nullptr && thr_idx == 0) {
+    float out_lse = logf(out_se) + max_lse;
+    output_lse[head_idx * num_tokens + token_idx] = out_lse;
+  }
+
+  if (thr_offset < head_size) {
+    // Pack 128b load
+    pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+        prefix_output_blk)[thr_offset / pack_size];
+    pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+        suffix_output_blk)[thr_offset / pack_size];
+    pack_128b_t o_out_pack;
+
+#pragma unroll
+    for (uint i = 0; i < pack_size; ++i) {
+      // Always use float for FMA to keep precision.
+      // half(uint16_t), bfloat16, float -> float.
+      const float p_out_f =
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+      const float s_out_f =
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+      // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
+      const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+      // float -> half(uint16_t), bfloat16, float.
+      vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+    }
+
+    // Pack 128b storage
+    reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+        o_out_pack;
+  }
+}
+
+template <typename scalar_t, bool kLoopOverHead, bool kFlattenOverHead = false>
 __global__ void merge_attn_states_kernel(
     scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
@@ -25,132 +97,42 @@ __global__ void merge_attn_states_kernel(
     const uint num_heads,                        // NUM QUERY HEADS
     const uint head_size  // HEAD_SIZE, 32,48,64,...,512,etc
 ) {
-  // TODO(DefTruth): May need to support fp8?
   if constexpr (kLoopOverHead) {
-    // May loop over num heads for large NUM_TOKENS
+    // May loop over num heads for large num_tokens
     const uint token_idx = blockIdx.x;
     const uint thread_idx = threadIdx.x;
-    // float -> 4, half/bf16 -> 8
-    using pack_128b_t = uint4;
-    constexpr uint pack_size = 16 / sizeof(scalar_t);
-    const uint thr_offset = thread_idx * pack_size;
 
+    if constexpr (kFlattenOverHead) {
+      // thread num = (num_heads * head_size) / pack_size
+      // = num_heads * (head_size / pack_size), 16 * (128 / 8)
+      // tid: 0~255, 0~15->head 0, 16~31->head 1, ..., etc.
+      constexpr uint pack_size = 16 / sizeof(scalar_t);
+      const uint head_idx = thread_idx / (head_size / pack_size);
+      const uint thr_idx = thread_idx % (head_size / pack_size);
+      merge_attn_states_per_thread<scalar_t>(
+          output, output_lse, prefix_output, prefix_lse, suffix_output,
+          suffix_lse, num_tokens, num_heads, head_size, token_idx, head_idx,
+          thr_idx);
+    } else {
+      const uint thr_idx = thread_idx;
 #pragma unroll
-    for (uint head_idx = 0; head_idx < num_heads; ++head_idx) {
-      const uint blk_offset =
-          token_idx * num_heads * head_size + head_idx * head_size;
-      const scalar_t* prefix_output_blk = prefix_output + blk_offset;
-      const scalar_t* suffix_output_blk = suffix_output + blk_offset;
-      scalar_t* output_blk = output + blk_offset;
-
-      float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
-      float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
-      p_lse =
-          std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
-      s_lse =
-          std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
-
-      const float max_lse = fmaxf(p_lse, s_lse);
-      p_lse = p_lse - max_lse;
-      s_lse = s_lse - max_lse;
-      const float p_se = expf(p_lse);
-      const float s_se = expf(s_lse);
-      const float out_se = p_se + s_se;
-      const float p_scale = p_se / out_se;
-      const float s_scale = s_se / out_se;
-
-      // We only need to write to output_lse once per head.
-      if (output_lse != nullptr && thread_idx == 0) {
-        float out_lse = logf(out_se) + max_lse;
-        output_lse[head_idx * num_tokens + token_idx] = out_lse;
-      }
-
-      if (thr_offset < head_size) {
-        // Pack 128b load
-        pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
-            prefix_output_blk)[thr_offset / pack_size];
-        pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
-            suffix_output_blk)[thr_offset / pack_size];
-        pack_128b_t o_out_pack;
-
-#pragma unroll
-        for (uint i = 0; i < pack_size; ++i) {
-          // Always use float for FMA to keep high precision.
-          // half(uint16_t), bfloat16, float -> float.
-          const float p_out_f =
-              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-          const float s_out_f =
-              vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-          // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
-          const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
-          // float -> half(uint16_t), bfloat16, float.
-          vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i],
-                           o_out_f);
-        }
-        // Pack 128b storage
-        reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
-            o_out_pack;
-      }
-    }  // End loop over heads
+      for (uint head_idx = 0; head_idx < num_heads; ++head_idx) {
+        merge_attn_states_per_thread<scalar_t>(
+            output, output_lse, prefix_output, prefix_lse, suffix_output,
+            suffix_lse, num_tokens, num_heads, head_size, token_idx, head_idx,
+            thr_idx);
+      }  // End kFlattenOverHead
+    }  // End kLoopOverHead
   } else {
     const uint token_idx = blockIdx.x;
     const uint head_idx = blockIdx.y;
     const uint thread_idx = threadIdx.x;
-    // float -> 4, half/bf16 -> 8
-    using pack_128b_t = uint4;  // 16 bytes
-    constexpr uint pack_size = 16 / sizeof(scalar_t);
-    const uint thr_offset = thread_idx * pack_size;
-    const uint blk_offset =
-        token_idx * num_heads * head_size + head_idx * head_size;
-    const scalar_t* prefix_output_blk = prefix_output + blk_offset;
-    const scalar_t* suffix_output_blk = suffix_output + blk_offset;
-    scalar_t* output_blk = output + blk_offset;
+    const uint thr_idx = thread_idx;
 
-    float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
-    float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
-    p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
-    s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
-
-    const float max_lse = fmaxf(p_lse, s_lse);
-    p_lse = p_lse - max_lse;
-    s_lse = s_lse - max_lse;
-    const float p_se = expf(p_lse);
-    const float s_se = expf(s_lse);
-    const float out_se = p_se + s_se;
-    const float p_scale = p_se / out_se;
-    const float s_scale = s_se / out_se;
-
-    // We only need to write to output_lse once per head.
-    if (output_lse != nullptr && thread_idx == 0) {
-      float out_lse = logf(out_se) + max_lse;
-      output_lse[head_idx * num_tokens + token_idx] = out_lse;
-    }
-
-    if (thr_offset < head_size) {
-      // Pack 128b load
-      pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
-          prefix_output_blk)[thr_offset / pack_size];
-      pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
-          suffix_output_blk)[thr_offset / pack_size];
-      pack_128b_t o_out_pack;
-
-#pragma unroll
-      for (uint i = 0; i < pack_size; ++i) {
-        // Always use float for FMA to keep high precision.
-        // half(uint16_t), bfloat16, float -> float.
-        const float p_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
-        const float s_out_f =
-            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
-        // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
-        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
-        // float -> half(uint16_t), bfloat16, float.
-        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
-      }
-      // Pack 128b storage
-      reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
-          o_out_pack;
-    }
+    merge_attn_states_per_thread<scalar_t>(
+        output, output_lse, prefix_output, prefix_lse, suffix_output,
+        suffix_lse, num_tokens, num_heads, head_size, token_idx, head_idx,
+        thr_idx);
   }
 }
 
@@ -172,15 +154,16 @@ __global__ void merge_attn_states_kernel(
     }                                                                   \
   }
 
-#define LAUNCH_MERGE_ATTN_STATES(SCALAR_T, kLoopOverHead)                     \
+#define LAUNCH_MERGE_ATTN_STATES(SCALAR_T, kLoopOverHead, kFlattenOverHead)   \
   {                                                                           \
-    vllm::merge_attn_states_kernel<SCALAR_T, kLoopOverHead><<<grid, block>>>( \
-        reinterpret_cast<SCALAR_T*>(output.data_ptr()), output_lse_ptr,       \
-        reinterpret_cast<SCALAR_T*>(prefix_output.data_ptr()),                \
-        reinterpret_cast<float*>(prefix_lse.data_ptr()),                      \
-        reinterpret_cast<SCALAR_T*>(suffix_output.data_ptr()),                \
-        reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,          \
-        num_heads, head_size);                                                \
+    vllm::merge_attn_states_kernel<SCALAR_T, kLoopOverHead, kFlattenOverHead> \
+        <<<grid, block>>>(                                                    \
+            reinterpret_cast<SCALAR_T*>(output.data_ptr()), output_lse_ptr,   \
+            reinterpret_cast<SCALAR_T*>(prefix_output.data_ptr()),            \
+            reinterpret_cast<float*>(prefix_lse.data_ptr()),                  \
+            reinterpret_cast<SCALAR_T*>(suffix_output.data_ptr()),            \
+            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,      \
+            num_heads, head_size);                                            \
   }
 
 template <typename SCALAR_T>
@@ -205,18 +188,32 @@ void merge_attn_states_launcher(
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();
   }
+  // Keep threads num <= 512 per thread block.
+  const bool skip_flatten_over_head =
+      ((num_heads * head_size) / pack_size > 512);
+
   const bool skip_loop_over_head =
-      (num_tokens <= 1024 || num_heads >= 64 || disable_loop_over_head);
+      (disable_loop_over_head || num_tokens <= 1024 ||
+       (num_heads >= 64 && skip_flatten_over_head));
 
   if (skip_loop_over_head) {
     dim3 grid(num_tokens, num_heads);
     dim3 block(head_size / pack_size);
-    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, false);
+    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, false, false);
   } else {
-    // Try loop over num heads for large num_tokens
-    dim3 grid(num_tokens);
-    dim3 block(head_size / pack_size);
-    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, true);
+    // try loop over num heads for large num_tokens
+    if (skip_flatten_over_head) {
+      dim3 grid(num_tokens);
+      dim3 block(head_size / pack_size);
+      LAUNCH_MERGE_ATTN_STATES(SCALAR_T, true, false);
+    } else {
+      // cases:
+      // num_tokens 8192, num_heads 16, head_size 128
+      // num_tokens 4096, num_heads 16, head_size 128
+      dim3 grid(num_tokens);
+      dim3 block((num_heads * head_size) / pack_size);
+      LAUNCH_MERGE_ATTN_STATES(SCALAR_T, true, true);
+    }
   }
 }
 

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,35 +1,44 @@
 #include <optional>
-#include <cuda_runtime.h>
-#include <cmath>
 #include <torch/all.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <algorithm>
+
+#include "attention_dtypes.h"
+#include "attention_utils.cuh"
+
+namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-// May loop over num heads for large NUM_TOKENS
-template <const bool LOOP_OVER_HEAD, const bool OUTPUT_LSE>
+template <typename scalar_t, vllm::Fp8KVCacheDataType KV_DTYPE,
+          bool LOOP_OVER_HEAD>
 __global__ void merge_attn_states_kernel(
-    float* output,      // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const float* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                              // HEAD_SIZE]
-    const float* __restrict__ prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const float* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                              // HEAD_SIZE]
-    const float* __restrict__ suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const uint NUM_TOKENS,                    // NUM_TOKENS
-    const uint NUM_HEADS,                     // NUM QUERY HEADS
-    const uint HEAD_SIZE                      // HEAD_SIZE, 32,48,64,...,512,etc
+    const scalar_t* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ prefix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const scalar_t* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                                 // HEAD_SIZE]
+    const float* __restrict__ suffix_lse,        // [NUM_HEADS, NUM_TOKENS]
+    const uint num_tokens,                       // NUM_TOKENS
+    const uint num_heads,                        // NUM QUERY HEADS
+    const uint head_size  // HEAD_SIZE, 32,48,64,...,512,etc
 ) {
+  // TODO(DefTruth): may need to support fp8?
+  static_assert(KV_DTYPE == Fp8KVCacheDataType::kAuto,
+                "Currently merge_attn_states_kernel is not support for FP8.");
+
   if constexpr (LOOP_OVER_HEAD) {
+    // May loop over num heads for large NUM_TOKENS
     const uint token_idx = blockIdx.x;
     const uint thread_idx = threadIdx.x;
 
 #pragma unroll
-    for (uint head_idx = 0; head_idx < NUM_HEADS; ++head_idx) {
-      float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
-      float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    for (uint head_idx = 0; head_idx < num_heads; ++head_idx) {
+      float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+      float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
       p_lse =
           std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
       s_lse =
@@ -42,40 +51,60 @@ __global__ void merge_attn_states_kernel(
       const float s_se = expf(s_lse);
       const float out_se = p_se + s_se;
 
-      if constexpr (OUTPUT_LSE) {
-        if (output_lse != nullptr) {
-          float out_lse = logf(out_se) + max_lse;
-          output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
-        }
+      if (output_lse != nullptr) {
+        float out_lse = logf(out_se) + max_lse;
+        output_lse[head_idx * num_tokens + token_idx] = out_lse;
       }
 
       const uint blk_offset =
-          token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
-      const uint thr_offset = thread_idx * 4;
+          token_idx * num_heads * head_size + head_idx * head_size;
+      const scalar_t* prefix_output_blk = prefix_output + blk_offset;
+      const scalar_t* suffix_output_blk = suffix_output + blk_offset;
+      scalar_t* output_blk = output + blk_offset;
+
+      // float -> 4, half/bf16 -> 8
+      using pack_128b_t = uint4;
+      constexpr uint pack_size = 16 / sizeof(scalar_t);
+
+      const uint thr_offset = thread_idx * pack_size;
       const float p_scale = p_se / out_se;
       const float s_scale = s_se / out_se;
-      const float* prefix_output_blk = prefix_output + blk_offset;
-      const float* suffix_output_blk = suffix_output + blk_offset;
-      float* output_blk = output + blk_offset;
 
-      if (thr_offset < HEAD_SIZE) {
-        float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
-        float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+      if (thr_offset < head_size) {
+        // Pack 128b load
+        pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+            prefix_output_blk)[thr_offset / pack_size];
+        pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+            suffix_output_blk)[thr_offset / pack_size];
+        pack_128b_t o_out_pack;
 
-        float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
-                                  p_out4.y * p_scale + s_out4.y * s_scale,
-                                  p_out4.z * p_scale + s_out4.z * s_scale,
-                                  p_out4.w * p_scale + s_out4.w * s_scale);
-        ((float4*)(output_blk))[thr_offset / 4] = out4;
+#pragma unroll
+        for (uint i = 0; i < pack_size; ++i) {
+          // Always use float for FMA to keep precision.
+          // half(uint16_t), bfloat16, float -> float.
+          const float p_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+          const float s_out_f =
+              vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+          // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
+          const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+          // float -> half(uint16_t), bfloat16, float.
+          vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i],
+                           o_out_f);
+        }
+
+        // Pack 128b storage
+        reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+            o_out_pack;
       }
-    }  // end loop over heads
+    }  // End loop over heads
   } else {
     const uint token_idx = blockIdx.x;
     const uint head_idx = blockIdx.y;
     const uint thread_idx = threadIdx.x;
 
-    float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
-    float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+    float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
     p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
     s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
 
@@ -86,43 +115,124 @@ __global__ void merge_attn_states_kernel(
     const float s_se = expf(s_lse);
     const float out_se = p_se + s_se;
 
-    if constexpr (OUTPUT_LSE) {
-      if (output_lse != nullptr) {
-        float out_lse = logf(out_se) + max_lse;
-        output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
-      }
+    if (output_lse != nullptr) {
+      float out_lse = logf(out_se) + max_lse;
+      output_lse[head_idx * num_tokens + token_idx] = out_lse;
     }
 
     const uint blk_offset =
-        token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
-    const uint thr_offset = thread_idx * 4;
+        token_idx * num_heads * head_size + head_idx * head_size;
+    const scalar_t* prefix_output_blk = prefix_output + blk_offset;
+    const scalar_t* suffix_output_blk = suffix_output + blk_offset;
+    scalar_t* output_blk = output + blk_offset;
+
+    // float -> 4, half/bf16 -> 8
+    using pack_128b_t = uint4;  // 16 bytes
+    constexpr uint pack_size = 16 / sizeof(scalar_t);
+
+    const uint thr_offset = thread_idx * pack_size;
     const float p_scale = p_se / out_se;
     const float s_scale = s_se / out_se;
-    const float* prefix_output_blk = prefix_output + blk_offset;
-    const float* suffix_output_blk = suffix_output + blk_offset;
-    float* output_blk = output + blk_offset;
 
-    if (thr_offset < HEAD_SIZE) {
-      float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
-      float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+    if (thr_offset < head_size) {
+      // Pack 128b load
+      pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
+          prefix_output_blk)[thr_offset / pack_size];
+      pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
+          suffix_output_blk)[thr_offset / pack_size];
+      pack_128b_t o_out_pack;
 
-      float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
-                                p_out4.y * p_scale + s_out4.y * s_scale,
-                                p_out4.z * p_scale + s_out4.z * s_scale,
-                                p_out4.w * p_scale + s_out4.w * s_scale);
+#pragma unroll
+      for (uint i = 0; i < pack_size; ++i) {
+        // Always use float for FMA to keep precision.
+        // half(uint16_t), bfloat16, float -> float.
+        const float p_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
+        const float s_out_f =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_out_pack)[i]);
+        // fma: a * b + c = p_out_f * p_scale + (s_out_f * s_scale)
+        const float o_out_f = p_out_f * p_scale + (s_out_f * s_scale);
+        // float -> half(uint16_t), bfloat16, float.
+        vllm::from_float(reinterpret_cast<scalar_t*>(&o_out_pack)[i], o_out_f);
+      }
 
-      ((float4*)(output_blk))[thr_offset / 4] = out4;
+      // Pack 128b storage
+      reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+          o_out_pack;
     }
   }
 }
 
-#define LAUNCH_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)        \
-  {                                                                        \
-    merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
-        output.data_ptr<float>(), output_lse_ptr,                          \
-        prefix_output.data_ptr<float>(), prefix_lse.data_ptr<float>(),     \
-        suffix_output.data_ptr<float>(), suffix_lse.data_ptr<float>(),     \
-        NUM_TOKENS, NUM_HEADS, HEAD_SIZE);                                 \
+}  // namespace vllm
+
+// The following macro is used to dispatch the conversion function based on
+// the output data type. The FN is a macro that calls a function with
+// template<typename SCALAR_T, KV_DTYPE>.
+#define DISPATCH_BY_SCALAR_DTYPE(SCALAR_DTYPE, FN)                      \
+  {                                                                     \
+    if (SCALAR_DTYPE == at::ScalarType::Float) {                        \
+      FN(float, vllm::Fp8KVCacheDataType::kAuto);                       \
+    } else if (SCALAR_DTYPE == at::ScalarType::Half) {                  \
+      FN(uint16_t, vllm::Fp8KVCacheDataType::kAuto);                    \
+    } else if (SCALAR_DTYPE == at::ScalarType::BFloat16) {              \
+      FN(__nv_bfloat16, vllm::Fp8KVCacheDataType::kAuto);               \
+    } else {                                                            \
+      TORCH_CHECK(false, "Unsupported data type of O: ", SCALAR_DTYPE); \
+    }                                                                   \
+  }
+
+#define LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, LOOP_OVER_HEAD)        \
+  {                                                                         \
+    vllm::merge_attn_states_kernel<SCALAR_T, KV_DTYPE, LOOP_OVER_HEAD>      \
+        <<<grid, block>>>(                                                  \
+            reinterpret_cast<SCALAR_T*>(output.data_ptr()), output_lse_ptr, \
+            reinterpret_cast<SCALAR_T*>(prefix_output.data_ptr()),          \
+            reinterpret_cast<float*>(prefix_lse.data_ptr()),                \
+            reinterpret_cast<SCALAR_T*>(suffix_output.data_ptr()),          \
+            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,    \
+            num_heads, head_size);                                          \
+  }
+
+template <typename SCALAR_T, vllm::Fp8KVCacheDataType KV_DTYPE>
+void merge_attn_states_launcher(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const bool disable_loop_over_head) {
+  const uint num_tokens = output.size(0);
+  const uint num_heads = output.size(1);  // num query heads
+  const uint head_size = output.size(2);
+  // float -> 4, half/bf16 -> 8, 128b = 16 bytes.
+  constexpr uint pack_size = 16 / sizeof(SCALAR_T);
+  TORCH_CHECK(head_size % pack_size == 0,
+              "headsize must be multiple of pack_size:", pack_size);
+  TORCH_CHECK(head_size / pack_size <= 1024,
+              "headsize/pack_size must be <= of 1024, pack_size: ", pack_size);
+  float* output_lse_ptr = nullptr;
+  if (output_lse.has_value()) {
+    output_lse_ptr = output_lse.value().data_ptr<float>();
+  }
+
+  if (num_tokens <= 1024 || num_heads >= 64 || disable_loop_over_head) {
+    dim3 grid(num_tokens, num_heads);
+    dim3 block(head_size / pack_size);
+    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, false);
+  } else {
+    // try loop over num heads for large NUM_TOKENS
+    dim3 grid(num_tokens);
+    dim3 block(head_size / pack_size);
+    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, KV_DTYPE, true);
+  }
+}
+
+#define CALL_MERGE_ATTN_STATES_LAUNCHER(SCALAR_T, KV_DTYPE)           \
+  {                                                                   \
+    merge_attn_states_launcher<SCALAR_T, KV_DTYPE>(                   \
+        output, output_lse, prefix_output, prefix_lse, suffix_output, \
+        suffix_lse, disable_loop_over_head);                          \
   }
 
 void merge_attn_states(
@@ -133,32 +243,5 @@ void merge_attn_states(
     const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
     const bool disable_loop_over_head) {
-  const uint NUM_TOKENS = output.size(0);
-  const uint NUM_HEADS = output.size(1);  // num query heads
-  const uint HEAD_SIZE = output.size(2);
-  assert(HEAD_SIZE % 4 == 0);     // headsize must be multiple of 4
-  assert(HEAD_SIZE / 4 <= 1024);  // headsize must be <= of 4096
-  float* output_lse_ptr = nullptr;
-  if (output_lse.has_value()) {
-    output_lse_ptr = output_lse.value().data_ptr<float>();
-  }
-
-  if (NUM_TOKENS <= 1024 || NUM_HEADS >= 64 || disable_loop_over_head) {
-    dim3 grid(NUM_TOKENS, NUM_HEADS);
-    dim3 block(HEAD_SIZE / 4);
-    if (output_lse_ptr != nullptr) {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, true);
-    } else {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(false, false);
-    }
-  } else {
-    // try loop over num heads for large NUM_TOKENS
-    dim3 grid(NUM_TOKENS);
-    dim3 block(HEAD_SIZE / 4);
-    if (output_lse_ptr != nullptr) {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, true);
-    } else {
-      LAUNCH_MERGE_ATTN_STATES_KERNEL(true, false);
-    }
-  }
+  DISPATCH_BY_SCALAR_DTYPE(output.dtype(), CALL_MERGE_ATTN_STATES_LAUNCHER);
 }

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -117,20 +117,16 @@ __global__ void merge_attn_states_kernel(
   }
 
 /*@brief Merges the attention states from prefix and suffix
- * into the output tensor.
+ * into the output tensor. NUM_TOKENS: n, NUM_HEADS: h, HEAD_SIZE: d
  *
- * @param output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The output
- * tensor to store the merged attention states.
- * @param output_lse [NUM_HEADS, NUM_TOKENS] Optional tensor to
- * store the log-sum-exp values.
- * @param prefix_output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The
- * prefix attention states.
- * @param prefix_lse [NUM_HEADS, NUM_TOKENS] The log-sum-exp
- * values for the prefix attention states.
- * @param suffix_output [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] The
- * suffix attention states.
- * @param suffix_lse [NUM_HEADS, NUM_TOKENS] The log-sum-exp
- * values for the suffix attention states.
+ * @param output [n,h,d] The output tensor to store the merged attention states.
+ * @param output_lse [h,d] Optional tensor to store the log-sum-exp values.
+ * @param prefix_output [n,h,d] The prefix attention states.
+ * @param prefix_lse [h,d] The log-sum-exp values for the prefix attention
+ * states.
+ * @param suffix_output [n,h,d] The suffix attention states.
+ * @param suffix_lse [h,d] The log-sum-exp values for the suffix attention
+ * states.
  */
 template <typename scalar_t>
 void merge_attn_states_launcher(torch::Tensor& output,

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -1,0 +1,164 @@
+#include <optional>
+#include <cuda_runtime.h>
+#include <cmath>
+#include <torch/all.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+// Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+// can be used to combine partial attention results (in the split-KV case)
+// May loop over num heads for large NUM_TOKENS
+template <const bool LOOP_OVER_HEAD, const bool OUTPUT_LSE>
+__global__ void merge_attn_states_kernel(
+    float* output,      // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const float* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                              // HEAD_SIZE]
+    const float* __restrict__ prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const float* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
+                                              // HEAD_SIZE]
+    const float* __restrict__ suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const uint NUM_TOKENS,                    // NUM_TOKENS
+    const uint NUM_HEADS,                     // NUM QUERY HEADS
+    const uint HEAD_SIZE                      // HEAD_SIZE, 32,48,64,...,512,etc
+) {
+  if constexpr (LOOP_OVER_HEAD) {
+    const uint token_idx = blockIdx.x;
+    const uint thread_idx = threadIdx.x;
+
+#pragma unroll
+    for (uint head_idx = 0; head_idx < NUM_HEADS; ++head_idx) {
+      float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
+      float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+      p_lse =
+          std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+      s_lse =
+          std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+
+      const float max_lse = fmaxf(p_lse, s_lse);
+      p_lse = p_lse - max_lse;
+      s_lse = s_lse - max_lse;
+      const float p_se = expf(p_lse);
+      const float s_se = expf(s_lse);
+      const float out_se = p_se + s_se;
+
+      if constexpr (OUTPUT_LSE) {
+        if (output_lse != nullptr) {
+          float out_lse = logf(out_se) + max_lse;
+          output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
+        }
+      }
+
+      const uint blk_offset =
+          token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
+      const uint thr_offset = thread_idx * 4;
+      const float p_scale = p_se / out_se;
+      const float s_scale = s_se / out_se;
+      const float* prefix_output_blk = prefix_output + blk_offset;
+      const float* suffix_output_blk = suffix_output + blk_offset;
+      float* output_blk = output + blk_offset;
+
+      if (thr_offset < HEAD_SIZE) {
+        float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
+        float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+
+        float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
+                                  p_out4.y * p_scale + s_out4.y * s_scale,
+                                  p_out4.z * p_scale + s_out4.z * s_scale,
+                                  p_out4.w * p_scale + s_out4.w * s_scale);
+        ((float4*)(output_blk))[thr_offset / 4] = out4;
+      }
+    }  // end loop over heads
+  } else {
+    const uint token_idx = blockIdx.x;
+    const uint head_idx = blockIdx.y;
+    const uint thread_idx = threadIdx.x;
+
+    float p_lse = prefix_lse[head_idx * NUM_TOKENS + token_idx];
+    float s_lse = suffix_lse[head_idx * NUM_TOKENS + token_idx];
+    p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+    s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+
+    const float max_lse = fmaxf(p_lse, s_lse);
+    p_lse = p_lse - max_lse;
+    s_lse = s_lse - max_lse;
+    const float p_se = expf(p_lse);
+    const float s_se = expf(s_lse);
+    const float out_se = p_se + s_se;
+
+    if constexpr (OUTPUT_LSE) {
+      if (output_lse != nullptr) {
+        float out_lse = logf(out_se) + max_lse;
+        output_lse[head_idx * NUM_TOKENS + token_idx] = out_lse;
+      }
+    }
+
+    const uint blk_offset =
+        token_idx * NUM_HEADS * HEAD_SIZE + head_idx * HEAD_SIZE;
+    const uint thr_offset = thread_idx * 4;
+    const float p_scale = p_se / out_se;
+    const float s_scale = s_se / out_se;
+    const float* prefix_output_blk = prefix_output + blk_offset;
+    const float* suffix_output_blk = suffix_output + blk_offset;
+    float* output_blk = output + blk_offset;
+
+    if (thr_offset < HEAD_SIZE) {
+      float4 p_out4 = ((const float4*)(prefix_output_blk))[thr_offset / 4];
+      float4 s_out4 = ((const float4*)(suffix_output_blk))[thr_offset / 4];
+
+      float4 out4 = make_float4(p_out4.x * p_scale + s_out4.x * s_scale,
+                                p_out4.y * p_scale + s_out4.y * s_scale,
+                                p_out4.z * p_scale + s_out4.z * s_scale,
+                                p_out4.w * p_scale + s_out4.w * s_scale);
+
+      ((float4*)(output_blk))[thr_offset / 4] = out4;
+    }
+  }
+}
+
+#define LAUNCHE_MERGE_ATTN_STATES_KERNEL(LOOP_OVER_HEAD, OUTPUT_LSE)       \
+  {                                                                        \
+    merge_attn_states_kernel<LOOP_OVER_HEAD, OUTPUT_LSE><<<grid, block>>>( \
+        output.data_ptr<float>(), output_lse_ptr,                          \
+        prefix_output.data_ptr<float>(), prefix_lse.data_ptr<float>(),     \
+        suffix_output.data_ptr<float>(), suffix_lse.data_ptr<float>(),     \
+        NUM_TOKENS, NUM_HEADS, HEAD_SIZE);                                 \
+  }
+
+void merge_attn_states(
+    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
+    const bool disable_loop_over_head) {
+  const uint NUM_TOKENS = output.size(0);
+  const uint NUM_HEADS = output.size(1);  // num query heads
+  const uint HEAD_SIZE = output.size(2);
+  assert(HEAD_SIZE % 4 == 0);     // headsize must be multiple of 4
+  assert(HEAD_SIZE / 4 <= 1024);  // headsize must be <= of 4096
+  float* output_lse_ptr = nullptr;
+  if (output_lse.has_value()) {
+    output_lse_ptr = output_lse.value().data_ptr<float>();
+  }
+
+  if (NUM_TOKENS <= 1024 || NUM_HEADS >= 64 || disable_loop_over_head) {
+    dim3 grid(NUM_TOKENS, NUM_HEADS);
+    dim3 block(HEAD_SIZE / 4);
+    if (output_lse_ptr != nullptr) {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, true);
+    } else {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(false, false);
+    }
+  } else {
+    // try loop over num heads for large NUM_TOKENS
+    dim3 grid(NUM_TOKENS);
+    dim3 block(HEAD_SIZE / 4);
+    if (output_lse_ptr != nullptr) {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, true);
+    } else {
+      LAUNCHE_MERGE_ATTN_STATES_KERNEL(true, false);
+    }
+  }
+}

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -11,24 +11,33 @@ namespace vllm {
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
 // can be used to combine partial attention results (in the split-KV case)
-template <typename scalar_t>
-__device__ __forceinline__ void merge_attn_states_common(
-    scalar_t* output, float* output_lse,
-    const scalar_t* __restrict__ prefix_output,
-    const float* __restrict__ prefix_lse,
-    const scalar_t* __restrict__ suffix_output,
-    const float* __restrict__ suffix_lse, const uint num_tokens,
-    const uint num_heads, const uint head_size, const uint token_idx,
-    const uint head_idx, const uint thr_idx) {
-  using pack_128b_t = uint4;  // float -> 4, half/bf16 -> 8
-  constexpr uint pack_size = 16 / sizeof(scalar_t);
+template <typename scalar_t, const uint NUM_THREADS>
+__global__ void merge_attn_states_kernel(
+    scalar_t* output, float* output_lse, const scalar_t* prefix_output,
+    const float* prefix_lse, const scalar_t* suffix_output,
+    const float* suffix_lse, const uint num_tokens, const uint num_heads,
+    const uint head_size) {
+  const uint pack_size = 16 / sizeof(scalar_t);
+  const uint threads_per_head = head_size / pack_size;
 
-  const uint thr_offset = thr_idx * pack_size;  // (0~15)*8, etc.
-  const uint blk_offset =
+  const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
+  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
+
+  if (global_idx >= token_head_threads) return;
+
+  // global_idx -> token_idx + head_idx + pack_idx
+  const uint token_head_idx = global_idx / threads_per_head;
+  const uint pack_idx = global_idx % threads_per_head;
+
+  const uint token_idx = token_head_idx / num_heads;
+  const uint head_idx = token_head_idx % num_heads;
+
+  const uint pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
+  const uint head_offset =
       token_idx * num_heads * head_size + head_idx * head_size;
-  const scalar_t* prefix_output_blk = prefix_output + blk_offset;
-  const scalar_t* suffix_output_blk = suffix_output + blk_offset;
-  scalar_t* output_blk = output + blk_offset;
+  const scalar_t* prefix_head_ptr = prefix_output + head_offset;
+  const scalar_t* suffix_head_ptr = suffix_output + head_offset;
+  scalar_t* output_head_ptr = output + head_offset;
 
   float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
   float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
@@ -44,17 +53,17 @@ __device__ __forceinline__ void merge_attn_states_common(
   const float p_scale = p_se / out_se;
   const float s_scale = s_se / out_se;
 
-  if (thr_offset < head_size) {
+  if (pack_offset < head_size) {
     // Pack 128b load
     pack_128b_t p_out_pack = reinterpret_cast<const pack_128b_t*>(
-        prefix_output_blk)[thr_offset / pack_size];
+        prefix_head_ptr)[pack_offset / pack_size];
     pack_128b_t s_out_pack = reinterpret_cast<const pack_128b_t*>(
-        suffix_output_blk)[thr_offset / pack_size];
+        suffix_head_ptr)[pack_offset / pack_size];
     pack_128b_t o_out_pack;
 
 #pragma unroll
     for (uint i = 0; i < pack_size; ++i) {
-      // Always use float for FMA to keep precision.
+      // Always use float for FMA to keep high precision.
       // half(uint16_t), bfloat16, float -> float.
       const float p_out_f =
           vllm::to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
@@ -67,41 +76,14 @@ __device__ __forceinline__ void merge_attn_states_common(
     }
 
     // Pack 128b storage
-    reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
+    reinterpret_cast<pack_128b_t*>(output_head_ptr)[pack_offset / pack_size] =
         o_out_pack;
   }
   // We only need to write to output_lse once per head.
-  if (output_lse != nullptr && thr_idx == 0) {
+  if (output_lse != nullptr && pack_idx == 0) {
     float out_lse = logf(out_se) + max_lse;
     output_lse[head_idx * num_tokens + token_idx] = out_lse;
   }
-}
-
-template <typename scalar_t>
-__global__ void merge_attn_states_kernel(
-    scalar_t* output, float* output_lse, const scalar_t* prefix_output,
-    const float* prefix_lse, const scalar_t* suffix_output,
-    const float* suffix_lse, const uint num_tokens, const uint num_heads,
-    const uint head_size) {
-  constexpr uint BLOCK_SIZE = 128;
-  const uint pack_size = 16 / sizeof(scalar_t);
-  const uint threads_per_head = head_size / pack_size;
-
-  const uint global_idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
-  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
-
-  if (global_idx >= token_head_threads) return;
-
-  // global_idx -> token_idx + head_idx + thr_idx
-  const uint token_head_idx = global_idx / threads_per_head;
-  const uint thr_idx = global_idx % threads_per_head;
-
-  const uint token_idx = token_head_idx / num_heads;
-  const uint head_idx = token_head_idx % num_heads;
-
-  merge_attn_states_common<scalar_t>(
-      output, output_lse, prefix_output, prefix_lse, suffix_output, suffix_lse,
-      num_tokens, num_heads, head_size, token_idx, head_idx, thr_idx);
 }
 
 }  // namespace vllm
@@ -122,15 +104,15 @@ __global__ void merge_attn_states_kernel(
     }                                                                   \
   }
 
-#define LAUNCH_MERGE_ATTN_STATES(scalar_t)                              \
-  {                                                                     \
-    vllm::merge_attn_states_kernel<scalar_t><<<grid, block>>>(          \
-        reinterpret_cast<scalar_t*>(output.data_ptr()), output_lse_ptr, \
-        reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),          \
-        reinterpret_cast<float*>(prefix_lse.data_ptr()),                \
-        reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),          \
-        reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,    \
-        num_heads, head_size);                                          \
+#define LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS)                     \
+  {                                                                         \
+    vllm::merge_attn_states_kernel<scalar_t, NUM_THREADS><<<grid, block>>>( \
+        reinterpret_cast<scalar_t*>(output.data_ptr()), output_lse_ptr,     \
+        reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),              \
+        reinterpret_cast<float*>(prefix_lse.data_ptr()),                    \
+        reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),              \
+        reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,        \
+        num_heads, head_size);                                              \
   }
 
 template <typename scalar_t>
@@ -142,22 +124,25 @@ void merge_attn_states_launcher(
     const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     const torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
 ) {
+  constexpr uint NUM_THREADS = 128;
   const uint num_tokens = output.size(0);
   const uint num_heads = output.size(1);
   const uint head_size = output.size(2);
   const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
-  const uint threads_per_head = head_size / pack_size;
-  const uint total_threads = num_tokens * num_heads * threads_per_head;
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();
   }
+  // process one pack elements per thread. float -> 4, half/bf16 -> 8
+  const uint threads_per_head = head_size / pack_size;
+  const uint total_threads = num_tokens * num_heads * threads_per_head;
 
-  dim3 block(128);
-  dim3 grid((total_threads + block.x - 1) / block.x);
-  LAUNCH_MERGE_ATTN_STATES(scalar_t);
+  dim3 block(NUM_THREADS);
+  dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);
+
+  LAUNCH_MERGE_ATTN_STATES(scalar_t, NUM_THREADS);
 }
 
 #define CALL_MERGE_ATTN_STATES_LAUNCHER(scalar_t)                           \
@@ -167,13 +152,11 @@ void merge_attn_states_launcher(
                                          suffix_lse);                       \
   }
 
-void merge_attn_states(
-    torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
-) {
+void merge_attn_states(torch::Tensor& output,
+                       std::optional<torch::Tensor> output_lse,
+                       const torch::Tensor& prefix_output,
+                       const torch::Tensor& prefix_lse,
+                       const torch::Tensor& suffix_output,
+                       const torch::Tensor& suffix_lse) {
   DISPATCH_BY_SCALAR_DTYPE(output.dtype(), CALL_MERGE_ATTN_STATES_LAUNCHER);
 }

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -13,18 +13,13 @@ namespace vllm {
 // can be used to combine partial attention results (in the split-KV case)
 template <typename scalar_t>
 __device__ __forceinline__ void merge_attn_states_common(
-    scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const scalar_t* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                                 // HEAD_SIZE]
-    const float* __restrict__ prefix_lse,        // [NUM_HEADS, NUM_TOKENS]
-    const scalar_t* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                                 // HEAD_SIZE]
-    const float* __restrict__ suffix_lse,        // [NUM_HEADS, NUM_TOKENS]
-    const uint num_tokens,                       // NUM_TOKENS
-    const uint num_heads,                        // NUM QUERY HEADS
-    const uint head_size,  // HEAD_SIZE, 32,48,64,...,512,etc
-    const uint token_idx, const uint head_idx, const uint thr_idx) {
+    scalar_t* output, float* output_lse,
+    const scalar_t* __restrict__ prefix_output,
+    const float* __restrict__ prefix_lse,
+    const scalar_t* __restrict__ suffix_output,
+    const float* __restrict__ suffix_lse, const uint num_tokens,
+    const uint num_heads, const uint head_size, const uint token_idx,
+    const uint head_idx, const uint thr_idx) {
   using pack_128b_t = uint4;  // float -> 4, half/bf16 -> 8
   constexpr uint pack_size = 16 / sizeof(scalar_t);
 
@@ -48,12 +43,6 @@ __device__ __forceinline__ void merge_attn_states_common(
   const float out_se = p_se + s_se;
   const float p_scale = p_se / out_se;
   const float s_scale = s_se / out_se;
-
-  // We only need to write to output_lse once per head.
-  if (output_lse != nullptr && thr_idx == 0) {
-    float out_lse = logf(out_se) + max_lse;
-    output_lse[head_idx * num_tokens + token_idx] = out_lse;
-  }
 
   if (thr_offset < head_size) {
     // Pack 128b load
@@ -81,147 +70,101 @@ __device__ __forceinline__ void merge_attn_states_common(
     reinterpret_cast<pack_128b_t*>(output_blk)[thr_offset / pack_size] =
         o_out_pack;
   }
+  // We only need to write to output_lse once per head.
+  if (output_lse != nullptr && thr_idx == 0) {
+    float out_lse = logf(out_se) + max_lse;
+    output_lse[head_idx * num_tokens + token_idx] = out_lse;
+  }
 }
 
-template <typename scalar_t, bool kLoopOverHead, bool kFlattenOverHead = false>
+template <typename scalar_t>
 __global__ void merge_attn_states_kernel(
-    scalar_t* output,   // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    float* output_lse,  // [NUM_HEADS, NUM_TOKENS]
-    const scalar_t* __restrict__ prefix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                                 // HEAD_SIZE]
-    const float* __restrict__ prefix_lse,        // [NUM_HEADS, NUM_TOKENS]
-    const scalar_t* __restrict__ suffix_output,  // [NUM_TOKENS, NUM_HEADS,
-                                                 // HEAD_SIZE]
-    const float* __restrict__ suffix_lse,        // [NUM_HEADS, NUM_TOKENS]
-    const uint num_tokens,                       // NUM_TOKENS
-    const uint num_heads,                        // NUM QUERY HEADS
-    const uint head_size  // HEAD_SIZE, 32,48,64,...,512,etc
-) {
-  if constexpr (kLoopOverHead) {
-    // May loop over num heads for large num_tokens
-    const uint token_idx = blockIdx.x;
-    const uint thread_idx = threadIdx.x;
+    scalar_t* output, float* output_lse, const scalar_t* prefix_output,
+    const float* prefix_lse, const scalar_t* suffix_output,
+    const float* suffix_lse, const uint num_tokens, const uint num_heads,
+    const uint head_size) {
+  constexpr uint BLOCK_SIZE = 128;
+  const uint pack_size = 16 / sizeof(scalar_t);
+  const uint threads_per_head = head_size / pack_size;
 
-    if constexpr (kFlattenOverHead) {
-      // thread num = (num_heads * head_size) / pack_size
-      // = num_heads * (head_size / pack_size), 16 * (128 / 8)
-      // tid: 0~255, 0~15->head 0, 16~31->head 1, ..., etc.
-      constexpr uint pack_size = 16 / sizeof(scalar_t);
-      const uint head_idx = thread_idx / (head_size / pack_size);
-      const uint thr_idx = thread_idx % (head_size / pack_size);
-      merge_attn_states_common<scalar_t>(output, output_lse, prefix_output,
-                                         prefix_lse, suffix_output, suffix_lse,
-                                         num_tokens, num_heads, head_size,
-                                         token_idx, head_idx, thr_idx);
-    } else {
-      const uint thr_idx = thread_idx;
-#pragma unroll
-      for (uint head_idx = 0; head_idx < num_heads; ++head_idx) {
-        merge_attn_states_common<scalar_t>(
-            output, output_lse, prefix_output, prefix_lse, suffix_output,
-            suffix_lse, num_tokens, num_heads, head_size, token_idx, head_idx,
-            thr_idx);
-      }  // End kFlattenOverHead
-    }  // End kLoopOverHead
-  } else {
-    const uint token_idx = blockIdx.x;
-    const uint head_idx = blockIdx.y;
-    const uint thread_idx = threadIdx.x;
-    const uint thr_idx = thread_idx;
+  const uint global_idx = blockIdx.x * BLOCK_SIZE + threadIdx.x;
+  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
 
-    merge_attn_states_common<scalar_t>(output, output_lse, prefix_output,
-                                       prefix_lse, suffix_output, suffix_lse,
-                                       num_tokens, num_heads, head_size,
-                                       token_idx, head_idx, thr_idx);
-  }
+  if (global_idx >= token_head_threads) return;
+
+  // global_idx -> token_idx + head_idx + thr_idx
+  const uint token_head_idx = global_idx / threads_per_head;
+  const uint thr_idx = global_idx % threads_per_head;
+
+  const uint token_idx = token_head_idx / num_heads;
+  const uint head_idx = token_head_idx % num_heads;
+
+  merge_attn_states_common<scalar_t>(
+      output, output_lse, prefix_output, prefix_lse, suffix_output, suffix_lse,
+      num_tokens, num_heads, head_size, token_idx, head_idx, thr_idx);
 }
 
 }  // namespace vllm
 
 // The following macro is used to dispatch the conversion function based on
 // the output data type. The FN is a macro that calls a function with
-// template<typename SCALAR_T>.
-#define DISPATCH_BY_SCALAR_DTYPE(SCALAR_DTYPE, FN)                      \
+// template<typename scalar_t>.
+#define DISPATCH_BY_SCALAR_DTYPE(scalar_dtype, fn)                      \
   {                                                                     \
-    if (SCALAR_DTYPE == at::ScalarType::Float) {                        \
-      FN(float);                                                        \
-    } else if (SCALAR_DTYPE == at::ScalarType::Half) {                  \
-      FN(uint16_t);                                                     \
-    } else if (SCALAR_DTYPE == at::ScalarType::BFloat16) {              \
-      FN(__nv_bfloat16);                                                \
+    if (scalar_dtype == at::ScalarType::Float) {                        \
+      fn(float);                                                        \
+    } else if (scalar_dtype == at::ScalarType::Half) {                  \
+      fn(uint16_t);                                                     \
+    } else if (scalar_dtype == at::ScalarType::BFloat16) {              \
+      fn(__nv_bfloat16);                                                \
     } else {                                                            \
-      TORCH_CHECK(false, "Unsupported data type of O: ", SCALAR_DTYPE); \
+      TORCH_CHECK(false, "Unsupported data type of O: ", scalar_dtype); \
     }                                                                   \
   }
 
-#define LAUNCH_MERGE_ATTN_STATES(SCALAR_T, kLoopOverHead, kFlattenOverHead)   \
-  {                                                                           \
-    vllm::merge_attn_states_kernel<SCALAR_T, kLoopOverHead, kFlattenOverHead> \
-        <<<grid, block>>>(                                                    \
-            reinterpret_cast<SCALAR_T*>(output.data_ptr()), output_lse_ptr,   \
-            reinterpret_cast<SCALAR_T*>(prefix_output.data_ptr()),            \
-            reinterpret_cast<float*>(prefix_lse.data_ptr()),                  \
-            reinterpret_cast<SCALAR_T*>(suffix_output.data_ptr()),            \
-            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,      \
-            num_heads, head_size);                                            \
+#define LAUNCH_MERGE_ATTN_STATES(scalar_t)                              \
+  {                                                                     \
+    vllm::merge_attn_states_kernel<scalar_t><<<grid, block>>>(          \
+        reinterpret_cast<scalar_t*>(output.data_ptr()), output_lse_ptr, \
+        reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),          \
+        reinterpret_cast<float*>(prefix_lse.data_ptr()),                \
+        reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),          \
+        reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,    \
+        num_heads, head_size);                                          \
   }
 
-template <typename SCALAR_T>
+template <typename scalar_t>
 void merge_attn_states_launcher(
     torch::Tensor& output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     std::optional<torch::Tensor> output_lse,  // [NUM_HEADS, NUM_TOKENS]
     const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
     const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const bool disable_loop_over_head) {
+    const torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
+) {
   const uint num_tokens = output.size(0);
-  const uint num_heads = output.size(1);  // num query heads
+  const uint num_heads = output.size(1);
   const uint head_size = output.size(2);
-  // float -> 4, half/bf16 -> 8, 128b = 16 bytes.
-  constexpr uint pack_size = 16 / sizeof(SCALAR_T);
+  const uint pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0,
               "headsize must be multiple of pack_size:", pack_size);
-  TORCH_CHECK(head_size / pack_size <= 1024,
-              "headsize/pack_size must be <= of 1024, pack_size: ", pack_size);
+  const uint threads_per_head = head_size / pack_size;
+  const uint total_threads = num_tokens * num_heads * threads_per_head;
   float* output_lse_ptr = nullptr;
   if (output_lse.has_value()) {
     output_lse_ptr = output_lse.value().data_ptr<float>();
   }
-  // Keep threads num <= 512 per thread block.
-  const bool skip_flatten_over_head =
-      ((num_heads * head_size) / pack_size > 512);
 
-  const bool skip_loop_over_head =
-      (disable_loop_over_head || num_tokens <= 1024 ||
-       (num_heads >= 64 && skip_flatten_over_head));
-
-  if (skip_loop_over_head) {
-    dim3 grid(num_tokens, num_heads);
-    dim3 block(head_size / pack_size);
-    LAUNCH_MERGE_ATTN_STATES(SCALAR_T, false, false);
-  } else {
-    // try loop over num heads for large num_tokens
-    if (skip_flatten_over_head) {
-      dim3 grid(num_tokens);
-      dim3 block(head_size / pack_size);
-      LAUNCH_MERGE_ATTN_STATES(SCALAR_T, true, false);
-    } else {
-      // cases:
-      // num_tokens 8192, num_heads 16, head_size 128
-      // num_tokens 4096, num_heads 16, head_size 128
-      dim3 grid(num_tokens);
-      dim3 block((num_heads * head_size) / pack_size);
-      LAUNCH_MERGE_ATTN_STATES(SCALAR_T, true, true);
-    }
-  }
+  dim3 block(128);
+  dim3 grid((total_threads + block.x - 1) / block.x);
+  LAUNCH_MERGE_ATTN_STATES(scalar_t);
 }
 
-#define CALL_MERGE_ATTN_STATES_LAUNCHER(SCALAR_T)                             \
-  {                                                                           \
-    merge_attn_states_launcher<SCALAR_T>(output, output_lse, prefix_output,   \
-                                         prefix_lse, suffix_output,           \
-                                         suffix_lse, disable_loop_over_head); \
+#define CALL_MERGE_ATTN_STATES_LAUNCHER(scalar_t)                           \
+  {                                                                         \
+    merge_attn_states_launcher<scalar_t>(output, output_lse, prefix_output, \
+                                         prefix_lse, suffix_output,         \
+                                         suffix_lse);                       \
   }
 
 void merge_attn_states(
@@ -230,7 +173,7 @@ void merge_attn_states(
     const torch::Tensor& prefix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     const torch::Tensor& prefix_lse,     // [NUM_HEADS, NUM_TOKENS]
     const torch::Tensor& suffix_output,  // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
-    const torch::Tensor& suffix_lse,     // [NUM_HEADS, NUM_TOKENS]
-    const bool disable_loop_over_head) {
+    const torch::Tensor& suffix_lse      // [NUM_HEADS, NUM_TOKENS]
+) {
   DISPATCH_BY_SCALAR_DTYPE(output.dtype(), CALL_MERGE_ATTN_STATES_LAUNCHER);
 }

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -52,6 +52,16 @@ void paged_attention_v2(
     const int64_t blocksparse_vert_stride, const int64_t blocksparse_block_size,
     const int64_t blocksparse_head_sliding_step);
 
+#ifndef USE_ROCM
+void merge_attn_states(torch::Tensor& output,
+                       std::optional<torch::Tensor> output_lse,
+                       const torch::Tensor& prefix_output,
+                       const torch::Tensor& prefix_lse,
+                       const torch::Tensor& suffix_output,
+                       const torch::Tensor& suffix_lse,
+                       const bool disable_loop_over_head);
+#endif
+
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,
               double epsilon);
 

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -58,8 +58,7 @@ void merge_attn_states(torch::Tensor& output,
                        const torch::Tensor& prefix_output,
                        const torch::Tensor& prefix_lse,
                        const torch::Tensor& suffix_output,
-                       const torch::Tensor& suffix_lse,
-                       const bool disable_loop_over_head);
+                       const torch::Tensor& suffix_lse);
 #endif
 
 void rms_norm(torch::Tensor& out, torch::Tensor& input, torch::Tensor& weight,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -74,8 +74,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    Tensor prefix_output,"
       "    Tensor prefix_lse,"
       "    Tensor suffix_output,"
-      "    Tensor suffix_lse,"
-      "    bool disable_loop_over_head) -> ()");
+      "    Tensor suffix_lse) -> ()");
   ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
 
   // Activation ops

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -64,6 +64,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    int blocksparse_head_sliding_step) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
+#ifndef USE_ROCM
   // Merge attn states
   // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
   // can be used to combine partial attention results (in the split-KV case)
@@ -76,6 +77,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    Tensor suffix_output,"
       "    Tensor suffix_lse) -> ()");
   ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
+#endif
 
   // Activation ops
   // Activation function used in SwiGLU.

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -64,6 +64,20 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    int blocksparse_head_sliding_step) -> ()");
   ops.impl("paged_attention_v2", torch::kCUDA, &paged_attention_v2);
 
+  // Merge attn states
+  // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+  // can be used to combine partial attention results (in the split-KV case)
+  ops.def(
+      "merge_attn_states("
+      "    Tensor! output,"
+      "    Tensor!? output_lse,"
+      "    Tensor prefix_output,"
+      "    Tensor prefix_lse,"
+      "    Tensor suffix_output,"
+      "    Tensor suffix_lse,"
+      "    bool disable_loop_over_head) -> ()");
+  ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
+
   // Activation ops
   // Activation function used in SwiGLU.
   ops.def("silu_and_mul(Tensor! out, Tensor input) -> ()");

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> list[torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor | None]:
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -57,13 +57,21 @@ def generate_markdown_table():
     table_header = ("| tokens | heads | headsize | dtype "
                     "| device | torch | triton | cuda | speedup |")
     table_separator = "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+
+    def shortly_dtype(dtype: torch.dtype) -> str:
+        return str(dtype).removeprefix("torch.")
+
+    def shortly_device(device: str) -> str:
+        return device.removeprefix("NVIDIA").strip()
+
     print(table_header)
     print(table_separator)
     for info in all_case_info:
         (num_tokens, num_heads, head_size, dtype, device,
          avg_time_torch_kernel, avg_time_triton_kernel, avg_time_cuda_kernel,
          performance_improved) = info
-        dtype = str(dtype).replace("torch.", "")
+        dtype = shortly_dtype(dtype)
+        device = shortly_device(device)
         print(f"| {num_tokens} | {num_heads} | {head_size} "
               f"| {dtype} | {device} | {avg_time_torch_kernel:.5f}ms "
               f"| {avg_time_triton_kernel:.5f}ms "

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -44,13 +44,13 @@ def merge_attn_states_torch(
     return output, output_lse
 
 
-NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096]
-NUM_QUERY_HEADS = [4, 8, 16, 32]
-HEAD_SIZES = [64, 96, 128]
+NUM_BATCH_TOKENS = [256, 512, 613, 1024, 1536, 4096]
+NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
+HEAD_SIZES = [32, 48, 64, 96, 128, 256]
 DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
 
-@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_tokens", NUM_BATCH_TOKENS)
 @pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
 @pytest.mark.parametrize("output_dtype", DTYPES)
@@ -178,6 +178,7 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
         total_time_cuda_kernel += start.elapsed_time(end)
 
     avg_time_cuda_kernel = total_time_cuda_kernel / repeat_times
+
     # 3. Performance compare
     performance_improved = avg_time_triton_kernel / avg_time_cuda_kernel
     print(f" Torch time: {avg_time_torch_kernel:.6f}ms")
@@ -206,9 +207,9 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
                                atol=1e-3,
                                rtol=rtol)
     print("Output all match, max abs diff:")
-    print(f" (CUDA  vs Triton): {diff(output_ref, output_cuda)}")
     print(f"(Triton vs Torch) : {diff(output_torch, output_ref)}")
     print(f"  (CUDA vs Torch) : {diff(output_torch, output_cuda)}")
+    print(f"  (CUDA vs Triton): {diff(output_ref, output_cuda)}")
     print("-" * 100)
 
     torch.testing.assert_close(output_lse_cuda.float(),
@@ -218,7 +219,7 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
     print("Output LSE all match, max abs diff:")
     print(f"(Triton vs Torch) : {diff(output_lse_torch, output_lse_ref)}")
     print(f"  (CUDA vs Torch) : {diff(output_lse_torch, output_lse_cuda)}")
-    print(f" (CUDA  vs Triton): {diff(output_lse_ref, output_lse_cuda)}")
+    print(f"  (CUDA vs Triton): {diff(output_lse_ref, output_lse_cuda)}")
     print("-" * 100)
 
     print("All output values test passed! All inf values "

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -54,8 +54,8 @@ all_case_info = []
 
 def generate_markdown_table():
     global all_case_info
-    table_header = ("| NUM_TOKENS | NUM_HEADS | HEAD_SIZE | DTYPE "
-                    "| Device | torch | triton | cuda | speedup |")
+    table_header = ("| tokens | heads | headsize | dtype "
+                    "| device | torch | triton | cuda | speedup |")
     table_separator = "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
     print(table_header)
     print(table_separator)
@@ -63,6 +63,7 @@ def generate_markdown_table():
         (num_tokens, num_heads, head_size, dtype, device,
          avg_time_torch_kernel, avg_time_triton_kernel, avg_time_cuda_kernel,
          performance_improved) = info
+        dtype = str(dtype).replace("torch.", "")
         print(f"| {num_tokens} | {num_heads} | {head_size} "
               f"| {dtype} | {device} | {avg_time_torch_kernel:.5f}ms "
               f"| {avg_time_triton_kernel:.5f}ms "

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
 import pytest
 import torch
 
@@ -7,29 +9,66 @@ from vllm.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton)
 from vllm.platforms import current_platform
 
-NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096, 8192, 16384]
-NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
-HEAD_SIZES = [48, 64, 96, 128, 256]
+
+# Naive PyTorch Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
+# can be used to combine partial attention results (in the split-KV case)
+def merge_attn_states_torch(
+        output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        prefix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        prefix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
+        suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
+        output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
+) -> None:
+    p_lse = prefix_lse.clone()
+    s_lse = suffix_lse.clone()
+    # inf -> -inf
+    p_lse[p_lse == torch.inf] = -torch.inf
+    s_lse[s_lse == torch.inf] = -torch.inf
+    # max_lse [NUM_HEADS, NUM_TOKENS]
+    max_lse = torch.maximum(p_lse, s_lse)
+    p_lse = p_lse - max_lse
+    s_lse = s_lse - max_lse
+    p_lse_exp = torch.exp(p_lse)
+    s_lse_exp = torch.exp(s_lse)
+    out_se = (p_lse_exp + s_lse_exp)
+    if output_lse is not None:
+        output_lse = torch.log(out_se) + max_lse
+    p_scale = p_lse_exp / out_se  # [NUM_HEADS, NUM_TOKENS]
+    s_scale = s_lse_exp / out_se  # [NUM_HEADS, NUM_TOKENS]
+    p_scale = torch.transpose(p_scale, 0,
+                              1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
+    s_scale = torch.transpose(s_scale, 0,
+                              1).unsqueeze(2)  # [NUM_TOKENS, NUM_HEADS, 1]
+    output = prefix_output * p_scale + suffix_output * s_scale
+    return output, output_lse
+
+
+NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096]
+NUM_QUERY_HEADS = [4, 8, 16, 32]
+HEAD_SIZES = [64, 96, 128]
+DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 @pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
 @pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("output_dtype", DTYPES)
 @torch.inference_mode()
 def test_merge_attn_states(num_tokens: int, num_query_heads: int,
-                           head_size: int):
+                           head_size: int, output_dtype: torch.dtype):
     if not current_platform.is_cuda():
         pytest.skip('Currently only support compare triton merge_attn_states '
                     'with custom cuda merge_attn_states kernel')
 
-    # Set test parameters
     NUM_TOKENS = num_tokens
-    # Num query heads
     NUM_HEADS = num_query_heads
-    # Set HEAD_SIZE to a power of 2 in the test code
     HEAD_SIZE = head_size
 
-    # Generate test inputs
+    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
+          f"HEAD_SIZE:{HEAD_SIZE}, DTYPE: {output_dtype}, "
+          f"Device: {current_platform.get_device_name()}")
+
     # prefix_lse and suffix_lse contain inf and normal values
     prefix_lse = torch.randn(NUM_HEADS,
                              NUM_TOKENS,
@@ -54,108 +93,131 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
     # Other input tensors (need to be initialized but
     # no actual calculation needed)
     output = torch.zeros((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                         dtype=torch.float32,
+                         dtype=output_dtype,
                          device="cuda")
     output_lse = torch.zeros((NUM_HEADS, NUM_TOKENS),
                              dtype=torch.float32,
                              device="cuda")
     prefix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                                dtype=torch.float32,
+                                dtype=output_dtype,
                                 device="cuda")
     suffix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
-                                dtype=torch.float32,
+                                dtype=output_dtype,
                                 device="cuda")
 
-    output_ref = output.clone()
-    output_lse_ref = output_lse.clone()
-
-    # Run the Triton kernel
-    # Warmup and measure performance of merge_attn_states_triton
     warmup_times = 2
     repeat_times = 20
-    total_time_kernel = 0
+
+    output_torch = output.clone()
+    output_lse_torch = output_lse.clone()
+    total_time_torch_kernel = 0
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
 
-    # Warmup
+    # 0. Run the Torch kernel
     for _ in range(warmup_times):
-        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
-                                 suffix_output, suffix_lse, output_lse_ref)
+        output_torch, output_lse_torch = merge_attn_states_torch(
+            output_torch, prefix_output, prefix_lse, suffix_output, suffix_lse,
+            output_lse_torch)
     torch.cuda.synchronize()
 
-    # Repeat and measure
     for _ in range(repeat_times):
         start.record()
-        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
-                                 suffix_output, suffix_lse, output_lse_ref)
+        output_torch, output_lse_torch = merge_attn_states_torch(
+            output_torch, prefix_output, prefix_lse, suffix_output, suffix_lse,
+            output_lse_torch)
         end.record()
         torch.cuda.synchronize()
-        total_time_kernel += start.elapsed_time(end)
+        total_time_torch_kernel += start.elapsed_time(end)
 
-    avg_time_kernel = total_time_kernel / repeat_times
+    avg_time_torch_kernel = total_time_torch_kernel / repeat_times
 
-    # Warmup and measure performance of merge_attn_states_cuda
-    total_time_kernel_cuda = 0
+    # 1. Run the Triton kernel
+    output_ref_triton = output.clone()
+    output_lse_ref_triton = output_lse.clone()
+
+    total_time_triton_kernel = 0
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    for _ in range(warmup_times):
+        merge_attn_states_triton(output_ref_triton, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse,
+                                 output_lse_ref_triton)
+    torch.cuda.synchronize()
+
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_triton(output_ref_triton, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse,
+                                 output_lse_ref_triton)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_triton_kernel += start.elapsed_time(end)
+
+    avg_time_triton_kernel = total_time_triton_kernel / repeat_times
+
+    # 2. Run the CUDA kernel
+    total_time_cuda_kernel = 0
     output_cuda = output.clone()
     output_lse_cuda = output_lse.clone()
 
-    # Warmup
     for _ in range(warmup_times):
         merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
                                suffix_output, suffix_lse, output_lse_cuda)
     torch.cuda.synchronize()
 
-    # Repeat and measure
     for _ in range(repeat_times):
         start.record()
         merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
                                suffix_output, suffix_lse, output_lse_cuda)
         end.record()
         torch.cuda.synchronize()
-        total_time_kernel_cuda += start.elapsed_time(end)
+        total_time_cuda_kernel += start.elapsed_time(end)
 
-    avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
-    performance_improved = avg_time_kernel / avg_time_kernel_cuda
-    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
-          f"HEAD_SIZE:{HEAD_SIZE}, "
-          f"Device: {current_platform.get_device_name()}")
-    print(f"Average time taken by Triton merge_attn_states "
-          f"kernel: {avg_time_kernel}ms")
-    print(f"Average time taken by   CUDA merge_attn_states "
-          f"kernel: {avg_time_kernel_cuda}ms, "
+    avg_time_cuda_kernel = total_time_cuda_kernel / repeat_times
+    # 3. Performance compare
+    performance_improved = avg_time_triton_kernel / avg_time_cuda_kernel
+    print(f" Torch time: {avg_time_torch_kernel:.6f}ms")
+    print(f"Triton time: {avg_time_triton_kernel:.6f}ms")
+    print(f"  CUDA time: {avg_time_cuda_kernel:.6f}ms, "
           f"Performance: {performance_improved:.5f}x")
     print("-" * 100)
 
-    if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):
-        diff = torch.abs(output_ref - output_cuda)
-        max_diff = torch.max(diff)
-        max_diff_index = torch.argmax(diff)
-        print(f"Max difference in output: {max_diff} "
-              f"at index {max_diff_index}")
-        print(f"Triton output at max diff index: "
-              f"{output_ref.flatten()[max_diff_index]}")
-        print(f"CUDA output at max diff index: "
-              f"{output_cuda.flatten()[max_diff_index]}")
-    assert torch.allclose(output_ref, output_cuda, rtol=1e-3,
-                          atol=1e-3), \
-           "Output of Triton and CUDA do not match."
-    print("Output of Triton and CUDA all match.")
+    # 4. Correctness compare
+    # Liger Kernel: Efficient Triton Kernels for LLM Training
+    # https://arxiv.org/pdf/2410.10989, 3.3 Correctness
+    # use rtol = 1e-2 for bfloat16.
+    rtol = 1e-2 if output_dtype == torch.bfloat16 else 1e-3
 
-    if not torch.allclose(
-            output_lse_ref, output_lse_cuda, rtol=1e-3, atol=1e-3):
-        diff = torch.abs(output_lse_ref - output_lse_cuda)
-        max_diff = torch.max(diff)
-        max_diff_index = torch.argmax(diff)
-        print(f"Max difference in output_lse: "
-              f"{max_diff} at index {max_diff_index}")
-        print(f"Triton output_lse at max diff index: "
-              f"{output_lse_ref.flatten()[max_diff_index]}")
-        print(f"CUDA output_lse at max diff index: "
-              f"{output_lse_cuda.flatten()[max_diff_index]}")
-    assert torch.allclose(
-        output_lse_ref, output_lse_cuda, rtol=1e-3,
-        atol=1e-3), "Output_lse of Triton and CUDA do not match."
-    print("Output LSE of Triton and CUDA all match.")
+    def diff(a: torch.Tensor, b: torch.Tensor):
+        max_diff = torch.max(torch.abs(a.float() - b.float()))
+        return max_diff
+
+    # Use Triton output as reference because we want to replace
+    # the Triton kernel with custom CUDA kernel for merge attn
+    # states operation.
+    output_ref = output_ref_triton
+    output_lse_ref = output_lse_ref_triton
+    torch.testing.assert_close(output_cuda.float(),
+                               output_ref.float(),
+                               atol=1e-3,
+                               rtol=rtol)
+    print("Output all match, max abs diff:")
+    print(f" (CUDA  vs Triton): {diff(output_ref, output_cuda)}")
+    print(f"(Triton vs Torch) : {diff(output_torch, output_ref)}")
+    print(f"  (CUDA vs Torch) : {diff(output_torch, output_cuda)}")
+    print("-" * 100)
+
+    torch.testing.assert_close(output_lse_cuda.float(),
+                               output_lse_ref.float(),
+                               atol=1e-3,
+                               rtol=rtol)
+    print("Output LSE all match, max abs diff:")
+    print(f"(Triton vs Torch) : {diff(output_lse_torch, output_lse_ref)}")
+    print(f"  (CUDA vs Torch) : {diff(output_lse_torch, output_lse_cuda)}")
+    print(f" (CUDA  vs Triton): {diff(output_lse_ref, output_lse_cuda)}")
+    print("-" * 100)
 
     print("All output values test passed! All inf values "
           "are correctly replaced with -inf.")

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -49,7 +49,7 @@ NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
 HEAD_SIZES = [32, 48, 64, 96, 128, 256]
 DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
-all_case_info = []
+all_case_info: list[tuple] = []
 
 
 def generate_markdown_table():

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -49,6 +49,26 @@ NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
 HEAD_SIZES = [32, 48, 64, 96, 128, 256]
 DTYPES = [torch.float32, torch.half, torch.bfloat16]
 
+all_case_info = []
+
+
+def generate_markdown_table():
+    global all_case_info
+    table_header = ("| NUM_TOKENS | NUM_HEADS | HEAD_SIZE | DTYPE "
+                    "| Device | torch | triton | cuda | speedup |")
+    table_separator = "| --- | --- | --- | --- | --- | --- | --- | --- | --- |"
+    print(table_header)
+    print(table_separator)
+    for info in all_case_info:
+        (num_tokens, num_heads, head_size, dtype, device,
+         avg_time_torch_kernel, avg_time_triton_kernel, avg_time_cuda_kernel,
+         performance_improved) = info
+        print(f"| {num_tokens} | {num_heads} | {head_size} "
+              f"| {dtype} | {device} | {avg_time_torch_kernel:.5f}ms "
+              f"| {avg_time_triton_kernel:.5f}ms "
+              f"| {avg_time_cuda_kernel:.5f}ms "
+              f"| {performance_improved:.4f}x |")
+
 
 @pytest.mark.parametrize("num_tokens", NUM_BATCH_TOKENS)
 @pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
@@ -225,3 +245,12 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
     print("All output values test passed! All inf values "
           "are correctly replaced with -inf.")
     print("-" * 100)
+
+    device = current_platform.get_device_name()
+    all_case_info.append(
+        (NUM_TOKENS, NUM_HEADS, HEAD_SIZE, output_dtype, device,
+         avg_time_torch_kernel, avg_time_triton_kernel, avg_time_cuda_kernel,
+         performance_improved))
+    if len(all_case_info) == (len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) *
+                              len(NUM_QUERY_HEADS) * len(DTYPES)):
+        generate_markdown_table()

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> tuple[torch.Tensor, torch.Tensor | None]:
+):
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -19,7 +19,7 @@ def merge_attn_states_torch(
         suffix_output: torch.Tensor,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         suffix_lse: torch.Tensor,  # [NUM_HEADS, NUM_TOKENS]
         output_lse: Optional[torch.Tensor] = None,  # [NUM_HEADS, NUM_TOKENS]
-) -> None:
+) -> list[torch.Tensor]:
     p_lse = prefix_lse
     s_lse = suffix_lse
     # inf -> -inf

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from vllm._custom_ops import merge_attn_states as merge_attn_states_cuda
+from vllm.attention.ops.triton_merge_attn_states import (
+    merge_attn_states as merge_attn_states_triton)
+from vllm.platforms import current_platform
+
+NUM_TOKENS = [512, 613, 1024, 1536, 4096, 8192]
+# NUM_TOKENS = [512]
+NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
+# NUM_QUERY_HEADS = [16]
+HEAD_SIZES = [32, 48, 64, 96, 128, 256]
+# HEAD_SIZES = [128]
+
+
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("num_query_heads", NUM_QUERY_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@torch.inference_mode()
+def test_merge_attn_states(num_tokens: int, num_query_heads: int,
+                           head_size: int):
+    if not current_platform.is_cuda():
+        pytest.skip('Currently only support compare triton merge_attn_states '
+                    'with custom cuda merge_attn_states kernel')
+
+    # Set test parameters
+    NUM_TOKENS = num_tokens
+    # Num query heads
+    NUM_HEADS = num_query_heads
+    # Set HEAD_SIZE to a power of 2 in the test code
+    HEAD_SIZE = head_size
+
+    # Generate test inputs
+    # prefix_lse and suffix_lse contain inf and normal values
+    prefix_lse = torch.randn(NUM_HEADS,
+                             NUM_TOKENS,
+                             dtype=torch.float32,
+                             device="cuda")
+    suffix_lse = torch.randn(NUM_HEADS,
+                             NUM_TOKENS,
+                             dtype=torch.float32,
+                             device="cuda")
+
+    # Generate boolean masks
+    mask_prefix = torch.rand(NUM_HEADS, NUM_TOKENS) < 0.1
+    mask_suffix = torch.rand(NUM_HEADS, NUM_TOKENS) < 0.1
+    # Ensure that the same position is not True at the same time
+    combined_mask = torch.logical_and(mask_prefix, mask_suffix)
+    mask_prefix = torch.logical_and(mask_prefix, ~combined_mask)
+    mask_suffix = torch.logical_and(mask_suffix, ~combined_mask)
+
+    prefix_lse[mask_prefix] = float('inf')
+    suffix_lse[mask_suffix] = float('inf')
+
+    # Other input tensors (need to be initialized but
+    # no actual calculation needed)
+    output = torch.zeros((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                         dtype=torch.float32,
+                         device="cuda")
+    output_lse = torch.zeros((NUM_HEADS, NUM_TOKENS),
+                             dtype=torch.float32,
+                             device="cuda")
+    prefix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                                dtype=torch.float32,
+                                device="cuda")
+    suffix_output = torch.randn((NUM_TOKENS, NUM_HEADS, HEAD_SIZE),
+                                dtype=torch.float32,
+                                device="cuda")
+
+    output_ref = output.clone()
+    output_lse_ref = output_lse.clone()
+
+    # Run the Triton kernel
+    # Warmup and measure performance of merge_attn_states_triton
+    warmup_times = 2
+    repeat_times = 20
+    total_time_kernel = 0
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+
+    # Warmup
+    for _ in range(warmup_times):
+        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse_ref)
+    torch.cuda.synchronize()
+
+    # Repeat and measure
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_triton(output_ref, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse_ref)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_kernel += start.elapsed_time(end)
+
+    avg_time_kernel = total_time_kernel / repeat_times
+
+    # Warmup and measure performance of merge_attn_states_cuda
+    total_time_kernel_cuda = 0
+    output_cuda = output.clone()
+    output_lse_cuda = output_lse.clone()
+
+    # Warmup
+    for _ in range(warmup_times):
+        merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
+                               suffix_output, suffix_lse, output_lse_cuda)
+    torch.cuda.synchronize()
+
+    # Repeat and measure
+    for _ in range(repeat_times):
+        start.record()
+        merge_attn_states_cuda(output_cuda, prefix_output, prefix_lse,
+                               suffix_output, suffix_lse, output_lse_cuda)
+        end.record()
+        torch.cuda.synchronize()
+        total_time_kernel_cuda += start.elapsed_time(end)
+
+    avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
+    print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
+          f"HEAD_SIZE:{HEAD_SIZE}, "
+          f"Device: {current_platform.get_device_name()}")
+    print(f"Average time taken by Triton merge_attn_states "
+          f"kernel: {avg_time_kernel} ms")
+    print(f"Average time taken by   CUDA merge_attn_states "
+          f"kernel: {avg_time_kernel_cuda} ms")
+    print("-" * 100)
+
+    if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):
+        diff = torch.abs(output_ref - output_cuda)
+        max_diff = torch.max(diff)
+        max_diff_index = torch.argmax(diff)
+        print(f"Max difference in output: {max_diff} "
+              f"at index {max_diff_index}")
+        print(f"Triton output at max diff index: "
+              f"{output_ref.flatten()[max_diff_index]}")
+        print(f"CUDA output at max diff index: "
+              f"{output_cuda.flatten()[max_diff_index]}")
+    assert torch.allclose(output_ref, output_cuda, rtol=1e-3,
+                          atol=1e-3), \
+           "Output of Triton and CUDA do not match."
+    print("Output of Triton and CUDA all match.")
+
+    if not torch.allclose(
+            output_lse_ref, output_lse_cuda, rtol=1e-3, atol=1e-3):
+        diff = torch.abs(output_lse_ref - output_lse_cuda)
+        max_diff = torch.max(diff)
+        max_diff_index = torch.argmax(diff)
+        print(f"Max difference in output_lse: "
+              f"{max_diff} at index {max_diff_index}")
+        print(f"Triton output_lse at max diff index: "
+              f"{output_lse_ref.flatten()[max_diff_index]}")
+        print(f"CUDA output_lse at max diff index: "
+              f"{output_lse_cuda.flatten()[max_diff_index]}")
+    assert torch.allclose(
+        output_lse_ref, output_lse_cuda, rtol=1e-3,
+        atol=1e-3), "Output_lse of Triton and CUDA do not match."
+    print("Output LSE of Triton and CUDA all match.")
+
+    print("All output values test passed! All inf values "
+          "are correctly replaced with -inf.")
+    print("-" * 100)

--- a/tests/kernels/test_merge_attn_states.py
+++ b/tests/kernels/test_merge_attn_states.py
@@ -7,12 +7,9 @@ from vllm.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton)
 from vllm.platforms import current_platform
 
-NUM_TOKENS = [512, 613, 1024, 1536, 4096, 8192]
-# NUM_TOKENS = [512]
+NUM_TOKENS = [256, 512, 613, 1024, 1536, 4096, 8192, 16384]
 NUM_QUERY_HEADS = [4, 8, 16, 32, 48, 64]
-# NUM_QUERY_HEADS = [16]
-HEAD_SIZES = [32, 48, 64, 96, 128, 256]
-# HEAD_SIZES = [128]
+HEAD_SIZES = [48, 64, 96, 128, 256]
 
 
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
@@ -118,13 +115,15 @@ def test_merge_attn_states(num_tokens: int, num_query_heads: int,
         total_time_kernel_cuda += start.elapsed_time(end)
 
     avg_time_kernel_cuda = total_time_kernel_cuda / repeat_times
+    performance_improved = avg_time_kernel / avg_time_kernel_cuda
     print(f"\nNUM_TOKENS:{NUM_TOKENS}, NUM_HEADS:{NUM_HEADS}, "
           f"HEAD_SIZE:{HEAD_SIZE}, "
           f"Device: {current_platform.get_device_name()}")
     print(f"Average time taken by Triton merge_attn_states "
-          f"kernel: {avg_time_kernel} ms")
+          f"kernel: {avg_time_kernel}ms")
     print(f"Average time taken by   CUDA merge_attn_states "
-          f"kernel: {avg_time_kernel_cuda} ms")
+          f"kernel: {avg_time_kernel_cuda}ms, "
+          f"Performance: {performance_improved:.5f}x")
     print("-" * 100)
 
     if not torch.allclose(output_ref, output_cuda, rtol=1e-3, atol=1e-3):

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -138,6 +138,19 @@ def mla_decode_kvcache_cpu(
                                         block_tables, seq_lens)
 
 
+# merge attn states ops
+def merge_attn_states(output: torch.Tensor,
+                      prefix_output: torch.Tensor,
+                      prefix_lse: torch.Tensor,
+                      suffix_output: torch.Tensor,
+                      suffix_lse: torch.Tensor,
+                      output_lse: Optional[torch.Tensor] = None,
+                      disable_loop_over_head: bool = False) -> None:
+    torch.ops._C.merge_attn_states(output, output_lse, prefix_output,
+                                   prefix_lse, suffix_output, suffix_lse,
+                                   disable_loop_over_head)
+
+
 # pos encoding ops
 def rotary_embedding(
     positions: torch.Tensor,

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -144,11 +144,9 @@ def merge_attn_states(output: torch.Tensor,
                       prefix_lse: torch.Tensor,
                       suffix_output: torch.Tensor,
                       suffix_lse: torch.Tensor,
-                      output_lse: Optional[torch.Tensor] = None,
-                      disable_loop_over_head: bool = False) -> None:
+                      output_lse: Optional[torch.Tensor] = None) -> None:
     torch.ops._C.merge_attn_states(output, output_lse, prefix_output,
-                                   prefix_lse, suffix_output, suffix_lse,
-                                   disable_loop_over_head)
+                                   prefix_lse, suffix_output, suffix_lse)
 
 
 # pos encoding ops

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -204,6 +204,7 @@ from vllm.attention.backends.abstract import (AttentionBackend, AttentionLayer,
 from vllm.attention.backends.utils import (PAD_SLOT_ID, compute_slot_mapping,
                                            compute_slot_mapping_start_idx,
                                            is_block_tables_empty)
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase, RowParallelLinear,
                                                UnquantizedLinearMethod)
@@ -217,9 +218,7 @@ from vllm.vllm_flash_attn.fa_utils import get_flash_attn_version
 
 if HAS_TRITON:
     from vllm.attention.ops.triton_flash_attention import triton_attention
-    from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
 else:
-    merge_attn_states = None
     triton_attention = None
 
 try:

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+from typing import Optional
+
+import torch
+
+from vllm.platforms import current_platform
+
+
+def merge_attn_states(
+    output: torch.Tensor,
+    prefix_output: torch.Tensor,
+    prefix_lse: torch.Tensor,
+    suffix_output: torch.Tensor,
+    suffix_lse: torch.Tensor,
+    output_lse: Optional[torch.Tensor] = None,
+) -> None:
+    if current_platform.is_cuda():
+        from vllm._custom_ops import merge_attn_states
+        return merge_attn_states(output, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse)
+    else:
+        from vllm.attention.ops.triton_merge_attn_states import (
+            merge_attn_states)
+        return merge_attn_states(output, prefix_output, prefix_lse,
+                                 suffix_output, suffix_lse, output_lse)

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 import torch
 
-import vllm.envs as envs
 from vllm.platforms import current_platform
 
 
@@ -31,8 +30,7 @@ def merge_attn_states(
             return headdim % 4 == 0
         return headdim % 8 == 0
 
-    if ((not envs.VLLM_DISABLE_MERGE_ATTN_CUDA_OP)
-            and current_platform.is_cuda() and supported_dtypes(output)
+    if (current_platform.is_cuda() and supported_dtypes(output)
             and supported_headdim(output)):
         from vllm._custom_ops import merge_attn_states
         return merge_attn_states(output, prefix_output, prefix_lse,

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import torch
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
@@ -20,7 +21,9 @@ def merge_attn_states(
     # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
     # is not support for FP8 dtype, fallback to use Triton kernel.
     supported_dtypes = [torch.float32, torch.half, torch.bfloat16]
-    if current_platform.is_cuda() and (output.dtype in supported_dtypes):
+    if ((not envs.VLLM_DISABLE_MERGE_ATTN_CUDA_OP)
+            and current_platform.is_cuda()
+            and (output.dtype in supported_dtypes)):
         from vllm._custom_ops import merge_attn_states
         return merge_attn_states(output, prefix_output, prefix_lse,
                                  suffix_output, suffix_lse, output_lse)

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -3,7 +3,10 @@ from typing import Optional
 
 import torch
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
 
 
 def merge_attn_states(
@@ -14,7 +17,10 @@ def merge_attn_states(
     suffix_lse: torch.Tensor,
     output_lse: Optional[torch.Tensor] = None,
 ) -> None:
-    if current_platform.is_cuda():
+    # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
+    # is not support for FP8 dtype, fallback to use Triton kernel.
+    supported_dtypes = [torch.float32, torch.half, torch.bfloat16]
+    if current_platform.is_cuda() and (output.dtype in supported_dtypes):
         from vllm._custom_ops import merge_attn_states
         return merge_attn_states(output, prefix_output, prefix_lse,
                                  suffix_output, suffix_lse, output_lse)

--- a/vllm/attention/ops/merge_attn_states.py
+++ b/vllm/attention/ops/merge_attn_states.py
@@ -21,12 +21,12 @@ def merge_attn_states(
     def supported_dtypes(o: torch.Tensor) -> bool:
         return o.dtype in [torch.float32, torch.half, torch.bfloat16]
 
+    # NOTE(DefTruth): Currently, custom merge_attn_states CUDA
+    # kernel load/store 128b(16 bytes) per memory issue within
+    # thread. Namely, the headsize(headdim) must be multiple of
+    # pack_size (float32 -> 4, half/bfloat16 -> 8).
     def supported_headdim(o: torch.Tensor) -> bool:
-        # NOTE(DefTruth): Currently, custom merge_attn_states CUDA
-        # kernel load/store 128b(16 bytes) per memory issue within
-        # thread. Namely, the headsize(headdim) must be multiple of
-        # pack_size (float32 -> 4, half/bfloat16 -> 8).
-        headdim = output.shape[2]  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+        headdim = o.shape[2]  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
         if o.dtype == torch.float32:
             return headdim % 4 == 0
         return headdim % 8 == 0

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -705,10 +705,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # It can be changed with this variable if needed for some reason.
     "VLLM_XGRAMMAR_CACHE_MB":
     lambda: int(os.getenv("VLLM_XGRAMMAR_CACHE_MB", "512")),
-
-    # Force disable merge_attn_states CUDA op, use Triton kernel.
-    "VLLM_DISABLE_MERGE_ATTN_CUDA_OP":
-    lambda: bool(int(os.getenv("VLLM_DISABLE_MERGE_ATTN_CUDA_OP", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -106,6 +106,7 @@ if TYPE_CHECKING:
     VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION: bool = False
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_USE_DEEP_GEMM: bool = False
+    VLLM_DISABLE_MERGE_ATTN_CUDA_OP: bool = False
 
 
 def get_default_cache_root():
@@ -697,6 +698,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM":
     lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "0"))),
+
+    # Force disable merge_attn_states CUDA op, use Triton kernel.
+    "VLLM_DISABLE_MERGE_ATTN_CUDA_OP":
+    lambda: bool(int(os.getenv("VLLM_DISABLE_MERGE_ATTN_CUDA_OP", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -107,7 +107,6 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_USE_DEEP_GEMM: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
-    VLLM_DISABLE_MERGE_ATTN_CUDA_OP: bool = False
 
 
 def get_default_cache_root():

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -705,7 +705,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # It can be changed with this variable if needed for some reason.
     "VLLM_XGRAMMAR_CACHE_MB":
     lambda: int(os.getenv("VLLM_XGRAMMAR_CACHE_MB", "512")),
-    
+
     # Force disable merge_attn_states CUDA op, use Triton kernel.
     "VLLM_DISABLE_MERGE_ATTN_CUDA_OP":
     lambda: bool(int(os.getenv("VLLM_DISABLE_MERGE_ATTN_CUDA_OP", "0"))),

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -10,7 +10,7 @@ from vllm import _custom_ops as ops
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionImpl,
                                               AttentionMetadata, AttentionType,
                                               is_quantized_kv_cache)
-from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils import cdiv

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -195,7 +195,7 @@ from vllm import _custom_ops as ops
 from vllm.attention.backends.abstract import (AttentionBackend, AttentionLayer,
                                               AttentionMetadata,
                                               MLAAttentionImpl)
-from vllm.attention.ops.triton_merge_attn_states import merge_attn_states
+from vllm.attention.ops.merge_attn_states import merge_attn_states
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase, RowParallelLinear,


### PR DESCRIPTION
base on [vllm/attention/ops/triton_merge_attn_states.py](https://github.com/vllm-project/vllm/blob/main/vllm/attention/ops/triton_merge_attn_states.py)

Use CUDA kernel instead of Triton to minimize CPU overhead. Compared to the Triton kernel, the CUDA kernel implemented in this PR can achieve a maximum speedup of over `3x`. @WoosukKwon, End2End performance improved for R1 with PP=3 + TP=8 on L20,  4K IN:1K OUT (TTFT 5687.80 ms -> 5654.02 ms). The performance of inference will not degrade.

- [x] float32
- [x] float16
- [x] bfloat16
- [x] dispatch by scalar_t
- [x] fallback strategy 
- [x] unit tests (performance & correctness)
- [x] end2end test   
- [x] CEval benchmark 
- [x] test cascade_flash_attn (used merge_attn_states), passed

## Performance

cases for MLA with TP=8, num query heads per rank is 16, headsize is 128.

| tokens | heads | headsize | dtype | device | torch | triton | cuda | speedup |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 256 | 16 | 128 | float32 | L20 | 0.15258ms | 0.05647ms | 0.01638ms | 3.4475x |
| 512 | 16 | 128 | float32 | L20 | 0.14940ms | 0.05417ms | 0.01654ms | 3.2749x |
| 613 | 16 | 128 | float32 | L20 | 0.14996ms | 0.05386ms | 0.01628ms | 3.3080x |
| 1024 | 16 | 128 | float32 | L20 | 0.14817ms | 0.05432ms | 0.01618ms | 3.3583x |
| 1536 | 16 | 128 | float32 | L20 | 0.14960ms | 0.05878ms | 0.01643ms | 3.5774x |
| 4096 | 16 | 128 | float32 | L20 | 0.38063ms | 0.12160ms | 0.06748ms | 1.8021x |
| 256 | 16 | 128 | float16 | L20 | 0.14776ms | 0.05509ms | 0.01567ms | 3.5165x |
| 512 | 16 | 128 | float16 | L20 | 0.14807ms | 0.05524ms | 0.01551ms | 3.5621x |
| 613 | 16 | 128 | float16 | L20 | 0.14843ms | 0.05380ms | 0.01557ms | 3.4564x |
| 1024 | 16 | 128 | float16 | L20 | 0.14945ms | 0.05437ms | 0.01556ms | 3.4938x |
| 1536 | 16 | 128 | float16 | L20 | 0.15718ms | 0.05836ms | 0.01557ms | 3.7494x |
| 4096 | 16 | 128 | float16 | L20 | 0.31852ms | 0.08372ms | 0.01955ms | 4.2813x |
| 256 | 16 | 128 | bfloat16 | L20 | 0.14842ms | 0.05381ms | 0.01546ms | 3.4801x |
| 512 | 16 | 128 | bfloat16 | L20 | 0.14782ms | 0.05356ms | 0.01536ms | 3.4858x |
| 613 | 16 | 128 | bfloat16 | L20 | 0.14848ms | 0.05320ms | 0.01547ms | 3.4398x |
| 1024 | 16 | 128 | bfloat16 | L20 | 0.14935ms | 0.05376ms | 0.01562ms | 3.4423x |
| 1536 | 16 | 128 | bfloat16 | L20 | 0.15765ms | 0.05934ms | 0.01572ms | 3.7736x |
| 4096 | 16 | 128 | bfloat16 | L20 | 0.31912ms | 0.08524ms | 0.01925ms | 4.4283x |

## Correctness 

- float16 (performance & correctness)

```bash
pytest -s test_merge_attn_states.py
----------------------------------------------------------------------------------------------------
NUM_TOKENS:512, NUM_HEADS:16, HEAD_SIZE:128, DTYPE: torch.float16, Device: NVIDIA L20
 Torch time: 0.149299ms
Triton time: 0.050995ms
  CUDA time: 0.015722ms, Performance: 3.24364x
----------------------------------------------------------------------------------------------------
Output all match, max abs diff:
 (CUDA  vs Triton): 0.0009765625
(Triton vs Torch) : 0.0015368461608886719
  (CUDA vs Torch) : 0.0015368461608886719
----------------------------------------------------------------------------------------------------
Output LSE all match, max abs diff:
(Triton vs Torch) : 2.384185791015625e-07
  (CUDA vs Torch) : 0.0
  (CUDA vs Triton): 2.384185791015625e-07
----------------------------------------------------------------------------------------------------
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
```
<details>
<summary> show more details </summary>
- float32 (performance & correctness)

```bash
pytest -s test_merge_attn_states.py
----------------------------------------------------------------------------------------------------
.
NUM_TOKENS:512, NUM_HEADS:16, HEAD_SIZE:128, DTYPE: torch.float32, Device: NVIDIA L20
 Torch time: 0.150216ms
Triton time: 0.051350ms
  CUDA time: 0.016072ms, Performance: 3.19502x
----------------------------------------------------------------------------------------------------
Output all match, max abs diff:
 (CUDA  vs Triton): 4.76837158203125e-07
(Triton vs Torch) : 4.76837158203125e-07
  (CUDA vs Torch) : 2.384185791015625e-07
----------------------------------------------------------------------------------------------------
Output LSE all match, max abs diff:
(Triton vs Torch) : 4.76837158203125e-07
  (CUDA vs Torch) : 0.0
 (CUDA  vs Triton): 4.76837158203125e-07
----------------------------------------------------------------------------------------------------
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
```

- bfloat16  (performance & correctness)

```bash
----------------------------------------------------------------------------------------------------
NUM_TOKENS:4096, NUM_HEADS:16, HEAD_SIZE:128, DTYPE: torch.bfloat16, Device: NVIDIA L20
 Torch time: 0.322397ms
Triton time: 0.081408ms
  CUDA time: 0.026824ms, Performance: 3.03489x
----------------------------------------------------------------------------------------------------
Output all match, max abs diff:
 (CUDA  vs Triton): 0.015625
(Triton vs Torch) : 0.011169910430908203
  (CUDA vs Torch) : 0.011169910430908203
----------------------------------------------------------------------------------------------------
Output LSE all match, max abs diff:
(Triton vs Torch) : 2.384185791015625e-07
  (CUDA vs Torch) : 0.0
 (CUDA  vs Triton): 2.384185791015625e-07
----------------------------------------------------------------------------------------------------
All output values test passed! All inf values are correctly replaced with -inf.
----------------------------------------------------------------------------------------------------
```
</details>

## End2End test  

R1 671B with L20x3, PP=3, TP=8

- launch cmd

```bash
nohup python3 -m vllm.entrypoints.openai.api_server \
        --model=/workspace/dev/hf_models/DeepSeek-R1 \
        --dtype=auto \
        --block-size 32 \
        --tokenizer-mode=slow \
        --max-model-len 32768 \
        --max-num-batched-tokens 2048 \
        --tensor-parallel-size 8 \
        --pipeline-parallel-size 3 \
        --gpu-memory-utilization 0.90 \
        --max-num-seqs 128 \
        --trust-remote-code \
        --no-enable-prefix-caching \
        --enable-chunked-prefill=True \
        --disable-custom-all-reduce \
        --port 8862 > vllm.R1.log.3 2>&1 &
```
4K IN:1K OUT (TTFT 5687.80 ms -> 5654.02 ms), The performance of inference will not degrade.

<details>
<summary> show more details </summary>

### 4K IN:1K OUT (TTFT 5687.80 ms -> 5654.02 ms)

- w/o this opt, 4K IN:1K OUT

```bash

Maximum request concurrency: 16
============ Serving Benchmark Result ============
Successful requests:                     32
Benchmark duration (s):                  207.14
Total input tokens:                      131072
Total generated tokens:                  32768
Request throughput (req/s):              0.15
Output token throughput (tok/s):         158.19
Total Token throughput (tok/s):          790.96
---------------Time to First Token----------------
Mean TTFT (ms):                          5687.80
Median TTFT (ms):                        3969.86
P99 TTFT (ms):                           11952.93
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          95.51
Median TPOT (ms):                        96.38
P99 TPOT (ms):                           98.71
---------------Inter-token Latency----------------
Mean ITL (ms):                           95.51
Median ITL (ms):                         89.71
P99 ITL (ms):                            97.03
==================================================
```

- w/ this opt, 4K IN:1K OUT (TTFT 5687.80 ms -> 5654.02 ms)
```bash
Maximum request concurrency: 16
============ Serving Benchmark Result ============
Successful requests:                     32
Benchmark duration (s):                  206.65
Total input tokens:                      131072
Total generated tokens:                  32768
Request throughput (req/s):              0.15
Output token throughput (tok/s):         158.57
Total Token throughput (tok/s):          792.83
---------------Time to First Token----------------
Mean TTFT (ms):                          5654.02
Median TTFT (ms):                        3958.66
P99 TTFT (ms):                           11861.09
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          95.30
Median TPOT (ms):                        95.98
P99 TPOT (ms):                           98.70
---------------Inter-token Latency----------------
Mean ITL (ms):                           95.30
Median ITL (ms):                         89.62
P99 ITL (ms):                            96.89
==================================================
```

### 8K IN:64 OUT (TTFT 8861.07ms -> 8767.16ms)

- w/o this opt, 8K IN:64 OUT

```bash
Maximum request concurrency: 16
============ Serving Benchmark Result ============
Successful requests:                     48
Benchmark duration (s):                  115.37
Total input tokens:                      393216
Total generated tokens:                  3072
Request throughput (req/s):              0.42
Output token throughput (tok/s):         26.63
Total Token throughput (tok/s):          3434.90
---------------Time to First Token----------------
Mean TTFT (ms):                          8861.07
Median TTFT (ms):                        6167.50
P99 TTFT (ms):                           23576.12
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          454.74
Median TPOT (ms):                        484.97
P99 TPOT (ms):                           504.62
---------------Inter-token Latency----------------
Mean ITL (ms):                           454.74
Median ITL (ms):                         273.69
P99 ITL (ms):                            1065.00
==================================================
```

- w/ this opt, 8K IN:64 OUT (TTFT 8861.07ms -> 8767.16ms)
```bash
Maximum request concurrency: 16
============ Serving Benchmark Result ============
Successful requests:                     48
Benchmark duration (s):                  115.19
Total input tokens:                      393216
Total generated tokens:                  3072
Request throughput (req/s):              0.42
Output token throughput (tok/s):         26.67
Total Token throughput (tok/s):          3440.28
---------------Time to First Token----------------
Mean TTFT (ms):                          8767.16
Median TTFT (ms):                        6170.44
P99 TTFT (ms):                           23594.15
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          455.34
Median TPOT (ms):                        483.54
P99 TPOT (ms):                           504.48
---------------Inter-token Latency----------------
Mean ITL (ms):                           455.34
Median ITL (ms):                         270.61
P99 ITL (ms):                            1066.51
==================================================
```
</details>

## CEval benchmark  (0.90197884615385)

We use [evalscope](https://github.com/modelscope/evalscope) to run benchmark on `CEval` dataset.

```bash
evalscope eval \
 --model /workspace/dev/hf_models/DeepSeek-R1 \
 --api-url http://0.0.0.0:8862/v1/chat/completions \
 --api-key EMPTY \
 --eval-batch-size 32 \
 --eval-type service \
 --datasets ceval \
 --dataset-args '{"ceval": {"local_path": "/workspace/dev/openllm/benchmarks/data/ceval"}}'
```

Total AverageAccuracy: 0.90197884615385

<details>
<summary> show more details </summary>

```bash
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| Model       | Dataset   | Metric          | Subset                                   |   Num |   Score | Cat.0          |
+=============+===========+=================+==========================================+=======+=========+================+
| DeepSeek-R1 | ceval     | AverageAccuracy | modern_chinese_history                   |    23 |  0.8696 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | ideological_and_moral_cultivation        |    19 |  1      | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | logic                                    |    22 |  0.9091 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | law                                      |    24 |  0.875  | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | chinese_language_and_literature          |    23 |  0.8261 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | art_studies                              |    33 |  0.9091 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | professional_tour_guide                  |    29 |  0.9655 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | legal_professional                       |    23 |  0.913  | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_chinese                      |    19 |  0.7895 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_history                      |    20 |  0.95   | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_history                    |    22 |  0.9545 | Humanities     |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | civil_servant                            |    47 |  0.8723 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | sports_science                           |    19 |  0.8947 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | plant_protection                         |    22 |  1      | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | basic_medicine                           |    19 |  1      | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | clinical_medicine                        |    22 |  0.9091 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | urban_and_rural_planner                  |    46 |  0.8913 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | accountant                               |    49 |  0.9184 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | fire_engineer                            |    31 |  1      | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | environmental_impact_assessment_engineer |    31 |  0.9032 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | tax_accountant                           |    49 |  0.9184 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | physician                                |    49 |  0.9184 | Other          |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | computer_network                         |    19 |  0.7895 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | operating_system                         |    19 |  0.8947 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | computer_architecture                    |    21 |  1      | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | college_programming                      |    37 |  0.9189 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | college_physics                          |    19 |  0.8947 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | college_chemistry                        |    24 |  0.9167 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | advanced_mathematics                     |    19 |  0.9474 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | probability_and_statistics               |    18 |  0.7778 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | discrete_mathematics                     |    16 |  0.5625 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | electrical_engineer                      |    37 |  0.7027 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | metrology_engineer                       |    24 |  0.9583 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_mathematics                  |    18 |  0.7778 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_physics                      |    19 |  1      | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_chemistry                    |    19 |  0.9474 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_biology                      |    19 |  0.9474 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_mathematics                |    19 |  1      | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_biology                    |    21 |  0.8571 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_physics                    |    19 |  1      | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_chemistry                  |    20 |  1      | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | veterinary_medicine                      |    23 |  0.8696 | STEM           |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | college_economics                        |    55 |  0.8727 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | business_administration                  |    33 |  0.8182 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | marxism                                  |    19 |  0.9474 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | mao_zedong_thought                       |    24 |  1      | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | education_science                        |    29 |  0.931  | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | teacher_qualification                    |    44 |  0.9318 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_politics                     |    19 |  1      | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | high_school_geography                    |    19 |  0.9474 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_politics                   |    21 |  1      | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
| DeepSeek-R1 | ceval     | AverageAccuracy | middle_school_geography                  |    12 |  0.9167 | Social Science |
+-------------+-----------+-----------------+------------------------------------------+-------+---------+----------------+
```
</details>

## Test cascade_flash_attn

```bash
pytest -s test_cascade_flash_attn.py
================================================================================== test session starts ===================================================================================
collected 198 items
Running 198 items in this shard

test_cascade_flash_attn.py ..............................................................................................................................ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss

============================================================================ 126 passed, 72 skipped in 1.05s =============================================================================
```