### PR TITLE
Update Numba to 0.61.2

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -2,7 +2,7 @@
 -r common.txt
 
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
-numba == 0.61; python_version > '3.9'
+numba == 0.61.2; python_version > '3.9'
 
 # Dependencies for NVIDIA GPUs
 ray[cgraph]>=2.43.0, !=2.44.* # Ray Compiled Graph, required for pipeline parallelism in V1.

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -2,7 +2,7 @@
 -r common.txt
 
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
-numba == 0.61; python_version > '3.9'
+numba == 0.61.2; python_version > '3.9'
 
 # Dependencies for AMD GPUs
 awscli

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -42,7 +42,7 @@ genai_perf==0.0.8
 tritonclient==2.51.0
 
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
-numba == 0.61; python_version > '3.9'
+numba == 0.61.2; python_version > '3.9'
 numpy
 runai-model-streamer==0.11.0
 runai-model-streamer-s3==0.11.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -267,7 +267,7 @@ nltk==3.9.1
     # via rouge-score
 num2words==0.5.14
     # via -r requirements/test.in
-numba==0.61.0
+numba==0.61.2
     # via
     #   -r requirements/test.in
     #   librosa


### PR DESCRIPTION
Numba 0.61.2 adds support for NumPy 2 and other bug fixes.