### PR TITLE
Improve configs - `TokenizerPoolConfig` + `DeviceConfig`

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import asdict
+from dataclasses import MISSING, Field, asdict, dataclass, field
 
 import pytest
 
-from vllm.config import ModelConfig, PoolerConfig
+from vllm.config import ModelConfig, PoolerConfig, get_field
 from vllm.model_executor.layers.pooler import PoolingType
 from vllm.platforms import current_platform
+
+
+def test_get_field():
+
+    @dataclass
+    class TestConfig:
+        a: int
+        b: dict = field(default_factory=dict)
+        c: str = "default"
+
+    with pytest.raises(ValueError):
+        get_field(TestConfig, "a")
+
+    b = get_field(TestConfig, "b")
+    assert isinstance(b, Field)
+    assert b.default is MISSING
+    assert b.default_factory is dict
+
+    c = get_field(TestConfig, "c")
+    assert isinstance(c, Field)
+    assert c.default == "default"
+    assert c.default_factory is MISSING
 
 
 @pytest.mark.parametrize(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -182,13 +182,12 @@ def config(cls: type[Config]) -> type[Config]:
     return cls
 
 
-def get_default(cls: type[Config], field_name: str) -> Any:
+def get_field(cls: type[Config], name: str) -> Field:
+    """Get the field of a dataclass by name. Primarily used for getting
+    non-trivial defaults for `EngineArgs`."""
     if not is_dataclass(cls):
         raise TypeError("The given class is not a dataclass.")
-    field: Field = {f.name: f for f in fields(cls)}.get(field_name)
-    # One of these will always be true for Configs with @config
-    return (field.default_factory
-            if field.default is MISSING else field.default)
+    return {f.name: f for f in fields(cls)}.get(name)
 
 
 class ModelConfig:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -183,8 +183,8 @@ def config(cls: type[Config]) -> type[Config]:
 
 
 def get_default_factory_field(cls: type[Config], name: str) -> Field:
-    """Get the field of a dataclass by name. Primarily used for getting
-    non-trivial defaults for `EngineArgs`."""
+    """Get the default factory field of a dataclass by name. Used for getting
+    default factory fields in `EngineArgs`."""
     if not is_dataclass(cls):
         raise TypeError("The given class is not a dataclass.")
     cls_fields = {f.name: f for f in fields(cls)}

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1488,7 +1488,7 @@ class LoadConfig:
     download_dir: Optional[str] = None
     """Directory to download and load the weights, default to the default
     cache directory of Hugging Face."""
-    model_loader_extra_config: Optional[Union[str, dict]] = None
+    model_loader_extra_config: dict = field(default_factory=dict)
     """Extra config for model loader. This will be passed to the model loader
     corresponding to the chosen load_format. This should be a JSON string that
     will be parsed into a dictionary."""
@@ -1519,10 +1519,6 @@ class LoadConfig:
         return hash_str
 
     def __post_init__(self):
-        model_loader_extra_config = self.model_loader_extra_config or {}
-        if isinstance(model_loader_extra_config, str):
-            self.model_loader_extra_config = json.loads(
-                model_loader_extra_config)
         if isinstance(self.load_format, str):
             load_format = self.load_format.lower()
             self.load_format = LoadFormat(load_format)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -182,13 +182,19 @@ def config(cls: type[Config]) -> type[Config]:
     return cls
 
 
-def get_field(cls: type[Config], name: str) -> Field:
+def get_default_factory_field(cls: type[Config], name: str) -> Field:
     """Get the field of a dataclass by name. Primarily used for getting
     non-trivial defaults for `EngineArgs`."""
     if not is_dataclass(cls):
         raise TypeError("The given class is not a dataclass.")
-    f = {f.name: f for f in fields(cls)}.get(name)
-    return field(default=f.default, default_factory=f.default_factory)
+    cls_fields = {f.name: f for f in fields(cls)}
+    if name not in cls_fields:
+        raise ValueError(f"Field '{name}' not found in {cls.__name__}.")
+    f: Field = cls_fields.get(name)
+    if f.default_factory is MISSING:
+        raise ValueError(
+            f"{cls.__name__}.{name} does not have a default factory.")
+    return field(default_factory=f.default_factory)
 
 
 class ModelConfig:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1356,20 +1356,24 @@ class CacheConfig:
             logger.warning("Possibly too large swap space. %s", msg)
 
 
+PoolType = Literal["ray"]
+
+
+@config
 @dataclass
 class TokenizerPoolConfig:
-    """Configuration for the tokenizer pool.
+    """Configuration for the tokenizer pool."""
 
-    Args:
-        pool_size: Number of tokenizer workers in the pool.
-        pool_type: Type of the pool.
-        extra_config: Additional config for the pool.
-            The way the config will be used depends on the
-            pool type.
-    """
-    pool_size: int
-    pool_type: Union[str, type["BaseTokenizerGroup"]]
-    extra_config: dict
+    pool_size: int = 0
+    """Number of tokenizer workers in the pool to use for asynchronous
+    tokenization. If 0, will use synchronous tokenization."""
+    pool_type: Union[PoolType, type["BaseTokenizerGroup"]] = "ray"
+    """Type of tokenizer pool to use for asynchronous tokenization. Ignored if
+    tokenizer_pool_size is 0."""
+    extra_config: Optional[dict] = None
+    """Additional config for the pool. The way the config will be used depends
+    on the pool type. This should be a JSON string that will be parsed into a
+    dictionary. Ignored if tokenizer_pool_size is 0."""
 
     def compute_hash(self) -> str:
         """
@@ -1400,7 +1404,7 @@ class TokenizerPoolConfig:
     @classmethod
     def create_config(
         cls, tokenizer_pool_size: int,
-        tokenizer_pool_type: Union[str, type["BaseTokenizerGroup"]],
+        tokenizer_pool_type: Union[PoolType, type["BaseTokenizerGroup"]],
         tokenizer_pool_extra_config: Optional[Union[str, dict]]
     ) -> Optional["TokenizerPoolConfig"]:
         """Create a TokenizerPoolConfig from the given parameters.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1382,9 +1382,11 @@ class TokenizerPoolConfig:
     pool_size: int = 0
     """Number of tokenizer workers in the pool to use for asynchronous
     tokenization. If 0, will use synchronous tokenization."""
+
     pool_type: Union[PoolType, type["BaseTokenizerGroup"]] = "ray"
     """Type of tokenizer pool to use for asynchronous tokenization. Ignored if
     tokenizer_pool_size is 0."""
+
     extra_config: dict = field(default_factory=dict)
     """Additional config for the pool. The way the config will be used depends
     on the pool type. This should be a JSON string that will be parsed into a

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -187,7 +187,8 @@ def get_field(cls: type[Config], name: str) -> Field:
     non-trivial defaults for `EngineArgs`."""
     if not is_dataclass(cls):
         raise TypeError("The given class is not a dataclass.")
-    return {f.name: f for f in fields(cls)}.get(name)
+    f = {f.name: f for f in fields(cls)}.get(name)
+    return field(default=f.default, default_factory=f.default_factory)
 
 
 class ModelConfig:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -182,6 +182,15 @@ def config(cls: type[Config]) -> type[Config]:
     return cls
 
 
+def get_default(cls: type[Config], field_name: str) -> Any:
+    if not is_dataclass(cls):
+        raise TypeError("The given class is not a dataclass.")
+    field: Field = {f.name: f for f in fields(cls)}.get(field_name)
+    # One of these will always be true for Configs with @config
+    return (field.default_factory
+            if field.default is MISSING else field.default)
+
+
 class ModelConfig:
     """Configuration for the model.
 
@@ -1370,7 +1379,7 @@ class TokenizerPoolConfig:
     pool_type: Union[PoolType, type["BaseTokenizerGroup"]] = "ray"
     """Type of tokenizer pool to use for asynchronous tokenization. Ignored if
     tokenizer_pool_size is 0."""
-    extra_config: Optional[dict] = None
+    extra_config: dict = field(default_factory=dict)
     """Additional config for the pool. The way the config will be used depends
     on the pool type. This should be a JSON string that will be parsed into a
     dictionary. Ignored if tokenizer_pool_size is 0."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -50,12 +50,11 @@ TypeHint = Union[type[Any], object]
 TypeHintT = Union[type[T], object]
 
 
-def optional_arg(val: str, return_type: Union[type[T],
-                                              Callable]) -> Optional[T]:
+def optional_arg(val: str, return_type: Callable[[str], T]) -> Optional[T]:
     if val == "" or val == "None":
         return None
     try:
-        return cast(Callable, return_type)(val)
+        return return_type(val)
     except ValueError as e:
         raise argparse.ArgumentTypeError(
             f"Value {val} cannot be converted to {return_type}.") from e

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,7 +24,7 @@ from vllm.config import (CacheConfig, CompilationConfig, Config, ConfigFormat,
                          ParallelConfig, PoolerConfig, PoolType,
                          PromptAdapterConfig, SchedulerConfig, SchedulerPolicy,
                          SpeculativeConfig, TaskOption, TokenizerPoolConfig,
-                         VllmConfig, get_attr_docs, get_default_factory_field)
+                         VllmConfig, get_attr_docs, get_field)
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
@@ -189,7 +189,7 @@ class EngineArgs:
     tokenizer_pool_type: Union[PoolType, Type["BaseTokenizerGroup"]] = \
         TokenizerPoolConfig.pool_type
     tokenizer_pool_extra_config: dict[str, Any] = \
