### PR TITLE
[Bugfix] Move current_platform import to avoid python import cache.

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -84,12 +84,12 @@ def test_env(
         m.setenv("VLLM_MLA_DISABLE", "1" if use_mla else "0")
 
         if device == "cpu":
-            with patch("vllm.attention.selector.current_platform", CpuPlatform()):
+            with patch("vllm.platforms.current_platform", CpuPlatform()):
                 backend = get_attn_backend(16, torch.float16, None, block_size)
             assert backend.get_name() == "TORCH_SDPA"
 
         elif device == "hip":
-            with patch("vllm.attention.selector.current_platform", RocmPlatform()):
+            with patch("vllm.platforms.current_platform", RocmPlatform()):
                 if use_mla:
                     # ROCm MLA backend logic:
                     # - TRITON_MLA: supported when block_size != 1
@@ -126,7 +126,7 @@ def test_env(
                     assert backend.get_name() == expected
 
         elif device == "cuda":
-            with patch("vllm.attention.selector.current_platform", CudaPlatform()):
+            with patch("vllm.platforms.current_platform", CudaPlatform()):
                 if use_mla:
                     # CUDA MLA backend logic:
                     # - CUTLASS_MLA: only supported with block_size == 128
@@ -214,12 +214,12 @@ def test_env(
 def test_fp32_fallback(device: str):
     """Test attention backend selection with fp32."""
     if device == "cpu":
-        with patch("vllm.attention.selector.current_platform", CpuPlatform()):
+        with patch("vllm.platforms.current_platform", CpuPlatform()):
             backend = get_attn_backend(16, torch.float32, None, 16)
         assert backend.get_name() == "TORCH_SDPA"
 
     elif device == "cuda":
-        with patch("vllm.attention.selector.current_platform", CudaPlatform()):
+        with patch("vllm.platforms.current_platform", CudaPlatform()):
             backend = get_attn_backend(16, torch.float32, None, 16)
         assert backend.get_name() == "FLEX_ATTENTION"
 
@@ -277,7 +277,7 @@ def test_invalid_env(monkeypatch: pytest.MonkeyPatch):
     """Test that invalid attention backend names raise ValueError."""
     with (
         monkeypatch.context() as m,
-        patch("vllm.attention.selector.current_platform", CudaPlatform()),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
     ):
         m.setenv(STR_BACKEND_ENV_VAR, STR_INVALID_VAL)
 

--- a/vllm/attention/selector.py
+++ b/vllm/attention/selector.py
@@ -14,7 +14,6 @@ import vllm.envs as envs
 from vllm.attention.backends.abstract import AttentionBackend
 from vllm.attention.backends.registry import _Backend, backend_name_to_enum
 from vllm.logger import init_logger
-from vllm.platforms import current_platform
 from vllm.utils import STR_BACKEND_ENV_VAR, resolve_obj_by_qualname
 
 logger = init_logger(__name__)
@@ -192,6 +191,8 @@ def _cached_get_attn_backend(
                 )
 
     # get device-specific attn_backend
+    from vllm.platforms import current_platform
+
     attention_cls = current_platform.get_attn_backend_cls(
         selected_backend,
         head_size,


### PR DESCRIPTION
We are adding a new platform to vLLM using plugin mechanism. To test our platform, we compare it with the CPU platform within a single file. 
```
from vllm import LLM, SamplingParams

import os
from vllm.platforms import builtin_platform_plugins
from vllm.utils import resolve_obj_by_qualname
from vllm import platforms

# Sample prompts.
prompts = [
    "Hello, my name is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=1)

# Run on cpu platform
platforms._current_platform = resolve_obj_by_qualname(
    "vllm.platforms.cpu.CpuPlatform"
)()
os.environ["VLLM_USE_V1"] = "0"
llm = LLM(model="facebook/opt-125m")
outputs = llm.generate(prompts, sampling_params)
print("\nGenerated Outputs:\n" + "-" * 60)

# Run on our platform
platforms._current_platform = resolve_obj_by_qualname(
    "vllm.platforms.Ourplatform"
)()

os.environ["VLLM_USE_V1"] = "1"
llm = LLM(model="facebook/opt-125m")
outputs = llm.generate(prompts, sampling_params)

```
However, due to Python’s import caching mechanism, the runner of our platform does not re-import current_platform when getting the attention backend for our platform.
https://github.com/vllm-project/vllm/blob/1dd23386ecab7b7c50ea61b8ff37ca14d2dbc0f7/vllm/worker/cpu_model_runner.py#L466
https://github.com/vllm-project/vllm/blob/1dd23386ecab7b7c50ea61b8ff37ca14d2dbc0f7/vllm/attention/selector.py#L13
So the solution is to move the import of `current_platform` inside the `_cached_get_attn_backend` function.