### PR TITLE
[Core][Bugfix] Fix Offline MM Beam Search

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -468,12 +468,19 @@ class HfRunner:
         prompts: list[str],
         beam_width: int,
         max_tokens: int,
+        images: Optional[PromptImageInput] = None,
+        videos: Optional[PromptVideoInput] = None,
+        audios: Optional[PromptAudioInput] = None,
     ) -> list[tuple[list[list[int]], list[str]]]:
         outputs = self.generate(prompts,
                                 do_sample=False,
                                 max_new_tokens=max_tokens,
                                 num_beams=beam_width,
-                                num_return_sequences=beam_width)
+                                num_return_sequences=beam_width,
+                                images=images,
+                                videos=videos,
+                                audios=audios)
+
         for i in range(len(outputs)):
             output_ids, output_str = outputs[i]
             for j in range(len(output_ids)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,12 +29,11 @@ from vllm.distributed import (cleanup_dist_env_and_memory,
                               init_distributed_environment,
                               initialize_model_parallel)
 from vllm.inputs import (ExplicitEncoderDecoderPrompt, TextPrompt,
-                         TokensPrompt, to_enc_dec_tuple_list,
-                         zip_enc_dec_prompts)
+                         to_enc_dec_tuple_list, zip_enc_dec_prompts)
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams
-from vllm.utils import cuda_device_count_stateless, is_list_of
+from vllm.utils import cuda_device_count_stateless
 
 logger = init_logger(__name__)
 
@@ -936,18 +935,20 @@ class VllmRunner:
 
     def generate_beam_search(
         self,
-        prompts: Union[list[str], list[list[int]]],
+        prompts: list[str],
         beam_width: int,
         max_tokens: int,
+        images: Optional[PromptImageInput] = None,
+        videos: Optional[PromptVideoInput] = None,
+        audios: Optional[PromptAudioInput] = None,
     ) -> list[tuple[list[list[int]], list[str]]]:
-        if is_list_of(prompts, str, check="all"):
-            prompts = [TextPrompt(prompt=prompt) for prompt in prompts]
-        else:
-            prompts = [
-                TokensPrompt(prompt_token_ids=tokens) for tokens in prompts
-            ]
+        inputs = self.get_inputs(prompts,
+                                 images=images,
+                                 videos=videos,
+                                 audios=audios)
+
         outputs = self.model.beam_search(
-            prompts,
+            inputs,
             BeamSearchParams(beam_width=beam_width, max_tokens=max_tokens))
         returned_outputs = []
         for output in outputs:

