### PR TITLE
[Model] Add Granite Speech Support

### DIFF
--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -893,6 +893,13 @@ See [this page](#generative-models) for more information on how to use generativ
   * ✅︎
   * ✅︎
   * ✅︎
+- * `GraniteSpeechForConditionalGeneration`
+  * Granite Speech
+  * T + A
+  * `ibm-granite/granite-speech-3.3-8b`
+  * ✅︎
+  * ✅︎
+  * ✅︎
 - * `H2OVLChatModel`
   * H2OVL
   * T + I<sup>E+</sup>

--- a/examples/offline_inference/audio_language.py
+++ b/examples/offline_inference/audio_language.py
@@ -38,6 +38,37 @@ class ModelRequestData(NamedTuple):
 # Unless specified, these settings have been tested to work on a single L4.
 
 
+# Granite Speech
+def run_granite_speech(question: str, audio_count: int) -> ModelRequestData:
+    # NOTE - the setting in this example are somehat different than what is
+    # optimal for granite speech, and it is generally recommended to use beam
+    # search. Check the model README for suggested settings.
+    # https://huggingface.co/ibm-granite/granite-speech-3.3-8b
+    model_name = "ibm-granite/granite-speech-3.3-8b"
+
+    engine_args = EngineArgs(
+        model=model_name,
+        trust_remote_code=True,
+        max_model_len=2048,
+        max_num_seqs=2,
+        enable_lora=True,
+        max_lora_rank=64,
+        limit_mm_per_prompt={"audio": audio_count},
+    )
+
+    # The model has an audio-specific lora directly in its model dir;
+    # it should be enabled whenever you pass audio inputs to the model.
+    speech_lora_path = model_name
+    audio_placeholder = "<|audio|>" * audio_count
+    prompts = f"<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\nToday's Date: December 19, 2024.\nYou are Granite, developed by IBM. You are a helpful AI assistant<|end_of_text|>\n<|start_of_role|>user<|end_of_role|>{audio_placeholder}{question}<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"  # noqa: E501
+
+    return ModelRequestData(
+        engine_args=engine_args,
+        prompt=prompts,
+        lora_requests=[LoRARequest("speech", 1, speech_lora_path)],
+    )
+
+
 # MiniCPM-O
 def run_minicpmo(question: str, audio_count: int) -> ModelRequestData:
     model_name = "openbmb/MiniCPM-o-2_6"
@@ -209,6 +240,7 @@ def run_whisper(question: str, audio_count: int) -> ModelRequestData:
 
 
 model_example_map = {
+    "granite_speech": run_granite_speech,
     "minicpmo": run_minicpmo,
     "phi4_mm": run_phi4mm,
     "qwen2_audio": run_qwen2_audio,

--- a/tests/models/decoder_only/audio_language/test_granite_speech.py
+++ b/tests/models/decoder_only/audio_language/test_granite_speech.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Sequence
+from typing import Optional
+
+import pytest
+from transformers import AutoModelForSpeechSeq2Seq
+
+from vllm.lora.request import LoRARequest
+from vllm.sequence import SampleLogprobs
+
+from ....conftest import HfRunner, PromptAudioInput, VllmRunner, _AudioAssets
+from ...registry import HF_EXAMPLE_MODELS
+from ...utils import check_logprobs_close
+
+HF_AUDIO_PROMPT = "<|start_of_role|>system<|end_of_role|>Knowledge Cutoff Date: April 2024.\nToday's Date: December 19, 2024.\nYou are Granite, developed by IBM. You are a helpful AI assistant<|end_of_text|>\n<|start_of_role|>user<|end_of_role|><|audio|>can you transcribe the speech into a written format?<|end_of_text|>\n<|start_of_role|>assistant<|end_of_role|>"  # noqa: E501
+
+
+def vllm_to_hf_output(
+    vllm_output: tuple[list[int], str, Optional[SampleLogprobs]],
+) -> tuple[list[int], str, Optional[SampleLogprobs]]:
+    """Sanitize hf output to be comparable with vllm output."""
+    output_ids, output_str, out_logprobs = vllm_output
+
+    hf_output_str = output_str + "<|end_of_text|>"
+
+    return output_ids, hf_output_str, out_logprobs
+
+
+MODEL_NAME = "ibm-granite/granite-speech-3.3-8b"
+# Audio lora co-exists directly in the model directory, but
+# currently still needs to be passed directly to vLLM.
+audio_lora_path = MODEL_NAME
+models = [MODEL_NAME]
+
+
+def run_test(
+    hf_runner: type[HfRunner],
+    vllm_runner: type[VllmRunner],
+    inputs: Sequence[tuple[list[str], PromptAudioInput]],
+    model: str,
+    *,
+    max_model_len: int,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+    tensor_parallel_size: int,
+    distributed_executor_backend: Optional[str] = None,
+):
+    """Inference result should be the same between hf and vllm.
+
+    All the audio fixtures for the test are from AUDIO_ASSETS.
+    For huggingface runner, we provide the audio as input.
+    For vllm runner, we provide MultiModalDataDict objects
+    and corresponding MultiModalConfig as input.
+    Note, the text input is also adjusted to abide by vllm contract.
+    The text output is sanitized to be able to compare with hf.
+    """
+    # NOTE: take care of the order. run vLLM first, and then run HF.
+    # vLLM needs a fresh new process without cuda initialization.
+    # if we run HF first, the cuda initialization will be done and it
+    # will hurt multiprocessing backend with fork method (the default method).
+    # max_model_len should be greater than image_feature_size
+    with vllm_runner(
+            model,
+            task="generate",
+            max_model_len=max_model_len,
+            max_num_seqs=1,
+            dtype=dtype,
+            limit_mm_per_prompt={"audio": 1},
+            tensor_parallel_size=tensor_parallel_size,
+            distributed_executor_backend=distributed_executor_backend,
+            enable_lora=True,
+            max_lora_rank=64,
+            enforce_eager=True,
+    ) as vllm_model:
+        lora_request = LoRARequest("audio", 1, audio_lora_path)
+        vllm_outputs_per_case = [
+            vllm_model.generate_greedy_logprobs(prompts,
+                                                max_tokens,
+                                                num_logprobs=num_logprobs,
+                                                audios=audios,
+                                                lora_request=lora_request)
+            for prompts, audios in inputs
+        ]
+
+    with hf_runner(model, dtype=dtype,
+                   auto_cls=AutoModelForSpeechSeq2Seq) as hf_model:
+
+        hf_processor = hf_model.processor
+        eos_token_id = hf_processor.tokenizer.eos_token_id
+
+        hf_outputs_per_case = [
+            hf_model.generate_greedy_logprobs_limit(prompts,
+                                                    max_tokens,
+                                                    num_logprobs=num_logprobs,
+                                                    audios=[audios],
+                                                    eos_token_id=eos_token_id)
+            for prompts, audios in inputs
+        ]
+
+    for hf_outputs, vllm_outputs in zip(hf_outputs_per_case,
+                                        vllm_outputs_per_case):
+        check_logprobs_close(
+            outputs_0_lst=hf_outputs,
+            outputs_1_lst=[
+                vllm_to_hf_output(output) for output in vllm_outputs
+            ],
+            name_0="hf",
+            name_1="vllm",
+        )
+
+
+@pytest.mark.parametrize("model", models)
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize("max_model_len", [2048])
+@pytest.mark.parametrize("max_tokens", [128])
+@pytest.mark.parametrize("num_logprobs", [10])
+def test_models(hf_runner, vllm_runner, model, audio_assets: _AudioAssets,
+                dtype: str, max_model_len: int, max_tokens: int,
+                num_logprobs: int) -> None:
+    model_info = HF_EXAMPLE_MODELS.find_hf_info(model)
+    model_info.check_available_online(on_fail="skip")
+    model_info.check_transformers_version(on_fail="skip")
+
+    audio, sr = audio_assets[0].audio_and_sample_rate
+    # This model expects 16k sample rate, which our test audio
+    # already is; if this changes, it may break this test,
+    # so we check it directly
+    assert sr == 16000
+    run_test(
+        hf_runner,
+        vllm_runner,
+        [[[HF_AUDIO_PROMPT], [audio]]],
+        model,
+        dtype=dtype,
+        max_model_len=max_model_len,
+        max_tokens=max_tokens,
+        num_logprobs=num_logprobs,
+        tensor_parallel_size=1,
+    )

--- a/tests/models/decoder_only/audio_language/test_granite_speech.py
+++ b/tests/models/decoder_only/audio_language/test_granite_speech.py
@@ -116,7 +116,7 @@ def run_test(
 @pytest.mark.parametrize("max_model_len", [2048])
 @pytest.mark.parametrize("max_tokens", [128])
 @pytest.mark.parametrize("num_logprobs", [10])
-def test_models(hf_runner, vllm_runner, model, audio_assets: _AudioAssets,
+def test_models(hf_runner, vllm_runner, model: str, audio_assets: _AudioAssets,
                 dtype: str, max_model_len: int, max_tokens: int,
                 num_logprobs: int) -> None:
     model_info = HF_EXAMPLE_MODELS.find_hf_info(model)
@@ -131,7 +131,9 @@ def test_models(hf_runner, vllm_runner, model, audio_assets: _AudioAssets,
     run_test(
         hf_runner,
         vllm_runner,
-        [[[HF_AUDIO_PROMPT], [audio]]],
+        [
+            ([HF_AUDIO_PROMPT], [audio]),
+        ],
         model,
         dtype=dtype,
         max_model_len=max_model_len,

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -254,7 +254,7 @@ def _test_processing_correctness_mistral(
     "adept/fuyu-8b",
     "google/gemma-3-4b-it",
     "THUDM/glm-4v-9b",
-    "ibm-granite/granite-speech-3.3-8b"
+    "ibm-granite/granite-speech-3.3-8b",
     "h2oai/h2ovl-mississippi-800m",
     "OpenGVLab/InternVL2-1B",
     "HuggingFaceM4/Idefics3-8B-Llama3",

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -303,12 +303,6 @@ def test_processing_correctness(
         # The slight difference should not be a problem though, since
         # attention_mask lets us ignore the difference.
         ignore_mm_keys = {"audio_features"}
-    elif 'granite-speech' in model_id:
-        # Similarly, for granite speech, audio features are variable length
-        # and can be a bit different due to padding prior to calculating
-        # audio features. In vLLM, we pass the sizes so that we can split
-        # the features back out after.
-        ignore_mm_keys = {"audio_embed_sizes"}
 
     _test_processing_correctness(
         model_id,
@@ -364,17 +358,6 @@ def _assert_inputs_equal(
     for key in ignore_mm_keys:
         a["mm_kwargs"].pop(key, None)
         b["mm_kwargs"].pop(key, None)
-
-    if ignore_mm_keys:
-        # Popping the mm_kwargs may result in a modality key mapping to an
-        # empty list in _items_by_modality; if this is the case,
-        # we should also pop the _items_by_modality to keep it comparable.
-        diff_keys = set(a["mm_kwargs"].modalities).symmetric_difference(
-            set(b["mm_kwargs"].modalities))
-
-        for modality_key in diff_keys:
-            a["mm_kwargs"]._items_by_modality.pop(modality_key, None)
-            b["mm_kwargs"]._items_by_modality.pop(modality_key, None)
 
     if msg is None:
         assert a == b

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -254,6 +254,7 @@ def _test_processing_correctness_mistral(
     "adept/fuyu-8b",
     "google/gemma-3-4b-it",
     "THUDM/glm-4v-9b",
+    "ibm-granite/granite-speech-3.3-8b"
     "h2oai/h2ovl-mississippi-800m",
     "OpenGVLab/InternVL2-1B",
     "HuggingFaceM4/Idefics3-8B-Llama3",
@@ -285,7 +286,6 @@ def _test_processing_correctness_mistral(
     "Skywork/Skywork-R1V-38B",
     "fixie-ai/ultravox-v0_5-llama-3_2-1b",
     "openai/whisper-large-v3",
-    "ibm-granite/granite-speech-3.3-8b"
 ])
 @pytest.mark.parametrize("hit_rate", [0.3, 0.5, 1.0])
 @pytest.mark.parametrize("num_batches", [32])

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -298,9 +298,11 @@ _MULTIMODAL_EXAMPLE_MODELS = {
                                                 extras={"fork": "Isotr0py/deepseek-vl2-tiny"},  # noqa: E501
                                                 max_transformers_version="4.48",  # noqa: E501
                                                 transformers_version_reason="HF model is not compatible.",  # noqa: E501
-                                               hf_overrides={"architectures": ["DeepseekVLV2ForCausalLM"]}),  # noqa: E501
+                                                hf_overrides={"architectures": ["DeepseekVLV2ForCausalLM"]}),  # noqa: E501
     "FuyuForCausalLM": _HfExamplesInfo("adept/fuyu-8b"),
     "Gemma3ForConditionalGeneration": _HfExamplesInfo("google/gemma-3-4b-it"),
+    "GraniteSpeechForConditionalGeneration": _HfExamplesInfo("ibm-granite/granite-speech-3.3-8b",  # noqa: E501
+                                                             min_transformers_version="4.52.0"),  # noqa: E501
     "GLM4VForCausalLM": _HfExamplesInfo("THUDM/glm-4v-9b",
                                         trust_remote_code=True,
                                         hf_overrides={"architectures": ["GLM4VForCausalLM"]}),  # noqa: E501

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -517,7 +517,7 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
 
             raise TypeError(f"Unknown {modality} model type: {model_type}")
         elif modality == "audio":
-            if model_type == "ultravox":
+            if model_type in ("ultravox", "granite_speech"):
                 return "<|audio|>"
             if model_type == "phi4mm":
                 return f"<|audio_{current_count}|>"

--- a/vllm/model_executor/models/blip2.py
+++ b/vllm/model_executor/models/blip2.py
@@ -365,6 +365,7 @@ class Blip2QFormerModel(nn.Module):
         *,
         quant_config: Optional[QuantizationConfig],
         cache_config: Optional[CacheConfig],
+        prefix: str = "",
     ) -> None:
         super().__init__()
 

--- a/vllm/model_executor/models/blip2.py
+++ b/vllm/model_executor/models/blip2.py
@@ -60,6 +60,7 @@ class Blip2QFormerMultiHeadAttention(nn.Module):
         quant_config: Optional[QuantizationConfig],
         cache_config: Optional[CacheConfig],
         is_cross_attention: bool = False,
+        prefix: str = "",
     ) -> None:
         super().__init__()
 
@@ -139,7 +140,7 @@ class Blip2QFormerMultiHeadAttention(nn.Module):
 
 class Blip2QFormerSelfOutput(nn.Module):
 
-    def __init__(self, config: Blip2QFormerConfig) -> None:
+    def __init__(self, config: Blip2QFormerConfig, prefix: str = "") -> None:
         super().__init__()
 
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
@@ -167,6 +168,7 @@ class Blip2QFormerAttention(nn.Module):
         quant_config: Optional[QuantizationConfig],
         cache_config: Optional[CacheConfig],
         is_cross_attention: bool = False,
+        prefix: str = "",
     ) -> None:
         super().__init__()
 
@@ -175,9 +177,10 @@ class Blip2QFormerAttention(nn.Module):
             quant_config=quant_config,
             cache_config=cache_config,
             is_cross_attention=is_cross_attention,
+            prefix=f"{prefix}.attention",
         )
 
-        self.output = Blip2QFormerSelfOutput(config)
+        self.output = Blip2QFormerSelfOutput(config, prefix=f"{prefix}.output")
 
     def forward(
         self,
@@ -195,7 +198,7 @@ class Blip2QFormerAttention(nn.Module):
 
 class Blip2QFormerIntermediate(nn.Module):
 
-    def __init__(self, config: Blip2QFormerConfig) -> None:
+    def __init__(self, config: Blip2QFormerConfig, prefix: str = "") -> None:
         super().__init__()
 
         self.dense = nn.Linear(config.hidden_size, config.intermediate_size)
@@ -209,7 +212,7 @@ class Blip2QFormerIntermediate(nn.Module):
 
 class Blip2QFormerOutput(nn.Module):
 
-    def __init__(self, config: Blip2QFormerConfig) -> None:
+    def __init__(self, config: Blip2QFormerConfig, prefix: str = "") -> None:
         super().__init__()
 
         self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
@@ -237,6 +240,7 @@ class Blip2QFormerLayer(nn.Module):
         quant_config: Optional[QuantizationConfig],
         cache_config: Optional[CacheConfig],
         layer_idx: int,
+        prefix: str = "",
     ) -> None:
         super().__init__()
 
@@ -244,7 +248,8 @@ class Blip2QFormerLayer(nn.Module):
         self.seq_len_dim = 1
         self.attention = Blip2QFormerAttention(config,
                                                quant_config=quant_config,
-                                               cache_config=cache_config)
+                                               cache_config=cache_config,
+                                               prefix=f"{prefix}.attention")
 
         self.layer_idx = layer_idx
 
@@ -253,13 +258,16 @@ class Blip2QFormerLayer(nn.Module):
                 config,
                 quant_config=quant_config,
                 cache_config=cache_config,
-                is_cross_attention=True)
+                is_cross_attention=True,
+                prefix=f"{prefix}.crossattention")
             self.has_cross_attention = True
         else:
             self.has_cross_attention = False
 
-        self.intermediate_query = Blip2QFormerIntermediate(config)
-        self.output_query = Blip2QFormerOutput(config)
+        self.intermediate_query = Blip2QFormerIntermediate(
+            config, prefix=f"{prefix}.intermediate_query")
+        self.output_query = Blip2QFormerOutput(config,
+                                               prefix=f"{prefix}.output_query")
 
     def forward(
         self,
@@ -325,6 +333,7 @@ class Blip2QFormerEncoder(nn.Module):
         *,
         quant_config: Optional[QuantizationConfig],
         cache_config: Optional[CacheConfig],
+        prefix: str = "",
     ) -> None:
         super().__init__()
 
@@ -334,7 +343,8 @@ class Blip2QFormerEncoder(nn.Module):
             Blip2QFormerLayer(config,
                               quant_config=quant_config,
                               cache_config=cache_config,
-                              layer_idx=layer_idx)
+                              layer_idx=layer_idx,
+                              prefix=f"{prefix}.layer.{layer_idx}")
             for layer_idx in range(config.num_hidden_layers)
         ])
 
