### PR TITLE
compile cumem_allocator for cuda and hip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -636,6 +636,7 @@ ext_modules = []
 
 if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
+    ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
 
 if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
@@ -650,7 +651,6 @@ if _is_cuda():
         # not targeting a hopper system
         ext_modules.append(
             CMakeExtension(name="vllm._flashmla_C", optional=True))
-    ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
 
 if _build_custom_ops():
     ext_modules.append(CMakeExtension(name="vllm._C"))


### PR DESCRIPTION
compile cumem_allocator for cuda and hip

FIX #12695 , the pull ignores the compilation of `cumem_allocator` on rocm devices. https://github.com/vllm-project/vllm/pull/12695 . Please merge the pull after #12695 merged.


<!--- pyml disable-next-line no-emphasis-as-heading -->
