### PR TITLE
[Misc] fix local pytest broken

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,13 @@ from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
                           BatchEncoding, BatchFeature)
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
 
-sys.path.insert(0, site.getsitepackages()[0])
+try:
+    # First, try import vllm from the local path or from the
+    # installed editable vllm package.
+    import vllm  # noqa: F401
+except ImportError:
+    # If that fails, try to import vllm from the installed package.
+    sys.path.insert(0, site.getsitepackages()[0])
 
 from tests.models.utils import (TokensTextLogprobs,
                                 TokensTextLogprobsPromptLogprobs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import site
+import sys
 import tempfile
 from collections import UserList
 from enum import Enum
@@ -17,6 +19,8 @@ from PIL import Image
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoTokenizer,
                           BatchEncoding, BatchFeature)
 from transformers.models.auto.auto_factory import _BaseAutoModelClass
+
+sys.path.insert(0, site.getsitepackages()[0])
 
 from tests.models.utils import (TokensTextLogprobs,
                                 TokensTextLogprobsPromptLogprobs)


### PR DESCRIPTION

Fix local pytest broken. We should prefer to import the vllm library from the site-packages directory rather than from the vllm source code directory.

- before 

```bash
pip install dist/vllm-*.whl
cd tests/kernels 
python3 -m pytest -s test_merge_attn_states.py

INFO 04-14 16:42:13 [__init__.py:239] Automatically detected platform cuda.
ImportError while loading conftest '/workspace/dev/vipshop/vllm/tests/conftest.py'.
../conftest.py:21: in <module>
    from tests.models.utils import (TokensTextLogprobs,
../models/utils.py:9: in <module>
    from vllm.config import ModelConfig, TaskOption
../../vllm/__init__.py:12: in <module>
    from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
../../vllm/engine/arg_utils.py:16: in <module>
    from vllm.config import (CacheConfig, CompilationConfig, ConfigFormat,
../../vllm/config.py:30: in <module>
    from vllm.model_executor.layers.quantization import (QUANTIZATION_METHODS,
../../vllm/model_executor/__init__.py:3: in <module>
    from vllm.model_executor.parameter import (BasevLLMParameter,
../../vllm/model_executor/parameter.py:9: in <module>
    from vllm.distributed import get_tensor_model_parallel_rank
../../vllm/distributed/__init__.py:3: in <module>
    from .communication_op import *
../../vllm/distributed/communication_op.py:8: in <module>
    from .parallel_state import get_tp_group
../../vllm/distributed/parallel_state.py:122: in <module>
    from vllm.platforms import current_platform
../../vllm/platforms/__init__.py:271: in __getattr__
    _current_platform = resolve_obj_by_qualname(
../../vllm/utils.py:2009: in resolve_obj_by_qualname
    module = importlib.import_module(module_name)
../../vllm/platforms/cuda.py:15: in <module>
    import vllm._C  # noqa
E   ModuleNotFoundError: No module named 'vllm._C'
```

- after  

```bash
pip install dist/vllm-*.whl
cd tests/kernels 
python3 -m pytest -s test_merge_attn_states.py

INFO 04-14 16:44:44 [__init__.py:239] Automatically detected platform cuda.
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:208: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /workspace/dev/vipshop/vllm
configfile: pyproject.toml
plugins: anyio-4.9.0, langsmith-0.3.18, forked-1.6.0, shard-0.1.2, buildkite-test-collector-0.1.9, mock-3.14.0, asyncio-0.24.0, rerunfailures-14.0
asyncio: mode=strict, default_loop_scope=None
collected 648 items
Running 648 items in this shard

test_merge_attn_states.py
NUM_TOKENS:256, NUM_HEADS:4, HEAD_SIZE:32, DTYPE: torch.float32, Device: NVIDIA L20
 Torch time: 0.162714ms
Triton time: 0.060317ms
  CUDA time: 0.017621ms, Performance: 3.42305x
----------------------------------------------------------------------------------------------------
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
