### PR TITLE
[CI] Cleanup `additional_dependencies: [toml]` for pre-commit yapf hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
   hooks:
   - id: yapf
     args: [--in-place, --verbose]
-    additional_dependencies: [toml] # TODO: Remove when yapf is upgraded
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.9.3
   hooks:


### PR DESCRIPTION
In https://github.com/vllm-project/vllm/blob/main/.pre-commit-config.yaml , there is a TODO note: "Remove when yapf is upgraded."

This PR https://github.com/vllm-project/vllm/pull/12475/file , yapf was upgraded from v0.32.0 to v0.43.0. According to yapf's [changelog](https://github.com/google/yapf/blob/main/CHANGELOG.md#0402-2023-09-22), starting from v0.40.2, toml is now included by default in additional_dependencies, making explicit declaration unnecessary.

This cleanup removes the redundant configuration.

<!--- pyml disable-next-line no-emphasis-as-heading -->
