### PR TITLE
Fix triton install condition on CPU

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -12,9 +12,9 @@ torchaudio; platform_machine != "ppc64le" and platform_machine != "s390x"
 torchaudio==2.6.0; platform_machine == "ppc64le"
 
 # required for the image processor of phi3v, this must be updated alongside torch
-torchvision; platform_machine != "ppc64le"  and platform_machine != "s390x"
+torchvision; platform_machine != "ppc64le" and platform_machine != "s390x"
 torchvision==0.21.0; platform_machine == "ppc64le"
 datasets # for benchmark scripts
 
 # cpu cannot use triton 3.3.0
-triton==3.2.0; platform_machine != "ppc64le"
+triton==3.2.0; platform_machine == "x86_64"


### PR DESCRIPTION
Issues were also seen when trying to install on Mac.

This PR inverts the condition to make it so that triton is only installed for x86 CPUs.