### PR TITLE
Disable the torch.compile cache checks when VLLM_DISABLE_COMPILE_CACHE=1

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -309,6 +309,9 @@ class InductorAdaptor(CompilerInterface):
                 inner_compile=hijacked_compile_fx_inner,
                 config_patches=current_config)
 
+        # We treat VLLM_DISABLE_COMPILE_CACHE as the overall switch for torch
+        # compilation cache. So turn off the checks if we disable the
+        # compilation cache.
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
             assert hash_str is not None, (
                 "failed to get the hash of the compiled graph")

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -11,6 +11,7 @@ import torch
 import torch._inductor.compile_fx
 import torch.fx as fx
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.utils import is_torch_equal_or_newer
 
@@ -308,10 +309,11 @@ class InductorAdaptor(CompilerInterface):
                 inner_compile=hijacked_compile_fx_inner,
                 config_patches=current_config)
 
-        assert hash_str is not None, (
-            "failed to get the hash of the compiled graph")
-        assert file_path is not None, (
-            "failed to get the file path of the compiled graph")
+        if not envs.VLLM_DISABLE_COMPILE_CACHE:
+            assert hash_str is not None, (
+                "failed to get the hash of the compiled graph")
+            assert file_path is not None, (
+                "failed to get the file path of the compiled graph")
         return compiled_graph, (hash_str, file_path)
 
     def load(self,


### PR DESCRIPTION
Disable the checks if it's not used.

Run the benchmark script to test

```
VLLM_USE_V1=1; with-proxy python3 benchmarks/benchmark_latency.py --model "meta-llama/Meta-Llama-3.1-70B" --tensor-parallel-size 8 --trust-remote-code --enable-chunked-prefill --disable-log-stats --gpu-memory-utilization=0.7
```

Output
```
Avg latency: 3.45998974510779 seconds
10% percentile latency: 3.2058258310426027 seconds
25% percentile latency: 3.2742707084398717 seconds
50% percentile latency: 3.4767037329729646 seconds
75% percentile latency: 3.6269146820995957 seconds
90% percentile latency: 3.6901761000510307 seconds
```