@@ -377,7 +387,8 @@ class Blip2QFormerModel(nn.Module):
 
         self.encoder = Blip2QFormerEncoder(config,
                                            quant_config=quant_config,
-                                           cache_config=cache_config)
+                                           cache_config=cache_config,
+                                           prefix=f"{prefix}.encoder")
 
     def forward(
         self,
@@ -512,7 +523,8 @@ class Blip2ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP,
 
         self.qformer = Blip2QFormerModel(config.qformer_config,
                                          cache_config=cache_config,
-                                         quant_config=quant_config)
+                                         quant_config=quant_config,
+                                         prefix=f"{prefix}.qformer")
 
         self.language_projection = nn.Linear(
             config.qformer_config.hidden_size,

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -34,7 +34,7 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
 from vllm.model_executor.layers.quantization import QuantizationConfig
-from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.layers.sampler import get_sampler
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -72,13 +72,6 @@ class GraniteSpeechMultiModalProcessingInfo(BaseProcessingInfo):
 
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
         return {"audio": 1}
-
-    def get_mm_max_tokens_per_item(
-        self,
-        seq_len: int,
-        mm_counts: Mapping[str, int],
-    ) -> Mapping[str, int]:
-        return {"audio": self.get_max_audio_tokens()}
 
     # There is no limit to the maximum number of audio tokens that can be
     # encoded as features; we pick ~5000 as a number that is probably higher
@@ -767,13 +760,6 @@ class GraniteSpeechForConditionalGeneration(
             hidden_states,
             sampling_metadata,
         )
-
-    def sample(
-        self,
-        logits: torch.Tensor,
-        sampling_metadata: SamplingMetadata,
-    ) -> Optional[SamplerOutput]:
-        return self.language_model.sample(logits, sampling_metadata)
 
     def load_weights(
         self,

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Adapted from
+# https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
+# Copyright 2023 The vLLM team.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only IBM Granite speeech model."""
+from typing import Iterable, Mapping, Optional, Set, Tuple, TypedDict, Union
+
+import torch
+from torch import nn
+from transformers import BatchFeature
+
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargs
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import (BaseMultiModalProcessor,
+                                        BaseProcessingInfo, PromptUpdate)
+from vllm.multimodal.profiling import BaseDummyInputsBuilder, ProcessorInputs
+from vllm.sequence import IntermediateTensors
+
+from .interfaces import SupportsMultiModal, SupportsPP
+from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
+
+
+# # === Audio Inputs === #
+class SpeechGraniteAudioInputs(TypedDict):
+    input_features: torch.Tensor
+    """Shape: `TODO`"""
+
+
+class SpeechGraniteMultiModalProcessingInfo(BaseProcessingInfo):
+
+    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+        # TODO - check if multi-audio is supported.
+        return {"audio": None}
+
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int]:
+        # hf_config = self.get_hf_config()
+        max_num_audio_tokens = 1000  # TODO calculate me
+        return {"audio": max_num_audio_tokens}
+
+
+class SpeechGraniteMultiModalProcessor(
+        BaseMultiModalProcessor[SpeechGraniteMultiModalProcessingInfo]):
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        raise NotImplementedError(
+            "mm config update not implemented for speech granite")
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> list[PromptUpdate]:
+        raise NotImplementedError(
+            "prompt update not implemented for speech granite")
+
+
+class SpeechGraniteDummyInputsBuilder(
+        BaseDummyInputsBuilder[SpeechGraniteMultiModalProcessingInfo]):
+
+    def get_dummy_processor_inputs(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> ProcessorInputs:
+        # TODO - calculate this correctly off the feature extractor
+        audio_len = 1000
+        num_audios = mm_counts.get("audio", 0)
+
+        mm_data = {
+            "audio":
+            self._get_dummy_audios(length=audio_len, num_audios=num_audios)
+        }
+
+        return ProcessorInputs(
+            # TODO - can we pull this from tokenizer?
+            prompt_text="<|audio|>" * num_audios,
+            mm_data=mm_data,
+        )
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    SpeechGraniteMultiModalProcessingInfo,
+    info=SpeechGraniteMultiModalProcessingInfo,
+    dummy_inputs=SpeechGraniteDummyInputsBuilder)
+class SpeechGraniteForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        lora_config = vllm_config.lora_config
+
+        self.config = config
+        self.lora_config = lora_config
+        self.quant_config = quant_config
+        self.sampler = get_sampler()
+
+        # this should be a granite causal LM, but written generically for now
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            hf_config=config.text_config,
+            prefix=maybe_prefix(
+                prefix,
+                "language_model"),  # TODO - pull me out of the actual weights
+        )
+
+        # TODO audio model initialization stuff :)
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    def _parse_and_validate_audio_input(
+            self, **kwargs: object) -> Optional[SpeechGraniteAudioInputs]:
+        raise NotImplementedError(
+            "Audio input parsing and validation not implemented")
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        model_output = self.model(input_ids, positions, intermediate_tensors,
+                                  inputs_embeds)
+        return model_output
+
+    def compute_logits(
+            self, hidden_states: torch.Tensor,
+            sampling_metadata: SamplingMetadata) -> Optional[torch.Tensor]:
+        logits = self.logits_processor(self.lm_head, hidden_states,
+                                       sampling_metadata)
+        return logits
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[SamplerOutput]:
+        return self.language_model.sample(logits, sampling_metadata)
+
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -32,6 +32,7 @@ from transformers import BatchFeature
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargs
@@ -573,3 +574,12 @@ class GraniteSpeechForConditionalGeneration(
                                                    torch.Tensor]]) -> Set[str]:
         loader = AutoWeightsLoader(self)
         return loader.load_weights(weights)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        """
+        Get the module prefix in multimodal models.
+        """
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="projector",
+            tower_model="encoder")

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -2,7 +2,7 @@
 
 # Adapted from
 # https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
