### PR TITLE
[BugFix] llama4 qknorm should be not shared across head

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -156,13 +156,13 @@ class Llama4Attention(nn.Module):
         self.max_position_embeddings = max_position_embeddings
         self.n_rep = self.num_heads // self.num_kv_heads
         self.q_norm = RMSNorm(
-            hidden_size=self.q_size,
+            hidden_size=self.head_dim,
             eps=config.rms_norm_eps,
             has_weight=False,
             dtype=torch.float32,
         ) if self.use_qk_norm else None
         self.k_norm = RMSNorm(
-            hidden_size=self.kv_size,
+            hidden_size=self.head_dim,
             eps=config.rms_norm_eps,
             has_weight=False,
             dtype=torch.float32,
@@ -227,9 +227,13 @@ class Llama4Attention(nn.Module):
         if self.rotary_emb is not None:
             q, k = self.rotary_emb(positions, q, k)
         if self.q_norm is not None:
-            q = self.q_norm(q.float()).to(q.dtype)
+            q = self.q_norm(q.float().reshape(-1, self.num_heads,
+                                              self.head_dim)).reshape(
+                                                  -1, self.q_size).to(q.dtype)
         if self.k_norm is not None:
-            k = self.k_norm(k.float()).to(k.dtype)
+            k = self.k_norm(k.float().reshape(-1, self.num_kv_heads,
+                                              self.head_dim)).reshape(
+                                                  -1, self.kv_size).to(k.dtype)
 
         # We are applying temperature tuning (https://arxiv.org/abs/2501.19399)
         # to NoPE layers, where the inference-time temperature tuning function

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -155,13 +155,7 @@ class Llama4Attention(nn.Module):
         self.rope_theta = rope_theta
         self.max_position_embeddings = max_position_embeddings
         self.n_rep = self.num_heads // self.num_kv_heads
-        self.q_norm = RMSNorm(
-            hidden_size=self.head_dim,
-            eps=config.rms_norm_eps,
-            has_weight=False,
-            dtype=torch.float32,
-        ) if self.use_qk_norm else None
-        self.k_norm = RMSNorm(
+        self.qk_norm = RMSNorm(
             hidden_size=self.head_dim,
             eps=config.rms_norm_eps,
             has_weight=False,
@@ -226,13 +220,11 @@ class Llama4Attention(nn.Module):
 
         if self.rotary_emb is not None:
             q, k = self.rotary_emb(positions, q, k)
-        if self.q_norm is not None:
-            q_reshaped = q.float().reshape(-1, self.num_heads, self.head_dim)
-            q = self.q_norm(q_reshaped).reshape(-1, self.q_size).to(q.dtype)
-        if self.k_norm is not None:
-            k_reshaped = k.float().reshape(-1, self.num_kv_heads,
-                                           self.head_dim)
-            k = self.k_norm(k_reshaped).reshape(1, self.kv_size).to(k.dtype)
+        if self.qk_norm is not None:
+            q = q.reshape(-1, self.num_heads, self.head_dim)
+            q = self.qk_norm(q.float()).reshape(-1, self.q_size).to(q.dtype)
+            k = k.reshape(-1, self.num_kv_heads, self.head_dim)
+            k = self.qk_norm(k.float()).reshape(-1, self.kv_size).to(k.dtype)
 
         # We are applying temperature tuning (https://arxiv.org/abs/2501.19399)
         # to NoPE layers, where the inference-time temperature tuning function

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -227,13 +227,12 @@ class Llama4Attention(nn.Module):
         if self.rotary_emb is not None:
             q, k = self.rotary_emb(positions, q, k)
         if self.q_norm is not None:
-            q = self.q_norm(q.float().reshape(-1, self.num_heads,
-                                              self.head_dim)).reshape(
-                                                  -1, self.q_size).to(q.dtype)
+            q_reshaped = q.float().reshape(-1, self.num_heads, self.head_dim)
+            q = self.q_norm(q_reshaped).reshape(-1, self.q_size).to(q.dtype)
         if self.k_norm is not None:
-            k = self.k_norm(k.float().reshape(-1, self.num_kv_heads,
-                                              self.head_dim)).reshape(
-                                                  -1, self.kv_size).to(k.dtype)
+            k_reshaped = k.float().reshape(-1, self.num_kv_heads,
+                                           self.head_dim)
+            k = self.k_norm(k_reshaped).reshape(1, self.kv_size).to(k.dtype)
 
         # We are applying temperature tuning (https://arxiv.org/abs/2501.19399)
         # to NoPE layers, where the inference-time temperature tuning function


### PR DESCRIPTION
QKNorm should not be across head, we need to do qknorm per head, score goes up from 0.6858 to 0.7153.
This also resovles TP=4 Accuracy Issue https://github.com/vllm-project/vllm/issues/16300

MMLU Pro Before fix:
```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|      |exact_match|↑  |0.6858|±  |0.0041|
| - biology         |    2.1|custom-extract|     5|exact_match|↑  |0.8215|±  |0.0143|
| - business        |    2.1|custom-extract|     5|exact_match|↑  |0.7414|±  |0.0156|
| - chemistry       |    2.1|custom-extract|     5|exact_match|↑  |0.7297|±  |0.0132|
| - computer_science|    2.1|custom-extract|     5|exact_match|↑  |0.6366|±  |0.0238|
| - economics       |    2.1|custom-extract|     5|exact_match|↑  |0.7879|±  |0.0141|
| - engineering     |    2.1|custom-extract|     5|exact_match|↑  |0.5810|±  |0.0159|
| - health          |    2.1|custom-extract|     5|exact_match|↑  |0.7029|±  |0.0160|
| - history         |    2.1|custom-extract|     5|exact_match|↑  |0.5879|±  |0.0252|
| - law             |    2.1|custom-extract|     5|exact_match|↑  |0.4478|±  |0.0150|
| - math            |    2.1|custom-extract|     5|exact_match|↑  |0.7698|±  |0.0115|
| - other           |    2.1|custom-extract|     5|exact_match|↑  |0.6418|±  |0.0158|
| - philosophy      |    2.1|custom-extract|     5|exact_match|↑  |0.5130|±  |0.0224|
| - physics         |    2.1|custom-extract|     5|exact_match|↑  |0.7537|±  |0.0120|
| - psychology      |    2.1|custom-extract|     5|exact_match|↑  |0.7556|±  |0.0152|

```
MMLU Pro After fix:
```
|       Tasks       |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|-------------------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro           |    2.0|custom-extract|      |exact_match|↑  |0.7153|±  |0.0040|
| - biology         |    2.1|custom-extract|     5|exact_match|↑  |0.6974|±  |0.0172|
| - business        |    2.1|custom-extract|     5|exact_match|↑  |0.7693|±  |0.0150|
| - chemistry       |    2.1|custom-extract|     5|exact_match|↑  |0.7756|±  |0.0124|
| - computer_science|    2.1|custom-extract|     5|exact_match|↑  |0.6951|±  |0.0228|
| - economics       |    2.1|custom-extract|     5|exact_match|↑  |0.8211|±  |0.0132|
| - engineering     |    2.1|custom-extract|     5|exact_match|↑  |0.6378|±  |0.0154|
| - health          |    2.1|custom-extract|     5|exact_match|↑  |0.7274|±  |0.0156|
| - history         |    2.1|custom-extract|     5|exact_match|↑  |0.5932|±  |0.0252|
| - law             |    2.1|custom-extract|     5|exact_match|↑  |0.4741|±  |0.0151|
| - math            |    2.1|custom-extract|     5|exact_match|↑  |0.8150|±  |0.0106|
| - other           |    2.1|custom-extract|     5|exact_match|↑  |0.7089|±  |0.0150|
| - philosophy      |    2.1|custom-extract|     5|exact_match|↑  |0.5992|±  |0.0220|
| - physics         |    2.1|custom-extract|     5|exact_match|↑  |0.7791|±  |0.0115|
| - psychology      |    2.1|custom-extract|     5|exact_match|↑  |0.7707|±  |0.0149|

```