### PR TITLE
Fix erroneous "model doesn't support compile" warning

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3880,7 +3880,9 @@ def set_current_vllm_config(vllm_config: VllmConfig, check_compile=False):
     try:
         _current_vllm_config = vllm_config
         yield
-    finally:
+    except Exception:
+        raise
+    else:
         logger.debug("enabled custom ops: %s",
                      vllm_config.compilation_config.enabled_custom_ops)
         logger.debug("disabled custom ops: %s",
@@ -3898,6 +3900,7 @@ def set_current_vllm_config(vllm_config: VllmConfig, check_compile=False):
                 " does not support it. Please open an issue on GitHub"
                 " if you want it to be supported.",
                 vllm_config.model_config.model)
+    finally:
         _current_vllm_config = old_vllm_config
 
 


### PR DESCRIPTION
The problem was:
- during model init, we use the set_current_vllm_config context manager
- if model init fails, the finally block is always executed.
- previously, the finally block would always warn that the model doesn't support compile (it assumes the model init doesn't fail)
- In this PR, we only execute the compile warning check IF the model init succeeded.

an example way model init can fail is that your GPUs can OOM if you don't use the right number for the large models.

Test Plan:
- tested locally

