### PR TITLE
[Frontend] Add sampling params to `v1/audio/transcriptions` endpoint

### DIFF
--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -396,6 +396,15 @@ To use the Transcriptions API, please install with extra audio dependencies usin
 
 <!-- TODO: api enforced limits + uploading audios -->
 
+#### Additional Transcription API Parameters
+
+Our Transcriptions API supports these extra optional parameters to fine-tune the sampling behavior during transcription:
+
+- **seed** (*Optional[int]*): The seed to use for sampling. Must be between `_LONG_INFO.min` and `_LONG_INFO.max`.
+- **frequency_penalty** (*Optional[float]*): Applies a penalty to tokens based on their frequency, reducing the likelihood of repeating common tokens (default: `0.0`).
+- **repetition_penalty** (*Optional[float]*): Discourages the model from repeating the same tokens by applying a penalty (default: `1.0`).
+- **presence_penalty** (*Optional[float]*): Encourages the introduction of new tokens by applying a penalty to those already present (default: `0.0`).
+
 Code example: <gh-file:examples/online_serving/openai_transcription_client.py>
 
 (tokenizer-api)=

--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -401,6 +401,9 @@ To use the Transcriptions API, please install with extra audio dependencies usin
 Our Transcriptions API supports these extra optional parameters to fine-tune the sampling behavior during transcription:
 
 - **seed** (*Optional[int]*): The seed to use for sampling. Must be between `_LONG_INFO.min` and `_LONG_INFO.max`.
+- **top_p** (*Optional[float]*): Enables nucleus (top-p) sampling, where tokens are selected from the smallest possible set whose cumulative probability exceeds `p` (default: `1.0`).
+- **top_k** (*Optional[int]*): Limits sampling to the `k` most probable tokens at each step. (default: `-1`).
+- **min_p** (*Optional[float]*): Filters out tokens with a probability lower than `min_p`, ensuring a minimum likelihood threshold during sampling (default: `0.0`).
 - **frequency_penalty** (*Optional[float]*): Applies a penalty to tokens based on their frequency, reducing the likelihood of repeating common tokens (default: `0.0`).
 - **repetition_penalty** (*Optional[float]*): Discourages the model from repeating the same tokens by applying a penalty (default: `1.0`).
 - **presence_penalty** (*Optional[float]*): Encourages the introduction of new tokens by applying a penalty to those already present (default: `0.0`).

