### PR TITLE
[CI][Bugfix] Fix bad tolerance for test_batch_base64_embedding

### DIFF
--- a/tests/entrypoints/openai/test_embedding.py
+++ b/tests/entrypoints/openai/test_embedding.py
@@ -201,11 +201,18 @@ async def test_batch_base64_embedding(client: openai.AsyncOpenAI,
             np.frombuffer(base64.b64decode(data.embedding),
                           dtype="float32").tolist())
 
+    rtol = 1e-3
+    atol = 1e-4
+
     assert len(responses_float.data) == len(decoded_responses_base64_data)
     assert np.allclose(responses_float.data[0].embedding,
-                       decoded_responses_base64_data[0])
+                       decoded_responses_base64_data[0],
+                       rtol=rtol,
+                       atol=atol)
     assert np.allclose(responses_float.data[1].embedding,
-                       decoded_responses_base64_data[1])
+                       decoded_responses_base64_data[1],
+                       rtol=rtol,
+                       atol=atol)
 
     # Default response is float32 decoded from base64 by OpenAI Client
     responses_default = await client.embeddings.create(input=input_texts,
@@ -213,9 +220,13 @@ async def test_batch_base64_embedding(client: openai.AsyncOpenAI,
 
     assert len(responses_float.data) == len(responses_default.data)
     assert np.allclose(responses_float.data[0].embedding,
-                       responses_default.data[0].embedding)
+                       responses_default.data[0].embedding,
+                       rtol=rtol,
+                       atol=atol)
     assert np.allclose(responses_float.data[1].embedding,
-                       responses_default.data[1].embedding)
+                       responses_default.data[1].embedding,
+                       rtol=rtol,
+                       atol=atol)
 
 
 @pytest.mark.asyncio

--- a/tests/entrypoints/openai/test_embedding.py
+++ b/tests/entrypoints/openai/test_embedding.py
@@ -197,9 +197,9 @@ async def test_batch_base64_embedding(client: openai.AsyncOpenAI,
 
     decoded_responses_base64_data = []
     for data in responses_base64.data:
-        decoded_embedding = np.frombuffer(base64.b64decode(data.embedding),
-                                          dtype=np.float32).tolist()
-        decoded_responses_base64_data.append(decoded_embedding)
+        decoded_responses_base64_data.append(
+            np.frombuffer(base64.b64decode(data.embedding),
+                          dtype="float32").tolist())
 
     assert len(responses_float.data) == len(decoded_responses_base64_data)
     assert np.allclose(responses_float.data[0].embedding,

--- a/tests/entrypoints/openai/test_embedding.py
+++ b/tests/entrypoints/openai/test_embedding.py
@@ -197,23 +197,25 @@ async def test_batch_base64_embedding(client: openai.AsyncOpenAI,
 
     decoded_responses_base64_data = []
     for data in responses_base64.data:
-        decoded_responses_base64_data.append(
-            np.frombuffer(base64.b64decode(data.embedding),
-                          dtype="float32").tolist())
+        decoded_embedding = np.frombuffer(base64.b64decode(data.embedding),
+                                          dtype=np.float32).tolist()
+        decoded_responses_base64_data.append(decoded_embedding)
 
-    assert responses_float.data[0].embedding == decoded_responses_base64_data[
-        0]
-    assert responses_float.data[1].embedding == decoded_responses_base64_data[
-        1]
+    assert len(responses_float.data) == len(decoded_responses_base64_data)
+    assert np.allclose(responses_float.data[0].embedding,
+                       decoded_responses_base64_data[0])
+    assert np.allclose(responses_float.data[1].embedding,
+                       decoded_responses_base64_data[1])
 
     # Default response is float32 decoded from base64 by OpenAI Client
     responses_default = await client.embeddings.create(input=input_texts,
                                                        model=model_name)
 
-    assert responses_float.data[0].embedding == responses_default.data[
-        0].embedding
-    assert responses_float.data[1].embedding == responses_default.data[
-        1].embedding
+    assert len(responses_float.data) == len(responses_default.data)
+    assert np.allclose(responses_float.data[0].embedding,
+                       responses_default.data[0].embedding)
+    assert np.allclose(responses_float.data[1].embedding,
+                       responses_default.data[1].embedding)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously the test was doing equality on float values, which is always a bad idea. See an example of flaky test https://buildkite.com/vllm/fastcheck/builds/19776/steps?jid=0196126c-0cdf-4b29-9363-d925adaf681a#0196126c-0cdf-4b29-9363-d925adaf681a/6-13621

This PR changes it to use allclose