### PR TITLE
[Bugfix] catch AssertionError in MistralTokenizer as ValueError

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1193,8 +1193,16 @@ def apply_mistral_chat_template(
         **kwargs,
     )
 
-    return tokenizer.apply_chat_template(
+    try:
+        tokens_ids = tokenizer.apply_chat_template(
         messages=messages,
         tools=tools,
         **kwargs,
-    )
+        )
+    # mistral-common uses assert statements to stop processing of input
+    # if input does not comply with the expected format.
+    # We convert those assertion errors to ValueErrors so they can be
+    # are properly caught in the preprocessing_input step
+    except AssertionError as e:
+        raise ValueError from e
+    return tokens_ids

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1194,7 +1194,7 @@ def apply_mistral_chat_template(
     )
 
     try:
-        tokens_ids = tokenizer.apply_chat_template(
+        return tokenizer.apply_chat_template(
         messages=messages,
         tools=tools,
         **kwargs,
@@ -1205,4 +1205,3 @@ def apply_mistral_chat_template(
     # are properly caught in the preprocessing_input step
     except AssertionError as e:
         raise ValueError from e
-    return tokens_ids

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1195,9 +1195,9 @@ def apply_mistral_chat_template(
 
     try:
         return tokenizer.apply_chat_template(
-        messages=messages,
-        tools=tools,
-        **kwargs,
+            messages=messages,
+            tools=tools,
+            **kwargs,
         )
     # mistral-common uses assert statements to stop processing of input
     # if input does not comply with the expected format.


### PR DESCRIPTION
When the `MistralTokenizer` is used, input preprocessing is delegated to `mistral-common` which [uses `assert` statements](https://github.com/mistralai/mistral-common/blob/6e637437fe4795353b7ba19cc8479c124b95b580/src/mistral_common/tokens/tokenizers/sentencepiece.py#L273) to stop the process if the received input is not conformed to what is expected.

Currently `AssertionError` are not catched when inputs are preprocessed in vLLM and therefore sending an incorrectly formatted message array to a model relying on the MistralTokenizer will result in a `500 Internal Server Error` error.

This PR convert `AssertionError` from the MistralTokenizer to ValueError, so they can be properly caught

```
# server started with: docker run --rm -d --gpus all --shm-size=1G --ulimit memlock=-1 vllm/vllm-openai:v0.8.3 --served-model-name mistral-small  --model=mistralai/Mistral-Small-3.1-24B-Instruct-2503 --tokenizer-mode mistral --load-format mistral --config-format mistral

from openai import OpenAI

client = OpenAI(
    base_url="http://localhost:8003/v1",
    api_key= "API_KEY",
)

response = client.chat.completions.create(
    model="mistral-small",
    messages=[
        {
            "role": "system",
            # system role content does not support the List[str] format like for user role
            "content": [ 
                {"type": "text", "text": "You are an expert at Maths"},
            ],
        },
        {"role": "user", "content": "What is 1+1?"},
    ]
)

print(response.choices[0].message.content)
```

assertion error result in `500 Internal Server Error`:
```
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 301, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 212, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/utils.py", line 63, in wrapper
    return handler_task.result()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/utils.py", line 85, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/api_server.py", line 476, in create_chat_completion
    generator = await handler.create_chat_completion(request, raw_request)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_chat.py", line 181, in create_chat_completion
    ) = await self._preprocess_chat(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/serving_engine.py", line 409, in _preprocess_chat
    request_prompt = apply_mistral_chat_template(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/chat_utils.py", line 1198, in apply_mistral_chat_template
    return tokenizer.apply_chat_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/vllm/transformers_utils/tokenizers/mistral.py", line 372, in apply_chat_template
    encoded = self.mistral.encode_chat_completion(request)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/mistral_common/tokens/tokenizers/mistral.py", line 245, in encode_chat_completion
    return self.instruct_tokenizer.encode_instruct(instruct_request)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/mistral_common/tokens/tokenizers/sentencepiece.py", line 232, in encode_instruct
    new_tokens = self.encode_system_message(msg)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/mistral_common/tokens/tokenizers/sentencepiece.py", line 609, in encode_system_message
    assert isinstance(message.content, str), "Message content must be normalized"
```

