### PR TITLE
Bugfix for PixtralHF models without spatial_merge_size

### DIFF
--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -926,8 +926,9 @@ class PixtralHFEncoderInfo(VisionEncoderInfo[PixtralVisionConfig]):
         return self.vision_config.image_size
 
     def get_patch_size(self) -> int:
-        return (self.vision_config.patch_size *
-                self.vision_config.spatial_merge_size)
+        spatial_merge_size = getattr(self.vision_config, "spatial_merge_size",
+                                     1)
+        return (self.vision_config.patch_size * spatial_merge_size)
 
     def get_patch_grid_length(self) -> int:
         image_size, patch_size = self.get_image_size(), self.get_patch_size()


### PR DESCRIPTION
Without this change, running an original PixtralHF model will fail during image inference

```
vllm serve nm-testing/pixtral-12b-FP8-dynamic --max-model-len 10000
...
  File "/home/mgoin/code/vllm/vllm/model_executor/models/pixtral.py", line 930, in get_patch_size
    self.vision_config.spatial_merge_size)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mgoin/venvs/vllm/lib/python3.12/site-packages/transformers/configuration_utils.py", line 210, in __getattribute__
    return super().__getattribute__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PixtralVisionConfig' object has no attribute 'spatial_merge_size'
```