### PR TITLE
[BugFix] Remove 224 from FA supported list

### DIFF
--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -43,7 +43,7 @@ class FlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_head_sizes() -> List[int]:
-        return [32, 64, 96, 128, 160, 192, 224, 256]
+        return [32, 64, 96, 128, 160, 192, 256]
 
     @staticmethod
     def get_name() -> str:

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -34,7 +34,7 @@ class FlashAttentionBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_head_sizes() -> list[int]:
-        return [32, 64, 96, 128, 160, 192, 224, 256]
+        return [32, 64, 96, 128, 160, 192, 256]
 
     @staticmethod
     def get_name() -> str:


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/16102#issuecomment-2784089249

224 headsize was removed from FA here: https://github.com/Dao-AILab/flash-attention/commit/751c762c9cc98f13e375f582974110d781fcf3ca , we should remove this from the FA supported headsizes list in vLLM so the fallbacks happen correctly, tested with:

```
vllm serve Zyphra/Zamba2-7B-Instruct
```


