### PR TITLE
fix sonnet dataset sample when prefix len is very small

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -472,7 +472,7 @@ class SonnetDataset(BenchmarkDataset):
 
         # Determine how many poem lines to use.
         num_input_lines = round((input_len - base_offset) / avg_len)
-        num_prefix_lines = round((prefix_len - base_offset) / avg_len)
+        num_prefix_lines = max(round((prefix_len - base_offset) / avg_len), 0)
         prefix_lines = self.data[:num_prefix_lines]
 
         samples = []


### PR DESCRIPTION
FIX #16375 

prefix lines are intended to be the first few lines of sonnet data, however, when `prefix_len  < base_offset`, `num_prefix_lines` will be negative number, then the input prompt will contain more tokens than expected and exceeds the `max_model_len`. Set the upper bound as 0 to avoid this error. 
