### PR TITLE
Add  "/server_info" endpoint in api_server to retrieve the vllm_config.  

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -12,6 +12,7 @@ import signal
 import socket
 import tempfile
 import uuid
+import dataclasses
 from argparse import Namespace
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -30,7 +31,7 @@ from starlette.routing import Mount
 from typing_extensions import assert_never
 
 import vllm.envs as envs
-from vllm.config import ModelConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine  # type: ignore
 from vllm.engine.multiprocessing.client import MQLLMEngineClient
@@ -103,6 +104,16 @@ logger = init_logger('vllm.entrypoints.openai.api_server')
 
 _running_tasks: set[asyncio.Task] = set()
 
+# Store global states
+@dataclasses.dataclass
+class _GlobalState:
+    vllmconfig: VllmConfig
+
+_global_state: Optional[_GlobalState] = None
+
+def set_global_state(global_state: _GlobalState):
+    global _global_state
+    _global_state = global_state
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -165,6 +176,11 @@ async def build_async_engine_client_from_engine_args(
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
+    set_global_state(
+        _GlobalState(
+            vllmconfig=vllm_config,
+        )
+    ) 
     # V1 AsyncLLM.
     if envs.VLLM_USE_V1:
         if disable_frontend_multiprocessing:
@@ -327,6 +343,7 @@ def mount_metrics(app: FastAPI):
                 "/load",
                 "/ping",
                 "/version",
+                "/server_info",
             ],
             registry=registry,
         ).add().instrument(app).expose(app)
@@ -460,6 +477,12 @@ async def show_available_models(raw_request: Request):
 async def show_version():
     ver = {"version": VLLM_VERSION}
     return JSONResponse(content=ver)
+
+
+@router.get("/server_info")
+async def show_server_info():
+    server_info = {"vllm_config": str(_global_state.vllmconfig)}
+    return JSONResponse(content=server_info)
 
 
 @router.post("/v1/chat/completions",

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import atexit
+import dataclasses
 import gc
 import importlib
 import inspect
@@ -12,7 +13,6 @@ import signal
 import socket
 import tempfile
 import uuid
-import dataclasses
 from argparse import Namespace
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -178,7 +178,7 @@ async def build_async_engine_client_from_engine_args(
 
     set_global_state(
         _GlobalState(
-            vllmconfig=vllm_config,
+            vllmconfig=vllm_config
         )
     ) 
     # V1 AsyncLLM.

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -481,7 +481,10 @@ async def show_version():
 
 @router.get("/server_info")
 async def show_server_info():
-    server_info = {"vllm_config": str(_global_state.vllmconfig)}
+    if _global_state is None:
+        server_info = {"vllm_config": "Vllm Config not available"}
+    else:
+        server_info = {"vllm_config": str(_global_state.vllmconfig)}
     return JSONResponse(content=server_info)
 
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -104,16 +104,20 @@ logger = init_logger('vllm.entrypoints.openai.api_server')
 
 _running_tasks: set[asyncio.Task] = set()
 
+
 # Store global states
 @dataclasses.dataclass
 class _GlobalState:
     vllmconfig: VllmConfig
 
+
 _global_state: Optional[_GlobalState] = None
+
 
 def set_global_state(global_state: _GlobalState):
     global _global_state
     _global_state = global_state
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -176,11 +180,7 @@ async def build_async_engine_client_from_engine_args(
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
 
-    set_global_state(
-        _GlobalState(
-            vllmconfig=vllm_config
-        )
-    ) 
+    set_global_state(_GlobalState(vllmconfig=vllm_config))
     # V1 AsyncLLM.
     if envs.VLLM_USE_V1:
         if disable_frontend_multiprocessing:


### PR DESCRIPTION
Add a server_info endpoint to allow users to directly retrieve the vllm configuration parameters without the need to parse logs..


Example APi -http://localhost:8000/server_info

`{"vllm_config":"model='deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=False, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={\"splitting_ops\":[],\"compile_sizes\":[],\"cudagraph_capture_sizes\":[],\"max_capture_size\":0}"}`