### PR TITLE
[Feature]a new functionality to enable the collection and dumping of expert parallel load using the API

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2165,6 +2165,9 @@ class LLMEngine:
         return self.model_executor.collective_rpc(method, timeout, args,
                                                   kwargs)
 
+    def moe_load(self, op: int):
+        self.model_executor.moe_load(op)
+
 
 if envs.is_set("VLLM_USE_V1") and envs.VLLM_USE_V1:
     from vllm.v1.engine.llm_engine import LLMEngine as V1LLMEngine

--- a/vllm/engine/multiprocessing/__init__.py
+++ b/vllm/engine/multiprocessing/__init__.py
@@ -162,10 +162,16 @@ class RPCAdapterLoadedResponse:
     request_id: str
 
 
+class RPCMoELoadRequest(Enum):
+    ENABLE_COLLECT_LOAD = 1
+    DISABLE_COLLECT_LOAD = 2
+    DUMP_LOAD = 3
+
+
 RPC_REQUEST_T = Union[RPCProcessRequest, RPCAbortRequest, RPCStartupRequest,
                       RPCUProfileRequest, RPCLoadAdapterRequest,
                       RPCResetPrefixCacheRequest, RPCSleepRequest,
-                      RPCWakeUpRequest, RPCIsSleepingRequest]
+                      RPCWakeUpRequest, RPCIsSleepingRequest, RPCMoELoadRequest]
 
 REQUEST_OUTPUTS_T = Union[List[RequestOutput], RPCAdapterLoadedResponse,
                           RPCIsSleepingResponse, RPCError]

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -34,7 +34,8 @@ from vllm.engine.multiprocessing import (ENGINE_DEAD_ERROR, IPC_DATA_EXT,
                                          RPCResetPrefixCacheRequest,
                                          RPCSleepRequest, RPCStartupRequest,
                                          RPCStartupResponse,
-                                         RPCUProfileRequest, RPCWakeUpRequest)
+                                         RPCUProfileRequest, RPCWakeUpRequest,
+                                         RPCMoELoadRequest)
 from vllm.engine.protocol import EngineClient
 # yapf: enable
 from vllm.envs import VLLM_RPC_TIMEOUT
@@ -740,3 +741,7 @@ class MQLLMEngineClient(EngineClient):
         # Raise on error, otherwise happily return None
         if isinstance(request_output, BaseException):
             raise request_output
+
+    async def moe_load(self, op: int) -> None:
+        return await self._send_one_way_rpc_request(
+            request=RPCMoELoadRequest(op), socket=self.input_socket)

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -25,7 +25,8 @@ from vllm.engine.multiprocessing import (ENGINE_DEAD_ERROR, IPC_DATA_EXT,
                                          RPCResetPrefixCacheRequest,
                                          RPCSleepRequest, RPCStartupRequest,
                                          RPCStartupResponse,
-                                         RPCUProfileRequest, RPCWakeUpRequest)
+                                         RPCUProfileRequest, RPCWakeUpRequest,
+                                         RPCMoELoadRequest)
 # yapf: enable
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
@@ -277,6 +278,8 @@ class MQLLMEngine:
                     self.wake_up(request.tags)
                 elif isinstance(request, RPCIsSleepingRequest):
                     self._handle_is_sleeping_request(request)
+                elif isinstance(request, RPCMoELoadRequest):
+                    self.moe_load(op=request.value)
                 else:
                     raise ValueError("Unknown RPCRequest Type: "
                                      f"{type(request)}")
@@ -420,6 +423,9 @@ class MQLLMEngine:
 
     def is_sleeping(self) -> bool:
         return self.engine.is_sleeping()
+
+    def moe_load(self, op: int):
+        return self.engine.moe_load(op)
 
 
 def signal_handler(*_) -> None:

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -295,3 +295,7 @@ class EngineClient(ABC):
     async def add_lora(self, lora_request: LoRARequest) -> None:
         """Load a new LoRA adapter into the engine for future requests."""
         ...
+
+    async def moe_load(self, op: int) -> None:
+        """Dump moe load"""
+        ...

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -803,6 +803,44 @@ if envs.VLLM_ALLOW_RUNTIME_LORA_UPDATING:
 
         return Response(status_code=200, content=response)
 
