### PR TITLE
Update sequence.py to prevent LogitsProcessor objects from being deepcopied

### DIFF
--- a/vllm/sequence.py
+++ b/vllm/sequence.py
@@ -1428,7 +1428,11 @@ class ParallelSampleSequenceGroup(SequenceGroupBase):
         for i in range(original_params.n):
             request_id_i = f"{request_id}_parallel_sample_{i}"
             group.seq_id_to_index[request_id_i] = i
-            params = copy.deepcopy(original_params)
+            
+            # Defensive copy of SamplingParams,
+            # this doesn't deep-copy LogitsProcessor objects
+            params = original_params.clone()
+            
             params.n = 1
             if params.seed is not None:
                 params.seed += i


### PR DESCRIPTION
Deepcopying sampling_params that include LogitsProcessor might lead to OOM. This has been an old issue here:

[https://github.com/vllm-project/vllm/issues/3087](https://github.com/vllm-project/vllm/issues/3087)

and the previous commit #3099 fixed this issue in vllm/engine/llm_engine.py

However it is re-occurring in vllm/sequence.py. This commit is trying to fix this again.
