### PR TITLE
[Misc] Avoiding errors in LoRA examples

### DIFF
--- a/examples/offline_inference/lora_with_quantization_inference.py
+++ b/examples/offline_inference/lora_with_quantization_inference.py
@@ -22,28 +22,16 @@ def create_test_prompts(
     return [
         # this is an example of using quantization without LoRA
         ("My name is",
-         SamplingParams(temperature=0.0,
-                        logprobs=1,
-                        prompt_logprobs=1,
-                        max_tokens=128), None),
+         SamplingParams(temperature=0.0, logprobs=1, max_tokens=128), None),
         # the next three examples use quantization with LoRA
         ("my name is",
-         SamplingParams(temperature=0.0,
-                        logprobs=1,
-                        prompt_logprobs=1,
-                        max_tokens=128),
+         SamplingParams(temperature=0.0, logprobs=1, max_tokens=128),
          LoRARequest("lora-test-1", 1, lora_path)),
         ("The capital of USA is",
-         SamplingParams(temperature=0.0,
-                        logprobs=1,
-                        prompt_logprobs=1,
-                        max_tokens=128),
+         SamplingParams(temperature=0.0, logprobs=1, max_tokens=128),
          LoRARequest("lora-test-2", 1, lora_path)),
         ("The capital of France is",
-         SamplingParams(temperature=0.0,
-                        logprobs=1,
-                        prompt_logprobs=1,
-                        max_tokens=128),
+         SamplingParams(temperature=0.0, logprobs=1, max_tokens=128),
          LoRARequest("lora-test-3", 1, lora_path)),
     ]
 

--- a/examples/offline_inference/multilora_inference.py
+++ b/examples/offline_inference/multilora_inference.py
@@ -27,10 +27,7 @@ def create_test_prompts(
     """
     return [
         ("A robot may not injure a human being",
-         SamplingParams(temperature=0.0,
-                        logprobs=1,
-                        prompt_logprobs=1,
-                        max_tokens=128), None),
+         SamplingParams(temperature=0.0, logprobs=1, max_tokens=128), None),
         ("To be or not to be,",
          SamplingParams(temperature=0.8,
                         top_k=5,
@@ -40,7 +37,6 @@ def create_test_prompts(
             "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",  # noqa: E501
             SamplingParams(temperature=0.0,
                            logprobs=1,
-                           prompt_logprobs=1,
                            max_tokens=128,
                            stop_token_ids=[32003]),
             LoRARequest("sql-lora", 1, lora_path)),
@@ -48,7 +44,6 @@ def create_test_prompts(
             "[user] Write a SQL query to answer the question based on the table schema.\n\n context: CREATE TABLE table_name_74 (icao VARCHAR, airport VARCHAR)\n\n question: Name the ICAO for lilongwe international airport [/user] [assistant]",  # noqa: E501
             SamplingParams(temperature=0.0,
                            logprobs=1,
-                           prompt_logprobs=1,
                            max_tokens=128,
                            stop_token_ids=[32003]),
             LoRARequest("sql-lora2", 2, lora_path)),

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1138,6 +1138,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if logprobs_tensors is not None else None
 
         # Compute prompt logprobs if needed.
+        # TODO: Fix compatibility issues between prompt_logprobs and LoRA.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
             hidden_states,
             scheduler_output,


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/16576
V1 LoRA is incompatible with prompt_logprobs causing errors. This PR is just a temporary workaround to avoid errors in LoRA examples. We will try to solve their compatibility issues later.
