### PR TITLE
check input length of sonnet samples

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -476,7 +476,7 @@ class SonnetDataset(BenchmarkDataset):
         prefix_lines = self.data[:num_prefix_lines]
 
         samples = []
-        for _ in range(num_requests):
+        while len(samples) < num_requests:
             extra_lines = random.choices(self.data,
                                          k=num_input_lines - num_prefix_lines)
             prompt = f"{base_prompt}{''.join(prefix_lines + extra_lines)}"
@@ -484,13 +484,14 @@ class SonnetDataset(BenchmarkDataset):
             prompt_formatted = tokenizer.apply_chat_template(
                 msg, add_generation_prompt=True, tokenize=False)
             prompt_len = len(tokenizer(prompt_formatted).input_ids)
-            samples.append(
-                SampleRequest(
-                    prompt=prompt_formatted
-                    if return_prompt_formatted else prompt,
-                    prompt_len=prompt_len,
-                    expected_output_len=output_len,
-                ))
+            if prompt_len <= input_len:
+                samples.append(
+                    SampleRequest(
+                        prompt=prompt_formatted
+                        if return_prompt_formatted else prompt,
+                        prompt_len=prompt_len,
+                        expected_output_len=output_len,
+                    ))
         return samples
 
 


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/16420
This PR adds a check for [prompt_len] before including it in the samples.

In the scenario described in the related issue, approximately 4% of requests failed due to input length limitations. This issue is influenced by the tokenizer and randomness in the selection process.

The root cause lies in the random selection of lines, which can occasionally exceed the input length constraints. An alternative approach to address this issue would be to implement a token budget mechanism. This mechanism would involve adding sonnet lines step by step while ensuring compliance with the input length limitations.
extra_lines = random.choices(self.data,
                             k=num_input_lines - num_prefix_lines)



