### PR TITLE
[Bugfix] Fix guidance backend for Qwen models

### DIFF
--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -46,7 +46,8 @@ class GuidanceBackend(StructuredOutputBackend):
             in vllm_config.decoding_config.guided_decoding_backend)
 
         tokenizer = tokenizer_group.get_lora_tokenizer(None)
-        self.ll_tokenizer = llguidance_hf.from_tokenizer(tokenizer, None)
+        self.ll_tokenizer = llguidance_hf.from_tokenizer(
+            tokenizer, self.vocab_size)
 
     def compile_grammar(self, request_type: StructuredOutputOptions,
                         grammar_spec: str) -> StructuredOutputGrammar:


### PR DESCRIPTION
The smaller of the Qwen models (such as `Qwen/Qwen2.5-Coder-3B-Instruct` for instance) have padding on their vocab size, such that the tokenizer will report a `vocab_size` which is smaller than the logits by 256 or 128.

This is an error for llguidance, which generates masks of the smaller size and therefore does not mask all bits. This leads to a guidance failure, producing no output.

The optional second argument overrides the vocab size to be the correct one.