### PR TITLE
Fix #15483 : Add error handling for model-dependent endpoints during sleep mode

### DIFF
--- a/docs/source/features/sleep_mode.md
+++ b/docs/source/features/sleep_mode.md
@@ -4,19 +4,16 @@ Sleep mode is a feature in vLLM that allows you to temporarily free up GPU resou
 
 ## Overview
 
-vLLM provides two levels of sleep mode:
-
-- **Level 1** (default): Model weights are backed up in CPU memory, and KV cache is discarded. This is useful when you plan to wake up and run the same model again. Requires sufficient CPU memory to store model weights.
-
-- **Level 2**: Both model weights and KV cache are discarded. This reduces CPU memory pressure and is useful when you plan to load a different model after waking up.
-
-During sleep mode, endpoints that don't require model weights continue to function normally.
+When a model is put to sleep:
+- GPU resources are freed up for other tasks
+- The model remains in an inactive state but can be reactivated
+- API endpoints that don't require model weights continue to function normally
 
 ## API Endpoints
 
 vLLM provides several endpoints to control the sleep mode:
 
-- `POST /sleep` - Put the model to sleep (accepts optional `level` parameter)
+- `POST /sleep` - Put the model to sleep
 - `POST /wake_up` - Wake up the model
 - `GET /is_sleeping` - Check if the model is currently in sleep mode
 
@@ -39,14 +36,8 @@ Other endpoints like `/tokenize`, `/detokenize`, and `/v1/models` continue to wo
 
 ### Putting a Model to Sleep
 
-Default (Level 1):
 ```bash
 curl -X POST http://localhost:8000/sleep
-```
-
-Specifying a sleep level:
-```bash
-curl -X POST http://localhost:8000/sleep?level=2
 ```
 
 ### Waking Up a Model

