### PR TITLE
[Bugfix][Frontend] Add missing "type":"function" in tool call streaming responses

### DIFF
--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -847,7 +847,7 @@ class OpenAIServingChat(OpenAIServing):
                             total_tokens=num_prompt_tokens + completion_tokens,
                         )
 
-                    data = chunk.model_dump_json(exclude_unset=True)
+                    data = chunk.model_dump_json()
                     yield f"data: {data}\n\n"
 
             # once the final token is handled, if stream_options.include_usage


### PR DESCRIPTION
FIX #16340

Fix OpenAI compatibility issue where streaming tool calls were missing the 
required "type":"function" field when using specific tool_choice parameter.
This ensures proper compatibility with clients that validate against OpenAI
API format specification (e.g., Vercel AI SDK).

The issue was present when streaming tool calls with arguments in both the
initial argument stage and argument update stages. This fix ensures all
tool call deltas consistently include the type field regardless of the
tool_choice configuration.

<!--- pyml disable-next-line no-emphasis-as-heading -->
