### PR TITLE
[V1][Spec Decode][Bugfix] Allocate lookahead token kvc in WAITING queue

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -330,7 +330,10 @@ class Scheduler(SchedulerInterface):
                     new_encoder_budget = encoder_budget
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
-                    request, num_new_tokens, computed_blocks)
+                    request, 
+                    num_new_tokens, 
+                    computed_blocks, 
+                    num_lookahead_tokens=self.num_lookahead_tokens)
                 if new_blocks is None:
                     # The request cannot be scheduled.
                     break


### PR DESCRIPTION
FIX #16612

PR #16370 uses num lookahead tokens for computing preallocated kv blocks in EAGLE. However, it skipped for WAITING req which would be req who enter the continous batching for the 1st time or the resumed requests. 