### PR TITLE
[Misc] Move Llama 4 projector call into encoder execution

### DIFF
--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -760,6 +760,8 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         flat_data = image_input["flat_data"]
         patches_per_image = image_input["patches_per_image"].tolist()
         vision_embeddings_flat = self.vision_model(flat_data)
+        vision_embeddings_flat = self.multi_modal_projector(
+            vision_embeddings_flat)
         return vision_embeddings_flat.split(patches_per_image, dim=0)
 
     def get_multimodal_embeddings(self,
@@ -791,10 +793,9 @@ class Llama4ForConditionalGeneration(nn.Module, SupportsMultiModal,
         inputs_embeds = self.language_model.get_input_embeddings(input_ids)
 
         if multimodal_embeddings is not None:
-            multimodal_embeddings = torch.cat(multimodal_embeddings)
-            mm_embeddings = self.multi_modal_projector(multimodal_embeddings)
             inputs_embeds = merge_multimodal_embeddings(
-                input_ids, inputs_embeds, select_patch_features(mm_embeddings),
+                input_ids, inputs_embeds,
+                select_patch_features(multimodal_embeddings),
                 self.config.image_token_index)
 
         return inputs_embeds


### PR DESCRIPTION
On vLLM we consider encoder execution to generate multimodal embeddings ready to be merged into text embeddings, thus it often includes the projector call even though it's not part of encoder. This PR moves the projection call into the encoder execution (i.e, `get_multimodal_embeddings`)

Tested with `pytest tests/models/decoder_only/vision_language/test_models.py -k "llama4"`
```
(vllm) ➜  vllm git:(move-projector) pytest tests/models/decoder_only/vision_language/test_models.py -k "llama4"
/tmp-nvme/vllm/lib/python3.12/site-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================================================================ test session starts =============================================================================
platform linux -- Python 3.12.9, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/jovyan/vllm
configfile: pyproject.toml
plugins: rerunfailures-14.0, forked-1.6.0, mock-3.14.0, asyncio-0.24.0, shard-0.1.2, buildkite-test-collector-0.1.9, anyio-4.6.2.post1
asyncio: mode=Mode.STRICT, default_loop_scope=None
collected 203 items / 201 deselected / 2 selected                                                                                                                            
Running 2 items in this shard

tests/models/decoder_only/vision_language/test_models.py ..                                                                                                            [100%]

============================================================================== warnings summary ==============================================================================
tests/models/decoder_only/vision_language/test_models.py::test_single_image_models_heavy[llama4-test_case6]
tests/models/decoder_only/vision_language/test_models.py::test_multi_image_models_heavy[llama4-test_case0]
  /home/jovyan/vllm/tests/utils.py:723: DeprecationWarning: This process (pid=58315) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 2 passed, 201 deselected, 2 warnings in 966.43s (0:16:06) ==========================================================
```