### PR TITLE
[Bugfix] Validate logit biases to prevent out of vocab ids crashing engine

### DIFF
--- a/tests/entrypoints/openai/test_chat_logit_bias_validation.py
+++ b/tests/entrypoints/openai/test_chat_logit_bias_validation.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import openai
+import pytest
+import pytest_asyncio
+
+from vllm.config import ModelConfig
+
+from ...utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+def get_vocab_size(model_name):
+    config = ModelConfig(
+        model=model_name,
+        task="auto",
+        tokenizer=model_name,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        seed=0,
+        dtype="bfloat16",
+    )
+    return config.get_vocab_size()
+
+
+@pytest.fixture(scope="module")
+def server():
+    args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "1024",
+        "--enforce-eager",
+    ]
+
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    async with server.get_async_client() as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_chat_logit_bias_valid(client):
+    """Test that valid logit_bias values are accepted in chat completions."""
+    vocab_size = get_vocab_size(MODEL_NAME)
+    valid_token_id = vocab_size - 1
+
+    completion = await client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{
+            "role": "user",
+            "content": "Testing valid logit bias"
+        }],
+        max_tokens=5,
+        logit_bias={str(valid_token_id): 1.0},
+    )
+
+    assert completion.choices[0].message.content is not None
+
+
+@pytest.mark.asyncio
+async def test_chat_logit_bias_invalid(client):
+    """Test that invalid logit_bias values are rejected in chat completions."""
+    vocab_size = get_vocab_size(MODEL_NAME)
+    invalid_token_id = vocab_size + 1
+
+    with pytest.raises(openai.BadRequestError) as excinfo:
+        await client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[{
+                "role": "user",
+                "content": "Testing invalid logit bias"
+            }],
+            max_tokens=5,
+            logit_bias={str(invalid_token_id): 1.0},
+        )
+
+    error = excinfo.value
+    error_message = str(error)
+
+    assert error.status_code == 400
+    assert str(invalid_token_id) in error_message
+    assert str(vocab_size) in error_message

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -95,14 +95,14 @@ class Processor:
         """Validate logit_bias token IDs are within vocabulary range."""
         if not params.logit_bias:
             return
-            
+
         vocab_size = self.model_config.get_vocab_size()
         invalid_token_ids = []
-        
+
         for token_id in params.logit_bias:
             if token_id < 0 or token_id >= vocab_size:
                 invalid_token_ids.append(token_id)
-                
+
         if invalid_token_ids:
             raise ValueError(
                 f"token_id(s) {invalid_token_ids} in logit_bias contain "

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -77,6 +77,7 @@ class Processor:
         params: SamplingParams,
     ) -> None:
         self._validate_structured_output(params)
+        self._validate_logit_bias(params)
 
         if params.allowed_token_ids is None:
             return
@@ -86,6 +87,26 @@ class Processor:
         if not all(0 <= tid < vocab_size for tid in params.allowed_token_ids):
             raise ValueError(
                 "allowed_token_ids contains out-of-vocab token id!")
