### PR TITLE
[CI]Fix hpu docker and numpy version for CI

### DIFF
--- a/docker/Dockerfile.hpu
+++ b/docker/Dockerfile.hpu
@@ -1,4 +1,4 @@
-FROM vault.habana.ai/gaudi-docker/1.19.1/ubuntu22.04/habanalabs/pytorch-installer-2.5.1:latest
+FROM vault.habana.ai/gaudi-docker/1.20.1/ubuntu22.04/habanalabs/pytorch-installer-2.6.0:latest
 
 COPY ./ /workspace/vllm
 

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -5,6 +5,7 @@
 ray
 triton==3.1.0
 pandas
+numpy==1.26.4
 tabulate
 setuptools>=61
 setuptools-scm>=8


### PR DESCRIPTION
see incompatible numpy version to in-docker torch.
Fix the numpy version to make HPU CI runnable.
