### PR TITLE
[Core] Enable IPv6 with vllm.utils.make_zmq_socket()

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,13 +10,15 @@ from unittest.mock import patch
 
 import pytest
 import torch
+import zmq
 from vllm_test_utils.monitor import monitor
 
 from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
 from vllm.utils import (CacheInfo, FlexibleArgumentParser, LRUCache,
                         MemorySnapshot, PlaceholderModule, StoreBoolean,
                         bind_kv_cache, deprecate_kwargs, get_open_port,
-                        memory_profiling, merge_async_iterators, sha256,
+                        make_zmq_socket, memory_profiling,
+                        merge_async_iterators, sha256, split_zmq_path,
                         supports_kw, swap_dict_values)
 
 from .utils import create_new_process_for_each_test, error_on_warning
@@ -662,3 +664,46 @@ def test_sha256(input: tuple, output: int):
 
     # hashing different input, returns different value
     assert hash != sha256(input + (1, ))
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("ipc://some_path", ("ipc", "some_path", "")),
+        ("tcp://127.0.0.1:5555", ("tcp", "127.0.0.1", "5555")),
+        ("tcp://[::1]:5555", ("tcp", "::1", "5555")),  # IPv6 address
+        ("inproc://some_identifier", ("inproc", "some_identifier", "")),
+    ]
+)
+def test_split_zmq_path(path, expected):
+    assert split_zmq_path(path) == expected
+
+
+@pytest.mark.parametrize(
+    "invalid_path",
+    [
+        "invalid_path",  # Missing scheme
+        "tcp://127.0.0.1",  # Missing port
+        "tcp://[::1]",  # Missing port for IPv6
+        "tcp://:5555",  # Missing host
+    ]
+)
+def test_split_zmq_path_invalid(invalid_path):
+    with pytest.raises(ValueError):
+        split_zmq_path(invalid_path)
+
+
+def test_make_zmq_socket_ipv6():
+    ctx = zmq.Context()
+    ipv6_path = "tcp://[::1]:5555"  # IPv6 loopback address
+    socket_type = zmq.REP  # Example socket type
+
+    # Create the socket
+    socket = make_zmq_socket(ctx, ipv6_path, socket_type)
+
+    # Verify that the IPV6 option is set
+    assert socket.getsockopt(zmq.IPV6) == 1, "IPV6 option should be enabled for IPv6 addresses"
+
+    # Clean up
+    socket.close()
+    ctx.term()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -706,11 +706,11 @@ def test_make_zmq_socket_ipv6():
     socket_type = zmq.REP  # Example socket type
 
     # Create the socket
-    socket = make_zmq_socket(ctx, ipv6_path, socket_type)
+    sock = make_zmq_socket(ctx, ipv6_path, socket_type)
 
     # Verify that the IPV6 option is set
-    assert socket.getsockopt(zmq.IPV6) == 1, "IPV6 option should be enabled for IPv6 addresses"
+    assert sock.getsockopt(zmq.IPV6) == 1, "IPV6 option should be enabled for IPv6 addresses"
 
     # Clean up
-    socket.close()
+    sock.close()
     ctx.term()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -706,11 +706,11 @@ def test_make_zmq_socket_ipv6():
     socket_type = zmq.REP  # Example socket type
 
     # Create the socket
-    sock = make_zmq_socket(ctx, ipv6_path, socket_type)
+    zsock: zmq.Socket = make_zmq_socket(ctx, ipv6_path, socket_type)
 
     # Verify that the IPV6 option is set
-    assert sock.getsockopt(zmq.IPV6) == 1, "IPV6 option should be enabled for IPv6 addresses"
+    assert zsock.getsockopt(zmq.IPV6) == 1, "IPV6 option should be enabled for IPv6 addresses"
 
     # Clean up
-    sock.close()
+    zsock.close()
     ctx.term()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -702,7 +702,7 @@ def test_make_zmq_socket_ipv6():
         pytest.skip("IPv6 is not supported on this system")
 
     ctx = zmq.Context()
-    ipv6_path = "tcp://[::1]:5555"  # IPv6 loopback address
+    ipv6_path = "tcp://[::]:5555"  # IPv6 loopback address
     socket_type = zmq.REP  # Example socket type
 
     # Create the socket

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -694,6 +694,13 @@ def test_split_zmq_path_invalid(invalid_path):
 
 
 def test_make_zmq_socket_ipv6():
+    # Check if IPv6 is supported by trying to create an IPv6 socket
+    try:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        sock.close()
+    except socket.error:
+        pytest.skip("IPv6 is not supported on this system")
+
     ctx = zmq.Context()
     ipv6_path = "tcp://[::1]:5555"  # IPv6 loopback address
     socket_type = zmq.REP  # Example socket type


### PR DESCRIPTION
This code did not previously support IPv6 addresses for a TCP
zmq socket. This fixes that, including some test cases.

I spotted this while reading #15977.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
