### PR TITLE
fix: missing modelscope

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -47,3 +47,4 @@ opentelemetry-sdk>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-api>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-exporter-otlp>=1.26.0,<1.27.0  # vllm.tracing
 opentelemetry-semantic-conventions-ai>=0.4.1,<0.5.0  # vllm.tracing
+modelscope>=1.18.1


### PR DESCRIPTION


- Cannot load if using `modelscope`:
```
$ export VLLM_USE_MODELSCOPE=True
$ vllm serve qwen/Qwen1.5-0.5B-Chat
Traceback (most recent call last):
  File "/Users/xxx/local/github_projects/vllm/vllm/distributed/kv_transfer/kv_connector/base.py", line 15, in <module>
    from vllm.sequence import IntermediateTensors
  File "/Users/xxx/local/github_projects/vllm/vllm/sequence.py", line 17, in <module>
    from vllm.inputs import SingletonInputs, SingletonInputsAdapter
  File "/Users/xxx/local/github_projects/vllm/vllm/inputs/__init__.py", line 9, in <module>
    from .registry import (DummyData, InputContext, InputProcessingContext,
  File "/Users/xxx/local/github_projects/vllm/vllm/inputs/registry.py", line 15, in <module>
    from vllm.transformers_utils.processor import cached_processor_from_config
  File "/Users/xxx/local/github_projects/vllm/vllm/transformers_utils/__init__.py", line 7, in <module>
    import modelscope
ModuleNotFoundError: No module named 'modelscope'
```

- Based on the loading version, so add it:
https://github.com/vllm-project/vllm/blob/802329dee9e5b70c0c73df93c9db1ecdc4632664/vllm/transformers_utils/__init__.py#L13

<!--- pyml disable-next-line no-emphasis-as-heading -->
