### PR TITLE
[Bugfix] Fix and reorganize broken GGUF tests and bump gguf version

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -28,7 +28,7 @@ filelock >= 3.16.1 # need to contain https://github.com/tox-dev/filelock/pull/31
 partial-json-parser # used for parsing partial JSON outputs
 pyzmq
 msgspec
-gguf == 0.10.0
+gguf >= 0.13.0
 importlib_metadata
 mistral_common[opencv] >= 1.5.4
 opencv-python-headless >= 4.11.0    # required for video IO


### PR DESCRIPTION

FIX #16180
FIX #16134

- The GGUF support is broken with numpy 2.0 installation, because we hardcode at a very old gguf version, this PR bump the gguf version to keep compatability with numpy 2.0.
- This PR also reorganizes the GGUF tests to keep Llama gguf test running on standard test.
- Also fix the GGUF TP test stucking issue by disabling TP on unquantized runner temporarily.

<!--- pyml disable-next-line no-emphasis-as-heading -->
