### PR TITLE
Add "/server_info" endpoint in api_server to retrieve the vllm_config. 

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -1171,6 +1171,10 @@ class AsyncLLMEngine(EngineClient):
         """Get the model configuration of the vLLM engine."""
         return self.engine.get_model_config()
 
+    async def get_vllm_config(self) -> VllmConfig:
+        """Get the vllm configuration of the vLLM engine."""
+        return self.engine.get_vllm_config()
+
     async def get_parallel_config(self) -> ParallelConfig:
         """Get the parallel configuration of the vLLM engine."""
         return self.engine.get_parallel_config()

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -1167,13 +1167,13 @@ class AsyncLLMEngine(EngineClient):
                                             exception=asyncio.CancelledError,
                                             verbose=self.log_requests)
 
-    async def get_model_config(self) -> ModelConfig:
-        """Get the model configuration of the vLLM engine."""
-        return self.engine.get_model_config()
-
     async def get_vllm_config(self) -> VllmConfig:
         """Get the vllm configuration of the vLLM engine."""
         return self.engine.get_vllm_config()
+
+    async def get_model_config(self) -> ModelConfig:
+        """Get the model configuration of the vLLM engine."""
+        return self.engine.get_model_config()
 
     async def get_parallel_config(self) -> ParallelConfig:
         """Get the parallel configuration of the vLLM engine."""

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -914,13 +914,13 @@ class LLMEngine:
             scheduler.abort_seq_group(
                 request_id, seq_id_to_seq_group=self.seq_id_to_seq_group)
 
-    def get_model_config(self) -> ModelConfig:
-        """Gets the model configuration."""
-        return self.model_config
-
     def get_vllm_config(self) -> VllmConfig:
         """Gets the vllm configuration."""
         return self.vllm_config
+
+    def get_model_config(self) -> ModelConfig:
+        """Gets the model configuration."""
+        return self.model_config
 
     def get_parallel_config(self) -> ParallelConfig:
         """Gets the parallel configuration."""

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -918,6 +918,10 @@ class LLMEngine:
         """Gets the model configuration."""
         return self.model_config
 
+    def get_vllm_config(self) -> VllmConfig:
+        """Gets the vllm configuration."""
+        return self.vllm_config
+
     def get_parallel_config(self) -> ParallelConfig:
         """Gets the parallel configuration."""
         return self.parallel_config

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -93,6 +93,7 @@ class MQLLMEngineClient(EngineClient):
         self._errored_with: Optional[BaseException] = None
 
         # Get the configs.
+        self.vllm_config = engine_config
         self.model_config = engine_config.model_config
         self.decoding_config = engine_config.decoding_config
 
@@ -382,6 +383,9 @@ class MQLLMEngineClient(EngineClient):
 
     async def get_model_config(self) -> ModelConfig:
         return self.model_config
+
+    async def get_vllm_config(self) -> VllmConfig:
+        return self.vllm_config
 
     async def is_tracing_enabled(self) -> bool:
         return self.tracing_flag

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -378,11 +378,11 @@ class MQLLMEngineClient(EngineClient):
     async def get_tokenizer(self, lora_request: Optional[LoRARequest] = None):
         return await self.tokenizer.get_lora_tokenizer_async(lora_request)
 
-    async def get_decoding_config(self) -> DecodingConfig:
-        return self.decoding_config
-
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config
+
+    async def get_decoding_config(self) -> DecodingConfig:
+        return self.decoding_config
 
     async def get_model_config(self) -> ModelConfig:
         return self.model_config

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -381,11 +381,11 @@ class MQLLMEngineClient(EngineClient):
     async def get_decoding_config(self) -> DecodingConfig:
         return self.decoding_config
 
-    async def get_model_config(self) -> ModelConfig:
-        return self.model_config
-
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config
+
+    async def get_model_config(self) -> ModelConfig:
+        return self.model_config
 
     async def is_tracing_enabled(self) -> bool:
         return self.tracing_flag

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Mapping, Optional
 
 from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
-from vllm.config import DecodingConfig, ModelConfig
+from vllm.config import DecodingConfig, ModelConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.inputs.data import PromptType, TokensPrompt
 from vllm.inputs.parse import is_explicit_encoder_decoder_prompt
