### PR TITLE
[CI][Bugfix] Pin triton version for CPU

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -15,3 +15,6 @@ torchaudio==2.6.0; platform_machine == "ppc64le"
 torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"
 torchvision==0.21.0; platform_machine == "ppc64le"
 datasets # for benchmark scripts
+
+# cpu cannot use triton 3.3.0
+triton==3.2.0


### PR DESCRIPTION
GHA lint & deploy that's based on `vllm-cpu-env:latest` broke because of the Triton `3.3.0` release. This PR pins the version to `0.3.2` in cpu.txt (not sure this is the best way to fix this issue).
