### PR TITLE
[Bugfix] Don't set an upper bound on repetition penalty

### DIFF
--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -385,9 +385,10 @@ class SamplingParams(
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError("frequency_penalty must be in [-2, 2], got "
                              f"{self.frequency_penalty}.")
-        if not self.repetition_penalty > 0.0:
-            raise ValueError("repetition_penalty must be greater than zero, got "
-                             f"{self.repetition_penalty}.")
+        if self.repetition_penalty <= 0.0:
+            raise ValueError(
+                "repetition_penalty must be greater than zero, got "
+                f"{self.repetition_penalty}.")
         if self.temperature < 0.0:
             raise ValueError(
                 f"temperature must be non-negative, got {self.temperature}.")

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -385,8 +385,8 @@ class SamplingParams(
         if not -2.0 <= self.frequency_penalty <= 2.0:
             raise ValueError("frequency_penalty must be in [-2, 2], got "
                              f"{self.frequency_penalty}.")
-        if not 0.0 < self.repetition_penalty <= 2.0:
-            raise ValueError("repetition_penalty must be in (0, 2], got "
+        if not self.repetition_penalty > 0.0:
+            raise ValueError("repetition_penalty must be non-negative, got "
                              f"{self.repetition_penalty}.")
         if self.temperature < 0.0:
             raise ValueError(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -386,7 +386,7 @@ class SamplingParams(
             raise ValueError("frequency_penalty must be in [-2, 2], got "
                              f"{self.frequency_penalty}.")
         if not self.repetition_penalty > 0.0:
-            raise ValueError("repetition_penalty must be non-negative, got "
+            raise ValueError("repetition_penalty must be greater than zero, got "
                              f"{self.repetition_penalty}.")
         if self.temperature < 0.0:
             raise ValueError(


### PR DESCRIPTION
This is a small fix to allow any non-negative values of repetition penalty to align with the transformers implementation ([ref](https://github.com/huggingface/transformers/blob/6d8b0b33786f6cf41791077624bf731f8c78e36b/src/transformers/generation/logits_process.py#L329)) instead of forcing (0, 2]! Not sure why this isn't allowed at the moment, maybe because of validation for allowed ranges for frequency/presence penalties based on openai docs being copied 🙂 