+
+    def _validate_logit_bias(
+        self,
+        params: SamplingParams,
+    ) -> None:
+        """Validate logit_bias token IDs are within vocabulary range."""
+        if not params.logit_bias:
+            return
+            
+        vocab_size = self.model_config.get_vocab_size()
+        invalid_token_ids = []
+        
+        for token_id in params.logit_bias:
+            if token_id < 0 or token_id >= vocab_size:
+                invalid_token_ids.append(token_id)
+                
+        if invalid_token_ids:
+            raise ValueError(
+                f"token_id(s) {invalid_token_ids} in logit_bias contain "
+                f"out-of-vocab token ids. Vocabulary size: {vocab_size}")
 
     def _validate_supported_sampling_params(
         self,

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -230,17 +230,19 @@ class Sampler(nn.Module):
         # TODO(houseroad): this implementation is extremely inefficient.
         # One idea is implement this as a PyTorch C++ op, and we may
         # even optimize the logit_bias layout.
-        
+
         # Get vocabulary size from logits
         vocab_size = logits.shape[-1]
-        
+
         for i, logit_bias in enumerate(sampling_metadata.logit_bias):
             if logit_bias:
                 for token_id, bias in logit_bias.items():
                     # Check token_id bounds to ensure within vocabulary
                     if token_id < 0 or token_id >= vocab_size:
-                        raise ValueError(f"token_id {token_id} in logit_bias contains "
-                                         f"out-of-vocab token id. Vocabulary size: {vocab_size}")
+                        raise ValueError(
+                            f"token_id {token_id} in logit_bias contains "
+                            f"out-of-vocab token id. Vocabulary size: "
+                            f"{vocab_size}")
                     logits[i, token_id] += bias
         return logits
 

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -230,9 +230,17 @@ class Sampler(nn.Module):
         # TODO(houseroad): this implementation is extremely inefficient.
         # One idea is implement this as a PyTorch C++ op, and we may
         # even optimize the logit_bias layout.
+        
+        # Get vocabulary size from logits
+        vocab_size = logits.shape[-1]
+        
         for i, logit_bias in enumerate(sampling_metadata.logit_bias):
             if logit_bias:
                 for token_id, bias in logit_bias.items():
+                    # Check token_id bounds to ensure within vocabulary
+                    if token_id < 0 or token_id >= vocab_size:
+                        raise ValueError(f"token_id {token_id} in logit_bias contains "
+                                         f"out-of-vocab token id. Vocabulary size: {vocab_size}")
                     logits[i, token_id] += bias
         return logits
 


### PR DESCRIPTION
In V1 when an out of vocab token ID is submitted within logit_bias in a request it will cause the engine to crash. 

For example, the following request will lead to an engine crash as the token ID is out of the vocab for the model.

```
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "meta-llama/Llama-3.1-8B-Instruct",
    "max_tokens": 4000,
    "logit_bias": {
      "191222": -100,
      "99999": 5
    },
    "messages": [
      {
        "role": "user",
        "content": "Hello, tell me about a nice dog."
      }
    ]
  }'
```

```
INFO 04-12 06:41:33 [async_llm.py:228] Added request chatcmpl-5da6fafa57b640e4835e057cf19021f2.
ERROR 04-12 06:41:33 [core.py:390] EngineCore hit an exception: Traceback (most recent call last):
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 383, in run_engine_core
ERROR 04-12 06:41:33 [core.py:390]     engine_core.run_busy_loop()
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 405, in run_busy_loop
ERROR 04-12 06:41:33 [core.py:390]     self._process_engine_step()
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 434, in _process_engine_step
ERROR 04-12 06:41:33 [core.py:390]     outputs = self.step_fn()
ERROR 04-12 06:41:33 [core.py:390]               ^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/engine/core.py", line 206, in step
ERROR 04-12 06:41:33 [core.py:390]     output = self.model_executor.execute_model(scheduler_output)
ERROR 04-12 06:41:33 [core.py:390]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/executor/abstract.py", line 77, in execute_model
ERROR 04-12 06:41:33 [core.py:390]     output = self.collective_rpc("execute_model",
ERROR 04-12 06:41:33 [core.py:390]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/executor/uniproc_executor.py", line 56, in collective_rpc
ERROR 04-12 06:41:33 [core.py:390]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 04-12 06:41:33 [core.py:390]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/utils.py", line 2347, in run_method
ERROR 04-12 06:41:33 [core.py:390]     return func(*args, **kwargs)
ERROR 04-12 06:41:33 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 04-12 06:41:33 [core.py:390]     return func(*args, **kwargs)
ERROR 04-12 06:41:33 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 242, in execute_model
ERROR 04-12 06:41:33 [core.py:390]     output = self.model_runner.execute_model(scheduler_output)
ERROR 04-12 06:41:33 [core.py:390]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
ERROR 04-12 06:41:33 [core.py:390]     return func(*args, **kwargs)
ERROR 04-12 06:41:33 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1070, in execute_model
ERROR 04-12 06:41:33 [core.py:390]     sampler_output = self.model.sample(
ERROR 04-12 06:41:33 [core.py:390]                      ^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/model_executor/models/llama.py", line 556, in sample
ERROR 04-12 06:41:33 [core.py:390]     next_tokens = self.sampler(logits, sampling_metadata)
ERROR 04-12 06:41:33 [core.py:390]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl
ERROR 04-12 06:41:33 [core.py:390]     return self._call_impl(*args, **kwargs)
ERROR 04-12 06:41:33 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
ERROR 04-12 06:41:33 [core.py:390]     return forward_call(*args, **kwargs)
ERROR 04-12 06:41:33 [core.py:390]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 45, in forward
ERROR 04-12 06:41:33 [core.py:390]     logits = self.apply_logits_bias(logits, sampling_metadata)
ERROR 04-12 06:41:33 [core.py:390]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390]   File "/home/ryan/venv/lib/python3.12/site-packages/vllm/v1/sample/sampler.py", line 236, in apply_logits_bias
ERROR 04-12 06:41:33 [core.py:390]     logits[i, token_id] += bias
ERROR 04-12 06:41:33 [core.py:390]     ~~~~~~^^^^^^^^^^^^^
ERROR 04-12 06:41:33 [core.py:390] IndexError: index 141718 is out of bounds for dimension 1 with size 128256
ERROR 04-12 06:41:33 [core.py:390]
CRITICAL 04-12 06:41:33 [core_client.py:361] Got fatal signal from worker processes, shutting down. See stack trace above for root cause issue.
Killed
```

After this fix, we return a 400 bad request error in V1
`{"object":"error","message":"token_id(s) [191222] in logit_bias contain out-of-vocab token ids. Vocabulary size: 128256","type":"BadRequestError","param":null,"code":400}`

which is similar to the error in V0
`{"object":"error","message":"token_id 191222 in logit_bias contains out-of-vocab token id","type":"BadRequestError","param":null,"code":400
`


