### PR TITLE
[Model][VLM] Add Qwen2.5-Omni model support (end-to-end full support)

### DIFF
--- a/examples/offline_inference/qwen2_5_omni/code2wav.py
+++ b/examples/offline_inference/qwen2_5_omni/code2wav.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import glob
+import json
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import List
+
+import numpy as np
+import soundfile as sf
+import torch
+
+from vllm.engine.arg_utils import nullable_str
+from vllm.logger import init_logger
+from vllm.model_executor.models.qwen2_code2wav_dit import Qwen2Code2wav
+
+logger = init_logger('vllm.omni')
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--code2wav-model',
+                    type=str,
+                    default=os.path.expanduser("~/models/omni-v4/code2wav"))
+parser.add_argument('--input-json',
+                    type=str,
+                    default=os.path.expanduser("~/vllm/generated-codes.json"))
+parser.add_argument('--voice-type', type=nullable_str, default='default')
+parser.add_argument("--batched-chunk", type=int, default=None)
+parser.add_argument("--frequency", type=str, default='50hz', choices=['50hz'])
+parser.add_argument('--sample-rate', type=int, default=24000)
+parser.add_argument('--warmup', type=int, default=1)
+parser.add_argument('--concurrency', type=int, default=1)
+parser.add_argument('--enable-torch-compile', action='store_true')
+parser.add_argument('--enable-torch-compile-first-chunk', action='store_true')
+parser.add_argument("--odeint-method",
+                    type=str,
+                    default="rk4",
+                    choices=["euler", "rk4"])
+parser.add_argument('--multi-waveforms', action='store_true')
+
+args = parser.parse_args()
+
+
+def process_code(
+    code: List[int],
+    code2wav: Qwen2Code2wav,
+    code2wav_cond: torch.Tensor,
+    code2wav_ref_mel: torch.Tensor,
+    code2wav_y_all: torch.Tensor,
+    code2wav_steps: int,
+    device: torch.device,
+) -> List[np.ndarray]:
+    # start the code2wav thread
+    code = torch.tensor(code, dtype=torch.long, device=device).reshape(1, -1)
+    progress, prev_generated, waveforms = 0, None, []
+    for i in range(code.size(1)):
+        finished = i == code.size(1) - 1
+        chunk_code_length = i * (2 if args.frequency == "50hz" else
+                                 4) - code2wav.future_cache_size
+        if (chunk_code_length > 0
+                and chunk_code_length % code2wav.chunk_size == 0) or finished:
+            start_chunk_time = time.perf_counter()
+
+            if progress == 0 and finished:
+                process_chunk = code2wav.process_little_chunk
+            else:
+                process_chunk = code2wav.process_chunk
+
+            prev_generated, audio = process_chunk(
+                code2wav_cond,
+                code2wav_ref_mel,
+                codec_all=code,
+                y_all=code2wav_y_all,
+                i=progress,
+                steps=code2wav_steps,
+                prev_generated=prev_generated,
+                finished=finished,
+            )
+            progress += 1
+            waveforms.append(audio)
+
+            end_chunk_time = time.perf_counter()
+            print(
+                f'Chunk {progress} took {end_chunk_time - start_chunk_time} seconds'
+            )
+    return [waveform.detach().cpu().numpy() for waveform in waveforms]
+
+
+def main():
+    # code2wav model
+    model_path = args.code2wav_model
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+    # code2wav model
+    dit_model_path = glob.glob(os.path.join(model_path, 'dit',
+                                            'model_*.pt'))[0]
+    bigvgan_model_path = glob.glob(os.path.join(model_path, 'bigvgan',
+                                                'g_*'))[0]
+
+    def parse_key(fname, key):
+        if fname == key:
+            return 'default'
+        return fname.split('_')[0]
+
+    code2wav_conds = {
+        parse_key(os.path.basename(f), 'spk_emb.npy'):
+        torch.tensor(np.load(f)).to(device)
+        for f in sorted(
+            glob.glob(os.path.join(model_path, 'inputs', '*spk_emb.npy')) +
+            glob.glob(
+                os.path.join(model_path, 'inputs_sft4spks', '*spk_emb.npy')))
+    }
+    code2wav_ref_mels = {
+        parse_key(os.path.basename(f), 'ref_mel.npy'):
+        torch.tensor(np.load(f)).to(device)
+        for f in sorted(
+            glob.glob(os.path.join(model_path, 'inputs', '*ref_mel.npy')) +
+            glob.glob(
+                os.path.join(model_path, 'inputs_sft4spks', '*ref_mel.npy')))
+    }
+
+    if 'default' not in code2wav_conds:
+        code2wav_conds['default'] = list(code2wav_conds.values())[0]
+    if 'default' not in code2wav_ref_mels:
+        code2wav_ref_mels['default'] = list(code2wav_ref_mels.values())[0]
+
+    code2wav_cond = code2wav_conds[args.voice_type]
+    code2wav_ref_mel = code2wav_ref_mels[args.voice_type]
+
+    if args.batched_chunk is None:
+        if args.frequency == "50hz":
+            args.batched_chunk = 2
+        else:
+            args.batched_chunk = 1
+    args.frequency = args.frequency
+
+    code2wav_steps: int = 10
+    code2wav_bs_mel: int = 24 if args.frequency == "50hz" else 32
+    code2wav = Qwen2Code2wav(dit_ckpt=dit_model_path,
+                             bigvgan_ckpt=bigvgan_model_path,
+                             steps=code2wav_steps,
+                             bs_mel=code2wav_bs_mel,
+                             odeint_method=args.odeint_method,
+                             batched_chunk=args.batched_chunk,
+                             frequency=args.frequency,
+                             device=device)
+
+    if args.enable_torch_compile:
+        code2wav.enable_torch_compile(args.enable_torch_compile_first_chunk)
+
+    # read the inputs
+    with open(args.input_json) as f:
+        code = json.load(f)
+
+    code2wav_y_all = torch.randn(args.concurrency,
+                                 1,
+                                 32768,
+                                 80,
+                                 device=device,
+                                 dtype=code2wav_ref_mel.dtype)
+
+    start_time = time.perf_counter()
+
+    # warmup
+    for _ in range(args.warmup):
+        process_code(
+            code,
+            code2wav,
+            code2wav_cond,
+            code2wav_ref_mel,
+            code2wav_y_all[0],
+            code2wav_steps,
+            device,
+        )
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as executor:
+        futures = []
+        for i in range(args.concurrency):
+            futures.append(
+                executor.submit(
+                    process_code,
+                    code,
+                    code2wav,
+                    code2wav_cond,
+                    code2wav_ref_mel,
+                    code2wav_y_all[i],
+                    code2wav_steps,
+                    device,
+                ))
+
+        waveforms = []
+        for future in futures:
+            waveforms.append(future.result())
+        waveforms = waveforms[0]
+
+    end_time = time.perf_counter()
+    print(f"Code2wav for {args.concurrency} times "
+          f"took {end_time - start_time} seconds "
+          f"for {len(code)} tokens, {len(waveforms)} waveforms")
+
+    print('Writting waveforms to output.wav')
+    if args.multi_waveforms:
+        for i, waveform in enumerate(waveforms):
+            sf.write(f'output_{i}.wav', waveform, samplerate=args.sample_rate)
+    else:
+        sf.write('output.wav',
+                 np.concatenate(waveforms),
+                 samplerate=args.sample_rate)
+
+    end_write_time = time.perf_counter()
+    print(f'Writing waveforms took {end_write_time - end_time} seconds')
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -623,9 +623,9 @@ def parse_voice_type(voice_type) -> str:
 
     voice_types = {
         "晨煦": "m02",
-        "Ethan": "m02",
+        "ethan": "m02",
         "千雪": "f030",
-        "Chelsie": "f030",
+        "chelsie": "f030",
     }
     voice_type = voice_type.lower()
     return voice_types.get(voice_type, voice_type)

--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import copy
+import json
+import os
+import queue
+import signal
+import tempfile
+import threading
+import time
+import uuid
+from datetime import datetime
+from io import BytesIO
+from typing import Dict, List, Optional, Union
+from urllib.request import urlopen
+
+import librosa
+import numpy as np
+import psutil
+import requests
+import resampy
+import soundfile as sf
+import torch
+from transformers import AutoConfig, AutoProcessor, AutoTokenizer
+
+from vllm.engine.arg_utils import nullable_str
+from vllm.engine.async_llm_engine import AsyncEngineArgs
+from vllm.engine.omni_llm_engine import OmniLLMEngine
+from vllm.inputs import TextPrompt, TokensPrompt
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
+from vllm.multimodal.processing_omni import fetch_image, fetch_video
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import SamplingParams
+
+logger = init_logger('vllm.omni')
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', type=str, required=True)
+parser.add_argument('--thinker-model', type=str, default=None)
+parser.add_argument('--talker-model', type=str, default=None)
+parser.add_argument('--code2wav-model', type=str, default=None)
+parser.add_argument('--tokenize', action='store_true')
+parser.add_argument('--legacy-omni-video', action='store_true')
+parser.add_argument("--thinker-only", action="store_true")
+parser.add_argument("--text-only", action="store_true")
+parser.add_argument("--do-wave", action="store_true")
+parser.add_argument('--max-num-seqs', type=int, default=64)
+parser.add_argument('--block-size', type=int, default=16)
+parser.add_argument('--enforce-eager', action='store_true')
+parser.add_argument('--thinker-enforce-eager', action='store_true')
+parser.add_argument('--talker-enforce-eager', action='store_true')
+parser.add_argument('--enable-prefix-caching', action='store_true')
+parser.add_argument('--thinker-quantization',
+                    type=nullable_str,
+                    choices=QUANTIZATION_METHODS)
+parser.add_argument('--talker-quantization',
+                    type=nullable_str,
+                    choices=QUANTIZATION_METHODS)
+parser.add_argument('--enable-torch-compile', action='store_true')
+parser.add_argument('--enable-torch-compile-first-chunk', action='store_true')
+parser.add_argument("--odeint-method",
+                    type=str,
+                    default="rk4",
+                    choices=["euler", "rk4"])
+parser.add_argument("--odeint-method-relaxed", action="store_true")
+parser.add_argument("--batched-chunk", type=int, default=None)
+parser.add_argument("--code2wav-frequency",
+                    type=str,
+                    default='50hz',
+                    choices=['50hz'])
+parser.add_argument('--voice-type', type=nullable_str, default='m02')
+parser.add_argument('--warmup-voice-type', type=nullable_str, default='m02')
+parser.add_argument('--seed', type=int, default=0)
+parser.add_argument("--max-tokens", type=int, default=2048)
+parser.add_argument("--num-prompts", type=int, default=1)
+parser.add_argument('--sample-rate', type=int, default=24000)
+parser.add_argument('--use-torchvision', action='store_true')
+parser.add_argument('--prompt',
+                    choices=[
+                        'text', 'audio', 'audio-long', 'audio-long-chunks',
+                        'audio-long-expand-chunks', 'image', 'video',
+                        'video-frames', 'audio-in-video', 'audio-in-video-v2',
+                        "audio-multi-round", "badcase-vl", "badcase-text",
+                        "badcase-image-early-stop", "badcase-two-audios",
+                        "badcase-two-videos", "badcase-multi-round",
+                        "badcase-voice-type", "badcase-voice-type-v2",
+                        "badcase-audio-tower-1", "badcase-audio-only"
+                    ],
+                    default='text')
+parser.add_argument("--vl-fastv", action="store_true")
+
+parser.add_argument('--thinker-devices', type=json.loads, default="[0]")
+parser.add_argument('--talker-devices', type=json.loads, default="[0]")
+parser.add_argument('--code2wav-devices', type=json.loads, default="[0]")
+parser.add_argument('--code2wav-dynamic-batch',
+                    action='store_true',
+                    help='Enable code2wav dynamic batch')
+
+args = parser.parse_args()
+
+
+def resample_wav_to_16khz(input_filepath):
+    data, original_sample_rate = sf.read(input_filepath)
+    # Only use the first channel
+    if len(data.shape) > 1:
+        data = data[:, 0]
+    # resample to 16kHz
+    data_resampled = resampy.resample(data,
+                                      sr_orig=original_sample_rate,
+                                      sr_new=16000)
+    return data_resampled
+
+
+def fetch_and_read_video(video_url: str, fps=2):
+    import torchvision.io
+
+    def read_video_with_torchvision(video_file_name: str):
+        video, audio, info = torchvision.io.read_video(
+            video_file_name,
+            start_pts=0.0,
+            end_pts=None,
+            pts_unit="sec",
+            output_format="TCHW",
+        )
+
+        total_frames, video_fps = video.size(0), info["video_fps"]
+        total_duration = round(total_frames / video_fps, 3)
+        nframes = int(total_frames / video_fps * fps)
+
+        frame_timestamps = total_duration * torch.arange(1,
+                                                         nframes + 1) / nframes
+        grid_timestamps = frame_timestamps[::2]
+        second_per_grid = grid_timestamps[1] - grid_timestamps[0]
+
+        idx = torch.linspace(0, video.size(0) - 1, nframes).round().long()
+        video_height, video_width = video.shape[2:]
+        video = video[idx]
+
+        if args.legacy_omni_video:
+            return [video, total_duration, nframes, second_per_grid.item()]
+        else:
+            return video
+
+    def read_video_with_transformers(video_file_name: Union[str, List[str]]):
+        video, total_duration, nframes, second_per_grid = fetch_video(
+            {'video': video_file_name})
+        if total_duration is None and nframes is None:
+            nframes = len(video)
+            total_duration = 0.5 * nframes
+            second_per_grid = 1.0
+        if args.legacy_omni_video:
+            return [video, total_duration, nframes, second_per_grid]
+        else:
+            return video
+
+    def read_video(video_file_name: str):
+        if args.use_torchvision:
+            return read_video_with_torchvision(video_file_name)
+        else:
+            return read_video_with_transformers(video_file_name)
+
+    if isinstance(video_url, str) and video_url.startswith("http"):
+        with tempfile.NamedTemporaryFile(delete=True) as temp_video_file:
+            resp = requests.get(video_url)
+            assert resp.status_code == requests.codes.ok, f"Failed to fetch video from {video_url}, status_code:{resp.status_code}, resp:{resp}"
+
+            temp_video_file.write(urlopen(video_url).read())
+            temp_video_file_path = temp_video_file.name
+            video_file_name = temp_video_file_path
+            return read_video(video_file_name)
+    else:
+        video_file_name = video_url
+        return read_video(video_file_name)
+
+
+def make_inputs_qwen2_omni(
+    messages: List[Dict[str, Union[str, List[Dict[str, str]]]]],
+    use_audio_in_video: Optional[bool] = False,
+    tokenize: bool = args.tokenize,
+) -> Union[TokensPrompt, TextPrompt]:
+    processor = AutoProcessor.from_pretrained(args.thinker_model)
+    tokenizer = AutoTokenizer.from_pretrained(args.thinker_model)
+
+    try:
+        config = AutoConfig.from_pretrained(args.thinker_model)
+        if 'Qwen2_5OmniModel' in config.architectures:
+            args.legacy_omni_video = False
+        else:
+            args.legacy_omni_video = True
+    except:
+        args.legacy_omni_video = True
+
+    audios, images, videos = [], [], []
+    for message in messages:
+        if not isinstance(message['content'], list):
+            message['content'] = [{
+                'type': 'text',
+                'text': message['content'],
+            }]
+        index, num_contents = 0, len(message['content'])
+        while index < num_contents:
+            ele = message['content'][index]
+            if 'type' not in ele:
+                if 'text' in ele:
+                    ele['type'] = 'text'
+                elif 'audio' in ele:
+                    ele['type'] = 'audio'
+                elif 'audio_url' in ele:
+                    ele['type'] = 'audio_url'
+                elif 'image' in ele:
+                    ele['type'] = 'image'
+                elif 'image_url' in ele:
+                    ele['type'] = 'image_url'
+                elif 'video' in ele:
+                    ele['type'] = 'video'
+                elif 'video_url' in ele:
+                    ele['type'] = 'video_url'
+                else:
+                    raise ValueError(f'Unknown ele: {ele}')
+
+            if ele['type'] == 'audio' or ele['type'] == 'audio_url':
+                if 'audio_url' in ele:
+                    audio_key = 'audio_url'
+                    with tempfile.NamedTemporaryFile(delete=True) as temp_audio_file:
+                        temp_audio_file.write(urlopen(ele[audio_key]).read())
+                        temp_audio_file_path = temp_audio_file.name
+                        audios.append(resample_wav_to_16khz(temp_audio_file_path))
+                        ele['audio'] = temp_audio_file_path
+                elif 'audio' in ele:
+                    audio_key = 'audio'
+                    audios.append(resample_wav_to_16khz(ele[audio_key]))
+                else:
+                    raise ValueError(f'Unknown ele {ele}')
+            elif use_audio_in_video and (ele['type'] == 'video' or ele['type'] == 'video_url'):
+                # use video as audio as well
+                if 'video_url' in ele:
+                    audio_key = 'video_url'
+                    with tempfile.NamedTemporaryFile(delete=True) as temp_video_file:
+                        temp_video_file.write(urlopen(ele[audio_key]).read())
+                        temp_video_file_path = temp_video_file.name
+                        ele[audio_key] = temp_video_file_path
+                        audios.append(
+                            librosa.load(temp_video_file_path,
+                                        sr=16000)[0])
+                        videos.append(fetch_and_read_video(temp_video_file_path))
+                        ele['video'] = temp_video_file_path
+                elif 'video' in ele:
+                    audio_key = 'video'
+                    audios.append(librosa.load(ele[audio_key], sr=16000)[0])
+                    videos.append(fetch_and_read_video(audio_key))
+                else:
+                    raise ValueError("Unknown ele {}".format(ele))
+                # insert a audio after the video
+                message['content'].insert(index + 1, {
+                    "type": "audio",
+                    "audio": ele[audio_key],
+                })
+                # no need to load the added audio again
+                index += 1
+            elif ele['type'] == 'video' or ele['type'] == 'video_url':
+                if 'video_url' in ele:
+                    video_key = 'video_url'
+                    with tempfile.NamedTemporaryFile(delete=True) as temp_video_file:
+                        temp_video_file.write(urlopen(ele['video_url']).read())
+                        temp_video_file_path = temp_video_file.name
+                        videos.append(fetch_and_read_video(temp_video_file))
+                        ele['video'] = temp_video_file_path
+                else:
+                    video_key = 'video'
+                    videos.append(fetch_and_read_video(ele[video_key]))
+            elif ele['type'] == 'image' or ele['type'] == 'image_url':
+                images.append(fetch_image(ele))
+
+            # move to the next content
+            index += 1
+
+    prompt = processor.apply_chat_template(
+        messages,
+        tokenize=tokenize,
+        add_generation_prompt=True,
+        add_vision_id=True,
+    )
+
+    audios = audios if len(audios) > 0 else None
+    images = images if len(images) > 0 else None
+    videos = videos if len(videos) > 0 else None
+
+    logger.info(f'{prompt}, '
+                f'audios = {len(audios) if audios else None}, '
+                f'images = {len(images) if images else None}, '
+                f'videos = {len(videos) if videos else None}')
+
+    multi_modal_data = {}
+    if audios:
+        multi_modal_data["audio"] = audios
+    if images:
+        multi_modal_data["image"] = images
+    if videos:
+        multi_modal_data["video"] = videos
+
+    # pass through the use_audio_in_video to llm engine
+    multi_modal_data["use_audio_in_video"] = use_audio_in_video
+
+    if isinstance(prompt, list) and isinstance(prompt[0], (list, str)):
+        prompt = prompt[0]
+
+    if tokenize:
+        return TokensPrompt(
+            prompt_token_ids=prompt,
+            multi_modal_data=multi_modal_data,
+        )
+    else:
+        return TextPrompt(
+            prompt=prompt,
+            multi_modal_data=multi_modal_data,
+        )
+
+
+def get_system_prompt():
+    if args.text_only:
+        return {
+            'role': 'system',
+            'content': [{
+                'type': 'text',
+                'text': 'You are a helpful assistant.'
+            }]
+        }
+    else:
+        return {
+            'role':
+            'system',
+            'content': [{
+                'type':
+                'text',
+                'text':
+                'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
+            }]
+        }
+
+
+def make_text_prompt():
+    messages = [
+        get_system_prompt(),
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Who are you?"
+                },
+            ]
+        },
+    ]
+
+    prompt = make_inputs_qwen2_omni(messages, )
+    return prompt
+
+
+def make_audio_in_video_v2_prompt():
+    messages = [
+        {
+            'role':
+            'system',
+            'content': [{
+                'type':
+                'text',
+                'text':
+                'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
+            }]
+        },
+        {
+            "role":
+            "user",
+            "content": [
+                {
+                    "type":
+                    "video_url",
+                    "video_url":
+                    "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2.5-Omni/draw_small.mp4"
+                },
+            ]
+        },
+    ]
+    prompt = make_inputs_qwen2_omni(
+        messages,
+        use_audio_in_video=True,
+    )
+    return prompt
+
+
+def init_omni_engine():
+    thinker_engine_args = AsyncEngineArgs(
+        model=args.thinker_model,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.4,
+        tensor_parallel_size=len(args.thinker_devices),
+        enforce_eager=args.enforce_eager or args.thinker_enforce_eager,
+        distributed_executor_backend="mp",
+        limit_mm_per_prompt={
+            'audio': 32,
+            'image': 960,
+            'video': 32
+        },
+        max_model_len=32768,
+        max_num_seqs=args.max_num_seqs,
+        block_size=args.block_size,
+        quantization=args.thinker_quantization,
+        enable_prefix_caching=args.enable_prefix_caching,
+    )
+    talker_engine_args = AsyncEngineArgs(
+        model=args.talker_model,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.4,
+        tensor_parallel_size=1,
+        enforce_eager=args.enforce_eager or args.talker_enforce_eager,
+        distributed_executor_backend="mp",
+        limit_mm_per_prompt={
+            'audio': 32,
+            'image': 960,
+            'video': 32
+        },
+        max_model_len=32768,
+        max_num_seqs=args.max_num_seqs,
+        block_size=args.block_size,
+        quantization=args.talker_quantization,
+        enable_prefix_caching=args.enable_prefix_caching,
+    )
+
+    if args.thinker_only:
+        return OmniLLMEngine(
+            thinker_engine_args,
+            thinker_visible_devices=args.thinker_devices,
+        )
+    elif not args.do_wave:
+        return OmniLLMEngine(
+            thinker_engine_args,
+            talker_engine_args,
+            thinker_visible_devices=args.thinker_devices,
+            talker_visible_devices=args.talker_devices,
+        )
+    else:
+        return OmniLLMEngine(
+            thinker_engine_args,
+            talker_engine_args,
+            args.code2wav_model,
+            code2wav_enable_torch_compile=args.enable_torch_compile,
+            code2wav_enable_torch_compile_first_chunk=args.
+            enable_torch_compile_first_chunk,
+            code2wav_odeint_method=args.odeint_method,
+            code2wav_odeint_method_relaxed=args.odeint_method_relaxed,
+            code2wav_batched_chunk=args.batched_chunk,
+            code2wav_frequency=args.code2wav_frequency,
+            thinker_visible_devices=args.thinker_devices,
+            talker_visible_devices=args.talker_devices,
+            code2wav_visible_devices=args.code2wav_devices,
+            code2wav_dynamic_batch=args.code2wav_dynamic_batch,
+        )
+
+
+def make_omni_prompt() -> Union[TokensPrompt, List[TokensPrompt]]:
+    if args.prompt == 'text':
+        prompt = make_text_prompt()
+    elif args.prompt == 'audio-in-video-v2':
+        prompt = make_audio_in_video_v2_prompt()
+    else:
+        raise ValueError(f'Unsupported prompt type: {args.prompt}')
+    return prompt
+
+
+def now():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+
+
+def parse_response(
+    i: int,
+    output_queue: queue.Queue[Union[RequestOutput, np.ndarray]],
+):
+    last_output: RequestOutput = None
+    waveforms: List[np.ndarray] = []
+
+    start_time = time.perf_counter()
+    thinker_finish_time = start_time
+    end_to_end_finish_time = start_time
+
+    waveform_times = [start_time]
+
+    while True:
+        output = output_queue.get()
+        if output is None:
+            end_to_end_finish_time = time.perf_counter()
+            break
+
+        if isinstance(output, RequestOutput):
+            if output.outputs[0].text:
+                print(
+                    f'[R-{i}][{now()}] Input: [{len(output.prompt_token_ids)}], '
+                    f'Output: [{len(output.outputs[0].token_ids)}] {output.outputs[0].text}'
+                )
+            else:
+                print(
+                    f'[R-{i}][{now()}] Input: [{len(output.prompt_token_ids)}], '
+                    f'Output: [{len(output.outputs[0].token_ids)}] {output.outputs[0].token_ids}'
+                )
+            if output.finished:
+                thinker_finish_time = time.perf_counter()
+            last_output = output
+        elif isinstance(output, tuple) and isinstance(output[0], np.ndarray):
+            output, output_tokens = output
+            print(
+                f'[R-{i}][{now()}] Waveform: [{len(waveforms)+1}] {output.dtype=}, {output.shape=}, {output_tokens=}'
+            )
+            waveforms.append(output)
+            waveform_times.append(time.perf_counter())
+        else:
+            raise ValueError(f'[R-{i}] Unknown output type: {output}')
+
+    print(
+        f'[R-{i}] Thinker finished in {thinker_finish_time - start_time} seconds'
+        f', end-to-end finished in {end_to_end_finish_time - start_time} seconds'
+        f', {len(last_output.outputs[0].token_ids)} tokens'
+        f', {len(waveforms)} waveforms')
+    waveform_times = [
+        waveform_times[i] - waveform_times[i - 1]
+        for i in range(1, len(waveform_times))
+    ]
+    print(f'[R-{i}] Waveform times: {waveform_times} seconds')
+
+    for j, waveform in enumerate(waveforms):
+        tmp_wav_path = f"waveform-{i}-chunk{j}.wav"
+        sf.write(tmp_wav_path, waveform, samplerate=args.sample_rate)
+        print(f"[R-{i}] Generated: {tmp_wav_path}")
+
+    # Write the complete wave file
+    print(
+        f'[R-{i}] Writting waveforms to waveform.wav: {len(waveforms)} waveforms'
+    )
+    if len(waveforms) > 0:
+        tmp_wav_path = f"waveform-{i}.wav"
+        sf.write(tmp_wav_path,
+                 np.concatenate(waveforms),
+                 samplerate=args.sample_rate)
+        print(f"[R-{i}] Generated: {tmp_wav_path}")
+
+
+def run_omni_engine(
+    prompt: Union[TokensPrompt, List[TokensPrompt]],
+    omni: OmniLLMEngine,
+    num_prompts: int = 1,
+    is_warmup: bool = False,
+):
+    sampling_params = SamplingParams(
+        temperature=0.0,
+        top_k=-1,
+        top_p=1.0,
+        repetition_penalty=1.1,
+        max_tokens=args.max_tokens,
+        detokenize=True,
+        seed=args.seed,
+    )
+    talker_sampling_params = SamplingParams(
+        temperature=0.9,
+        top_k=40,
+        top_p=0.8,
+        repetition_penalty=1.05,
+        max_tokens=2048,
+        detokenize=False,
+        seed=args.seed,
+    )
+
+    if not isinstance(prompt, list):
+        prompts = [copy.deepcopy(prompt) for _ in range(num_prompts)]
+    else:
+        prompts = prompt
+
+    # add request
+    output_queues = []
+    for i, prompt in enumerate(prompts):
+        request_id = str(uuid.uuid4())
+        logger.info(f'[R-{i}][{now()}] Adding request {request_id}')
+        output_queue = omni.add_request(
+            request_id,
+            prompt,
+            sampling_params,
+            **{
+                "talker_params": talker_sampling_params,
+            } if not args.thinker_only else {},
+            voice_type=args.warmup_voice_type
+            if is_warmup else args.voice_type,
+        )
+        logger.info(f'[R-{i}][{now()}] Added request {request_id}')
+        output_queues.append(output_queue)
+
+    parse_threads = []
+    for i, output_queue in enumerate(output_queues):
+        t = threading.Thread(target=parse_response, args=(i, output_queue))
+        t.start()
+        parse_threads.append(t)
+    for t in parse_threads:
+        t.join()
+
+
+def parse_voice_type(voice_type) -> str:
+    if not voice_type:
+        return voice_type
+
+    voice_types = {
+        "晨煦": "m02",
+        "Ethan": "m02",
+        "千雪": "f030",
+        "Chelsie": "f030",
+    }
+    voice_type = voice_type.lower()
+    return voice_types.get(voice_type, voice_type)
+
+
+def main():
+    if args.thinker_model is None or not os.path.exists(args.thinker_model):
+        if os.path.exists(f'{args.model}/thinker'):
+            args.thinker_model = f'{args.model}/thinker'
+        else:
+            args.thinker_model = f"{args.model}"
+    if args.talker_model is None or not os.path.exists(args.talker_model):
+        if os.path.exists(f'{args.model}/talker'):
+            args.talker_model = f'{args.model}/talker'
+        else:
+            args.talker_model = f"{args.model}"
+    if args.code2wav_model is None or not os.path.exists(args.code2wav_model):
+        if os.path.exists(f'{args.model}/code2wav'):
+            args.code2wav_model = f'{args.model}/code2wav'
+        else:
+            args.code2wav_model = f"{args.model}"
+
+    prompt = make_omni_prompt()
+
+    # init engine
+    omni = init_omni_engine()
+    args.voice_type = parse_voice_type(args.voice_type)
+    args.warmup_voice_type = parse_voice_type(args.warmup_voice_type)
+    logger.info("voice_type {} warmup_voice_type {}".format(
+        args.voice_type, args.warmup_voice_type))
+
+    # warmup
+    run_omni_engine(prompt, omni, num_prompts=args.num_prompts, is_warmup=True)
+
+    try:
+        run_omni_engine(prompt, omni, args.num_prompts, is_warmup=False)
+    except:
+        logger.exception('Error in run_omni_engine')
+
+    omni.shutdown()
+
+    current_process = psutil.Process()
+    children = current_process.children(recursive=True)
+    for child in children:
+        os.kill(child.pid, signal.SIGTERM)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/offline_inference/qwen2_5_omni/end2end.py
+++ b/examples/offline_inference/qwen2_5_omni/end2end.py
@@ -262,7 +262,7 @@ def make_inputs_qwen2_omni(
                 elif 'video' in ele:
                     audio_key = 'video'
                     audios.append(librosa.load(ele[audio_key], sr=16000)[0])
-                    videos.append(fetch_and_read_video(audio_key))
+                    videos.append(fetch_and_read_video(ele[audio_key]))
                 else:
                     raise ValueError("Unknown ele {}".format(ele))
                 # insert a audio after the video

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -36,6 +36,7 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=74.1.1; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
+torchdiffeq # Required for Qwen2.5-Omni.
 compressed-tensors == 0.9.3 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -118,15 +118,14 @@ def all_reduce_fake(tensor: torch.Tensor, group_name: str) -> torch.Tensor:
     return torch.empty_like(tensor)
 
 
-if supports_custom_op():
-    from vllm.platforms import current_platform
-    direct_register_custom_op(
-        op_name="all_reduce",
-        op_func=all_reduce,
-        mutates_args=[],
-        fake_impl=all_reduce_fake,
-        dispatch_key=current_platform.dispatch_key,
-    )
+from vllm.platforms import current_platform
+direct_register_custom_op(
+    op_name="all_reduce",
+    op_func=all_reduce,
+    mutates_args=[],
+    fake_impl=all_reduce_fake,
+    dispatch_key=current_platform.dispatch_key,
+)
 
 
 class GroupCoordinator:

--- a/vllm/engine/multiprocessing/__init__.py
+++ b/vllm/engine/multiprocessing/__init__.py
@@ -3,7 +3,7 @@
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Mapping, Optional, Union, overload
+from typing import Any, List, Mapping, Optional, Union, overload
 
 from typing_extensions import deprecated
 
@@ -36,6 +36,7 @@ class RPCProcessRequest:
     trace_headers: Optional[Mapping[str, str]] = None
     prompt_adapter_request: Optional[PromptAdapterRequest] = None
     priority: int = 0
+    resumable: Optional[bool] = False
 
     @overload
     def __init__(
@@ -47,6 +48,7 @@ class RPCProcessRequest:
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         priority: int = 0,
+        resumable: Optional[bool] = False,
     ) -> None:
         ...
 
@@ -62,6 +64,7 @@ class RPCProcessRequest:
         trace_headers: Optional[Mapping[str, str]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
         priority: int = 0,
+        resumable: Optional[bool] = False,
     ) -> None:
         ...
 
@@ -78,6 +81,7 @@ class RPCProcessRequest:
             trace_headers: Optional[Mapping[str, str]] = None,
             prompt_adapter_request: Optional[PromptAdapterRequest] = None,
             priority: int = 0,
+            resumable: Optional[bool] = False,
             *,
             inputs: Optional[PromptType] = None,  # DEPRECATED
     ) -> None:
@@ -95,6 +99,7 @@ class RPCProcessRequest:
         self.trace_headers = trace_headers
         self.prompt_adapter_request = prompt_adapter_request
         self.priority = priority
+        self.resumable = resumable
 
 
 @dataclass
@@ -162,10 +167,17 @@ class RPCAdapterLoadedResponse:
     request_id: str
 
 
+@dataclass
+class RPCResumeRequest:
+    request_id: str
+    prompt_embeds: Any
+    forever: bool = False
+
+
 RPC_REQUEST_T = Union[RPCProcessRequest, RPCAbortRequest, RPCStartupRequest,
                       RPCUProfileRequest, RPCLoadAdapterRequest,
                       RPCResetPrefixCacheRequest, RPCSleepRequest,
-                      RPCWakeUpRequest, RPCIsSleepingRequest]
+                      RPCWakeUpRequest, RPCIsSleepingRequest, RPCResumeRequest]
 
 REQUEST_OUTPUTS_T = Union[List[RequestOutput], RPCAdapterLoadedResponse,
                           RPCIsSleepingResponse, RPCError]

--- a/vllm/engine/omni_llm_engine.py
+++ b/vllm/engine/omni_llm_engine.py
@@ -1,0 +1,2201 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import collections
+import concurrent.futures
+import contextlib
+import copy
+import glob
+import multiprocessing
+import os
+import pickle
+import queue
+import signal
+import time
+from contextlib import contextmanager
+from threading import Thread
+from typing import (Any, AsyncGenerator, Dict, Generator, Iterator, List,
+                    Mapping, Optional, Set, Tuple, Union)
+
+import numpy as np
+import psutil
+import torch
+import zmq
+import zmq.asyncio
+from zmq import Frame  # type: ignore[attr-defined]
+from zmq.asyncio import Socket
+
+import vllm.envs as envs
+from vllm.config import LoadConfig, ModelConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.engine.async_llm_engine import AsyncEngineArgs, AsyncLLMEngine
+from vllm.engine.multiprocessing import (ENGINE_DEAD_ERROR, IPC_DATA_EXT,
+                                         IPC_HEALTH_EXT, IPC_INPUT_EXT,
+                                         IPC_OUTPUT_EXT, REQUEST_OUTPUTS_T,
+                                         RPC_REQUEST_T, VLLM_RPC_SUCCESS_STR,
+                                         RPCError, RPCStartupRequest,
+                                         RPCStartupResponse)
+from vllm.engine.multiprocessing.client import (MQClientClosedError,
+                                                MQLLMEngineClient)
+from vllm.engine.multiprocessing.engine import run_mp_engine
+from vllm.envs import VLLM_RPC_TIMEOUT
+from vllm.inputs import PromptType, TokensPrompt
+from vllm.logger import init_logger
+from vllm.lora.request import LoRARequest
+from vllm.model_executor.model_loader import get_model_loader
+from vllm.model_executor.model_loader.loader import (
+    safetensors_weights_iterator)
+from vllm.model_executor.models.qwen2_code2wav_dit import Qwen2Code2wav
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.pooling_params import PoolingParams
+from vllm.prompt_adapter.request import PromptAdapterRequest
+from vllm.sampling_params import SamplingParams
+from vllm.transformers_utils.config import (get_config,
+                                            try_get_generation_config)
+from vllm.transformers_utils.tokenizer import get_tokenizer
+from vllm.usage.usage_lib import UsageContext
+from vllm.utils import LRUCache, get_open_zmq_ipc_path
+
+POLLING_TIMEOUT_MS = 10000
+HEALTHY_RESPONSE = (pickle.dumps(VLLM_RPC_SUCCESS_STR), )
+
+logger = init_logger(__name__)
+
+# omni: use v0 engine.
+envs.VLLM_USE_V1 = 0
+
+
+@contextlib.contextmanager
+def envvars(
+    key: Union[str, Dict[str, str]],
+    value: Union[str, None] = None,
+) -> Generator[os._Environ, Any, Any]:
+    if isinstance(key, str):
+        if value is None:
+            items = dict()
+        else:
+            items: Dict[str, str] = {key: value}
+    else:
+        items: Dict[str, str] = key
+    original_items = dict()
+    for k, v in items.items():
+        original_items[k] = os.environ.get(k, None)
+        os.environ[k] = v
+
+    yield os.environ
+
+    for k, v in original_items.items():
+        if v is not None:
+            os.environ[k] = v
+        else:
+            del os.environ[k]
+
+
+class SynchronizedGenerator(Generator[RequestOutput, None, None]):
+
+    def __init__(
+        self,
+        generator: AsyncGenerator[RequestOutput, None],
+        loop: asyncio.AbstractEventLoop,
+    ):
+        self._generator = generator
+        self._loop = loop
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return asyncio.run_coroutine_threadsafe(
+                self._generator.__anext__(),
+                self._loop,
+            ).result()
+        except StopAsyncIteration as e:
+            raise StopIteration from e
+        except concurrent.futures._base.CancelledError as e:
+            raise StopIteration from e
+
+    def send(self, value):
+        return self.__next__()
+
+    def throw(self, type, value=None, traceback=None):
+        raise StopIteration
+
+
+# create a new class for code2wav engine request
+class Code2WavChunk:
+
+    def __init__(
+        self,
+        request_id: str,
+        voice_type: str,
+        code: List[int],
+        finished: bool,
+        progress: int,
+    ) -> None:
+        self.request_id = request_id
+        self.voice_type = voice_type
+        self.code = code
+        self.finished = finished
+        self.progress = progress
+        self.prev_generated = None
+
+    def is_little_chunk(self):
+        return self.progress == 0 and self.finished
+
+    def is_first_chunk(self):
+        return self.progress == 0 and not self.finished
+
+    def is_intermediate_chunk(self):
+        return self.progress > 0 and not self.finished
+
+    def is_last_chunk(self):
+        return self.progress != 0 and self.finished
+
+    def __eq__(self, value):
+        return self.request_id == value.request_id and \
+            self.voice_type == value.voice_type and \
+            self.code == value.code and \
+            self.finished == value.finished and \
+            self.progress == value.progress
+
+    def __str__(self):
+        return f"request_id: {self.request_id}, voice_type: {self.voice_type}, code: {self.code}, finished: {self.finished}, progress: {self.progress}"
+
+
+class ChunkScheduler:
+
+    def __init__(self):
+        self.little_chunks = []
+        self.first_chunks = []
+        self.intermediate_last_chunks = [
+        ]  # store is_intermediate_chunk and is_last_chunk
+        self.request_progress = collections.defaultdict(
+            lambda: -1
+        )  # record the last execution progress of each request_id.
+
+    def add_chunk(self, chunk: Code2WavChunk):
+        if chunk.is_little_chunk():
+            self.little_chunks.append(chunk)
+        elif chunk.is_first_chunk():
+            self.first_chunks.append(chunk)
+        elif chunk.is_intermediate_chunk() or chunk.is_last_chunk():
+            self.intermediate_last_chunks.append(chunk)
+        else:
+            raise ValueError("Unknown chunk type")
+
+    def can_execute(self, chunk: Code2WavChunk) -> bool:
+        """Determine whether the chunk meets the execution conditions (i.e., the dependent preceding chunks have been executed)."""
+        last_progress = self.request_progress[chunk.request_id]
+        return chunk.progress == last_progress + 1
+
+    def schedule(self) -> List[Code2WavChunk]:
+        """Select the list of chunks to be executed based on priority and dependency relationships."""
+        selected_chunks = []
+
+        # 1. process is_little_chunk
+        if self.little_chunks:
+            for i, chunk in enumerate(self.little_chunks):
+                if self.can_execute(chunk):
+                    selected_chunks.append(chunk)
+                    del self.little_chunks[i]
+                    self.request_progress[chunk.request_id] = chunk.progress
+                    return selected_chunks  # Execute only one is_little_chunk at a time.
+            # If there are no executable is_little_chunk, continue.
+
+        # 2. process is_first_chunk
+        if self.first_chunks:
+            sorted_chunks = copy.deepcopy(self.first_chunks)
+            for chunk in sorted_chunks:
+                if self.can_execute(chunk):
+                    selected_chunks.append(chunk)
+                    self.first_chunks.remove(chunk)
+                    self.request_progress[chunk.request_id] = chunk.progress
+                    return selected_chunks
+
+        # 3. process is_intermediate_chunk and is_last_chunk
+        if self.intermediate_last_chunks:
+            sorted_chunks = copy.deepcopy(self.intermediate_last_chunks)
+            first_chunk = sorted_chunks[0]
+
+            if self.can_execute(first_chunk):
+                if first_chunk.is_last_chunk():
+                    # execute single is_last_chunk
+                    selected_chunks.append(first_chunk)
+                    self.intermediate_last_chunks.remove(first_chunk)
+                    self.request_progress[
+                        first_chunk.request_id] = first_chunk.progress
+                    return selected_chunks
+                elif first_chunk.is_intermediate_chunk():
+                    # Execute multiple is_intermediate_chunk, with a maximum of one per request_id.
+                    selected_request_ids = set()
+                    for chunk in sorted_chunks:
+                        if chunk.is_intermediate_chunk() and self.can_execute(
+                                chunk):
+                            if chunk.request_id not in selected_request_ids:
+                                selected_chunks.append(chunk)
+                                selected_request_ids.add(chunk.request_id)
+                                self.request_progress[
+                                    chunk.request_id] = chunk.progress
+                                self.intermediate_last_chunks.remove(chunk)
+                    return selected_chunks
+
+        # If there are no executable chunks, return empty list
+        return selected_chunks
+
+
+class _MQOmniCode2WavEngine:
+
+    def __init__(
+        self,
+        ipc_path: str,
+        model_path: str,
+        enable_torch_compile: bool,
+        enable_torch_compile_first_chunk: bool,
+        odeint_method: str = "euler",
+        odeint_method_relaxed: bool = False,
+        batched_chunk: int = 3,
+        frequency: str = "50hz",
+        device: Union[int, str] = 'cuda',
+        log_requests: bool = True,
+        code2wav_dynamic_batch: bool = False,
+    ) -> None:
+        if isinstance(device, int):
+            device = f'cuda:{device}'
+        self.device = torch.device(device)
+
+        logger.info(
+            "Code2WavEngine starting up on device %s, with model %s, method: %s, relaxed: %r",
+            self.device, model_path, odeint_method, odeint_method_relaxed)
+
+        if os.path.exists(os.path.join(model_path, 'spk_dict.pt')):
+            self.code2wav_conds, self.code2wav_ref_mels = self._load_spk_dict(
+                model_path)
+        else:
+            self.code2wav_conds, self.code2wav_ref_mels = self._load_spk_dict_legacy(
+                model_path)
+
+        if 'm02' not in self.code2wav_conds and 'Ethan' in self.code2wav_conds:
+            self.code2wav_conds['m02'] = self.code2wav_conds['Ethan']
+            self.code2wav_ref_mels['m02'] = self.code2wav_ref_mels['Ethan']
+        if 'f030' not in self.code2wav_conds and 'Chelsie' in self.code2wav_conds:
+            self.code2wav_conds['f030'] = self.code2wav_conds['Chelsie']
+            self.code2wav_ref_mels['f030'] = self.code2wav_ref_mels['Chelsie']
+
+        self.frequency = frequency
+        self.code2wav_steps: int = 10
+        self.code2wav_bs_mel: int = 24 if frequency == "50hz" else 32
+        self.factor: int = 2 if frequency == "50hz" else 4
+
+        dit_model, bigvgan_model = self.load_code2wav_legacy(model_path)
+        if not dit_model and not bigvgan_model:
+            dit_model, bigvgan_model = self.load_code2wav(model_path)
+            with_weight_norm = False
+        else:
+            with_weight_norm = True
+
+        self.code2wav = Qwen2Code2wav(
+            dit_ckpt=dit_model,
+            bigvgan_ckpt=bigvgan_model,
+            steps=self.code2wav_steps,
+            bs_mel=self.code2wav_bs_mel,
+            odeint_method=odeint_method,
+            odeint_method_relaxed=odeint_method_relaxed,
+            batched_chunk=batched_chunk,
+            frequency=frequency,
+            device=self.device,
+            with_weight_norm=with_weight_norm,
+        )
+        self._torch_compile_model(enable_torch_compile,
+                                  enable_torch_compile_first_chunk)
+
+        self.code2wav_y_all = torch.randn(
+            1,
+            32768,
+            80,
+            device=self.device,
+            dtype=list(self.code2wav_ref_mels.values())[0].dtype)
+
+        self.code2wav_chunk_size: int = self.code2wav.chunk_size
+        self.code2wav_future_cache_size: int = self.code2wav.future_cache_size
+
+        # request id -> (progress, prev_generated)
+        self.code2wav_progress: Dict[
+            str,
+            Optional[torch.Tensor]] = collections.defaultdict(lambda: (0, []))
+        self.code2wav_progress_error: LRUCache = LRUCache(capacity=1024)
+
+        self.log_requests = log_requests
+
+        self.ctx = zmq.Context()  # type: ignore[attr-defined]
+
+        # Receive input from the client.
+        self.input_socket = self.ctx.socket(zmq.constants.PULL)
+        self.input_socket.bind(f"{ipc_path}{IPC_INPUT_EXT}")
+
+        # Send output stream back to client.
+        self.output_socket = self.ctx.socket(zmq.constants.PUSH)
+        self.output_socket.bind(f"{ipc_path}{IPC_OUTPUT_EXT}")
+
+        # Send heartbeats back to client.
+        self.heartbeat_socket = self.ctx.socket(zmq.constants.PUSH)
+        self.heartbeat_socket.bind(f"{ipc_path}{IPC_HEALTH_EXT}")
+
+        # IPC path for the data socket.
+        self.data_ipc_path = f"{ipc_path}{IPC_DATA_EXT}"
+
+        # Error state.
+        self._errored_with: Optional[BaseException] = None
+
+        # open batch mode or not
+        self.code2wav_dynamic_batch = code2wav_dynamic_batch
+        if code2wav_dynamic_batch:
+            self.chunk_scheduler = ChunkScheduler()
+
+    def _load_spk_dict(self, model_path):
+        code2wav_conds, code2wav_ref_mels = {}, {}
+
+        if not os.path.exists(os.path.join(model_path, 'spk_dict.pt')):
+            return code2wav_conds, code2wav_ref_mels
+
+        for key, value in torch.load(os.path.join(model_path,
+                                                  'spk_dict.pt')).items():
+            code2wav_conds[key] = value["cond"].to(self.device)
+            code2wav_ref_mels[key] = value["ref_mel"].to(self.device)
+        return code2wav_conds, code2wav_ref_mels
+
+    def _load_spk_dict_legacy(self, model_path):
+        code2wav_conds = {
+            _MQOmniCode2WavEngine.parse_key(os.path.basename(f), 'spk_emb.npy'):
+            torch.tensor(np.load(f)).to(self.device)
+            for f in sorted(
+                glob.glob(os.path.join(model_path, 'inputs', '*spk_emb.npy')) +
+                glob.glob(
+                    os.path.join(model_path, 'inputs_sft4spks',
+                                 '*spk_emb.npy')))
+        }
+        code2wav_ref_mels = {
+            _MQOmniCode2WavEngine.parse_key(os.path.basename(f), 'ref_mel.npy'):
+            torch.tensor(np.load(f)).to(self.device)
+            for f in sorted(
+                glob.glob(os.path.join(model_path, 'inputs', '*ref_mel.npy')) +
+                glob.glob(
+                    os.path.join(model_path, 'inputs_sft4spks',
+                                 '*ref_mel.npy')))
+        }
+        return code2wav_conds, code2wav_ref_mels
+
+    def load_code2wav_legacy(self, model_path):
+        # code2wav model
+        self.dit_model_path = glob.glob(
+            os.path.join(model_path, 'dit', 'model_*.pt'))
+        self.dit_model_path = self.dit_model_path[
+            0] if self.dit_model_path else None
+        self.bigvgan_model_path = glob.glob(
+            os.path.join(model_path, 'bigvgan', 'g_*'))
+        self.bigvgan_model_path = self.bigvgan_model_path[
+            0] if self.bigvgan_model_path else None
+        return self.dit_model_path, self.bigvgan_model_path
+
+    def load_code2wav(self, model_path):
+        import safetensors.torch
+
+        dit_model, bigvgan_model = {}, {}
+        safetensors = sorted(
+            glob.glob(os.path.join(model_path, '*.safetensors')))
+        legacy_weights = False
+        for key, value in safetensors_weights_iterator(safetensors,
+                                                       use_tqdm_on_load=True):
+            legacy_weights = legacy_weights or 'input_embed.spk_encoder.fc.conv.weight' in key
+            if legacy_weights:
+                break
+        for key, value in safetensors_weights_iterator(safetensors,
+                                                       use_tqdm_on_load=True):
+            if key.startswith('token2wav.code2wav_bigvgan_model.'):
+                if 'generator' not in bigvgan_model:
+                    bigvgan_model['generator'] = {}
+                bigvgan_model['generator'][key.replace(
+                    'token2wav.code2wav_bigvgan_model.', '')] = value
+            if key.startswith('token2wav.code2wav_dit_model.'):
+                key = key.replace('token2wav.code2wav_dit_model.',
+                                  'transformer.')
+                if key.startswith('transformer.input_embed.spk_encoder'):
+                    if legacy_weights:
+                        dit_model[key] = value
+                    else:
+                        dit_model[key.replace('.bias', '.conv.bias').replace(
+                            '.weight', '.conv.weight')] = value
+                elif '.ff.ff.0.weight' in key or '.ff.ff.0.bias' in key:
+                    dit_model[key.replace('.ff.ff.0.weight',
+                                          '.ff.ff.0.0.weight').replace(
+                                              '.ff.ff.0.bias',
+                                              '.ff.ff.0.0.bias')] = value
+                elif '.ff.ff.3.weight' in key or '.ff.ff.3.bias' in key:
+                    dit_model[key.replace('.ff.ff.3.weight',
+                                          '.ff.ff.2.weight').replace(
+                                              '.ff.ff.3.bias',
+                                              '.ff.ff.2.bias')] = value
+                else:
+                    dit_model[key] = value
+        return dit_model, bigvgan_model
+
+    @staticmethod
+    def parse_key(fname: str, key: str) -> str:
+        if fname == key:
+            return 'default'
+        return fname.split('_')[0].lower()
+
+    @property
+    def dead_error(self) -> BaseException:
+        if self._errored_with is not None:
+            return ENGINE_DEAD_ERROR(self._errored_with)
+        else:
+            return ENGINE_DEAD_ERROR()
+
+    def start(self):
+        try:
+            try:
+                logger.debug("Starting Startup Loop.")
+                self.run_startup_loop()
+                logger.debug("Starting Engine Loop.")
+                self.run_engine_loop()
+            except Exception as e:
+                logger.exception(repr(e))
+        except KeyboardInterrupt:
+            logger.debug("Shutting down MQOmniCode2WavEngine.")
+        finally:
+            logger.debug("MQOmniCode2WavEngine is shut down.")
+            self.cleanup()
+
+    def cleanup(self):
+        """Cleanup zeromq state on shutdown."""
+        # Closes all sockets and destroys context.
+        self.ctx.destroy(linger=0)
+        del self.code2wav
+        if self.code2wav_dynamic_batch:
+            del self.chunk_scheduler
+
+    @contextmanager
+    def make_data_socket(
+            self) -> Iterator[zmq.Socket]:  # type: ignore[name-defined]
+        socket = self.ctx.socket(zmq.constants.ROUTER)
+        try:
+            socket.bind(self.data_ipc_path)
+            yield socket
+        finally:
+            socket.close(linger=0)
+
+    def run_startup_loop(self) -> None:
+        """Startup loop for sending data from Engine -> Client."""
+
+        with self.make_data_socket() as socket:
+            response: Union[RPCStartupResponse, BaseException]
+            try:
+                identity, message = socket.recv_multipart(copy=False)
+                request: RPCStartupRequest = pickle.loads(message.buffer)
+
+                # Handle the query from the Client.
+                if request == RPCStartupRequest.IS_SERVER_READY:
+                    response = RPCStartupResponse(False)
+            except Exception as e:
+                response = e
+
+            socket.send_multipart((identity, pickle.dumps(response)),
+                                  copy=False)
+
+    def run_engine_loop(self):
+        """Core busy loop of the LLMEngine."""
+
+        while True:
+            if self.code2wav_dynamic_batch:
+                # Get new inputs, may contains multiple requests with more than one chunk
+                # Schedule arrived requests
+                self.handle_new_input_batch()
+                chunks_list = self.chunk_scheduler.schedule()
+                if len(chunks_list) == 0:
+                    # Poll until there is work to do.
+                    while self.input_socket.poll(
+                            timeout=POLLING_TIMEOUT_MS) == 0:
+                        # When there's no work, check on engine health and send
+                        # health status back to client
+                        self._health_check()
+                else:
+                    # Execute selected requests
+                    request_outputs = self.step_batch(chunks_list)
+                    # Send outputs back to client
+                    self.send_outputs_batch(request_outputs)
+                continue
+            # Poll until there is work to do.
+            while self.input_socket.poll(timeout=POLLING_TIMEOUT_MS) == 0:
+                # When there's no work, check on engine health and send
+                # health status back to client
+                self._health_check()
+
+            # Handle any input from the client.
+            request_output = self.handle_new_input()
+
+            # Send request outputs
+            if request_output is None:
+                continue
+            elif isinstance(request_output, Tuple):
+                request_id, audio, finished, output_tokens = request_output
+                self._send_outputs((request_id, audio, output_tokens))
+                if finished:
+                    self._send_outputs((request_id, None, output_tokens))
+            else:
+                logger.warning("Invalid request output: %r", request_output)
+
+    def step_batch(
+        self, chunks_list: List[Code2WavChunk]
+    ) -> List[Tuple[str, np.ndarray, bool, int]]:
+        request_outputs = []
+        # filter illegal chunks
+        execute_chunk_list = []
+        for chunk in chunks_list:
+            if chunk.code is None:
+                if chunk.request_id in self.code2wav_progress:
+                    del self.code2wav_progress[chunk.request_id]
+                continue
+
+            if chunk.finished and len(chunk.code) <= 1:
+                if chunk.request_id in self.code2wav_progress:
+                    del self.code2wav_progress[chunk.request_id]
+                request_outputs.append(
+                    (chunk.request_id, np.empty(
+                        (0),
+                        dtype=np.float32), chunk.finished, len(chunk.code)))
+                continue
+
+            if self.code2wav_progress_error.get(chunk.request_id) is not None:
+                request_outputs.append(
+                    (chunk.request_id, np.empty(
+                        (0),
+                        dtype=np.float32), chunk.finished, len(chunk.code)))
+                continue
+            execute_chunk_list.append(chunk)
+
+        if len(execute_chunk_list) == 0:
+            # No chunk to process, return directly
+            return request_outputs
+
+        if len(execute_chunk_list) == 1:
+            # Process single chunk
+            chunk = chunks_list[0]
+            request_id = chunk.request_id
+            voice_type = chunk.voice_type
+            code = chunk.code
+            finished = chunk.finished
+            request_outputs.append(
+                self.step(request_id, voice_type, code, finished))
+            return request_outputs
+
+        # Get execute input
+        cond_list, ref_mel_list, codec_list, y_list, prev_generated_list = [], [], [], [], []
+        for chunk in execute_chunk_list:
+            cond = self.code2wav_conds[chunk.voice_type]
+            ref_mel = self.code2wav_ref_mels[chunk.voice_type]
+            _, prev_generated = self.code2wav_progress[chunk.request_id]
+            # prev_generated = chunk.prev_generated
+            # Get codec and y for current progress
+            progress, code = chunk.progress, chunk.code
+            code = torch.tensor(code, dtype=torch.long,
+                                device=self.device).unsqueeze(0)
+            start_index = max(
+                progress * self.code2wav.chunk_size -
+                self.code2wav.past_cache_size, 0)
+            end_index = min((progress + 1) * self.code2wav.chunk_size +
+                            self.code2wav.future_cache_size,
+                            code.shape[1] * self.factor)
+            y0 = self.code2wav_y_all[:, start_index:end_index].reshape(
+                1, -1, 80).contiguous()
+            codec = code[:, start_index // self.factor:end_index //
+                         self.factor].reshape(1, -1).contiguous()
+            cond_list.append(cond)
+            ref_mel_list.append(ref_mel)
+            codec_list.append(codec)
+            y_list.append(y0)
+            prev_generated_list.append(prev_generated)
+
+        cond = torch.cat(cond_list, dim=0)
+        ref_mel = torch.cat(ref_mel_list, dim=0)
+        codec = torch.cat(codec_list, dim=0)
+        y0 = torch.cat(y_list, dim=0)
+        prev_generated = torch.cat(prev_generated_list, dim=0)
+
+        generated_batch = self.code2wav.process_chunk_dit_batch(
+            cond=cond,
+            ref_mel=ref_mel,
+            codec=codec,
+            y0=y0,
+            steps=self.code2wav_steps,
+        )
+
+        generated_batch = generated_batch.to(
+            torch.float32)[:, self.code2wav.
+                           past_cache_size:-self.code2wav.future_cache_size, :]
+        if self.frequency == "50hz":
+            mel = torch.cat([
+                prev_generated[:, -self.code2wav.future_size * 2:, :],
+                generated_batch
+            ],
+                            dim=1)
+        else:
+            mel = torch.cat([prev_generated, generated_batch], dim=1)
+
+        audio_batch = self.code2wav.process_chunk_bigvgan_batch(mel)
+        audio_output = audio_batch[:, self.code2wav.future_size *
+                                   240:-self.code2wav.future_size * 240]
+
+        # update code2wav progress
+        for idx, chunk in enumerate(execute_chunk_list):
+            request_id = chunk.request_id
+            progress = chunk.progress
+            if chunk.finished:
+                del self.code2wav_progress[chunk.request_id]
+            elif generated_batch[idx] is not None:
+                self.code2wav_progress[request_id] = (
+                    progress + 1, generated_batch[idx].unsqueeze(0))
+
+        # fill request_outputs
+        for idx, chunk in enumerate(execute_chunk_list):
+            request_outputs.append(
+                (chunk.request_id, audio_output[idx].detach().cpu().numpy(),
+                 chunk.finished, len(chunk.code)))
+
+        return request_outputs
+
+    def handle_new_input_batch(self):
+        try:
+            recv_chunks = 0
+            while self.input_socket.poll(timeout=0) != 0:
+                frame: Frame = self.input_socket.recv(copy=False)
+                request_id, voice_type, code, finished = pickle.loads(
+                    frame.buffer)
+                code_len = len(
+                    code
+                ) * self.factor - self.code2wav.future_cache_size - self.code2wav.chunk_size
+                progress = max((code_len + self.code2wav.chunk_size - 1) //
+                               self.code2wav.chunk_size, 0)
+                new_chunk = Code2WavChunk(request_id, voice_type, code,
+                                          finished, progress)
+                self.chunk_scheduler.add_chunk(new_chunk)
+                recv_chunks += 1
+
+        except Exception as e:
+            self._set_errored(e)
+            self._send_unhealthy(e)
+            raise e
+
+    def send_outputs_batch(self, request_outputs: List[Tuple[str, np.ndarray,
+                                                             bool]]):
+        for request_output in request_outputs:
+            if request_output is None:
+                continue
+            elif isinstance(request_output, Tuple):
+                request_id, audio, finished, output_tokens = request_output
+                self._send_outputs((request_id, audio, output_tokens))
+                if finished:
+                    self._send_outputs((request_id, None, output_tokens))
+            else:
+                logger.warning("Invalid request output: %r", request_output)
+        return
+
+    def handle_new_input(self) -> Optional[Tuple[str, np.ndarray, bool, int]]:
+        """Handle new input from the socket"""
+        try:
+            if self.input_socket.poll(timeout=0) == 0:
+                return None
+
+            frame: Frame = self.input_socket.recv(copy=False)
+            request_id, voice_type, code, finished = pickle.loads(frame.buffer)
+            try:
+                return self.step(request_id, voice_type, code, finished)
+            except SystemExit:
+                raise
+            except BaseException as e:
+                self._set_errored(e)
+                rpc_err = RPCError(request_id=request_id,
+                                   is_engine_errored=True,
+                                   exception=e)
+                self._send_outputs(rpc_err)
+                raise e
+        except Exception as e:
+            self._set_errored(e)
+            self._send_unhealthy(e)
+            raise e
+
+    def step(
+        self,
+        request_id: str,
+        voice_type: str,
+        code: List[int],
+        finished: bool,
+    ) -> Optional[Tuple[str, np.ndarray, bool, int]]:
+        if code is None:
+            if request_id in self.code2wav_progress:
+                del self.code2wav_progress[request_id]
+            return None
+        output_tokens = len(code)
+
+        if finished and output_tokens <= 1:
+            if request_id in self.code2wav_progress:
+                del self.code2wav_progress[request_id]
+            return request_id, np.empty(
+                (0), dtype=np.float32), finished, output_tokens
+
+        if self.code2wav_progress_error.get(request_id) is not None:
+            return request_id, np.empty(
+                (0), dtype=np.float32), finished, output_tokens
+
+        # list to tensor
+        code = torch.tensor(code, dtype=torch.long,
+                            device=self.device).unsqueeze(0)
+
+        start_code2wav_chunk_time = time.perf_counter()
+        progress, prev_generated = self.code2wav_progress[request_id]
+
+        if progress == 0 and finished:
+            process_chunk = self.code2wav.process_little_chunk
+        else:
+            process_chunk = self.code2wav.process_chunk
+
+        try:
+            generated, audio = process_chunk(
+                self.code2wav_conds[voice_type],
+                self.code2wav_ref_mels[voice_type],
+                codec_all=code,
+                y_all=self.code2wav_y_all,
+                i=progress,
+                steps=self.code2wav_steps,
+                prev_generated=prev_generated,
+                finished=finished,
+            )
+            audio = audio.detach().cpu().numpy()
+        except RuntimeError as e:
+            generated, audio = None, np.empty((0), dtype=np.float32)
+            self.code2wav_progress_error.put(request_id, True)
+            logger.exception("Code2wav request %s chunk %d exception %s",
+                             request_id, progress, e)
+
+        end_code2wav_chunk_time = time.perf_counter()
+        logger.info("Code2wav request %s chunk %d took %.6f seconds",
+                    request_id, progress + 1,
+                    end_code2wav_chunk_time - start_code2wav_chunk_time)
+
+        # cleanup
+        if finished:
+            del self.code2wav_progress[request_id]
+        elif generated is not None:
+            self.code2wav_progress[request_id] = (progress + 1, generated)
+        return request_id, audio, finished, output_tokens
+
+    def _health_check(self):
+        # Send unhealthy if engine has already errored
+        if self._errored_with is not None:
+            self._send_unhealthy(self._errored_with)
+        try:
+            self._send_healthy()
+        except Exception as e:
+            self._set_errored(e)
+            self._send_unhealthy(e)
+
+    def _send_outputs(self, outputs: REQUEST_OUTPUTS_T):
+        """Send List of RequestOutput to RPCClient."""
+        if outputs:
+            output_bytes = pickle.dumps(outputs)
+            self.output_socket.send_multipart((output_bytes, ), copy=False)
+
+    def _send_healthy(self):
+        """Send HEALTHY message to RPCClient."""
+        if not self.heartbeat_socket.closed:
+            self.heartbeat_socket.send_multipart(HEALTHY_RESPONSE, copy=False)
+
+    def _send_unhealthy(self, error: BaseException):
+        """Send UNHEALTHY message to RPCClient."""
+        if not self.heartbeat_socket.closed:
+            error_bytes = pickle.dumps(error)
+            self.heartbeat_socket.send_multipart((error_bytes, ), copy=False)
+
+    def _set_errored(self, e: BaseException):
+        """Log and set errored status if this is the first issue."""
+        if self._errored_with is None:
+            self._errored_with = e
+
+    def _torch_compile_model(
+        self,
+        enable_torch_compile,
+        enable_torch_compile_first_chunk,
+    ):
+        if not enable_torch_compile:
+            return
+
+        # compile the bigvgan
+        self.code2wav.code2wav_bigvgan_model.vocoder.forward = torch.compile(
+            self.code2wav.code2wav_bigvgan_model.vocoder.forward, )
+        # compile the dit
+        if hasattr(self.code2wav, 'enable_torch_compile'):
+            self.code2wav.enable_torch_compile(
+                enable_torch_compile_first_chunk)
+
+        logger.info("Code2Wav model torch compiled")
+
+    @staticmethod
+    def signal_handler(*_) -> None:
+        raise KeyboardInterrupt("Code2WavEngine terminated")
+
+    @staticmethod
+    def run_code2wav_engine(
+        ipc_path: str,
+        model_path: str,
+        enable_torch_compile: bool,
+        enable_torch_compile_first_chunk: bool,
+        odeint_method: str,
+        odeint_method_relaxed: bool,
+        batched_chunk: int = 3,
+        frequency: str = "50hz",
+        engine_alive: Any = None,
+        device: Union[int, str] = 'cuda',
+        code2wav_dynamic_batch: Optional[bool] = False,
+    ):
+        try:
+            engine = _MQOmniCode2WavEngine(
+                ipc_path,
+                model_path,
+                enable_torch_compile=enable_torch_compile,
+                enable_torch_compile_first_chunk=
+                enable_torch_compile_first_chunk,
+                odeint_method=odeint_method,
+                odeint_method_relaxed=odeint_method_relaxed,
+                batched_chunk=batched_chunk,
+                frequency=frequency,
+                device=device,
+                code2wav_dynamic_batch=code2wav_dynamic_batch,
+            )
+
+            signal.signal(signal.SIGTERM, engine.signal_handler)
+
+            engine.start()
+        except BaseException as e:
+            logger.exception("Code2WavEngine failed with exception: %s", e)
+            engine_alive.value = False
+            raise e
+
+
+class _MQCode2WavEngineClient:
+
+    def __init__(self, ipc_path: str, engine_pid: int):
+        self.context = zmq.asyncio.Context()
+        self._errored_with: Optional[BaseException] = None
+
+        # Send RPCGenerateRequest to the MQLLMEngine.
+        self.input_socket: Socket = self.context.socket(zmq.constants.PUSH)
+        self.input_socket.connect(f"{ipc_path}{IPC_INPUT_EXT}")
+
+        # Receive streams of RequestOutput from the MQLLMEngine.
+        self.output_socket: Socket = self.context.socket(zmq.constants.PULL)
+        self.output_socket.connect(f"{ipc_path}{IPC_OUTPUT_EXT}")
+
+        # IPC path for acking heartbeats.
+        self.heartbeat_socket: Socket = self.context.socket(zmq.constants.PULL)
+        self.heartbeat_socket.connect(f"{ipc_path}{IPC_HEALTH_EXT}")
+
+        # IPC path for the data socket.
+        self.data_ipc_path = f"{ipc_path}{IPC_DATA_EXT}"
+
+        # Stream for requests.
+        self.output_queue: asyncio.Queue[Tuple[str, Union[
+            np.ndarray, BaseException]]] = asyncio.Queue()
+
+        # Loop to handle output of the LLMEngine periodically.
+        # Started after the MQLLMEngine is ready so that we can
+        # build the Client in an executor to enable clean shutdown.
+        self.output_loop: Optional[asyncio.Task] = None
+
+        # Loop to check health of the LLMEngine periodically.
+        # Started after the MQLLMEngine is ready.
+        self.health_loop: Optional[asyncio.Task] = None
+        self._engine_process = psutil.Process(engine_pid)
+
+    @contextmanager
+    def get_data_socket(self) -> Iterator[Socket]:
+        socket = self.context.socket(zmq.constants.DEALER)
+        try:
+            socket.connect(self.data_ipc_path)
+            yield socket
+        finally:
+            socket.close(linger=0)
+
+    async def run_heartbeat_loop(self, timeout: int):
+        """Background loop that continually checks to ensure the engine process
+        is still alive.
+        """
+        try:
+            while True:
+                # Check if the engine process is running:
+                if not self._engine_process.is_running() or (
+                        self._engine_process.status() == psutil.STATUS_ZOMBIE):
+                    # NB: is_running() returns True for zombies
+                    self._set_errored(
+                        RuntimeError(
+                            f"Engine process (pid {self._engine_process.pid}) "
+                            "died."))
+                    break
+
+                if await self.heartbeat_socket.poll(timeout=timeout):
+                    # Heartbeat received- check the message
+                    await self._check_success(
+                        error_message="Heartbeat failed.",
+                        socket=self.heartbeat_socket)
+
+                logger.debug("Heartbeat successful.")
+
+        except asyncio.CancelledError:
+            logger.debug("Shutting down MQLLMEngineClient check health loop.")
+
+        except psutil.NoSuchProcess:
+            self._set_errored(
+                RuntimeError(
+                    f"Engine process (pid {self._engine_process.pid}) died."))
+
+        except Exception as e:
+            self._set_errored(e)
+
+    async def run_output_handler_loop(self):
+        """Get RequestOutputs from Engine and stream to Request Queues"""
+
+        try:
+            while True:
+                await self.run_output_handler()
+        except asyncio.CancelledError:
+            logger.debug("Shutting down MQLLMEngineClient output handler.")
+
+    async def run_output_handler(self):
+        # Poll, checking for ENGINE_DEAD
+        while await self.output_socket.poll(timeout=VLLM_RPC_TIMEOUT) == 0:
+            logger.debug("Waiting for output from MQLLMEngine.")
+
+            # If errored, alert all running requests.
+            if self.errored:
+                logger.error("Engine is errored.")
+                return
+
+        message: Frame = await self.output_socket.recv(copy=False)
+        request_outputs: Tuple[str, np.ndarray,
+                               int] = pickle.loads(message.buffer)
+
+        is_error = isinstance(request_outputs, (BaseException, RPCError))
+        if is_error:
+            if isinstance(request_outputs, RPCError):
+                rpc_error: RPCError = request_outputs
+                request_id = rpc_error.request_id
+                exception = rpc_error.exception
+                is_engine_errored = rpc_error.is_engine_errored
+            else:
+                # MPLLMEngine should always return an RPCError to
+                # the output_socket when an issue arises.
+                # If we are here, we are in a bad state and
+                # should shut down the server.
+                error: BaseException = request_outputs
+                logger.error(
+                    "Received Exception %s rather than RPCError from "
+                    "MPLLMEngine. This should never happen.", error)
+                request_id = None
+                exception = error
+                is_engine_errored = True
+
+            # Set to error state only on engine critical error
+            # (and record only the first one)
+            if is_engine_errored and not self._errored_with:
+                self._errored_with = exception
+                # If engine is errored, no matter the type of exception
+                # it will no longer be able to receive new requests,
+                # therefore we have to inform that the current
+                # processed requests failed as well. Send back a dead
+                # engine error give this feedback and also give a
+                # 'hint' to the server to shutdown next.
+                exception = self.dead_error
+
+            if request_id is not None:
+                self.output_queue.put_nowait((request_id, exception))
+        else:
+            # Put each output into the appropriate steam.
+            request_id, request_output, output_tokens = request_outputs
+            self.output_queue.put_nowait(
+                (request_id, request_output, output_tokens))
+
+    async def setup(self):
+        """Setup the client before it starts sending server requests."""
+
+        # Start output_loop
+        self.output_loop = asyncio.create_task(self.run_output_handler_loop())
+
+        with self.get_data_socket() as socket:
+            # Wait until server is ready.
+            response = await self._wait_for_server_rpc(socket)
+
+            self.tracing_flag = response.tracing_enabled
+
+            # Start health_loop.
+            self.health_loop = asyncio.create_task(
+                self.run_heartbeat_loop(timeout=VLLM_RPC_TIMEOUT))
+
+    def close(self):
+        """Destroy the ZeroMQ Context."""
+        # Close all sockets and terminate the context.
+        self.context.destroy(linger=0)
+
+        # Cancel background tasks.
+        if self.health_loop is not None:
+            self.health_loop.cancel()
+        if self.output_loop is not None:
+            self.output_loop.cancel()
+
+    def _set_errored(self, e: BaseException):
+        logger.exception(repr(e))
+        if self._errored_with is None:
+            self._errored_with = e
+
+    @staticmethod
+    async def _send_get_data_rpc_request(request: RPCStartupRequest,
+                                         expected_type: Any,
+                                         error_message: str,
+                                         socket: Socket) -> Any:
+        """Send an RPC request that is expecting data back."""
+
+        # Ping RPCServer with a request.
+        await socket.send_multipart((pickle.dumps(request), ), copy=False)
+
+        # Make sure the server responds in time.
+        if await socket.poll(timeout=VLLM_RPC_TIMEOUT) == 0:
+            raise TimeoutError("RPCServer didn't reply within "
+                               f"{VLLM_RPC_TIMEOUT} ms")
+
+        # Await the data from the Server.
+        frame = await socket.recv(copy=False)
+        data = pickle.loads(frame.buffer)
+
+        if isinstance(data, BaseException):
+            raise data
+        elif not isinstance(data, expected_type):
+            raise ValueError(error_message)
+
+        return data
+
+    @staticmethod
+    async def _send_one_way_rpc_request(request: RPC_REQUEST_T,
+                                        socket: Socket):
+        """Send one-way RPC request to trigger an action."""
+
+        if socket.closed:
+            raise MQClientClosedError()
+
+        await socket.send_multipart((pickle.dumps(request), ))
+
+    async def _await_ack(self, error_message: str, socket: Socket):
+        """Await acknowledgement that a request succeeded."""
+
+        if socket.closed:
+            raise MQClientClosedError()
+
+        if await socket.poll(timeout=VLLM_RPC_TIMEOUT) == 0:
+            raise TimeoutError("MQLLMEngine didn't reply within "
+                               f"{VLLM_RPC_TIMEOUT}ms")
+
+        await self._check_success(error_message, socket)
+
+    @staticmethod
+    async def _check_success(error_message: str, socket: Socket):
+        """Confirm that socket has a VLLM_RPC_SUCCESS_STR message"""
+
+        if socket.closed:
+            raise MQClientClosedError()
+
+        frame = await socket.recv(copy=False)
+        response = pickle.loads(frame.buffer)
+
+        # Raise error if unsuccessful
+        if isinstance(response, BaseException):
+            raise response
+        elif (not isinstance(response, str)
+              or response != VLLM_RPC_SUCCESS_STR):
+            raise ValueError(error_message)
+
+    async def check_health(self):
+        """
+        The check health loop probes the health status of the
+        Engine's health every N seconds and sets _errored_with
+        if the engine is unhealthy.
+        """
+        if self._errored_with is not None:
+            raise self._errored_with
+
+    @property
+    def is_running(self) -> bool:
+        return not self.errored
+
+    @property
+    def is_stopped(self) -> bool:
+        return self.errored
+
+    @property
+    def errored(self) -> bool:
+        return self._errored_with is not None
+
+    @property
+    def dead_error(self) -> BaseException:
+        return ENGINE_DEAD_ERROR(self._errored_with)
+
+    async def _wait_for_server_rpc(self, socket: Socket) -> RPCStartupResponse:
+        """Wait for the RPCServer to start up."""
+
+        return await self._send_get_data_rpc_request(
+            request=RPCStartupRequest.IS_SERVER_READY,
+            expected_type=RPCStartupResponse,
+            error_message="Unable to start RPC Server",
+            socket=socket)
+
+    async def process_chunk(
+        self,
+        request_id: str,
+        voice_type: str,
+        code: List[int],
+        finished: bool = False,
+    ):
+        """Send an RPCGenerateRequest to the RPCServer and stream responses."""
+
+        # If already dead, error out.
+        if self._errored_with is not None:
+            raise ENGINE_DEAD_ERROR(self._errored_with)
+
+        request_bytes = pickle.dumps((request_id, voice_type, code, finished))
+        await self.input_socket.send(request_bytes, copy=False)
+
+    async def get_chunk(self) -> Tuple[str, Union[np.ndarray, BaseException]]:
+        """Get the next chunk of audio from the engine."""
+        return await self.output_queue.get()
+
+
+class suppress_output_queue_exception(contextlib.AbstractContextManager):
+    """Context manager to suppress specified exceptions
+
+    After the exception is suppressed, execution proceeds with the next
+    statement following the with statement.
+
+         with suppress(FileNotFoundError):
+             os.remove(somefile)
+         # Execution still resumes here if the file was already removed
+    """
+
+    def __init__(self):
+        self._exceptions = (Exception, )
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exctype, excinst, exctb):
+        # Unlike isinstance and issubclass, CPython exception handling
+        # currently only looks at the concrete type hierarchy (ignoring
+        # the instance and subclass checking hooks). While Guido considers
+        # that a bug rather than a feature, it's a fairly hard one to fix
+        # due to various internal implementation details. suppress provides
+        # the simpler issubclass based semantics, rather than trying to
+        # exactly reproduce the limitations of the CPython interpreter.
+        #
+        # See http://bugs.python.org/issue12029 for more details
+        if exctype is not None:
+            logger.exception("Exception in output queue: %s, %r, %r", exctype,
+                             excinst, exctb)
+        return exctype is not None and issubclass(exctype, self._exceptions)
+
+
+class OmniLLMEngine:
+
+    def __init__(
+        self,
+        thinker_engine_args: AsyncEngineArgs,
+        talker_engine_args: Union[Mapping[str, AsyncEngineArgs],
+                                  AsyncEngineArgs] = None,
+        code2wav_model_path: Optional[str] = None,
+        code2wav_data_parallelism: int = 1,
+        code2wav_enable_torch_compile: bool = False,
+        code2wav_enable_torch_compile_first_chunk: bool = False,
+        code2wav_odeint_method: str = "rk4",
+        code2wav_odeint_method_relaxed: bool = False,
+        code2wav_batched_chunk: int = None,
+        code2wav_frequency: str = '50hz',
+        thinker_visible_devices: Optional[List[int]] = None,
+        talker_visible_devices: Optional[List[int]] = None,
+        code2wav_visible_devices: Optional[List[int]] = None,
+        code2wav_dynamic_batch: Optional[bool] = False,
+    ):
+        self.thinker_engine_args = thinker_engine_args
+        if talker_engine_args is None:
+            talker_engine_args = {}
+        if not isinstance(talker_engine_args, dict):
+            talker_engine_args = {
+                'default': talker_engine_args,
+            }
+        self.talker_engine_args = talker_engine_args
+        self.code2wav_model_path = code2wav_model_path
+        self.code2wav_enable_torch_compile = code2wav_enable_torch_compile
+        self.code2wav_enable_torch_compile_first_chunk = code2wav_enable_torch_compile_first_chunk
+        self.code2wav_data_parallelism = code2wav_data_parallelism
+        self.code2wav_odeint_method = code2wav_odeint_method
+        self.code2wav_odeint_method_relaxed = code2wav_odeint_method_relaxed
+        if code2wav_batched_chunk is None:
+            if code2wav_frequency == "50hz":
+                code2wav_batched_chunk = 2
+            else:
+                code2wav_batched_chunk = 1
+        self.code2wav_batched_chunk = code2wav_batched_chunk
+        self.code2wav_frequency = code2wav_frequency
+
+        self.thinker_visible_devices = thinker_visible_devices
+        self.talker_visible_devices = talker_visible_devices
+        self.code2wav_visible_devices = code2wav_visible_devices
+
+        if (self.thinker_visible_devices
+                and not isinstance(self.thinker_visible_devices, list)):
+            self.thinker_visible_devices = [self.thinker_visible_devices]
+        if (self.talker_visible_devices
+                and not isinstance(self.talker_visible_devices, list)):
+            self.talker_visible_devices = [self.talker_visible_devices]
+        if (self.code2wav_visible_devices
+                and not isinstance(self.code2wav_visible_devices, list)):
+            self.code2wav_visible_devices = [self.code2wav_visible_devices]
+
+        # Enable hidden state caching for the thinker engine.
+        self.thinker_engine_args.enable_hidden_state_caching = True
+
+        if not code2wav_model_path:
+            self.code2wav_data_parallelism = 0
+
+        # Start RPCServer in separate process (holds the LLMEngine).
+        # the current process might have CUDA context,
+        # so we need to spawn a new process
+        self.context = multiprocessing.get_context("spawn")
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+
+        self._async_loop_thread = Thread(target=self._start_async_loop,
+                                         daemon=True)
+        self._async_loop_thread.start()
+
+        # thinker: async engine
+        self.thinker_engine = self._start_thinker_engine(
+            thinker_engine_args, self.thinker_visible_devices)
+        self.device = self.thinker_engine.engine.device_config.device
+
+        # thinker state
+        # request_id -> prompt_embeds
+        self.thinker_prompt_embeds: Dict[str, torch.Tensor] = dict()
+        # request_id -> listener thread
+        self.thinker_listener: Dict[str, Thread] = dict()
+        # talker type -> (request_id, voice_type, thinker request_output)
+        self.thinker_outputs: Dict[
+            str,
+            queue.Queue[Tuple[str, str, RequestOutput]],
+        ] = collections.defaultdict(queue.Queue)
+        self.thinker_finished: Set[str] = set()
+
+        # thinker model config
+        self.thinker_config = get_config(
+            thinker_engine_args.model,
+            trust_remote_code=thinker_engine_args.trust_remote_code)
+        self.thinker_generation_config = try_get_generation_config(
+            thinker_engine_args.model,
+            trust_remote_code=thinker_engine_args.trust_remote_code,
+        )
+
+        # thinker tokenizer
+        self.thinker_tokenizer = get_tokenizer(
+            thinker_engine_args.tokenizer,
+            tokenizer_mode=thinker_engine_args.tokenizer_mode,
+            trust_remote_code=thinker_engine_args.trust_remote_code,
+            revision=thinker_engine_args.revision,
+            download_dir=thinker_engine_args.download_dir,
+        )
+
+        # talker: async mp engine(s)
+        self._talker_pids = []
+        self._talker_processes = []
+        self._talker_engine_clients: Dict[str, MQLLMEngineClient] = {}
+        self._talker_engine_threads: Dict[str, Thread] = {}
+        for i, (talker_type,
+                engine_args) in enumerate(talker_engine_args.items()):
+            # use thinker as talkers tokenizer
+            if thinker_engine_args.tokenizer:
+                engine_args.tokenizer = thinker_engine_args.tokenizer
+            else:
+                engine_args.tokenizer = thinker_engine_args.model
+            if thinker_engine_args.processor:
+                engine_args.processor = thinker_engine_args.processor
+            else:
+                engine_args.processor = thinker_engine_args.model
+            if not engine_args.hf_overrides:
+                engine_args.hf_overrides = {}
+
+            if hasattr(self.thinker_config, 'audio_config'):
+                engine_args.hf_overrides[
+                    'audio_config'] = self.thinker_config.audio_config
+            if hasattr(self.thinker_config, 'vision_config'):
+                engine_args.hf_overrides[
+                    'vision_config'] = self.thinker_config.vision_config
+
+            # Adapt the qwen2_5_omni_model
+            if 'Qwen2_5OmniModel' in self.thinker_config.architectures:
+                engine_args.hf_overrides['architectures'] = [
+                    'Qwen2_5OmniTalkerModel'
+                ]
+
+            if self.talker_visible_devices:
+                visible_devices = [self.talker_visible_devices[i]]
+            else:
+                visible_devices = None
+
+            (
+                pid,
+                process,
+                engine_client,
+                thread,
+            ) = self._start_talker_engine(talker_type, engine_args,
+                                          visible_devices)
+            self._talker_pids.append(pid)
+            self._talker_processes.append(process)
+            self._talker_engine_clients[talker_type] = engine_client
+            self._talker_engine_threads[talker_type] = thread
+
+        if talker_engine_args:
+            # talker model config
+            default_talker_args = next(iter(talker_engine_args.values()))
+            self.talker_config = get_config(
+                default_talker_args.model,
+                trust_remote_code=default_talker_args.trust_remote_code)
+            self.talker_generation_config = try_get_generation_config(
+                default_talker_args.model,
+                trust_remote_code=default_talker_args.trust_remote_code,
+            )
+            # init embeddings for special tokens
+            self._init_special_tokens_embeddings(thinker_engine_args,
+                                                 default_talker_args)
+
+        # talker request state
+        self.talker_requests: Dict[str, Tuple[PromptType,
+                                              SamplingParams]] = dict()
+        self.talker_listener: Dict[str, Thread] = dict()
+        self.talker_finished: Set[str] = set()
+        self.talker_inputs: Dict[
+            str,
+            queue.Queue[Optional[Tuple[torch.Tensor, bool]]],
+        ] = dict()
+
+        # code2wav: async mp engine(s)
+        self._code2wav_pids = []
+        self._code2wav_processes = []
+        self._code2wav_engine_clients: List[_MQCode2WavEngineClient] = []
+        for i in range(self.code2wav_data_parallelism):
+            assert code2wav_model_path, "code2wav_model_path is required"
+
+            (
+                pid,
+                process,
+                engine_client,
+            ) = self._start_code2wav_engine(
+                get_open_zmq_ipc_path(),
+                code2wav_model_path,
+                code2wav_enable_torch_compile,
+                code2wav_enable_torch_compile_first_chunk,
+                code2wav_odeint_method,
+                code2wav_odeint_method_relaxed,
+                code2wav_batched_chunk,
+                code2wav_frequency,
+                visible_devices=([
+                    self.code2wav_visible_devices[i % len(
+                        self.code2wav_visible_devices)]
+                ] if self.code2wav_visible_devices else None),
+                code2wav_dynamic_batch=code2wav_dynamic_batch,
+            )
+            self._code2wav_pids.append(pid)
+            self._code2wav_processes.append(process)
+            self._code2wav_engine_clients.append(engine_client)
+
+        # code2wav voice types
+        if self.code2wav_model_path:
+            self.code2wav_voice_types = self._load_code2wav_voice_types_legacy(
+            )
+            if not self.code2wav_voice_types:
+                self.code2wav_voice_types = self._load_code2wav_voice_types()
+        else:
+            self.code2wav_voice_types = []
+        # for prefix-caching
+        if self.code2wav_voice_types:
+            self.code2wav_voice_types.append('prefix_caching')
+        logger.info("Code2Wav voice types: %s", self.code2wav_voice_types)
+
+        # code2wav parameters
+        self.code2wav_bs_mel = 24 if code2wav_frequency == "50hz" else 32
+        self.code2wav_future_cache_size = self.code2wav_bs_mel * 1
+        self.code2wav_chunk_size = self.code2wav_bs_mel * self.code2wav_batched_chunk
+
+        # code2wav result listener
+        self._code2wav_listener_thread = []
+        for i in range(self.code2wav_data_parallelism):
+            self._code2wav_listener_thread.append(
+                Thread(target=self._listen_code2wav, args=(i, ), daemon=True))
+            self._code2wav_listener_thread[i].start()
+
+        # request id -> [union(request_output, (waveform, finished))]
+        self.output_queue: Dict[str, queue.Queue[Union[RequestOutput, Tuple[
+            np.ndarray, int]]]] = collections.defaultdict(queue.Queue)
+
+    def _load_code2wav_voice_types_legacy(self):
+        return [
+            _MQOmniCode2WavEngine.parse_key(os.path.basename(f), 'spk_emb.npy')
+            for f in sorted(
+                glob.glob(
+                    os.path.join(self.code2wav_model_path, 'inputs',
+                                 '*spk_emb.npy')) +
+                glob.glob(
+                    os.path.join(self.code2wav_model_path, 'inputs_sft4spks',
+                                 '*spk_emb.npy')))
+        ]
+
+    def _load_code2wav_voice_types(self):
+        voice_type_mapping = {
+            'Ethan': 'm02',
+            'Chelsie': 'f030',
+        }
+        code2wav_voice_types = []
+
+        if not os.path.exists(
+                os.path.join(self.code2wav_model_path, 'spk_dict.pt')):
+            return code2wav_voice_types
+
+        for key, value in torch.load(
+                os.path.join(self.code2wav_model_path, 'spk_dict.pt')).items():
+            code2wav_voice_types.append(voice_type_mapping.get(key, key))
+        return code2wav_voice_types
+
+    def _start_async_loop(self):
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def _start_thinker_engine(
+        self,
+        engine_args: AsyncEngineArgs,
+        visible_devices: Optional[List[int]] = None,
+    ) -> AsyncLLMEngine:
+        if visible_devices:
+            device_ctx = envvars(
+                'CUDA_VISIBLE_DEVICES',
+                ','.join(str(device) for device in visible_devices))
+        else:
+            device_ctx = contextlib.nullcontext()
+        with device_ctx:
+            return AsyncLLMEngine.from_engine_args(
+                engine_args,
+                start_engine_loop=True,
+            )
+
+    def _start_talker_engine(
+        self,
+        talker_type: str,
+        engine_args: AsyncEngineArgs,
+        visible_devices: Optional[List[int]] = None,
+    ) -> Tuple[int, multiprocessing.Process, MQLLMEngineClient, Thread]:
+        ipc_path = get_open_zmq_ipc_path()
+        logger.info(
+            "Multiprocessing frontend to use %s for IPC Path for model %s.",
+            ipc_path, engine_args.model)
+
+        # The Process can raise an exception during startup, which may
+        # not actually result in an exitcode being reported. As a result
+        # we use a shared variable to communicate the information.
+        engine_alive = multiprocessing.Value('b', True, lock=False)
+        if visible_devices:
+            device_ctx = envvars(
+                'CUDA_VISIBLE_DEVICES',
+                ','.join(str(device) for device in visible_devices))
+        else:
+            device_ctx = contextlib.nullcontext()
+        with device_ctx:
+            usage_context = UsageContext.API_SERVER
+            vllm_config = engine_args.create_engine_config(
+                usage_context=usage_context)
+            engine_process = self.context.Process(
+                target=run_mp_engine,
+                args=(vllm_config, usage_context, ipc_path,
+                      engine_args.disable_log_stats,
+                      engine_args.disable_log_requests, engine_alive))
+            engine_process.start()
+        engine_pid = engine_process.pid
+        assert engine_pid is not None, "Engine process failed to start."
+        logger.info("Started engine process with PID %d", engine_pid)
+
+        # Build RPCClient, which conforms to EngineClient Protocol.
+        engine_config = engine_args.create_engine_config()
+        mq_engine_client: MQLLMEngineClient = MQLLMEngineClient(
+            ipc_path, engine_config, engine_pid)
+
+        while True:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    mq_engine_client.setup(),
+                    self._loop,
+                ).result()
+                break
+            except TimeoutError:
+                if (not engine_process.is_alive() or not engine_alive.value):
+                    raise RuntimeError(
+                        "Engine process failed to start. See stack "
+                        "trace for the root cause.") from None
+
+        logger.info("Engine process with PID %d has started", engine_pid)
+
+        thread = Thread(
+            target=self._thinker_to_talker_loop,
+            args=(self.thinker_outputs[talker_type], mq_engine_client),
+            daemon=True,
+        )
+        thread.start()
+        return engine_pid, engine_process, mq_engine_client, thread
+
+    def _start_code2wav_engine(
+        self,
+        ipc_path: str,
+        model_path: str,
+        enable_torch_compile: bool,
+        enable_torch_compile_first_chunk: bool,
+        odeint_method: str = "euler",
+        odeint_method_relaxed: bool = False,
+        batched_chunk: int = 2,
+        frequency: str = "50hz",
+        device: Union[int, str] = 'cuda',
+        visible_devices: Optional[List[int]] = None,
+        code2wav_dynamic_batch: Optional[bool] = False,
+    ) -> Tuple[int, multiprocessing.Process, _MQCode2WavEngineClient]:
+        logger.info(
+            "Multiprocessing frontend to use %s for IPC Path for model %s.",
+            ipc_path, model_path)
+
+        # The Process can raise an exception during startup, which may
+        # not actually result in an exitcode being reported. As a result
+        # we use a shared variable to communicate the information.
+        engine_alive = multiprocessing.Value('b', True, lock=False)
+        if visible_devices:
+            device_ctx = envvars(
+                'CUDA_VISIBLE_DEVICES',
+                ','.join(str(device) for device in visible_devices))
+        else:
+            device_ctx = contextlib.nullcontext()
+        with device_ctx:
+            engine_process = self.context.Process(
+                target=_MQOmniCode2WavEngine.run_code2wav_engine,
+                args=(ipc_path, model_path, enable_torch_compile,
+                      enable_torch_compile_first_chunk, odeint_method,
+                      odeint_method_relaxed, batched_chunk, frequency,
+                      engine_alive, device, code2wav_dynamic_batch))
+            engine_process.start()
+        engine_pid = engine_process.pid
+        assert engine_pid is not None, "Engine process failed to start."
+        logger.info("Started engine process with PID %d", engine_pid)
+
+        mq_engine_client: _MQCode2WavEngineClient = _MQCode2WavEngineClient(
+            ipc_path, engine_pid)
+
+        while True:
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    mq_engine_client.setup(),
+                    self._loop,
+                ).result()
+                break
+            except TimeoutError:
+                if (not engine_process.is_alive() or not engine_alive.value):
+                    raise RuntimeError(
+                        "Engine process failed to start. See stack "
+                        "trace for the root cause.") from None
+
+        logger.info("Engine process with PID %d has started", engine_pid)
+        return engine_pid, engine_process, mq_engine_client
+
+    def _shutdown_mp_engine(
+        self,
+        engine_pid: int,
+        engine_process: multiprocessing.Process,
+        mq_engine_client: MQLLMEngineClient,
+    ):
+        engine_process.terminate()
+        mq_engine_client.close()
+        engine_process.join(5)
+        if engine_process.is_alive():
+            logger.warning("Engine process did not terminate in time.")
+            engine_process.kill()
+        logger.info("Engine process with PID %d has stopped", engine_pid)
+
+    def __del__(self):
+        self.shutdown()
+
+    def shutdown(self):
+        self._closed = True
+        # shutdown thinker engine
+        self.thinker_engine.shutdown_background_loop()
+        # shutdown talker engines
+        for pid, process, engine_client in zip(
+                self._talker_pids,
+                self._talker_processes,
+                self._talker_engine_clients.values(),
+        ):
+            self._shutdown_mp_engine(pid, process, engine_client)
+        # shutdown code2wav engines
+        for pid, process, engine_client in zip(
+                self._code2wav_pids,
+                self._code2wav_processes,
+                self._code2wav_engine_clients,
+        ):
+            self._shutdown_mp_engine(pid, process, engine_client)
+
+    def _load_model_embedding(
+            self,
+            engine_args: EngineArgs,
+            kind: str,  # thinker or talker
+    ) -> torch.nn.Embedding:
+        model_loader = get_model_loader(
+            LoadConfig(
+                load_format=engine_args.load_format,
+                download_dir=engine_args.download_dir,
+                model_loader_extra_config=engine_args.
+                model_loader_extra_config,
+                ignore_patterns=engine_args.ignore_patterns,
+            ))
+        for key, value in model_loader._get_all_weights(
+                ModelConfig(
+                    model=engine_args.model,
+                    task=engine_args.task,
+                    tokenizer=engine_args.tokenizer,
+                    tokenizer_mode=engine_args.tokenizer_mode,
+                    processor=engine_args.processor,
+                    trust_remote_code=engine_args.trust_remote_code,
+                    dtype=engine_args.dtype,
+                    seed=engine_args.seed,
+                ),
+                model=None,
+        ):
+            if key in [
+                    "model.embed_tokens.weight",
+                    *(["thinker.model.embed_tokens.weight"]
+                      if kind == 'thinker' else []),
+                    *(["talker.model.embed_tokens.weight"]
+                      if kind == 'talker' else []),
+            ]:
+                return torch.nn.Embedding.from_pretrained(value).to(
+                    self.device)
+        raise ValueError(
+            "Embedding weight 'model.embed.weight' not found in model weights."
+        )
+
+    def _init_special_tokens_embeddings(
+        self,
+        thinker_engine_args: AsyncEngineArgs,
+        talker_engine_args: AsyncEngineArgs,
+    ):
+        # thinker and talker embeddings
+        self.thinker_embedding = self._load_model_embedding(
+            thinker_engine_args, 'thinker')
+        self.talker_embedding = self._load_model_embedding(
+            talker_engine_args, 'talker')
+
+        # embed_text_bos_token
+        self.tts_text_spk_token_ids = {
+            # M02：我是个会说标准普通话、带部分北方口音的男声
+            'm02': 151870,
+            'Ethan': 151870,
+
+            # F030：我是你的二次元虚拟女友
+            'f030': 151872,
+            'Chelsie': 151872,
+        }
+        self.default_tts_text_spk_type = list(
+            self.tts_text_spk_token_ids.keys())[0]
+        self.tts_text_spk_token_ids['prefix_caching'] = 151870
+
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, 'talker_config'):
+            talker_hf_config = talker_hf_config.talker_config
+
+        self.embed_text_bos_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_start_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+        self.embed_text_spk_tokens = {
+            key:
+            self.thinker_embedding(
+                torch.tensor(
+                    [value],
+                    dtype=torch.long,
+                    device=self.device,
+                ))
+            for key, value in self.tts_text_spk_token_ids.items()
+        }
+        self.embed_text_eos_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_end_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+        self.embed_text_pad_token = self.thinker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_text_pad_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+        self.embed_codec_bos_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_start_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+        self.embed_codec_eos_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_end_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+        self.embed_codec_pad_token = self.talker_embedding(
+            torch.tensor(
+                [talker_hf_config.tts_codec_pad_token_id],
+                dtype=torch.long,
+                device=self.device,
+            ))
+
+    def _get_embed_text_spk_token(self, voice_type: str):
+        if voice_type not in self.embed_text_spk_tokens:
+            return self.embed_text_bos_token
+        return self.embed_text_spk_tokens[voice_type]
+
+    def _get_text_spk_token_id(self, voice_type: str):
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, 'talker_config'):
+            talker_hf_config = talker_hf_config.talker_config
+
+        if voice_type not in self.tts_text_spk_token_ids:
+            return talker_hf_config.tts_text_start_token_id
+        return self.tts_text_spk_token_ids[voice_type]
+
+    def _listen_thinker(
+        self,
+        request_id: str,
+        voice_type: str,
+        generator: AsyncGenerator[RequestOutput, None],
+        thinker_outputs: queue.Queue[Tuple[str, str, RequestOutput]],
+    ):
+        include_voice = not self._ignore_voice(voice_type)
+
+        def _listen():
+            last_output = None
+            for output in SynchronizedGenerator(generator, self._loop):
+                if include_voice and self.talker_engine_args:
+                    if output.finished:
+                        thinker_output = copy.deepcopy(output)
+                        if len(output.outputs[0].token_ids) > 1:
+                            thinker_output.finished = False
+                    else:
+                        thinker_output = output
+                    thinker_outputs.put(
+                        (request_id, voice_type, thinker_output))
+                last_output = output
+                with suppress_output_queue_exception():
+                    self.output_queue[request_id].put(output)
+            if not include_voice or not self.talker_engine_args:
+                with suppress_output_queue_exception():
+                    self.output_queue[request_id].put(None)
+                    self.output_queue.pop(request_id)
+            logger.info(
+                "Thinker request %s finished, reason: (%r, %r), outputs: %r, output tokens: %r",
+                request_id, last_output.outputs[0].finish_reason,
+                last_output.outputs[0].stop_reason,
+                last_output.outputs[0].text, last_output.outputs[0].token_ids)
+
+            if include_voice and self.talker_engine_args and len(
+                    last_output.outputs[0].token_ids) > 1:
+                # add two special tokens for talker model.
+                special_token_embeds = [
+                    self.embed_text_eos_token,
+                    self.embed_text_pad_token,
+                ]
+                for i, token_embed in enumerate(special_token_embeds):
+                    thinker_outputs.put(
+                        (request_id, voice_type,
+                         RequestOutput(
+                             request_id=request_id,
+                             prompt=last_output.prompt,
+                             prompt_token_ids=last_output.prompt_token_ids,
+                             prompt_logprobs=last_output.prompt_logprobs,
+                             outputs=[
+                                 CompletionOutput(
+                                     index=0,
+                                     text='',
+                                     token_ids=[],
+                                     cumulative_logprob=None,
+                                     logprobs=None,
+                                     prompt_embeds=token_embed,
+                                 )
+                             ],
+                             finished=i == len(special_token_embeds) - 1,
+                         )))
+
+            with contextlib.suppress(Exception):
+                del self.thinker_listener[request_id]
+
+        self.thinker_listener[request_id] = Thread(target=_listen, daemon=True)
+        self.thinker_listener[request_id].start()
+
+    def _listen_talker(
+        self,
+        talker_client: MQLLMEngineClient,
+        request_id: str,
+        voice_type: str,
+        generator: AsyncGenerator[RequestOutput, None],
+        output_queue: queue.Queue[Union[RequestOutput, np.ndarray]],
+        talker_input_queue: queue.Queue[Optional[Tuple[torch.Tensor, bool]]],
+    ):
+        include_code2wav = not self._ignore_code2wav(voice_type)
+
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, 'talker_config'):
+            talker_hf_config = talker_hf_config.talker_config
+
+        def _listen():
+            last_output, finished = None, False
+            for output in SynchronizedGenerator(generator, self._loop):
+                if not self._code2wav_engine_clients or not include_code2wav:
+                    output_queue.put(output)
+                elif last_output is None:
+                    if output.finished:
+                        self._talker_to_code2wav(output.request_id, voice_type,
+                                                 [], True)
+                else:
+                    last_code = list(last_output.outputs[0].token_ids)
+                    if output.finished:
+                        curr_code = list(output.outputs[0].token_ids)
+                        if curr_code[-1] in [
+                                talker_hf_config.tts_codec_end_token_id,
+                                talker_hf_config.tts_codec_start_token_id
+                        ]:
+                            self._talker_to_code2wav(output.request_id,
+                                                     voice_type, last_code,
+                                                     False)
+                            self._talker_to_code2wav(output.request_id,
+                                                     voice_type,
+                                                     curr_code[:-1], True)
+                        else:
+                            self._talker_to_code2wav(output.request_id,
+                                                     voice_type, last_code,
+                                                     False)
+                            self._talker_to_code2wav(output.request_id,
+                                                     voice_type, curr_code,
+                                                     True)
+                    else:
+                        self._talker_to_code2wav(output.request_id, voice_type,
+                                                 last_code, False)
+                last_output = output
+
+                if not finished and not output.finished:
+                    prompt_embeds, finished = talker_input_queue.get()
+                    if prompt_embeds is not None:
+                        asyncio.run_coroutine_threadsafe(
+                            talker_client.resume_request(
+                                request_id, prompt_embeds, finished),
+                            self._loop,
+                        ).result()
+
+            if not self._code2wav_engine_clients or not include_code2wav:
+                output_queue.put(None)
+
+            logger.info(
+                "Talker request %s finished, reason: (%r, %r), output tokens: %r",
+                request_id, last_output.outputs[0].finish_reason,
+                last_output.outputs[0].stop_reason,
+                last_output.outputs[0].token_ids)
+
+            with contextlib.suppress(Exception):
+                del self.talker_listener[request_id]
+                del self.talker_inputs[request_id]
+
+        self.talker_listener[request_id] = Thread(target=_listen, daemon=True)
+        self.talker_listener[request_id].start()
+
+    def _listen_code2wav(self, code2wav_engine_client_id):
+        while True:
+            try:
+                request_id, audio, output_tokens = asyncio.run_coroutine_threadsafe(
+                    self._code2wav_engine_clients[code2wav_engine_client_id].
+                    get_chunk(),
+                    self._loop,
+                ).result()
+                if audio is None:
+                    logger.info("Code2Wav request %s finished", request_id)
+                    with suppress_output_queue_exception():
+                        self.output_queue[request_id].put(None)
+                        self.output_queue.pop(request_id)
+                else:
+                    with suppress_output_queue_exception():
+                        self.output_queue[request_id].put(
+                            (audio, output_tokens))
+            except:
+                logger.exception("Error in code2wav listener")
+
+    def _thinker_to_talker_loop(
+        self,
+        thinker_outputs: queue.Queue[Tuple[str, str, RequestOutput]],
+        talker_client: MQLLMEngineClient,
+    ):
+        while True:
+            try:
+                request_id, voice_type, output = thinker_outputs.get()
+                self._thinker_to_talker(request_id, voice_type, output,
+                                        talker_client)
+            except:
+                logger.exception("Error in thinker to talker loop")
+
+    def _thinker_to_talker(
+        self,
+        request_id: str,
+        voice_type: str,
+        output: RequestOutput,
+        talker_client: MQLLMEngineClient,
+    ):
+        # structure of prompt tokens, embeddings and thinker_reply_part:
+        #
+        #   tokens: [input_tokens] + [codec_pad_token] + [codec_bos_token]
+        #   embeddings: [input_embeds] + [text_bos_token] + [thinker_reply_part[0]]
+        #   thinker_reply_part: [thinker_reply_part[1:]] + [text_eos_token] + [text_pad_token]
+
+        if output == None:
+            asyncio.run_coroutine_threadsafe(
+                talker_client.abort(request_id),
+                self._loop,
+            ).result()
+            with suppress_output_queue_exception():
+                self.output_queue[request_id].put(None)
+                self.output_queue.pop(request_id)
+            return
+
+        if len(output.outputs[0].token_ids) == 1 and output.finished:
+            # don't involve talker model.
+            with suppress_output_queue_exception():
+                self.output_queue[request_id].put(None)
+                self.output_queue.pop(request_id)
+            return
+
+        output_prompt_embeds = output.outputs[0].prompt_embeds.to(self.device)
+
+        if len(output.outputs[0].token_ids) == 1:
+            self.thinker_prompt_embeds[
+                output.request_id] = output_prompt_embeds
+            return
+
+        talker_hf_config = self.talker_config
+        if hasattr(talker_hf_config, 'talker_config'):
+            talker_hf_config = talker_hf_config.talker_config
+
+        if len(output.outputs[0].token_ids) == 2:
+            # issue request
+            prompt_embeds = torch.cat([
+                self.thinker_prompt_embeds.pop(output.request_id),
+                self._get_embed_text_spk_token(voice_type) +
+                self.embed_codec_pad_token,
+                output_prompt_embeds + self.embed_codec_bos_token,
+            ],
+                                      dim=0)
+            prompt, sampling_params = self.talker_requests.pop(request_id)
+            if isinstance(prompt, str):
+                prompt_token_ids = self.thinker_tokenizer.encode(prompt)
+            else:
+                if 'prompt_token_ids' in prompt:
+                    prompt_token_ids = prompt['prompt_token_ids']
+                else:
+                    prompt_token_ids = self.thinker_tokenizer.encode(
+                        prompt['prompt'])
+            prompt_token_ids += [
+                # input_text_ids:
+                # the first token should be: self._get_text_spk_token_id(voice_type),
+                # but it will be ignored in the detokenize-tokenize round
+                # during preprocessing, so we use tts_codec_pad_token_id instead.
+                # self._get_text_spk_token_id(voice_type),
+                talker_hf_config.tts_codec_pad_token_id,
+                output.outputs[0].token_ids[0],
+
+                # input_ids (will be replaced in model_runner):
+                # talker_hf_config.tts_codec_pad_token_id,
+                # talker_hf_config.tts_codec_start_token_id,
+            ]
+            generator = talker_client.generate(
+                request_id=output.request_id,
+                prompt=TokensPrompt(
+                    prompt_token_ids=prompt_token_ids,
+                    prompt_embeds=prompt_embeds,
+                    multi_modal_data=prompt.get('multi_modal_data', None),
+                    mm_processor_kwargs=prompt.get('mm_processor_kwargs',
+                                                   None),
+                ),
+                sampling_params=sampling_params,
+                resumable=not bool(output.finished),
+            )
+            self.talker_inputs[output.request_id] = queue.Queue()
+            self._listen_talker(
+                talker_client,
+                output.request_id,
+                voice_type,
+                generator,
+                self.output_queue[output.request_id],
+                self.talker_inputs[output.request_id],
+            )
+        elif output.request_id in self.talker_inputs:
+            self.talker_inputs[output.request_id].put(
+                (output_prompt_embeds, output.finished))
+        else:
+            logger.warning("Warning: talker has been over for request_id: %s",
+                           request_id)
+
+    def _talker_to_code2wav(
+        self,
+        request_id: str,
+        voice_type: str,
+        code: List[int],
+        finished: bool,
+    ):
+        if finished:
+            logger.info("Talker request %s finished with %d tokens",
+                        request_id, len(code))
+        chunk_code_length = len(code) * (2 if self.code2wav_frequency == "50hz"
+                                         else
+                                         4) - self.code2wav_future_cache_size
+        if (chunk_code_length > 0 and
+                chunk_code_length % self.code2wav_chunk_size == 0) or finished:
+
+            code2wav_engine_id = 0
+            if self.code2wav_data_parallelism > 0:
+                request_hash = hash(request_id) if len(
+                    request_id) > 1 else ord(request_id)
+                code2wav_engine_id = request_hash % self.code2wav_data_parallelism
+            asyncio.run_coroutine_threadsafe(
+                self._code2wav_engine_clients[code2wav_engine_id].
+                process_chunk(request_id=request_id,
+                              voice_type=voice_type,
+                              code=code,
+                              finished=finished),
+                self._loop,
+            ).result()
+
+    def add_request(
+        self,
+        request_id: str,
+        prompt: Optional[PromptType] = None,
+        params: Optional[Union[SamplingParams, PoolingParams]] = None,
+        lora_request: Optional[LoRARequest] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        prompt_adapter_request: Optional[PromptAdapterRequest] = None,
+        priority: int = 0,
+        talker_params: Optional[Union[SamplingParams, PoolingParams]] = None,
+        *,
+        inputs: Optional[PromptType] = None,  # DEPRECATED
+        talker_type: str = "default",
+        voice_type: str = "default",
+    ) -> queue.Queue[Union[RequestOutput, np.ndarray]]:
+        # normalize voice_type
+        if voice_type:
+            voice_type = voice_type.lower()
+
+        if (self.talker_engine_args and voice_type
+                and (not self._ignore_voice(voice_type))
+                and self.code2wav_voice_types
+                and voice_type not in self.code2wav_voice_types):
+            raise ValueError(
+                f"Voice type '{voice_type}' not found in available voice types: {self.code2wav_voice_types}"
+            )
+
+        if voice_type == "default":
+            voice_type = self.default_tts_text_spk_type
+
+        if not params:
+            params = SamplingParams(
+                top_k=self.thinker_generation_config.top_k,
+                top_p=self.thinker_generation_config.top_p,
+                temperature=self.thinker_generation_config.temperature,
+                repetition_penalty=self.thinker_generation_config.
+                repetition_penalty,
+                stop_token_ids=self.thinker_config.eos_token_id,
+            )
+
+        generator = asyncio.run_coroutine_threadsafe(
+            self.thinker_engine.add_request(
+                request_id=request_id,
+                prompt=prompt,
+                params=params,
+                lora_request=lora_request,
+                trace_headers=trace_headers,
+                prompt_adapter_request=prompt_adapter_request,
+                priority=priority,
+                inputs=inputs,
+            ),
+            self._loop,
+        ).result()
+        self._listen_thinker(request_id, voice_type, generator,
+                             self.thinker_outputs[talker_type])
+
+        if self.talker_engine_args and not self._ignore_voice(voice_type):
+            talker_hf_config = self.talker_config
+            if hasattr(talker_hf_config, 'talker_config'):
+                talker_hf_config = talker_hf_config.talker_config
+
+            if not talker_params:
+                talker_params = SamplingParams(
+                    top_k=self.talker_generation_config.top_k,
+                    top_p=self.talker_generation_config.top_p,
+                    temperature=self.talker_generation_config.temperature,
+                    repetition_penalty=self.talker_generation_config.
+                    repetition_penalty,
+                    max_tokens=8192,
+                )
+            if not talker_params.stop_token_ids:
+                talker_params.stop_token_ids = []
+            talker_params.stop_token_ids.extend([
+                talker_hf_config.tts_codec_start_token_id,
+                talker_hf_config.tts_codec_end_token_id,
+            ])
+
+            # talker: chunked output to reduce overhead of zmq
+            talker_params.chunked_return = True
+            talker_params.chunked_return_first_size = self.code2wav_future_cache_size // (
+                2 if self.code2wav_frequency == "50hz" else 4)
+            talker_params.chunked_return_size = self.code2wav_chunk_size // (
+                2 if self.code2wav_frequency == "50hz" else 4)
+
+            if params and params.max_tokens:
+                factor = 1 if self._ignore_code2wav(voice_type) else 40
+                talker_params.max_tokens = min(talker_params.max_tokens,
+                                               params.max_tokens * factor)
+
+            self.talker_requests[request_id] = (prompt, talker_params)
+
+        return self.output_queue[request_id]
+
+    def abort_request(self, request_id: str, talker_type: str = "default"):
+        # cancel thinker
+        asyncio.run_coroutine_threadsafe(
+            self.thinker_engine.abort(request_id),
+            self._loop,
+        ).result()
+        # cancel talker
+        self.thinker_outputs[talker_type].put((request_id, None, None))
+
+    def _ignore_voice(self, voice_type: str = "default") -> bool:
+        return (not voice_type or voice_type == "null" or voice_type == "none")
+
+    def _ignore_code2wav(self, voice_type: str = "default") -> bool:
+        return voice_type and voice_type.lower() in ["prefix_caching"]

--- a/vllm/engine/output_processor/single_step.py
+++ b/vllm/engine/output_processor/single_step.py
@@ -120,6 +120,9 @@ class SingleStepOutputProcessor(SequenceGroupOutputProcessor):
         seq = seq_group.first_seq
         if not is_async:
             seq.append_token_id(sample.output_token, sample.logprobs)
+        # bind the prompt embeds if in both async and non-async mode
+        if outputs.prompt_embeds is not None:
+            seq.data.prompt_embeds = outputs.prompt_embeds
         if sampling_params.detokenize and self.detokenizer:
             new_char_count = self.detokenizer.decode_sequence_inplace(
                 seq, sampling_params)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -504,6 +504,8 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                 return "<|image|>"
             if model_type in ("qwen2_vl", "qwen2_5_vl"):
                 return "<|vision_start|><|image_pad|><|vision_end|>"
+            if model_type == "qwen2_5_omni":
+                return "<|vision_start|><|IMAGE|><|vision_end|>"
             if model_type == "molmo":
                 return ""
             if model_type == "aria":
@@ -517,7 +519,7 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                 return "<|audio|>"
             if model_type == "phi4mm":
                 return "<|endoftext11|>"  # 200011 (see vocab.json in hf model)
-            if model_type == "qwen2_audio":
+            if model_type in ("qwen2_audio", "qwen2_5_omni"):
                 return (f"Audio {current_count}: "
                         f"<|audio_bos|><|AUDIO|><|audio_eos|>")
             if model_type == "minicpmo":
@@ -526,6 +528,8 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
         elif modality == "video":
             if model_type in ("qwen2_vl", "qwen2_5_vl"):
                 return "<|vision_start|><|video_pad|><|vision_end|>"
+            if model_type == "qwen2_5_omni":
+                return "<|vision_start|><|VIDEO|><|vision_end|>"
             if model_type in ("minicpmo", "minicpmv"):
                 return "(<video>./</video>)"
             if model_type.startswith("llava"):

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -906,6 +906,28 @@ def _parse_chat_message_content_mm_part(
     """
     assert isinstance(
         part, dict)  # This is needed to avoid mypy errors: part.get() from str
+
+    if 'text' in part and 'type' not in part:
+        part['type'] = 'text'
+    if part['type'] == 'audio' or part['type'] == 'audio_url':
+        audio = part.pop("audio", part.pop("audio_url", None))
+        if isinstance(audio, str):
+            audio = {"url": audio}
+        part["audio_url"] = audio
+        part["type"] = "audio_url"
+    if part['type'] == 'video' or part['type'] == 'video_url':
+        video = part.pop("video", part.pop("video_url", None))
+        if isinstance(video, str):
+            video = {"url": video}
+        part["video_url"] = video
+        part["type"] = "video_url"
+    if part['type'] == 'image' or part['type'] == 'image_url':
+        image = part.pop("image", part.pop("image_url", None))
+        if isinstance(image, str):
+            image = {"url": image}
+        part["image_url"] = image
+        part["type"] = "image_url"
+
     part_type = part.get("type", None)
 
     if isinstance(part_type, str) and part_type in MM_PARSER_MAP:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -11,6 +11,8 @@ import torch.nn as nn
 from tqdm import tqdm
 from typing_extensions import TypeVar, deprecated
 
+import torch
+
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence, get_beam_search_score)
 from vllm.config import CompilationConfig
@@ -282,6 +284,7 @@ class LLM:
         sampling_params: Optional[Union[SamplingParams,
                                         Sequence[SamplingParams]]] = None,
         *,
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -298,6 +301,7 @@ class LLM:
         sampling_params: Optional[Union[SamplingParams,
                                         list[SamplingParams]]] = None,
         prompt_token_ids: Optional[list[int]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -314,6 +318,7 @@ class LLM:
         sampling_params: Optional[Union[SamplingParams,
                                         list[SamplingParams]]] = None,
         prompt_token_ids: Optional[list[list[int]]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -331,6 +336,7 @@ class LLM:
                                         list[SamplingParams]]] = None,
         *,
         prompt_token_ids: list[int],
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -348,6 +354,7 @@ class LLM:
                                         list[SamplingParams]]] = None,
         *,
         prompt_token_ids: list[list[int]],
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -363,6 +370,7 @@ class LLM:
         prompts: None,
         sampling_params: None,
         prompt_token_ids: Union[list[int], list[list[int]]],
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -383,6 +391,7 @@ class LLM:
         sampling_params: Optional[Union[SamplingParams,
                                         Sequence[SamplingParams]]] = None,
         prompt_token_ids: Optional[Union[list[int], list[list[int]]]] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
         use_tqdm: bool = True,
         lora_request: Optional[Union[list[LoRARequest], LoRARequest]] = None,
         prompt_adapter_request: Optional[PromptAdapterRequest] = None,
@@ -446,6 +455,9 @@ class LLM:
         else:
             parsed_prompts = cast(Union[PromptType, Sequence[PromptType]],
                                   prompts)
+
+        if prompt_embeds is not None:
+            parsed_prompts.prompt_embeds = prompt_embeds
 
         if isinstance(guided_options_request, dict):
             if len(guided_options_request) > 1:

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -20,6 +20,9 @@ class TextPrompt(TypedDict):
     prompt: str
     """The input text to be tokenized before passing to the model."""
 
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
+
     multi_modal_data: NotRequired["MultiModalDataDict"]
     """
     Optional multi-modal data to pass to the model,
@@ -40,6 +43,9 @@ class TokensPrompt(TypedDict):
 
     prompt_token_ids: list[int]
     """A list of token IDs to pass to the model."""
+
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
 
     token_type_ids: NotRequired[list[int]]
     """A list of token type IDs to pass to the cross encoder model."""
@@ -147,6 +153,9 @@ class TokenInputs(TypedDict):
     The original prompt text corresponding to the token IDs, if available.
     """
 
+    prompt_embeds: NotRequired[torch.Tensor]
+    """The embeddings of the prompt, if available."""
+
     multi_modal_data: NotRequired["MultiModalDataDict"]
     """
     Optional multi-modal data to pass to the model,
@@ -182,6 +191,7 @@ def token_inputs(
     prompt_token_ids: list[int],
     token_type_ids: Optional[list[int]] = None,
     prompt: Optional[str] = None,
+    prompt_embeds: Optional[torch.Tensor] = None,
     multi_modal_data: Optional["MultiModalDataDict"] = None,
     multi_modal_inputs: Optional["MultiModalKwargs"] = None,
     multi_modal_hashes: Optional[list[str]] = None,
@@ -193,6 +203,8 @@ def token_inputs(
 
     if prompt is not None:
         inputs["prompt"] = prompt
+    if prompt_embeds is not None:
+        inputs["prompt_embeds"] = prompt_embeds
     if token_type_ids is not None:
         inputs["token_type_ids"] = token_type_ids
     if multi_modal_data is not None:
@@ -277,7 +289,7 @@ class SingletonInputsAdapter:
         inputs = self.inputs
 
         if inputs["type"] == "token" or inputs["type"] == "multimodal":
-            return None
+            return inputs.get("prompt_embeds")
 
         assert_never(inputs)  # type: ignore[arg-type]
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -333,6 +333,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=parsed.get("prompt_embeds"),
             )
 
         if parsed["type"] == "tokens":
@@ -344,16 +345,19 @@ class InputPreprocessor:
             mm_processor_kwargs = tokens_content.get("mm_processor_kwargs")
 
             if multi_modal_data is not None and self._can_process_multimodal():
-                return self._process_multimodal(
+                inputs = self._process_multimodal(
                     prompt_token_ids,
                     multi_modal_data,
                     mm_processor_kwargs,
                     lora_request=lora_request,
                     return_mm_hashes=return_mm_hashes,
                 )
+                inputs["prompt_embeds"] = tokens_content.get("prompt_embeds")
+                return inputs
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=tokens_content.get("prompt_embeds"),
                 token_type_ids=token_type_ids,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
@@ -367,13 +371,15 @@ class InputPreprocessor:
             mm_processor_kwargs = text_content.get("mm_processor_kwargs")
 
             if multi_modal_data is not None and self._can_process_multimodal():
-                return self._process_multimodal(
+                inputs = self._process_multimodal(
                     prompt_text,
                     multi_modal_data,
                     mm_processor_kwargs,
                     lora_request=lora_request,
                     return_mm_hashes=return_mm_hashes,
                 )
+                inputs["prompt_embeds"] = tokens_content.get("prompt_embeds")
+                return inputs
 
             prompt_token_ids = self._tokenize_prompt(
                 prompt_text,
@@ -382,6 +388,7 @@ class InputPreprocessor:
 
             return token_inputs(
                 prompt=prompt_text,
+                prompt_embeds=text_content.get("prompt_embeds"),
                 prompt_token_ids=prompt_token_ids,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
@@ -408,6 +415,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=parsed.get("prompt_embeds"),
             )
 
         if parsed["type"] == "tokens":
@@ -418,16 +426,19 @@ class InputPreprocessor:
             mm_processor_kwargs = tokens_content.get("mm_processor_kwargs")
 
             if multi_modal_data is not None and self._can_process_multimodal():
-                return await self._process_multimodal_async(
+                inputs = await self._process_multimodal_async(
                     prompt_token_ids,
                     multi_modal_data,
                     mm_processor_kwargs,
                     lora_request=lora_request,
                     return_mm_hashes=return_mm_hashes,
                 )
+                inputs["prompt_embeds"] = tokens_content.get("prompt_embeds")
+                return inputs
 
             return token_inputs(
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=tokens_content.get("prompt_embeds"),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )
@@ -440,13 +451,15 @@ class InputPreprocessor:
             mm_processor_kwargs = text_content.get("mm_processor_kwargs")
 
             if multi_modal_data is not None and self._can_process_multimodal():
-                return await self._process_multimodal_async(
+                inputs = await self._process_multimodal_async(
                     prompt_text,
                     multi_modal_data,
                     mm_processor_kwargs,
                     lora_request=lora_request,
                     return_mm_hashes=return_mm_hashes,
                 )
+                inputs["prompt_embeds"] = text_content.get("prompt_embeds")
+                return inputs
 
             prompt_token_ids = await self._tokenize_prompt_async(
                 prompt_text,
@@ -456,6 +469,7 @@ class InputPreprocessor:
             return token_inputs(
                 prompt=prompt_text,
                 prompt_token_ids=prompt_token_ids,
+                prompt_embeds=text_content.get("prompt_embeds"),
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=mm_processor_kwargs,
             )

--- a/vllm/model_executor/models/qwen2_5_omni_talker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_talker.py
@@ -1,0 +1,158 @@
+# Copyright 2024 The Qwen team.
+# Copyright 2023 The vLLM team.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only Qwen2-Audio model compatible with HuggingFace weights."""
+from functools import cached_property
+from typing import Iterable, List, Optional, Set, Tuple, Union
+
+import torch
+import torch.nn as nn
+from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import Qwen2_5OmniTalkerConfig
+
+from vllm.attention import AttentionMetadata
+from vllm.config import VllmConfig
+from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.model_executor.models.qwen2_5_omni_thinker import (
+    Qwen2_5OmniConditionalGenerationMixin,
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    Qwen2_5OmniThinkerProcessingInfo,
+    Qwen2_5OmniThinkerDummyInputsBuilder)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.sequence import IntermediateTensors
+
+from .interfaces import SupportsMultiModal, SupportsPP
+from .utils import (AutoWeightsLoader, WeightsMapper,
+                    init_vllm_registered_model,
+                    maybe_prefix)
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    info=Qwen2_5OmniThinkerProcessingInfo,
+    dummy_inputs=Qwen2_5OmniThinkerDummyInputsBuilder,
+)
+class Qwen2_5OmniTalkerForConditionalGeneration(nn.Module, SupportsMultiModal,
+                                                SupportsPP,
+                                                Qwen2_5OmniConditionalGenerationMixin):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: Qwen2_5OmniTalkerConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+
+        if hasattr(config, "talker_config"):
+            self.config = config.talker_config
+        else:
+            self.config = config
+
+        self.thinker_to_talker_proj = ColumnParallelLinear(
+            self.config.embedding_size,
+            self.config.hidden_size,
+            bias=True,
+            gather_output=True,
+            skip_bias_add=False,
+            quant_config=quant_config,
+        )
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            hf_config=getattr(self.config, 'text_config', self.config),
+            architectures=["Qwen2ForCausalLM"],
+        )
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    @cached_property
+    def sampler(self):
+        if hasattr(self.language_model, "sampler"):
+            return self.language_model.sampler
+
+        return get_sampler()
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.language_model.get_input_embeddings(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+
+        forward_context: ForwardContext = get_forward_context()
+        attn_metadata: AttentionMetadata = forward_context.attn_metadata
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        elif inputs_embeds is None:
+            # for profile_run:
+            inputs_embeds = self.get_input_embeddings(input_ids)
+        else:
+            # in the decoding stage, the "input_embeds" means "thinker_reply_part"
+            if attn_metadata.prefill_metadata is None:
+                inputs_embeds += self.get_input_embeddings(input_ids)
+
+        input_ids = None
+
+        # projection
+        inputs_embeds, _ = self.thinker_to_talker_proj(inputs_embeds)
+
+        hidden_states = self.language_model.model(input_ids,
+                                                  positions,
+                                                  intermediate_tensors,
+                                                  inputs_embeds=inputs_embeds)
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states,
+                                                  sampling_metadata)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[SamplerOutput]:
+        return self.language_model.sample(logits, sampling_metadata)
+
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        hf_to_vllm_mapper = WeightsMapper(
+            orig_to_new_prefix={
+                "talker.codec_head.": "language_model.lm_head.",
+                "talker.model.": "language_model.model.",
+                "talker.": "",
+            })
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=['thinker.', 'token2wav.'],
+        )
+        return loader.load_weights(weights, mapper=hf_to_vllm_mapper)

--- a/vllm/model_executor/models/qwen2_5_omni_talker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_talker.py
@@ -61,6 +61,8 @@ class Qwen2_5OmniTalkerForConditionalGeneration(nn.Module, SupportsMultiModal,
 
         if hasattr(config, "talker_config"):
             self.config = config.talker_config
+            vllm_config.model_config.hf_text_config = \
+                    vllm_config.model_config.hf_config.talker_config
         else:
             self.config = config
 

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -1,0 +1,737 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 The Qwen team.
+# Copyright 2023 The vLLM team.
+# Copyright 2022 EleutherAI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only Qwen2.5-Omni model (thinker part)."""
+
+from functools import cached_property, partial
+from typing import (Any, Dict, Iterable, List, Mapping, Optional, Sequence,
+                    Set, Tuple, Union)
+
+import torch
+import torch.nn as nn
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.models.qwen2_5_omni.configuration_qwen2_5_omni import (
+    Qwen2_5OmniConfig, Qwen2_5OmniThinkerConfig)
+from transformers.models.qwen2_5_omni.modeling_qwen2_5_omni import (
+    Qwen2_5OmniAudioEncoder)
+from transformers.models.qwen2_5_omni.processing_qwen2_5_omni import (
+    Qwen2_5OmniProcessor)
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.layers.sampler import SamplerOutput, get_sampler
+from vllm.model_executor.models.qwen2_5_vl import (
+    Qwen2_5_VisionTransformer, Qwen2_5_VLImageEmbeddingInputs,
+    Qwen2_5_VLImageInputs, Qwen2_5_VLImagePixelInputs,
+    Qwen2_5_VLProcessingInfo, Qwen2_5_VLVideoEmbeddingInputs,
+    Qwen2_5_VLVideoInputs, Qwen2_5_VLVideoPixelInputs)
+from vllm.model_executor.models.qwen2_audio import (
+    Qwen2AudioInputs, Qwen2AudioProcessingInfo,
+    _get_feat_extract_output_lengths)
+from vllm.model_executor.models.qwen2_vl import Qwen2VLMultiModalDataParser
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (ImageItem, ModalityData,
+                                    MultiModalFieldConfig, MultiModalKwargs,
+                                    NestedTensors)
+from vllm.multimodal.parse import (AudioProcessorItems, DictEmbeddingItems,
+                                   ModalityDataItems, MultiModalDataItems,
+                                   MultiModalDataParser)
+from vllm.multimodal.processing import (BaseMultiModalProcessor,
+                                        PromptReplacement, PromptUpdate)
+from vllm.multimodal.profiling import BaseDummyInputsBuilder, ProcessorInputs
+from vllm.sequence import IntermediateTensors, SequenceData
+from vllm.transformers_utils.processor import (
+    cached_feature_extractor_from_config)
+from vllm.utils import LRUCache
+
+from .interfaces import SupportsMultiModal, SupportsPP
+from .utils import (AutoWeightsLoader, WeightsMapper,
+                    init_vllm_registered_model, maybe_prefix,
+                    merge_multimodal_embeddings)
+
+try:
+    import flash_attn
+except (ImportError, ModuleNotFoundError):
+    flash_attn = None
+
+logger = init_logger(__name__)
+
+
+def _qwen2_5_omni_thinker_field_config(hf_inputs: Mapping[str, torch.Tensor]):
+    audio_feature_lengths = hf_inputs.get("audio_feature_lengths",
+                                          torch.empty((0, 0)))
+
+    image_grid_thw = hf_inputs.get("image_grid_thw", torch.empty((0, 3)))
+    image_grid_sizes = image_grid_thw.prod(-1)
+
+    video_grid_thw = hf_inputs.get("video_grid_thw", torch.empty((0, 3)))
+    video_grid_sizes = video_grid_thw.prod(-1)
+
+    return dict(
+        input_audio_features=MultiModalFieldConfig.flat_from_sizes(
+            "audio", audio_feature_lengths, dim=1),
+        feature_attention_mask=MultiModalFieldConfig.batched("audio"),
+        audio_feature_lengths=MultiModalFieldConfig.batched("audio"),
+        pixel_values=MultiModalFieldConfig.flat_from_sizes(
+            "image", image_grid_sizes),
+        image_embeds=MultiModalFieldConfig.flat_from_sizes(
+            "image", image_grid_sizes),
+        image_grid_thw=MultiModalFieldConfig.batched("image"),
+        pixel_values_videos=MultiModalFieldConfig.flat_from_sizes(
+            "video", video_grid_sizes),
+        video_embeds=MultiModalFieldConfig.flat_from_sizes(
+            "video", video_grid_sizes),
+        video_grid_thw=MultiModalFieldConfig.batched("video"),
+        second_per_grid_ts=MultiModalFieldConfig.batched("video"),
+    )
+
+
+class Qwen2_5OmniThinkerMultiModalDataParser(Qwen2VLMultiModalDataParser):
+
+    def _parse_audio_data(
+        self,
+        data: Union[dict[str, torch.Tensor], ModalityData[ImageItem]],
+    ) -> ModalityDataItems[Any, Any]:
+        if isinstance(data, dict):
+            return DictEmbeddingItems(
+                data,
+                modality="audio",
+                required_fields={
+                    "input_audio_features", "audio_feature_lengths"
+                },
+                fields_factory=_qwen2_5_omni_thinker_field_config,
+            )
+
+        return super()._parse_audio_data(data)
+
+
+class Qwen2_5OmniThinkerProcessingInfo(Qwen2AudioProcessingInfo,
+                                       Qwen2_5_VLProcessingInfo):
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(Qwen2_5OmniConfig).thinker_config
+
+    def get_hf_processor(
+        self,
+        *,
+        sampling_rate: Optional[int] = None,
+        min_pixels: Optional[int] = None,
+        max_pixels: Optional[int] = None,
+        size: Optional[dict[str, int]] = None,
+        fps: Optional[Union[float, List[float]]] = None,
+        **kwargs: object,
+    ) -> Qwen2_5OmniProcessor:
+        if fps is not None:
+            kwargs["fps"] = fps
+        processor = self.ctx.get_hf_processor(
+            Qwen2_5OmniProcessor,
+            feature_extractor=self.get_feature_extractor(
+                sampling_rate=sampling_rate),
+            image_processor=self.get_image_processor(min_pixels=min_pixels,
+                                                     max_pixels=max_pixels,
+                                                     size=size),
+            **kwargs,
+        )
+        if not hasattr(processor, "audio_token"):
+            processor.audio_token = "<|AUDIO|>"
+        if not hasattr(processor, "image_token"):
+            processor.image_token = "<|IMAGE|>"
+        if not hasattr(processor, "video_token"):
+            processor.video_token = "<|VIDEO|>"
+        return processor
+
+    def get_feature_extractor(
+        self,
+        *,
+        sampling_rate: Optional[int] = None,
+        **kwargs: object,
+    ):
+        return cached_feature_extractor_from_config(
+            self.ctx.model_config,
+            **self._get_feature_extractor_kwargs(sampling_rate=sampling_rate,
+                                                 **kwargs),
+        )
+
+    def _get_feature_extractor_kwargs(
+        self,
+        *,
+        sampling_rate: Optional[int] = None,
+        **kwargs: object,
+    ):
+        if sampling_rate is not None:
+            kwargs["sampling_rate"] = sampling_rate
+        return kwargs
+
+    def get_max_audio_tokens(self) -> int:
+        hf_config = self.get_hf_config()
+        max_source_position = hf_config.audio_config.max_source_positions
+        output_lengths = (max_source_position - 2) // 2 + 1
+        return output_lengths
+
+    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+        return {"audio": None, "image": None, "video": None}
+
+    def get_mm_max_tokens_per_item(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> Mapping[str, int]:
+        return {
+            "audio": self.get_max_audio_tokens(),
+            "image": self.get_max_image_tokens(),
+            "video": self.get_max_video_tokens(seq_len, mm_counts),
+        }
+
+
+class Qwen2_5OmniThinkerDummyInputsBuilder(
+        BaseDummyInputsBuilder[Qwen2_5OmniThinkerProcessingInfo]):
+    _processor_inputs_cache: LRUCache = LRUCache(capacity=1024)
+
+    def get_dummy_processor_inputs(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> ProcessorInputs:
+        num_audios = mm_counts.get("audio", 0)
+        num_images = mm_counts.get("image", 0)
+        num_videos = mm_counts.get("video", 0)
+        cache_key = (f"qwen2_omni_thinker_dummy_processor_inputs_"
+                     f"{seq_len}_{num_audios}_{num_images}_{num_videos}")
+        dummy_processor_inputs = (Qwen2_5OmniThinkerDummyInputsBuilder.
+                                  _processor_inputs_cache.get(cache_key))
+        if dummy_processor_inputs is not None:
+            return dummy_processor_inputs
+
+        dummy_processor_inputs = self._get_dummy_processor_inputs(
+            seq_len, num_audios, num_images, num_videos)
+        Qwen2_5OmniThinkerDummyInputsBuilder._processor_inputs_cache.put(
+            cache_key, dummy_processor_inputs)
+        return dummy_processor_inputs
+
+    def _get_dummy_processor_inputs(self, seq_len: int, num_audios: int,
+                                    num_images: int,
+                                    num_videos: int) -> ProcessorInputs:
+        hf_processor = self.info.get_hf_processor()
+        feature_extractor = self.info.get_feature_extractor()
+
+        audio_token: str = getattr(
+            hf_processor, "audio_token",
+            getattr(hf_processor.tokenizer, "audio_token", "<|AUDIO|>"))
+        image_token: str = getattr(
+            hf_processor, "image_token",
+            getattr(hf_processor.tokenizer, "image_token", "<|IMAGE|>"))
+        video_token: str = getattr(
+            hf_processor, "video_token",
+            getattr(hf_processor.tokenizer, "video_token", "<|VIDEO|>"))
+
+        target_audio_length = min(
+            feature_extractor.chunk_length,
+            30,
+        ) * feature_extractor.sampling_rate
+        target_width, target_height = \
+            self.info.get_image_size_with_most_features()
+        target_num_frames = \
+            self.info.get_num_frames_with_most_features(seq_len, mm_counts={
+                "audio": num_audios,
+                "image": num_images,
+                "video": num_videos,
+            })
+
+        mm_data = {
+            "audio":
+            self._get_dummy_audios(length=target_audio_length,
+                                   num_audios=num_audios),
+            "image":
+            self._get_dummy_images(width=target_width,
+                                   height=target_height,
+                                   num_images=num_images),
+            "video":
+            self._get_dummy_videos(width=target_width,
+                                   height=target_height,
+                                   num_frames=target_num_frames,
+                                   num_videos=num_videos),
+        }
+
+        inputs = ProcessorInputs(
+            prompt_text=(audio_token * num_audios + image_token * num_images +
+                         video_token * num_videos),
+            mm_data=mm_data,
+        )
+        return inputs
+
+
+class Qwen2_5OmniThinkerMultiModalProcessor(
+        BaseMultiModalProcessor[Qwen2_5OmniThinkerProcessingInfo]):
+
+    def _get_data_parser(self) -> MultiModalDataParser:
+        feature_extractor = self.info.get_feature_extractor()
+        return Qwen2_5OmniThinkerMultiModalDataParser(
+            target_sr=feature_extractor.sampling_rate)
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        mm_data = dict(mm_data)
+        audios = mm_data.pop("audios", [])
+
+        if audios:
+            # NOTE: Qwen2.5-Omni processor accept "audio" rather than "audios" since
+            # certain version.
+            mm_data["audio"] = audios
+            mm_kwargs = dict(**mm_kwargs, )
+        else:
+            # NOTE: WhisperFeatureExtractor cannot handle empty list of audios
+            pass
+
+        hf_inputs = super()._call_hf_processor(
+            prompt=prompt,
+            mm_data=mm_data,
+            mm_kwargs=mm_kwargs,
+        )
+
+        input_features = hf_inputs.pop('input_features', None)
+        feature_attention_mask = hf_inputs.get('feature_attention_mask', None)
+        if ('input_audio_features' not in hf_inputs
+                and input_features is not None):
+            if feature_attention_mask is not None:
+                input_features = input_features.permute(
+                    0, 2, 1)[feature_attention_mask.bool()].permute(1, 0)
+            hf_inputs['input_audio_features'] = input_features
+        if ('audio_feature_lengths' not in hf_inputs
+                and feature_attention_mask is not None):
+            hf_inputs['audio_feature_lengths'] = feature_attention_mask.sum(-1)
+        return hf_inputs
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        return _qwen2_5_omni_thinker_field_config(hf_inputs)
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, Any],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> Sequence[PromptUpdate]:
+        processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
+        tokenizer = self.info.get_tokenizer()
+        image_processor = self.info.get_image_processor(
+            **hf_processor_mm_kwargs)
+        vocab = tokenizer.get_vocab()
+
+        # Use getattr with default to be compatible with transformers<4.48
+        audio_token = getattr(processor, "audio_token",
+                              getattr(tokenizer, "audio_token", "<|AUDIO|>"))
+        image_token = getattr(processor, "image_token",
+                              getattr(tokenizer, "image_token", "<|IMAGE|>"))
+        video_token = getattr(processor, "video_token",
+                              getattr(tokenizer, "video_token", "<|VIDEO|>"))
+
+        audio_token_id = vocab[audio_token]
+        image_token_id = vocab[image_token]
+        video_token_id = vocab[video_token]
+
+        audio_feature_lengths = out_mm_kwargs.get("audio_feature_lengths")
+        feature_attention_mask = out_mm_kwargs.get("feature_attention_mask")
+        if audio_feature_lengths is None and feature_attention_mask is None:
+            audio_output_lengths = []
+        elif audio_feature_lengths is not None:
+            _, audio_output_lens = _get_feat_extract_output_lengths(
+                audio_feature_lengths)
+            audio_output_lengths = audio_output_lens.tolist()
+        elif feature_attention_mask is not None:
+            assert isinstance(feature_attention_mask, torch.Tensor)
+            _, audio_output_lens = _get_feat_extract_output_lengths(
+                feature_attention_mask.sum(-1))
+            audio_output_lengths = audio_output_lens.tolist()
+
+        def get_replacement_qwen2_audio(item_idx: int):
+            num_features = audio_output_lengths[item_idx]
+            if num_features == 0:
+                audios = mm_items.get_items("audio", AudioProcessorItems)
+                audio = audios.get(item_idx)
+                raise ValueError(
+                    f"The audio {audio} (len={len(audio)}) is too short "
+                    "to be represented inside the model")
+
+            return [audio_token_id] * num_features
+
+        def get_replacement_qwen2_vision(item_idx: int, modality: str):
+            grid_thw = out_mm_kwargs[f"{modality}_grid_thw"][item_idx]
+            assert isinstance(grid_thw, torch.Tensor)
+            merge_length = image_processor.merge_size**2
+
+            token_id = image_token_id if modality == "image" else video_token_id
+            return [token_id] * (int(grid_thw.prod()) // merge_length)
+
+        return [
+            PromptReplacement(
+                modality="audio",
+                target=audio_token,
+                replacement=get_replacement_qwen2_audio,
+            ),
+            PromptReplacement(
+                modality="image",
+                target=image_token,
+                replacement=partial(get_replacement_qwen2_vision,
+                                    modality="image"),
+            ),
+            PromptReplacement(
+                modality="video",
+                target=video_token,
+                replacement=partial(get_replacement_qwen2_vision,
+                                    modality="video"),
+            ),
+        ]
+
+
+class Qwen2_5OmniConditionalGenerationMixin:
+
+    def _validate_and_reshape_mm_tensor(self, mm_input: object,
+                                        name: str) -> torch.Tensor:
+        if not isinstance(mm_input, (torch.Tensor, list)):
+            raise ValueError(f"Incorrect type of {name}. "
+                             f"Got type: {type(mm_input)}")
+        if isinstance(mm_input, torch.Tensor):
+            return torch.concat(list(mm_input))
+        else:
+            return torch.concat(mm_input)
+
+    def _parse_and_validate_audio_input(
+            self, **kwargs: object) -> Optional[Qwen2AudioInputs]:
+        input_audio_features = kwargs.pop('input_audio_features', None)
+        audio_feature_lengths = kwargs.pop('audio_feature_lengths', None)
+        feature_attention_mask = kwargs.pop('feature_attention_mask', None)
+        if input_audio_features is None:
+            return None
+        input_audio_features = self._validate_and_reshape_mm_tensor(
+            input_audio_features, 'input_audio_features')
+        if feature_attention_mask is not None:
+            feature_attention_mask = self._validate_and_reshape_mm_tensor(
+                feature_attention_mask, 'feature_attention_mask')
+        if not isinstance(input_audio_features, (torch.Tensor, list)):
+            raise ValueError("Incorrect type of audio input features. "
+                             f"Got type: {type(input_audio_features)}")
+        return Qwen2AudioInputs(input_features=input_audio_features,
+                                audio_feature_lengths=audio_feature_lengths,
+                                feature_attention_mask=feature_attention_mask)
+
+    def _parse_and_validate_image_input(
+        self,
+        **kwargs: Dict[str, Any],
+    ) -> Optional[Qwen2_5_VLImageInputs]:
+        pixel_values = kwargs.pop("pixel_values", None)
+        image_embeds = kwargs.pop("image_embeds", None)
+        image_grid_thw = kwargs.pop("image_grid_thw", None)
+
+        if pixel_values is None and image_embeds is None:
+            return None
+
+        if pixel_values is not None:
+            pixel_values = self._validate_and_reshape_mm_tensor(
+                pixel_values, "image pixel values")
+            image_grid_thw = self._validate_and_reshape_mm_tensor(
+                image_grid_thw, "image grid_thw")
+
+            if not isinstance(pixel_values, (torch.Tensor, list)):
+                raise ValueError("Incorrect type of image pixel values. "
+                                 f"Got type: {type(pixel_values)}")
+
+            return Qwen2_5_VLImagePixelInputs(type="pixel_values",
+                                              pixel_values=pixel_values,
+                                              image_grid_thw=image_grid_thw)
+
+        if image_embeds is not None:
+            image_embeds = self._validate_and_reshape_mm_tensor(
+                image_embeds, "image embeds")
+            image_grid_thw = self._validate_and_reshape_mm_tensor(
+                image_grid_thw, "image grid_thw")
+
+            if not isinstance(image_embeds, torch.Tensor):
+                raise ValueError("Incorrect type of image embeddings. "
+                                 f"Got type: {type(image_embeds)}")
+            return Qwen2_5_VLImageEmbeddingInputs(
+                type="image_embeds",
+                image_embeds=image_embeds,
+                image_grid_thw=image_grid_thw)
+
+    def _parse_and_validate_video_input(
+        self,
+        **kwargs: Dict[str, Any],
+    ) -> Optional[Qwen2_5_VLVideoInputs]:
+        pixel_values_videos = kwargs.pop("pixel_values_videos", None)
+        video_embeds = kwargs.pop("video_embeds", None)
+        video_grid_thw = kwargs.pop("video_grid_thw", None)
+
+        if pixel_values_videos is None and video_embeds is None:
+            return None
+
+        if pixel_values_videos is not None:
+            pixel_values_videos = self._validate_and_reshape_mm_tensor(
+                pixel_values_videos, "video pixel values")
+            video_grid_thw = self._validate_and_reshape_mm_tensor(
+                video_grid_thw, "video grid_thw")
+
+            return Qwen2_5_VLVideoPixelInputs(
+                type="pixel_values_videos",
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+            )
+
+        if video_embeds is not None:
+            video_embeds = self._validate_and_reshape_mm_tensor(
+                video_embeds, "video embeds")
+            video_grid_thw = self._validate_and_reshape_mm_tensor(
+                video_grid_thw, "video grid_thw")
+
+            if not isinstance(video_embeds, torch.Tensor):
+                raise ValueError("Incorrect type of video embeddings. "
+                                 f"Got type: {type(video_embeds)}")
+            return Qwen2_5_VLVideoEmbeddingInputs(
+                type="video_embeds",
+                video_embeds=video_embeds,
+                video_grid_thw=video_grid_thw)
+
+    def _process_audio_input(
+        self,
+        audio_input: Qwen2AudioInputs,
+        audio_hashes: List[str] = None,
+        cached_audio_features: torch.Tensor = None,
+    ) -> torch.Tensor:
+
+        input_features = audio_input["input_features"]
+        audio_feature_lengths = audio_input["audio_feature_lengths"]
+
+        if input_features.ndim == 3:
+            assert input_features.shape[0] == 1
+            input_features = input_features.squeeze(0)
+        if audio_feature_lengths.ndim == 2:
+            assert audio_feature_lengths.shape[0] == 1
+            audio_feature_lengths = audio_feature_lengths.squeeze(0)
+
+        audio_feat_lengths, audio_output_lengths = (
+            self.audio_tower._get_feat_extract_output_lengths(
+                audio_feature_lengths))
+
+        audio_outputs = self.audio_tower(
+            input_features,
+            feature_lens=audio_feature_lengths,
+            aftercnn_lens=audio_feat_lengths,
+        )
+        audio_features = audio_outputs.last_hidden_state
+        return audio_features
+
+    def _process_image_input(
+            self, image_input: Qwen2_5_VLImageInputs) -> torch.Tensor:
+        if image_input["type"] == "image_embeds":
+            return image_input["image_embeds"].type(self.visual.dtype)
+
+        pixel_values = image_input["pixel_values"].type(self.visual.dtype)
+        image_embeds = self.visual(pixel_values,
+                                   grid_thw=image_input["image_grid_thw"])
+        return image_embeds
+
+    def _process_video_input(
+            self,
+            video_input: Qwen2_5_VLVideoInputs,
+            video_hashes: List[str] = None,
+            cached_video_embeds: torch.Tensor = None) -> torch.Tensor:
+        if video_input["type"] == "video_embeds":
+            return video_input["video_embeds"].type(self.visual.dtype)
+
+        video_grid_thw = video_input["video_grid_thw"]
+        pixel_values_videos = video_input["pixel_values_videos"].type(
+            self.visual.dtype)
+        video_embeds = self.visual(pixel_values_videos,
+                                   grid_thw=video_grid_thw)
+        return video_embeds
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen2_5OmniThinkerMultiModalProcessor,
+    info=Qwen2_5OmniThinkerProcessingInfo,
+    dummy_inputs=Qwen2_5OmniThinkerDummyInputsBuilder,
+)
+class Qwen2_5OmniThinkerForConditionalGeneration(
+        nn.Module, SupportsMultiModal, SupportsPP,
+        Qwen2_5OmniConditionalGenerationMixin):
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        thinker_config: Qwen2_5OmniThinkerConfig = (
+            vllm_config.model_config.hf_config.thinker_config)
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        self.config = thinker_config
+        self.multimodal_config = multimodal_config
+
+        # force "use_flash_attention_2=True" to audio tower to align
+        # the results.
+        if flash_attn is not None:
+            audio_config = thinker_config.audio_config
+            audio_config._attn_implementation_autoset = True
+            audio_config._attn_implementation = "flash_attention_2"
+        else:
+            logger.warning(
+                "flash_attn is not available, the model may not yield the "
+                "exactly same result as the transformers implementation "
+                "in the audio tower part.")
+
+        self.audio_tower = Qwen2_5OmniAudioEncoder(thinker_config.audio_config)
+        self.visual = Qwen2_5_VisionTransformer(
+            vision_config=thinker_config.vision_config,
+            norm_eps=getattr(getattr(thinker_config, 'text_config', thinker_config), "rms_norm_eps", 1e-6),
+            # quant_config=self._maybe_ignore_quant_config(quant_config),
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "visual"),
+        )
+        self.quant_config = quant_config
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            hf_config=getattr(thinker_config, 'text_config', thinker_config),
+            architectures=["Qwen2ForCausalLM"],
+        )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    @cached_property
+    def sampler(self):
+        if hasattr(self.language_model, "sampler"):
+            return self.language_model.sampler
+
+        return get_sampler()
+
+    def get_multimodal_embeddings(self, **kwargs) -> Optional[NestedTensors]:
+        audio_input = self._parse_and_validate_audio_input(**kwargs)
+        image_input = self._parse_and_validate_image_input(**kwargs)
+        video_input = self._parse_and_validate_video_input(**kwargs)
+
+        if audio_input is None and image_input is None and video_input is None:
+            return None
+
+        multimodal_embeddings: List[Tuple[NestedTensors, str]] = []
+
+        if audio_input is not None:
+            audio_embeds = self._process_audio_input(audio_input)
+            multimodal_embeddings.append((audio_embeds, "audio"))
+        if image_input is not None:
+            image_embeds = self._process_image_input(image_input)
+            multimodal_embeddings.append((image_embeds, "image"))
+        if video_input is not None:
+            video_embeds = self._process_video_input(video_input)
+            multimodal_embeddings.append((video_embeds, "video"))
+        return multimodal_embeddings
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: Optional[NestedTensors] = None,
+        seq_data: Optional[SequenceData] = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+        if multimodal_embeddings is None:
+            return inputs_embeds
+
+        for embeddings, modality in multimodal_embeddings:
+            if modality == "audio":
+                placeholder_token_id = self.config.audio_token_index
+            if modality == "image":
+                placeholder_token_id = self.config.image_token_index
+            if modality == "video":
+                placeholder_token_id = self.config.video_token_index
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids, inputs_embeds, embeddings, placeholder_token_id)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+
+        # NOTE: In v1, inputs_embeds is always generated at model runner, this
+        # condition is for v0 compatibility.
+        elif inputs_embeds is None:
+            multimodal_embeddings = self.get_multimodal_embeddings(**kwargs)
+            inputs_embeds = self.get_input_embeddings(input_ids,
+                                                      multimodal_embeddings)
+            # Return the embeddings for the input text before merging the
+            # multimodal data, align with "modeling_qwen2_omni_thinker.py".
+            text_inputs_embeds = self.get_input_embeddings(
+                input_ids,
+                [ (torch.zeros_like(embeddings), modality)
+                   for embeddings, modality in multimodal_embeddings]
+                if multimodal_embeddings is not None else None)
+
+            input_ids = None
+        else:
+            text_inputs_embeds = inputs_embeds
+
+        hidden_states = self.language_model.model(input_ids,
+                                                  positions,
+                                                  intermediate_tensors,
+                                                  inputs_embeds=inputs_embeds)
+        return text_inputs_embeds, hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states,
+                                                  sampling_metadata)
+
+    def sample(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[SamplerOutput]:
+        return self.language_model.sample(logits, sampling_metadata)
+
+    def load_weights(self, weights: Iterable[Tuple[str,
+                                                   torch.Tensor]]) -> Set[str]:
+        hf_to_vllm_mapper = WeightsMapper(
+            orig_to_new_prefix={
+                "thinker.audio_tower.positional_embedding": "audio_tower.positional_embedding",
+                "thinker.lm_head.": "language_model.lm_head.",
+                "thinker.model.": "language_model.model.",
+                "thinker.": "",
+            })
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=['talker.', 'token2wav.'],
+        )
+        return loader.load_weights(weights, mapper=hf_to_vllm_mapper)

--- a/vllm/model_executor/models/qwen2_5_omni_thinker.py
+++ b/vllm/model_executor/models/qwen2_5_omni_thinker.py
@@ -271,10 +271,18 @@ class Qwen2_5OmniThinkerDummyInputsBuilder(
                                    num_videos=num_videos),
         }
 
+        hf_processor_mm_kwargs = {
+            'videos_kwargs': {
+                'min_pixels' : None,
+                'max_pixels' : None,
+            }
+        }
+
         inputs = ProcessorInputs(
             prompt_text=(audio_token * num_audios + image_token * num_images +
                          video_token * num_videos),
             mm_data=mm_data,
+            hf_processor_mm_kwargs=hf_processor_mm_kwargs
         )
         return inputs
 

--- a/vllm/model_executor/models/qwen2_code2wav_dit.py
+++ b/vllm/model_executor/models/qwen2_code2wav_dit.py
@@ -1,0 +1,554 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import contextlib
+from typing import Callable, Dict, List, Tuple, Union
+
+import torch
+from torchdiffeq import odeint
+
+from vllm.transformers_utils.qwen2_code2wav_dit.model.dit import DiT
+from vllm.transformers_utils.qwen2_code2wav_dit.model.t2w_cfm import CodecCFM
+from vllm.transformers_utils.qwen2_code2wav_dit.model.utils import (
+    exists, load_checkpoint)
+from vllm.transformers_utils.qwen2_code2wav_dit.modeling_qwen2_code2wav import (
+    Qwen2Code2wavBigvgan)
+
+
+class CudaGraphRunner:
+
+    def __init__(self, fn, device):
+        """
+        initialize CUDA Graph Wrapper.
+
+        Args:
+            original_fast_forward (callable): original fast_forward method.
+            device (torch.device): CUDA device.
+        """
+        torch._dynamo.config.cache_size_limit = 64
+        self.fn_compile = torch.compile(
+            fn,
+            mode="default",
+            fullgraph=False,
+        )
+        self.cuda_graph: Dict[Tuple[int, int], torch.cuda.CUDAGraph] = dict()
+        self.input_buffers: Dict[Tuple[int, int], Dict[str,
+                                                       torch.Tensor]] = dict()
+        self.output_buffers: Dict[Tuple[int, int], torch.Tensor] = dict()
+
+        self.device = device
+
+        # Create customized CUDA stream for Cuda Graph capture
+        self.capture_stream = torch.cuda.Stream(device=self.device)
+
+    def capture_cuda_graph(self, x, cond, spk, text, time, mask):
+        """
+        Capture CUDA Graph。
+
+        Args:
+            x (torch.Tensor): nosied input audio.
+            cond (torch.Tensor): masked cond audio.
+            spk (torch.Tensor): spk embedding.
+            text (torch.Tensor): text.
+            time (torch.Tensor): time step.
+            mask (torch.Tensor or None): mask.
+        """
+        # Move the input data to the specified device and detach it from the computation graph.
+
+        size = (text.size(0), text.size(1))
+
+        with torch.no_grad():
+            if size not in self.input_buffers:
+                self.input_buffers[size] = {
+                    "x":
+                    x.to(self.device, non_blocking=True).clone().detach(),
+                    "cond":
+                    cond.to(self.device, non_blocking=True).clone().detach(),
+                    "spk":
+                    spk.to(self.device, non_blocking=True).clone().detach(),
+                    "text":
+                    text.to(self.device, non_blocking=True).clone().detach(),
+                    "time":
+                    time.to(self.device, non_blocking=True).clone().detach(),
+                    "mask":
+                    mask.to(self.device, non_blocking=True).clone().detach()
+                    if mask is not None else None,
+                }
+
+        # Determine the output shape through a single forward pass and pre-allocate the output buffer.
+        with torch.no_grad():
+            if size not in self.output_buffers:
+                generated = self.fn_compile(
+                    x=self.input_buffers[size]["x"],
+                    cond=self.input_buffers[size]["cond"],
+                    spk=self.input_buffers[size]["spk"],
+                    text=self.input_buffers[size]["text"],
+                    time=self.input_buffers[size]["time"],
+                    mask=self.input_buffers[size]["mask"],
+                )
+                self.output_buffers[size] = torch.empty_like(
+                    generated, device=self.device)
+
+        # Ensure that all previous operations are complete.
+        torch.cuda.synchronize(self.device)
+
+        # Begin to capture CUDA Graph
+        self.cuda_graph[size] = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self.cuda_graph[size],
+                              stream=self.capture_stream):
+            # Perform the forward pass and copy the results to the pre-allocated buffer.
+            generated = self.fn_compile(
+                x=self.input_buffers[size]["x"],
+                cond=self.input_buffers[size]["cond"],
+                spk=self.input_buffers[size]["spk"],
+                text=self.input_buffers[size]["text"],
+                time=self.input_buffers[size]["time"],
+                mask=self.input_buffers[size]["mask"],
+            )
+            self.output_buffers[size].copy_(generated)
+
+        # Make sure capture complete
+        torch.cuda.synchronize(self.device)
+
+    def __call__(self, x, cond, spk, text, time, mask=None):
+        """
+        Args:
+            x (torch.Tensor): nosied input audio.
+            cond (torch.Tensor): masked cond audio.
+            spk (torch.Tensor): spk embedding.
+            text (torch.Tensor): text.
+            time (torch.Tensor): time step.
+            mask (torch.Tensor or None): mask.
+
+        Returns:
+            torch.Tensor: generated
+        """
+
+        size = (text.size(0), text.size(1))
+
+        if size not in self.cuda_graph:
+            # Capture the CUDA Graph on the first call.
+            self.capture_cuda_graph(x, cond, spk, text, time, mask)
+
+        # Update input to buffer.
+        self.input_buffers[size]["x"].copy_(
+            x.to(self.device, non_blocking=True))
+        self.input_buffers[size]['cond'].copy_(
+            cond.to(self.device, non_blocking=True))
+        self.input_buffers[size]["spk"].copy_(
+            spk.to(self.device, non_blocking=True))
+        self.input_buffers[size]["text"].copy_(
+            text.to(self.device, non_blocking=True))
+        self.input_buffers[size]["time"].copy_(
+            time.to(self.device, non_blocking=True))
+        if self.input_buffers[size]["mask"] is not None and mask is not None:
+            self.input_buffers[size]["mask"].copy_(
+                mask.to(self.device, non_blocking=True))
+        elif mask is None:
+            self.input_buffers[size]["mask"] = None
+        # Replay CUDA Graph
+        self.cuda_graph[size].replay()
+        return self.output_buffers[size]
+
+
+class BatchCodecCFM(CodecCFM):
+
+    @torch.no_grad()
+    def fast_block_sample(
+        self,
+        cond: float["b n d"] | float["b nw"],  # noqa: F722
+        codec: int["b nc dc"],
+        ref_mel: float["b n d"],  # noqa: F722
+        y0: float["b n d"],
+        lens: int[b] | None = None,  # noqa: F821
+        steps=32,
+        cfg_strength=1.0,
+        sway_sampling_coef=None,
+        seed: int | None = None,
+        max_duration=4096,
+        vocoder: Callable[[float["b d n"]], float["b nw"]]
+        | None = None,  # noqa: F722
+        no_ref_audio=False,
+        duplicate_test=False,
+        t_inter=0.1,
+        edit_mask=None,
+    ):
+        self.eval()
+
+        max_duration = y0.shape[1]
+        if next(self.parameters()).dtype == torch.float16:
+            cond = cond.half()
+            ref_mel = ref_mel.half()
+            y0 = y0.half()
+            # print(next(self.parameters()).dtype)
+
+        # raw wave
+
+        cond = cond.unsqueeze(1).repeat(1, max_duration, 1)
+        batch, cond_seq_len, device = *ref_mel.shape[:2], cond.device
+        if not exists(lens):
+            lens = torch.full((batch, ),
+                              cond_seq_len,
+                              device=device,
+                              dtype=torch.long)
+
+        mask = None
+
+        # test for no ref audio
+        if no_ref_audio:
+            cond = torch.zeros_like(cond)
+
+        # neural ode
+
+        def fn(t, x):
+            out_put = self.transformer.fast_forward(
+                x=x,
+                text=codec,
+                spk=cond,
+                cond=ref_mel,
+                time=t,
+                mask=mask,
+            )
+            pred, null_pred = torch.chunk(out_put, 2, dim=0)
+            return pred + (pred - null_pred) * cfg_strength
+
+        t_start = 0
+        t = torch.linspace(t_start,
+                           1,
+                           steps,
+                           device=self.device,
+                           dtype=ref_mel.dtype)
+        if sway_sampling_coef is not None:
+            t = t + sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
+
+        trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
+
+        sampled = trajectory[-1]
+        out = sampled
+        # out = torch.where(cond_mask, ref_mel, out)
+        return out, trajectory
+
+
+class Qwen2Code2wavDit(torch.nn.Module):
+
+    def __init__(self, ckpt, frequency: str = "50hz", device='cpu'):
+        super().__init__()
+        self.frequency = frequency
+        self.device = device
+        self.dit = DiT(
+            dim=1024,
+            depth=22 if frequency == '50hz' else 32,
+            heads=16,
+            ff_mult=2,
+            text_dim=512,
+            conv_layers=4,
+            use_codec=True,
+            repeats=2 if frequency == '50hz' else 4,
+            attn_processor='stream_block_sr'
+            if frequency == '50hz' else 'stream_block_8_L_4',
+            text_num_embeds=8193 if frequency == '50hz' else 32769,
+            mel_dim=80,
+        )
+        self.mel_spec_kwargs = dict(
+            target_sample_rate=16000,
+            n_mel_channels=80,
+            hop_length=160,
+        )
+        self.odeint_kwargs = dict(method="euler", )
+        self.cfm_model = BatchCodecCFM(
+            transformer=self.dit,
+            mel_spec_kwargs=self.mel_spec_kwargs,
+            odeint_kwargs=self.odeint_kwargs,
+        ).to(device)
+        self.cfm_model = load_checkpoint(self.cfm_model,
+                                         ckpt,
+                                         device,
+                                         use_ema=True)
+
+    def sample(self,
+               cond,
+               ref_mel,
+               codec,
+               steps=10,
+               cfg_strength=0.5,
+               sway_sampling_coef=-1.0):
+        y_all = torch.randn([1, 30000, 80],
+                            device=self.device,
+                            dtype=ref_mel.dtype)
+        expect_y_len = codec.shape[1] * (2 if self.frequency == '50hz' else 4)
+        y0 = y_all[:, :expect_y_len]
+        with torch.inference_mode():
+            generated, _ = self.cfm_model.sample(
+                cond=cond,
+                ref_mel=ref_mel,
+                codec=codec,
+                steps=steps,
+                cfg_strength=cfg_strength,
+                sway_sampling_coef=sway_sampling_coef,
+                y0=y0)
+        generated = generated.to(torch.float32)
+        generated_mel_spec = generated.permute(0, 2, 1)
+        return generated_mel_spec
+
+    def fast_block_sample(
+        self,
+        cond,
+        codec,
+        ref_mel,
+        y0,
+        steps=10,
+        cfg_strength=0.5,
+        sway_sampling_coef=-1.0,
+    ):
+        return self.cfm_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+        )
+
+
+class Qwen2Code2wav(torch.nn.Module):
+
+    def __init__(self,
+                 dit_ckpt,
+                 bigvgan_ckpt,
+                 steps: int = 10,
+                 bs_mel: int = 24,
+                 odeint_method: str = "euler",
+                 odeint_method_relaxed: bool = False,
+                 batched_chunk: int = 3,
+                 frequency: str = "50hz",
+                 device='cpu',
+                 with_weight_norm: bool = True):
+        super().__init__()
+        self.frequency = frequency
+        self.code2wav_dit_model = Qwen2Code2wavDit(ckpt=dit_ckpt,
+                                                   frequency=frequency,
+                                                   device=device)
+        self.code2wav_bigvgan_model = Qwen2Code2wavBigvgan(
+            ckpt=bigvgan_ckpt,
+            frequency=frequency,
+            device=device,
+            with_weight_norm=with_weight_norm)
+        self.device = device
+
+        # odeint method: use ruler for first and last chunk to optimize performance
+        self.odeint_method_relaxed = odeint_method_relaxed
+
+        # cfm model: override the odeint method
+        self.code2wav_dit_model.cfm_model.odeint_kwargs[
+            "method"] = odeint_method
+
+        # dit autocast
+        self.code2wav_dit_model.dit.fast_forward = torch.autocast(
+            device_type="cuda",
+            dtype=torch.bfloat16,
+        )(self.code2wav_dit_model.dit.fast_forward)
+
+        self.dit_forward = self.code2wav_dit_model.dit.fast_forward
+        self.dit_forward_compiled = self.code2wav_dit_model.dit.fast_forward
+        self.dit_forward_compiled_first_chunk = self.code2wav_dit_model.dit.fast_forward
+        self.dit_forward_cudagraph_first = self.code2wav_dit_model.dit.fast_forward
+        self.dit_forward_cudagraph_intermediate = self.code2wav_dit_model.dit.fast_forward
+        self.dit_forward_cudagraph_last = self.code2wav_dit_model.dit.fast_forward
+
+        self.torch_compile_first_chunk = False
+
+        self.factor = 2 if frequency == '50hz' else 4
+        self.steps = steps
+        self.bs_mel = bs_mel
+        self.bs_codec = bs_mel // self.factor
+        self.past_cache_size = bs_mel * self.factor
+        self.future_cache_size = bs_mel * 1
+        self.chunk_size = bs_mel * batched_chunk
+        self.future_size = 20 if self.frequency == '50hz' else 13
+        self.past_size = 20 if self.frequency == '50hz' else 51
+
+        text_embed = self.code2wav_dit_model.dit.text_embed
+        if hasattr(text_embed, 'codec_embed'):
+            self.codec_embed_size = text_embed.codec_embed.weight.size(0)
+        elif hasattr(text_embed, 'text_embed'):
+            self.codec_embed_size = text_embed.text_embed.weight.size(0)
+        else:
+            self.codec_embed_size = -1
+
+    @contextlib.contextmanager
+    def relax_odeint_method(self, relax: bool = False):
+        if relax and self.odeint_method_relaxed:
+            odeint_method = self.code2wav_dit_model.cfm_model.odeint_kwargs[
+                "method"]
+            self.code2wav_dit_model.cfm_model.odeint_kwargs["method"] = "euler"
+        yield
+        if relax and self.odeint_method_relaxed:
+            self.code2wav_dit_model.cfm_model.odeint_kwargs[
+                "method"] = odeint_method
+
+    def enable_torch_compile(self, compile_first_chunk: bool = False):
+        self.torch_compile_first_chunk = compile_first_chunk
+
+        self.dit_forward_compiled = torch.compile(
+            self.code2wav_dit_model.dit.fast_forward,
+            # mode="default",
+            mode="reduce-overhead",
+            fullgraph=False,
+        )
+        self.dit_forward_cudagraph_first = CudaGraphRunner(
+            self.code2wav_dit_model.dit.fast_forward, self.device)
+        self.dit_forward_cudagraph_intermediate = CudaGraphRunner(
+            self.code2wav_dit_model.dit.fast_forward, self.device)
+        self.dit_forward_cudagraph_last = CudaGraphRunner(
+            self.code2wav_dit_model.dit.fast_forward, self.device)
+
+    @torch.inference_mode()
+    def forward(self, cond, ref_mel, codec):
+        generated_mel = self.code2wav_dit_model.sample(cond, ref_mel, codec)
+        generated_mel = generated_mel.permute(0, 2, 1)
+        waveform = self.code2wav_bigvgan_model(generated_mel)
+        return waveform
+
+    @torch.inference_mode()
+    def process_chunk_dit_batch(
+        self,
+        cond,
+        ref_mel,
+        codec,
+        y0,
+        steps,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.codec_embed_size > 0:
+            codec[codec >= self.codec_embed_size] = 0
+
+        self.code2wav_dit_model.dit.fast_forward = self.dit_forward_cudagraph_intermediate
+        generated, _ = self.code2wav_dit_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=0.5,
+            sway_sampling_coef=-1.0,
+        )
+        return generated
+
+    @torch.inference_mode()
+    def process_chunk_bigvgan_batch(self, mel_batch):
+        return self.code2wav_bigvgan_model(mel_batch)
+
+    @torch.inference_mode()
+    def process_little_chunk(
+        self,
+        cond,
+        ref_mel,
+        codec_all,
+        y_all,
+        i,
+        steps,
+        prev_generated: torch.Tensor,
+        finished: bool = False,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # mask to prevent codec from being out of range (the eos token)
+        if self.codec_embed_size > 0:
+            codec_all[codec_all >= self.codec_embed_size] = 0
+
+        return None, self.forward(cond, ref_mel, codec_all)
+
+    @torch.inference_mode()
+    def process_chunk(
+        self,
+        cond,
+        ref_mel,
+        codec_all,
+        y_all,
+        i,
+        steps,
+        prev_generated: Union[torch.Tensor, List[torch.Tensor]],
+        finished: bool = False,
+    ) -> Tuple[Union[torch.Tensor, List[torch.Tensor]], torch.Tensor]:
+        start_index = max(i * self.chunk_size - self.past_cache_size, 0)
+        end_index = min((i + 1) * self.chunk_size + self.future_cache_size,
+                        codec_all.shape[1] * self.factor)
+        y0 = y_all[:, start_index:end_index].reshape(1, -1, 80).contiguous()
+        codec = codec_all[:, start_index // self.factor:end_index //
+                          self.factor].reshape(1, -1).contiguous()
+
+        # mask to prevent codec from being out of range (the eos token)
+        if self.codec_embed_size > 0:
+            codec[codec >= self.codec_embed_size] = 0
+
+        # N.B. when using cuda graph ("reduce-overhead" mode), don't compile
+        # shape for the first and the last chunk, as it will affect the performance
+        # for normal chunks.
+        #
+        # The reason is not clear yet. The default torch.compile() mode is not affected.
+        if i == 0:
+            if self.torch_compile_first_chunk:
+                self.code2wav_dit_model.dit.fast_forward = self.dit_forward_compiled
+            else:
+                self.code2wav_dit_model.dit.fast_forward = self.dit_forward_cudagraph_first
+        elif finished:
+            self.code2wav_dit_model.dit.fast_forward = self.dit_forward_cudagraph_last
+        else:
+            self.code2wav_dit_model.dit.fast_forward = self.dit_forward_cudagraph_intermediate
+
+        with self.relax_odeint_method(relax=i == 0 or finished):
+            generated, _ = self.code2wav_dit_model.fast_block_sample(
+                cond=cond,
+                codec=codec,
+                ref_mel=ref_mel,
+                y0=y0,
+                steps=steps,
+                cfg_strength=0.5,
+                sway_sampling_coef=-1.0,
+            )
+
+        if self.frequency == "50hz":
+            return self.process_chunk_for_50hz(
+                i,
+                start_index,
+                end_index,
+                finished,
+                prev_generated,
+                generated,
+            )
+        else:
+            raise ValueError(f"Unsupported frequency: {self.frequency}")
+
+    def process_chunk_for_50hz(
+        self,
+        i: int,
+        start_index: int,
+        end_index: int,
+        finished: bool,
+        prev_generated: torch.Tensor,
+        generated: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if start_index == 0:
+            generated = generated.to(torch.float32)[:, :self.chunk_size, :]
+            mel = generated
+        elif finished:
+            generated = generated.to(torch.float32)[:,
+                                                    self.past_cache_size:, :]
+            mel = torch.cat(
+                [prev_generated[:, -self.future_size * 2:, :], generated],
+                dim=1)
+        else:
+            generated = generated.to(
+                torch.float32)[:,
+                               self.past_cache_size:-self.future_cache_size, :]
+            mel = torch.cat(
+                [prev_generated[:, -self.future_size * 2:, :], generated],
+                dim=1)
+
+        audio = self.code2wav_bigvgan_model(mel)
+        if i == 0:
+            audio_output = audio[:-self.future_size * 240]
+        elif finished:
+            audio_output = audio[self.future_size * 240:]
+        else:
+            audio_output = audio[self.future_size * 240:-self.future_size *
+                                 240]
+        return generated, audio_output

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -191,6 +191,9 @@ _MULTIMODAL_MODELS = {
     "QwenVLForConditionalGeneration": ("qwen_vl", "QwenVLForConditionalGeneration"),  # noqa: E501
     "Qwen2VLForConditionalGeneration": ("qwen2_vl", "Qwen2VLForConditionalGeneration"),  # noqa: E501
     "Qwen2_5_VLForConditionalGeneration": ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),  # noqa: E501
+    "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
+    "Qwen2_5OmniThinkerModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
+    "Qwen2_5OmniTalkerModel": ("qwen2_5_omni_talker", "Qwen2_5OmniTalkerForConditionalGeneration"),  # noqa: E501
     "Qwen2AudioForConditionalGeneration": ("qwen2_audio", "Qwen2AudioForConditionalGeneration"),  # noqa: E501
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -443,7 +443,8 @@ def merge_multimodal_embeddings(
     inputs_embeds: torch.Tensor,
     multimodal_embeddings: NestedTensors,
     placeholder_token_id: Union[int, List[int]],
-) -> torch.Tensor:
+    seq_data=None,
+    modality=None) -> torch.Tensor:
     """
     Merge ``multimodal_embeddings`` into ``inputs_embeds`` by overwriting the
     positions in ``inputs_embeds`` corresponding to placeholder tokens in
@@ -480,7 +481,7 @@ def merge_multimodal_embeddings(
 
     return _merge_multimodal_embeddings(
         inputs_embeds,
-        (input_ids == placeholder_token_id),
+        torch.isin(input_ids, placeholder_token_id),
         multimodal_embeddings,
     )
 

--- a/vllm/model_executor/sampling_metadata.py
+++ b/vllm/model_executor/sampling_metadata.py
@@ -430,7 +430,7 @@ class SamplingTensors:
             if not do_penalties and (abs(p) >= _SAMPLING_EPS
                                      or abs(f) >= _SAMPLING_EPS
                                      or abs(r - 1.0) >= _SAMPLING_EPS):
-                do_penalties = True
+                do_penalties = sampling_params.do_penalties
 
             is_prompt = seq_group.is_prompt
             if is_prompt and sampling_params.prompt_logprobs is not None:

--- a/vllm/multimodal/processing_omni.py
+++ b/vllm/multimodal/processing_omni.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import base64
+import logging
+import math
+import os
+import sys
+import time
+import warnings
+from functools import lru_cache
+from io import BytesIO
+import requests
+import torch
+import torchvision
+from packaging import version
+from PIL import Image
+from torchvision import io, transforms
+from torchvision.transforms import InterpolationMode
+# from qwen_vl_utils import process_vision_info as a
+
+logger = logging.getLogger(__name__)
+
+IMAGE_FACTOR = 28
+MIN_PIXELS = 4 * 28 * 28
+MAX_PIXELS = 16384 * 28 * 28
+MAX_RATIO = 200
+
+VIDEO_MIN_PIXELS = 128 * 28 * 28
+VIDEO_MAX_PIXELS = 768 * 28 * 28
+VIDEO_TOTAL_PIXELS = 24576 * 28 * 28
+FRAME_FACTOR = 2
+FPS = 2.0
+FPS_MIN_FRAMES = 4
+FPS_MAX_FRAMES = 768
+
+temporal_patch_size = 2
+spatial_patch_size = 14
+spatial_merge_size = 2
+
+
+def round_by_factor(number: int, factor: int) -> int:
+    """Returns the closest integer to 'number' that is divisible by 'factor'."""
+    return round(number / factor) * factor
+
+
+def ceil_by_factor(number: int, factor: int) -> int:
+    """Returns the smallest integer greater than or equal to 'number' that is divisible by 'factor'."""
+    return math.ceil(number / factor) * factor
+
+
+def floor_by_factor(number: int, factor: int) -> int:
+    """Returns the largest integer less than or equal to 'number' that is divisible by 'factor'."""
+    return math.floor(number / factor) * factor
+
+
+def smart_resize(height: int,
+                 width: int,
+                 factor: int = IMAGE_FACTOR,
+                 min_pixels: int = MIN_PIXELS,
+                 max_pixels: int = MAX_PIXELS) -> tuple[int, int]:
+    """
+    Rescales the image so that the following conditions are met:
+
+    1. Both dimensions (height and width) are divisible by 'factor'.
+
+    2. The total number of pixels is within the range ['min_pixels', 'max_pixels'].
+
+    3. The aspect ratio of the image is maintained as closely as possible.
+    """
+    if max(height, width) / min(height, width) > MAX_RATIO:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than {MAX_RATIO}, got {max(height, width) / min(height, width)}"
+        )
+    h_bar = max(factor, round_by_factor(height, factor))
+    w_bar = max(factor, round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = floor_by_factor(height / beta, factor)
+        w_bar = floor_by_factor(width / beta, factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = ceil_by_factor(height * beta, factor)
+        w_bar = ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def fetch_image(ele: dict[str, str | Image.Image],
+                size_factor: int = IMAGE_FACTOR) -> Image.Image:
+    if "image" in ele:
+        image = ele["image"]
+    else:
+        image = ele["image_url"]
+    image_obj = None
+    if isinstance(image, Image.Image):
+        image_obj = image
+    elif image.startswith("http://") or image.startswith("https://"):
+        image_obj = Image.open(requests.get(image, stream=True).raw)
+    elif image.startswith("file://"):
+        image_obj = Image.open(image[7:])
+    elif image.startswith("data:image"):
+        if "base64," in image:
+            _, base64_data = image.split("base64,", 1)
+            data = base64.b64decode(base64_data)
+            image_obj = Image.open(BytesIO(data))
+    else:
+        image_obj = Image.open(image)
+    if image_obj is None:
+        raise ValueError(
+            f"Unrecognized image input, support local path, http url, base64 and PIL.Image, got {image}"
+        )
+    image = image_obj.convert("RGB")
+    ## resize
+    if "resized_height" in ele and "resized_width" in ele:
+        resized_height, resized_width = smart_resize(
+            ele["resized_height"],
+            ele["resized_width"],
+            factor=size_factor,
+        )
+    else:
+        width, height = image.size
+        min_pixels = ele.get("min_pixels", MIN_PIXELS)
+        max_pixels = ele.get("max_pixels", MAX_PIXELS)
+        resized_height, resized_width = smart_resize(
+            height,
+            width,
+            factor=size_factor,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
+    image = image.resize((resized_width, resized_height))
+
+    return image
+
+
+def smart_nframes(
+    ele: dict,
+    total_frames: int,
+    video_fps: int | float,
+) -> int:
+    """calculate the number of frames for video used for model inputs.
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+            support either `fps` or `nframes`:
+                - nframes: the number of frames to extract for model inputs.
+                - fps: the fps to extract frames for model inputs.
+                    - min_frames: the minimum number of frames of the video, only used when fps is provided.
+                    - max_frames: the maximum number of frames of the video, only used when fps is provided.
+        total_frames (int): the original total number of frames of the video.
+        video_fps (int | float): the original fps of the video.
+
+    Raises:
+        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
+
+    Returns:
+        int: the number of frames for video used for model inputs.
+    """
+    assert not ("fps" in ele
+                and "nframes" in ele), "Only accept either `fps` or `nframes`"
+    if "nframes" in ele:
+        nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
+    else:
+        fps = ele.get("fps", FPS)
+        min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES),
+                                    FRAME_FACTOR)
+        max_frames = floor_by_factor(
+            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)),
+            FRAME_FACTOR)
+        nframes = total_frames / video_fps * fps
+        nframes = min(max(nframes, min_frames), max_frames)
+        nframes = round_by_factor(nframes, FRAME_FACTOR)
+    if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
+        raise ValueError(
+            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
+        )
+    return nframes
+
+
+def _read_video_torchvision(ele: dict, ) -> torch.Tensor:
+    """read video using torchvision.io.read_video
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+        support keys:
+            - video: the path of video. support "file://", "http://", "https://" and local path.
+            - video_start: the start time of video.
+            - video_end: the end time of video.
+    Returns:
+        torch.Tensor: the video tensor with shape (T, C, H, W).
+    """
+    video_path = ele["video"]
+    if version.parse(torchvision.__version__) < version.parse("0.19.0"):
+        if "http://" in video_path or "https://" in video_path:
+            warnings.warn(
+                "torchvision < 0.19.0 does not support http/https video path, please upgrade to 0.19.0."
+            )
+        if "file://" in video_path:
+            video_path = video_path[7:]
+    st = time.time()
+    video, audio, info = io.read_video(
+        video_path,
+        start_pts=ele.get("video_start", 0.0),
+        end_pts=ele.get("video_end", None),
+        pts_unit="sec",
+        output_format="TCHW",
+    )
+    total_frames, video_fps = video.size(0), info["video_fps"]
+    total_duration = round(total_frames / video_fps, 3)
+    logger.info(
+        f"torchvision:  {video_path=}, {total_frames=}, {video_fps=}, duration={total_duration}s, time={time.time() - st:.3f}s"
+    )
+    nframes = smart_nframes(ele,
+                            total_frames=total_frames,
+                            video_fps=video_fps)
+    idx = torch.linspace(0, total_frames - 1, nframes).round().long()
+    video = video[idx]
+    return video, total_duration, nframes
+
+
+def is_decord_available() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("decord") is not None
+
+
+def _read_video_decord(ele: dict, ) -> torch.Tensor:
+    """read video using decord.VideoReader
+
+    Args:
+        ele (dict): a dict contains the configuration of video.
+        support keys:
+            - video: the path of video. support "file://", "http://", "https://" and local path.
+            - video_start: the start time of video.
+            - video_end: the end time of video.
+    Returns:
+        torch.Tensor: the video tensor with shape (T, C, H, W).
+    """
+    import decord
+    video_path = ele["video"]
+    st = time.time()
+    vr = decord.VideoReader(video_path)
+    # TODO: support start_pts and end_pts
+    if 'video_start' in ele or 'video_end' in ele:
+        raise NotImplementedError(
+            "not support start_pts and end_pts in decord for now.")
+    total_frames, video_fps = len(vr), vr.get_avg_fps()
+    total_duration = round(total_frames / video_fps, 3)
+    logger.info(
+        f"decord:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s"
+    )
+    nframes = smart_nframes(ele,
+                            total_frames=total_frames,
+                            video_fps=video_fps)
+    idx = torch.linspace(0, total_frames - 1, nframes).round().long().tolist()
+    video = vr.get_batch(idx).asnumpy()
+    video = torch.tensor(video).permute(0, 3, 1, 2)  # Convert to TCHW format
+    return video, total_duration, nframes
+
+
+VIDEO_READER_BACKENDS = {
+    "decord": _read_video_decord,
+    "torchvision": _read_video_torchvision,
+}
+
+FORCE_QWENVL_VIDEO_READER = os.getenv("FORCE_QWENVL_VIDEO_READER", None)
+
+
+@lru_cache(maxsize=1)
+def get_video_reader_backend() -> str:
+    if FORCE_QWENVL_VIDEO_READER is not None:
+        video_reader_backend = FORCE_QWENVL_VIDEO_READER
+    elif is_decord_available():
+        video_reader_backend = "decord"
+    else:
+        video_reader_backend = "torchvision"
+    # print(f"qwen-vl-utils using {video_reader_backend} to read video.", file=sys.stderr)
+    return video_reader_backend
+
+
+def fetch_video(
+        ele: dict,
+        image_factor: int = IMAGE_FACTOR) -> torch.Tensor | list[Image.Image]:
+    if isinstance(ele["video"], str):
+        video_reader_backend = get_video_reader_backend()
+        video, total_dur, nframes = VIDEO_READER_BACKENDS[
+            video_reader_backend](ele)
+        frame_timestamps = total_dur * torch.arange(1, nframes + 1) / nframes
+        grid_timestamps = frame_timestamps[::FRAME_FACTOR]
+        second_per_grid = grid_timestamps[1] - grid_timestamps[0]
+        nframes, _, height, width = video.shape
+        factor = spatial_patch_size * spatial_merge_size
+        min_pixels = ele.get("min_pixels", VIDEO_MIN_PIXELS)
+        total_pixels = ele.get("total_pixels", VIDEO_TOTAL_PIXELS)
+        max_pixels = max(
+            min(VIDEO_MAX_PIXELS, total_pixels / nframes * FRAME_FACTOR),
+            int(min_pixels * 1.05))
+        max_pixels = ele.get("max_pixels", max_pixels)
+        # min_pixels = (factor ** 2) * 52
+        # max_pixels = (factor ** 2) * min(768, (16384 / nframes * temporal_patch_size))
+        if "resized_height" in ele and "resized_width" in ele:
+            resized_height, resized_width = smart_resize(
+                ele["resized_height"],
+                ele["resized_width"],
+                factor=image_factor,
+            )
+        else:
+            resized_height, resized_width = smart_resize(
+                height,
+                width,
+                factor=image_factor,
+                min_pixels=min_pixels,
+                max_pixels=max_pixels,
+            )
+        video = transforms.functional.resize(
+            video,
+            [resized_height, resized_width],
+            interpolation=InterpolationMode.BICUBIC,
+            antialias=True,
+        ).float()
+        return video, total_dur, nframes, second_per_grid
+    else:
+        assert isinstance(ele["video"], (list, tuple))
+        process_info = ele.copy()
+        process_info.pop("type", None)
+        process_info.pop("video", None)
+        images = [
+            fetch_image({
+                "image": video_element,
+                **process_info
+            },
+                        size_factor=image_factor)
+            for video_element in ele["video"]
+        ]
+        nframes = ceil_by_factor(len(images), FRAME_FACTOR)
+        if len(images) < nframes:
+            images.extend([images[-1]] * (nframes - len(images)))
+        return images, None, None, None
+
+
+def extract_vision_info(
+        conversations: list[dict] | list[list[dict]]) -> list[dict]:
+    vision_infos = []
+    if isinstance(conversations[0], dict):
+        conversations = [conversations]
+    for conversation in conversations:
+        for message in conversation:
+            if isinstance(message["content"], list):
+                for ele in message["content"]:
+                    if ("image" in ele or "image_url" in ele or "video" in ele
+                            or ele["type"] in ("image", "image_url", "video")):
+                        vision_infos.append(ele)
+    return vision_infos
+
+
+def process_vision_info(
+    conversations: list[dict] | list[list[dict]],
+) -> tuple[list[Image.Image] | None, list[torch.Tensor | list[Image.Image]]
+           | None]:
+    vision_infos = extract_vision_info(conversations)
+    ## Read images or videos
+    image_inputs = []
+    video_inputs = []
+    for vision_info in vision_infos:
+        if "image" in vision_info or "image_url" in vision_info:
+            image_inputs.append(fetch_image(vision_info))
+        elif "video" in vision_info:
+            video_inputs.append(fetch_video(vision_info))
+        else:
+            raise ValueError("image, image_url or video should in content.")
+    if len(image_inputs) == 0:
+        image_inputs = None
+    if len(video_inputs) == 0:
+        video_inputs = None
+    return image_inputs, video_inputs

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -129,8 +129,10 @@ class MultiModalProfiler(Generic[_I]):
         supported_mm_limits = self.processing_info.get_supported_mm_limits()
 
         mm_limits = {
-            modality: mm_config.get_limit_per_prompt(modality)
-            for modality in supported_mm_limits
+            modality:
+            1 if limit is None else min(limit,
+                                        mm_config.get_limit_per_prompt(modality))
+            for modality, limit in supported_mm_limits.items()
         }
 
         for modality, supported_limit in supported_mm_limits.items():

--- a/vllm/multimodal/utils.py
+++ b/vllm/multimodal/utils.py
@@ -104,7 +104,7 @@ class MediaConnector:
         if url_spec.scheme == "data":
             return self._load_data_url(url_spec, media_io)
 
-        if url_spec.scheme == "file":
+        if url_spec.scheme == "file" or url_spec.scheme == "":
             return self._load_file_url(url_spec, media_io)
 
         msg = "The URL must be either a HTTP, data or file URL."

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -43,6 +43,7 @@ class CompletionOutput:
     finish_reason: Optional[str] = None
     stop_reason: Union[int, str, None] = None
     lora_request: Optional[LoRARequest] = None
+    prompt_embeds: Optional[torch.Tensor] = None
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -264,6 +265,7 @@ class RequestOutput:
                 output.finish_reason = SequenceStatus.get_finished_reason(
                     seq.status)
                 output.stop_reason = seq.stop_reason
+                output.prompt_embeds = seq.data.prompt_embeds
 
             else:
                 output = CompletionOutput(
@@ -272,7 +274,8 @@ class RequestOutput:
                     seq.get_cumulative_logprob() if include_logprobs else None,
                     output_logprobs,
                     SequenceStatus.get_finished_reason(seq.status),
-                    seq.stop_reason)
+                    seq.stop_reason,
+                    prompt_embeds=seq.data.prompt_embeds)
 
             outputs.append(output)
 

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -21,11 +21,11 @@ def vllm_version_matches_substr(substr: str) -> bool:
     from importlib.metadata import PackageNotFoundError, version
     try:
         vllm_version = version("vllm")
-    except PackageNotFoundError as e:
+    except PackageNotFoundError:
         logger.warning(
             "The vLLM package was not found, so its version could not be "
             "inspected. This may cause platform detection to fail.")
-        raise e
+        vllm_version = "dev"
     return substr in vllm_version
 
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -256,7 +256,10 @@ class CudaPlatformBase(Platform):
         # installed.
         if target_backend == _Backend.FLASH_ATTN:
             try:
-                import vllm.vllm_flash_attn  # noqa: F401
+                try:
+                    import vllm.vllm_flash_attn  # noqa: F401
+                except (ImportError, ModuleNotFoundError):
+                    import vllm_flash_attn  # noqa: F401
                 from vllm.attention.backends.flash_attn import (  # noqa: F401
                     FlashAttentionBackend, flash_attn_supports_fp8)
 

--- a/vllm/transformers_utils/processor.py
+++ b/vllm/transformers_utils/processor.py
@@ -104,9 +104,59 @@ def cached_processor_from_config(
     **kwargs: Any,
 ) -> _P:
     return cached_get_processor(
-        model_config.model,
+        model_config.processor or model_config.model,
         trust_remote_code=model_config.trust_remote_code,
         processor_cls=processor_cls,  # type: ignore[arg-type]
+        **_merge_mm_kwargs(model_config, **kwargs),
+    )
+
+
+def get_feature_extractor(
+    processor_name: str,
+    *args: Any,
+    trust_remote_code: bool = False,
+    **kwargs: Any,
+):
+    """Load an image processor for the given model name via HuggingFace."""
+    # don't put this import at the top level
+    # it will call torch.cuda.device_count()
+    from transformers import AutoFeatureExtractor
+    from transformers.feature_extraction_utils import FeatureExtractionMixin
+
+    try:
+        feature_extractor = AutoFeatureExtractor.from_pretrained(
+            processor_name,
+            *args,
+            trust_remote_code=trust_remote_code,
+            **kwargs)
+    except ValueError as e:
+        # If the error pertains to the processor class not existing or not
+        # currently being imported, suggest using the --trust-remote-code flag.
+        # Unlike AutoTokenizer, AutoImageProcessor does not separate such errors
+        if not trust_remote_code:
+            err_msg = (
+                "Failed to load the feature extractor. If the feature extractor is "
+                "a custom extractor not yet available in the HuggingFace "
+                "transformers library, consider setting "
+                "`trust_remote_code=True` in LLM or using the "
+                "`--trust-remote-code` flag in the CLI.")
+            raise RuntimeError(err_msg) from e
+        else:
+            raise e
+
+    return cast(FeatureExtractionMixin, feature_extractor)
+
+
+cached_get_feature_extractor = lru_cache(get_feature_extractor)
+
+
+def cached_feature_extractor_from_config(
+    model_config: "ModelConfig",
+    **kwargs: Any,
+):
+    return cached_get_feature_extractor(
+        model_config.processor,
+        trust_remote_code=model_config.trust_remote_code,
         **_merge_mm_kwargs(model_config, **kwargs),
     )
 
@@ -155,7 +205,7 @@ def cached_image_processor_from_config(
     **kwargs: Any,
 ):
     return cached_get_image_processor(
-        model_config.model,
+        model_config.processor or model_config.model,
         trust_remote_code=model_config.trust_remote_code,
         **_merge_mm_kwargs(model_config, **kwargs),
     )

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/dit.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/dit.py
@@ -1,0 +1,298 @@
+"""
+ein notation:
+b - batch
+n - sequence
+nt - text sequence
+nw - raw wave length
+d - dimension
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from x_transformers.x_transformers import RotaryEmbedding
+
+from vllm.transformers_utils.qwen2_code2wav_dit.model.spk_encoder import ECAPA_TDNN
+from vllm.transformers_utils.qwen2_code2wav_dit.model.dit_modules import (
+    TimestepEmbedding,
+    ConvNeXtV2Block,
+    ConvPositionEmbedding,
+    DiTBlock,
+    AdaLayerNormZero_Final,
+    precompute_freqs_cis,
+    get_pos_embed_indices,
+)
+
+# Text embedding
+class CodecEmbedding(nn.Module):
+    def __init__(self, codec_num_embeds, codec_dim, repeats):
+        super().__init__()
+        self.repeats = repeats
+        self.codec_embed = nn.Embedding(codec_num_embeds + 1, codec_dim)
+
+    def forward(self, codec: int["b nc"], seq_len, drop_text=False):
+        if drop_text:
+            codec = torch.zeros_like(codec)
+        codec = self.codec_embed(codec)
+        codec = torch.repeat_interleave(codec, repeats=self.repeats, dim=1)
+        return codec
+
+class TextEmbedding(nn.Module):
+    def __init__(self, text_num_embeds, text_dim, conv_layers=0, conv_mult=2):
+        super().__init__()
+        self.text_embed = nn.Embedding(text_num_embeds + 1, text_dim)  # use 0 as filler token
+
+        if conv_layers > 0:
+            self.extra_modeling = True
+            self.precompute_max_pos = 4096  # ~44s of 24khz audio
+            self.register_buffer("freqs_cis", precompute_freqs_cis(text_dim, self.precompute_max_pos), persistent=False)
+            self.text_blocks = nn.Sequential(
+                *[ConvNeXtV2Block(text_dim, text_dim * conv_mult) for _ in range(conv_layers)]
+            )
+        else:
+            self.extra_modeling = False
+
+    def forward(self, text: int["b nt"], seq_len, drop_text=False):  # noqa: F722
+        text = text + 1  # use 0 as filler token. preprocess of batch pad -1, see list_str_to_idx()
+        text = text[:, :seq_len]  # curtail if character tokens are more than the mel spec tokens
+        batch, text_len = text.shape[0], text.shape[1]
+        text = F.pad(text, (0, seq_len - text_len), value=0)
+
+        if drop_text:  # cfg for text
+            text = torch.zeros_like(text)
+
+        text = self.text_embed(text)  # b n -> b n d
+
+        # possible extra modeling
+        if self.extra_modeling:
+            # sinus pos emb
+            batch_start = torch.zeros((batch,), dtype=torch.long)
+            pos_idx = get_pos_embed_indices(batch_start, seq_len, max_pos=self.precompute_max_pos)
+            text_pos_embed = self.freqs_cis[pos_idx]
+            text = text + text_pos_embed
+
+            # convnextv2 blocks
+            text = self.text_blocks(text)
+
+        return text
+
+
+# noised input audio and context mixing embedding
+
+
+class InputEmbedding(nn.Module):
+    def __init__(self, mel_dim, text_dim, out_dim):
+        super().__init__()
+        self.proj = nn.Linear(mel_dim+ 128 + 192 + text_dim, out_dim) # 192 for x-vector
+        self.spk_encoder = ECAPA_TDNN(80, 128,
+                                        channels=[256, 256, 256, 256, 768],
+                                        kernel_sizes=[5, 3, 3, 3, 1],
+                                        dilations=[1, 2, 3, 4, 1],
+                                        attention_channels=64,
+                                        res2net_scale=2,
+                                        se_channels=64,
+                                        global_context=True,
+                                        batch_norm=False)
+        # remove convposembedding for causal or block causal
+        # self.conv_pos_embed = ConvPositionEmbedding(dim=out_dim)
+
+    def forward(self, x: float["b n d"],spk: float["b n d"], cond: float["b n d"], text_embed: float["b n d"], drop_audio_cond=False):  # noqa: F722
+        
+        if drop_audio_cond:  # cfg for cond audio
+            cond = torch.zeros_like(cond)
+            spk = torch.zeros_like(spk)
+        cond = self.spk_encoder(cond).unsqueeze(1).repeat(1, x.size(1), 1)
+        # import pdb; pdb.set_trace() 
+        # print(x.shape,cond.shape,text_embed.shape)
+        x = self.proj(torch.cat((x, cond, text_embed, spk), dim=-1))
+        # x = self.conv_pos_embed(x) + x
+        return x
+    
+    def fast_forward(self, x, spk, cond, text_embed,text_embed_uncond):
+        x = torch.cat([x,x],dim=0)
+        spk = torch.cat([spk,torch.zeros_like(spk)],dim=0)
+        cond = torch.cat([cond,torch.rand_like(cond)],dim=0)
+        cond = self.spk_encoder(cond).unsqueeze(1).repeat(1, x.size(1), 1)
+        text_emb = torch.cat([text_embed,text_embed_uncond],dim=0)
+        x = self.proj(torch.cat((x, cond, text_emb, spk), dim=-1))
+
+        return x
+
+
+
+# Transformer backbone using DiT blocks
+
+
+class DiT(nn.Module):
+    def __init__(
+        self,
+        *,
+        dim,
+        depth=8,
+        heads=8,
+        dim_head=64,
+        dropout=0.1,
+        ff_mult=4,
+        mel_dim=100,
+        text_num_embeds=256,
+        text_dim=None,
+        conv_layers=0,
+        long_skip_connection=False,
+        use_codec=False, 
+        attn_processor="",
+        repeats=2
+    ):
+        super().__init__()
+        self.repeats = repeats
+        self.time_embed = TimestepEmbedding(dim)
+        if text_dim is None:
+            text_dim = mel_dim
+        if not use_codec:
+            self.text_embed = TextEmbedding(text_num_embeds, text_dim, conv_layers=conv_layers)
+        else:
+            self.text_embed = CodecEmbedding(text_num_embeds, text_dim, repeats=repeats)
+        self.input_embed = InputEmbedding(mel_dim, text_dim, dim)
+        
+        self.rotary_embed = RotaryEmbedding(dim_head)
+
+        self.dim = dim
+        self.depth = depth
+        if attn_processor == "stream_block_sr":
+            attn_processor_0 = 'stream_block_sr_00'
+            attn_processor_1 = 'stream_block_sr_10'
+            attn_processor_2 = 'stream_block_sr_01'
+            self.transformer_blocks = nn.ModuleList()
+            for i in range(depth):
+                if i == 0 or i == 20:
+                    attn_processor_in = attn_processor_1
+                elif i == 10: 
+                    attn_processor_in = attn_processor_2
+                else:
+                    attn_processor_in = attn_processor_0
+                self.transformer_blocks.append(
+                    DiTBlock(dim=dim, heads=heads, dim_head=dim_head, ff_mult=ff_mult, dropout=dropout, attn_processor=attn_processor_in)
+                )
+        elif attn_processor == "stream_block_sr_low":
+            attn_processor_0 = 'stream_block_sr_00'
+            attn_processor_1 = 'stream_block_sr_11'
+            attn_processor_2 = 'stream_block_sr_10'
+            self.transformer_blocks = nn.ModuleList()
+            for i in range(depth):
+                if i == 0:
+                    attn_processor_in = attn_processor_1
+                elif i == 10 or i == 20: 
+                    attn_processor_in = attn_processor_2
+                else:
+                    attn_processor_in = attn_processor_0
+                self.transformer_blocks.append(
+                    DiTBlock(dim=dim, heads=heads, dim_head=dim_head, ff_mult=ff_mult, dropout=dropout, attn_processor=attn_processor_in)
+                )
+        elif attn_processor == 'stream_block':
+            attn_processor_0 = 'stream_block_0'
+            attn_processor_1 = 'stream_block_1'
+            self.transformer_blocks = nn.ModuleList(
+                [DiTBlock(dim=dim, heads=heads, dim_head=dim_head, ff_mult=ff_mult, dropout=dropout, attn_processor=attn_processor_1 if i%5==0 else attn_processor_0) for i in range(depth)]
+            )
+        elif attn_processor == "stream_block_8_L_4":
+            attn_processor_0 = 'stream_block_8_00'
+            attn_processor_1 = 'stream_block_8_10'
+            attn_processor_2 = 'stream_block_8_01'
+            self.transformer_blocks = nn.ModuleList()
+            for i in range(depth):
+                if i == 0 or i == 8 or i == 24 or i == 30:
+                    attn_processor_in = attn_processor_1
+                elif i == 15:
+                    attn_processor_in = attn_processor_2
+                else:
+                    attn_processor_in = attn_processor_0
+                self.transformer_blocks.append(
+                    DiTBlock(dim=dim, heads=heads, dim_head=dim_head, ff_mult=ff_mult, dropout=dropout, attn_processor=attn_processor_in)
+                )
+        else:
+            self.transformer_blocks = nn.ModuleList(
+                [DiTBlock(dim=dim, heads=heads, dim_head=dim_head, ff_mult=ff_mult, dropout=dropout, attn_processor=attn_processor) for i in range(depth)]
+            )
+        self.long_skip_connection = nn.Linear(dim * 2, dim, bias=False) if long_skip_connection else None
+
+        self.norm_out = AdaLayerNormZero_Final(dim)  # final modulation
+        self.proj_out = nn.Linear(dim, mel_dim)
+
+    def forward(
+        self,
+        x: float["b n d"],  # nosied input audio  # noqa: F722
+        cond: float["b n d"],  # masked cond audio  # noqa: F722
+        spk: float["b n d"],  # spk embedding  # noqa: F722
+        text: int["b nt"],  # text  # noqa: F722
+        time: float["b"] | float[""],  # time step  # noqa: F821 F722
+        drop_audio_cond,  # cfg for cond audio
+        drop_text,  # cfg for text
+        mask: bool["b n"] | None = None,  # noqa: F722
+    ):
+        batch, seq_len = x.shape[0], x.shape[1]
+        if time.ndim == 0:
+            time = time.repeat(batch)
+
+        # t: conditioning time, c: context (text + masked cond audio), x: noised input audio
+        t = self.time_embed(time)
+        text_embed = self.text_embed(text, seq_len, drop_text=drop_text)
+        # print(spk.dtype, cond.dtype, text_embed.dtype)
+        # import pdb; pdb.set_trace()
+        x = self.input_embed(x, spk, cond, text_embed, drop_audio_cond=drop_audio_cond)
+
+        rope = self.rotary_embed.forward_from_seq_len(seq_len)
+
+        if self.long_skip_connection is not None:
+            residual = x
+
+        for block in self.transformer_blocks:
+            x = block(x, t, mask=mask, rope=rope)
+
+        if self.long_skip_connection is not None:
+            x = self.long_skip_connection(torch.cat((x, residual), dim=-1))
+
+        x = self.norm_out(x, t)
+        output = self.proj_out(x)
+
+        return output
+
+    @torch.no_grad()
+    def fast_forward(
+        self,
+        x: float["b n d"],  # nosied input audio  # noqa: F722
+        cond: float["b n d"],  # masked cond audio  # noqa: F722
+        spk: float["b n d"],  # spk embedding  # noqa: F722
+        text: int["b nt"],  # text  # noqa: F722
+        time: float["b"] | float[""],  # time step  # noqa: F821 F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+    ) -> float["b n d"]:
+        batch, seq_len = x.shape[0]*2, x.shape[1]
+        if time.ndim == 0:
+            time = time.repeat(batch)
+
+        # t: conditioning time, c: context (text + masked cond audio), x: noised input audio
+        t = self.time_embed(time)
+        text_embed = self.text_embed(text, seq_len, drop_text=False)
+        text_embed_uncond = self.text_embed(text, seq_len, drop_text=True)
+        # print(spk.dtype, cond.dtype, text_embed.dtype)
+        # import pdb; pdb.set_trace()
+        x = self.input_embed.fast_forward(x, spk, cond, text_embed, text_embed_uncond)
+
+        rope = self.rotary_embed.forward_from_seq_len(seq_len)
+
+        if self.long_skip_connection is not None:
+            residual = x
+
+        for block in self.transformer_blocks:
+            x = block(x, t, mask=mask, rope=rope)
+
+        if self.long_skip_connection is not None:
+            x = self.long_skip_connection(torch.cat((x, residual), dim=-1))
+
+        x = self.norm_out(x, t)
+        output = self.proj_out(x)
+
+        return output
+    

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/dit_modules.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/dit_modules.py
@@ -1,0 +1,898 @@
+"""
+ein notation:
+b - batch
+n - sequence
+nt - text sequence
+nw - raw wave length
+d - dimension
+"""
+
+from __future__ import annotations
+from typing import Optional
+import math
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torchaudio
+
+from x_transformers.x_transformers import apply_rotary_pos_emb
+
+
+# raw wav to mel spec
+
+
+class MelSpec(nn.Module):
+    def __init__(
+        self,
+        filter_length=1024,
+        hop_length=256,
+        win_length=1024,
+        n_mel_channels=100,
+        target_sample_rate=24_000,
+        normalize=False,
+        power=1,
+        norm=None,
+        center=True,
+    ):
+        super().__init__()
+        self.n_mel_channels = n_mel_channels
+
+        self.mel_stft = torchaudio.transforms.MelSpectrogram(
+            sample_rate=target_sample_rate,
+            n_fft=filter_length,
+            win_length=win_length,
+            hop_length=hop_length,
+            n_mels=n_mel_channels,
+            power=power,
+            center=center,
+            normalized=normalize,
+            norm=norm,
+        )
+
+        self.register_buffer("dummy", torch.tensor(0), persistent=False)
+
+    def forward(self, inp):
+        if len(inp.shape) == 3:
+            inp = inp.squeeze(1)  # 'b 1 nw -> b nw'
+
+        assert len(inp.shape) == 2
+
+        if self.dummy.device != inp.device:
+            self.to(inp.device)
+
+        mel = self.mel_stft(inp)
+        mel = mel.clamp(min=1e-5).log()
+        return mel
+
+
+# sinusoidal position embedding
+
+
+class SinusPositionEmbedding(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x, scale=1000):
+        device = x.device
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = torch.exp(torch.arange(half_dim, device=device).float() * -emb)
+        emb = scale * x.unsqueeze(1) * emb.unsqueeze(0)
+        emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
+        return emb
+
+
+# convolutional position embedding
+
+
+class ConvPositionEmbedding(nn.Module):
+    def __init__(self, dim, kernel_size=31, groups=16):
+        super().__init__()
+        assert kernel_size % 2 != 0
+        self.conv1d = nn.Sequential(
+            nn.Conv1d(dim, dim, kernel_size, groups=groups, padding=kernel_size // 2),
+            nn.Mish(),
+            nn.Conv1d(dim, dim, kernel_size, groups=groups, padding=kernel_size // 2),
+            nn.Mish(),
+        )
+
+    def forward(self, x: float["b n d"], mask: bool["b n"] | None = None):  # noqa: F722
+        if mask is not None:
+            mask = mask[..., None]
+            x = x.masked_fill(~mask, 0.0)
+
+        x = x.permute(0, 2, 1)
+        x = self.conv1d(x)
+        out = x.permute(0, 2, 1)
+
+        if mask is not None:
+            out = out.masked_fill(~mask, 0.0)
+
+        return out
+
+
+# rotary positional embedding related
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, theta_rescale_factor=1.0):
+    # proposed by reddit user bloc97, to rescale rotary embeddings to longer sequence length without fine-tuning
+    # has some connection to NTK literature
+    # https://www.reddit.com/r/LocalLLaMA/comments/14lz7j5/ntkaware_scaled_rope_allows_llama_models_to_have/
+    # https://github.com/lucidrains/rotary-embedding-torch/blob/main/rotary_embedding_torch/rotary_embedding_torch.py
+    theta *= theta_rescale_factor ** (dim / (dim - 2))
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    freqs_cos = torch.cos(freqs)  # real part
+    freqs_sin = torch.sin(freqs)  # imaginary part
+    return torch.cat([freqs_cos, freqs_sin], dim=-1)
+
+
+def get_pos_embed_indices(start, length, max_pos, scale=1.0):
+    # length = length if isinstance(length, int) else length.max()
+    scale = scale * torch.ones_like(start, dtype=torch.float32)  # in case scale is a scalar
+    pos = (
+        start.unsqueeze(1)
+        + (torch.arange(length, device=start.device, dtype=torch.float32).unsqueeze(0) * scale.unsqueeze(1)).long()
+    )
+    # avoid extra long error.
+    pos = torch.where(pos < max_pos, pos, max_pos - 1)
+    return pos
+
+
+# Global Response Normalization layer (Instance Normalization ?)
+
+
+class GRN(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gamma = nn.Parameter(torch.zeros(1, 1, dim))
+        self.beta = nn.Parameter(torch.zeros(1, 1, dim))
+
+    def forward(self, x):
+        Gx = torch.norm(x, p=2, dim=1, keepdim=True)
+        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)
+        return self.gamma * (x * Nx) + self.beta + x
+
+
+# ConvNeXt-V2 Block https://github.com/facebookresearch/ConvNeXt-V2/blob/main/models/convnextv2.py
+# ref: https://github.com/bfs18/e2_tts/blob/main/rfwave/modules.py#L108
+
+
+class ConvNeXtV2Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        intermediate_dim: int,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        padding = (dilation * (7 - 1)) // 2
+        self.dwconv = nn.Conv1d(
+            dim, dim, kernel_size=7, padding=padding, groups=dim, dilation=dilation
+        )  # depthwise conv
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, intermediate_dim)  # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.grn = GRN(intermediate_dim)
+        self.pwconv2 = nn.Linear(intermediate_dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = x.transpose(1, 2)  # b n d -> b d n
+        x = self.dwconv(x)
+        x = x.transpose(1, 2)  # b d n -> b n d
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.grn(x)
+        x = self.pwconv2(x)
+        return residual + x
+
+
+# AdaLayerNormZero
+# return with modulated x for attn input, and params for later mlp modulation
+
+
+class AdaLayerNormZero(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(dim, dim * 6)
+
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(self, x, emb=None):
+        emb = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = torch.chunk(emb, 6, dim=1)
+
+        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+# AdaLayerNormZero for final layer
+# return only with modulated x for attn input, cuz no more mlp modulation
+
+
+class AdaLayerNormZero_Final(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(dim, dim * 2)
+
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(self, x, emb):
+        emb = self.linear(self.silu(emb))
+        scale, shift = torch.chunk(emb, 2, dim=1)
+
+        x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+        return x
+
+
+# FeedForward
+
+
+class FeedForward(nn.Module):
+    def __init__(self, dim, dim_out=None, mult=4, dropout=0.0, approximate: str = "none"):
+        super().__init__()
+        inner_dim = int(dim * mult)
+        dim_out = dim_out if dim_out is not None else dim
+
+        activation = nn.GELU(approximate=approximate)
+        project_in = nn.Sequential(nn.Linear(dim, inner_dim), activation)
+        self.ff = nn.Sequential(project_in, nn.Dropout(dropout), nn.Linear(inner_dim, dim_out))
+
+    def forward(self, x):
+        for i in range(len(self.ff)):
+            tmp = self.ff[i](x)
+            x = tmp 
+        return x
+        # return self.ff(x)
+
+
+# Attention with possible joint part
+# modified from diffusers/src/diffusers/models/attention_processor.py
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        processor: JointAttnProcessor | AttnProcessor | BlockSelfAttnProcessor|SteamingAttnProcessor,
+        dim: int,
+        heads: int = 8,
+        dim_head: int = 64,
+        dropout: float = 0.0,
+        context_dim: Optional[int] = None,  # if not None -> joint attention
+        context_pre_only=None,
+    ):
+        super().__init__()
+
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("Attention equires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+        # print('use attn processor:',processor)
+        self.processor = processor
+
+        self.dim = dim
+        self.heads = heads
+        self.inner_dim = dim_head * heads
+        self.dropout = dropout
+
+        self.context_dim = context_dim
+        self.context_pre_only = context_pre_only
+
+        self.to_q = nn.Linear(dim, self.inner_dim)
+        self.to_k = nn.Linear(dim, self.inner_dim)
+        self.to_v = nn.Linear(dim, self.inner_dim)
+
+        if self.context_dim is not None:
+            self.to_k_c = nn.Linear(context_dim, self.inner_dim)
+            self.to_v_c = nn.Linear(context_dim, self.inner_dim)
+            if self.context_pre_only is not None:
+                self.to_q_c = nn.Linear(context_dim, self.inner_dim)
+
+        self.to_out = nn.ModuleList([])
+        self.to_out.append(nn.Linear(self.inner_dim, dim))
+        self.to_out.append(nn.Dropout(dropout))
+
+        if self.context_pre_only is not None and not self.context_pre_only:
+            self.to_out_c = nn.Linear(self.inner_dim, dim)
+
+    def forward(
+        self,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        c: float["b n d"] = None,  # context c  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding for x
+        c_rope=None,  # rotary position embedding for c
+    ) -> torch.Tensor:
+        if c is not None:
+            return self.processor(self, x, c=c, mask=mask, rope=rope, c_rope=c_rope)
+        else:
+            return self.processor(self, x, mask=mask, rope=rope)
+
+
+# Attention processor
+
+
+class AttnProcessor:
+    def __init__(self):
+        pass
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        else:
+            attn_mask = None
+
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+    
+
+class GlobalStreamSelfAttnProcessor:
+    def __init__(self, block_size=50,global_size=200,look_ahead_block=0,look_backward_block=0):
+        self.block_size = block_size
+        self.global_size = global_size 
+        self.look_ahead_block = look_ahead_block
+        self.look_backward_block = look_backward_block
+    def create_global_block_causal_mask(self,seq_length,device):
+
+        
+        
+        # 为每个 token 分配块索引
+        positions = torch.arange(seq_length, device=device)  # [seq_length]
+        
+        if self.global_size > 0:
+            # 分配块索引：全局块为 0，其余块从 1 开始
+            block_indices = torch.where(
+                positions < self.global_size,
+                torch.zeros_like(positions),
+                1 + (positions - self.global_size) // self.block_size
+            )
+        else:
+            # 没有全局块，所有块按普通块分配
+            block_indices = positions // self.block_size  # [seq_length]
+        
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        
+        # 计算块索引的差值
+        block_diff = block_j - block_i  # 形状为 (seq_length, seq_length)
+        
+        # 定义允许的块范围
+        mask = (block_diff >= -float(self.look_backward_block)) & (block_diff <= float(self.look_ahead_block))
+        
+        if self.global_size > 0:
+            # 确定哪些位置属于全局块
+            is_global_i = block_i == 0  # [seq_length, 1]
+            is_global_j = block_j == 0  # [1, seq_length]
+            
+            # 所有块都可以看到全局块
+            # 这意味着如果 j 是全局块，mask[i, j] = True
+            mask = (mask | is_global_j) & (~is_global_i|is_global_j)
+            
+            # 全局块可以看到所有块
+            # 这意味着如果 i 是全局块，mask[i, j] = True
+            # mask = mask | is_global_i
+        
+        # 调整掩码形状为 [1, 1, seq_length, seq_length] 以适配多头注意力
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        
+        return mask
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_global_block_causal_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+
+
+class BlockSelfAttnProcessor:
+    def __init__(self, block_size=100):
+        self.block_size = block_size
+
+    def create_block_causal_mask(self, seq_length, device=None):
+        """
+        创建 Block Causal Attention 的 attention mask。
+
+        参数：
+        - seq_length (int): 序列的长度。
+        - device (torch.device, optional): 设备类型。
+
+        返回：
+        - mask (torch.Tensor): attention mask，形状为 [1, 1, seq_length, seq_length]。
+        """
+        # 为每个 token 分配块索引
+        block_indices = torch.arange(seq_length, device=device) // self.block_size  # [seq_length]
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        
+        # 创建 mask：如果 j 所属块 <= i 所属块，则允许关注
+        mask = block_j <= block_i  # [seq_length, seq_length]
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        return mask
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_block_causal_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+
+
+class SteamingAttnProcessor:
+    def __init__(self, block_size=40,look_ahead_block=1,look_backward_block=1):
+        self.block_size = block_size
+        self.look_ahead_block = look_ahead_block
+        self.look_backward_block = look_backward_block
+
+    def create_block_mask(self, seq_length, device=None):
+
+        """
+        创建 Block Causal Attention 的 attention mask。
+
+        参数：
+        - seq_length (int): 序列的长度。
+        - block_size (int): 每个块的大小。
+        - device (torch.device, optional): 设备类型。
+
+        返回：
+        - mask (torch.Tensor): attention mask，形状为 [1, 1, seq_length, seq_length]。
+        """
+        # 为每个 token 分配块索引
+        block_indices = torch.arange(seq_length, device=device) // self.block_size  # [seq_length]
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        # 计算块索引的差值
+        block_diff = block_j - block_i  # 形状为 (n, n)
+
+        # 定义允许的块范围
+        mask = (block_diff >= -float(self.look_backward_block)) & (block_diff <= float(self.look_ahead_block))
+        # 创建 mask：如果 j 所属块 <= i 所属块，则允许关注
+        # mask = block_j <= block_i  # [seq_length, seq_length]
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        return mask
+    
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_block_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+# Joint Attention processor for MM-DiT
+# modified from diffusers/src/diffusers/models/attention_processor.py
+
+
+class JointAttnProcessor:
+    def __init__(self):
+        pass
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        c: float["b nt d"] = None,  # context c, here text # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding for x
+        c_rope=None,  # rotary position embedding for c
+    ) -> torch.FloatTensor:
+        residual = x
+
+        batch_size = c.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # `context` projections.
+        c_query = attn.to_q_c(c)
+        c_key = attn.to_k_c(c)
+        c_value = attn.to_v_c(c)
+
+        # apply rope for context and noised input independently
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+        if c_rope is not None:
+            freqs, xpos_scale = c_rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+            c_query = apply_rotary_pos_emb(c_query, freqs, q_xpos_scale)
+            c_key = apply_rotary_pos_emb(c_key, freqs, k_xpos_scale)
+
+        # attention
+        query = torch.cat([query, c_query], dim=1)
+        key = torch.cat([key, c_key], dim=1)
+        value = torch.cat([value, c_value], dim=1)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        if mask is not None:
+            attn_mask = F.pad(mask, (0, c.shape[1]), value=True)  # no mask for c (text)
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        else:
+            attn_mask = None
+
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # Split the attention outputs.
+        x, c = (
+            x[:, : residual.shape[1]],
+            x[:, residual.shape[1] :],
+        )
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+        if not attn.context_pre_only:
+            c = attn.to_out_c(c)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+            # c = c.masked_fill(~mask, 0.)  # no mask for c (text)
+
+        return x, c
+
+
+# DiT Block
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, heads, dim_head, ff_mult=4, dropout=0.1, attn_processor=""):
+        super().__init__()
+        self.attn_norm = AdaLayerNormZero(dim)
+        # import pdb;pdb.set_trace()
+        # print(attn_processor)
+        if attn_processor == "block_attn":
+            processor = BlockSelfAttnProcessor()
+        elif attn_processor == "block_attn_50":
+            processor = BlockSelfAttnProcessor(block_size=50)
+        elif attn_processor == "stream_block_0":
+            processor = SteamingAttnProcessor(look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "stream_block_1":
+            processor = SteamingAttnProcessor(look_ahead_block=1,look_backward_block=1)
+        elif attn_processor == "stream_block_sr_00":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "stream_block_sr_01":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=0)
+        elif attn_processor == "stream_block_sr_10":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=1)
+        elif attn_processor == "stream_block_sr_11":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=1)
+        elif attn_processor == "g_stream_block_sr_00":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "g_stream_block_sr_01":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=0)
+        elif attn_processor == "g_stream_block_sr_10":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=1)
+        elif attn_processor == "stream_block_8_00":
+            processor = SteamingAttnProcessor(block_size=32,look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "stream_block_8_01":
+            processor = SteamingAttnProcessor(block_size=32,look_ahead_block=1,look_backward_block=0)
+        elif attn_processor == "stream_block_8_10":
+            processor = SteamingAttnProcessor(block_size=32,look_ahead_block=0,look_backward_block=1)
+        
+        else:
+            processor = AttnProcessor()
+        self.attn = Attention(
+            processor=processor,
+            dim=dim,
+            heads=heads,
+            dim_head=dim_head,
+            dropout=dropout,
+        )
+
+        self.ff_norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+
+    def forward(self, x, t, mask=None, rope=None):  # x: noised input, t: time embedding
+        # pre-norm & modulation for attention input
+        norm, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.attn_norm(x, emb=t)
+
+        # attention
+        attn_output = self.attn(x=norm, mask=mask, rope=rope)
+
+        # process attention output for input x
+        x = x + gate_msa.unsqueeze(1) * attn_output
+
+        norm = self.ff_norm(x) * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        ff_output = self.ff(norm)
+        x = x + gate_mlp.unsqueeze(1) * ff_output
+
+        return x
+
+
+# MMDiT Block https://arxiv.org/abs/2403.03206
+
+
+class MMDiTBlock(nn.Module):
+    r"""
+    modified from diffusers/src/diffusers/models/attention.py
+
+    notes.
+    _c: context related. text, cond, etc. (left part in sd3 fig2.b)
+    _x: noised input related. (right part)
+    context_pre_only: last layer only do prenorm + modulation cuz no more ffn
+    """
+
+    def __init__(self, dim, heads, dim_head, ff_mult=4, dropout=0.1, context_pre_only=False):
+        super().__init__()
+
+        self.context_pre_only = context_pre_only
+
+        self.attn_norm_c = AdaLayerNormZero_Final(dim) if context_pre_only else AdaLayerNormZero(dim)
+        self.attn_norm_x = AdaLayerNormZero(dim)
+        self.attn = Attention(
+            processor=JointAttnProcessor(),
+            dim=dim,
+            heads=heads,
+            dim_head=dim_head,
+            dropout=dropout,
+            context_dim=dim,
+            context_pre_only=context_pre_only,
+        )
+
+        if not context_pre_only:
+            self.ff_norm_c = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+            self.ff_c = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+        else:
+            self.ff_norm_c = None
+            self.ff_c = None
+        self.ff_norm_x = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff_x = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+
+    def forward(self, x, c, t, mask=None, rope=None, c_rope=None):  # x: noised input, c: context, t: time embedding
+        # pre-norm & modulation for attention input
+        if self.context_pre_only:
+            norm_c = self.attn_norm_c(c, t)
+        else:
+            norm_c, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = self.attn_norm_c(c, emb=t)
+        norm_x, x_gate_msa, x_shift_mlp, x_scale_mlp, x_gate_mlp = self.attn_norm_x(x, emb=t)
+
+        # attention
+        x_attn_output, c_attn_output = self.attn(x=norm_x, c=norm_c, mask=mask, rope=rope, c_rope=c_rope)
+
+        # process attention output for context c
+        if self.context_pre_only:
+            c = None
+        else:  # if not last layer
+            c = c + c_gate_msa.unsqueeze(1) * c_attn_output
+
+            norm_c = self.ff_norm_c(c) * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
+            c_ff_output = self.ff_c(norm_c)
+            c = c + c_gate_mlp.unsqueeze(1) * c_ff_output
+
+        # process attention output for input x
+        x = x + x_gate_msa.unsqueeze(1) * x_attn_output
+
+        norm_x = self.ff_norm_x(x) * (1 + x_scale_mlp[:, None]) + x_shift_mlp[:, None]
+        x_ff_output = self.ff_x(norm_x)
+        x = x + x_gate_mlp.unsqueeze(1) * x_ff_output
+
+        return c, x
+
+
+# time step conditioning embedding
+
+
+class TimestepEmbedding(nn.Module):
+    def __init__(self, dim, freq_embed_dim=256):
+        super().__init__()
+        self.time_embed = SinusPositionEmbedding(freq_embed_dim)
+        self.time_mlp = nn.Sequential(nn.Linear(freq_embed_dim, dim), nn.SiLU(), nn.Linear(dim, dim))
+
+    def forward(self, timestep: float["b"]):  # noqa: F821
+        time_hidden = self.time_embed(timestep)
+        time_hidden = time_hidden.to(timestep.dtype)
+        time = self.time_mlp(time_hidden)  # b d
+        return time

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/modules.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/modules.py
@@ -1,0 +1,889 @@
+"""
+ein notation:
+b - batch
+n - sequence
+nt - text sequence
+nw - raw wave length
+d - dimension
+"""
+
+from __future__ import annotations
+from typing import Optional
+import math
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import torchaudio
+
+from x_transformers.x_transformers import apply_rotary_pos_emb
+
+
+# raw wav to mel spec
+
+
+class MelSpec(nn.Module):
+    def __init__(
+        self,
+        filter_length=1024,
+        hop_length=256,
+        win_length=1024,
+        n_mel_channels=100,
+        target_sample_rate=24_000,
+        normalize=False,
+        power=1,
+        norm=None,
+        center=True,
+    ):
+        super().__init__()
+        self.n_mel_channels = n_mel_channels
+
+        self.mel_stft = torchaudio.transforms.MelSpectrogram(
+            sample_rate=target_sample_rate,
+            n_fft=filter_length,
+            win_length=win_length,
+            hop_length=hop_length,
+            n_mels=n_mel_channels,
+            power=power,
+            center=center,
+            normalized=normalize,
+            norm=norm,
+        )
+
+        self.register_buffer("dummy", torch.tensor(0), persistent=False)
+
+    def forward(self, inp):
+        if len(inp.shape) == 3:
+            inp = inp.squeeze(1)  # 'b 1 nw -> b nw'
+
+        assert len(inp.shape) == 2
+
+        if self.dummy.device != inp.device:
+            self.to(inp.device)
+
+        mel = self.mel_stft(inp)
+        mel = mel.clamp(min=1e-5).log()
+        return mel
+
+
+# sinusoidal position embedding
+
+
+class SinusPositionEmbedding(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, x, scale=1000):
+        device = x.device
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = torch.exp(torch.arange(half_dim, device=device).float() * -emb)
+        emb = scale * x.unsqueeze(1) * emb.unsqueeze(0)
+        emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
+        return emb
+
+
+# convolutional position embedding
+
+
+class ConvPositionEmbedding(nn.Module):
+    def __init__(self, dim, kernel_size=31, groups=16):
+        super().__init__()
+        assert kernel_size % 2 != 0
+        self.conv1d = nn.Sequential(
+            nn.Conv1d(dim, dim, kernel_size, groups=groups, padding=kernel_size // 2),
+            nn.Mish(),
+            nn.Conv1d(dim, dim, kernel_size, groups=groups, padding=kernel_size // 2),
+            nn.Mish(),
+        )
+
+    def forward(self, x: float["b n d"], mask: bool["b n"] | None = None):  # noqa: F722
+        if mask is not None:
+            mask = mask[..., None]
+            x = x.masked_fill(~mask, 0.0)
+
+        x = x.permute(0, 2, 1)
+        x = self.conv1d(x)
+        out = x.permute(0, 2, 1)
+
+        if mask is not None:
+            out = out.masked_fill(~mask, 0.0)
+
+        return out
+
+
+# rotary positional embedding related
+
+
+def precompute_freqs_cis(dim: int, end: int, theta: float = 10000.0, theta_rescale_factor=1.0):
+    # proposed by reddit user bloc97, to rescale rotary embeddings to longer sequence length without fine-tuning
+    # has some connection to NTK literature
+    # https://www.reddit.com/r/LocalLLaMA/comments/14lz7j5/ntkaware_scaled_rope_allows_llama_models_to_have/
+    # https://github.com/lucidrains/rotary-embedding-torch/blob/main/rotary_embedding_torch/rotary_embedding_torch.py
+    theta *= theta_rescale_factor ** (dim / (dim - 2))
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 2)[: (dim // 2)].float() / dim))
+    t = torch.arange(end, device=freqs.device)  # type: ignore
+    freqs = torch.outer(t, freqs).float()  # type: ignore
+    freqs_cos = torch.cos(freqs)  # real part
+    freqs_sin = torch.sin(freqs)  # imaginary part
+    return torch.cat([freqs_cos, freqs_sin], dim=-1)
+
+
+def get_pos_embed_indices(start, length, max_pos, scale=1.0):
+    # length = length if isinstance(length, int) else length.max()
+    scale = scale * torch.ones_like(start, dtype=torch.float32)  # in case scale is a scalar
+    pos = (
+        start.unsqueeze(1)
+        + (torch.arange(length, device=start.device, dtype=torch.float32).unsqueeze(0) * scale.unsqueeze(1)).long()
+    )
+    # avoid extra long error.
+    pos = torch.where(pos < max_pos, pos, max_pos - 1)
+    return pos
+
+
+# Global Response Normalization layer (Instance Normalization ?)
+
+
+class GRN(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gamma = nn.Parameter(torch.zeros(1, 1, dim))
+        self.beta = nn.Parameter(torch.zeros(1, 1, dim))
+
+    def forward(self, x):
+        Gx = torch.norm(x, p=2, dim=1, keepdim=True)
+        Nx = Gx / (Gx.mean(dim=-1, keepdim=True) + 1e-6)
+        return self.gamma * (x * Nx) + self.beta + x
+
+
+# ConvNeXt-V2 Block https://github.com/facebookresearch/ConvNeXt-V2/blob/main/models/convnextv2.py
+# ref: https://github.com/bfs18/e2_tts/blob/main/rfwave/modules.py#L108
+
+
+class ConvNeXtV2Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        intermediate_dim: int,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        padding = (dilation * (7 - 1)) // 2
+        self.dwconv = nn.Conv1d(
+            dim, dim, kernel_size=7, padding=padding, groups=dim, dilation=dilation
+        )  # depthwise conv
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, intermediate_dim)  # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.grn = GRN(intermediate_dim)
+        self.pwconv2 = nn.Linear(intermediate_dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = x.transpose(1, 2)  # b n d -> b d n
+        x = self.dwconv(x)
+        x = x.transpose(1, 2)  # b d n -> b n d
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.grn(x)
+        x = self.pwconv2(x)
+        return residual + x
+
+
+# AdaLayerNormZero
+# return with modulated x for attn input, and params for later mlp modulation
+
+
+class AdaLayerNormZero(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(dim, dim * 6)
+
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(self, x, emb=None):
+        emb = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = torch.chunk(emb, 6, dim=1)
+
+        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+# AdaLayerNormZero for final layer
+# return only with modulated x for attn input, cuz no more mlp modulation
+
+
+class AdaLayerNormZero_Final(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+
+        self.silu = nn.SiLU()
+        self.linear = nn.Linear(dim, dim * 2)
+
+        self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(self, x, emb):
+        emb = self.linear(self.silu(emb))
+        scale, shift = torch.chunk(emb, 2, dim=1)
+
+        x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+        return x
+
+
+# FeedForward
+
+
+class FeedForward(nn.Module):
+    def __init__(self, dim, dim_out=None, mult=4, dropout=0.0, approximate: str = "none"):
+        super().__init__()
+        inner_dim = int(dim * mult)
+        dim_out = dim_out if dim_out is not None else dim
+
+        activation = nn.GELU(approximate=approximate)
+        project_in = nn.Sequential(nn.Linear(dim, inner_dim), activation)
+        self.ff = nn.Sequential(project_in, nn.Dropout(dropout), nn.Linear(inner_dim, dim_out))
+
+    def forward(self, x):
+        for i in range(len(self.ff)):
+            tmp = self.ff[i](x)
+            x = tmp 
+        return x
+        # return self.ff(x)
+
+
+# Attention with possible joint part
+# modified from diffusers/src/diffusers/models/attention_processor.py
+
+
+class Attention(nn.Module):
+    def __init__(
+        self,
+        processor: JointAttnProcessor | AttnProcessor | BlockSelfAttnProcessor|SteamingAttnProcessor,
+        dim: int,
+        heads: int = 8,
+        dim_head: int = 64,
+        dropout: float = 0.0,
+        context_dim: Optional[int] = None,  # if not None -> joint attention
+        context_pre_only=None,
+    ):
+        super().__init__()
+
+        if not hasattr(F, "scaled_dot_product_attention"):
+            raise ImportError("Attention equires PyTorch 2.0, to use it, please upgrade PyTorch to 2.0.")
+        self.processor = processor
+
+        self.dim = dim
+        self.heads = heads
+        self.inner_dim = dim_head * heads
+        self.dropout = dropout
+
+        self.context_dim = context_dim
+        self.context_pre_only = context_pre_only
+
+        self.to_q = nn.Linear(dim, self.inner_dim)
+        self.to_k = nn.Linear(dim, self.inner_dim)
+        self.to_v = nn.Linear(dim, self.inner_dim)
+
+        if self.context_dim is not None:
+            self.to_k_c = nn.Linear(context_dim, self.inner_dim)
+            self.to_v_c = nn.Linear(context_dim, self.inner_dim)
+            if self.context_pre_only is not None:
+                self.to_q_c = nn.Linear(context_dim, self.inner_dim)
+
+        self.to_out = nn.ModuleList([])
+        self.to_out.append(nn.Linear(self.inner_dim, dim))
+        self.to_out.append(nn.Dropout(dropout))
+
+        if self.context_pre_only is not None and not self.context_pre_only:
+            self.to_out_c = nn.Linear(self.inner_dim, dim)
+
+    def forward(
+        self,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        c: float["b n d"] = None,  # context c  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding for x
+        c_rope=None,  # rotary position embedding for c
+    ) -> torch.Tensor:
+        if c is not None:
+            return self.processor(self, x, c=c, mask=mask, rope=rope, c_rope=c_rope)
+        else:
+            return self.processor(self, x, mask=mask, rope=rope)
+
+
+# Attention processor
+
+
+class AttnProcessor:
+    def __init__(self):
+        pass
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        else:
+            attn_mask = None
+
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+    
+
+class GlobalStreamSelfAttnProcessor:
+    def __init__(self, block_size=50,global_size=200,look_ahead_block=0,look_backward_block=0):
+        self.block_size = block_size
+        self.global_size = global_size 
+        self.look_ahead_block = look_ahead_block
+        self.look_backward_block = look_backward_block
+    def create_global_block_causal_mask(self,seq_length,device):
+
+        
+        
+        # 为每个 token 分配块索引
+        positions = torch.arange(seq_length, device=device)  # [seq_length]
+        
+        if self.global_size > 0:
+            # 分配块索引：全局块为 0，其余块从 1 开始
+            block_indices = torch.where(
+                positions < self.global_size,
+                torch.zeros_like(positions),
+                1 + (positions - self.global_size) // self.block_size
+            )
+        else:
+            # 没有全局块，所有块按普通块分配
+            block_indices = positions // self.block_size  # [seq_length]
+        
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        
+        # 计算块索引的差值
+        block_diff = block_j - block_i  # 形状为 (seq_length, seq_length)
+        
+        # 定义允许的块范围
+        mask = (block_diff >= -float(self.look_backward_block)) & (block_diff <= float(self.look_ahead_block))
+        
+        if self.global_size > 0:
+            # 确定哪些位置属于全局块
+            is_global_i = block_i == 0  # [seq_length, 1]
+            is_global_j = block_j == 0  # [1, seq_length]
+            
+            # 所有块都可以看到全局块
+            # 这意味着如果 j 是全局块，mask[i, j] = True
+            mask = (mask | is_global_j) & (~is_global_i|is_global_j)
+            
+            # 全局块可以看到所有块
+            # 这意味着如果 i 是全局块，mask[i, j] = True
+            # mask = mask | is_global_i
+        
+        # 调整掩码形状为 [1, 1, seq_length, seq_length] 以适配多头注意力
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        
+        return mask
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_global_block_causal_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+
+
+class BlockSelfAttnProcessor:
+    def __init__(self, block_size=100):
+        self.block_size = block_size
+
+    def create_block_causal_mask(self, seq_length, device=None):
+        """
+        创建 Block Causal Attention 的 attention mask。
+
+        参数：
+        - seq_length (int): 序列的长度。
+        - device (torch.device, optional): 设备类型。
+
+        返回：
+        - mask (torch.Tensor): attention mask，形状为 [1, 1, seq_length, seq_length]。
+        """
+        # 为每个 token 分配块索引
+        block_indices = torch.arange(seq_length, device=device) // self.block_size  # [seq_length]
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        
+        # 创建 mask：如果 j 所属块 <= i 所属块，则允许关注
+        mask = block_j <= block_i  # [seq_length, seq_length]
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        return mask
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_block_causal_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+
+
+class SteamingAttnProcessor:
+    def __init__(self, block_size=40,look_ahead_block=1,look_backward_block=1):
+        self.block_size = block_size
+        self.look_ahead_block = look_ahead_block
+        self.look_backward_block = look_backward_block
+
+    def create_block_mask(self, seq_length, device=None):
+
+        """
+        创建 Block Causal Attention 的 attention mask。
+
+        参数：
+        - seq_length (int): 序列的长度。
+        - block_size (int): 每个块的大小。
+        - device (torch.device, optional): 设备类型。
+
+        返回：
+        - mask (torch.Tensor): attention mask，形状为 [1, 1, seq_length, seq_length]。
+        """
+        # 为每个 token 分配块索引
+        block_indices = torch.arange(seq_length, device=device) // self.block_size  # [seq_length]
+        # 拓展维度以进行块间比较
+        # block_i: [seq_length, 1], block_j: [1, seq_length]
+        block_i = block_indices.unsqueeze(1)  # [seq_length, 1]
+        block_j = block_indices.unsqueeze(0)  # [1, seq_length]
+        # 计算块索引的差值
+        block_diff = block_j - block_i  # 形状为 (n, n)
+
+        # 定义允许的块范围
+        mask = (block_diff >= -float(self.look_backward_block)) & (block_diff <= float(self.look_ahead_block))
+        # 创建 mask：如果 j 所属块 <= i 所属块，则允许关注
+        # mask = block_j <= block_i  # [seq_length, seq_length]
+        mask = mask.unsqueeze(0).unsqueeze(0)  # [1, 1, seq_length, seq_length]
+        return mask
+    
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding
+    ) -> torch.FloatTensor:
+        batch_size = x.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # apply rotary position embedding
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+
+        # attention
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        assert query.shape[2] == key.shape[2] and query.shape[2] == value.shape[2], f"block self attn require self attn but get query_shape: {query.shape}, key_shape: {key.shape}, value_shape: {value.shape}"
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        block_attn_mask = self.create_block_mask(seq_length=query.shape[2], device=query.device)
+        block_attn_mask = block_attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        if mask is not None:
+            attn_mask = mask
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+            attn_mask = torch.logical_and(block_attn_mask, attn_mask)
+        else:
+            attn_mask = block_attn_mask
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+
+        return x
+# Joint Attention processor for MM-DiT
+# modified from diffusers/src/diffusers/models/attention_processor.py
+
+
+class JointAttnProcessor:
+    def __init__(self):
+        pass
+
+    def __call__(
+        self,
+        attn: Attention,
+        x: float["b n d"],  # noised input x  # noqa: F722
+        c: float["b nt d"] = None,  # context c, here text # noqa: F722
+        mask: bool["b n"] | None = None,  # noqa: F722
+        rope=None,  # rotary position embedding for x
+        c_rope=None,  # rotary position embedding for c
+    ) -> torch.FloatTensor:
+        residual = x
+
+        batch_size = c.shape[0]
+
+        # `sample` projections.
+        query = attn.to_q(x)
+        key = attn.to_k(x)
+        value = attn.to_v(x)
+
+        # `context` projections.
+        c_query = attn.to_q_c(c)
+        c_key = attn.to_k_c(c)
+        c_value = attn.to_v_c(c)
+
+        # apply rope for context and noised input independently
+        if rope is not None:
+            freqs, xpos_scale = rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+            query = apply_rotary_pos_emb(query, freqs, q_xpos_scale)
+            key = apply_rotary_pos_emb(key, freqs, k_xpos_scale)
+        if c_rope is not None:
+            freqs, xpos_scale = c_rope
+            q_xpos_scale, k_xpos_scale = (xpos_scale, xpos_scale**-1.0) if xpos_scale is not None else (1.0, 1.0)
+            c_query = apply_rotary_pos_emb(c_query, freqs, q_xpos_scale)
+            c_key = apply_rotary_pos_emb(c_key, freqs, k_xpos_scale)
+
+        # attention
+        query = torch.cat([query, c_query], dim=1)
+        key = torch.cat([key, c_key], dim=1)
+        value = torch.cat([value, c_value], dim=1)
+
+        inner_dim = key.shape[-1]
+        head_dim = inner_dim // attn.heads
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # mask. e.g. inference got a batch with different target durations, mask out the padding
+        if mask is not None:
+            attn_mask = F.pad(mask, (0, c.shape[1]), value=True)  # no mask for c (text)
+            attn_mask = attn_mask.unsqueeze(1).unsqueeze(1)  # 'b n -> b 1 1 n'
+            attn_mask = attn_mask.expand(batch_size, attn.heads, query.shape[-2], key.shape[-2])
+        else:
+            attn_mask = None
+
+        x = F.scaled_dot_product_attention(query, key, value, attn_mask=attn_mask, dropout_p=0.0, is_causal=False)
+        x = x.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        x = x.to(query.dtype)
+
+        # Split the attention outputs.
+        x, c = (
+            x[:, : residual.shape[1]],
+            x[:, residual.shape[1] :],
+        )
+
+        # linear proj
+        x = attn.to_out[0](x)
+        # dropout
+        x = attn.to_out[1](x)
+        if not attn.context_pre_only:
+            c = attn.to_out_c(c)
+
+        if mask is not None:
+            mask = mask.unsqueeze(-1)
+            x = x.masked_fill(~mask, 0.0)
+            # c = c.masked_fill(~mask, 0.)  # no mask for c (text)
+
+        return x, c
+
+
+# DiT Block
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim, heads, dim_head, ff_mult=4, dropout=0.1, attn_processor=""):
+        super().__init__()
+        self.attn_norm = AdaLayerNormZero(dim)
+        if attn_processor == "block_attn":
+            processor = BlockSelfAttnProcessor()
+        elif attn_processor == "block_attn_50":
+            processor = BlockSelfAttnProcessor(block_size=50)
+        elif attn_processor == "stream_block_0":
+            processor = SteamingAttnProcessor(look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "stream_block_1":
+            processor = SteamingAttnProcessor(look_ahead_block=1,look_backward_block=1)
+        elif attn_processor == "stream_block_sr_00":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "stream_block_sr_01":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=0)
+        elif attn_processor == "stream_block_sr_10":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=1)
+        elif attn_processor == "stream_block_sr_11":
+            processor = SteamingAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=1)
+        elif attn_processor == "g_stream_block_sr_00":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=0)
+        elif attn_processor == "g_stream_block_sr_01":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=1,look_backward_block=0)
+        elif attn_processor == "g_stream_block_sr_10":
+            processor = GlobalStreamSelfAttnProcessor(block_size=24,look_ahead_block=0,look_backward_block=1)
+        
+        else:
+            processor = AttnProcessor()
+        self.attn = Attention(
+            processor=processor,
+            dim=dim,
+            heads=heads,
+            dim_head=dim_head,
+            dropout=dropout,
+        )
+
+        self.ff_norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+
+    def forward(self, x, t, mask=None, rope=None):  # x: noised input, t: time embedding
+        # pre-norm & modulation for attention input
+        norm, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.attn_norm(x, emb=t)
+
+        # attention
+        attn_output = self.attn(x=norm, mask=mask, rope=rope)
+
+        # process attention output for input x
+        x = x + gate_msa.unsqueeze(1) * attn_output
+
+        norm = self.ff_norm(x) * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        ff_output = self.ff(norm)
+        x = x + gate_mlp.unsqueeze(1) * ff_output
+
+        return x
+
+
+# MMDiT Block https://arxiv.org/abs/2403.03206
+
+
+class MMDiTBlock(nn.Module):
+    r"""
+    modified from diffusers/src/diffusers/models/attention.py
+
+    notes.
+    _c: context related. text, cond, etc. (left part in sd3 fig2.b)
+    _x: noised input related. (right part)
+    context_pre_only: last layer only do prenorm + modulation cuz no more ffn
+    """
+
+    def __init__(self, dim, heads, dim_head, ff_mult=4, dropout=0.1, context_pre_only=False):
+        super().__init__()
+
+        self.context_pre_only = context_pre_only
+
+        self.attn_norm_c = AdaLayerNormZero_Final(dim) if context_pre_only else AdaLayerNormZero(dim)
+        self.attn_norm_x = AdaLayerNormZero(dim)
+        self.attn = Attention(
+            processor=JointAttnProcessor(),
+            dim=dim,
+            heads=heads,
+            dim_head=dim_head,
+            dropout=dropout,
+            context_dim=dim,
+            context_pre_only=context_pre_only,
+        )
+
+        if not context_pre_only:
+            self.ff_norm_c = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+            self.ff_c = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+        else:
+            self.ff_norm_c = None
+            self.ff_c = None
+        self.ff_norm_x = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff_x = FeedForward(dim=dim, mult=ff_mult, dropout=dropout, approximate="tanh")
+
+    def forward(self, x, c, t, mask=None, rope=None, c_rope=None):  # x: noised input, c: context, t: time embedding
+        # pre-norm & modulation for attention input
+        if self.context_pre_only:
+            norm_c = self.attn_norm_c(c, t)
+        else:
+            norm_c, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = self.attn_norm_c(c, emb=t)
+        norm_x, x_gate_msa, x_shift_mlp, x_scale_mlp, x_gate_mlp = self.attn_norm_x(x, emb=t)
+
+        # attention
+        x_attn_output, c_attn_output = self.attn(x=norm_x, c=norm_c, mask=mask, rope=rope, c_rope=c_rope)
+
+        # process attention output for context c
+        if self.context_pre_only:
+            c = None
+        else:  # if not last layer
+            c = c + c_gate_msa.unsqueeze(1) * c_attn_output
+
+            norm_c = self.ff_norm_c(c) * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
+            c_ff_output = self.ff_c(norm_c)
+            c = c + c_gate_mlp.unsqueeze(1) * c_ff_output
+
+        # process attention output for input x
+        x = x + x_gate_msa.unsqueeze(1) * x_attn_output
+
+        norm_x = self.ff_norm_x(x) * (1 + x_scale_mlp[:, None]) + x_shift_mlp[:, None]
+        x_ff_output = self.ff_x(norm_x)
+        x = x + x_gate_mlp.unsqueeze(1) * x_ff_output
+
+        return c, x
+
+
+# time step conditioning embedding
+
+
+class TimestepEmbedding(nn.Module):
+    def __init__(self, dim, freq_embed_dim=256):
+        super().__init__()
+        self.time_embed = SinusPositionEmbedding(freq_embed_dim)
+        self.time_mlp = nn.Sequential(nn.Linear(freq_embed_dim, dim), nn.SiLU(), nn.Linear(dim, dim))
+
+    def forward(self, timestep: float["b"]):  # noqa: F821
+        time_hidden = self.time_embed(timestep)
+        time_hidden = time_hidden.to(timestep.dtype)
+        time = self.time_mlp(time_hidden)  # b d
+        return time

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/spk_encoder.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/spk_encoder.py
@@ -1,0 +1,931 @@
+
+"""A popular speaker recognition and diarization model.
+
+Authors
+ * Hwidong Na 2020
+"""
+
+import math
+import os
+import torch  # noqa: F401
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+def length_to_mask(length, max_len=None, dtype=None, device=None):
+    """Creates a binary mask for each sequence.
+
+    Reference: https://discuss.pytorch.org/t/how-to-generate-variable-length-mask/23397/3
+
+    Arguments
+    ---------
+    length : torch.LongTensor
+        Containing the length of each sequence in the batch. Must be 1D.
+    max_len : int
+        Max length for the mask, also the size of the second dimension.
+    dtype : torch.dtype, default: None
+        The dtype of the generated mask.
+    device: torch.device, default: None
+        The device to put the mask variable.
+
+    Returns
+    -------
+    mask : tensor
+        The binary mask.
+
+    Example
+    -------
+    >>> length=torch.Tensor([1,2,3])
+    >>> mask=length_to_mask(length)
+    >>> mask
+    tensor([[1., 0., 0.],
+            [1., 1., 0.],
+            [1., 1., 1.]])
+    """
+    assert len(length.shape) == 1
+
+    if max_len is None:
+        max_len = length.max().long().item()  # using arange to generate mask
+    mask = torch.arange(
+        max_len, device=length.device, dtype=length.dtype
+    ).expand(len(length), max_len) < length.unsqueeze(1)
+
+    if dtype is None:
+        dtype = length.dtype
+
+    if device is None:
+        device = length.device
+
+    mask = torch.as_tensor(mask, dtype=dtype, device=device)
+    return mask
+
+
+def get_padding_elem(L_in: int, stride: int, kernel_size: int, dilation: int):
+    """This function computes the number of elements to add for zero-padding.
+
+    Arguments
+    ---------
+    L_in : int
+    stride: int
+    kernel_size : int
+    dilation : int
+    """
+    if stride > 1:
+        n_steps = math.ceil(((L_in - kernel_size * dilation) / stride) + 1)
+        L_out = stride * (n_steps - 1) + kernel_size * dilation
+        padding = [kernel_size // 2, kernel_size // 2]
+
+    else:
+        L_out = (L_in - dilation * (kernel_size - 1) - 1) // stride + 1
+
+        padding = [(L_in - L_out) // 2, (L_in - L_out) // 2]
+    return padding
+
+
+class Conv1d(nn.Module):
+    """This function implements 1d convolution.
+
+    Arguments
+    ---------
+    out_channels : int
+        It is the number of output channels.
+    kernel_size : int
+        Kernel size of the convolutional filters.
+    input_shape : tuple
+        The shape of the input. Alternatively use ``in_channels``.
+    in_channels : int
+        The number of input channels. Alternatively use ``input_shape``.
+    stride : int
+        Stride factor of the convolutional filters. When the stride factor > 1,
+        a decimation in time is performed.
+    dilation : int
+        Dilation factor of the convolutional filters.
+    padding : str
+        (same, valid, causal). If "valid", no padding is performed.
+        If "same" and stride is 1, output shape is the same as the input shape.
+        "causal" results in causal (dilated) convolutions.
+    padding_mode : str
+        This flag specifies the type of padding. See torch.nn documentation
+        for more information.
+    skip_transpose : bool
+        If False, uses batch x time x channel convention of speechbrain.
+        If True, uses batch x channel x time convention.
+
+    Example
+    -------
+    >>> inp_tensor = torch.rand([10, 40, 16])
+    >>> cnn_1d = Conv1d(
+    ...     input_shape=inp_tensor.shape, out_channels=8, kernel_size=5
+    ... )
+    >>> out_tensor = cnn_1d(inp_tensor)
+    >>> out_tensor.shape
+    torch.Size([10, 40, 8])
+    """
+
+    def __init__(
+        self,
+        out_channels,
+        kernel_size,
+        input_shape=None,
+        in_channels=None,
+        stride=1,
+        dilation=1,
+        padding="same",
+        groups=1,
+        bias=True,
+        padding_mode="reflect",
+        skip_transpose=True,
+    ):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.stride = stride
+        self.dilation = dilation
+        self.padding = padding
+        self.padding_mode = padding_mode
+        self.unsqueeze = False
+        self.skip_transpose = skip_transpose
+
+        if input_shape is None and in_channels is None:
+            raise ValueError("Must provide one of input_shape or in_channels")
+
+        if in_channels is None:
+            in_channels = self._check_input_shape(input_shape)
+
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            self.kernel_size,
+            stride=self.stride,
+            dilation=self.dilation,
+            padding=0,
+            groups=groups,
+            bias=bias,
+        )
+
+    def forward(self, x):
+        """Returns the output of the convolution.
+
+        Arguments
+        ---------
+        x : torch.Tensor (batch, time, channel)
+            input to convolve. 2d or 4d tensors are expected.
+        """
+
+        if not self.skip_transpose:
+            x = x.transpose(1, -1)
+
+        if self.unsqueeze:
+            x = x.unsqueeze(1)
+
+        if self.padding == "same":
+            x = self._manage_padding(
+                x, self.kernel_size, self.dilation, self.stride
+            )
+
+        elif self.padding == "causal":
+            num_pad = (self.kernel_size - 1) * self.dilation
+            x = F.pad(x, (num_pad, 0))
+
+        elif self.padding == "valid":
+            pass
+
+        else:
+            raise ValueError(
+                "Padding must be 'same', 'valid' or 'causal'. Got "
+                + self.padding
+            )
+        # print(x.shape)
+        wx = self.conv(x)
+
+        if self.unsqueeze:
+            wx = wx.squeeze(1)
+
+        if not self.skip_transpose:
+            wx = wx.transpose(1, -1)
+
+        return wx
+
+    def _manage_padding(
+        self, x, kernel_size: int, dilation: int, stride: int,
+    ):
+        """This function performs zero-padding on the time axis
+        such that their lengths is unchanged after the convolution.
+
+        Arguments
+        ---------
+        x : torch.Tensor
+            Input tensor.
+        kernel_size : int
+            Size of kernel.
+        dilation : int
+            Dilation used.
+        stride : int
+            Stride.
+        """
+
+        # Detecting input shape
+        L_in = x.shape[-1]
+
+        # Time padding
+        padding = get_padding_elem(L_in, stride, kernel_size, dilation)
+
+        # Applying padding
+        x = F.pad(x, padding, mode=self.padding_mode)
+
+        return x
+
+    def _check_input_shape(self, shape):
+        """Checks the input shape and returns the number of input channels.
+        """
+
+        if len(shape) == 2:
+            self.unsqueeze = True
+            in_channels = 1
+        elif self.skip_transpose:
+            in_channels = shape[1]
+        elif len(shape) == 3:
+            in_channels = shape[2]
+        else:
+            raise ValueError(
+                "conv1d expects 2d, 3d inputs. Got " + str(len(shape))
+            )
+
+        # Kernel size must be odd
+        if self.kernel_size % 2 == 0:
+            raise ValueError(
+                "The field kernel size must be an odd number. Got %s."
+                % (self.kernel_size)
+            )
+        return in_channels
+
+
+class Fp32BatchNorm(nn.Module):
+    def __init__(self, sync=True, *args, **kwargs):
+        super().__init__()
+
+        if not torch.distributed.is_initialized() or torch.distributed.get_world_size() == 1:
+            sync = False
+
+        if sync:
+            self.bn = nn.SyncBatchNorm(*args, **kwargs)
+        else:
+            self.bn = nn.BatchNorm1d(*args, **kwargs)
+
+        self.sync = sync
+
+    def forward(self, input):
+        if self.bn.running_mean.dtype != torch.float:
+            if self.sync:
+                self.bn.running_mean = self.bn.running_mean.float()
+                self.bn.running_var = self.bn.running_var.float()
+                if self.bn.affine:
+                    try:
+                        self.bn.weight = self.bn.weight.float()
+                        self.bn.bias = self.bn.bias.float()
+                    except:
+                        self.bn.float()
+            else:
+                self.bn.float()
+
+        output = self.bn(input.float())
+        return output.type_as(input)
+
+
+class BatchNorm1d(nn.Module):
+    """Applies 1d batch normalization to the input tensor.
+
+    Arguments
+    ---------
+    input_shape : tuple
+        The expected shape of the input. Alternatively, use ``input_size``.
+    input_size : int
+        The expected size of the input. Alternatively, use ``input_shape``.
+    eps : float
+        This value is added to std deviation estimation to improve the numerical
+        stability.
+    momentum : float
+        It is a value used for the running_mean and running_var computation.
+    affine : bool
+        When set to True, the affine parameters are learned.
+    track_running_stats : bool
+        When set to True, this module tracks the running mean and variance,
+        and when set to False, this module does not track such statistics.
+    combine_batch_time : bool
+        When true, it combines batch an time axis.
+
+
+    Example
+    -------
+    >>> input = torch.randn(100, 10)
+    >>> norm = BatchNorm1d(input_shape=input.shape)
+    >>> output = norm(input)
+    >>> output.shape
+    torch.Size([100, 10])
+    """
+
+    def __init__(
+        self,
+        input_shape=None,
+        input_size=None,
+        eps=1e-05,
+        momentum=0.1,
+        affine=True,
+        track_running_stats=True,
+        combine_batch_time=False,
+        skip_transpose=True,
+        enabled=True
+    ):
+        super().__init__()
+        self.combine_batch_time = combine_batch_time
+        self.skip_transpose = skip_transpose
+
+        if input_size is None and skip_transpose:
+            input_size = input_shape[1]
+        elif input_size is None:
+            input_size = input_shape[-1]
+
+        if enabled:
+            self.norm = Fp32BatchNorm(
+                num_features=input_size,
+                eps=eps,
+                momentum=momentum,
+                affine=affine,
+                track_running_stats=track_running_stats,
+            )
+        else: 
+            self.norm = nn.Identity()
+
+    def forward(self, x):
+        """Returns the normalized input tensor.
+
+        Arguments
+        ---------
+        x : torch.Tensor (batch, time, [channels])
+            input to normalize. 2d or 3d tensors are expected in input
+            4d tensors can be used when combine_dims=True.
+        """
+        shape_or = x.shape
+        if self.combine_batch_time:
+            if x.ndim == 3:
+                x = x.reshape(shape_or[0] * shape_or[1], shape_or[2])
+            else:
+                x = x.reshape(
+                    shape_or[0] * shape_or[1], shape_or[3], shape_or[2]
+                )
+
+        elif not self.skip_transpose:
+            x = x.transpose(-1, 1)
+
+        x_n = self.norm(x)
+
+        if self.combine_batch_time:
+            x_n = x_n.reshape(shape_or)
+        elif not self.skip_transpose:
+            x_n = x_n.transpose(1, -1)
+
+        return x_n
+
+
+class Linear(torch.nn.Module):
+    """Computes a linear transformation y = wx + b.
+
+    Arguments
+    ---------
+    n_neurons : int
+        It is the number of output neurons (i.e, the dimensionality of the
+        output).
+    bias : bool
+        If True, the additive bias b is adopted.
+    combine_dims : bool
+        If True and the input is 4D, combine 3rd and 4th dimensions of input.
+
+    Example
+    -------
+    >>> inputs = torch.rand(10, 50, 40)
+    >>> lin_t = Linear(input_shape=(10, 50, 40), n_neurons=100)
+    >>> output = lin_t(inputs)
+    >>> output.shape
+    torch.Size([10, 50, 100])
+    """
+
+    def __init__(
+        self,
+        n_neurons,
+        input_shape=None,
+        input_size=None,
+        bias=True,
+        combine_dims=False,
+    ):
+        super().__init__()
+        self.combine_dims = combine_dims
+
+        if input_shape is None and input_size is None:
+            raise ValueError("Expected one of input_shape or input_size")
+
+        if input_size is None:
+            input_size = input_shape[-1]
+            if len(input_shape) == 4 and self.combine_dims:
+                input_size = input_shape[2] * input_shape[3]
+
+        # Weights are initialized following pytorch approach
+        self.w = nn.Linear(input_size, n_neurons, bias=bias)
+
+    def forward(self, x):
+        """Returns the linear transformation of input tensor.
+
+        Arguments
+        ---------
+        x : torch.Tensor
+            Input to transform linearly.
+        """
+        if x.ndim == 4 and self.combine_dims:
+            x = x.reshape(x.shape[0], x.shape[1], x.shape[2] * x.shape[3])
+
+        wx = self.w(x)
+
+        return wx
+
+
+class TDNNBlock(nn.Module):
+    """An implementation of TDNN.
+
+    Arguments
+    ----------
+    in_channels : int
+        Number of input channels.
+    out_channels : int
+        The number of output channels.
+    kernel_size : int
+        The kernel size of the TDNN blocks.
+    dilation : int
+        The dilation of the Res2Net block.
+    activation : torch class
+        A class for constructing the activation layers.
+
+    Example
+    -------
+    >>> inp_tensor = torch.rand([8, 120, 64]).transpose(1, 2)
+    >>> layer = TDNNBlock(64, 64, kernel_size=3, dilation=1)
+    >>> out_tensor = layer(inp_tensor).transpose(1, 2)
+    >>> out_tensor.shape
+    torch.Size([8, 120, 64])
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        dilation,
+        activation=nn.ReLU,
+        batch_norm=True,
+    ):
+        super(TDNNBlock, self).__init__()
+        self.conv = Conv1d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=kernel_size,
+            dilation=dilation,
+        )
+        self.activation = activation()
+        self.norm = BatchNorm1d(input_size=out_channels, enabled=batch_norm)
+
+    def forward(self, x):
+        return self.norm(self.activation(self.conv(x)))
+
+
+class Res2NetBlock(torch.nn.Module):
+    """An implementation of Res2NetBlock w/ dilation.
+
+    Arguments
+    ---------
+    in_channels : int
+        The number of channels expected in the input.
+    out_channels : int
+        The number of output channels.
+    scale : int
+        The scale of the Res2Net block.
+    kernel_size: int
+        The kernel size of the Res2Net block.
+    dilation : int
+        The dilation of the Res2Net block.
+
+    Example
+    -------
+    >>> inp_tensor = torch.rand([8, 120, 64]).transpose(1, 2)
+    >>> layer = Res2NetBlock(64, 64, scale=4, dilation=3)
+    >>> out_tensor = layer(inp_tensor).transpose(1, 2)
+    >>> out_tensor.shape
+    torch.Size([8, 120, 64])
+    """
+
+    def __init__(
+        self, in_channels, out_channels, scale=8, kernel_size=3, dilation=1, batch_norm=True,
+    ):
+        super(Res2NetBlock, self).__init__()
+        assert in_channels % scale == 0
+        assert out_channels % scale == 0
+
+        in_channel = in_channels // scale
+        hidden_channel = out_channels // scale
+
+        self.blocks = nn.ModuleList(
+            [
+                TDNNBlock(
+                    in_channel,
+                    hidden_channel,
+                    kernel_size=kernel_size,
+                    dilation=dilation,
+                    batch_norm=batch_norm
+                )
+                for i in range(scale - 1)
+            ]
+        )
+        self.scale = scale
+
+    def forward(self, x):
+        y = []
+        for i, x_i in enumerate(torch.chunk(x, self.scale, dim=1)):
+            if i == 0:
+                y_i = x_i
+            elif i == 1:
+                y_i = self.blocks[i - 1](x_i)
+            else:
+                y_i = self.blocks[i - 1](x_i + y_i)
+            y.append(y_i)
+        y = torch.cat(y, dim=1)
+        return y
+
+
+class SEBlock(nn.Module):
+    """An implementation of squeeze-and-excitation block.
+
+    Arguments
+    ---------
+    in_channels : int
+        The number of input channels.
+    se_channels : int
+        The number of output channels after squeeze.
+    out_channels : int
+        The number of output channels.
+
+    Example
+    -------
+    >>> inp_tensor = torch.rand([8, 120, 64]).transpose(1, 2)
+    >>> se_layer = SEBlock(64, 16, 64)
+    >>> lengths = torch.rand((8,))
+    >>> out_tensor = se_layer(inp_tensor, lengths).transpose(1, 2)
+    >>> out_tensor.shape
+    torch.Size([8, 120, 64])
+    """
+
+    def __init__(self, in_channels, se_channels, out_channels):
+        super(SEBlock, self).__init__()
+
+        self.conv1 = Conv1d(
+            in_channels=in_channels, out_channels=se_channels, kernel_size=1
+        )
+        self.relu = torch.nn.ReLU(inplace=True)
+        self.conv2 = Conv1d(
+            in_channels=se_channels, out_channels=out_channels, kernel_size=1
+        )
+        self.sigmoid = torch.nn.Sigmoid()
+
+    def forward(self, x, lengths=None):
+        L = x.shape[-1]
+        if lengths is not None:
+            mask = length_to_mask(lengths * L, max_len=L, device=x.device)
+            mask = mask.unsqueeze(1)
+            total = mask.sum(dim=2, keepdim=True)
+            s = (x * mask).sum(dim=2, keepdim=True) / total
+        else:
+            s = x.mean(dim=2, keepdim=True)
+
+        s = self.relu(self.conv1(s))
+        s = self.sigmoid(self.conv2(s))
+
+        return s * x
+
+
+class AttentiveStatisticsPooling(nn.Module):
+    """This class implements an attentive statistic pooling layer for each channel.
+    It returns the concatenated mean and std of the input tensor.
+
+    Arguments
+    ---------
+    channels: int
+        The number of input channels.
+    attention_channels: int
+        The number of attention channels.
+
+    Example
+    -------
+    >>> inp_tensor = torch.rand([8, 120, 64]).transpose(1, 2)
+    >>> asp_layer = AttentiveStatisticsPooling(64)
+    >>> lengths = torch.rand((8,))
+    >>> out_tensor = asp_layer(inp_tensor, lengths).transpose(1, 2)
+    >>> out_tensor.shape
+    torch.Size([8, 1, 128])
+    """
+
+    def __init__(self, channels, attention_channels=128, global_context=True, batch_norm=True):
+        super().__init__()
+
+        self.eps = 1e-12
+        self.global_context = global_context
+        if global_context:
+            self.tdnn = TDNNBlock(channels * 3, attention_channels, 1, 1, batch_norm=batch_norm)
+        else:
+            self.tdnn = TDNNBlock(channels, attention_channels, 1, 1, batch_norm, batch_norm)
+        self.tanh = nn.Tanh()
+        self.conv = Conv1d(
+            in_channels=attention_channels, out_channels=channels, kernel_size=1
+        )
+
+    def forward(self, x, lengths=None):
+        """Calculates mean and std for a batch (input tensor).
+
+        Arguments
+        ---------
+        x : torch.Tensor
+            Tensor of shape [N, C, L].
+        """
+        L = x.shape[-1]
+
+        def _compute_statistics(x, m, dim=2, eps=self.eps):
+            mean = (m * x).sum(dim)
+            std = torch.sqrt(
+                (m * (x - mean.unsqueeze(dim)).pow(2)).sum(dim).clamp(eps)
+            )
+            return mean, std
+
+        if lengths is None:
+            lengths = torch.ones(x.shape[0], device=x.device)
+
+        # Make binary mask of shape [N, 1, L]
+        mask = length_to_mask(lengths * L, max_len=L, device=x.device)
+        mask = mask.unsqueeze(1)
+
+        # Expand the temporal context of the pooling layer by allowing the
+        # self-attention to look at global properties of the utterance.
+        if self.global_context:
+            # torch.std is unstable for backward computation
+            # https://github.com/pytorch/pytorch/issues/4320
+            total = mask.sum(dim=2, keepdim=True)
+            
+            mean, std = _compute_statistics(x, mask / total)
+            if x.dtype == torch.float16:
+                mean = mean.half()
+                std = std.half()
+            mean = mean.unsqueeze(2).repeat(1, 1, L)
+            std = std.unsqueeze(2).repeat(1, 1, L)
+            attn = torch.cat([x, mean, std], dim=1)
+        else:
+            attn = x
+
+        # Apply layers
+        attn = self.conv(self.tanh(self.tdnn(attn)))
+
+        # Filter out zero-paddings
+        attn = attn.masked_fill(mask == 0, float("-inf"))
+
+        attn = F.softmax(attn, dim=2)
+        mean, std = _compute_statistics(x, attn)
+        # Append mean and std of the batch
+        pooled_stats = torch.cat((mean, std), dim=1)
+        pooled_stats = pooled_stats.unsqueeze(2)
+
+        return pooled_stats
+
+
+class SERes2NetBlock(nn.Module):
+    """An implementation of building block in ECAPA-TDNN, i.e.,
+    TDNN-Res2Net-TDNN-SEBlock.
+
+    Arguments
+    ----------
+    out_channels: int
+        The number of output channels.
+    res2net_scale: int
+        The scale of the Res2Net block.
+    kernel_size: int
+        The kernel size of the TDNN blocks.
+    dilation: int
+        The dilation of the Res2Net block.
+    activation : torch class
+        A class for constructing the activation layers.
+
+    Example
+    -------
+    >>> x = torch.rand(8, 120, 64).transpose(1, 2)
+    >>> conv = SERes2NetBlock(64, 64, res2net_scale=4)
+    >>> out = conv(x).transpose(1, 2)
+    >>> out.shape
+    torch.Size([8, 120, 64])
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        res2net_scale=8,
+        se_channels=128,
+        kernel_size=1,
+        dilation=1,
+        activation=torch.nn.ReLU,
+        batch_norm=True,
+    ):
+        super().__init__()
+        self.out_channels = out_channels
+        self.tdnn1 = TDNNBlock(
+            in_channels,
+            out_channels,
+            kernel_size=1,
+            dilation=1,
+            activation=activation,
+            batch_norm=batch_norm
+        )
+        self.res2net_block = Res2NetBlock(
+            out_channels, out_channels, res2net_scale, kernel_size, dilation, batch_norm=batch_norm
+        )
+        self.tdnn2 = TDNNBlock(
+            out_channels,
+            out_channels,
+            kernel_size=1,
+            dilation=1,
+            activation=activation,
+            batch_norm=batch_norm
+        )
+        self.se_block = SEBlock(out_channels, se_channels, out_channels)
+
+        self.shortcut = None
+        if in_channels != out_channels:
+            self.shortcut = Conv1d(
+                in_channels=in_channels,
+                out_channels=out_channels,
+                kernel_size=1,
+            )
+
+    def forward(self, x, lengths=None):
+        residual = x
+        if self.shortcut:
+            residual = self.shortcut(x)
+
+        x = self.tdnn1(x)
+        x = self.res2net_block(x)
+        x = self.tdnn2(x)
+        x = self.se_block(x, lengths)
+
+        return x + residual
+
+
+class ECAPA_TDNN(torch.nn.Module):
+    """An implementation of the speaker embedding model in a paper.
+    "ECAPA-TDNN: Emphasized Channel Attention, Propagation and Aggregation in
+    TDNN Based Speaker Verification" (https://arxiv.org/abs/2005.07143).
+
+    Arguments
+    ---------
+    device : str
+        Device used, e.g., "cpu" or "cuda".
+    activation : torch class
+        A class for constructing the activation layers.
+    channels : list of ints
+        Output channels for TDNN/SERes2Net layer.
+    kernel_sizes : list of ints
+        List of kernel sizes for each layer.
+    dilations : list of ints
+        List of dilations for kernels in each layer.
+    lin_neurons : int
+        Number of neurons in linear layers.
+
+    Example
+    -------
+    >>> input_feats = torch.rand([5, 120, 80])
+    >>> compute_embedding = ECAPA_TDNN(80, lin_neurons=192)
+    >>> outputs = compute_embedding(input_feats)
+    >>> outputs.shape
+    torch.Size([5, 1, 192])
+    """
+
+    def __init__(
+        self,
+        input_size,
+        lin_neurons=192,
+        activation=torch.nn.ReLU,
+        channels=[512, 512, 512, 512, 1536],
+        kernel_sizes=[5, 3, 3, 3, 1],
+        dilations=[1, 2, 3, 4, 1],
+        attention_channels=128,
+        res2net_scale=8,
+        se_channels=128,
+        global_context=True,
+        batch_norm=True,
+    ):
+
+        super().__init__()
+        assert len(channels) == len(kernel_sizes)
+        assert len(channels) == len(dilations)
+        self.channels = channels
+        self.blocks = nn.ModuleList()
+
+        # The initial TDNN layer
+        self.blocks.append(
+            TDNNBlock(
+                input_size,
+                channels[0],
+                kernel_sizes[0],
+                dilations[0],
+                activation,
+                batch_norm=batch_norm
+            )
+        )
+
+        # SE-Res2Net layers
+        for i in range(1, len(channels) - 1):
+            self.blocks.append(
+                SERes2NetBlock(
+                    channels[i - 1],
+                    channels[i],
+                    res2net_scale=res2net_scale,
+                    se_channels=se_channels,
+                    kernel_size=kernel_sizes[i],
+                    dilation=dilations[i],
+                    activation=activation,
+                    batch_norm=batch_norm
+                )
+            )
+
+        # Multi-layer feature aggregation
+        self.mfa = TDNNBlock(
+            channels[-1],
+            channels[-1],
+            kernel_sizes[-1],
+            dilations[-1],
+            activation,
+            batch_norm=batch_norm
+        )
+
+        # Attentive Statistical Pooling
+        self.asp = AttentiveStatisticsPooling(
+            channels[-1],
+            attention_channels=attention_channels,
+            global_context=global_context,
+            batch_norm=batch_norm
+        )
+        self.asp_bn = BatchNorm1d(input_size=channels[-1] * 2, enabled=batch_norm)
+
+        # Final linear transformation
+        self.fc = Conv1d(
+            in_channels=channels[-1] * 2,
+            out_channels=lin_neurons,
+            kernel_size=1,
+        )
+
+    # @torch.cuda.amp.autocast(enabled=True, dtype=torch.float32)
+    def forward(self, x, lengths=None):
+        """Returns the embedding vector.
+
+        Arguments
+        ---------
+        x : torch.Tensor
+            Tensor of shape (batch, time, channel).
+        """
+        # Minimize transpose for efficiency
+        x = x.transpose(1, 2)
+
+        xl = []
+        for layer in self.blocks:
+            try:
+                x = layer(x, lengths=lengths)
+            except TypeError:
+                x = layer(x)
+            xl.append(x)
+
+        # Multi-layer feature aggregation
+        x = torch.cat(xl[1:], dim=1)
+        x = self.mfa(x)
+
+        # Attentive Statistical Pooling
+        x = self.asp(x, lengths=lengths)
+        x = self.asp_bn(x)
+
+        # Final linear transformation
+        x = self.fc(x)
+
+        x = x.squeeze(-1)
+        return x
+
+
+if __name__ == '__main__':
+    model = ECAPA_TDNN(80, 512,
+                        channels=[256, 256, 256, 256, 768],
+                        kernel_sizes=[5, 3, 3, 3, 1],
+                        dilations=[1, 2, 3, 4, 1],
+                        attention_channels=64,
+                        res2net_scale=2,
+                        se_channels=64,
+                        global_context=True,
+                        batch_norm=False)
+
+    # print(model)

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/t2w_cfm.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/t2w_cfm.py
@@ -1,0 +1,438 @@
+"""
+ein notation:
+b - batch
+n - sequence
+nt - text sequence
+nw - raw wave length
+d - dimension
+"""
+
+from __future__ import annotations
+from typing import Callable
+import random
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_sequence
+
+from torchdiffeq import odeint
+
+from vllm.transformers_utils.qwen2_code2wav_dit.model.modules import MelSpec
+from vllm.transformers_utils.qwen2_code2wav_dit.model.utils import (
+    default,
+    exists,
+    list_str_to_idx,
+    list_str_to_tensor,
+    lens_to_mask,
+    mask_from_frac_lengths,
+)
+
+
+class CodecCFM(nn.Module):
+    def __init__(
+        self,
+        transformer: nn.Module,
+        sigma=0.0,
+        odeint_kwargs: dict = dict(
+            # atol = 1e-5,
+            # rtol = 1e-5,
+            method="euler"  # 'midpoint'
+        ),
+        audio_drop_prob=0.3,
+        cond_drop_prob=0.2,
+        num_channels=None,
+        mel_spec_module: nn.Module | None = None,
+        mel_spec_kwargs: dict = dict(),
+        frac_lengths_mask: tuple[float, float] = (0.7, 1.0),
+        upsample_rate: int = 2,
+    ):
+        super().__init__()
+
+       
+
+        # mel spec
+        self.mel_spec = default(mel_spec_module, MelSpec(**mel_spec_kwargs))
+        num_channels = default(num_channels, self.mel_spec.n_mel_channels)
+        self.num_channels = num_channels
+
+        # classifier-free guidance
+        self.audio_drop_prob = audio_drop_prob
+        self.cond_drop_prob = cond_drop_prob
+
+        # transformer
+        self.transformer = transformer
+        dim = transformer.dim
+        self.dim = dim
+
+        # self.spk_proj = nn.Linear(192, 80)
+
+        # conditional flow related
+        self.sigma = sigma
+
+        # sampling related
+        self.odeint_kwargs = odeint_kwargs
+
+        self.upsample_rate = upsample_rate
+    def logit_normal_sample(self, batch, dtype, device, m=0.0, s=1.0 ):
+
+        u = torch.randn((batch,),dtype=dtype,device=device) * s + m  # u ~ N(m, s^2)
+        samples = torch.sigmoid(u)  # logistic(u) = 1 / (1 + exp(-u))
+        
+        return samples
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+    @torch.no_grad()
+    def sample(
+        self,
+        cond: float["b n d"] | float["b nw"],  # noqa: F722
+        codec: int["b nc dc"],
+        ref_mel: float["b n d"],  # noqa: F722
+        *,
+        lens: int["b"] | None = None,  # noqa: F821
+        steps=32,
+        cfg_strength=1.0,
+        sway_sampling_coef=None,
+        seed: int | None = None,
+        max_duration=4096,
+        vocoder: Callable[[float["b d n"]], float["b nw"]] | None = None,  # noqa: F722
+        no_ref_audio=False,
+        y0: float["b n d"] | None = None,
+        duplicate_test=False,
+        t_inter=0.1,
+        edit_mask=None,
+    ):
+        self.eval()
+
+        max_duration = codec.shape[1] * self.transformer.repeats
+        if next(self.parameters()).dtype == torch.float16:
+            cond = cond.half()
+            ref_mel = ref_mel.half()
+            if y0 is not None:
+                y0 = y0.half()
+        # raw wave
+        cond = cond.unsqueeze(1).repeat(1,max_duration, 1)
+        # if cond.ndim == 2:
+        #     cond = self.mel_spec(cond)
+        #     cond = cond.permute(0, 2, 1)
+        #     assert cond.shape[-1] == self.num_channels
+
+        batch, cond_seq_len, device = *ref_mel.shape[:2], codec.device
+        assert batch == 1, "only support batch size = 1 currently"
+        if not exists(lens):
+            lens = torch.full((batch,), cond_seq_len, device=device, dtype=torch.long)
+
+        # cond_mask = lens_to_mask(lens)
+        # ref_mel = F.pad(ref_mel, (0, 0, 0, cond_seq_len), value=0.0)
+        # cond_mask = F.pad(cond_mask, (0, max_duration - cond_mask.shape[-1]), value=False)
+        # cond_mask = cond_mask.unsqueeze(-1)
+        # step_cond = torch.where(
+        #     cond_mask, ref_mel, torch.zeros_like(ref_mel)
+        # )  # allow direct control (cut cond audio) with lens passed in
+
+        mask = None
+
+        # test for no ref audio
+        if no_ref_audio:
+            ref_mel = torch.zeros_like(ref_mel)
+            cond = torch.zeros_like(cond)
+        # neural ode
+
+        def fn(t, x):
+            # at each step, conditioning is fixed
+            # step_cond = torch.where(cond_mask, ref_mel, torch.zeros_like(ref_mel))
+
+            # predict flow
+            # print(x.dtype,cond.dtype,ref_mel.dtype)
+            pred = self.transformer(
+                x=x, spk=cond,cond=ref_mel, text=codec, time=t, mask=mask, drop_audio_cond=False, drop_text=False
+            )
+            if cfg_strength < 1e-5:
+                return pred
+
+            null_pred = self.transformer(
+                x=x, spk=cond,cond=ref_mel , text=codec, time=t, mask=mask, drop_audio_cond=True, drop_text=True
+            )
+            return pred + (pred - null_pred) * cfg_strength
+
+        # noise input
+        if y0 is None:
+            y0 = torch.randn([1, max_duration, self.num_channels], device=self.device, dtype=cond.dtype)
+        
+        t_start = 0
+        t = torch.linspace(t_start, 1, steps, device=self.device, dtype=cond.dtype)
+        if sway_sampling_coef is not None:
+            t = t + sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
+
+        trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
+
+        sampled = trajectory[-1]
+        out = sampled
+        # out = torch.where(cond_mask, cond, out)
+        return out, trajectory
+    
+    @torch.no_grad()
+    def block_sample(
+        self,
+        cond: float["b n d"] | float["b nw"],  # noqa: F722
+        codec: int["b nc dc"],
+        ref_mel: float["b n d"],  # noqa: F722
+        y0: float["b n d"],
+        lens: int["b"] | None = None,  # noqa: F821
+        steps=32,
+        cfg_strength=1.0,
+        sway_sampling_coef=None,
+        seed: int | None = None,
+        max_duration=4096,
+        vocoder: Callable[[float["b d n"]], float["b nw"]] | None = None,  # noqa: F722
+        no_ref_audio=False,
+        duplicate_test=False,
+        t_inter=0.1,
+        edit_mask=None,
+    ):
+        self.eval()
+
+        max_duration = y0.shape[1]
+        if next(self.parameters()).dtype == torch.float16:
+            cond = cond.half()
+            ref_mel = ref_mel.half()
+            y0 = y0.half()
+            # print(next(self.parameters()).dtype)
+
+        # raw wave
+
+        # if cond.ndim == 2:
+        #     cond = self.mel_spec(cond)
+        #     cond = cond.permute(0, 2, 1)
+        #     assert cond.shape[-1] == self.num_channels
+        cond = cond.unsqueeze(1).repeat(1,max_duration, 1)
+        batch, cond_seq_len, device = *ref_mel.shape[:2], cond.device
+        assert batch == 1, "only support batch size = 1 currently"
+        if not exists(lens):
+            lens = torch.full((batch,), cond_seq_len, device=device, dtype=torch.long)
+
+        # cond_mask = lens_to_mask(lens)
+        # ref_mel = F.pad(ref_mel, (0, 0, 0, max_duration - cond_seq_len), value=0.0)
+        # cond_mask = F.pad(cond_mask, (0, max_duration - cond_mask.shape[-1]), value=False)
+        # cond_mask = cond_mask.unsqueeze(-1)
+        # step_cond = torch.where(
+        #     cond_mask, ref_mel, torch.zeros_like(ref_mel)
+        # )  # allow direct control (cut cond audio) with lens passed in
+        # ref_mel = F.pad(ref_mel, (0, 0, 0, cond_seq_len), value=0.0)
+        mask = None
+
+        # test for no ref audio
+        if no_ref_audio:
+            cond = torch.zeros_like(cond)
+
+        # neural ode
+
+        def fn(t, x):
+            # at each step, conditioning is fixed
+            # step_cond = torch.where(cond_mask, ref_mel, torch.zeros_like(ref_mel))
+
+            # predict flow
+            # import pdb;pdb.set_trace()
+            pred = self.transformer(
+                x=x, cond=ref_mel, spk=cond, text=codec, time=t, mask=mask, drop_audio_cond=False, drop_text=False
+            )
+            if cfg_strength < 1e-5:
+                return pred
+
+            null_pred = self.transformer(
+                x=x, cond=ref_mel, spk=cond, text=codec, time=t, mask=mask, drop_audio_cond=True, drop_text=True
+            )
+            return pred + (pred - null_pred) * cfg_strength
+
+        # noise input
+        # y0 = torch.randn([1, max_duration, self.num_channels], device=self.device, dtype=step_cond.dtype)
+        
+        t_start = 0
+        t = torch.linspace(t_start, 1, steps, device=self.device, dtype=ref_mel.dtype)
+        if sway_sampling_coef is not None:
+            t = t + sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
+
+        trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
+
+        sampled = trajectory[-1]
+        out = sampled
+        # out = torch.where(cond_mask, ref_mel, out)
+        return out, trajectory
+
+    @torch.no_grad()
+    def fast_block_sample(
+        self,
+        cond: float["b n d"] | float["b nw"],  # noqa: F722
+        codec: int["b nc dc"],
+        ref_mel: float["b n d"],  # noqa: F722
+        y0: float["b n d"],
+        lens: int["b"] | None = None,  # noqa: F821
+        steps=32,
+        cfg_strength=1.0,
+        sway_sampling_coef=None,
+        seed: int | None = None,
+        max_duration=4096,
+        vocoder: Callable[[float["b d n"]], float["b nw"]] | None = None,  # noqa: F722
+        no_ref_audio=False,
+        duplicate_test=False,
+        t_inter=0.1,
+        edit_mask=None,
+    ):
+        self.eval()
+
+        max_duration = y0.shape[1]
+        if next(self.parameters()).dtype == torch.float16:
+            cond = cond.half()
+            ref_mel = ref_mel.half()
+            y0 = y0.half()
+            # print(next(self.parameters()).dtype)
+
+        # raw wave
+
+        # if cond.ndim == 2:
+        #     cond = self.mel_spec(cond)
+        #     cond = cond.permute(0, 2, 1)
+        #     assert cond.shape[-1] == self.num_channels
+        cond = cond.unsqueeze(1).repeat(1,max_duration, 1)
+        batch, cond_seq_len, device = *ref_mel.shape[:2], cond.device
+        assert batch == 1, "only support batch size = 1 currently"
+        if not exists(lens):
+            lens = torch.full((batch,), cond_seq_len, device=device, dtype=torch.long)
+
+        # cond_mask = lens_to_mask(lens)
+        # ref_mel = F.pad(ref_mel, (0, 0, 0, max_duration - cond_seq_len), value=0.0)
+        # cond_mask = F.pad(cond_mask, (0, max_duration - cond_mask.shape[-1]), value=False)
+        # cond_mask = cond_mask.unsqueeze(-1)
+        # step_cond = torch.where(
+        #     cond_mask, ref_mel, torch.zeros_like(ref_mel)
+        # )  # allow direct control (cut cond audio) with lens passed in
+        # ref_mel = F.pad(ref_mel, (0, 0, 0, cond_seq_len), value=0.0)
+        mask = None
+
+        # test for no ref audio
+        if no_ref_audio:
+            cond = torch.zeros_like(cond)
+
+        # neural ode
+
+        def fn(t, x):
+            # at each step, conditioning is fixed
+            # step_cond = torch.where(cond_mask, ref_mel, torch.zeros_like(ref_mel))
+
+            # predict flow
+            # print(x.dtype,cond.dtype,ref_mel.dtype)
+            out_put = self.transformer.fast_forward(
+                x=x,
+                text=codec,
+                spk=cond,
+                cond=ref_mel,
+                time=t,
+                mask=mask,
+            )
+            pred,null_pred = torch.chunk(out_put,2,dim=0)
+            # pred = self.transformer(
+            #     x=x, spk=cond,cond=ref_mel, text=codec, time=t, mask=mask, drop_audio_cond=False, drop_text=False
+            # )
+            # if cfg_strength < 1e-5:
+            #     return pred
+
+            # null_pred = self.transformer(
+            #     x=x, spk=cond,cond=ref_mel , text=codec, time=t, mask=mask, drop_audio_cond=True, drop_text=True
+            # )
+            return pred + (pred - null_pred) * cfg_strength
+
+        # noise input
+        # y0 = torch.randn([1, max_duration, self.num_channels], device=self.device, dtype=step_cond.dtype)
+        
+        t_start = 0
+        t = torch.linspace(t_start, 1, steps, device=self.device, dtype=ref_mel.dtype)
+        if sway_sampling_coef is not None:
+            t = t + sway_sampling_coef * (torch.cos(torch.pi / 2 * t) - 1 + t)
+
+        trajectory = odeint(fn, y0, t, **self.odeint_kwargs)
+
+        sampled = trajectory[-1]
+        out = sampled
+        # out = torch.where(cond_mask, ref_mel, out)
+        return out, trajectory
+        
+    def forward(
+        self,
+        inp: float["b n d"] | float["b nw"],  # mel or raw wave  # noqa: F722
+        codec: int["b nc dc"],
+        lens: int["b"] | None = None,  # noqa: F821
+        spk: int["b nc"] | None = None,
+        ref_mel: float["b n d"] | None = None,
+        noise_scheduler: str | None = None,
+        use_log_norm: bool = True,
+    ):
+
+        batch, seq_len, dtype, device, sigma = *inp.shape[:2], inp.dtype, self.device, self.sigma
+
+        # lens and mask
+        if not exists(lens):
+            lens = torch.full((batch,), seq_len, device=device)
+
+        mask = lens_to_mask(lens, length=seq_len)  # useless here, as collate_fn will pad to max length in batch
+
+        # # get a random span to mask out for training conditionally
+        # frac_lengths = torch.zeros((batch,), device=self.device).float().uniform_(*self.frac_lengths_mask)
+        # rand_span_mask = mask_from_frac_lengths(lens, 0.2)
+
+        # if exists(mask):
+        #     rand_span_mask &= mask
+
+        # mel is x1
+        x1 = inp
+        # cond = self.spk_proj(cond)
+        spk = spk.unsqueeze(1).repeat(1, inp.size(1), 1)
+        # x0 is gaussian noise
+        x0 = torch.randn_like(x1)
+        # cond = torch.zeros_like(x1)
+        # cond_mask  = torch.zeros_like(cond,dtype=torch.bool)
+        # for i,j in enumerate(lens):
+        #     if random.random() < 0.6:
+        #         continue
+        #     index = random.randint(0,int(0.6*j))
+        #     length = random.randint(0,int(0.3*j))
+        #     cond[i,index:index+length,:] = x1[i,index:index+length,:]
+        #     cond_mask[i,index:index+length,:] = True
+        
+        # import pdb;pdb.set_trace()
+        # time step
+        if use_log_norm:
+            time = self.logit_normal_sample(batch, dtype=dtype, device=self.device)
+        else:
+            time = torch.rand((batch,), dtype=dtype, device=self.device)
+        # TODO. noise_scheduler
+
+        # sample xt (φ_t(x) in the paper)
+        t = time.unsqueeze(-1).unsqueeze(-1)
+        phi = (1 - t) * x0 + t * x1
+        flow = x1 - x0
+
+        # only predict what is within the random mask span for infilling
+        # cond = torch.where(rand_span_mask[..., None], torch.zeros_like(x1), x1)
+        
+        # transformer and cfg training with a drop rate
+        drop_audio_cond = random.random() < self.audio_drop_prob  # p_drop in voicebox paper
+        if random.random() < self.cond_drop_prob:  # p_uncond in voicebox paper
+            drop_audio_cond = True
+            drop_text = True
+        else:
+            drop_text = False
+
+        # if want rigourously mask out padding, record in collate_fn in dataset.py, and pass in here
+        # adding mask will use more memory, thus also need to adjust batchsampler with scaled down threshold for long sequences
+        pred = self.transformer(
+            x=phi, cond=ref_mel,spk=spk, text=codec, time=time, drop_audio_cond=drop_audio_cond, drop_text=drop_text
+        )
+
+        # flow matching loss
+        loss = F.mse_loss(pred, flow, reduction="none")
+        # mask = cond_mask&mask.unsqueeze(-1)
+        loss = loss[mask]
+
+        return loss.mean(), ref_mel, pred

--- a/vllm/transformers_utils/qwen2_code2wav_dit/model/utils.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/model/utils.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import os
+import math
+import random
+import string
+from tqdm import tqdm
+from collections import defaultdict
+
+import torch
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_sequence
+import torchaudio
+
+
+
+
+
+def seed_everything(seed=0):
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def exists(v):
+    return v is not None
+
+
+def default(v, d):
+    return v if exists(v) else d
+
+def lens_to_mask(t: int["b"], length: int | None = None) -> bool["b n"]:  # noqa: F722 F821
+    if not exists(length):
+        length = t.amax()
+
+    seq = torch.arange(length, device=t.device)
+    return seq[None, :] < t[:, None]
+
+
+def mask_from_start_end_indices(seq_len: int["b"], start: int["b"], end: int["b"]):  # noqa: F722 F821
+    max_seq_len = seq_len.max().item()
+    seq = torch.arange(max_seq_len, device=start.device).long()
+    start_mask = seq[None, :] >= start[:, None]
+    end_mask = seq[None, :] < end[:, None]
+    return start_mask & end_mask
+
+
+def mask_from_frac_lengths(seq_len: int["b"], frac_lengths: float["b"]):  # noqa: F722 F821
+    lengths = (frac_lengths * seq_len).long()
+    max_start = seq_len - lengths
+
+    rand = torch.rand_like(frac_lengths)
+    start = (max_start * rand).long().clamp(min=0)
+    end = start + lengths
+
+    return mask_from_start_end_indices(seq_len, start, end)
+
+
+def maybe_masked_mean(t: float["b n d"], mask: bool["b n"] = None) -> float["b d"]:  # noqa: F722
+    if not exists(mask):
+        return t.mean(dim=1)
+
+    t = torch.where(mask[:, :, None], t, torch.tensor(0.0, device=t.device))
+    num = t.sum(dim=1)
+    den = mask.float().sum(dim=1)
+
+    return num / den.clamp(min=1.0)
+
+
+# simple utf-8 tokenizer, since paper went character based
+def list_str_to_tensor(text: list[str], padding_value=-1) -> int["b nt"]:  # noqa: F722
+    list_tensors = [torch.tensor([*bytes(t, "UTF-8")]) for t in text]  # ByT5 style
+    text = pad_sequence(list_tensors, padding_value=padding_value, batch_first=True)
+    return text
+
+
+# char tokenizer, based on custom dataset's extracted .txt file
+def list_str_to_idx(
+    text: list[str] | list[list[str]],
+    vocab_char_map: dict[str, int],  # {char: idx}
+    padding_value=-1,
+) -> int["b nt"]:  # noqa: F722
+    list_idx_tensors = [torch.tensor([vocab_char_map.get(c, 0) for c in t]) for t in text]  # pinyin or char style
+    text = pad_sequence(list_idx_tensors, padding_value=padding_value, batch_first=True)
+    return text
+
+
+# padded to max length mel batch
+def padded_mel_batch(ref_mels):
+    max_mel_length = torch.LongTensor([mel.shape[-1] for mel in ref_mels]).amax()
+    padded_ref_mels = []
+    for mel in ref_mels:
+        padded_ref_mel = F.pad(mel, (0, max_mel_length - mel.shape[-1]), value=0)
+        padded_ref_mels.append(padded_ref_mel)
+    padded_ref_mels = torch.stack(padded_ref_mels)
+    padded_ref_mels = padded_ref_mels.permute(0, 2, 1)
+    return padded_ref_mels
+
+
+def load_checkpoint(model, ckpt_path_or_ckpt, device, use_ema=True):
+    if not isinstance(ckpt_path_or_ckpt, str):
+        checkpoint = ckpt_path_or_ckpt
+        ckpt_type = "safetensors"
+    else:
+        ckpt_type = ckpt_path_or_ckpt.split(".")[-1]
+        if ckpt_type == "safetensors":
+            from safetensors.torch import load_file
+
+            checkpoint = load_file(ckpt_path_or_ckpt)
+        else:
+            checkpoint = torch.load(ckpt_path_or_ckpt, weights_only=True)
+
+    if use_ema:
+        if ckpt_type == "safetensors":
+            checkpoint = {"ema_model_state_dict": checkpoint}
+        checkpoint["model_state_dict"] = {
+            k.replace("ema_model.", ""): v
+            for k, v in checkpoint["ema_model_state_dict"].items()
+            if k not in ["initted", "step"]
+        }
+        missing_keys, unexpected_keys = \
+            model.load_state_dict(checkpoint["model_state_dict"], strict=False)
+    else:
+        if ckpt_type == "safetensors":
+            checkpoint = {"model_state_dict": checkpoint}
+        missing_keys, unexpected_keys = \
+            model.load_state_dict(checkpoint["model_state_dict"], strict=False)
+
+    assert unexpected_keys == [], f"Unexpected keys: {unexpected_keys}"
+    assert missing_keys == [] or missing_keys == [
+        "mel_spec.mel_stft.spectrogram.window",
+        "mel_spec.mel_stft.mel_scale.fb",
+    ], f"Missing keys: {missing_keys}"
+
+    return model.to(device)

--- a/vllm/transformers_utils/qwen2_code2wav_dit/modeling_qwen2_code2wav.py
+++ b/vllm/transformers_utils/qwen2_code2wav_dit/modeling_qwen2_code2wav.py
@@ -1,0 +1,1195 @@
+# SPDX-License-Identifier: Apache-2.0
+import math
+
+import numpy as np
+import torch
+from torch import nn, pow, sin
+from torch.nn import Conv1d, ConvTranspose1d, Parameter
+from torch.nn import functional as F
+from torch.nn.utils import remove_weight_norm, weight_norm
+
+from vllm.transformers_utils.qwen2_code2wav_dit.model.dit import DiT
+from vllm.transformers_utils.qwen2_code2wav_dit.model.t2w_cfm import CodecCFM
+from vllm.transformers_utils.qwen2_code2wav_dit.model.utils import (
+    load_checkpoint)
+
+
+class CausalConv1d(nn.Conv1d):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.causal_padding = self.dilation[0] * (self.kernel_size[0] - 1)
+
+    def forward(self, x):
+        return self._conv_forward(F.pad(x, [self.causal_padding, 0]),
+                                  self.weight, self.bias)
+
+
+class Snake(nn.Module):
+    """
+    Implementation of a sine-based periodic activation function
+    Shape:
+        - Input: (B, C, T)
+        - Output: (B, C, T), same shape as the input
+    Parameters:
+        - alpha - trainable parameter
+    References:
+        - This activation function is from this paper by Liu Ziyin, Tilman Hartwig, Masahito Ueda:
+        https://arxiv.org/abs/2006.08195
+    Examples:
+        >>> a1 = snake(256)
+        >>> x = torch.randn(256)
+        >>> x = a1(x)
+    """
+
+    def __init__(self,
+                 in_features,
+                 alpha=1.0,
+                 alpha_trainable=True,
+                 alpha_logscale=False):
+        """
+        Initialization.
+        INPUT:
+            - in_features: shape of the input
+            - alpha: trainable parameter
+            alpha is initialized to 1 by default, higher values = higher-frequency.
+            alpha will be trained along with the rest of your model.
+        """
+        super(Snake, self).__init__()
+        self.in_features = in_features
+
+        # initialize alpha
+        self.alpha_logscale = alpha_logscale
+        if self.alpha_logscale:  # log scale alphas initialized to zeros
+            self.alpha = Parameter(torch.zeros(in_features) * alpha)
+        else:  # linear scale alphas initialized to ones
+            self.alpha = Parameter(torch.ones(in_features) * alpha)
+
+        self.alpha.requires_grad = alpha_trainable
+
+        self.no_div_by_zero = 0.000000001
+
+    def forward(self, x):
+        """
+        Forward pass of the function.
+        Applies the function to the input elementwise.
+        Snake ∶= x + 1/a * sin^2 (xa)
+        """
+        alpha = self.alpha.unsqueeze(0).unsqueeze(
+            -1)  # line up with x to [B, C, T]
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+        x = x + (1.0 / (alpha + self.no_div_by_zero)) * pow(sin(x * alpha), 2)
+
+        return x
+
+
+class SnakeBeta(nn.Module):
+    """
+    A modified Snake function which uses separate parameters for the magnitude of the periodic components
+    Shape:
+        - Input: (B, C, T)
+        - Output: (B, C, T), same shape as the input
+    Parameters:
+        - alpha - trainable parameter that controls frequency
+        - beta - trainable parameter that controls magnitude
+    References:
+        - This activation function is a modified version based on this paper by Liu Ziyin, Tilman Hartwig, Masahito Ueda:
+        https://arxiv.org/abs/2006.08195
+    Examples:
+        >>> a1 = snakebeta(256)
+        >>> x = torch.randn(256)
+        >>> x = a1(x)
+    """
+
+    def __init__(self,
+                 in_features,
+                 alpha=1.0,
+                 alpha_trainable=True,
+                 alpha_logscale=False):
+        """
+        Initialization.
+        INPUT:
+            - in_features: shape of the input
+            - alpha - trainable parameter that controls frequency
+            - beta - trainable parameter that controls magnitude
+            alpha is initialized to 1 by default, higher values = higher-frequency.
+            beta is initialized to 1 by default, higher values = higher-magnitude.
+            alpha will be trained along with the rest of your model.
+        """
+        super(SnakeBeta, self).__init__()
+        self.in_features = in_features
+
+        # initialize alpha
+        self.alpha_logscale = alpha_logscale
+        if self.alpha_logscale:  # log scale alphas initialized to zeros
+            self.alpha = Parameter(torch.zeros(in_features) * alpha)
+            self.beta = Parameter(torch.zeros(in_features) * alpha)
+        else:  # linear scale alphas initialized to ones
+            self.alpha = Parameter(torch.ones(in_features) * alpha)
+            self.beta = Parameter(torch.ones(in_features) * alpha)
+
+        self.alpha.requires_grad = alpha_trainable
+        self.beta.requires_grad = alpha_trainable
+
+        self.no_div_by_zero = 0.000000001
+
+    def forward(self, x):
+        """
+        Forward pass of the function.
+        Applies the function to the input elementwise.
+        SnakeBeta ∶= x + 1/b * sin^2 (xa)
+        """
+        alpha = self.alpha.unsqueeze(0).unsqueeze(
+            -1)  # line up with x to [B, C, T]
+        beta = self.beta.unsqueeze(0).unsqueeze(-1)
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+            beta = torch.exp(beta)
+        x = x + (1.0 / (beta + self.no_div_by_zero)) * pow(sin(x * alpha), 2)
+
+        return x
+
+
+if "sinc" in dir(torch):
+    sinc = torch.sinc
+else:
+    # This code is adopted from adefossez's julius.core.sinc under the MIT License
+    # https://adefossez.github.io/julius/julius/core.html
+    #   LICENSE is in incl_licenses directory.
+    def sinc(x: torch.Tensor):
+        """
+        Implementation of sinc, i.e. sin(pi * x) / (pi * x)
+        __Warning__: Different to julius.sinc, the input is multiplied by `pi`!
+        """
+        return torch.where(
+            x == 0,
+            torch.tensor(1.0, device=x.device, dtype=x.dtype),
+            torch.sin(math.pi * x) / math.pi / x,
+        )
+
+
+# This code is adopted from adefossez's julius.lowpass.LowPassFilters under the MIT License
+# https://adefossez.github.io/julius/julius/lowpass.html
+#   LICENSE is in incl_licenses directory.
+def kaiser_sinc_filter1d(cutoff, half_width,
+                         kernel_size):  # return filter [1,1,kernel_size]
+    even = kernel_size % 2 == 0
+    half_size = kernel_size // 2
+
+    # For kaiser window
+    delta_f = 4 * half_width
+    A = 2.285 * (half_size - 1) * math.pi * delta_f + 7.95
+    if A > 50.0:
+        beta = 0.1102 * (A - 8.7)
+    elif A >= 21.0:
+        beta = 0.5842 * (A - 21)**0.4 + 0.07886 * (A - 21.0)
+    else:
+        beta = 0.0
+    window = torch.kaiser_window(kernel_size, beta=beta, periodic=False)
+
+    # ratio = 0.5/cutoff -> 2 * cutoff = 1 / ratio
+    if even:
+        time = torch.arange(-half_size, half_size) + 0.5
+    else:
+        time = torch.arange(kernel_size) - half_size
+    if cutoff == 0:
+        filter_ = torch.zeros_like(time)
+    else:
+        filter_ = 2 * cutoff * window * sinc(2 * cutoff * time)
+        # Normalize filter to have sum = 1, otherwise we will have a small leakage
+        # of the constant component in the input signal.
+        filter_ /= filter_.sum()
+        filter = filter_.view(1, 1, kernel_size)
+
+    return filter
+
+
+class LowPassFilter1d(nn.Module):
+
+    def __init__(
+        self,
+        cutoff=0.5,
+        half_width=0.6,
+        stride: int = 1,
+        padding: bool = True,
+        padding_mode: str = "replicate",
+        kernel_size: int = 12,
+    ):
+        # kernel_size should be even number for stylegan3 setup,
+        # in this implementation, odd number is also possible.
+        super().__init__()
+        if cutoff < -0.0:
+            raise ValueError("Minimum cutoff must be larger than zero.")
+        if cutoff > 0.5:
+            raise ValueError("A cutoff above 0.5 does not make sense.")
+        self.kernel_size = kernel_size
+        self.even = kernel_size % 2 == 0
+        self.pad_left = kernel_size // 2 - int(self.even)
+        self.pad_right = kernel_size // 2
+        self.stride = stride
+        self.padding = padding
+        self.padding_mode = padding_mode
+        filter = kaiser_sinc_filter1d(cutoff, half_width, kernel_size)
+        self.register_buffer("filter", filter)
+
+    # input [B, C, T]
+    def forward(self, x):
+        _, C, _ = x.shape
+
+        if self.padding:
+            x = F.pad(x, (self.pad_left, self.pad_right),
+                      mode=self.padding_mode)
+        out = F.conv1d(x,
+                       self.filter.expand(C, -1, -1),
+                       stride=self.stride,
+                       groups=C)
+
+        return out
+
+
+class UpSample1d(nn.Module):
+
+    def __init__(self, ratio=2, kernel_size=None):
+        super().__init__()
+        self.ratio = ratio
+        self.kernel_size = (int(6 * ratio // 2) *
+                            2 if kernel_size is None else kernel_size)
+        self.stride = ratio
+        self.pad = self.kernel_size // ratio - 1
+        self.pad_left = self.pad * self.stride + (self.kernel_size -
+                                                  self.stride) // 2
+        self.pad_right = (self.pad * self.stride +
+                          (self.kernel_size - self.stride + 1) // 2)
+        filter = kaiser_sinc_filter1d(cutoff=0.5 / ratio,
+                                      half_width=0.6 / ratio,
+                                      kernel_size=self.kernel_size)
+        self.register_buffer("filter", filter)
+
+    # x: [B, C, T]
+    def forward(self, x):
+        _, C, _ = x.shape
+
+        x = F.pad(x, (self.pad, self.pad), mode="replicate")
+        x = self.ratio * F.conv_transpose1d(
+            x, self.filter.expand(C, -1, -1), stride=self.stride, groups=C)
+        x = x[..., self.pad_left:-self.pad_right]
+
+        return x
+
+
+class DownSample1d(nn.Module):
+
+    def __init__(self, ratio=2, kernel_size=None):
+        super().__init__()
+        cutoff = 0.5 / ratio
+        half_width = 0.6 / ratio
+        if cutoff < -0.0:
+            raise ValueError("Minimum cutoff must be larger than zero.")
+        if cutoff > 0.5:
+            raise ValueError("A cutoff above 0.5 does not make sense.")
+        self.kernel_size = kernel_size
+        self.even = kernel_size % 2 == 0
+        self.pad_left = kernel_size // 2 - int(self.even)
+        self.pad_right = kernel_size // 2
+        self.stride = ratio
+        filter = kaiser_sinc_filter1d(cutoff, half_width, kernel_size)
+        self.register_buffer("filter", filter, persistent=False)
+
+    def forward(self, x):
+        _, C, _ = x.shape
+
+        x = F.pad(x, (self.pad_left, self.pad_right), mode="replicate")
+        out = F.conv1d(x,
+                       self.filter.expand(C, -1, -1),
+                       stride=self.stride,
+                       groups=C)
+
+        return out
+
+
+class TorchActivation1d(nn.Module):
+
+    def __init__(
+        self,
+        activation,
+        up_ratio: int = 2,
+        down_ratio: int = 2,
+        up_kernel_size: int = 12,
+        down_kernel_size: int = 12,
+    ):
+        super().__init__()
+        self.up_ratio = up_ratio
+        self.down_ratio = down_ratio
+        self.act = activation
+        self.upsample = UpSample1d(up_ratio, up_kernel_size)
+        self.downsample = DownSample1d(down_ratio, down_kernel_size)
+
+    # x: [B,C,T]
+    def forward(self, x):
+        x = self.upsample(x)
+        x = self.act(x)
+        x = self.downsample(x)
+
+        return x
+
+
+def init_weights(m, mean=0.0, std=0.01):
+    classname = m.__class__.__name__
+    if classname.find("Conv") != -1:
+        m.weight.data.normal_(mean, std)
+
+
+def get_padding(kernel_size, dilation=1):
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+class AMPBlock1(torch.nn.Module):
+
+    def __init__(
+        self,
+        channels,
+        kernel_size=3,
+        dilation=(1, 3, 5),
+        activation=None,
+        snake_logscale=True,
+        frequency='50hz',
+        causal_type='1',
+    ):
+        super(AMPBlock1, self).__init__()
+
+        self.frequency = frequency
+        if self.frequency == '50hz':
+            self.convs1 = nn.ModuleList([
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[0],
+                        padding=get_padding(kernel_size, dilation[0]),
+                    )),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[1],
+                        padding=get_padding(kernel_size, dilation[1]),
+                    )),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[2],
+                        padding=get_padding(kernel_size, dilation[2]),
+                    )),
+            ])
+        else:
+            self.convs1 = nn.ModuleList([
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[0],
+                        # padding=get_padding(kernel_size, dilation[0]),
+                    )),
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[1],
+                        # padding=get_padding(kernel_size, dilation[1]),
+                    )),
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=dilation[2],
+                        # padding=get_padding(kernel_size, dilation[2]),
+                    )),
+            ])
+        self.convs1.apply(init_weights)
+
+        if causal_type == '1':
+            self.convs2 = nn.ModuleList([
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        padding=get_padding(kernel_size, 1),
+                    )),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        padding=get_padding(kernel_size, 1),
+                    )),
+                weight_norm(
+                    Conv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        padding=get_padding(kernel_size, 1),
+                    )),
+            ])
+        else:
+            self.convs2 = nn.ModuleList([
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        # padding=get_padding(kernel_size, 1),
+                    )),
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        # padding=get_padding(kernel_size, 1),
+                    )),
+                weight_norm(
+                    CausalConv1d(
+                        channels,
+                        channels,
+                        kernel_size,
+                        1,
+                        dilation=1,
+                        # padding=get_padding(kernel_size, 1),
+                    )),
+            ])
+        self.convs2.apply(init_weights)
+
+        self.num_layers = len(self.convs1) + len(
+            self.convs2)  # total number of conv layers
+
+        Activation1d = TorchActivation1d
+
+        if (activation == "snake"
+            ):  # periodic nonlinearity with snake function and anti-aliasing
+            self.activations = nn.ModuleList([
+                Activation1d(
+                    activation=Snake(channels, alpha_logscale=snake_logscale))
+                for _ in range(self.num_layers)
+            ])
+        elif (
+                activation == "snakebeta"
+        ):  # periodic nonlinearity with snakebeta function and anti-aliasing
+            self.activations = nn.ModuleList([
+                Activation1d(activation=SnakeBeta(
+                    channels, alpha_logscale=snake_logscale))
+                for _ in range(self.num_layers)
+            ])
+        else:
+            raise NotImplementedError(
+                "activation incorrectly specified. check the config file and look for 'activation'."
+            )
+
+        if causal_type == '1':
+            self.pre_conv = nn.Identity()
+            self.pre_act = nn.Identity()
+        else:
+            self.pre_conv = weight_norm(
+                Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    stride=1,
+                    padding=get_padding(kernel_size, 1),
+                ))
+            self.pre_conv.apply(init_weights)
+            if activation == "snake":
+                self.pre_act = Activation1d(
+                    activation=Snake(channels, alpha_logscale=snake_logscale))
+            elif activation == "snakebeta":
+                self.pre_act = Activation1d(activation=SnakeBeta(
+                    channels, alpha_logscale=snake_logscale))
+            else:
+                raise NotImplementedError(
+                    "activation incorrectly specified. check the config file and look for 'activation'."
+                )
+
+    def forward(self, x):
+        if self.frequency == '50hz':
+            return self.forward_50hz(x)
+        else:
+            raise ValueError(f"Unsupported frequency: {self.frequency}")
+
+    def forward_50hz(self, x):
+        x = self.pre_conv(x)
+        x = self.pre_act(x)
+        acts1, acts2 = self.activations[::2], self.activations[1::2]
+        for c1, c2, a1, a2 in zip(self.convs1, self.convs2, acts1, acts2):
+            xt = a1(x)
+            xt = c1(xt)
+            xt = a2(xt)
+            xt = c2(xt)
+            x = xt + x
+
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs1:
+            remove_weight_norm(l)
+        for l in self.convs2:
+            remove_weight_norm(l)
+
+
+class AMPBlock2(torch.nn.Module):
+
+    def __init__(
+            self,
+            channels,
+            kernel_size=3,
+            dilation=(1, 3),
+            activation=None,
+            snake_logscale=True,
+    ):
+        super(AMPBlock2, self).__init__()
+
+        self.convs = nn.ModuleList([
+            weight_norm(
+                Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[0],
+                    padding=get_padding(kernel_size, dilation[0]),
+                )),
+            weight_norm(
+                Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[1],
+                    padding=get_padding(kernel_size, dilation[1]),
+                )),
+        ])
+        self.convs.apply(init_weights)
+
+        self.num_layers = len(self.convs)  # total number of conv layers
+
+        Activation1d = TorchActivation1d
+
+        if (activation == "snake"
+            ):  # periodic nonlinearity with snake function and anti-aliasing
+            self.activations = nn.ModuleList([
+                Activation1d(
+                    activation=Snake(channels, alpha_logscale=snake_logscale))
+                for _ in range(self.num_layers)
+            ])
+        elif (
+                activation == "snakebeta"
+        ):  # periodic nonlinearity with snakebeta function and anti-aliasing
+            self.activations = nn.ModuleList([
+                Activation1d(activation=SnakeBeta(
+                    channels, alpha_logscale=snake_logscale))
+                for _ in range(self.num_layers)
+            ])
+        else:
+            raise NotImplementedError(
+                "activation incorrectly specified. check the config file and look for 'activation'."
+            )
+
+    def forward(self, x):
+        for c, a in zip(self.convs, self.activations):
+            xt = a(x)
+            xt = c(xt)
+            x = xt + x
+
+        return x
+
+    def remove_weight_norm(self):
+        for l in self.convs:
+            remove_weight_norm(l)
+
+
+class BigVGAN(torch.nn.Module):
+    # this is our main BigVGAN model. Applies anti-aliased periodic activation for resblocks.
+    def __init__(
+        self,
+        frequency: str = '50hz',  # 50hz or 25 hz
+        num_mels=80,
+        initial_kernel=5,
+        upsample_initial_channel=1536,
+        resblock_kernel_sizes=[3, 7, 11],
+        resblock_dilation_sizes=[[1, 3, 5], [1, 3, 5], [1, 3, 5]],
+        upsample_rates=[5, 3, 2, 2, 2, 2],
+        upsample_kernel_sizes=[11, 7, 4, 4, 4, 4],
+        resblock_type="1",
+        snake_logscale=True,
+        activation="snakebeta",
+        use_tanh_at_final=False,
+        use_bias_at_final=False,
+    ):
+        super(BigVGAN, self).__init__()
+
+        self.num_kernels = len(resblock_kernel_sizes)
+        self.num_upsamples = len(upsample_rates)
+
+        # pre conv
+        self.conv_pre = weight_norm(
+            Conv1d(num_mels,
+                   upsample_initial_channel,
+                   initial_kernel,
+                   1,
+                   padding=initial_kernel // 2))
+
+        # define which AMPBlock to use. BigVGAN uses AMPBlock1 as default
+        resblock = AMPBlock1 if resblock_type == "1" else AMPBlock2
+
+        # transposed conv-based upsamplers. does not apply anti-aliasing
+        self.ups = nn.ModuleList()
+        for i, (u, k) in enumerate(zip(upsample_rates, upsample_kernel_sizes)):
+            self.ups.append(
+                nn.ModuleList([
+                    weight_norm(
+                        ConvTranspose1d(
+                            upsample_initial_channel // (2**i),
+                            upsample_initial_channel // (2**(i + 1)),
+                            k,
+                            u,
+                            padding=(k - u) // 2,
+                        ))
+                ]))
+
+        # residual blocks using anti-aliased multi-periodicity composition modules (AMP)
+        self.resblocks = nn.ModuleList()
+        for i in range(len(self.ups)):
+            if frequency == '50hz':
+                causal_type = '1'
+            else:
+                if i > 1:
+                    causal_type = '1'
+                else:
+                    causal_type = '2'
+            ch = upsample_initial_channel // (2**(i + 1))
+            for j, (k, d) in enumerate(
+                    zip(resblock_kernel_sizes, resblock_dilation_sizes)):
+                self.resblocks.append(
+                    resblock(
+                        ch,
+                        k,
+                        d,
+                        activation=activation,
+                        snake_logscale=snake_logscale,
+                        frequency=frequency,
+                        causal_type=causal_type,
+                    ))
+
+        Activation1d = TorchActivation1d
+
+        # post conv
+        if (activation == "snake"
+            ):  # periodic nonlinearity with snake function and anti-aliasing
+            activation_post = Snake(ch, alpha_logscale=snake_logscale)
+            self.activation_post = Activation1d(activation=activation_post)
+        elif (
+                activation == "snakebeta"
+        ):  # periodic nonlinearity with snakebeta function and anti-aliasing
+            activation_post = SnakeBeta(ch, alpha_logscale=snake_logscale)
+            self.activation_post = Activation1d(activation=activation_post)
+        else:
+            raise NotImplementedError(
+                "activation incorrectly specified. check the config file and look for 'activation'."
+            )
+
+        # whether to use bias for the final conv_post. Defaults to True for backward compatibility
+        self.use_bias_at_final = use_bias_at_final
+        self.conv_post = weight_norm(
+            Conv1d(ch, 1, 7, 1, padding=3, bias=self.use_bias_at_final))
+
+        # weight initialization
+        for i in range(len(self.ups)):
+            self.ups[i].apply(init_weights)
+        self.conv_post.apply(init_weights)
+
+        # final tanh activation. Defaults to True for backward compatibility
+        self.use_tanh_at_final = use_tanh_at_final
+
+    def _normalize(self, S, max_abs_value, min_db):
+        return torch.clamp(
+            (2 * max_abs_value) * ((S - min_db) / (-min_db)) - max_abs_value,
+            -max_abs_value, max_abs_value)
+
+    def _amp_to_db(self, x, min_level_db):
+        min_level = np.exp(min_level_db / 20 * np.log(10))
+        min_level = torch.ones_like(x) * min_level
+        return 20 * torch.log10(torch.maximum(min_level, x))
+
+    def apm_to_db(self, apm_mel):
+        mel_spec = torch.exp(apm_mel)
+
+        mel_spec = self._amp_to_db(mel_spec, -115) - 20
+        mel_spec = self._normalize(mel_spec, 1, -115)
+
+        return mel_spec
+
+    def forward(self, x, is_db=False):
+        if not is_db:
+            x = self.apm_to_db(x)
+        # pre conv
+        x = self.conv_pre(x)
+
+        for i in range(self.num_upsamples):
+            # upsampling
+            for i_up in range(len(self.ups[i])):
+                x = self.ups[i][i_up](x)
+            # AMP blocks
+            xs = None
+            for j in range(self.num_kernels):
+                if xs is None:
+                    xs = self.resblocks[i * self.num_kernels + j](x)
+                else:
+                    xs += self.resblocks[i * self.num_kernels + j](x)
+            x = xs / self.num_kernels
+
+        # post conv
+        x = self.activation_post(x)
+        x = self.conv_post(x)
+        # final tanh activation
+        if self.use_tanh_at_final:
+            x = torch.tanh(x)
+        else:
+            x = torch.clamp(x, min=-1.0,
+                            max=1.0)  # bound the output to [-1, 1]
+
+        return x
+
+    def remove_weight_norm(self):
+        print("Removing weight norm...")
+        for l in self.ups:
+            for l_i in l:
+                remove_weight_norm(l_i)
+        for l in self.resblocks:
+            l.remove_weight_norm()
+        remove_weight_norm(self.conv_pre)
+        remove_weight_norm(self.conv_post)
+
+
+class Qwen2Code2wavBigvgan(torch.nn.Module):
+
+    def __init__(
+        self,
+        ckpt,
+        frequency: str = '50hz',  # 50hz or 25 hz
+        device='cpu',
+        with_weight_norm: bool = True,
+    ):
+        super().__init__()
+        self.frequency = frequency
+        initial_kernel = 7 if frequency == '50hz' else 5
+        resblock_kernel_sizes = [3, 7, 11
+                                 ] if frequency == '50hz' else [3, 5, 9, 11]
+        resblock_dilation_sizes = [[1, 3, 5], [1, 3, 5], [
+            1, 3, 5
+        ]] if frequency == '50hz' else [[1, 3, 5], [1, 3, 5], [1, 3, 5],
+                                        [1, 3, 5]]
+        self.vocoder = BigVGAN(
+            num_mels=80,
+            frequency=frequency,
+            initial_kernel=initial_kernel,
+            upsample_initial_channel=1536,
+            resblock_kernel_sizes=resblock_kernel_sizes,
+            resblock_dilation_sizes=resblock_dilation_sizes,
+            upsample_rates=[5, 3, 2, 2, 2, 2],
+            upsample_kernel_sizes=[11, 7, 4, 4, 4, 4],
+            resblock_type="1",
+            snake_logscale=True,
+            activation="snakebeta",
+            use_tanh_at_final=False,
+            use_bias_at_final=False,
+        )
+        if isinstance(ckpt, str):
+            state_dict = torch.load(ckpt)
+        else:
+            state_dict = ckpt
+
+        if with_weight_norm:
+            loaded_keys = self.vocoder.load_state_dict(state_dict['generator'],
+                                                       strict=False)
+            self.vocoder.remove_weight_norm()
+        else:
+            self.vocoder.remove_weight_norm()
+            loaded_keys = self.vocoder.load_state_dict(state_dict['generator'],
+                                                       strict=False)
+        unexpected_keys = [
+            k for k in loaded_keys.unexpected_keys
+            if 'downsample' not in k and 'upsample' not in k
+        ]
+        assert unexpected_keys == [], f"Unexpected keys (except downsample/upsample): {loaded_keys.unexpected_keys}"
+        missing_keys = [
+            k for k in loaded_keys.missing_keys
+            if 'downsample' not in k and 'upsample' not in k
+        ]
+        assert missing_keys == [], f"Missing keys (except downsample/upsample): {missing_keys}"
+        self.vocoder.eval()
+        self.use_f0 = False
+        self.mel_bin = 80
+        self.device = device
+        self.vocoder = self.vocoder.to(device)
+
+    @torch.no_grad()
+    def forward(self, mel, wav=None):
+        if len(mel.shape) != 3:
+            mel = mel.unsqueeze(0)
+
+        if mel.shape[-1] == self.mel_bin:
+            mel = mel.transpose(1, 2)
+
+        mel = mel.to(self.device)
+        y_g_hat = self.vocoder(mel)
+        audio = y_g_hat.squeeze().cpu()
+        return audio
+
+    def cache_forward(self, mel, future_cache_size, past_cache_size):
+        if len(mel.shape) != 3:
+            mel = mel.unsqueeze(0)
+
+        if mel.shape[-1] == self.mel_bin:
+            mel = mel.transpose(1, 2)
+
+        mel = mel.to(self.device)
+        y_g_hat = self.vocoder(mel,
+                               past_cache_size=past_cache_size,
+                               future_cache_size=future_cache_size)
+        audio = y_g_hat.squeeze().detach().cpu()
+        return audio
+
+
+class Qwen2Code2wavDit(torch.nn.Module):
+
+    def __init__(
+        self,
+        ckpt,
+        frequency: str = '50hz',  # 50hz or 25 hz
+        device='cpu',
+    ):
+        super().__init__()
+        self.freqnecy = frequency
+        self.device = device
+        self.dit = DiT(
+            dim=1024,
+            depth=22 if frequency == '50hz' else 32,
+            heads=16,
+            ff_mult=2,
+            text_dim=512,
+            conv_layers=4,
+            use_codec=True,
+            repeats=2 if frequency == '50hz' else 4,
+            attn_processor='stream_block_sr'
+            if frequency == '50hz' else 'stream_block_8_L_4',
+            text_num_embeds=8193 if frequency == '50hz' else 32769,
+            mel_dim=80,
+        )
+        self.mel_spec_kwargs = dict(
+            target_sample_rate=16000,
+            n_mel_channels=80,
+            hop_length=160,
+        )
+        self.odeint_kwargs = dict(
+            method="rk4" if frequency == '50hz' else "euler", )
+        self.cfm_model = CodecCFM(
+            transformer=self.dit,
+            mel_spec_kwargs=self.mel_spec_kwargs,
+            odeint_kwargs=self.odeint_kwargs,
+        ).to(device)
+        self.cfm_model = load_checkpoint(self.cfm_model,
+                                         ckpt,
+                                         device,
+                                         use_ema=True)
+
+    def sample(self,
+               cond,
+               ref_mel,
+               codec,
+               steps=10,
+               cfg_strength=0.5,
+               sway_sampling_coef=-1.0):
+        y_all = torch.randn([1, 30000, 80],
+                            device=self.device,
+                            dtype=ref_mel.dtype)
+        expect_y_len = codec.shape[1] * (2 if self.freqnecy == '50hz' else 4)
+        y0 = y_all[:, :expect_y_len]
+        with torch.inference_mode():
+            generated, _ = self.cfm_model.sample(
+                cond=cond,
+                ref_mel=ref_mel,
+                codec=codec,
+                steps=steps,
+                cfg_strength=cfg_strength,
+                sway_sampling_coef=sway_sampling_coef,
+                y0=y0)
+        generated = generated.to(torch.float32)
+        generated_mel_spec = generated.permute(0, 2, 1)
+        return generated_mel_spec
+
+    def fast_block_sample(
+        self,
+        cond,
+        codec,
+        ref_mel,
+        y0,
+        steps=10,
+        cfg_strength=0.5,
+        sway_sampling_coef=-1.0,
+    ):
+        return self.cfm_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=cfg_strength,
+            sway_sampling_coef=sway_sampling_coef,
+        )
+
+
+class Qwen2Code2wav(torch.nn.Module):
+
+    def __init__(
+            self,
+            dit_ckpt,
+            bigvgan_ckpt,
+            device='cpu',
+            with_weight_norm: bool = True,
+            frequency: str = '50hz',  # 50hz or 25 hz
+    ):
+        super().__init__()
+        self.freqnecy = frequency
+        self.code2wav_dit_model = Qwen2Code2wavDit(ckpt=dit_ckpt,
+                                                   frequency=frequency,
+                                                   device=device)
+        self.code2wav_bigvgan_model = Qwen2Code2wavBigvgan(
+            ckpt=bigvgan_ckpt,
+            frequency=frequency,
+            device=device,
+            with_weight_norm=with_weight_norm)
+        self.device = device
+
+    def forward(self, cond, ref_mel, codec):
+        generated_mel = self.code2wav_dit_model.sample(cond, ref_mel, codec)
+        generated_mel = generated_mel.permute(0, 2, 1)
+        waveform = self.code2wav_bigvgan_model(generated_mel)
+        return waveform
+
+    def init_variables(self, cond, ref_mel, codec_all, bs_mel):
+        self.bs_codec = bs_mel // (2 if self.freqnecy == '50hz' else 4)
+        self.past_cache_size = bs_mel * (2 if self.freqnecy == '50hz' else 4)
+        self.future_cache_size = bs_mel * 1
+        self.chunk_size = bs_mel * (3 if self.freqnecy == '50hz' else 1)
+        self.gt_codec_len = codec_all.shape[1]
+        self.gt_mel_len = (2 if self.frequency == "50hz" else
+                           4) * self.gt_codec_len
+        if 0 < self.gt_mel_len <= bs_mel * 4:
+            self.n_iter = 1
+        else:
+            self.n_iter = math.ceil(
+                (self.gt_mel_len - self.future_cache_size) / self.chunk_size)
+        self.future_size = 20 if self.freqnecy == '50hz' else 13
+        self.past_size = 20 if self.freqnecy == '50hz' else 51
+        self.generated_list = []
+        self.audio_list3 = []
+        self.y_all = torch.randn([1, 30000, 80],
+                                 device=self.device,
+                                 dtype=ref_mel.dtype)
+
+    def process_initial_chunk(self, cond, ref_mel, codec_all, y_all, steps):
+        factor = 2 if self.freqnecy == '50hz' else 4
+        y0 = y_all[:, :self.chunk_size + self.future_cache_size]
+        codec = codec_all[:, :(self.chunk_size + self.future_cache_size) //
+                          factor]
+        generated, _ = self.code2wav_dit_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=0.5,
+            sway_sampling_coef=-1.0,
+        )
+        self.generated_list.append(
+            generated.to(torch.float32)[:, :self.chunk_size, :])
+        mel = self.generated_list[0]
+        audio = self.code2wav_bigvgan_model(mel)
+        audio_output = audio[:-self.future_size * 240]
+        self.audio_list3.append(audio_output)
+
+    def process_little_chunk(self, cond, ref_mel, codec_all, y_all, steps):
+        y0 = y_all[:, :self.gt_mel_len]
+        codec = codec_all
+        generated, _ = self.code2wav_dit_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=0.5,
+            sway_sampling_coef=-1.0,
+        )
+        self.generated_list.append(generated.to(torch.float32)[:, :, :])
+        mel = self.generated_list[0]
+        audio = self.code2wav_bigvgan_model(mel)
+        audio_output = audio
+        self.audio_list3.append(audio_output)
+
+    def process_subsequent_chunks(self, cond, ref_mel, codec_all, y_all, i,
+                                  steps):
+        factor = 2 if self.freqnecy == '50hz' else 4
+        start_index = max(i * self.chunk_size - self.past_cache_size, 0)
+        end_index = min((i + 1) * self.chunk_size + self.future_cache_size,
+                        self.gt_mel_len)
+        y0 = y_all[:, start_index:end_index]
+        codec = codec_all[:, start_index // factor:end_index // factor]
+        generated, _ = self.code2wav_dit_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=0.5,
+            sway_sampling_coef=-1.0,
+        )
+
+        if self.freqnecy == '50hz':
+            if start_index == 0:
+                mel = self.generated_list[0]
+                self.generated_list.append(
+                    generated.to(torch.float32)
+                    [:, i * self.chunk_size:-self.future_cache_size, :])
+            else:
+                self.generated_list.append(
+                    generated.to(torch.float32)
+                    [:, self.past_cache_size:-self.future_cache_size, :])
+                mel = torch.cat([
+                    self.generated_list[i - 1][:, -self.future_size * 2:, :],
+                    self.generated_list[i]
+                ],
+                                dim=1)
+        else:
+            if start_index == 0:
+                mel = self.generated_list[0]
+                self.generated_list.append(
+                    generated.to(torch.float32)
+                    [:, i * self.chunk_size:-self.future_cache_size, :])
+            else:
+                self.generated_list.append(
+                    generated.to(torch.float32)
+                    [:, self.past_cache_size:-self.future_cache_size, :])
+                if len(self.generated_list) <= 2:
+                    mel = torch.cat(self.generated_list, dim=1)
+                else:  # all past mel length >= self.past_size + self.future_size
+                    mel = torch.cat([
+                        self.generated_list[i - 2], self.generated_list[i - 1],
+                        self.generated_list[i]
+                    ],
+                                    dim=1)
+
+        audio = self.code2wav_bigvgan_model(mel)
+
+        if self.freqnecy == '50hz':
+            audio_output = audio[self.future_size * 240:-self.future_size *
+                                 240]
+        else:
+            if len(self.generated_list) <= 2:
+                audio_output = audio[(self.past_size - self.chunk_size) *
+                                     240:-self.future_size * 240]
+            else:  # all past mel length >= self.past_size + self.future_size
+                audio_output = audio[self.past_size * 240:-self.future_size *
+                                     240]
+        self.audio_list3.append(audio_output)
+
+    def process_final_chunk(self, cond, ref_mel, codec_all, y_all, steps):
+        factor = 2 if self.freqnecy == '50hz' else 4
+        start_index = max(
+            (self.n_iter - 1) * self.chunk_size - self.past_cache_size, 0)
+        end_index = self.gt_codec_len * factor
+        y0 = y_all[:, start_index:end_index]
+        codec = codec_all[:, start_index // factor:self.gt_codec_len]
+        generated, _ = self.code2wav_dit_model.fast_block_sample(
+            cond=cond,
+            codec=codec,
+            ref_mel=ref_mel,
+            y0=y0,
+            steps=steps,
+            cfg_strength=0.5,
+            sway_sampling_coef=-1.0,
+        )
+        self.generated_list.append(
+            generated.to(torch.float32)[:, self.past_cache_size:, :])
+        if self.freqnecy == '50hz':
+            mel = torch.cat([
+                self.generated_list[-2][:, -self.future_size * 2:, :],
+                self.generated_list[-1]
+            ],
+                            dim=1)
+        else:
+            if len(self.generated_list) <= 2:
+                mel = torch.cat(self.generated_list, dim=1)
+            else:
+                mel = torch.cat([
+                    self.generated_list[-3], self.generated_list[-2],
+                    self.generated_list[-1]
+                ],
+                                dim=1)
+        audio = self.code2wav_bigvgan_model(mel)
+        if self.freqnecy == '50hz':
+            audio_output = audio[self.future_size * 240:]
+        else:
+            if len(self.generated_list) <= 2:
+                audio_output = audio[(self.past_size - self.chunk_size) * 240:]
+            else:
+                audio_output = audio[self.past_size * 240:]
+        self.audio_list3.append(audio_output)
+
+    def get_full_audio(self):
+        audio = torch.cat(self.audio_list3, dim=0)
+        return audio
+
+    def fast_forward(self, cond, ref_mel, codec, steps=10, bs_mel=24):
+        if self.freqnecy == "50hz":
+            assert self.bs_mel == 24
+        else:
+            assert self.bs_mel == 32
+        self.init_variables(cond, ref_mel, codec, bs_mel)
+        with torch.inference_mode():
+            if self.n_iter <= 0:
+                return
+            if self.n_iter == 1:
+                self.process_little_chunk(cond, ref_mel, codec, self.y_all,
+                                          steps)
+            else:
+                self.process_initial_chunk(cond, ref_mel, codec, self.y_all,
+                                           steps)
+                for i in range(1, self.n_iter - 1):
+                    self.process_subsequent_chunks(cond, ref_mel, codec,
+                                                   self.y_all, i, steps)
+
+                self.process_final_chunk(cond, ref_mel, codec, self.y_all,
+                                         steps)
+            return self.get_full_audio()

--- a/vllm/vllm_flash_attn/fa_utils.py
+++ b/vllm/vllm_flash_attn/fa_utils.py
@@ -11,8 +11,12 @@ def get_flash_attn_version(requires_alibi: bool = False) -> Optional[int]:
     # import here to avoid circular dependencies
     from vllm.platforms import current_platform
     try:
-        from vllm.vllm_flash_attn.flash_attn_interface import (
-            fa_version_unsupported_reason, is_fa_version_supported)
+        try:
+            from vllm.vllm_flash_attn.flash_attn_interface import (
+                fa_version_unsupported_reason, is_fa_version_supported)
+        except (ImportError, ModuleNotFoundError):
+            from vllm_flash_attn.flash_attn_interface import (
+                fa_version_unsupported_reason, is_fa_version_supported)
         device_capability = current_platform.get_device_capability()
 
         assert device_capability is not None

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -74,6 +74,11 @@ class Worker(LocalOrDistributedWorkerBase):
                 not in ("medusa", "mlp_speculator", "eagle", "deepseek_mtp")) \
                     else {"return_hidden_states": True}
 
+        model_runner_args = {}
+        if model_config.is_omni_thinker_model():
+            model_runner_args["return_hidden_states"] = True
+        model_runner_args.update(speculative_args)
+
         ModelRunnerClass: Type[GPUModelRunnerBase] = ModelRunner
         if model_config.runner_type == "pooling":
             ModelRunnerClass = PoolingModelRunner
@@ -83,7 +88,7 @@ class Worker(LocalOrDistributedWorkerBase):
             vllm_config=self.vllm_config,
             kv_cache_dtype=self.cache_config.cache_dtype,
             is_driver_worker=is_driver_worker,
-            **speculative_args,
+            **model_runner_args,
         )
         if model_runner_cls is not None:
             self.model_runner = model_runner_cls(self.model_runner)


### PR DESCRIPTION
**UPDATE**: This PR is deprecated, please use <https://github.com/vllm-project/vllm-omni> instead.

This draft PR adding support for Qwen2.5-Omni model (end-to-end full support).

This PR is a later version of #15130, it adds support for talker, code2wav, and an `OmniLLMEngine` class to manage the end-to-end audio generation process.
You can see #15130 for more details about `Qwen2.5-Omni` model architecture.

**NOTE**: Since this PR makes significant changes to vLLM, its a draft and will not be merged in the short term.

## Requirements

This PR requires https://github.com/huggingface/transformers/pull/36752.

```bash
pip install git+https://github.com/huggingface/transformers@f742a644ca32e65758c3adb36225aef1731bd2a8
```

**Note: You need to install transformers from source from that branch**

## Example Usage

```bash
python examples/offline_inference/qwen2_5_omni/end2end.py --model Qwen/Qwen2.5-Omni-7B --prompt audio-in-video-v2 --enforce-eager --do-wave --voice-type m02 --warmup-voice-type m02
```

This command will print text output and generate `.wav` output files under current folder.
