### PR TITLE
Revert "Update label-tpu mergify and remove removal bot"

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -90,9 +90,10 @@ pull_request_rules:
 
 - name: label-tpu
   description: Automatically apply tpu label
+  # Keep this list in sync with `label-tpu-remove` conditions
   conditions:
     - or:
-      - files~=tpu.
+      - files~=tpu.py
       - files~=_tpu
       - files~=tpu_
       - files~=/tpu/
@@ -100,6 +101,21 @@ pull_request_rules:
   actions:
     label:
       add:
+        - tpu
+
+- name: label-tpu-remove
+  description: Automatically remove tpu label
+  # Keep this list in sync with `label-tpu` conditions
+  conditions:
+    - and:
+      - -files~=tpu.py
+      - -files~=_tpu
+      - -files~=tpu_
+      - -files~=/tpu/
+      - -files~=pallas
+  actions:
+    label:
+      remove:
         - tpu
 
 - name: ping author on conflicts and add 'needs-rebase' label


### PR DESCRIPTION
Reverts vllm-project/vllm#16298

It seems the check is too flaky and many unrelated PRs are marked as TPU