### PR TITLE
[BugFix] Handle non-contiguous tensors properly when serializing

### DIFF
--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -14,6 +14,7 @@ from msgspec import msgpack
 
 CUSTOM_TYPE_PICKLE = 1
 CUSTOM_TYPE_CLOUDPICKLE = 2
+CUSTOM_TYPE_RAW_VIEW = 3
 
 # TODO calibrate this size
 MIN_NOCOPY_BUF_SIZE = 512
@@ -76,13 +77,15 @@ class MsgpackEncoder:
         self, obj: np.ndarray
     ) -> tuple[str, tuple[int, ...], Union[int, memoryview]]:
         assert self.aux_buffers is not None
-        if not obj.data.contiguous or obj.nbytes < MIN_NOCOPY_BUF_SIZE:
-            # Encode in-line if small or non-contiguous.
-            data = obj.data
+        arr_data = obj.data if obj.data.c_contiguous else obj.tobytes()
+        if not obj.shape or obj.nbytes < MIN_NOCOPY_BUF_SIZE:
+            # Encode small arrays and scalars inline. Using this extension type
+            # ensures we can avoid copying when decoding.
+            data = msgpack.Ext(CUSTOM_TYPE_RAW_VIEW, arr_data)
         else:
             # Otherwise encode index of backing buffer to avoid copy.
             data = len(self.aux_buffers)
-            self.aux_buffers.append(data)
+            self.aux_buffers.append(arr_data)
 
         # We serialize the ndarray as a tuple of native types.
         # The data is either inlined if small, or an index into a list of
@@ -131,6 +134,8 @@ class MsgpackDecoder:
         return np.ndarray(buffer=buffer, dtype=np.dtype(dtype), shape=shape)
 
     def ext_hook(self, code: int, data: memoryview) -> Any:
+        if code == CUSTOM_TYPE_RAW_VIEW:
+            return data
         if code == CUSTOM_TYPE_PICKLE:
             return pickle.loads(data)
         if code == CUSTOM_TYPE_CLOUDPICKLE:


### PR DESCRIPTION
Follow-on to https://github.com/vllm-project/vllm/pull/13790. Both msgpack and zmq require contiguous tensors so ensure the tensor is converted in all cases.

Also use a msgpack ext for the inline case to avoid a copy on the decode side.