-        get_default_factory_field(TokenizerPoolConfig, "extra_config")
+        get_field(TokenizerPoolConfig, "extra_config")
     limit_mm_per_prompt: Optional[Mapping[str, int]] = None
     mm_processor_kwargs: Optional[Dict[str, Any]] = None
     disable_mm_preprocessor_cache: bool = False
@@ -212,7 +212,7 @@ class EngineArgs:
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
     model_loader_extra_config: dict = \
-        get_default_factory_field(LoadConfig, "model_loader_extra_config")
+        get_field(LoadConfig, "model_loader_extra_config")
     ignore_patterns: Optional[Union[str,
                                     List[str]]] = LoadConfig.ignore_patterns
     preemption_mode: Optional[str] = SchedulerConfig.preemption_mode

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,7 +24,7 @@ from vllm.config import (CacheConfig, CompilationConfig, Config, ConfigFormat,
                          ParallelConfig, PoolerConfig, PoolType,
                          PromptAdapterConfig, SchedulerConfig, SchedulerPolicy,
                          SpeculativeConfig, TaskOption, TokenizerPoolConfig,
-                         VllmConfig, get_attr_docs, get_field)
+                         VllmConfig, get_attr_docs, get_default_factory_field)
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
@@ -190,7 +190,7 @@ class EngineArgs:
     tokenizer_pool_type: Union[PoolType, Type["BaseTokenizerGroup"]] = \
         TokenizerPoolConfig.pool_type
     tokenizer_pool_extra_config: dict[str, Any] = \