+if envs.VLLM_EP_LOAD_COLLECT:
+    """"
+    the op is from vllm/engine/multiprocessing/__init__.py
+    class RPCMoELoadRequest(Enum):
+        ENABLE_COLLECT_LOAD = 1
+        DISABLE_COLLECT_LOAD = 2
+        DUMP_LOAD = 3
+    """
+    @router.post("/v1/enable_collect_moe_load")
+    async def enable_collect_moe_load(raw_request: Request):
+        """
+        Enable collecting moe load.
+        """
+        logger.info("enable moe loads collecting ...")
+        await engine_client(raw_request).moe_load(op=1)
+        logger.info("enable moe loads collecting done.")
+        return Response(status_code=200)
+
+    @router.post("/v1/disable_collect_moe_load")
+    async def disable_collect_moe_load(raw_request: Request):
+        """
+        Disable collecting moe load.
+        """
+        logger.info("disable moe loads collecting...")
+        await engine_client(raw_request).moe_load(op=2)
+        logger.info("disable moe loads collecting done.")
+        return Response(status_code=200)
+
+    @router.post("/v1/dump_moe_load")
+    async def dump_moe_load(raw_request: Request):
+        """
+        Dump moe loads to local file
+        """
+        logger.info("dumping moe loads...")
+        await engine_client(raw_request).moe_load(op=3)
+        logger.info("dumping moe loads done.")
+        return Response(status_code=200)
+
 
 def build_app(args: Namespace) -> FastAPI:
     if args.disable_fastapi_docs:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -107,6 +107,9 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_USE_DEEP_GEMM: bool = False
     VLLM_XGRAMMAR_CACHE_MB: int = 0
+    VLLM_EP_LOAD_COLLECT: bool = False
+    VLLM_EP_LOAD_COLLECT_MASTER_IP: str = ""
+    VLLM_EP_LOAD_COLLECT_MASTER_PORT: int = 37000
 
 
 def get_default_cache_root():
@@ -704,6 +707,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # It can be changed with this variable if needed for some reason.
     "VLLM_XGRAMMAR_CACHE_MB":
     lambda: int(os.getenv("VLLM_XGRAMMAR_CACHE_MB", "512")),
+
+    # Whether to collect expert parallel load
+    "VLLM_EP_LOAD_COLLECT":
+    lambda: bool(int(os.getenv("VLLM_EP_LOAD_COLLECT", "0"))),
+
+    # IP address of the master node when collecting the expert parallel load
+    "VLLM_EP_LOAD_COLLECT_MASTER_IP":
+        lambda: os.getenv("VLLM_EP_LOAD_MASTER_IP", ""),
+
+    # Port of the master node when collecting the expert parallel load
+    "VLLM_EP_LOAD_COLLECT_MASTER_PORT":
+        lambda: int(os.getenv("VLLM_EP_LOAD_MASTER_PORT", "37000")),
 }
 
 # end-env-vars-definition

