### PR TITLE
Fix cuda_version_str reset logic.

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -583,7 +583,6 @@ def get_env_info():
             cfg = torch._C._show_config().split('\n')
             hip_runtime_version = get_version_or_na(cfg, 'HIP Runtime')
             miopen_runtime_version = get_version_or_na(cfg, 'MIOpen')
-            cuda_version_str = 'N/A'
             hip_compiled_version = torch.version.hip
     else:
         version_str = debug_mode_str = cuda_available_str = cuda_version_str = 'N/A'


### PR DESCRIPTION

Why reset cuda_version_str when torch.hip is exists?