-# Copyright 2023 The vLLM team.
+# Copyright 2025 The vLLM team.
 # Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
 #
 # This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
@@ -22,34 +22,365 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only IBM Granite speeech model."""
+import math
 from typing import Iterable, Mapping, Optional, Set, Tuple, TypedDict, Union
 
 import torch
-from torch import nn
+import torch.nn.functional as F
+from torch import einsum, nn
 from transformers import BatchFeature
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
 from vllm.model_executor.sampling_metadata import SamplingMetadata
-from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargs
 from vllm.multimodal.parse import MultiModalDataItems
 from vllm.multimodal.processing import (BaseMultiModalProcessor,
-                                        BaseProcessingInfo, PromptUpdate)
+                                        BaseProcessingInfo, PromptReplacement,
+                                        PromptUpdate)
 from vllm.multimodal.profiling import BaseDummyInputsBuilder, ProcessorInputs
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsMultiModal, SupportsPP
+from .blip2 import Blip2QFormerModel
+from .interfaces import SupportsPP
 from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
 
+###########################################################
+# Below is a direct copy of the non-lang model components from transformers
 
-# # === Audio Inputs === #
-class SpeechGraniteAudioInputs(TypedDict):
+
+class GraniteSpeechEncoderProjectorQFormer(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.ds_rate = config.downsample_rate
+        self.window_size = config.window_size
+        self.num_queries = self.window_size // self.ds_rate
+        self.query = nn.Parameter(
+            torch.zeros(1, self.num_queries, config.hidden_size))
+        self.query.data.normal_(mean=0.0, std=1.0)
+        # It would be nice if we could do this generically...
+        self.qformer = Blip2QFormerModel(
+            config,
+            quant_config=None,
+            cache_config=None,
+        )  #### HACK HACK HACK - TODO need to add configs
+        self.linear = nn.Linear(config.hidden_size, config.llm_dim)
+
+    def forward(self, x, atts):
+        batch_size, seq_len, dim = x.size()
+        nblocks = math.ceil(seq_len / self.window_size)
+        pad = nblocks * self.window_size - seq_len
+        x = nn.functional.pad(x, (0, 0, 0, pad), "constant", 0)
+        x = x.view(batch_size * nblocks, self.window_size, dim)
+
+        query_output = self.qformer(
+            query_embeds=self.query.data,
+            encoder_hidden_states=x,
+            encoder_attention_mask=atts,
+            return_dict=True,
+        )
+        query_proj = self.linear(
+            query_output.last_hidden_state.view(
+                batch_size, nblocks * self.window_size // self.ds_rate, -1))
+        return query_proj
+
+
+### Encoder
+class GraniteSpeechCTCModel(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+
+        self.rnn_tr = nn.ModuleList(
+            [nn.Linear(config.input_dim, config.hidden_dim, bias=True)] + [
+                GraniteSpeechConformerBlock(
+                    dim=config.hidden_dim,
+                    dim_head=config.dim_head,
+                    heads=config.num_heads,
+                    ff_mult=config.feedforward_mult,
+                    conv_expansion_factor=config.conv_expansion_factor,
+                    conv_kernel_size=config.conv_kernel_size,
+                    context_size=config.context_size,  # attention context size
+                    attn_dropout=config.dropout,
+                    ff_dropout=config.dropout,
+                    conv_dropout=config.dropout,
+                ) for layer_idx in range(config.num_layers)
+            ])
+
+        self.out = nn.Linear(config.hidden_dim, config.output_dim, bias=True)
+        self.out_mid = nn.Linear(config.output_dim,
+                                 config.hidden_dim,
+                                 bias=True)
+        self.context_size = config.context_size
+        self.input_dim = config.input_dim
+        self.num_layers = config.num_layers
+        self.hidden_dim = config.hidden_dim
+        self.output_dim = config.output_dim
+
+    def forward(self, x: torch.Tensor):
+        x = self.rnn_tr[0](x)
+        for idx, layer in enumerate(self.rnn_tr[1:], start=1):
+            x = layer(x, self.context_size)
+            if idx == self.num_layers // 2:
+                x_mid = x.clone()
+                x_mid = self.out(x_mid)
+                x += self.out_mid(nn.Softmax(dim=-1)(x_mid))
+        return x
+
+
+# NOTE: Conformer adapted from: https://github.com/lucidrains/conformer.git
+class GraniteSpeechConformerPermute(nn.Module):
+
+    def __init__(self, dims):
+        super().__init__()
+        self.dims = dims
+
+    def forward(self, x):
+        x = x.permute(self.dims)
+        return x
+
+
+class GraniteSpeechConformerDepthWiseConv1d(nn.Module):
+
+    def __init__(self, chan_in, chan_out, kernel_size, padding):
+        super().__init__()
+        self.padding = padding
+        self.conv = nn.Conv1d(chan_in,
+                              chan_out,
+                              kernel_size,
+                              groups=chan_in,
+                              bias=False)
+
+    def forward(self, x):
+        x = F.pad(x, self.padding)
+        return self.conv(x)
+
+
+class GraniteSpeechConformerScale(nn.Module):
+
+    def __init__(self, scale, fn):
+        super().__init__()
+        self.fn = fn
+        self.scale = scale
+
+    def forward(self, x, **kwargs):
+        return self.fn(x, **kwargs) * self.scale
+
+
+class GraniteSpeechConformerPreNorm(nn.Module):
+
+    def __init__(self, dim, fn):
+        super().__init__()
+        self.fn = fn
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, x, **kwargs):
+        x = self.norm(x)
+        return self.fn(x, **kwargs)
+
+
+class GraniteSpeechConformerPreNormAttn(nn.Module):
+
+    def __init__(self, dim, fn):
+        super().__init__()
+        self.fn = fn
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, x, context_size, **kwargs):
+        x = self.norm(x)
+        return self.fn(x, context_size, **kwargs)
+
+
+class GraniteSpeechConformerAttention(nn.Module):
+
+    def __init__(
+        self,
+        dim,
+        heads=8,
+        dim_head=64,
+        dropout=0.0,
+        context_size=200,
+        max_pos_emb=512,
+    ):
+        super().__init__()
+        inner_dim = dim_head * heads
+        self.heads = heads
+        self.dim_head = dim_head
+        self.scale = dim_head**-0.5
+        self.to_q = nn.Linear(dim, inner_dim, bias=False)
+        self.to_kv = nn.Linear(dim, inner_dim * 2, bias=False)
+        self.to_out = nn.Linear(inner_dim, dim)
+
+        self.max_pos_emb = max_pos_emb
+        self.rel_pos_emb = nn.Embedding(2 * max_pos_emb + 1, dim_head)
+
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x, context_size):
+        device, h, max_pos_emb = x.device, self.heads, self.max_pos_emb
+        bs, n, d = x.shape
+        assert context_size > 0 and context_size <= max_pos_emb
+
+        nb = math.ceil(n / context_size)
+        nr = n % context_size
+        if nr > 0:
+            # right padding to reach block size
+            x = torch.nn.functional.pad(x, (0, 0, 0, context_size - nr))
+
+        q, k, v = (self.to_q(x), *self.to_kv(x).chunk(2, dim=-1))
+        q, k, v = [
+            t.reshape(bs, nb, context_size, h, -1).transpose(2, 3)
+            for t in (q, k, v)
+        ]
+
+        dots = einsum("b m h i d, b m h j d -> b m h i j", q, k) * self.scale
+
+        # shaw's relative positional embedding
+        seq = torch.arange(context_size, device=device)
+        dist = seq.view(-1, 1) - seq.view(1, -1)
+        dist = torch.clamp(dist, -context_size, context_size) + max_pos_emb
+        rel_pos_emb = self.rel_pos_emb(dist).to(q)
+        pos_attn = einsum("b m h c d, c r d -> b m h c r", q,
+                          rel_pos_emb) * self.scale
+        dots = dots + pos_attn
+
+        if nr > 0:
+            # masked attention in the extended block
+            mask = torch.ones(context_size,
+                              context_size,
+                              dtype=bool,
+                              device=device)
+            mask[:nr, :nr] = 0
+            mask_value = -torch.finfo(dots.dtype).max
+            dots[:, -1, :].masked_fill_(mask, mask_value)
+
+        attn = dots.softmax(dim=-1)
+
+        out = einsum("b m h i j, b m h j d -> b m h i d", attn, v)
+        out = out.transpose(2, 3).reshape(bs, x.shape[1], -1)
+        out = self.to_out(out[:, :n, :])
+        return self.dropout(out)
+
+
+class GraniteSpeechConformerFeedForward(nn.Module):
+
+    def __init__(self, dim, mult=4, dropout=0.0):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(dim, dim * mult), nn.SiLU(),
+                                 nn.Dropout(dropout),
+                                 nn.Linear(dim * mult,
+                                           dim), nn.Dropout(dropout))
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class GraniteSpeechConformerConvModule(nn.Module):
+
+    def __init__(self,
+                 dim,
+                 causal=False,
+                 expansion_factor=2,
+                 kernel_size=31,
+                 dropout=0.0):
+        super().__init__()
+
+        inner_dim = dim * expansion_factor
+        padding = self.calc_same_padding(kernel_size) if not causal else (
+            kernel_size - 1, 0)
+
+        self.net = nn.Sequential(
+            nn.LayerNorm(dim),
+            GraniteSpeechConformerPermute(dims=(0, 2, 1)),
+            nn.Conv1d(dim, inner_dim * 2, 1),
+            nn.GLU(dim=1),
+            GraniteSpeechConformerDepthWiseConv1d(inner_dim,
+                                                  inner_dim,
+                                                  kernel_size=kernel_size,
+                                                  padding=padding),
+            nn.BatchNorm1d(inner_dim) if not causal else nn.Identity(),
+            nn.SiLU(),
+            nn.Conv1d(inner_dim, dim, 1),
+            GraniteSpeechConformerPermute(dims=(0, 2, 1)),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+    @staticmethod
+    def calc_same_padding(kernel_size: int):
+        pad = kernel_size // 2
+        return (pad, pad - (kernel_size + 1) % 2)
+
+
+class GraniteSpeechConformerBlock(nn.Module):
+
+    def __init__(
+        self,
+        *,
+        dim,
+        dim_head=64,
+        heads=8,
+        ff_mult=2,
+        conv_expansion_factor=2,
+        conv_kernel_size=31,
+        context_size=-1,
+        attn_dropout=0.0,
+        ff_dropout=0.0,
+        conv_dropout=0.0,
+    ):
+        super().__init__()
+        self.ff1 = GraniteSpeechConformerFeedForward(dim=dim,
+                                                     mult=ff_mult,
+                                                     dropout=ff_dropout)
+        self.attn = GraniteSpeechConformerAttention(
+            dim=dim,
+            dim_head=dim_head,
+            heads=heads,
+            dropout=attn_dropout,
+            context_size=context_size,
+        )
+        self.conv = GraniteSpeechConformerConvModule(
+            dim=dim,
+            causal=False,
+            expansion_factor=conv_expansion_factor,
+            kernel_size=conv_kernel_size,
+            dropout=conv_dropout,
+        )
+        self.ff2 = GraniteSpeechConformerFeedForward(dim=dim,
+                                                     mult=ff_mult,
+                                                     dropout=ff_dropout)
+
+        self.attn = GraniteSpeechConformerPreNormAttn(dim, self.attn)
+        self.ff1 = GraniteSpeechConformerScale(
+            0.5, GraniteSpeechConformerPreNorm(dim, self.ff1))
+        self.ff2 = GraniteSpeechConformerScale(
+            0.5, GraniteSpeechConformerPreNorm(dim, self.ff2))
+
+        self.post_norm = nn.LayerNorm(dim)
+
+    def forward(self, x, context_size):
+        x = self.ff1(x) + x
+        x = self.attn(x, context_size) + x
+        x = self.conv(x) + x
+        x = self.ff2(x) + x
+        x = self.post_norm(x)
+        return x
+
+
+###########################################################
+
+
+# === Audio Inputs === #
+class GraniteSpeechAudioInputs(TypedDict):
     input_features: torch.Tensor
     """Shape: `TODO`"""
 
 
-class SpeechGraniteMultiModalProcessingInfo(BaseProcessingInfo):
+class GraniteSpeechMultiModalProcessingInfo(BaseProcessingInfo):
 
     def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
         # TODO - check if multi-audio is supported.
@@ -65,16 +396,15 @@ class SpeechGraniteMultiModalProcessingInfo(BaseProcessingInfo):
         return {"audio": max_num_audio_tokens}
 
 
-class SpeechGraniteMultiModalProcessor(
-        BaseMultiModalProcessor[SpeechGraniteMultiModalProcessingInfo]):
+class GraniteSpeechMultiModalProcessor(
+        BaseMultiModalProcessor[GraniteSpeechMultiModalProcessingInfo]):
 
     def _get_mm_fields_config(
         self,
         hf_inputs: BatchFeature,
         hf_processor_mm_kwargs: Mapping[str, object],
     ) -> Mapping[str, MultiModalFieldConfig]:
-        raise NotImplementedError(
-            "mm config update not implemented for speech granite")
+        return dict(input_features=MultiModalFieldConfig.batched("audio"), )
 
     def _get_prompt_updates(
         self,
@@ -82,12 +412,21 @@ class SpeechGraniteMultiModalProcessor(
         hf_processor_mm_kwargs: Mapping[str, object],
         out_mm_kwargs: MultiModalKwargs,
     ) -> list[PromptUpdate]:
-        raise NotImplementedError(
-            "prompt update not implemented for speech granite")
+        # TODO - implement this properly, need to add feature calc
+        def get_replacement(item_idx: int):
+            return [49155] * 1
+
+        return [
+            PromptReplacement(
+                modality="audio",
+                target=[49155],
+                replacement=get_replacement,
+            ),
+        ]
 
 
-class SpeechGraniteDummyInputsBuilder(
-        BaseDummyInputsBuilder[SpeechGraniteMultiModalProcessingInfo]):
+class GraniteSpeechDummyInputsBuilder(
+        BaseDummyInputsBuilder[GraniteSpeechMultiModalProcessingInfo]):
 
     def get_dummy_processor_inputs(
         self,
@@ -95,7 +434,7 @@ class SpeechGraniteDummyInputsBuilder(
         mm_counts: Mapping[str, int],
     ) -> ProcessorInputs:
         # TODO - calculate this correctly off the feature extractor
-        audio_len = 1000
+        audio_len = 1
         num_audios = mm_counts.get("audio", 0)
 
         mm_data = {
@@ -110,11 +449,15 @@ class SpeechGraniteDummyInputsBuilder(
         )
 
 
-@MULTIMODAL_REGISTRY.register_processor(
-    SpeechGraniteMultiModalProcessingInfo,
-    info=SpeechGraniteMultiModalProcessingInfo,
-    dummy_inputs=SpeechGraniteDummyInputsBuilder)
-class SpeechGraniteForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
+# @MULTIMODAL_REGISTRY.register_processor(
+#     GraniteSpeechMultiModalProcessor,
+#     info=GraniteSpeechMultiModalProcessingInfo,
+#     dummy_inputs=GraniteSpeechDummyInputsBuilder)
+class GraniteSpeechForConditionalGeneration(
+        nn.Module,
+        #SupportsMultiModal,
+        SupportsPP,
+):
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
@@ -131,18 +474,18 @@ class SpeechGraniteForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         self.language_model = init_vllm_registered_model(
             vllm_config=vllm_config,
             hf_config=config.text_config,
-            prefix=maybe_prefix(
-                prefix,
-                "language_model"),  # TODO - pull me out of the actual weights
+            prefix=maybe_prefix(prefix, "language_model"),
         )
-
-        # TODO audio model initialization stuff :)
+        hf_config = vllm_config.model_config.hf_config
+        self.encoder = GraniteSpeechCTCModel(config=hf_config.encoder_config)
+        self.projector = GraniteSpeechEncoderProjectorQFormer(
+            config=hf_config.projector_config)
 
         self.make_empty_intermediate_tensors = (
             self.language_model.make_empty_intermediate_tensors)
 
     def _parse_and_validate_audio_input(
-            self, **kwargs: object) -> Optional[SpeechGraniteAudioInputs]:
+            self, **kwargs: object) -> Optional[GraniteSpeechAudioInputs]:
         raise NotImplementedError(
             "Audio input parsing and validation not implemented")
 
@@ -153,16 +496,17 @@ class SpeechGraniteForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
         intermediate_tensors: Optional[IntermediateTensors] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, IntermediateTensors]:
-        model_output = self.model(input_ids, positions, intermediate_tensors,
-                                  inputs_embeds)
+        model_output = self.language_model(input_ids, positions,
+                                           intermediate_tensors, inputs_embeds)
         return model_output
 
     def compute_logits(
-            self, hidden_states: torch.Tensor,
-            sampling_metadata: SamplingMetadata) -> Optional[torch.Tensor]:
-        logits = self.logits_processor(self.lm_head, hidden_states,
-                                       sampling_metadata)
-        return logits
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states,
+                                                  sampling_metadata)
 
     def sample(
         self,
@@ -171,7 +515,32 @@ class SpeechGraniteForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
     ) -> Optional[SamplerOutput]:
         return self.language_model.sample(logits, sampling_metadata)
 
+    def _get_ignore_hacked_ignore_weight_dict(self):
+        ## FIXME - there are issues with loading BN, needs to be resolved;
+        # the problem is that batch norm puts the tensors in the state
+        # dict, but not in the named parameters.
+        #
+        # For example, in keys:
+        # >>> dict(self.encoder.rnn_tr[1].conv.net[5].named_parameters()).keys()
+        # we do not have things like num_batches_tracked, which breaks when
+        # we export the model and try to reload them.
+        print("🚨 Currently we are not loading batch norm stats correctly! 🚨")
+        ignore_suffixes = [
+            "bias",
+            "num_batches_tracked",
+            "running_mean",
+            "running_var",
+        ]
+        ignore_layers = []
+        for idx1 in range(1, 11):
+            for idx2 in range(1, 11):
+                for suffix in ignore_suffixes:
+                    ignore_layers.append(
+                        f"encoder.rnn_tr.{idx1}.conv.net.{idx2}.{suffix}")
+        return {"ignore_unexpected_prefixes": ignore_layers}
+
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:
-        loader = AutoWeightsLoader(self)
+        extra_kwargs = self._get_ignore_hacked_ignore_weight_dict()
+        loader = AutoWeightsLoader(self, **extra_kwargs)
         return loader.load_weights(weights)

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -211,7 +211,6 @@ class GraniteSpeechEncoderProjector(nn.Module):
         self.query = nn.Parameter(
             torch.zeros(1, self.num_queries,
                         config.projector_config.hidden_size))
-        self.query.data.normal_(mean=0.0, std=1.0)
 
         # NOTE - this is implemented generically in transformers,
         # but for now we create the QFormer model directly since

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -27,7 +27,7 @@ from typing import Iterable, Mapping, Optional, Set, Tuple, TypedDict, Union
 
 import torch
 import torch.nn.functional as F
-from torch import einsum, nn
+from torch import nn
 from transformers import BatchFeature
 
 from vllm.config import VllmConfig
@@ -49,116 +49,248 @@ from .interfaces import (MultiModalEmbeddings, SupportsLoRA,
 from .utils import (AutoWeightsLoader, embed_multimodal,
                     init_vllm_registered_model, maybe_prefix)
 
-###########################################################
-# Below is a direct copy of the non-lang model components from transformers
 
-
-class GraniteSpeechEncoderProjectorQFormer(nn.Module):
+class GraniteSpeechEncoderProjector(nn.Module):
 
     def __init__(self, config, quant_config, cache_config):
         super().__init__()
-        self.hidden_size = config.hidden_size
-        self.ds_rate = config.downsample_rate
+        self.hidden_size = config.projector_config.hidden_size
+        self.downsample_rate = config.downsample_rate
         self.window_size = config.window_size
-        self.num_queries = self.window_size // self.ds_rate
+        self.num_queries = config.window_size // config.downsample_rate
+
         self.query = nn.Parameter(
-            torch.zeros(1, self.num_queries, config.hidden_size))
+            torch.zeros(1, self.num_queries,
+                        config.projector_config.hidden_size))
         self.query.data.normal_(mean=0.0, std=1.0)
-        # It would be nice if we could do this generically...
+
         self.qformer = Blip2QFormerModel(
-            config,
+            config.projector_config,
             quant_config=quant_config,
             cache_config=cache_config,
         )
-        self.linear = nn.Linear(config.hidden_size, config.llm_dim)
+        self.linear = nn.Linear(config.projector_config.hidden_size,
+                                config.text_config.hidden_size)
 
-    def forward(self, x, atts):
-        batch_size, seq_len, dim = x.size()
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, dim = hidden_states.size()
         nblocks = math.ceil(seq_len / self.window_size)
         pad = nblocks * self.window_size - seq_len
-        x = nn.functional.pad(x, (0, 0, 0, pad), "constant", 0)
-        x = x.view(batch_size * nblocks, self.window_size, dim)
+        hidden_states = nn.functional.pad(hidden_states, (0, 0, 0, pad),
+                                          "constant", 0)
+        hidden_states = hidden_states.view(batch_size * nblocks,
+                                           self.window_size, dim)
 
         query_output = self.qformer(
             query_embeds=self.query.data,
-            encoder_hidden_states=x,
-            # encoder_attention_mask=atts,
+            encoder_hidden_states=hidden_states,
+            # encoder_attention_mask=None,
             # return_dict=True,
         )
-        # NOTE - rewrite this, just making it explicit so that
-        # we remember we change this for now
         last_hidden_state = query_output
-
         query_proj = self.linear(
-            last_hidden_state.view(batch_size,
-                                   nblocks * self.window_size // self.ds_rate,
-                                   -1))
+            last_hidden_state.view(
+                batch_size, nblocks * self.window_size // self.downsample_rate,
+                -1))
         return query_proj
 
 
-### Encoder
-class GraniteSpeechCTCModel(nn.Module):
+### Encoder - conformer is adapted from: https://github.com/lucidrains/conformer.git
+class GraniteSpeechCTCEncoder(nn.Module):
 
     def __init__(self, config):
         super().__init__()
-
-        self.rnn_tr = nn.ModuleList(
-            [nn.Linear(config.input_dim, config.hidden_dim, bias=True)] + [
-                GraniteSpeechConformerBlock(
-                    dim=config.hidden_dim,
-                    dim_head=config.dim_head,
-                    heads=config.num_heads,
-                    ff_mult=config.feedforward_mult,
-                    conv_expansion_factor=config.conv_expansion_factor,
-                    conv_kernel_size=config.conv_kernel_size,
-                    context_size=config.context_size,  # attention context size
-                    attn_dropout=config.dropout,
-                    ff_dropout=config.dropout,
-                    conv_dropout=config.dropout,
-                ) for layer_idx in range(config.num_layers)
-            ])
+        self.config = config
+        self.input_linear = nn.Linear(config.input_dim,
+                                      config.hidden_dim,
+                                      bias=True)
+        self.layers = nn.ModuleList([
+            GraniteSpeechConformerBlock(config)
+            for _ in range(config.num_layers)
+        ])
 
         self.out = nn.Linear(config.hidden_dim, config.output_dim, bias=True)
         self.out_mid = nn.Linear(config.output_dim,
                                  config.hidden_dim,
                                  bias=True)
-        self.context_size = config.context_size
-        self.input_dim = config.input_dim
         self.num_layers = config.num_layers
-        self.hidden_dim = config.hidden_dim
-        self.output_dim = config.output_dim
 
-    def forward(self, x: torch.Tensor):
-        # TODO - currently we unsqueeze a singleton dim when we have one audio
-        # output, but vLLM stacks along a new axis....
-        if len(x.shape) == 4:
-            x = x.squeeze(1)
-
-        x = self.rnn_tr[0](x)
-        for idx, layer in enumerate(self.rnn_tr[1:], start=1):
-            x = layer(x, self.context_size)
+    def forward(self, hidden_states: torch.Tensor):
+        hidden_states = self.input_linear(hidden_states)
+        for idx, layer in enumerate(self.layers, start=1):
+            hidden_states = layer(hidden_states)
             if idx == self.num_layers // 2:
-                x_mid = x.clone()
-                x_mid = self.out(x_mid)
-                x += self.out_mid(nn.Softmax(dim=-1)(x_mid))
-        return x
+                hidden_states_mid = hidden_states.clone()
+                hidden_states_mid = self.out(hidden_states_mid)
+                hidden_states += self.out_mid(
+                    nn.Softmax(dim=-1)(hidden_states_mid))
+        return hidden_states
 
 
-# NOTE: Conformer adapted from: https://github.com/lucidrains/conformer.git
-class GraniteSpeechConformerPermute(nn.Module):
+class GraniteSpeechConformerBlock(nn.Module):
+    """Conformer block, consisting largely of linear layers,
+    attention, and convolutional layers."""
 
-    def __init__(self, dims):
+    def __init__(self, config):
         super().__init__()
-        self.dims = dims
+        self.ff1 = GraniteSpeechConformerFeedForward(config)
+        self.attn = GraniteSpeechConformerAttention(config)
+        self.conv = GraniteSpeechConformerConvModule(config)
+        self.ff2 = GraniteSpeechConformerFeedForward(config)
+        self.post_norm = nn.LayerNorm(config.hidden_dim)
 
-    def forward(self, x):
-        x = x.permute(self.dims)
-        return x
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = 0.5 * self.ff1(hidden_states) + hidden_states
+        hidden_states = self.attn(hidden_states) + hidden_states
+        hidden_states = self.conv(hidden_states) + hidden_states
+        hidden_states = 0.5 * self.ff2(hidden_states) + hidden_states
+        hidden_states = self.post_norm(hidden_states)
+        return hidden_states
+
+
+class GraniteSpeechConformerFeedForward(nn.Module):
+    """Feedforward module for conformer encoder blocks."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.pre_norm = nn.LayerNorm(config.hidden_dim)
+        self.up_proj = nn.Linear(config.hidden_dim,
+                                 config.hidden_dim * config.feedforward_mult)
+        self.silu = nn.SiLU()
+        self.dropout = nn.Dropout(config.dropout)
+        self.down_proj = nn.Linear(config.hidden_dim * config.feedforward_mult,
+                                   config.hidden_dim)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.pre_norm(hidden_states)
+        hidden_states = self.up_proj(hidden_states)
+        hidden_states = self.dropout(self.silu(hidden_states))
+        hidden_states = self.down_proj(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        return hidden_states
+
+
+class GraniteSpeechConformerAttention(nn.Module):
+    """Attention for conformer blocks with shaw's relpos embeddings."""
+
+    def __init__(self, config):
+        super().__init__()
+
+        inner_dim = config.dim_head * config.num_heads
+        self.max_pos_emb = config.max_pos_emb
+        self.context_size = config.context_size
+        self.num_heads = config.num_heads
+        self.dim_head = config.dim_head
+        self.scale = self.dim_head**-0.5
+        self.pre_norm = nn.LayerNorm(config.hidden_dim)
+        self.to_q = nn.Linear(config.hidden_dim, inner_dim, bias=False)
+        self.to_kv = nn.Linear(config.hidden_dim, inner_dim * 2, bias=False)
+        self.to_out = nn.Linear(inner_dim, config.hidden_dim)
+        self.rel_pos_emb = nn.Embedding(2 * self.max_pos_emb + 1,
+                                        self.dim_head)
+        self.dropout = nn.Dropout(config.dropout)
+
+        if self.context_size <= 0 or self.context_size > self.max_pos_emb:
+            raise ValueError(
+                "Context size is either less than 0 or exceeds the max_pos_emb"
+            )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.pre_norm(hidden_states)
+        bsz, num_features, _ = hidden_states.shape
+
+        num_blocks = math.ceil(num_features / self.context_size)
+        remainder = num_features % self.context_size
+        if remainder > 0:
+            # right padding to reach block size
+            hidden_states = torch.nn.functional.pad(
+                hidden_states, (0, 0, 0, self.context_size - remainder))
+
+        query_states = self.to_q(hidden_states)
+        key_states, value_states = self.to_kv(hidden_states).chunk(2, dim=-1)
+        query_states, key_states, value_states = [
+            t.reshape(bsz, num_blocks, self.context_size, self.num_heads,
+                      -1).transpose(2, 3)
+            for t in (query_states, key_states, value_states)
+        ]
+
+        # shaw's relative positional embedding
+        seq = torch.arange(self.context_size, device=hidden_states.device)
+        dist = seq.view(-1, 1) - seq.view(1, -1)
+        dist = torch.clamp(dist, -self.context_size,
+                           self.context_size) + self.max_pos_emb
+        rel_pos_emb = self.rel_pos_emb(dist).to(query_states)
+        rel_pos_emb_expanded = rel_pos_emb.view([1, 1, 1] +
+                                                list(rel_pos_emb.shape))
+        pos_attn = torch.sum(query_states.unsqueeze(-2) * rel_pos_emb_expanded,
+                             dim=-1) * self.scale
+
+        if remainder > 0:
+            # masked attention in the extended block
+            mask = torch.ones(self.context_size,
+                              self.context_size,
+                              dtype=bool,
+                              device=hidden_states.device)
+            mask[:remainder, :remainder] = 0
+            mask_value = -torch.finfo(pos_attn.dtype).max
+            pos_attn[:, -1, :].masked_fill_(mask, mask_value)
+
+        with torch.nn.attention.sdpa_kernel(
+                torch.nn.attention.SDPBackend.MATH):
+            out = F.scaled_dot_product_attention(query_states,
+                                                 key_states,
+                                                 value_states,
+                                                 attn_mask=pos_attn,
+                                                 scale=self.scale)
+        out = out.transpose(2, 3).reshape(bsz, hidden_states.shape[1], -1)
+        out = self.to_out(out[:, :num_features, :])
+        return self.dropout(out)
+
+
+class GraniteSpeechConformerConvModule(nn.Module):
+    """Conformer conv module consisting of several 1D/depthwise 1D
+    convolutional layers."""
+
+    def __init__(self, config):
+        super().__init__()
+        inner_dim = config.hidden_dim * config.conv_expansion_factor
+        padding = self.calc_same_padding(config.conv_kernel_size)
+
+        self.norm = nn.LayerNorm(config.hidden_dim)
+        self.up_conv = nn.Conv1d(config.hidden_dim, inner_dim * 2, 1)
+        self.glu = nn.GLU(dim=1)
+        self.depth_conv = GraniteSpeechConformerDepthWiseConv1d(
+            inner_dim,
+            inner_dim,
+            kernel_size=config.conv_kernel_size,
+            padding=padding)
+        self.silu = nn.SiLU()
+        self.batch_norm = nn.BatchNorm1d(inner_dim)
+        self.down_conv = nn.Conv1d(inner_dim, config.hidden_dim, 1)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.norm(hidden_states)
+        hidden_states = self.up_conv(hidden_states.permute(0, 2, 1))
+        hidden_states = self.glu(hidden_states)
+        hidden_states = self.depth_conv(hidden_states)
+        hidden_states = self.silu(self.batch_norm(hidden_states))
+        hidden_states = self.down_conv(hidden_states).permute(0, 2, 1)
+        hidden_states = self.dropout(hidden_states)
+        return hidden_states
+
+    @staticmethod
+    def calc_same_padding(kernel_size: int) -> Tuple[int, int]:
+        """Calculates symmetric padding for the depthwise 1D convolution."""
+        pad = kernel_size // 2
+        return (pad, pad - (kernel_size + 1) % 2)
 
 
 class GraniteSpeechConformerDepthWiseConv1d(nn.Module):
+    """Wrapper for padded 1D pointwise convolution."""
 
-    def __init__(self, chan_in, chan_out, kernel_size, padding):
+    def __init__(self, chan_in: int, chan_out: int, kernel_size: int,
+                 padding: Tuple[int, int]):
         super().__init__()
         self.padding = padding
         self.conv = nn.Conv1d(chan_in,
@@ -167,225 +299,9 @@ class GraniteSpeechConformerDepthWiseConv1d(nn.Module):
                               groups=chan_in,
                               bias=False)
 
-    def forward(self, x):
-        x = F.pad(x, self.padding)
-        return self.conv(x)
-
-
-class GraniteSpeechConformerScale(nn.Module):
-
-    def __init__(self, scale, fn):
-        super().__init__()
-        self.fn = fn
-        self.scale = scale
-
-    def forward(self, x, **kwargs):
-        return self.fn(x, **kwargs) * self.scale
-
-
-class GraniteSpeechConformerPreNorm(nn.Module):
-
-    def __init__(self, dim, fn):
-        super().__init__()
-        self.fn = fn
-        self.norm = nn.LayerNorm(dim)
-
-    def forward(self, x, **kwargs):
-        x = self.norm(x)
-        return self.fn(x, **kwargs)
-
-
-class GraniteSpeechConformerPreNormAttn(nn.Module):
-
-    def __init__(self, dim, fn):
-        super().__init__()
-        self.fn = fn
-        self.norm = nn.LayerNorm(dim)
-
-    def forward(self, x, context_size, **kwargs):
-        x = self.norm(x)
-        return self.fn(x, context_size, **kwargs)
-
-
-class GraniteSpeechConformerAttention(nn.Module):
-
-    def __init__(
-        self,
-        dim,
-        heads=8,
-        dim_head=64,
-        dropout=0.0,
-        context_size=200,
-        max_pos_emb=512,
-    ):
-        super().__init__()
-        inner_dim = dim_head * heads
-        self.heads = heads
-        self.dim_head = dim_head
-        self.scale = dim_head**-0.5
-        self.to_q = nn.Linear(dim, inner_dim, bias=False)
-        self.to_kv = nn.Linear(dim, inner_dim * 2, bias=False)
-        self.to_out = nn.Linear(inner_dim, dim)
-
-        self.max_pos_emb = max_pos_emb
-        self.rel_pos_emb = nn.Embedding(2 * max_pos_emb + 1, dim_head)
-
-        self.dropout = nn.Dropout(dropout)
-
-    def forward(self, x, context_size):
-        device, h, max_pos_emb = x.device, self.heads, self.max_pos_emb
-        bs, n, d = x.shape
-        assert context_size > 0 and context_size <= max_pos_emb
-
-        nb = math.ceil(n / context_size)
-        nr = n % context_size
-        if nr > 0:
-            # right padding to reach block size
-            x = torch.nn.functional.pad(x, (0, 0, 0, context_size - nr))
-
-        q, k, v = (self.to_q(x), *self.to_kv(x).chunk(2, dim=-1))
-        q, k, v = [
-            t.reshape(bs, nb, context_size, h, -1).transpose(2, 3)
-            for t in (q, k, v)
-        ]
-
-        dots = einsum("b m h i d, b m h j d -> b m h i j", q, k) * self.scale
-
-        # shaw's relative positional embedding
-        seq = torch.arange(context_size, device=device)
-        dist = seq.view(-1, 1) - seq.view(1, -1)
-        dist = torch.clamp(dist, -context_size, context_size) + max_pos_emb
-        rel_pos_emb = self.rel_pos_emb(dist).to(q)
-        pos_attn = einsum("b m h c d, c r d -> b m h c r", q,
-                          rel_pos_emb) * self.scale
-        dots = dots + pos_attn
-
-        if nr > 0:
-            # masked attention in the extended block
-            mask = torch.ones(context_size,
-                              context_size,
-                              dtype=bool,
-                              device=device)
-            mask[:nr, :nr] = 0
-            mask_value = -torch.finfo(dots.dtype).max
-            dots[:, -1, :].masked_fill_(mask, mask_value)
-
-        attn = dots.softmax(dim=-1)
-
-        out = einsum("b m h i j, b m h j d -> b m h i d", attn, v)
-        out = out.transpose(2, 3).reshape(bs, x.shape[1], -1)
-        out = self.to_out(out[:, :n, :])
-        return self.dropout(out)
-
-
-class GraniteSpeechConformerFeedForward(nn.Module):
-
-    def __init__(self, dim, mult=4, dropout=0.0):
-        super().__init__()
-        self.net = nn.Sequential(nn.Linear(dim, dim * mult), nn.SiLU(),
-                                 nn.Dropout(dropout),
-                                 nn.Linear(dim * mult,
-                                           dim), nn.Dropout(dropout))
-
-    def forward(self, x):
-        return self.net(x)
-
-
-class GraniteSpeechConformerConvModule(nn.Module):
-
-    def __init__(self,
-                 dim,
-                 causal=False,
-                 expansion_factor=2,
-                 kernel_size=31,
-                 dropout=0.0):
-        super().__init__()
-
-        inner_dim = dim * expansion_factor
-        padding = self.calc_same_padding(kernel_size) if not causal else (
-            kernel_size - 1, 0)
-
-        self.net = nn.Sequential(
-            nn.LayerNorm(dim),
-            GraniteSpeechConformerPermute(dims=(0, 2, 1)),
-            nn.Conv1d(dim, inner_dim * 2, 1),
-            nn.GLU(dim=1),
-            GraniteSpeechConformerDepthWiseConv1d(inner_dim,
-                                                  inner_dim,
-                                                  kernel_size=kernel_size,
-                                                  padding=padding),
-            nn.BatchNorm1d(inner_dim) if not causal else nn.Identity(),
-            nn.SiLU(),
-            nn.Conv1d(inner_dim, dim, 1),
-            GraniteSpeechConformerPermute(dims=(0, 2, 1)),
-            nn.Dropout(dropout),
-        )
-
-    def forward(self, x):
-        return self.net(x)
-
-    @staticmethod
-    def calc_same_padding(kernel_size: int):
-        pad = kernel_size // 2
-        return (pad, pad - (kernel_size + 1) % 2)
-
-
-class GraniteSpeechConformerBlock(nn.Module):
-
-    def __init__(
-        self,
-        *,
-        dim,
-        dim_head=64,
-        heads=8,
-        ff_mult=2,
-        conv_expansion_factor=2,
-        conv_kernel_size=31,
-        context_size=-1,
-        attn_dropout=0.0,
-        ff_dropout=0.0,
-        conv_dropout=0.0,
-    ):
-        super().__init__()
-        self.ff1 = GraniteSpeechConformerFeedForward(dim=dim,
-                                                     mult=ff_mult,
-                                                     dropout=ff_dropout)
-        self.attn = GraniteSpeechConformerAttention(
-            dim=dim,
-            dim_head=dim_head,
-            heads=heads,
-            dropout=attn_dropout,
-            context_size=context_size,
-        )
-        self.conv = GraniteSpeechConformerConvModule(
-            dim=dim,
-            causal=False,
-            expansion_factor=conv_expansion_factor,
-            kernel_size=conv_kernel_size,
-            dropout=conv_dropout,
-        )
-        self.ff2 = GraniteSpeechConformerFeedForward(dim=dim,
-                                                     mult=ff_mult,
-                                                     dropout=ff_dropout)
-
-        self.attn = GraniteSpeechConformerPreNormAttn(dim, self.attn)
-        self.ff1 = GraniteSpeechConformerScale(
-            0.5, GraniteSpeechConformerPreNorm(dim, self.ff1))
-        self.ff2 = GraniteSpeechConformerScale(
-            0.5, GraniteSpeechConformerPreNorm(dim, self.ff2))
-
-        self.post_norm = nn.LayerNorm(dim)
-
-    def forward(self, x, context_size):
-        x = self.ff1(x) + x
-        x = self.attn(x, context_size) + x
-        x = self.conv(x) + x
-        x = self.ff2(x) + x
-        x = self.post_norm(x)
-        return x
-
-
-###########################################################
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = F.pad(hidden_states, self.padding)
+        return self.conv(hidden_states)
 
 
 # === Audio Inputs === #
@@ -423,7 +339,7 @@ class GraniteSpeechMultiModalProcessor(
         BaseMultiModalProcessor[GraniteSpeechMultiModalProcessingInfo]):
 
     def _get_data_parser(self) -> MultiModalDataParser:
-        feature_extractor = self.info.get_hf_processor().feature_extractor
+        feature_extractor = self.info.get_hf_processor().audio_processor
         sampling_rate = feature_extractor.melspec_kwargs["sample_rate"]
         return MultiModalDataParser(target_sr=sampling_rate)
 
@@ -442,7 +358,7 @@ class GraniteSpeechMultiModalProcessor(
     ) -> list[PromptUpdate]:
         processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
         tokenizer = self.info.get_tokenizer()
-        feature_extractor = processor.feature_extractor
+        feature_extractor = processor.audio_processor
         vocab = tokenizer.get_vocab()
 
         # Use getattr with default to be compatible with transformers<4.48
@@ -546,9 +462,9 @@ class GraniteSpeechForConditionalGeneration(
             prefix=maybe_prefix(prefix, "language_model"),
         )
         hf_config = vllm_config.model_config.hf_config
-        self.encoder = GraniteSpeechCTCModel(config=hf_config.encoder_config)
-        self.projector = GraniteSpeechEncoderProjectorQFormer(
-            config=hf_config.projector_config,
+        self.encoder = GraniteSpeechCTCEncoder(config=hf_config.encoder_config)
+        self.projector = GraniteSpeechEncoderProjector(
+            config=hf_config,
             quant_config=quant_config,
             cache_config=cache_config,
         )
@@ -589,7 +505,7 @@ class GraniteSpeechForConditionalGeneration(
         input_features = audio_input["input_features"].to(
             torch.bfloat16).squeeze(0)
         encoder_embeds = self.encoder(input_features)
-        projected_embeds = self.projector(encoder_embeds, None)
+        projected_embeds = self.projector(encoder_embeds)
         return projected_embeds
 
     def get_multimodal_embeddings(

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -143,6 +143,13 @@ class GraniteSpeechMultiModalProcessor(
         mm_data: Mapping[str, object],
         mm_kwargs: Mapping[str, object],
     ) -> BatchFeature:
+        mm_data = dict(mm_data)
+        audios = mm_data.pop("audios", [])
+
+        if audios:
+            # GraniteSpeechFeatureExtractor processor accepts "audio"
+            mm_data["audio"] = audios
+
         processed_outputs = super()._call_hf_processor(
             prompt=prompt,
             mm_data=mm_data,

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -308,6 +308,8 @@ class GraniteSpeechConformerDepthWiseConv1d(nn.Module):
 # === Audio Inputs === #
 class GraniteSpeechAudioInputs(TypedDict):
     input_features: torch.Tensor
+    """Shape: `(bsz, num_features, 160)`"""
+
     input_features_mask: torch.Tensor
     """Shape: `TODO`"""
 
@@ -483,12 +485,13 @@ class GraniteSpeechForConditionalGeneration(
             raise ValueError("Incorrect type of audio input features. "
                              f"Got type: {type(input_features)}")
 
-        # Granite speech features are already unsqueezed in the processor, so
-        # one instance will have shape [1, {num_features}, 160]; input features
-        # will usually be of shape[1, bsz, num_features, 160] as a result of
-        # MultiModalKwargs.batch, so we squeeze the extra dimension.
+        # Granite speech currently only allows one audio token per instance,
+        # and features are already unsqueezed in the processor, so one
+        # instance will have shape [1, {num_features}, 160]. As such,
+        # input features will usually be of shape[bsz, 1, num_features, 160],
+        # which we squeeze to [bsz, num_features, 160] here.
         if len(input_features.shape) == 4:
-            input_features = input_features.squeeze(0)
+            input_features = input_features.squeeze(1)
         if len(input_features.shape) != 3:
             raise ValueError(
                 "Squeezed input features should be 3D but are of shape "

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -203,6 +203,8 @@ _MULTIMODAL_MODELS = {
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
+    # alex - TODO - check class names  / architecture
+    "SpeechGraniteForConditionalGeneration": ("speech_granite", "SpeechGraniteForConditionalGeneration"),  # noqa: E501
     # [Encoder-decoder]
     "Florence2ForConditionalGeneration": ("florence2", "Florence2ForConditionalGeneration"),  # noqa: E501
     "MllamaForConditionalGeneration": ("mllama", "MllamaForConditionalGeneration"),  # noqa: E501

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -178,6 +178,7 @@ _MULTIMODAL_MODELS = {
     "FuyuForCausalLM": ("fuyu", "FuyuForCausalLM"),
     "Gemma3ForConditionalGeneration": ("gemma3_mm", "Gemma3ForConditionalGeneration"),  # noqa: E501
     "GLM4VForCausalLM": ("glm4v", "GLM4VForCausalLM"),
+    "GraniteSpeechForConditionalGeneration": ("granite_speech", "GraniteSpeechForConditionalGeneration"),  # noqa: E501
     "H2OVLChatModel": ("h2ovl", "H2OVLChatModel"),
     "InternVLChatModel": ("internvl", "InternVLChatModel"),
     "Idefics3ForConditionalGeneration":("idefics3","Idefics3ForConditionalGeneration"),
@@ -203,8 +204,6 @@ _MULTIMODAL_MODELS = {
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
-    # alex - TODO - check class names  / architecture
-    "SpeechGraniteForConditionalGeneration": ("speech_granite", "SpeechGraniteForConditionalGeneration"),  # noqa: E501
     # [Encoder-decoder]
     "Florence2ForConditionalGeneration": ("florence2", "Florence2ForConditionalGeneration"),  # noqa: E501
     "MllamaForConditionalGeneration": ("mllama", "MllamaForConditionalGeneration"),  # noqa: E501


### PR DESCRIPTION
This PR adds support for Granite Speech models, and is a port of the corresponding [PR in Transformers](https://github.com/huggingface/transformers/pull/36801). The model uses a conformer-based encoder, with a blip2 qformer-based projector to encode the audio, and masks it into a granite LLM. This model also uses an audio-specific lora adapter, which should only be enabled when the model is processing audio inputs. Currently, this means that the user needs to make a `LoraRequest` every time they send audio. 

It is probably a good idea to wait for the transformers PR to be merged so that everything is aligned, but opening this PR in case anyone has feedback 🙂 unfortunately, a model compatible with this PR is not publicly available yet - I am happy to submit a follow-up PR adding an example / docs + tests once one it is out.

Some quirks that are good to be aware of / have kind of gross edge cases that I am actively looking into:

- The (rank 64) lora is bundled in the same dir as the model. At least in offline mode, it seems that the lora is loaded, but the lora layers are adding zero tensors, which result in unchanged outputs - still looking into this.

- The model is very sensitive - I haven't optimized the conformer implementation yet, but if possible, it would be great if we could for now avoid optimizing the conformer layers until we also have some tests for alignment with HF once the model is released, as the optimizations in the granite LLM already seem to shift things a bit, and I still need to run a quality benchmark (still looking into whatever is going on with the lora first!)

- Batching is a bit quirky because we don't use a feature attention mask and do zero padding _prior_ to calculating the Mel features in the HF processor (i.e., the padding indices end up at small negative numbers that are dependent on the batch, though they are masked out in transformers with a masked scatter which is the most important thing). Since the static batch is submitted one instance at a time to the processor in vLLM, this results in the features being unpadded; this PR handles this after the fact by zero padding the 3D Mel features and torch splitting the result, though maybe there is a better small negative value to use here.

CC @DarkLight1337 @njhill @tlrmchlsmth 