### PR TITLE
Fix syntaxWarning: invalid escape sequence '\s'

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1233,8 +1233,8 @@ class SortedHelpFormatter(ArgumentDefaultsHelpFormatter):
         3. Each line is wrapped to the specified width (width of terminal).
         """
         # The patterns also include whitespace after the newline
-        single_newline = re.compile("(?<!\n)\n(?!\n)\s*")
-        multiple_newlines = re.compile("\n{2,}\s*")
+        single_newline = re.compile(r"(?<!\n)\n(?!\n)\s*")
+        multiple_newlines = re.compile(r"\n{2,}\s*")
         text = single_newline.sub(' ', text)
         lines = re.split(multiple_newlines, text)
         return sum([textwrap.wrap(line, width) for line in lines], [])


### PR DESCRIPTION
This fixes the following warnings after https://github.com/vllm-project/vllm/pull/16422 .
```
/usr/local/lib/python3.12/dist-packages/vllm/utils.py:1236: SyntaxWarning: invalid escape sequence '\s'
  single_newline = re.compile("(?<!\n)\n(?!\n)\s*")
/usr/local/lib/python3.12/dist-packages/vllm/utils.py:1237: SyntaxWarning: invalid escape sequence '\s'
  multiple_newlines = re.compile("\n{2,}\s*")
```
