### PR TITLE
[Llama4] Enable attention temperature tuning by default for long context (>32k)

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -146,7 +146,9 @@ class Llama4Attention(nn.Module):
         self.q_size = self.num_heads * self.head_dim
         self.kv_size = self.num_kv_heads * self.head_dim
         self.scaling = self.head_dim**-0.5
-        self.attn_temperature_tuning = self.nope
+        # TODO: attn_temperature_tuning should be a bool in huggingface
+        self.attn_temperature_tuning = self.nope and \
+            config.attn_temperature_tuning > 0
 
         self.floor_scale = getattr(config, "floor_scale", 8192.0)
         self.attn_scale = getattr(config, "attn_scale", 0.1)
@@ -232,7 +234,7 @@ class Llama4Attention(nn.Module):
         #
         # We should apply temperature tuning between (after) rotary / QK norm
         # and (before) attention.
-        if self.attn_temperature_tuning:
+        if self.attn_temperature_tuning and self.nope:
             attn_scale = self._get_attn_scale(positions)
             q = (q * attn_scale).to(q.dtype)
         attn_output = self.attn(q, k, v)
@@ -465,6 +467,16 @@ class Llama4ForCausalLM(LlamaForCausalLM):
     }
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # update temperature tuning config from generation config
+        gen_config = vllm_config.model_config.try_get_generation_config()
+        gen_config.update(vllm_config.model_config.override_generation_config)
+        # enable temperature tuning by default when max_model_len > 32K
+        default_attn_temperature_tuning = \
+            vllm_config.model_config.max_model_len > 32768
+        vllm_config.model_config.hf_config.attn_temperature_tuning \
+            = gen_config.get(
+                "attn_temperature_tuning", default_attn_temperature_tuning)
+
         super().__init__(vllm_config=vllm_config,
                          prefix=prefix,
                          layer_type=Llama4DecoderLayer)


### PR DESCRIPTION
Attention temperature tuning (on nope layers) improves accuracy on long context (>32k) tasks. Enabling it by default for long context unless explicitly disabled by the user.

Eval results on [RULER](https://github.com/NVIDIA/RULER) with and without attention temperature tuning (@luccafong):

<img width="1519" alt="Screenshot 2025-04-10 at 17 31 37" src="https://github.com/user-attachments/assets/78a35dd3-9197-446b-9061-dc18e6ea986d" />

cc: @ywang96 @simon-mo @DarkLight1337 
