### PR TITLE
[V1][Spec Decode] Make Eagle compatible with pipeline parallelism

### DIFF
--- a/vllm/model_executor/models/llama_eagle.py
+++ b/vllm/model_executor/models/llama_eagle.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Iterable, Set, Tuple
+from typing import Iterable, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -14,6 +14,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.llama import (LlamaDecoderLayer,
                                               LlamaForCausalLM)
+from vllm.sequence import IntermediateTensors
 
 from .utils import AutoWeightsLoader, maybe_prefix
 
@@ -70,6 +71,7 @@ class LlamaModel(nn.Module):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> torch.Tensor:
         input_embeds = self.embed_tokens(input_ids)
         hidden_states = self.fc(
@@ -132,6 +134,7 @@ class EagleLlamaForCausalLM(LlamaForCausalLM):
         input_ids: torch.Tensor,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> torch.Tensor:
         return self.model(input_ids, positions, hidden_states)
 


### PR DESCRIPTION
This PR aims to make speculative decoding compatible with pipeline parallelism.
* Introducing draft_pipeline_parallel_size config. Currently drafter are only loaded in the last pp stage, which essentially means draft_pipeline_parallel_size=1.
* EagleLlamaForCausalLM already inherits SupportsPP from LlamaForCausalLM.

Commands:

```
export VLLM_USE_V1=1
vllm serve unsloth/llama-3-8b-Instruct \
    --tensor-parallel-size 2 \
    --pipeline-parallel-size 2 \
    --distributed-executor-backend ray \
    --speculative-config '{"method": "eagle", "model":"yuhuili/EAGLE-LLaMA3-Instruct-8B", "num_speculative_tokens": 3, "draft_pipeline_parallel_size": 2}'
```


<!--- pyml disable-next-line no-emphasis-as-heading -->
