### PR TITLE
change name `specialized_manager` to `specialized_kv_cache_manager`

### DIFF
--- a/tests/v1/core/test_specialized_kv_cache_manager.py
+++ b/tests/v1/core/test_specialized_kv_cache_manager.py
@@ -4,7 +4,7 @@ import torch
 
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import BlockHashType, KVCacheBlock
-from vllm.v1.core.specialized_manager import SlidingWindowManager
+from vllm.v1.core.specialized_kv_cache_manager import SlidingWindowManager
 from vllm.v1.kv_cache_interface import SlidingWindowSpec
 
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -9,7 +9,7 @@ from vllm.utils import cdiv, sha256
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (BlockHashType, KVCacheBlock,
                                          hash_request_tokens)
-from vllm.v1.core.specialized_manager import get_specialized_manager
+from vllm.v1.core.specialized_kv_cache_manager import get_specialized_kv_cache_manager
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats
 from vllm.v1.request import Request, RequestStatus
@@ -57,7 +57,7 @@ class KVCacheManager:
 
         self.block_pool = BlockPool(self.num_gpu_blocks, enable_caching)
 
-        self.specialized_manager = get_specialized_manager(
+        self.specialized_kv_cache_manager = get_specialized_kv_cache_manager(
             kv_cache_spec=kv_cache_spec,
             block_pool=self.block_pool,
         )
@@ -144,7 +144,7 @@ class KVCacheManager:
             last_block_hash = None
 
         computed_blocks = (
-            self.specialized_manager.find_longest_cache_hit(block_hashes))
+            self.specialized_kv_cache_manager.find_longest_cache_hit(block_hashes))
         self.prefix_cache_stats.queries += len(block_hashes)
         self.prefix_cache_stats.hits += len(computed_blocks)
 
@@ -203,7 +203,7 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
-        removed_blocks = self.specialized_manager.remove_skipped_blocks(
+        removed_blocks = self.specialized_kv_cache_manager.remove_skipped_blocks(
             req_blocks, request.num_computed_tokens)
         self.block_pool.free_blocks(removed_blocks)
 

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -9,7 +9,8 @@ from vllm.utils import cdiv, sha256
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (BlockHashType, KVCacheBlock,
                                          hash_request_tokens)
-from vllm.v1.core.specialized_kv_cache_manager import get_specialized_kv_cache_manager
+from vllm.v1.core.specialized_kv_cache_manager \
+    import get_specialized_kv_cache_manager
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats
 from vllm.v1.request import Request, RequestStatus
@@ -203,7 +204,8 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
-        removed_blocks = self.specialized_kv_cache_manager.remove_skipped_blocks(
+        removed_blocks = self.specialized_kv_cache_manager \
+            .remove_skipped_blocks(
             req_blocks, request.num_computed_tokens)
         self.block_pool.free_blocks(removed_blocks)
 

--- a/vllm/v1/core/specialized_kv_cache_manager.py
+++ b/vllm/v1/core/specialized_kv_cache_manager.py
@@ -154,7 +154,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SpecializedManager]] = {
 }
 
 
-def get_specialized_manager(kv_cache_spec: KVCacheSpec,
+def get_specialized_kv_cache_manager(kv_cache_spec: KVCacheSpec,
                             block_pool: BlockPool) -> SpecializedManager:
     manager_class = spec_manager_map[type(kv_cache_spec)]
     manager = manager_class(kv_cache_spec, block_pool)


### PR DESCRIPTION

When I was watching Yihua's vLLM livestream, Yihua and the host both felt that the name specialized_manager wasn't ideal, because even though the function is related to the KV cache, the name doesn't reflect that. Yihua suggested renaming it to specialized_kv_cache_manager, and the host said it would make an excellent "good start" PR. So I went ahead and updated the relevant functions and file names accordingly, and submitted this PR.

<!--- pyml disable-next-line no-emphasis-as-heading -->
