### PR TITLE
[Misc] Fix chat input string in xgrammar format

### DIFF
--- a/tests/tool_use/utils.py
+++ b/tests/tool_use/utils.py
@@ -187,7 +187,11 @@ WEATHER_TOOL: ChatCompletionToolParam = {
                 "unit": {
                     "type": "string",
                     "description": "The unit to fetch the temperature in",
-                    "enum": ["celsius", "fahrenheit"]
+                    "oneOf": [{
+                        "const": "celsius"
+                    }, {
+                        "const": "fahrenheit"
+                    }]
                 }
             }
         }


### PR DESCRIPTION
No related Issue， just fix chat input string in xgrammar format

If I launch an api server as follow:
```
python3 -m vllm.entrypoints.openai.api_server --model=mistralai/Mistral-7B-Instruct-v0.3
```

If I send a chat request as follow:
```
curl -X POST http://0.0.0.0:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "messages": [{
      "role": "user",
      "content": "What is the weather in Dallas, Texas in Fahrenheit?"
    }],
  "max_completion_tokens": 100,
  "temperature": 0.0,
  "tools": [{
     "type": "function",
     "function": {
       "name": "get_current_weather",
       "description": "Get the current weather in a given location",
       "parameters": {
         "type": "object",
         "properties": {
           "city": {
             "type": "string",
             "description": "The city to find the weather for, e.g. \"San Francisco\""
           },
           "state": {
             "type": "string",
             "description": "must the two-letter abbreviation for the state that the city is in, e.g. \"CA\" which would mean \"California\""
           },
           "unit": {
             "type": "string",
             "description": "The unit to fetch the temperature in",
             "enum": ["celsius", "fahrenheit"]
           }
         }
       }
     }
  }],
  "tool_choice": {
    "type": "function",
    "function": { "name": "get_current_weather" }
  },
  "logprobs": false
}'
```

I will receive response `{"object":"error","message":"The provided JSON schema contains features not supported by xgrammar.","type":"BadRequestError","param":null,"code":400}`

After modifying the input content as below:
```
curl -X POST http://0.0.0.0:8000/v1/chat/completions \
-H "Content-Type: application/json" \
-d '{
  "model": "mistralai/Mistral-7B-Instruct-v0.3",
  "messages": [{
      "role": "user",
      "content": "What is the weather in Dallas, Texas in Fahrenheit?"
    }],
  "max_completion_tokens": 100,
  "temperature": 0.0,
  "tools": [{
     "type": "function",
     "function": {
       "name": "get_current_weather",
       "description": "Get the current weather in a given location",
       "parameters": {
         "type": "object",
         "properties": {
           "city": {
             "type": "string",
             "description": "The city to find the weather for, e.g. \"San Francisco\""
           },
           "state": {
             "type": "string",
             "description": "must the two-letter abbreviation for the state that the city is in, e.g. \"CA\" which would mean \"California\""
           },
           "unit": {
             "type": "string",
             "description": "The unit to fetch the temperature in",
             "oneOf": [
               {"const": "celsius"},
               {"const": "fahrenheit"}
             ]
           }
         }
       }
     }
  }],
  "tool_choice": {
    "type": "function",
    "function": { "name": "get_current_weather" }
  },
  "logprobs": false
}'
```

I will receive response `{"id":"chatcmpl-730d806c0eeb4a058b4892a51d8c740f","object":"chat.completion","created":1744094949,"model":"mistralai/Mistral-7B-Instruct-v0.3","choices":[{"index":0,"message":{"role":"assistant","reasoning_content":null,"content":"","tool_calls":[{"id":"chatcmpl-tool-e505d4794688402f9fda7f1685adc933","type":"function","function":{"name":"get_current_weather","arguments":"{\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"}}]},"logprobs":null,"finish_reason":"length","stop_reason":null}],"usage":{"prompt_tokens":188,"total_tokens":288,"completion_tokens":100,"prompt_tokens_details":null},"prompt_logprobs":null}`