--- a/vllm/executor/executor_base.py
+++ b/vllm/executor/executor_base.py
@@ -274,6 +274,10 @@ class ExecutorBase(ABC):
         exception."""
         self.check_health()
 
+    def moe_load(self, op: int) -> None:
+        """moe_load mainly for collecting moe expert load."""
+        return
+
 
 class DistributedExecutorBase(ExecutorBase):
     """Abstract superclass of distributed executor implementations."""

--- a/vllm/executor/mp_distributed_executor.py
+++ b/vllm/executor/mp_distributed_executor.py
@@ -241,3 +241,7 @@ class MultiprocessingDistributedExecutor(DistributedExecutorBase):
             for worker in self.non_driver_workers
         ]
         return await asyncio.gather(*coros)
+
+    def moe_load(self, op: int) -> None:
+        self._run_workers("moe_load", op)
+        return

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -698,3 +698,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         # Assume that the Ray workers are healthy.
         # TODO: check the health of the Ray workers
         return
+
+    def moe_load(self, op: int) -> None:
+        self._run_workers("moe_load", op)
+        return

--- a/vllm/model_executor/layers/fused_moe/moe_load.py
+++ b/vllm/model_executor/layers/fused_moe/moe_load.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import os
+import csv
+import time
+from vllm.logger import init_logger
+from typing import Optional
+from vllm.distributed.utils import stateless_init_torch_distributed_process_group
+import vllm.envs as envs
+from typing import Tuple
+
+logger = init_logger(__name__)
+
+
+class MoEExpertLoad:
+    """Load data for each expert on each layer.
+    """
+
+    def __init__(self, ep_rank: int, ep_size: int, global_expert_num: int):
+        self.layer_index = []  # all layer ids, which using the moe feature
+        self.layer_expert_map: torch.tensor = None  # expert id list on each layer
+        self.global_expert_num = global_expert_num
+        self.ep_rank_id = ep_rank
+        self.ep_size = ep_size
+        self.layer_expert_tokens_tensor_zero: torch.tensor = None
+        self.layer_expert_tokens_tensor: torch.tensor = None
+        self._current_layer_id: str = "unknown"
+        self.ep_load_master_ip = envs.VLLM_EP_LOAD_COLLECT_MASTER_IP
+        self.ep_load_port = envs.VLLM_EP_LOAD_COLLECT_MASTER_PORT
+        self._collect_load_enabled = False
+
+        assert self.ep_load_master_ip != "", "VLLM_EP_LOAD_COLLECT_MASTER_IP must be set"
+        self.ep_load_group = stateless_init_torch_distributed_process_group(
+            self.ep_load_master_ip,
+            self.ep_load_port,
+            ep_rank,
+            ep_size,
+            backend="gloo")
+        logger.info("initialize ep load collecting processGroup with {}:{} for rank {} out of {} done"
+                    .format(self.ep_load_master_ip, self.ep_load_port, ep_rank, ep_size))
+
+        logger.info("initialized MoE Expert Load for rank {}".format(ep_rank))
+
+    def add_layer(self, layer_id: str, expert_map: torch.tensor):
+        """Add the layer to the expert load"""
+
+        self.layer_index.append(layer_id)
+
+        # each layer have the different expert map
+        if self.layer_expert_map is None:
+            self.layer_expert_map = expert_map.unsqueeze(0)
+        else:
+            self.layer_expert_map = torch.cat([self.layer_expert_map, expert_map.unsqueeze(0)], dim=0)
+
+        if self.layer_expert_tokens_tensor is None:
+            self.layer_expert_tokens_tensor = torch.zeros(1, self.global_expert_num,
+                                                          device=f'cuda:{torch.cuda.current_device()}',
+                                                          dtype=torch.int64)
+        else:
+            self.layer_expert_tokens_tensor = torch.cat([self.layer_expert_tokens_tensor,
+                                                         torch.zeros(1, self.global_expert_num,
+                                                                     device=f'cuda:{torch.cuda.current_device()}',
+                                                                     dtype=torch.int64)], dim=0)
+
+        logger.debug("[rank {}]add layer {} to MoE expert Load with expert list {}"
+                     .format(self.ep_rank_id, layer_id, expert_map.tolist()))
+
+    def set_current_layer_id(self, layer_id: str):
+        self._current_layer_id = layer_id
+
+    def add_token_experts(self, token_experts: torch.tensor):
+        expert_tokens_list_index = self.layer_index.index(self._current_layer_id)
+        flattened = token_experts.flatten().long()
+        src = torch.ones_like(flattened, dtype=self.layer_expert_tokens_tensor.dtype)
+        self.layer_expert_tokens_tensor[expert_tokens_list_index].scatter_add_(dim=0, index=flattened, src=src)
+
+    def enable_collect_load(self):
+        logger.info("enable moe collecting expert load")
+        self._collect_load_enabled = True
+
+    def disable_collect_load(self):
+        logger.info("disable moe collecting expert load")
+        self._collect_load_enabled = False
+
+    def collect_load_enabled(self) -> bool:
+        return self._collect_load_enabled
+
+    def dump_load(self):
+        ex_load, rank_load = self.calculate_load()
+        torch.distributed.all_reduce(ex_load, group=self.ep_load_group)
+        torch.distributed.all_reduce(rank_load, group=self.ep_load_group)
+
+        # just generate the load file on the node with rank 0
+        if self.ep_rank_id == 0:
+            self.dump_load_to_file(ex_load, rank_load)
+
+        return
+
+    def calculate_load(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Calculate load for each expert and rank in each layer."""
+        load_rank = torch.zeros(
+                len(self.layer_index), self.ep_size,
+                device="cpu", dtype=torch.int64
+            )
+        if self.layer_expert_tokens_tensor is not None:
+            if self.layer_expert_tokens_tensor_zero is None:
+                self.layer_expert_tokens_tensor_zero = torch.zeros_like(self.layer_expert_tokens_tensor)
+
+            # filter the expert id on the rank
+            mask = self.layer_expert_map != -1
+            filter_tokens = torch.where(mask, self.layer_expert_tokens_tensor, self.layer_expert_tokens_tensor_zero[0])
+            load_expert = filter_tokens.cpu()
+            torch.cuda.synchronize()
+
+            load_rank[:, self.ep_rank_id] = load_expert.sum(dim=1).squeeze()
+        else:
+            logger.error("[rank {}]No expert tokens available".format(self.ep_rank_id))
+            load_expert = torch.zeros(
+                len(self.layer_index), self.global_expert_num,
+                device="cpu", dtype=torch.int64
+            )
+
+        # must clear the date to compute for next time
+        self.reset()
+
+        return load_expert, load_rank
+
+    def reset(self):
+        """Reset metrics.
+        """
+        if self.layer_expert_tokens_tensor is not None:
+            self.layer_expert_tokens_tensor = torch.zeros_like(self.layer_expert_tokens_tensor_zero)
+
+    def dump_load_to_file(self, expert_load: torch.Tensor, rank_load: torch.Tensor):
+        timestamp = int(time.time())
+
+        # statics data in expert level
+        expert_load_csv_file = f"/tmp/moe_load_for_expert_on_layer_{timestamp}.csv"
+        MoEExpertLoad.create_load_file(expert_load_csv_file, expert_load.shape[1])
+        expert_load_statistics_csv_file = f"/tmp/moe_load_for_expert_statistics_on_layer_{timestamp}.csv"
+        MoEExpertLoad.create_load_statistics_file(expert_load_statistics_csv_file)
+        self.generate_load_file(expert_load_csv_file, expert_load_statistics_csv_file, expert_load)
+
+        # statics data in rank level
+        rank_load_csv_file = f"/tmp/moe_load_for_rank_on_layer_{timestamp}.csv"
+        MoEExpertLoad.create_load_file(rank_load_csv_file, rank_load.shape[1])
+        rank_load_statistics_csv_file = f"/tmp/moe_load_for_rank_statistics_on_layer_{timestamp}.csv"
+        MoEExpertLoad.create_load_statistics_file(rank_load_statistics_csv_file)
+        self.generate_load_file(rank_load_csv_file, rank_load_statistics_csv_file, rank_load)
+
+    def generate_load_file(self, load_csv_file: str, load_statistics_csv_file: str, loads: torch.Tensor):
+        for layer_id_index in range(len(self.layer_index)):
+            layer_id = self.layer_index[layer_id_index]
+            layer_load = loads[layer_id_index].tolist()
+            with open(load_csv_file, "a", newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow([layer_id] + layer_load)
+
+            rank_load_stats_data = MoEExpertLoad.calculate_statistics_value(str(layer_id), layer_load)
+            with open(load_statistics_csv_file, "a", newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    rank_load_stats_data["layer"],
+                    rank_load_stats_data["total"],
+                    rank_load_stats_data["mean"],
+                    rank_load_stats_data["stddev"],
+                    rank_load_stats_data["max"],
+                    rank_load_stats_data["min"],
+                    rank_load_stats_data["disparity"]
+                ])
+
+    @staticmethod
+    def calculate_statistics_value(layer_id: str, layer_load: []):
+        total_loads = sum(layer_load)
+
+        # Calculate mean and variance
+        mean = total_loads / len(layer_load) if len(layer_load) > 0 else 0
+        variance = sum((x - mean) ** 2 for x in layer_load) / len(layer_load) if len(layer_load) > 0 else 0
+        std_dev = variance ** 0.5
+
+        sorted_loads = sorted(enumerate(layer_load), key=lambda x: x[1], reverse=True)
+
+        max_value = sorted_loads[0][1]
+        min_value = sorted_loads[-1][1]
+        disparity = max_value / min_value if min_value != 0 else float('inf')
+
+        return {
+            "layer": layer_id,
+            "total": total_loads,
+            "mean": round(mean, 2),
+            "stddev": round(std_dev, 2),
+            "max": max_value,
+            "min": min_value,
+            "disparity": round(disparity, 2)
+        }
+
+    @staticmethod
+    def create_load_statistics_file(csv_file: str):
+        file_exists = os.path.exists(csv_file)
+        if not file_exists:
+            with open(csv_file, "w", newline='') as f:
+                writer = csv.writer(f)
+                writer.writerow(["layer", "total", "mean", "stddev", "max", "min", "disparity"])
+
+    @staticmethod
+    def create_load_file(csv_file: str, num_columns: int):
+        file_exists = os.path.exists(csv_file)
+        if not file_exists:
+            with open(csv_file, "w", newline='') as f:
+                writer = csv.writer(f)
+                if "expert" in csv_file:
+                    header = ["layer"] + [f"exp_{i}" for i in range(num_columns)]
+                elif "rank" in csv_file:
+                    header = ["layer"] + [f"rank_{i}" for i in range(num_columns)]
+                writer.writerow(header)
+
+
+_EL: Optional[MoEExpertLoad] = None
+
+
+def get_expert_load() -> MoEExpertLoad:
+    return _EL
+
+
+def new_expert_load(ep_rank: int, ep_size: int, global_expert_num: int) -> bool:
+    if not envs.VLLM_EP_LOAD_COLLECT:
+        logger.warning("expert load is disabled for VLLM_EP_LOAD_COLLECT env variable is not set")
+        return False
+
+    global _EL
+    _EL = MoEExpertLoad(ep_rank=ep_rank, ep_size=ep_size, global_expert_num=global_expert_num)
+
+    return True
+
+
+def add_layer_to_expert_load(layer_id: str, expert_map: torch.tensor):
+    _EL.add_layer(layer_id, expert_map)
+
+
+def set_current_layer_id(layer_id: str):
+    if _EL is not None:
+        _EL.set_current_layer_id(layer_id)
+
+
+def add_token_exper_list(token_experts: torch.tensor):
+    if _EL is not None and _EL.collect_load_enabled():
+        _EL.add_token_experts(token_experts=token_experts)
+
+
+def enable_collect_load():
+    if _EL is None:
+        logger.warning("MoELoadBalancer is not initialized.")
+        return None
+    logger.info("Enable collecting expert load.")
+    _EL.enable_collect_load()
+
+
+def disable_collect_load():
+    if _EL is None:
+        logger.warning("MoELoadBalancer is not initialized.")
+        return None
+    logger.info("Disable collecting expert load.")
+    _EL.disable_collect_load()
+
+
+def dump_load():
+    if _EL is None:
+        logger.warning("MoELoadBalancer is not initialized.")
+        return None
+    logger.info("Dump expert load.")
+    _EL.dump_load()

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -58,6 +58,9 @@ from vllm.worker.model_runner_base import (
     _add_sampling_metadata_broadcastable_dict,
     _init_attn_metadata_from_tensor_dict,
     _init_sampling_metadata_from_tensor_dict)
