### PR TITLE
[V1][Spec Dec Bug Fix] Respect Spec Dec Method Specification

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2335,7 +2335,9 @@ class SpeculativeConfig:
                 )
 
                 # Automatically detect the method
-                if "eagle-" in self.draft_model_config.model.lower():
+                if self.method == 'eagle':
+                    pass
+                elif "eagle-" in self.draft_model_config.model.lower():
                     self.method = "eagle"
                 elif self.draft_model_config.hf_config.model_type == "medusa":
                     self.method = "medusa"


### PR DESCRIPTION
Currently, we try to automatically detect the speculative decoding method. For EAGLE, it detects via the draft model checkpoint folder. However, if the folder name does not have the `eagle-` substring, the current logic will make the method `draft_model` even if one has directly specify the method as `eagle`, which leads to subsequent errors. This fix avoids this confusion. 

@LiuXiaoxuanPKU 