### PR TITLE
[Misc] Update compressed-tensors to version 0.9.3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -36,7 +36,7 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=74.1.1; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.9.2 # required for compressed-tensors
+compressed-tensors == 0.9.3 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py
 watchfiles # required for http server to monitor the updates of TLS files


### PR DESCRIPTION
The current version of [llm-compressor](https://github.com/vllm-project/llm-compressor/) (0.5.0) is incompatible with vLLM. This is because it requires `compressed-tensors==0.9.3`, while vLLM is pinned to `compressed-tensors==0.9.2`. This PR updates the version of compressed-tensors pinned by vLLM.