### PR TITLE
[Bugfix][Core] add seq_id_to_seq_group clearing to avoid memory leak when s…

### DIFF
--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -173,6 +173,13 @@ class RequestOutput:
                 group.finish_seq(seq_group)
             if assembled_seq_group is None:
                 return None
+
+            # clear finished seq in seq_id_to_seq_group
+            if len(group.to_be_finished) == 0:
+                for sub_request_id in list(group.seq_id_to_index.keys()):
+                    if sub_request_id in seq_id_to_seq_group:
+                        del seq_id_to_seq_group[sub_request_id]
+
             return cls.from_seq_group(assembled_seq_group, use_cache,
                                       seq_id_to_seq_group)
 


### PR DESCRIPTION
Fix CPU memory leak when generate `n` completions per-prompt.

Related issue: 
FIX https://github.com/vllm-project/vllm/issues/12973

When set `n>1`, vllm uses `ParallelSampleSequenceGroup` to manage and put requests into engine.
In `ParallelSampleSequenceGroup`, it keeps adding `id: processed request` pair to `engine.seq_id_to_seq_group`:
```
class ParallelSampleSequenceGroup(SequenceGroupBase):

    @staticmethod
    def add_request(request_id: str, engine, params, **kwargs):
        original_params = params
        group = ParallelSampleSequenceGroup(request_id)
        seqs = []
        for i in range(original_params.n):
            request_id_i = f"{request_id}_parallel_sample_{i}"
            group.seq_id_to_index[request_id_i] = i
            params = copy.deepcopy(original_params)
            params.n = 1
            if params.seed is not None:
                params.seed += i
            seq_group = engine._add_processed_request(
                request_id_i,
                params=params,
                **kwargs,
            )  # type: ignore
            assert seq_group is not None
            engine.seq_id_to_seq_group[request_id_i] = group
            group.to_be_finished[request_id_i] = seq_group
            seqs.append(seq_group.seqs[0])

```
`seq_id_to_seq_group` is never released during inference.
  
Adding clearing codes to free the memory.