### PR TITLE
[Misc] Merge the logs of pp layers partitions

### DIFF
--- a/vllm/distributed/utils.py
+++ b/vllm/distributed/utils.py
@@ -102,10 +102,11 @@ def get_pp_indices(num_hidden_layers: int, pp_rank: int,
         if remaining_layers := num_hidden_layers % pp_size:
             for i in range(2, remaining_layers + 2):
                 partitions[-i] += 1
-            logger.info("Hidden layers were unevenly partitioned: %s",
-                        ",".join(str(p) for p in partitions))
-            logger.info("This can be manually overridden using the "
-                        "VLLM_PP_LAYER_PARTITION environment variable")
+            logger.info(
+                "Hidden layers were unevenly partitioned: [%s]. "
+                "This can be manually overridden using the "
+                "VLLM_PP_LAYER_PARTITION environment variable",
+                ",".join(str(p) for p in partitions))
 
     start_layer = sum(partitions[:pp_rank])
     end_layer = start_layer + partitions[pp_rank]


### PR DESCRIPTION
Follow https://github.com/vllm-project/vllm/pull/13839

Previously, the PP Layers partition information and prompts were divided into two lines, which was a bit confusing for users. It would be clearer to put them in one line. [Slack discuss](https://vllm-dev.slack.com/archives/C08AD2B5HH8/p1740505963168829?thread_ts=1740503158.346139&cid=C08AD2B5HH8)