### PR TITLE
[BUG] MM LRU cache fixing

### DIFF
--- a/vllm/v1/engine/mm_input_cache.py
+++ b/vllm/v1/engine/mm_input_cache.py
@@ -51,6 +51,13 @@ class MirroredProcessingCache:
         full_mm_inputs = list[Optional[MultiModalKwargs]]()
         for mm_input, mm_hash in zip(mm_inputs, mm_hashes):
             if mm_hash in self.mm_cache:
+                # Client and Server must be exactly the same (see description
+                # in the top of this file).
+                # `in` in above statement don't update access time by design.
+                # But server side make a direct access and update access time.
+                # Have to make a dummy access to update access time to keep
+                # LRU order of caches consistent.
+                _ = self.mm_cache[mm_hash]
                 mm_input = None
             else:
                 self.mm_cache[mm_hash] = mm_input


### PR DESCRIPTION
We keep 2 MM caches in Client/Frontend and Server/EngineCore (see detailed description in the top of [`/vllm/v1/engine/mm_input_cache.py`](https://github.com/vllm-project/vllm/blob/main/vllm/v1/engine/mm_input_cache.py) ). 

In case on cache hit on Client side we didn't update access time because did only `in` that not update access time by design. On Server side we make explicit access. In result LRU order was inconsistent and over time, the cache content also became inconsistent.

This PR add dummy access on Client side to keep access times consistent.
