### PR TITLE
[CI][Bugfix] Add mistral_tool_use to Ci

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -378,8 +378,10 @@ steps:
   source_file_dependencies:
     - vllm/
     - tests/tool_use
+    - tests/mistral_tool_use
   commands:
     - pytest -v -s tool_use
+    - pytest -v -s mistral_tool_use
 
 #####  models test  #####
 


### PR DESCRIPTION
This folder was forgotten to be added to the actual buildkite job in https://github.com/vllm-project/vllm/pull/12332