### PR TITLE
[Bugfix][TPU] Fix TPU validate_request

### DIFF
--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -7,20 +7,17 @@ import torch
 import vllm.envs as envs
 from vllm.inputs import PromptType
 from vllm.logger import init_logger
+from vllm.sampling_params import SamplingParams
 
 from .interface import Platform, PlatformEnum, _Backend
 
 if TYPE_CHECKING:
     from vllm.config import ModelConfig, VllmConfig
-    from vllm.lora.request import LoRARequest
     from vllm.pooling_params import PoolingParams
-    from vllm.sampling_params import SamplingParams
 else:
     ModelConfig = None
     VllmConfig = None
-    LoRARequest = None
     PoolingParams = None
-    SamplingParams = None
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
Fix due to https://github.com/vllm-project/vllm/pull/16291, we needed to actually import SamplingParams rather than just using it for TYPE_CHECKING

Without this change you hit this error when making a request on TPU in V1
```
  File "/home/mgoin/code/vllm/vllm/v1/engine/processor.py", line 186, in process_inputs
    current_platform.validate_request(
  File "/home/mgoin/code/vllm/vllm/platforms/tpu.py", line 157, in validate_request
    if isinstance(params,
       ^^^^^^^^^^^^^^^^^^
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```