### PR TITLE
[TPU] Increase block size and reset block shapes

### DIFF
--- a/examples/offline_inference/tpu.py
+++ b/examples/offline_inference/tpu.py
@@ -22,7 +22,8 @@ def main():
     # In real workloads, `enforace_eager` should be `False`.
     llm = LLM(model="Qwen/Qwen2-1.5B-Instruct",
               max_num_batched_tokens=64,
-              max_num_seqs=4)
+              max_num_seqs=4,
+              max_model_len=128)
     outputs = llm.generate(prompts, sampling_params)
     print("-" * 50)
     for output, answer in zip(outputs, answers):

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -18,9 +18,9 @@ setuptools==78.1.0
 --find-links https://storage.googleapis.com/libtpu-releases/index.html
 --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
 --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-torch==2.8.0.dev20250408
-torchvision==0.22.0.dev20250408
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250408-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250408-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
-torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250408-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
+torch==2.8.0.dev20250430
+torchvision==0.22.0.dev20250430
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250430-cp39-cp39-linux_x86_64.whl ; python_version == "3.9"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250430-cp310-cp310-linux_x86_64.whl ; python_version == "3.10"
+torch_xla[tpu, pallas] @ https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-2.8.0.dev20250430-cp311-cp311-linux_x86_64.whl ; python_version == "3.11"
 

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -73,9 +73,9 @@ class TpuPlatform(Platform):
         from vllm.config import CompilationLevel
 
         cache_config = vllm_config.cache_config
+        # For v0, the default block size is 16.
         if cache_config and cache_config.block_size is None:
             cache_config.block_size = 16
-
         compilation_config = vllm_config.compilation_config
 
         # TPU only supports DYNAMO_ONCE compilation level
@@ -98,16 +98,18 @@ class TpuPlatform(Platform):
         if envs.VLLM_USE_V1:
             from vllm.v1.attention.backends.pallas import (
                 PallasAttentionBackend)
+            cache_config.block_size = PallasAttentionBackend.get_page_size(
+                vllm_config)
             min_page_size = PallasAttentionBackend.get_min_page_size(
                 vllm_config)
-            if min_page_size > vllm_config.cache_config.block_size:
+            if min_page_size > cache_config.block_size:
                 logger.warning(
                     "Increase the page size from %s to %s to make sure there's"
                     "no SMEM OOM",
-                    vllm_config.cache_config.block_size,
+                    cache_config.block_size,
                     min_page_size,
                 )
-                vllm_config.cache_config.block_size = min_page_size
+                cache_config.block_size = min_page_size
 
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -704,6 +704,13 @@ def cdiv(a: int, b: int) -> int:
     return -(a // -b)
 
 
+def next_power_of_2(n) -> int:
+    """The next power of 2 (inclusive)"""
+    if n < 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
 def round_up(x: int, y: int) -> int:
     return ((x + y - 1) // y) * y
 


### PR DESCRIPTION
Increase kv cache block size and reset kernel block shapes based on autotuned results from kernel. 
But still need to retune the kernel block shapes in kernel.

> Note: we should wait for https://github.com/pytorch/xla/pull/9041 to be checkin and update new torch_xla version in requirements.txt

Benchmarked without cache:

## v6e-1 (single chip): 7.87  -> 8.37 req / sec 

Benchmarking script:

```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.1-8B-Instruct  --disable-log-requests --port 8003 --gpu-memory-utilization 0.95 --max-num-batched-tokens 512 --tensor-parallel-size 1 --max-model-len 2048 --max_num_seqs 512 &> /tmp/serve.log &

python benchmarks/benchmark_serving.py --backend vllm --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --port=8003 --random-input-len 1800 --random-output-len 128
```

Before:
```
============ Serving Benchmark Result ============
Successful requests:                     987       
Benchmark duration (s):                  125.47    
Total input tokens:                      1776600   
Total generated tokens:                  118669    
Request throughput (req/s):              7.87      
Output token throughput (tok/s):         945.80    
Total Token throughput (tok/s):          15105.47  
---------------Time to First Token----------------
Mean TTFT (ms):                          61168.93  
Median TTFT (ms):                        60913.25  
P99 TTFT (ms):                           121404.06 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          31.70     
Median TPOT (ms):                        31.98     
P99 TPOT (ms):                           32.56     
---------------Inter-token Latency----------------
Mean ITL (ms):                           31.69     
Median ITL (ms):                         31.93     
P99 ITL (ms):                            33.08     
==================================================
```

After:
```
============ Serving Benchmark Result ============
Successful requests:                     987       
Benchmark duration (s):                  117.96    
Total input tokens:                      1776600   
Total generated tokens:                  118669    
Request throughput (req/s):              8.37      
Output token throughput (tok/s):         1006.00   
Total Token throughput (tok/s):          16066.94  
---------------Time to First Token----------------
Mean TTFT (ms):                          57649.43  
Median TTFT (ms):                        57545.37  
P99 TTFT (ms):                           113943.35 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.78     
Median TPOT (ms):                        29.96     
P99 TPOT (ms):                           30.49     
---------------Inter-token Latency----------------
Mean ITL (ms):                           29.76     
Median ITL (ms):                         29.97     
P99 ITL (ms):                            30.93     
==================================================
```

## v6e-8 (multi chip): 4.92  -> 5.42 req / sec 

```
VLLM_USE_V1=1 vllm serve "meta-llama/Llama-3.1-70B" --download_dir "/root/.cache" --disable-log-requests --tensor_parallel_size=8 --max-model-len=2048 --gpu-memory-utilization 0.95 --max-num-batched-tokens 512 --max_num_seqs 512  &> /tmp/serve.log &


python benchmarks/benchmark_serving.py --backend vllm --model meta-llama/Llama-3.1-70B --dataset-name random --port=8003 --random-input-len 1800 --random-output-len 128
```

Before:

```
============ Serving Benchmark Result ============
Successful requests:                     987       
Benchmark duration (s):                  200.42    
Total input tokens:                      1776600   
Total generated tokens:                  111817    
Request throughput (req/s):              4.92      
Output token throughput (tok/s):         557.91    
Total Token throughput (tok/s):          9422.22   
---------------Time to First Token----------------
Mean TTFT (ms):                          98990.46  
Median TTFT (ms):                        99069.74  
P99 TTFT (ms):                           195396.73 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          51.12     
Median TPOT (ms):                        51.44     
P99 TPOT (ms):                           52.66     
---------------Inter-token Latency----------------
Mean ITL (ms):                           51.27     
Median ITL (ms):                         51.38     
P99 ITL (ms):                            53.50     
==================================================
````

After

```
============ Serving Benchmark Result ============
Successful requests:                     987       
Benchmark duration (s):                  182.04    
Total input tokens:                      1776600   
Total generated tokens:                  111445    
Request throughput (req/s):              5.42      
Output token throughput (tok/s):         612.19    
Total Token throughput (tok/s):          10371.49  
---------------Time to First Token----------------
Mean TTFT (ms):                          89566.91  
Median TTFT (ms):                        89369.13  
P99 TTFT (ms):                           177012.56 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          46.24     
Median TPOT (ms):                        46.64     
P99 TPOT (ms):                           47.39     
---------------Inter-token Latency----------------
Mean ITL (ms):                           46.45     
Median ITL (ms):                         46.59     
P99 ITL (ms):                            48.17     
==================================================
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
