### PR TITLE
[Bugfix] Fix broken GritLM model and tests (missing pooling_metadata)

### DIFF
--- a/vllm/model_executor/models/gritlm.py
+++ b/vllm/model_executor/models/gritlm.py
@@ -170,7 +170,7 @@ class GritLMPooler(nn.Module):
         mean_embeddings = sum_embeddings / num_non_instruction_tokens.unsqueeze(
             1)
 
-        pooled_data = self.head(mean_embeddings)
+        pooled_data = self.head(mean_embeddings, pooling_metadata=pooling_metadata)
 
         pooled_outputs = [
             PoolingSequenceGroupOutput(data) for data in pooled_data

--- a/vllm/model_executor/models/gritlm.py
+++ b/vllm/model_executor/models/gritlm.py
@@ -170,7 +170,8 @@ class GritLMPooler(nn.Module):
         mean_embeddings = sum_embeddings / num_non_instruction_tokens.unsqueeze(
             1)
 
-        pooled_data = self.head(mean_embeddings, pooling_metadata=pooling_metadata)
+        pooled_data = self.head(mean_embeddings,
+                                pooling_metadata=pooling_metadata)
 
         pooled_outputs = [
             PoolingSequenceGroupOutput(data) for data in pooled_data


### PR DESCRIPTION
Pass pooling_metadata to pooler head in gritlm. This was broken by https://github.com/vllm-project/vllm/pull/16331.

https://github.com/vllm-project/vllm/pull/14516 broke gritlm tests due to switching attention backend from xformers to flash_attn.



<!--- pyml disable-next-line no-emphasis-as-heading -->