-        get_field(TokenizerPoolConfig, "extra_config")
+        get_default_factory_field(TokenizerPoolConfig, "extra_config")
     limit_mm_per_prompt: Optional[Mapping[str, int]] = None
     mm_processor_kwargs: Optional[Dict[str, Any]] = None
     disable_mm_preprocessor_cache: bool = False
@@ -213,7 +213,7 @@ class EngineArgs:
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
     model_loader_extra_config: dict = \
-        get_field(LoadConfig, "model_loader_extra_config")
+        get_default_factory_field(LoadConfig, "model_loader_extra_config")
     ignore_patterns: Optional[Union[str,
                                     List[str]]] = LoadConfig.ignore_patterns
     preemption_mode: Optional[str] = SchedulerConfig.preemption_mode

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -24,7 +24,7 @@ from vllm.config import (CacheConfig, CompilationConfig, Config, ConfigFormat,
                          ParallelConfig, PoolerConfig, PoolType,
                          PromptAdapterConfig, SchedulerConfig, SchedulerPolicy,
                          SpeculativeConfig, TaskOption, TokenizerPoolConfig,
-                         VllmConfig, get_attr_docs, get_default)
+                         VllmConfig, get_attr_docs, get_field)
 from vllm.executor.executor_base import ExecutorBase
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS
@@ -190,7 +190,7 @@ class EngineArgs:
     tokenizer_pool_type: Union[PoolType, Type["BaseTokenizerGroup"]] = \
         TokenizerPoolConfig.pool_type
     tokenizer_pool_extra_config: dict[str, Any] = \
-        get_default(TokenizerPoolConfig, "extra_config")
+        get_field(TokenizerPoolConfig, "extra_config")
     limit_mm_per_prompt: Optional[Mapping[str, int]] = None
     mm_processor_kwargs: Optional[Dict[str, Any]] = None
     disable_mm_preprocessor_cache: bool = False
@@ -213,7 +213,7 @@ class EngineArgs:
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
     model_loader_extra_config: dict = \
-        get_default(LoadConfig, "model_loader_extra_config")
+        get_field(LoadConfig, "model_loader_extra_config")
     ignore_patterns: Optional[Union[str,
                                     List[str]]] = LoadConfig.ignore_patterns
     preemption_mode: Optional[str] = SchedulerConfig.preemption_mode

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -50,7 +50,8 @@ TypeHint = Union[type[Any], object]
 TypeHintT = Union[type[T], object]
 
 
-def optional_arg(val: str, return_type: type[T]) -> Optional[T]:
+def optional_arg(val: str, return_type: Union[type[T],
+                                              Callable]) -> Optional[T]:
     if val == "" or val == "None":
         return None
     try:
