### PR TITLE
[Bugfix] Fix output token length check logic

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -156,7 +156,7 @@ def calculate_metrics(
         if outputs[i].success:
             output_len = outputs[i].output_tokens
 
-            if output_len is None:
+            if not output_len:
                 # We use the tokenizer to count the number of output tokens
                 # for some serving backends instead of looking at
                 # len(outputs[i].itl) since multiple output tokens may be


### PR DESCRIPTION
- When the model interface doesn't return usage, output_tokens value defaults to 0
- Using 'is None' check fails to correctly calculate output_len in this case

This fix ensures proper calculation of output length even when usage data is not provided.

<!--- pyml disable-next-line no-emphasis-as-heading -->
