### PR TITLE
[TPU][V1] Make `--disable_chunked_mm_input` mandatory for serving MM models

### DIFF
--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -120,6 +120,11 @@ class TpuPlatform(Platform):
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TPU backend")
 
+        if scheduler_config.is_multimodal_model and not \
+            scheduler_config.disable_chunked_mm_input:
+            raise ValueError("TPU does not support running Multimodal models"\
+            " without setting `--disable_chunked_mm_input`.")
+
     @classmethod
     def is_pin_memory_available(cls):
         logger.warning("Pin memory is not supported on TPU.")

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -122,8 +122,10 @@ class TpuPlatform(Platform):
 
         if scheduler_config.is_multimodal_model and not \
             scheduler_config.disable_chunked_mm_input:
-            raise ValueError("TPU does not support running Multimodal models"\
-            " without setting `--disable_chunked_mm_input`.")
+            logger.warning("TPU does not support running Multimodal models"\
+            " without setting `--disable_chunked_mm_input`. " \
+            "Forcing --disable_chunked_mm_input.")
+            scheduler_config.disable_chunked_mm_input = True
 
     @classmethod
     def is_pin_memory_available(cls):


### PR DESCRIPTION
This feature was intended to avoid XLA recompiliations when running on TPUs. Make it mandatory.
