### PR TITLE
[Benchmark][Bugfix] Fix SonnetDataset default values in benchmark_throughput.py

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -597,18 +597,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--prefix-len",
         type=int,
-        default=0,
-        help="Number of fixed prefix tokens before the random "
-        "context in a request (default: 0).",
+        default=None,
+        help="Number of prefix tokens to be used in RandomDataset "
+        "and SonnetDataset.",
     )
     # random dataset
     parser.add_argument(
         "--random-range-ratio",
         type=float,
-        default=0.0,
+        default=None,
         help="Range ratio for sampling input/output length, "
-        "used only for RandomDataset. Must be in the range [0, 1) to define "
-        "a symmetric sampling range "
+        "used only for RandomDataset. Must be in the range [0, 1) to "
+        "define a symmetric sampling range "
         "[length * (1 - range_ratio), length * (1 + range_ratio)].",
     )
 

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -599,7 +599,9 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="Number of prefix tokens to be used in RandomDataset "
-        "and SonnetDataset.",
+        "and SonnetDataset. For RandomDataset, it is the number of "
+        "fixed prefix tokens before the random context. For SonnetDataset, "
+        "it is the number of prefix tokens in the prompt.",
     )
     # random dataset
     parser.add_argument(

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -598,19 +598,23 @@ if __name__ == "__main__":
         "--prefix-len",
         type=int,
         default=None,
-        help="Number of prefix tokens to be used in RandomDataset "
+        help=f"Number of prefix tokens to be used in RandomDataset "
         "and SonnetDataset. For RandomDataset, the total input "
-        "length is the sum of `prefix-len` and a random context length "
+        "length is the sum of prefix-len (default: "
+        f"{RandomDataset.DEFAULT_PREFIX_LEN}) and a random context length "
         "sampled from [input_len * (1 - range_ratio), "
         "input_len * (1 + range_ratio)]. For SonnetDataset, "
-        "prefix_len controls how much of the input is fixed versus random, "
-        "but the total input length remains approximately input_len tokens.")
+        f"prefix_len (default: {SonnetDataset.DEFAULT_PREFIX_LEN}) "
+        "controls how much of the input is fixed lines versus "
+        "random lines, but the total input length remains approximately "
+        "input_len tokens.")
     # random dataset
     parser.add_argument(
         "--random-range-ratio",
         type=float,
         default=None,
-        help="Range ratio for sampling input/output length, "
+        help=f"Range ratio (default : {RandomDataset.DEFAULT_RANGE_RATIO}) "
+        "for sampling input/output length, "
         "used only for RandomDataset. Must be in the range [0, 1) to "
         "define a symmetric sampling range "
         "[length * (1 - range_ratio), length * (1 + range_ratio)].",

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -599,10 +599,12 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help="Number of prefix tokens to be used in RandomDataset "
-        "and SonnetDataset. For RandomDataset, it is the number of "
-        "fixed prefix tokens before the random context. For SonnetDataset, "
-        "it is the number of prefix tokens in the prompt.",
-    )
+        "and SonnetDataset. For RandomDataset, the total input "
+        "length is the sum of `prefix-len` and a random context length "
+        "sampled from [input_len * (1 - range_ratio), "
+        "input_len * (1 + range_ratio)]. For SonnetDataset, "
+        "prefix_len controls how much of the input is fixed versus random, "
+        "but the total input length remains approximately input_len tokens.")
     # random dataset
     parser.add_argument(
         "--random-range-ratio",


### PR DESCRIPTION
The `prefix-len` parameter is used by both RandomDataset and SonnetDataset. It was set to 0 in #16126 , which unintentionally altered the default behavior of SonnetDataset in benchmark_throughput.py.

This PR restores the original behavior by reverting the prefix-len default value in `benchmark_throughput.py`.


Testing 
```
python3 vllm/benchmarks/benchmark_throughput.py \
  --model NousResearch/Hermes-3-Llama-3.1-8B \
  --dataset-name sonnet \
  --dataset-path vllm/benchmarks/sonnet.txt \
  --num-prompts 10
```

This branch
```
Processed prompts: 100%|█████████████████████████████████████████████████████| 10/10 [00:02<00:00,  4.46it/s, est. speed input: 2237.04 toks/s, output: 669.23 toks/s]
Throughput: 4.43 requests/s, 2885.26 total tokens/s, 664.40 output tokens/s
Total num prompt tokens:  5014
Total num output tokens:  1500
```

Main

```
Processed prompts: 100%|█████████████████████████████████████████████████████| 10/10 [00:02<00:00,  4.39it/s, est. speed input: 2190.68 toks/s, output: 658.12 toks/s]
Throughput: 4.35 requests/s, 2827.69 total tokens/s, 653.25 output tokens/s
Total num prompt tokens:  4993
Total num output tokens:  1500

```

Before #16126 change

```
# git checkout 268c325~1
Processed prompts: 100%|█████████████████████████████████████████████████████| 10/10 [00:02<00:00,  4.58it/s, est. speed input: 2296.63 toks/s, output: 687.06 toks/s]
Throughput: 4.55 requests/s, 2961.71 total tokens/s, 682.00 output tokens/s
Total num prompt tokens:  5014
Total num output tokens:  1500
```
<!--- pyml disable-next-line no-emphasis-as-heading -->