+from vllm.model_executor.layers.fused_moe.moe_load import (enable_collect_load,
+                                                           disable_collect_load,
+                                                           dump_load)
 
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionBackend
@@ -1621,6 +1624,24 @@ class GPUModelRunnerBase(ModelRunnerBase[TModelInputForGPU]):
     @property
     def vocab_size(self) -> int:
         return self.model_config.get_vocab_size()
+
+    def moe_load(self, op: int) -> None:
+        """"
+        the op is from vllm/engine/multiprocessing/__init__.py
+        class RPCMoELoadRequest(Enum):
+            ENABLE_COLLECT_LOAD = 1
+            DISABLE_COLLECT_LOAD = 2
+            DUMP_LOAD = 3
+        """
+        if op == 1:
+            enable_collect_load()
+        elif op == 2:
+            disable_collect_load()
+        elif op == 3:
+            dump_load()
+        else:
+            raise NotImplementedError
+        return
 
 
 class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -247,6 +247,9 @@ class ModelRunnerBase(ABC, Generic[T]):
 
         return self.generators
 
+    def moe_load(self, op: str) -> None:
+        raise NotImplementedError
+
 
 class ModelRunnerWrapperBase:
     """

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -491,6 +491,13 @@ class Worker(LocalOrDistributedWorkerBase):
                                                 self.model_config,
                                                 self.parallel_config)
 
+    def moe_load(self, op: str) -> None:
+        from contextlib import nullcontext
+        context = nullcontext()
+        with context:
+            self.model_runner.moe_load(op)
+        return
+
 
 def init_worker_distributed_environment(
     vllm_config: VllmConfig,

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -129,6 +129,9 @@ class WorkerBase:
         """Get vocabulary size from model configuration."""
         return self.model_config.get_vocab_size()
 
+    def moe_load(self, op: str) -> None:
+        raise NotImplementedError
+
 
 class DelegateWorkerBase(WorkerBase):
     """


### PR DESCRIPTION
In this RP, we have introduced a new feature that allows the collection of expert parallel load and the dumping of the load into a local file, both at the expert and rank level. This feature is particularly valuable for load balancing expert load when expert parallelism is enabled. Additionally, we have added an API to trigger these operations, providing a convenient way to control and manage the load collection and dumping process.