### PR TITLE
[Misc] Human-readable `max-model-len` cli arg

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -167,7 +167,7 @@ def test_human_readable_model_len():
     args = parser.parse_args(["--max-model-len", "10M"])
     assert args.max_model_len == 2**20 * 10
 
-    # Decimal values..
+    # Decimal values
     args = parser.parse_args(["--max-model-len", "10.2k"])
     assert args.max_model_len == 10200
     # ..truncated to the nearest int

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -155,12 +155,26 @@ def test_human_readable_model_len():
     args = parser.parse_args(["--max-model-len", "1024"])
     assert args.max_model_len == 1024
 
-    args = parser.parse_args(["--max-model-len", "1M"])
+    # Lower
+    args = parser.parse_args(["--max-model-len", "1m"])
     assert args.max_model_len == 1_000_000
     args = parser.parse_args(["--max-model-len", "10k"])
     assert args.max_model_len == 10_000
 
-    # Invalid
-    for invalid in ["1a", "pwd", "10.24"]:
+    # Capital
+    args = parser.parse_args(["--max-model-len", "3K"])
+    assert args.max_model_len == 1024 * 3
+    args = parser.parse_args(["--max-model-len", "10M"])
+    assert args.max_model_len == 2**20 * 10
+
+    # Decimal values..
+    args = parser.parse_args(["--max-model-len", "10.2k"])
+    assert args.max_model_len == 10200
+    # ..truncated to the nearest int
+    args = parser.parse_args(["--max-model-len", "10.212345k"])
+    assert args.max_model_len == 10212
+
+    # Invalid (do not allow decimals with binary multipliers)
+    for invalid in ["1a", "pwd", "10.24", "1.23M"]:
         with pytest.raises(ArgumentError):
             args = parser.parse_args(["--max-model-len", invalid])

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1774,7 +1774,12 @@ def human_readable_int(value):
         elif suffix in binary_multiplier:
             mult = binary_multiplier[suffix]
             # Do not allow decimals with binary multipliers
-            return int(number) * mult
+            try:
+                return int(number) * mult
+            except ValueError as e:
+                raise argparse.ArgumentTypeError("Decimals are not allowed " \
+                f"with binary suffixes like {suffix}. Did you mean to use " \
+                f"{number}{suffix.lower()} instead?") from e
 
     # Regular plain number.
     return int(value)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -368,10 +368,11 @@ class EngineArgs:
             'data type. CUDA 11.8+ supports fp8 (=fp8_e4m3) and fp8_e5m2. '
             'ROCm (AMD GPU) supports fp8 (=fp8_e4m3)')
         parser.add_argument('--max-model-len',
-                            type=int,
+                            type=human_readable_int,
                             default=EngineArgs.max_model_len,
                             help='Model context length. If unspecified, will '
-                            'be automatically derived from the model config.')
+                            'be automatically derived from the model config. '
+                            'Supports k, M, G suffixes.')
         parser.add_argument(
             '--guided-decoding-backend',
             type=str,
@@ -1737,6 +1738,22 @@ def _warn_or_fallback(feature_name: str) -> bool:
             "Falling back to V0 Engine.", feature_name)
         should_exit = True
     return should_exit
+
+
+def human_readable_int(value):
+    """Parse human-readable integers like '1k', '2M', etc."""
+    value = value.strip().lower()
+
+    multipliers = {
+        'k': 1e3,
+        'm': 1e6,
+        'g': 1e9,
+    }
+
+    if value[-1] in multipliers:
+        number = float(value[:-1])
+        return int(number * multipliers[value[-1]])
+    return int(value)
 
 
 # These functions are used by sphinx to build the documentation

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -373,7 +373,7 @@ class EngineArgs:
                             default=EngineArgs.max_model_len,
                             help='Model context length. If unspecified, will '
                             'be automatically derived from the model config. '
-                            'Supports k/m/g+K/M/G in human-readable format.\n'
+                            'Supports k/m/g/K/M/G in human-readable format.\n'
                             'Examples:\n'
                             '- 1k → 1000\n'
                             '- 1K → 1024\n')


### PR DESCRIPTION
`--max--model-len 10000000 ==> --max--model-len 10M` 

Supports k/m/g/K/M/G in human-readable format. Including decimal values with decimal multipliers.
Examples:
- '1k' -> 1,000
- '1K' -> 1,024
- '25.6k' -> 25,600