--- a/docs/source/features/sleep_mode.md
+++ b/docs/source/features/sleep_mode.md
@@ -53,6 +53,7 @@ curl -X GET http://localhost:8000/is_sleeping
 ```
 
 Response:
+
 ```json
 {"is_sleeping": true}
 ```
@@ -77,4 +78,4 @@ Clients can catch this error and automatically wake up the model before retrying
 
 - Sleep mode is only supported on CUDA devices
 - The first request after waking up a model may have higher latency as the model is reloaded
-- Sleep mode state is global for the server - all models managed by the server are either asleep or awake 
+- Sleep mode state is global for the server - all models managed by the server are either asleep or awake

--- a/docs/source/features/sleep_mode.md
+++ b/docs/source/features/sleep_mode.md
@@ -1,0 +1,87 @@
+# Sleep Mode
+
+Sleep mode is a feature in vLLM that allows you to temporarily offload model weights from GPU memory to CPU memory, freeing up valuable GPU resources when the model is not in use. This is particularly useful in production environments where you want to optimize resource utilization.
+
+## Overview
+
+When a model is put to sleep:
+- Model weights are offloaded from GPU memory to CPU memory
+- GPU resources are freed up for other tasks
+- The model remains loaded but in an inactive state
+- API endpoints that don't require model weights continue to function normally
+
+## API Endpoints
+
+vLLM provides several endpoints to control the sleep mode:
+
+- `POST /sleep` - Put the model to sleep, offloading weights from GPU memory
+- `POST /wake_up` - Wake up the model, restoring weights to GPU memory
+- `GET /is_sleeping` - Check if the model is currently in sleep mode
+
+### Protected Endpoints
+
+When the model is in sleep mode, endpoints that require access to model weights will return a 503 Service Unavailable error with a message indicating that the model is sleeping. The following endpoints are protected:
+
+- `/v1/chat/completions`
+- `/v1/completions`
+- `/v1/embeddings`
+- `/pooling`
+- `/score` and `/v1/score`
+- `/rerank`, `/v1/rerank`, and `/v2/rerank`
+- `/v1/audio/transcriptions`
+- `/invocations`
+
+Other endpoints like `/tokenize`, `/detokenize`, and `/v1/models` continue to work normally as they don't require access to model weights.
+
+## Usage
+
+### Putting a Model to Sleep
+
+```bash
+curl -X POST http://localhost:8000/sleep
+```
+
+You can specify a sleep level (default is 1):
+
+```bash
+curl -X POST http://localhost:8000/sleep?level=1
+```
+
+### Waking Up a Model
+
+```bash
+curl -X POST http://localhost:8000/wake_up
+```
+
+### Checking Sleep Status
+
+```bash
+curl -X GET http://localhost:8000/is_sleeping
+```
+
+Response:
+```json
+{"is_sleeping": true}
+```
+
+### Handling Sleep Mode in Client Applications
+
+When using vLLM with sleep mode enabled, client applications should handle 503 error responses with the `ModelSleepingError` type. Here's an example of the error response:
+
+```json
+{
+  "error": {
+    "message": "Model is currently in sleep mode. Please wake it up first with a POST request to /wake_up",
+    "type": "ModelSleepingError",
+    "code": 503
+  }
+}
+```
+
+Clients can catch this error and automatically wake up the model before retrying the request.
+
+## Limitations
+
+- Sleep mode is only supported on CUDA devices
+- The first request after waking up a model may have higher latency as weights are restored to GPU memory
+- Sleep mode state is global for the server - all models managed by the server are either asleep or awake 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -98,6 +98,7 @@ features/automatic_prefix_caching
 features/disagg_prefill
 features/spec_decode
 features/compatibility_matrix
+features/sleep_mode
 :::
 
 % Details about running vLLM

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -563,9 +563,7 @@ sentence-transformers==3.2.1
 sentencepiece==0.2.0
     # via mistral-common
 setuptools==75.8.0
-    # via
-    #   pytablewriter
-    #   torch
+    # via pytablewriter
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -563,7 +563,9 @@ sentence-transformers==3.2.1
 sentencepiece==0.2.0
     # via mistral-common
 setuptools==75.8.0
-    # via pytablewriter
+    # via
+    #   pytablewriter
+    #   torch
 shellingham==1.5.4
     # via typer
 six==1.16.0

--- a/tests/entrypoints/openai/test_sleep.py
+++ b/tests/entrypoints/openai/test_sleep.py
@@ -40,10 +40,8 @@ def test_sleep_mode():
             "prompt": "Hello, world",
             "max_tokens": 5
         }
-        response = requests.post(
-            remote_server.url_for("v1/completions"),
-            json=completion_payload
-        )
+        response = requests.post(remote_server.url_for("v1/completions"),
+                                 json=completion_payload)
         assert response.status_code == 503
         error_data = response.json()
         assert "error" in error_data
@@ -53,13 +51,14 @@ def test_sleep_mode():
         # Test chat completions endpoint
         chat_payload = {
             "model": MODEL_NAME,
-            "messages": [{"role": "user", "content": "Hello"}],
+            "messages": [{
+                "role": "user",
+                "content": "Hello"
+            }],
             "max_tokens": 5
         }
-        response = requests.post(
-            remote_server.url_for("v1/chat/completions"),
-            json=chat_payload
-        )
+        response = requests.post(remote_server.url_for("v1/chat/completions"),
+                                 json=chat_payload)
         assert response.status_code == 503
         error_data = response.json()
         assert "error" in error_data
@@ -82,10 +81,8 @@ def test_sleep_mode():
         assert response.json().get("is_sleeping") is False
 
         # Verify completions endpoint works after waking up
-        response = requests.post(
-            remote_server.url_for("v1/completions"),
-            json=completion_payload
-        )
+        response = requests.post(remote_server.url_for("v1/completions"),
+                                 json=completion_payload)
         assert response.status_code == 200
 
         # test wake up with tags

--- a/tests/entrypoints/openai/test_sleep.py
+++ b/tests/entrypoints/openai/test_sleep.py
@@ -25,6 +25,7 @@ def test_sleep_mode():
                                 "VLLM_SERVER_DEV_MODE": "1",
                                 "CUDA_VISIBLE_DEVICES": "0"
                             }) as remote_server:
+        # Test basic sleep/wake functionality
         response = requests.post(remote_server.url_for("sleep"),
                                  params={"level": "1"})
         assert response.status_code == 200
@@ -32,11 +33,60 @@ def test_sleep_mode():
         assert response.status_code == 200
         assert response.json().get("is_sleeping") is True
 
+        # Test model-dependent endpoints return errors when model is sleeping
+        # Test completions endpoint
+        completion_payload = {
+            "model": MODEL_NAME,
+            "prompt": "Hello, world",
+            "max_tokens": 5
+        }
+        response = requests.post(
+            remote_server.url_for("v1/completions"),
+            json=completion_payload
+        )
+        assert response.status_code == 503
+        error_data = response.json()
+        assert "error" in error_data
+        assert error_data["error"]["type"] == "ModelSleepingError"
+        assert "sleep mode" in error_data["error"]["message"].lower()
+
+        # Test chat completions endpoint
+        chat_payload = {
+            "model": MODEL_NAME,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 5
+        }
+        response = requests.post(
+            remote_server.url_for("v1/chat/completions"),
+            json=chat_payload
+        )
+        assert response.status_code == 503
+        error_data = response.json()
+        assert "error" in error_data
+        assert error_data["error"]["type"] == "ModelSleepingError"
+
+        # Test non-model endpoints still work when model is sleeping
+        # Models endpoint should work
+        response = requests.get(remote_server.url_for("v1/models"))
+        assert response.status_code == 200
+
+        # Health check should work
+        response = requests.get(remote_server.url_for("health"))
+        assert response.status_code == 200
+
+        # Wake up and verify model-dependent endpoints now work
         response = requests.post(remote_server.url_for("wake_up"))
         assert response.status_code == 200
         response = requests.get(remote_server.url_for("is_sleeping"))
         assert response.status_code == 200
         assert response.json().get("is_sleeping") is False
+
+        # Verify completions endpoint works after waking up
+        response = requests.post(
+            remote_server.url_for("v1/completions"),
+            json=completion_payload
+        )
+        assert response.status_code == 200
 
         # test wake up with tags
         response = requests.post(remote_server.url_for("sleep"),

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -844,10 +844,10 @@ def build_app(args: Namespace) -> FastAPI:
     async def check_sleep_status_middleware(request: Request, call_next):
         # Only check sleep status for endpoints that access model weights
         url_path = request.url.path
-        if app.root_path and url_path.startswith(app.root_path):
-            url_path = url_path[len(app.root_path):]
+        if app.root_path:
+            url_path = url_path.removeprefix(app.root_path)
             
-        if url_path in model_access_endpoints and request.method == "POST":
+        if url_path in model_access_endpoints:
             try:
                 is_sleeping = await engine_client(request).is_sleeping()
                 if is_sleeping:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -854,7 +854,10 @@ def build_app(args: Namespace) -> FastAPI:
                     return JSONResponse(
                         content={
                             "error": {
-                                "message": "Model is currently in sleep mode. Please wake it up first with a POST request to /wake_up",
+                                "message": (
+                                    "Model is currently in sleep mode. "
+                                    "Please wake it up first with a POST request to /wake_up"
+                                ),
                                 "type": "ModelSleepingError",
                                 "code": 503
                             }
@@ -863,7 +866,7 @@ def build_app(args: Namespace) -> FastAPI:
                     )
             except Exception as e:
                 # Log the error but don't prevent the request from proceeding
-                logger.warning(f"Error checking sleep status: {e}")
+                logger.warning("Error checking sleep status: %s", e)
         
         return await call_next(request)
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -832,22 +832,6 @@ def build_app(args: Namespace) -> FastAPI:
         "/v2/rerank", "/v1/audio/transcriptions", "/invocations"
     ]
 
-    # Simple sleep status check that doesn't affect metrics
-    def get_sleep_status(app_state) -> bool:
-        """Check if model is in sleep mode without going through engine client metrics.
-        
-        This function accesses the sleep flag directly instead of using engine_client.is_sleeping()
-        to prevent triggering metrics collection.
-        """
-        try:
-            # Directly access the model_executor's is_sleeping attribute
-            # This bypasses the metric-collecting engine client methods
-            return app_state.engine_client.engine.model_executor.is_sleeping
-        except Exception as e:
-            logger.warning(f"Error in direct sleep status check: {e}")
-            # Default to not sleeping if we can't check
-            return False
-
     @app.middleware("http")
     async def check_sleep_status_middleware(request: Request, call_next):
         # Only check sleep status for endpoints that access model weights
@@ -857,8 +841,7 @@ def build_app(args: Namespace) -> FastAPI:
 
         if url_path in model_access_endpoints:
             try:
-                # Use the direct check instead of engine_client().is_sleeping()
-                is_sleeping = get_sleep_status(request.app.state)
+                is_sleeping = await engine_client(request).is_sleeping()
                 if is_sleeping:
                     return JSONResponse(content={
                         "error": {

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -856,7 +856,8 @@ def build_app(args: Namespace) -> FastAPI:
                             "error": {
                                 "message": (
                                     "Model is currently in sleep mode. "
-                                    "Please wake it up first with a POST request to /wake_up"
+                                    "Please wake it up first with a POST "
+                                    "request to /wake_up"
                                 ),
                                 "type": "ModelSleepingError",
                                 "code": 503

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -827,17 +827,9 @@ def build_app(args: Namespace) -> FastAPI:
 
     # Endpoints that directly access model weights and need sleep status check
     model_access_endpoints = [
-        "/v1/chat/completions",
-        "/v1/completions",
-        "/v1/embeddings",
-        "/pooling",
-        "/score", 
-        "/v1/score",
-        "/rerank", 
-        "/v1/rerank", 
-        "/v2/rerank",
-        "/v1/audio/transcriptions",
-        "/invocations"
+        "/v1/chat/completions", "/v1/completions", "/v1/embeddings",
+        "/pooling", "/score", "/v1/score", "/rerank", "/v1/rerank",
+        "/v2/rerank", "/v1/audio/transcriptions", "/invocations"
     ]
 
     @app.middleware("http")
@@ -846,29 +838,27 @@ def build_app(args: Namespace) -> FastAPI:
         url_path = request.url.path
         if app.root_path:
             url_path = url_path.removeprefix(app.root_path)
-            
+
         if url_path in model_access_endpoints:
             try:
                 is_sleeping = await engine_client(request).is_sleeping()
                 if is_sleeping:
-                    return JSONResponse(
-                        content={
-                            "error": {
-                                "message": (
-                                    "Model is currently in sleep mode. "
-                                    "Please wake it up first with a POST "
-                                    "request to /wake_up"
-                                ),
-                                "type": "ModelSleepingError",
-                                "code": 503
-                            }
-                        },
-                        status_code=503
-                    )
+                    return JSONResponse(content={
+                        "error": {
+                            "message": ("Model is currently in sleep mode. "
+                                        "Please wake it up first with a POST "
+                                        "request to /wake_up"),
+                            "type":
+                            "ModelSleepingError",
+                            "code":
+                            503
+                        }
+                    },
+                                        status_code=503)
             except Exception as e:
                 # Log the error but don't prevent the request from proceeding
                 logger.warning("Error checking sleep status: %s", e)
-        
+
         return await call_next(request)
 
     @app.exception_handler(RequestValidationError)


### PR DESCRIPTION
## Problem
When vLLM is put into sleep mode, model-dependent endpoints (like completions, embeddings, etc.) crash with CUDA errors instead of providing graceful error handling. (FIX for existing issue https://github.com/vllm-project/vllm/issues/15483)

FIX #15483

## Solution
Added a middleware that checks if the model is sleeping before processing requests to endpoints that require model access. When the model is sleeping, these endpoints now return a proper 503 error response with a clear message instead of crashing.

## Changes
- Added a list of model-dependent endpoints that need protection
- Added a middleware that checks sleep status for these endpoints
- Added proper error response handling
- Added comprehensive documentation for sleep mode functionality
- Extended tests to verify error handling behavior

## Testing
- Extended the existing sleep mode test with error handling verification

## Example Error Response

When attempting to use model-dependent endpoints while the model is sleeping, users now receive a clear error message:

```bash
curl -X 'POST' \
  'http://localhost:8000/v1/chat/completions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "messages": [
    {
      "content": "Hello",
      "role": "user"
    }
  ],
  "model": "/home/ai/models/meta-llama-Llama-3.2-1B-Instruct"
}'
```

Response:
```json
{
  "error": {
    "message": "Model is currently in sleep mode. Please wake it up first with a POST request to /wake_up",
    "type": "ModelSleepingError",
    "code": 503
  }
}
```

## Implementation Alternatives

Two approaches were considered for this solution:

1. **Middleware approach (implemented)**: Uses a single HTTP middleware to check all endpoints, providing centralized error handling.

2. **FastAPI Dependencies approach**: Adds a dependency to each endpoint declaration:
   ```python
   async def check_engine_sleep_status(raw_request: Request):
       if await engine_client(raw_request).is_sleeping():
           raise HTTPException(status_code=HTTPStatus.SERVICE_UNAVAILABLE,
                              detail="Engine is sleeping")

   @router.post("/v1/completions",
                dependencies=[
                    Depends(validate_json_request),
                    Depends(check_engine_sleep_status)
                ])
   async def create_completion(...):
       # Endpoint implementation
   ```

The middleware approach was chosen for its centralized error handling, ease of maintenance, and reduced code duplication.

## Documentation
Added a new documentation page at `docs/source/features/sleep_mode.md` that explains:
- How sleep mode works
- Which endpoints are protected
- The error response format
- How to handle sleep mode in client applications