### PR TITLE
Fix vLLM x torch.compile config caching

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -294,12 +294,18 @@ class ModelConfig:
         factors.append(self.quantization)
         factors.append(self.revision)
         factors.append(self.code_revision)
+        factors.append(self.max_model_len)
+        factors.append(self.max_logprobs)
+        factors.append(self.disable_sliding_window)
         factors.append(self.trust_remote_code)
+        factors.append(self.mm_processor_kwargs)
+        factors.append(self.generation_config)
+        factors.append(self.model_impl)
+        factors.append(self.override_generation_config)
         factors.append(self.rope_scaling)
         factors.append(self.rope_theta)
-        # rope cos/sin cache depends on the max_position_embeddings
-        factors.append(
-            getattr(self.hf_config, "max_position_embeddings", "None"))
+        # hf_config can control how the model looks!
+        factors.append(self.hf_config.to_json_string())
         return hashlib.sha256(str(factors).encode()).hexdigest()
 
     def __init__(


### PR DESCRIPTION
Fixes https://github.com/vllm-project/vllm/issues/16150

Based on the ModelConfig, we decide if we can reuse an existing torch.compile'd artifact or if we need to recompile. Unfortunately we were not checking enough flags on the config, so if one runs `vllm serve` enough times with different arguments, it leads to weird errors (like in the issue).

The problem in #16150 was specifically that if the override_generation_config flag changed then we need to recompile.

I went through ModelConfig and I added some more things to be checked for if a model needs to recompile. Disclaimer: I do not know what a lot of these things to do, but I figure that it is better to add things than not (we risk silent incorrectness if the caching is wrong). We can remove more things if we are compiling too much.

This is also one of the reasons the PyTorch Team recommended that vLLM use torch.compile's built-in caching (we want to try to migrate vLLM to using this in the long term), because torch.compile programmatically decides what needs to be cached and that is tested really well.

Test Plan:
- `rm -rf ~/.cache/vllm`
- run `vllm serve "meta-llama/Llama-4-Scout-17B-16E-Instruct" -tp 8 --max_ model_len 1000 `
- run `vllm serve "meta-llama/Llama-4-Scout-17B-16E-Instruct" -tp 8 --max_ model_len 1000 --override-generation-config='{"attn_temperature_tuning": true}'`, note that there is no error and that vLLM decided to do a new compilation rather than reuse an existing artifact


