### PR TITLE
[FeatureRequest] Support Cascade Attention for Sliding Window Attention #15738

### DIFF
--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -658,9 +658,8 @@ def cascade_attention(
     v_descale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert alibi_slopes is None, ("Cascade attention does not support ALiBi.")
-    # TODO: Support sliding window.
-    assert sliding_window == (-1, -1), (
-        "Cascade attention does not support sliding window.")
+    # Support sliding window.
+    sliding_window = (-1, -1)
 
     num_tokens = query.shape[0]
     block_size = key_cache.shape[-3]

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -573,9 +573,10 @@ def use_cascade_attention(
     if common_prefix_len < 256:
         return False
     # Cascade attention is currently not supported with these variants.
-    # For sliding window, we could support it if the query length does not exceed
-    # the sliding window size.
-    def get_sliding_window(sliding_window: Optional[Union[int, list[Optional[int]]]]) -> int:
+    # For sliding window, we could support it if the query length does not
+    # exceed sliding window size.
+    def get_sliding_window(
+            sliding_window: Optional[Union[int, list[Optional[int]]]]) -> int:
         if sliding_window is None:
             return 0
         if isinstance(sliding_window, int):
@@ -585,7 +586,10 @@ def use_cascade_attention(
             return sum(x for x in sliding_window if x is not None)
         return 0
 
-    if use_alibi or (use_sliding_window and np.any(query_lens > get_sliding_window(sliding_window))):
+    if use_alibi:
+        return False
+    if use_sliding_window and np.any(
+            query_lens > get_sliding_window(sliding_window)):
         return False
     # Too few queries. Probably not worth using cascade attention.
     # We use an arbitrary threshold of 8 queries. TODO: Tune this threshold.

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Attention layer with FlashAttention."""
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 import torch
@@ -558,6 +558,7 @@ def use_cascade_attention(
     use_alibi: bool,
     use_sliding_window: bool,
     num_sms: int,
+    sliding_window: Optional[Union[int, list[Optional[int]]]],
 ) -> bool:
     """Decide whether to use cascade attention.
 
@@ -572,7 +573,19 @@ def use_cascade_attention(
     if common_prefix_len < 256:
         return False
     # Cascade attention is currently not supported with these variants.
-    if use_alibi or use_sliding_window:
+    # For sliding window, we could support it if the query length does not exceed
+    # the sliding window size.
+    def get_sliding_window(sliding_window: Optional[Union[int, list[Optional[int]]]]) -> int:
+        if sliding_window is None:
+            return 0
+        if isinstance(sliding_window, int):
+            return sliding_window
+        if isinstance(sliding_window, list):
+            # Filter out None values and sum the remaining integers
+            return sum(x for x in sliding_window if x is not None)
+        return 0
+
+    if use_alibi or (use_sliding_window and np.any(query_lens > get_sliding_window(sliding_window))):
         return False
     # Too few queries. Probably not worth using cascade attention.
     # We use an arbitrary threshold of 8 queries. TODO: Tune this threshold.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -702,6 +702,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             use_alibi=self.use_alibi,
             use_sliding_window=self.window_size is not None,
             num_sms=self.num_sms,
+            sliding_window=self.window_size,
         )
         return common_prefix_len if use_cascade else 0
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -688,9 +688,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # a fundamental problem, our current implementation does not support
         # this case.
         num_reqs = len(num_scheduled_tokens)
-        common_prefix_len = min(
-            common_prefix_len,
-            self.input_batch.num_computed_tokens_cpu[:num_reqs].min())
+        context_lens = self.input_batch.num_computed_tokens_cpu[:num_reqs]
+        common_prefix_len = min(common_prefix_len, context_lens.min())
         # common_prefix_len should be a multiple of the block size.
         common_prefix_len = (common_prefix_len // self.block_size *
                              self.block_size)
@@ -700,9 +699,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             num_query_heads=self.num_query_heads,
             num_kv_heads=self.num_kv_heads,
             use_alibi=self.use_alibi,
-            use_sliding_window=self.window_size is not None,
+            use_sliding_window=self.sliding_window is not None,
             num_sms=self.num_sms,
-            sliding_window=self.window_size,
+            context_lens=context_lens,
+            sliding_window=self.sliding_window,
         )
         return common_prefix_len if use_cascade else 0
 


### PR DESCRIPTION
For https://github.com/vllm-project/vllm/issues/15710
Apply cascade attention under sliding window attention when all context lens < sliding window size.
If context does not exceed sliding window, it means prefix and surfix is within window. It is the same as no sliding window.

<!--- pyml disable-next-line no-emphasis-as-heading -->
