### PR TITLE
[Bugfix][Model] fix Phi3Small model only support v0

### DIFF
--- a/vllm/model_executor/models/phi3_small.py
+++ b/vllm/model_executor/models/phi3_small.py
@@ -25,7 +25,7 @@ from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
-from .interfaces import SupportsPP
+from .interfaces import SupportsPP, SupportsV0Only
 from .utils import (is_pp_missing_parameter,
                     make_empty_intermediate_tensors_factory, make_layers,
                     maybe_prefix)
@@ -354,7 +354,7 @@ class Phi3SmallModel(nn.Module):
         return hidden_states
 
 
-class Phi3SmallForCausalLM(nn.Module, SupportsPP):
+class Phi3SmallForCausalLM(nn.Module, SupportsPP, SupportsV0Only):
     _tied_weights_keys = ["lm_head.weight"]
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):


### PR DESCRIPTION
When i use python3 -m vllm.entrypoints.cli.main serve microsoft/Phi-3-small-8k-instruct --trust-remote-code --gpu-memory-utilization 0.95 command to run this model, got this error.

![image](https://github.com/user-attachments/assets/5478e0b1-3893-4f54-92b2-9e3794b2ba19)

<!--- pyml disable-next-line no-emphasis-as-heading -->
