### PR TITLE
Optimized topk for topk=1 (Llama-4)

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -37,7 +37,7 @@ from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 
 from .llama import LlamaForCausalLM, LlamaMLP, LlamaModel
-from .utils import (AutoWeightsLoader, extract_layer_index,
+from .utils import (AutoWeightsLoader, extract_layer_index, fast_topk,
                     is_pp_missing_parameter)
 
 
@@ -50,7 +50,7 @@ class Llama4MoE(nn.Module):
         topk: int,
         renormalize: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        router_scores, router_indices = torch.topk(gating_output, topk, dim=-1)
+        router_scores, router_indices = fast_topk(gating_output, topk, dim=-1)
         router_scores = torch.sigmoid(router_scores.float()).to(
             hidden_states.dtype)
         return (router_scores, router_indices.to(torch.int32))

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -703,3 +703,12 @@ def cast_overflow_tensors(
         clamp_value = torch.finfo(tensors.dtype).max - offset
         tensors = torch.clamp(tensors, min=-clamp_value, max=clamp_value)
     return tensors
+
+
+def fast_topk(values, topk, dim):
+    if topk == 1:
+        # Use max along the specified dimension to get both value and index
+        return torch.max(values, dim=dim, keepdim=True)
+    else:
+        # Use topk for efficiency with larger k values
+        return torch.topk(values, topk, dim=dim)


### PR DESCRIPTION
Clear speedup for latency case, adapted from https://github.com/sgl-project/sglang/commit/86a876d883a7c7a0e2b0fca5ef86e20ab92c0694 (thank you!)

Llama Scout FP8 on 2xH100, input/output=1000/1000 batch_size=1
```
# benchmark
python benchmarks/benchmark_latency.py --model RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --max-model-len 8000 --tensor-parallel-size 2 --input-len 1000 --output-len 1000 --batch-size 1 --num-iters-warmup 5 --num-iters 5 

# torch.topk
Avg latency: 12.93838309822604 seconds
10% percentile latency: 12.891319572227076 seconds
25% percentile latency: 12.904249292099848 seconds
50% percentile latency: 12.921604027971625 seconds
75% percentile latency: 12.932637538062409 seconds
90% percentile latency: 13.00348993963562 seconds
99% percentile latency: 13.046001380579547 seconds

# fast_topk
Avg latency: 12.725665437569841 seconds
10% percentile latency: 12.664348530210555 seconds
25% percentile latency: 12.665923552820459 seconds
50% percentile latency: 12.72062187595293 seconds
75% percentile latency: 12.734881401993334 seconds
90% percentile latency: 12.800113665964455 seconds
99% percentile latency: 12.839253024347126 seconds

```

Llama Scout FP8 on 2xH100, input/output=1000/1000 batch_size=32
```
# benchmark
python benchmarks/benchmark_latency.py --model RedHatAI/Llama-4-Scout-17B-16E-Instruct-FP8-dynamic --max-model-len 8000 --tensor-parallel-size 2 --input-len 1000 --output-len 1000 --batch-size 32 --num-iters-warmup 3 --num-iters 3

# torch.topk
Avg latency: 23.997261434715863 seconds
10% percentile latency: 23.722837531426922 seconds
25% percentile latency: 23.844304106081836 seconds
50% percentile latency: 24.04674839717336 seconds
75% percentile latency: 24.174962244578637 seconds
90% percentile latency: 24.251890553021802 seconds
99% percentile latency: 24.298047538087705 seconds

# fast_topk
Avg latency: 23.815591983729973 seconds
10% percentile latency: 23.6753818389494 seconds
25% percentile latency: 23.733925551641732 seconds
50% percentile latency: 23.831498406128958 seconds
75% percentile latency: 23.905211627017707 seconds
90% percentile latency: 23.949439559550957 seconds
99% percentile latency: 23.975976319070906 seconds