### PR TITLE
[Misc] remove warning if triton>=3.2.0

### DIFF
--- a/vllm/attention/ops/triton_decode_attention.py
+++ b/vllm/attention/ops/triton_decode_attention.py
@@ -39,11 +39,12 @@ is_hip_ = current_platform.is_rocm()
 
 logger = logging.getLogger(__name__)
 
-# TODO: Remove this when triton>=3.2.0. This issue will not affect performance
+# Remove this warning when triton>=3.2.0. This issue will not affect performance
 # and accuracy.
-logger.warning(
-    "The following error message 'operation scheduled before its operands' "
-    "can be ignored.")
+if triton.__version__ < '3.2.0':
+    logger.warning(
+        "The following error message 'operation scheduled before its operands' "
+        "can be ignored.")
 
 
 @triton.jit

--- a/vllm/attention/ops/triton_decode_attention.py
+++ b/vllm/attention/ops/triton_decode_attention.py
@@ -39,8 +39,8 @@ is_hip_ = current_platform.is_rocm()
 
 logger = logging.getLogger(__name__)
 
-# Remove this warning when triton>=3.2.0. This issue will not affect performance
-# and accuracy.
+# Only print the following warnings when triton version < 3.2.0.
+# The issue won't affect performance or accuracy.
 if triton.__version__ < '3.2.0':
     logger.warning(
         "The following error message 'operation scheduled before its operands' "


### PR DESCRIPTION


Remove warning if triton>=3.2.0, since now triton are already >= 3.2.0

<!--- pyml disable-next-line no-emphasis-as-heading -->