@@ -218,6 +218,11 @@ class EngineClient(ABC):
         Args:
             request_id: The unique id of the request.
         """
+        ...
+
+    @abstractmethod
+    async def get_vllm_config(self) -> VllmConfig:
+        """Get the vllm configuration of the vLLM engine."""
         ...
 
     @abstractmethod

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -30,7 +30,7 @@ from starlette.routing import Mount
 from typing_extensions import assert_never
 
 import vllm.envs as envs
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine  # type: ignore
 from vllm.engine.multiprocessing.client import MQLLMEngineClient

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -688,6 +688,11 @@ TASK_HANDLERS: dict[str, dict[str, tuple]] = {
 
 if envs.VLLM_SERVER_DEV_MODE:
 
+    @router.get("/server_info")
+    async def show_server_info(raw_request: Request):
+        server_info = {"vllm_config": str(raw_request.app.state.vllm_config)}
+        return JSONResponse(content=server_info)
+
     @router.post("/reset_prefix_cache")
     async def reset_prefix_cache(raw_request: Request):
         """
@@ -728,11 +733,6 @@ if envs.VLLM_SERVER_DEV_MODE:
         logger.info("check whether the engine is sleeping")
         is_sleeping = await engine_client(raw_request).is_sleeping()
         return JSONResponse(content={"is_sleeping": is_sleeping})
-
-    @router.get("/server_info")
-    async def show_server_info(raw_request: Request):
-        server_info = {"vllm_config": str(raw_request.app.state.vllm_config)}
-        return JSONResponse(content=server_info)
 
 
 @router.post("/invocations", dependencies=[Depends(validate_json_request)])

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -479,15 +479,6 @@ async def show_version():
     return JSONResponse(content=ver)
 
 
-@router.get("/server_info")
-async def show_server_info():
-    if _global_state is None:
-        server_info = {"vllm_config": "Vllm Config not available"}
-    else:
-        server_info = {"vllm_config": str(_global_state.vllmconfig)}
-    return JSONResponse(content=server_info)
-
-
 @router.post("/v1/chat/completions",
              dependencies=[Depends(validate_json_request)])
 @with_cancellation
@@ -753,6 +744,14 @@ if envs.VLLM_SERVER_DEV_MODE:
         logger.info("check whether the engine is sleeping")
         is_sleeping = await engine_client(raw_request).is_sleeping()
         return JSONResponse(content={"is_sleeping": is_sleeping})
+    
+    @router.get("/server_info")
+    async def show_server_info():
+        if _global_state is None:
+            server_info = {"vllm_config": "Vllm Config not available"}
+        else:
+            server_info = {"vllm_config": str(_global_state.vllmconfig)}
+        return JSONResponse(content=server_info)
 
 
 @router.post("/invocations", dependencies=[Depends(validate_json_request)])

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -64,7 +64,7 @@ class AsyncLLM(EngineClient):
         assert start_engine_loop
 
         self.model_config = vllm_config.model_config
-
+        self.vllm_config = vllm_config
         self.log_requests = log_requests
         self.log_stats = log_stats
 
@@ -378,6 +378,9 @@ class AsyncLLM(EngineClient):
         priority: int = 0,
     ):
         raise ValueError("Not Supported on V1 yet.")
+
+    async def get_vllm_config(self) -> VllmConfig:
+        return self.vllm_config
 
     async def get_model_config(self) -> ModelConfig:
         return self.model_config

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -230,6 +230,9 @@ class LLMEngine:
 
         return processed_outputs.request_outputs
 
+    def get_vllm_config(self):
+        return self.vllm_config
+
     def get_model_config(self):
         return self.model_config
 


### PR DESCRIPTION
Add a server_info endpoint to allow users to directly retrieve the vllm configuration parameters without the need to parse logs..

Example APi -http://localhost:8000/server_info
`{"vllm_config":"model='deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-R1-Distill-Qwen-7B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=True, kv_cache_dtype=auto, device_config=cuda, decoding_config=DecodingConfig(guided_decoding_backend='xgrammar', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=deepseek-ai/DeepSeek-R1-Distill-Qwen-7B, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=True, chunked_prefill_enabled=True, use_async_output_proc=False, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={\"splitting_ops\":[],\"compile_sizes\":[],\"cudagraph_capture_sizes\":[],\"max_capture_size\":0}"}`