### PR TITLE
[Hardware] add platform-specific request validation api

### DIFF
--- a/vllm/platforms/cpu.py
+++ b/vllm/platforms/cpu.py
@@ -180,7 +180,3 @@ class CpuPlatform(Platform):
         Get device specific communicator class for distributed communication.
         """
         return "vllm.distributed.device_communicators.cpu_communicator.CpuCommunicator"  # noqa
-
-    @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -309,10 +309,6 @@ class CudaPlatformBase(Platform):
         return True
 
     @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True
-
-    @classmethod
     def use_custom_allreduce(cls) -> bool:
         return True
 

--- a/vllm/platforms/hpu.py
+++ b/vllm/platforms/hpu.py
@@ -92,7 +92,3 @@ class HpuPlatform(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return "vllm.distributed.device_communicators.hpu_communicator.HpuCommunicator"  # noqa
-
-    @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-
 import enum
 import platform
 import random
@@ -9,10 +8,14 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple, Union
 import numpy as np
 import torch
 
+from vllm.inputs import PromptType
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
+    from vllm.lora.request import LoRARequest
+    from vllm.pooling_params import PoolingParams
+    from vllm.sampling_params import SamplingParams
     from vllm.utils import FlexibleArgumentParser
 else:
     ModelConfig = None
@@ -392,6 +395,15 @@ class Platform:
         Returns if custom allreduce is supported on the current platform
         """
         return False
+
+    @classmethod
+    def validate_request(
+        cls,
+        prompt: PromptType,
+        params: Union[SamplingParams, PoolingParams],
+        lora_request: Optional[LoRARequest] = None,
+    ) -> None:
+        """Raises if this request is unsupported on this platform"""
 
 
 class UnspecifiedPlatform(Platform):

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -20,6 +20,9 @@ if TYPE_CHECKING:
 else:
     ModelConfig = None
     VllmConfig = None
+    LoRARequest = None
+    PoolingParams = None
+    SamplingParams = None
     FlexibleArgumentParser = None
 
 logger = init_logger(__name__)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -386,13 +386,6 @@ class Platform:
         return False
 
     @classmethod
-    def supports_structured_output(cls) -> bool:
-        """
-        Returns whether the current platform can support structured output.
-        """
-        return False
-
-    @classmethod
     def use_custom_allreduce(cls) -> bool:
         """
         Returns if custom allreduce is supported on the current platform

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -404,7 +404,6 @@ class Platform:
         cls,
         prompt: PromptType,
         params: Union[SamplingParams, PoolingParams],
-        lora_request: Optional[LoRARequest] = None,
     ) -> None:
         """Raises if this request is unsupported on this platform"""
 

--- a/vllm/platforms/neuron.py
+++ b/vllm/platforms/neuron.py
@@ -67,7 +67,3 @@ class NeuronPlatform(Platform):
     @classmethod
     def use_all_gather(cls) -> bool:
         return True
-
-    @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -304,10 +304,6 @@ class RocmPlatform(Platform):
         return True
 
     @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True
-
-    @classmethod
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
         gcn_arch = torch.cuda.get_device_properties(0).gcnArchName

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -1,19 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 
 import vllm.envs as envs
+from vllm.inputs import PromptType
 from vllm.logger import init_logger
 
 from .interface import Platform, PlatformEnum, _Backend
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
+    from vllm.lora.request import LoRARequest
+    from vllm.pooling_params import PoolingParams
+    from vllm.sampling_params import SamplingParams
 else:
     ModelConfig = None
     VllmConfig = None
+    LoRARequest = None
+    PoolingParams = None
+    SamplingParams = None
 
 logger = init_logger(__name__)
 
@@ -138,3 +145,15 @@ class TpuPlatform(Platform):
     def supports_structured_output(cls) -> bool:
         # Structured output is not supported on TPU.
         return False
+
+    @classmethod
+    def validate_request(
+        cls,
+        prompt: PromptType,
+        params: Union[SamplingParams, PoolingParams],
+    ) -> None:
+        """Raises if this request is unsupported on this platform"""
+        if isinstance(params,
+                      SamplingParams) and params.guided_decoding is not None:
+            raise ValueError("Structured output is not supported on "
+                             f"{cls.device_name}.")

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -142,11 +142,6 @@ class TpuPlatform(Platform):
         return True
 
     @classmethod
-    def supports_structured_output(cls) -> bool:
-        # Structured output is not supported on TPU.
-        return False
-
-    @classmethod
     def validate_request(
         cls,
         prompt: PromptType,

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -140,7 +140,3 @@ class XPUPlatform(Platform):
     @classmethod
     def get_device_communicator_cls(cls) -> str:
         return "vllm.distributed.device_communicators.xpu_communicator.XpuCommunicator"  # noqa
-
-    @classmethod
-    def supports_structured_output(cls) -> bool:
-        return True

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -183,6 +183,12 @@ class Processor:
         # TODO(woosuk): Support pooling models.
         # TODO(woosuk): Support encoder-decoder models.
 
+        from vllm.platforms import current_platform
+        current_platform.validate_request(
+            prompt=prompt,
+            params=params,
+            lora_request=lora_request,
+        )
         self._validate_lora(lora_request)
         self._validate_params(params)
         if priority != 0:

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -137,11 +137,6 @@ class Processor:
         else:
             params.guided_decoding.backend = engine_level_backend
 
-        from vllm.platforms import current_platform
-        if not current_platform.supports_structured_output():
-            raise ValueError("Structured output is not supported on "
-                             f"{current_platform.device_name}.")
-
         # Request content validation
         if engine_level_backend.startswith("xgrammar"):
             # xgrammar with no fallback

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -187,7 +187,6 @@ class Processor:
         current_platform.validate_request(
             prompt=prompt,
             params=params,
-            lora_request=lora_request,
         )
         self._validate_lora(lora_request)
         self._validate_params(params)


### PR DESCRIPTION
This PR adds a generic `validate_request` api to the platform interface. This allows platforms to implement any runtime checks on each request to ensure that all the requested features are supported before scheduling it. There is already one existing check in this category, `supports_structured_output`, and I'd like to avoid a proliferation of more platform apis for individual features like this.

Currently, the spyre plugin needs to implement some extra validation around the shape of inputs, as we have more constraints on valid prompt lengths and max token requests. This new api would let us do that without needing to hack around rejecting requests from the scheduler.

FIX https://github.com/vllm-project/vllm-spyre/issues/77

<!--- pyml disable-next-line no-emphasis-as-heading -->
