### PR TITLE
Disable remote caching when calling compile_fx

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -290,6 +290,19 @@ class InductorAdaptor(CompilerInterface):
             # Dynamo metrics context, see method for more details.
             stack.enter_context(self.metrics_context())
 
+            # Disable remote caching. When these are on, on remote cache-hit,
+            # the monkey-patched functions never actually get called.
+            # vLLM today assumes and requires the monkey-patched functions to
+            # get hit.
+            # TODO(zou3519): we're going to replace this all with
+            # standalone_compile sometime.
+            if is_torch_equal_or_newer("2.6"):
+                stack.enter_context(
+                    torch._inductor.config.patch(fx_graph_remote_cache=False))
+                stack.enter_context(
+                    torch._functorch.config.patch(
+                        enable_remote_autograd_cache=False))
+
             compiled_graph = compile_fx(
                 graph,
                 example_inputs,


### PR DESCRIPTION
The problem is as follows:
- vLLM requires its monkeypatched functions to run (e.g. https://github.com/vllm-project/vllm/blob/7b5ecf79bd94aab0d782c70126d0dcc37c16bc60/vllm/compilation/compiler_interface.py#L251)
- These functions may not run if (1) a user has torch.compile remote cache set up and (2) there is a remote cache hit.
- When the monkeypatched/hijacked functions fail to run, we get some assertions: https://github.com/vllm-project/vllm/blob/7b5ecf79bd94aab0d782c70126d0dcc37c16bc60/vllm/compilation/compiler_interface.py#L299-L302

This PR disables torch.compile remote caching for vLLM compile.

Test Plan:
- tested locally with `vllm serve "meta-llama/Llama-4-Scout-17B-16E-Instruct" -tp 8 --max_
model_len 1000 --override-generation-config='{"attn_temperature_tuning": true}'`