@@ -118,7 +119,7 @@ def optional_dict(val: str) -> Optional[dict[str, int]]:
             "Failed to parse JSON string. Attempting to parse as "
             "comma-separated key=value pairs. This will be deprecated in a "
             "future release.")
-        nullable_kvs(val)
+        return nullable_kvs(val)
 
 
 @dataclass

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -211,8 +211,7 @@ class EngineArgs:
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
-    model_loader_extra_config: Optional[
-        dict] = LoadConfig.model_loader_extra_config
+    model_loader_extra_config: dict = LoadConfig.model_loader_extra_config
     ignore_patterns: Optional[Union[str,
                                     List[str]]] = LoadConfig.ignore_patterns
     preemption_mode: Optional[str] = SchedulerConfig.preemption_mode
@@ -1308,8 +1307,6 @@ class EngineArgs:
 
         if self.qlora_adapter_name_or_path is not None and \
             self.qlora_adapter_name_or_path != "":
-            if self.model_loader_extra_config is None:
-                self.model_loader_extra_config = {}
             self.model_loader_extra_config[
                 "qlora_adapter_name_or_path"] = self.qlora_adapter_name_or_path
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -16,7 +16,7 @@ from typing_extensions import TypeIs
 
 import vllm.envs as envs
 from vllm import version
-from vllm.config import (CacheConfig, CompilationConfig, ConfigFormat,
+from vllm.config import (CacheConfig, CompilationConfig, Config, ConfigFormat,
                          DecodingConfig, Device, DeviceConfig,
                          DistributedExecutorBackend, HfOverrides,
                          KVTransferConfig, LoadConfig, LoadFormat, LoRAConfig,
@@ -286,7 +286,7 @@ class EngineArgs:
             """Check if the class is a custom type."""
             return cls.__module__ != "builtins"
 
-        def get_kwargs(cls: type[Any]) -> dict[str, Any]:
+        def get_kwargs(cls: type[Config]) -> dict[str, Any]:
             cls_docs = get_attr_docs(cls)
             kwargs = {}
             for field in fields(cls):

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -72,8 +72,11 @@ def optional_float(val: str) -> Optional[float]:
     return optional_arg(val, float)
 
 
-def nullable_kvs(val: str) -> Optional[Mapping[str, int]]:
-    """Parses a string containing comma separate key [str] to value [int]
+def nullable_kvs(val: str) -> Optional[dict[str, int]]:
+    """NOTE: This function is deprecated, args should be passed as JSON
+    strings instead.
+    
+    Parses a string containing comma separate key [str] to value [int]
     pairs into a dictionary.
 
     Args:
@@ -105,6 +108,17 @@ def nullable_kvs(val: str) -> Optional[Mapping[str, int]]:
         out_dict[key] = parsed_value
 
     return out_dict
+
+
+def optional_dict(val: str) -> Optional[dict[str, int]]:
+    try:
+        return optional_arg(val, json.loads)
+    except ValueError:
+        logger.warning(
+            "Failed to parse JSON string. Attempting to parse as "
+            "comma-separated key=value pairs. This will be deprecated in a "
+            "future release.")
+        nullable_kvs(val)
 
 
 @dataclass
@@ -324,8 +338,9 @@ class EngineArgs:
                 elif can_be_type(field_type, float):
                     kwargs[name][
                         "type"] = optional_float if optional else float
+                elif can_be_type(field_type, dict):
+                    kwargs[name]["type"] = optional_dict
                 elif (can_be_type(field_type, str)
-                      or can_be_type(field_type, dict)
                       or is_custom_type(field_type)):
                     kwargs[name]["type"] = optional_str if optional else str
                 else:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -212,7 +212,8 @@ class EngineArgs:
     ray_workers_use_nsight: bool = ParallelConfig.ray_workers_use_nsight
     num_gpu_blocks_override: Optional[int] = None
     num_lookahead_slots: int = SchedulerConfig.num_lookahead_slots
-    model_loader_extra_config: dict = LoadConfig.model_loader_extra_config
+    model_loader_extra_config: dict = \
+        get_default(LoadConfig, "model_loader_extra_config")
     ignore_patterns: Optional[Union[str,
                                     List[str]]] = LoadConfig.ignore_patterns
     preemption_mode: Optional[str] = SchedulerConfig.preemption_mode


### PR DESCRIPTION
Follows #16332, #16422, #16533

Notable changes:
- Correctly handle `default_factory=dict`
- Better type hint for `get_kwargs` in `args_utils.py`