### PR TITLE
[MISC] Make GroupCoordinator compatible with out-of-tree devices

### DIFF
--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -194,7 +194,6 @@ class GroupCoordinator:
 
         from vllm.platforms import current_platform
 
-        # TODO: fix it for other platforms
         if current_platform.is_cuda_alike():
             self.device = torch.device(f"cuda:{local_rank}")
         elif current_platform.is_out_of_tree():

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -197,6 +197,9 @@ class GroupCoordinator:
         # TODO: fix it for other platforms
         if current_platform.is_cuda_alike():
             self.device = torch.device(f"cuda:{local_rank}")
+        elif current_platform.is_out_of_tree():
+            self.device = torch.device(
+                f"{current_platform.device_name}:{local_rank}")
         else:
             self.device = torch.device("cpu")
 


### PR DESCRIPTION
We are working on making vllm-ascend support rlhf-related functions, and a key step is to provide functions similar to PyHcclComunicator. When migrating the test cases related to test_pynccl in vLLM, I found that GroupCoordinator seems incompatible with out-of-tree devices. (see:https://github.com/vllm-project/vllm-ascend/actions/runs/14406599923/job/40404534132?pr=503). This PR has fixed this issue.

cc @youkaichao  @DarkLight1337