--- a/tests/samplers/test_beam_search.py
+++ b/tests/samplers/test_beam_search.py
@@ -5,6 +5,9 @@ Run `pytest tests/samplers/test_beam_search.py`.
 """
 
 import pytest
+from transformers import AutoModelForSeq2SeqLM
+
+from vllm.assets.audio import AudioAsset
 
 
 @pytest.fixture(autouse=True)
@@ -48,15 +51,83 @@ def test_beam_search_single_input(
     for i in range(len(example_prompts)):
         hf_output_ids, hf_output_texts = hf_outputs[i]
         vllm_output_ids, vllm_output_texts = vllm_outputs[i]
-        for i, (hf_text,
+        for j, (hf_text,
                 vllm_text) in enumerate(zip(hf_output_texts,
                                             vllm_output_texts)):
-            print(f">>>{i}-th hf output:")
+            print(f">>>{j}-th hf output:")
             print(hf_text)
-            print(f">>>{i}-th vllm output:")
+            print(f">>>{j}-th vllm output:")
             print(vllm_text)
         assert len(hf_output_ids) == len(vllm_output_ids)
         for j in range(len(hf_output_ids)):
             assert hf_output_ids[j] == vllm_output_ids[j], (
                 f"Test{i} output{j}:\nHF: {hf_output_ids}\n"
                 f"vLLM: {vllm_output_ids}")
+
+
+@pytest.mark.parametrize("dtype", ["half"])
+@pytest.mark.parametrize("max_tokens", MAX_TOKENS)
+@pytest.mark.parametrize("beam_width", BEAM_WIDTHS)
+def test_beam_search_passes_multimodal_data(
+    hf_runner,
+    vllm_runner,
+    dtype: str,
+    max_tokens: int,
+    beam_width: int,
+) -> None:
+    """Ensure that beam search passes multimodal data through correctly."""
+    # NOTE - this test is primarily to check that mm data is passed to beams
+    # correctly. As such, we just need to check one extra modality to make
+    # sure things pass through properly.
+    audios = [AudioAsset("mary_had_lamb").audio_and_sample_rate]
+    model = "Qwen/Qwen2-Audio-7B-Instruct"
+    audio_seq = "<|audio_bos|><|AUDIO|><|audio_eos|>"
+    prompts = [
+        f"<|im_start|>user\n{audio_seq}Can you transcribe this?<|im_end|>\n<|im_start|>assistant\n"  #noqa: E501
+    ]
+
+    with hf_runner(model, dtype=dtype,
+                   auto_cls=AutoModelForSeq2SeqLM) as hf_model:
+        audio_token_id = hf_model.config.audio_token_index
+        hf_outputs = hf_model.generate_beam_search(
+            prompts,
+            beam_width=beam_width,
+            max_tokens=max_tokens,
+            audios=audios,
+        )
+
+    with vllm_runner(model, dtype=dtype) as vllm_model:
+        vllm_outputs = vllm_model.generate_beam_search(
+            prompts,
+            beam_width=beam_width,
+            max_tokens=max_tokens,
+            audios=audios,
+        )
+
+    seq_with_no_audio_toks = lambda seq: [
+        tok for tok in seq if tok != audio_token_id
+    ]
+
+    for i in range(len(prompts)):
+        hf_output_ids, hf_output_texts = hf_outputs[i]
+        vllm_output_ids, vllm_output_texts = vllm_outputs[i]
+
+        for j, (hf_text,
+                vllm_text) in enumerate(zip(hf_output_texts,
+                                            vllm_output_texts)):
+            print(f">>>{j}-th hf output [NOTE: special tokens are filtered]:")
+            print(hf_text)
+            print(f">>>{j}-th vllm output:")
+            print(vllm_text)
+        assert len(hf_output_ids) == len(vllm_output_ids)
+
+        for j in range(len(hf_output_ids)):
+            # Compare everything except for the audio tokens; we do this since
+            # the IDs returned from the transformers helper expands the audio
+            # token to match features, while the vLLM helper maintains the
+            # single audio token in the input text
+            filtered_hf_output_ids = seq_with_no_audio_toks(hf_output_ids[j])
+            filtered_vllm_output_ids = seq_with_no_audio_toks(
+                vllm_output_ids[j])
+
+            assert filtered_hf_output_ids == filtered_vllm_output_ids

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -38,12 +38,16 @@ class BeamSearchOutput:
 
 class BeamSearchInstance:
 
-    def __init__(self, prompt_tokens: list[int], **kwargs):
-        logprobs = kwargs.pop("logprobs", [])
+    def __init__(
+        self,
+        prompt_tokens: list[int],
+        logprobs: Optional[list[dict[int, Logprob]]] = None,
+        **kwargs,
+    ):
         self.beams: list[BeamSearchSequence] = [
             BeamSearchSequence(
                 tokens=prompt_tokens,
-                logprobs=logprobs,
+                logprobs=[] if logprobs is None list(logprobs),
                 **kwargs,
             )
         ]

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -38,9 +38,14 @@ class BeamSearchOutput:
 
 class BeamSearchInstance:
 
-    def __init__(self, prompt_tokens: list[int]):
+    def __init__(self, prompt_tokens: list[int], **kwargs):
+        logprobs = kwargs.pop("logprobs", [])
         self.beams: list[BeamSearchSequence] = [
-            BeamSearchSequence(tokens=prompt_tokens, logprobs=[])
+            BeamSearchSequence(
+                tokens=prompt_tokens,
+                logprobs=logprobs,
+                **kwargs,
+            )
         ]
         self.completed: list[BeamSearchSequence] = []
 

--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -47,7 +47,7 @@ class BeamSearchInstance:
         self.beams: list[BeamSearchSequence] = [
             BeamSearchSequence(
                 tokens=prompt_tokens,
-                logprobs=[] if logprobs is None list(logprobs),
+                logprobs=[] if logprobs is None else list(logprobs),
                 **kwargs,
             )
         ]

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -546,23 +546,19 @@ class LLM:
         instances: list[BeamSearchInstance] = []
 
         for prompt in prompts:
-
-            # TODO Probably need to handle different prompt types
-            multi_modal_kwargs = {}
+            # Add multimodal processor kwargs & data
+            mm_kwargs = {}
             if "multi_modal_data" in prompt:
-                multi_modal_kwargs["multi_modal_data"] = prompt[
-                    "multi_modal_data"]
+                mm_kwargs["multi_modal_data"] = prompt["multi_modal_data"]
             if "mm_processor_kwargs" in prompt:
-                multi_modal_kwargs["mm_processor_kwargs"] = prompt[
+                mm_kwargs["mm_processor_kwargs"] = prompt[
                     "mm_processor_kwargs"]
 
             if is_token_prompt(prompt):
                 prompt_tokens = prompt["prompt_token_ids"]
             else:
                 prompt_tokens = tokenizer.encode(prompt["prompt"])
-
-            instances.append(
-                BeamSearchInstance(prompt_tokens, **multi_modal_kwargs))
+            instances.append(BeamSearchInstance(prompt_tokens, **mm_kwargs))
 
         for _ in range(max_tokens):
             all_beams: list[BeamSearchSequence] = list(


### PR DESCRIPTION
Fixes passing the multimodal data for offline beam search.

FIX https://github.com/vllm-project/vllm/issues/16240
FIX https://github.com/vllm-project/vllm/issues/15694


Snippet to verify:
```python
import vllm
from vllm import LLM
from vllm.sampling_params import BeamSearchParams, SamplingParams
from vllm.assets.audio import AudioAsset

model_name = "Qwen/Qwen2-Audio-7B-Instruct"

wav = AudioAsset("mary_had_lamb").audio_and_sample_rate

question = "What is recited in the audio?"
audio_in_prompt = "Audio 1: <|audio_bos|><|AUDIO|><|audio_eos|>\n"
prompt = ("<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
            "<|im_start|>user\n"
            f"{audio_in_prompt}{question}<|im_end|>\n"
            "<|im_start|>assistant\n")

inputs = [
    {
        "prompt": prompt,
        "multi_modal_data": {"audio": wav},
    },
]


llm = LLM(
    model=model_name,
    max_model_len=4096,
    max_num_seqs=5,
    limit_mm_per_prompt={"audio": 1}, 
)

outputs = llm.beam_search(inputs, BeamSearchParams(beam_width=1, max_tokens=50, temperature=0))
for output in outputs:
    generated_text = output.sequences[0].text
    print(f"Generated text from beam search (single beam 0 temp): {generated_text!r}")

outputs = llm.generate(inputs, SamplingParams(max_tokens=50, temperature=0))
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"From greedy decoding (generate): {generated_text!r}")
```

Now considers the mm data in the beam search result.
```
Generated text from beam search (single beam 0 temp): "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\nAudio 1: <|audio_bos|><|AUDIO|><|audio_eos|>\nWhat is recited in the audio?<|im_end|>\n<|im_start|>assistant\nThe recited content in the audio is: 'First words I spoke in the original cornograph A little piece of practical poetry Mary had a little lamb Its fleece was white as snow And everywhere that Mary went The lamb was sure to go.'<|im_end|>"
Processed prompts: 100%|██████████████████████| 1/1 [00:01<00:00,  1.54s/it, est. speed input: 283.70 toks/s, output: 31.88 toks/s]
From greedy decoding (generate): "The recited content in the audio is: 'First words I spoke in the original cornograph A little piece of practical poetry Mary had a little lamb Its fleece was white as snow And everywhere that Mary went The lamb was sure to go.'"
```

CC @DarkLight1337 🙂 

