### PR TITLE
Revert "[Model] use AutoWeightsLoader for deepseek_v2, internlm2"

### DIFF
--- a/vllm/model_executor/models/internlm2.py
+++ b/vllm/model_executor/models/internlm2.py
@@ -32,7 +32,7 @@ from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.sequence import IntermediateTensors, PoolerOutput
 
 from .interfaces import SupportsLoRA, SupportsPP
-from .utils import (AutoWeightsLoader, is_pp_missing_parameter,
+from .utils import (is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
 
@@ -306,42 +306,6 @@ class InternLM2Model(nn.Module):
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
-    def load_weights(self, weights: Iterable[Tuple[str,
-                                                   torch.Tensor]]) -> Set[str]:
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("gate_up_proj", "w1", 0),
-            ("gate_up_proj", "w3", 1),
-        ]
-        params_dict = dict(self.named_parameters())
-        loaded_params: Set[str] = set()
-        for name, loaded_weight in weights:
-            for (param_name, weight_name, shard_id) in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader",
-                                        default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
-
 
 class InternLM2ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
     packed_modules_mapping = {
@@ -409,8 +373,41 @@ class InternLM2ForCausalLM(nn.Module, SupportsPP, SupportsLoRA):
 
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:
-        loader = AutoWeightsLoader(self, skip_prefixes=["rotary_emb.inv_freq"])
-        return loader.load_weights(weights)
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("gate_up_proj", "w1", 0),
+            ("gate_up_proj", "w3", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        loaded_params: Set[str] = set()
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+            for (param_name, weight_name, shard_id) in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                # Skip loading extra bias for GPTQ models.
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    continue
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
 
 
 class InternLM2ForRewardModel(InternLM2ForCausalLM):


### PR DESCRIPTION
Reverts vllm-project/vllm#16383, temporary fix https://github.com/vllm-project/vllm/issues/16450


Before revert vllm-project/vllm#16383, i got launch error for R1 with pp3+tp8
- cmd

```bash
export VLLM_USE_V1=0 && export VLLM_PP_LAYER_PARTITION="22,20,19"
nohup python3 -m vllm.entrypoints.openai.api_server \
        --model=/workspace/dev/hf_models/DeepSeek-R1 \
        --dtype=auto \
        --block-size 32 \
        --tokenizer-mode=slow \
        --max-model-len 32768 \
        --max-num-batched-tokens 2048 \
        --tensor-parallel-size 8 \
        --pipeline-parallel-size 3 \
        --gpu-memory-utilization 0.90 \
        --max-num-seqs 48 \
        --trust-remote-code \
        --no-enable-prefix-caching \
        --enable-chunked-prefill=True \
        --disable-custom-all-reduce \
        --max-log-len 0 \
        --port 8862 > vllm.R1.log.3 2>&1 &
```

- error

```bash
 quantized or ignored modules [repeated 22x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620] Error executing method 'load_model'. This might cause deadlock in distributed execution. [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620] Traceback (most recent call last): [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker_base.py", line 612, in execute_method [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     return run_method(self, method, args, kwargs) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/utils.py", line 2363, in run_method [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     return func(*args, **kwargs) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/loader.py", line 455, in load_model [repeated 21x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     self.model_runner.load_model() [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     self.model = get_model(vllm_config=self.vllm_config) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/__init__.py", line 14, in get_model [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     return loader.load_model(vllm_config=vllm_config) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     loaded_weights = model.load_weights( [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 728, in load_weights [repeated 21x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     return loader.load_weights(weights) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     autoloaded_weights = set(self._load_module("", self.module, weights)) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/utils.py", line 195, in _load_module [repeated 14x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     yield from self._load_module(prefix, [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     loaded_params = module_load_weights(weights) [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620]     param = params_dict[name] [repeated 7x across cluster]
(RayWorkerWrapper pid=269885, ip=10.189.109.87) ERROR 04-11 11:26:12 [worker_base.py:620] KeyError: 'layers.61.mlp.experts.w2_weight' [repeated 7x across cluster]
```

more log:

```bash
[rank0]: Traceback (most recent call last):
[rank0]:   File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank0]:     return _run_code(code, main_globals, None,
[rank0]:   File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
[rank0]:     exec(code, run_globals)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/openai/api_server.py", line 1121, in <module>
[rank0]:     uvloop.run(run_server(args))
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/uvloop/__init__.py", line 82, in run
[rank0]:     return loop.run_until_complete(wrapper())
[rank0]:   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/uvloop/__init__.py", line 61, in wrapper
[rank0]:     return await main
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/openai/api_server.py", line 1069, in run_server
[rank0]:     async with build_async_engine_client(args) as engine_client:
[rank0]:   File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
[rank0]:     return await anext(self.gen)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/openai/api_server.py", line 146, in build_async_engine_client
[rank0]:     async with build_async_engine_client_from_engine_args(
[rank0]:   File "/usr/lib/python3.10/contextlib.py", line 199, in __aenter__
[rank0]:     return await anext(self.gen)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/entrypoints/openai/api_server.py", line 194, in build_async_engine_client_from_engine_args
[rank0]:     engine_client = AsyncLLMEngine.from_vllm_config(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 653, in from_vllm_config
[rank0]:     return cls(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 608, in __init__
[rank0]:     self.engine = self._engine_class(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 267, in __init__
[rank0]:     super().__init__(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 282, in __init__
[rank0]:     self.model_executor = executor_class(vllm_config=vllm_config, )
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/executor_base.py", line 286, in __init__
[rank0]:     super().__init__(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/executor_base.py", line 52, in __init__
[rank0]:     self._init_executor()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/ray_distributed_executor.py", line 114, in _init_executor
[rank0]:     self._init_workers_ray(placement_group)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/ray_distributed_executor.py", line 396, in _init_workers_ray
[rank0]:     self._run_workers("load_model",
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/ray_distributed_executor.py", line 516, in _run_workers
[rank0]:     self.driver_worker.execute_method(sent_method, *args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker_base.py", line 621, in execute_method
[rank0]:     raise e
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker_base.py", line 612, in execute_method
[rank0]:     return run_method(self, method, args, kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/utils.py", line 2363, in run_method
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 183, in load_model
[rank0]:     self.model_runner.load_model()
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 1113, in load_model
[rank0]:     self.model = get_model(vllm_config=self.vllm_config)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/__init__.py", line 14, in get_model
[rank0]:     return loader.load_model(vllm_config=vllm_config)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader/loader.py", line 455, in load_model
[rank0]:     loaded_weights = model.load_weights(
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 826, in load_weights
[rank0]:     return loader.load_weights(weights)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/utils.py", line 261, in load_weights
[rank0]:     autoloaded_weights = set(self._load_module("", self.module, weights))
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/utils.py", line 222, in _load_module
[rank0]:     yield from self._load_module(prefix,
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/utils.py", line 195, in _load_module
[rank0]:     loaded_params = module_load_weights(weights)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/deepseek_v2.py", line 728, in load_weights
[rank0]:     param = params_dict[name]
[rank0]: KeyError: 'layers.61.mlp.experts.w2_weight'
```