### PR TITLE
[Misc] Avoid stripping meaningful whitespace from `nvidia-smi topo -m` output in collect_env.py

### DIFF
--- a/collect_env.py
+++ b/collect_env.py
@@ -105,8 +105,14 @@ def run(command):
     else:
         enc = locale.getpreferredencoding()
     output = raw_output.decode(enc)
+    if command == 'nvidia-smi topo -m':
+        # don't remove the leading whitespace of `nvidia-smi topo -m`
+        #   because they are meaningful
+        output = output.rstrip()
+    else:
+        output = output.strip()
     err = raw_err.decode(enc)
-    return rc, output.strip(), err.strip()
+    return rc, output, err.strip()
 
 
 def run_and_read_all(run_lambda, command):


### PR DESCRIPTION
The `collect_env.py` script runs `nvidia-smi topo -m` to gather GPU topology information. However, when processing the output, it applies .strip(), removing leading whitespace.

This causes a formatting issue because the output of `nvidia-smi topo -m` uses leading whitespace for table header's alignment.

Current PR fixes this issue.

---

**main branch `collect_env.py` output**

```
GPU Topology:
GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	CPU Affinity	NUMA Affinity	GPU NUMA ID
GPU0	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU1	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU2	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU3	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU4	SYS	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	56-111,168-223	1		N/A
GPU5	SYS	SYS	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	56-111,168-223	1		N/A
GPU6	SYS	SYS	SYS	SYS	SYS	SYS	 X 	SYS	PHB	PHB	56-111,168-223	1		N/A
GPU7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	 X 	SYS	SYS	56-111,168-223	1		N/A
NIC0	SYS	SYS	SYS	SYS	SYS	SYS	PHB	SYS	 X 	PIX
NIC1	SYS	SYS	SYS	SYS	SYS	SYS	PHB	SYS	PIX	 X
```

**Current PR's `collect_env.py` output**

```
GPU Topology:
	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	CPU Affinity	NUMA Affinity	GPU NUMA ID
GPU0	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU1	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU2	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU3	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	SYS	0-55,112-167	0		N/A
GPU4	SYS	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	SYS	56-111,168-223	1		N/A
GPU5	SYS	SYS	SYS	SYS	SYS	 X 	SYS	SYS	SYS	SYS	56-111,168-223	1		N/A
GPU6	SYS	SYS	SYS	SYS	SYS	SYS	 X 	SYS	PHB	PHB	56-111,168-223	1		N/A
GPU7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	 X 	SYS	SYS	56-111,168-223	1		N/A
NIC0	SYS	SYS	SYS	SYS	SYS	SYS	PHB	SYS	 X 	PIX
NIC1	SYS	SYS	SYS	SYS	SYS	SYS	PHB	SYS	PIX	 X
```