--- a/docs/source/serving/openai_compatible_server.md
+++ b/docs/source/serving/openai_compatible_server.md
@@ -394,21 +394,26 @@ you can use the [official OpenAI Python client](https://github.com/openai/openai
 To use the Transcriptions API, please install with extra audio dependencies using `pip install vllm[audio]`.
 :::
 
+Code example: <gh-file:examples/online_serving/openai_transcription_client.py>
 <!-- TODO: api enforced limits + uploading audios -->
 
-#### Additional Transcription API Parameters
+#### Extra Parameters
 
-Our Transcriptions API supports these extra optional parameters to fine-tune the sampling behavior during transcription:
+The following [sampling parameters](#sampling-params) are supported.
 
-- **seed** (*Optional[int]*): The seed to use for sampling. Must be between `_LONG_INFO.min` and `_LONG_INFO.max`.
-- **top_p** (*Optional[float]*): Enables nucleus (top-p) sampling, where tokens are selected from the smallest possible set whose cumulative probability exceeds `p` (default: `1.0`).
-- **top_k** (*Optional[int]*): Limits sampling to the `k` most probable tokens at each step. (default: `-1`).
-- **min_p** (*Optional[float]*): Filters out tokens with a probability lower than `min_p`, ensuring a minimum likelihood threshold during sampling (default: `0.0`).
-- **frequency_penalty** (*Optional[float]*): Applies a penalty to tokens based on their frequency, reducing the likelihood of repeating common tokens (default: `0.0`).
-- **repetition_penalty** (*Optional[float]*): Discourages the model from repeating the same tokens by applying a penalty (default: `1.0`).
-- **presence_penalty** (*Optional[float]*): Encourages the introduction of new tokens by applying a penalty to those already present (default: `0.0`).
+:::{literalinclude} ../../../vllm/entrypoints/openai/protocol.py
+:language: python
+:start-after: begin-transcription-sampling-params
+:end-before: end-transcription-sampling-params
+:::
 
-Code example: <gh-file:examples/online_serving/openai_transcription_client.py>
+The following extra parameters are supported:
+
+:::{literalinclude} ../../../vllm/entrypoints/openai/protocol.py
+:language: python
+:start-after: begin-transcription-extra-params
+:end-before: end-transcription-extra-params
+:::
 
 (tokenizer-api)=
 

--- a/examples/online_serving/openai_transcription_client.py
+++ b/examples/online_serving/openai_transcription_client.py
@@ -27,6 +27,7 @@ def sync_openai():
             language="en",
             response_format="json",
             temperature=0.0,
+            # Additional sampling params not provided by OpenAI API.
             extra_body=dict(
                 seed=4419,
                 repetition_penalty=1.3,

--- a/examples/online_serving/openai_transcription_client.py
+++ b/examples/online_serving/openai_transcription_client.py
@@ -26,7 +26,11 @@ def sync_openai():
             model="openai/whisper-large-v3",
             language="en",
             response_format="json",
-            temperature=0.0)
+            temperature=0.0,
+            extra_body=dict(
+                seed=4419,
+                repetition_penalty=1.3,
+            ))
         print("transcription result:", transcription.text)
 
 

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -192,3 +192,33 @@ async def test_stream_options(winning_call):
                 else:
                     continuous = continuous and hasattr(chunk, 'usage')
             assert final and continuous
+
+
+@pytest.mark.asyncio
+async def test_sampling_params(mary_had_lamb):
+    """
+    Compare sampling with params and greedy sampling to assert results
+    are different when extreme sampling parameters values are picked. 
+    """
+    model_name = "openai/whisper-small"
+    server_args = ["--enforce-eager"]
+    with RemoteOpenAIServer(model_name, server_args) as remote_server:
+        client = remote_server.get_async_client()
+        transcription = await client.audio.transcriptions.create(
+            model=model_name,
+            file=mary_had_lamb,
+            language="en",
+            temperature=0.8,
+            extra_body=dict(seed=42,
+                            repetition_penalty=1.9,
+                            frequency_penalty=1.8,
+                            presence_penalty=2.0))
+
+        greedy_transcription = await client.audio.transcriptions.create(
+            model=model_name,
+            file=mary_had_lamb,
+            language="en",
+            temperature=0.0,
+            extra_body=dict(seed=42))
+
+        assert greedy_transcription.text != transcription.text

--- a/tests/entrypoints/openai/test_transcription_validation.py
+++ b/tests/entrypoints/openai/test_transcription_validation.py
@@ -211,6 +211,9 @@ async def test_sampling_params(mary_had_lamb):
             temperature=0.8,
             extra_body=dict(seed=42,
                             repetition_penalty=1.9,
+                            top_k=12,
+                            top_p=0.4,
+                            min_p=0.5,
                             frequency_penalty=1.8,
                             presence_penalty=2.0))
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1577,16 +1577,6 @@ class TranscriptionRequest(OpenAIBaseModel):
     """
 
     ## TODO (varun) : Support if set to 0, certain thresholds are met !!
-    # doc: begin-transcription-sampling-params
-    temperature: float = Field(default=0.0)
-    """The sampling temperature, between 0 and 1.
-
-    Higher values like 0.8 will make the output more random, while lower values
-    like 0.2 will make it more focused / deterministic. If set to 0, the model
-    will use [log probability](https://en.wikipedia.org/wiki/Log_probability)
-    to automatically increase the temperature until certain thresholds are hit.
-    """
-    # doc: end-transcription-sampling-params
 
     timestamp_granularities: list[Literal["word", "segment"]] = Field(
         alias="timestamp_granularities[]", default=[])
@@ -1598,6 +1588,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     timestamps incurs additional latency.
     """
 
+    # doc: begin-transcription-extra-params
     stream: Optional[bool] = False
     """Custom field not present in the original OpenAI definition. When set, 
     it will enable output to be streamed in a similar fashion as the Chat
@@ -1606,8 +1597,18 @@ class TranscriptionRequest(OpenAIBaseModel):
     # Flattened stream option to simplify form data.
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False
+    # doc: end-transcription-extra-params
 
-    # doc: begin-transcription-extra-params
+    # doc: begin-transcription-sampling-params
+    temperature: float = Field(default=0.0)
+    """The sampling temperature, between 0 and 1.
+
+    Higher values like 0.8 will make the output more random, while lower values
+    like 0.2 will make it more focused / deterministic. If set to 0, the model
+    will use [log probability](https://en.wikipedia.org/wiki/Log_probability)
+    to automatically increase the temperature until certain thresholds are hit.
+    """
+
     top_p: Optional[float] = None
     """Enables nucleus (top-p) sampling, where tokens are selected from the 
     smallest possible set whose cumulative probability exceeds `p`.
@@ -1632,7 +1633,7 @@ class TranscriptionRequest(OpenAIBaseModel):
 
     presence_penalty: Optional[float] = 0.0
     """The presence penalty to use for sampling."""
-    # doc: end-transcription-extra-params
+    # doc: end-transcription-sampling-params
 
     # Default sampling parameters for transcription requests.
     _DEFAULT_SAMPLING_PARAMS: dict = {

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1604,10 +1604,26 @@ class TranscriptionRequest(OpenAIBaseModel):
     # Flattened stream option to simplify form data.
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False
+    
+    seed: Optional[int] = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
+    """The seed to use for sampling."""
+
+    frequency_penalty: Optional[float] = Field(default=0.0)
+    """The frequency penalty to use for sampling."""
+
+    repetition_penalty: Optional[float] = Field(default=1.0)
+    """The repetition penalty to use for sampling."""
+
+    presence_penalty: Optional[float] = Field(default=0.0)
+    """The presence penalty to use for sampling."""
 
     # Default sampling parameters for transcription requests.
     _DEFAULT_SAMPLING_PARAMS: dict = {
         "temperature": 0,
+        "seed": None,
+        "frequency_penalty": 0.0,
+        "repetition_penalty": 1.0,
+        "presence_penalty": 0.0,
     }
 
     def to_sampling_params(
@@ -1624,8 +1640,32 @@ class TranscriptionRequest(OpenAIBaseModel):
             temperature = default_sampling_params.get(
                 "temperature", self._DEFAULT_SAMPLING_PARAMS["temperature"])
 
+        if (seed := self.seed) is None:
+            seed = default_sampling_params.get(
+                "seed", self._DEFAULT_SAMPLING_PARAMS["seed"])
+
+        if (frequency_penalty := self.frequency_penalty) is None:
+            frequency_penalty = default_sampling_params.get(
+                "frequency_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["frequency_penalty"])
+
+        if (repetition_penalty := self.repetition_penalty) is None:
+            repetition_penalty = default_sampling_params.get(
+                "repetition_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["repetition_penalty"])
+
+        if (presence_penalty := self.presence_penalty) is None:
+            presence_penalty = default_sampling_params.get(
+                "presence_penalty",
+                self._DEFAULT_SAMPLING_PARAMS["presence_penalty"])
+
+
         return SamplingParams.from_optional(temperature=temperature,
                                             max_tokens=max_tokens,
+                                            seed=seed,
+                                            frequency_penalty=frequency_penalty,
+                                            repetition_penalty=repetition_penalty,
+                                            presence_penalty=presence_penalty,
                                             output_kind=RequestOutputKind.DELTA
                                             if self.stream \
                                             else RequestOutputKind.FINAL_ONLY)

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1577,6 +1577,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     """
 
     ## TODO (varun) : Support if set to 0, certain thresholds are met !!
+    # doc: begin-transcription-sampling-params
     temperature: float = Field(default=0.0)
     """The sampling temperature, between 0 and 1.
 
@@ -1585,6 +1586,7 @@ class TranscriptionRequest(OpenAIBaseModel):
     will use [log probability](https://en.wikipedia.org/wiki/Log_probability)
     to automatically increase the temperature until certain thresholds are hit.
     """
+    # doc: end-transcription-sampling-params
 
     timestamp_granularities: list[Literal["word", "segment"]] = Field(
         alias="timestamp_granularities[]", default=[])
@@ -1605,10 +1607,20 @@ class TranscriptionRequest(OpenAIBaseModel):
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False
 
-    # Additional sampling parameters.
+    # doc: begin-transcription-extra-params
     top_p: Optional[float] = None
+    """Enables nucleus (top-p) sampling, where tokens are selected from the 
+    smallest possible set whose cumulative probability exceeds `p`.
+    """
+
     top_k: Optional[int] = None
+    """Limits sampling to the `k` most probable tokens at each step."""
+
     min_p: Optional[float] = None
+    """Filters out tokens with a probability lower than `min_p`, ensuring a 
+    minimum likelihood threshold during sampling.
+    """
+
     seed: Optional[int] = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
     """The seed to use for sampling."""
 
@@ -1620,6 +1632,7 @@ class TranscriptionRequest(OpenAIBaseModel):
 
     presence_penalty: Optional[float] = 0.0
     """The presence penalty to use for sampling."""
+    # doc: end-transcription-extra-params
 
     # Default sampling parameters for transcription requests.
     _DEFAULT_SAMPLING_PARAMS: dict = {

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1604,26 +1604,26 @@ class TranscriptionRequest(OpenAIBaseModel):
     # Flattened stream option to simplify form data.
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False
-    
+
     seed: Optional[int] = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
     """The seed to use for sampling."""
 
-    frequency_penalty: Optional[float] = Field(default=0.0)
+    frequency_penalty: Optional[float] = 0.0
     """The frequency penalty to use for sampling."""
 
-    repetition_penalty: Optional[float] = Field(default=1.0)
+    repetition_penalty: Optional[float] = None
     """The repetition penalty to use for sampling."""
 
-    presence_penalty: Optional[float] = Field(default=0.0)
+    presence_penalty: Optional[float] = 0.0
     """The presence penalty to use for sampling."""
 
     # Default sampling parameters for transcription requests.
     _DEFAULT_SAMPLING_PARAMS: dict = {
-        "temperature": 0,
-        "seed": None,
-        "frequency_penalty": 0.0,
         "repetition_penalty": 1.0,
-        "presence_penalty": 0.0,
+        "temperature": 1.0,
+        "top_p": 1.0,
+        "top_k": -1,
+        "min_p": 0.0,
     }
 
     def to_sampling_params(
@@ -1635,37 +1635,23 @@ class TranscriptionRequest(OpenAIBaseModel):
 
         if default_sampling_params is None:
             default_sampling_params = {}
+
         # Default parameters
         if (temperature := self.temperature) is None:
             temperature = default_sampling_params.get(
                 "temperature", self._DEFAULT_SAMPLING_PARAMS["temperature"])
-
-        if (seed := self.seed) is None:
-            seed = default_sampling_params.get(
-                "seed", self._DEFAULT_SAMPLING_PARAMS["seed"])
-
-        if (frequency_penalty := self.frequency_penalty) is None:
-            frequency_penalty = default_sampling_params.get(
-                "frequency_penalty",
-                self._DEFAULT_SAMPLING_PARAMS["frequency_penalty"])
 
         if (repetition_penalty := self.repetition_penalty) is None:
             repetition_penalty = default_sampling_params.get(
                 "repetition_penalty",
                 self._DEFAULT_SAMPLING_PARAMS["repetition_penalty"])
 
-        if (presence_penalty := self.presence_penalty) is None:
-            presence_penalty = default_sampling_params.get(
-                "presence_penalty",
-                self._DEFAULT_SAMPLING_PARAMS["presence_penalty"])
-
-
         return SamplingParams.from_optional(temperature=temperature,
                                             max_tokens=max_tokens,
-                                            seed=seed,
-                                            frequency_penalty=frequency_penalty,
+                                            seed=self.seed,
+                                            frequency_penalty=self.frequency_penalty,
                                             repetition_penalty=repetition_penalty,
-                                            presence_penalty=presence_penalty,
+                                            presence_penalty=self.presence_penalty,
                                             output_kind=RequestOutputKind.DELTA
                                             if self.stream \
                                             else RequestOutputKind.FINAL_ONLY)

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1605,6 +1605,10 @@ class TranscriptionRequest(OpenAIBaseModel):
     stream_include_usage: Optional[bool] = False
     stream_continuous_usage_stats: Optional[bool] = False
 
+    # Additional sampling parameters.
+    top_p: Optional[float] = None
+    top_k: Optional[int] = None
+    min_p: Optional[float] = None
     seed: Optional[int] = Field(None, ge=_LONG_INFO.min, le=_LONG_INFO.max)
     """The seed to use for sampling."""
 
@@ -1640,6 +1644,15 @@ class TranscriptionRequest(OpenAIBaseModel):
         if (temperature := self.temperature) is None:
             temperature = default_sampling_params.get(
                 "temperature", self._DEFAULT_SAMPLING_PARAMS["temperature"])
+        if (top_p := self.top_p) is None:
+            top_p = default_sampling_params.get(
+                "top_p", self._DEFAULT_SAMPLING_PARAMS["top_p"])
+        if (top_k := self.top_k) is None:
+            top_k = default_sampling_params.get(
+                "top_k", self._DEFAULT_SAMPLING_PARAMS["top_k"])
+        if (min_p := self.min_p) is None:
+            min_p = default_sampling_params.get(
+                "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"])
 
         if (repetition_penalty := self.repetition_penalty) is None:
             repetition_penalty = default_sampling_params.get(
@@ -1649,6 +1662,9 @@ class TranscriptionRequest(OpenAIBaseModel):
         return SamplingParams.from_optional(temperature=temperature,
                                             max_tokens=max_tokens,
                                             seed=self.seed,
+                                            top_p=top_p,
+                                            top_k=top_k,
+                                            min_p=min_p,
                                             frequency_penalty=self.frequency_penalty,
                                             repetition_penalty=repetition_penalty,
                                             presence_penalty=self.presence_penalty,


### PR DESCRIPTION
Based on the work here https://github.com/vllm-project/vllm/pull/13910.

This PR adds the following sampling parameters to the transcriptions endpoint:

seed, topk, topp, minp, frequency_penalty, repetition_penalty, presence_penalty.


cc @joennlae
