### PR TITLE
[BugFix][ROCm] Fix GGUF MoE Dispatch Block_Dim for ROCm

### DIFF
--- a/csrc/quantization/gguf/moe.cuh
+++ b/csrc/quantization/gguf/moe.cuh
@@ -129,7 +129,7 @@ static __device__ __forceinline__ void moe_q(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q4_0 64
+  #define MOE_X_Q4_0 8
   #define MOE_Y_Q4_0 128
   #define NWARPS_Q4_0 8
 #else
@@ -190,7 +190,7 @@ static void ggml_moe_q4_0_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q4_1 64
+  #define MOE_X_Q4_1 8
   #define MOE_Y_Q4_1 128
   #define NWARPS_Q4_1 8
 #else
@@ -251,7 +251,7 @@ static void ggml_moe_q4_1_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q5_0 64
+  #define MOE_X_Q5_0 8
   #define MOE_Y_Q5_0 128
   #define NWARPS_Q5_0 8
 #else
@@ -312,7 +312,7 @@ static void ggml_moe_q5_0_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q5_1 64
+  #define MOE_X_Q5_1 8
   #define MOE_Y_Q5_1 128
   #define NWARPS_Q5_1 8
 #else
@@ -373,7 +373,7 @@ static void ggml_moe_q5_1_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q8_0 64
+  #define MOE_X_Q8_0 8
   #define MOE_Y_Q8_0 128
   #define NWARPS_Q8_0 8
 #else
@@ -434,7 +434,7 @@ static void ggml_moe_q8_0_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q2_K 64
+  #define MOE_X_Q2_K 8
   #define MOE_Y_Q2_K 128
   #define NWARPS_Q2_K 8
 #else
@@ -495,7 +495,7 @@ static void ggml_moe_q2_K_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q3_K 64
+  #define MOE_X_Q3_K 8
   #define MOE_Y_Q3_K 128
   #define NWARPS_Q3_K 8
 #else
@@ -556,7 +556,7 @@ static void ggml_moe_q3_K_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q4_K 64
+  #define MOE_X_Q4_K 8
   #define MOE_Y_Q4_K 128
   #define NWARPS_Q4_K 8
 #else
@@ -617,7 +617,7 @@ static void ggml_moe_q4_K_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q5_K 64
+  #define MOE_X_Q5_K 8
   #define MOE_Y_Q5_K 128
   #define NWARPS_Q5_K 8
 #else
@@ -678,7 +678,7 @@ static void ggml_moe_q5_K_q8_1_cuda(
 }
 
 #if defined(USE_ROCM)
-  #define MOE_X_Q6_K 64
+  #define MOE_X_Q6_K 8
   #define MOE_Y_Q6_K 128
   #define NWARPS_Q6_K 8
 #else


### PR DESCRIPTION
**Issue Description**
Observed failed results when running the GGUF MoE unit tests on ROCm.
To reproduce the failure, simply run the following command:
```pytest /mnt/vllm/tests/kernels/test_gguf.py::test_moe``` 

And expect the error report as the following:
>192 failed, 1 warning in 913.28s (0:15:13)


**Root Cause**
The [Triton MoE kernel](https://github.com/vllm-project/vllm/blob/995e3d1f41ddd3068664e8f7ff578e36df9c642d/vllm/model_executor/layers/fused_moe/fused_moe.py#L253) loads token offset id from the sorted token array with stride = BLOCK_SIZE_M and range = (0, BLOCK_SIZE_M)
https://github.com/vllm-project/vllm/blob/995e3d1f41ddd3068664e8f7ff578e36df9c642d/vllm/model_executor/layers/fused_moe/fused_moe.py#L343-L348

However, the [GGUF MoE kernel](https://github.com/vllm-project/vllm/blob/995e3d1f41ddd3068664e8f7ff578e36df9c642d/csrc/quantization/gguf/moe.cuh#L9C38-L9C40) set stride = MOE_X and range = (0, NWARPS)
https://github.com/vllm-project/vllm/blob/995e3d1f41ddd3068664e8f7ff578e36df9c642d/csrc/quantization/gguf/moe.cuh#L25-L30

When USE_ROCM was set, MOE_X = 64 and NWARPS = 8, which led to the result that some padding data were loaded as the token offset id due to the misalignment, and it further caused the test failure.

**Local Verification**
With this RP, no failure can be observed anymore when running ```pytest /mnt/vllm/tests/kernels/test_gguf.py::test_moe``` on ROCm.
