### PR TITLE
Fix glm4.py residual bug

### DIFF
--- a/vllm/model_executor/models/glm4.py
+++ b/vllm/model_executor/models/glm4.py
@@ -200,7 +200,8 @@ class Glm4DecoderLayer(nn.Module):
         hidden_states = residual + hidden_states
 
         # Fully Connected
-        hidden_states = self.post_attention_layernorm(hidden_states, residual)
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = self.post_mlp_layernorm(hidden_states)
         hidden_states = residual + hidden_states


### PR DESCRIPTION
Fix residual handling in Glm4DecoderLayer according to https://github.com/huggingface/transformers/blob/main/src/transformers/models/glm4/modeling_glm4.py .

The bug will cause the GLM-4 inference to fail, with the failure reason being:

```
ERROR 04-15 16:20:02 [core.py:387] EngineCore hit an exception: Traceback (most recent call last):
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2586, in run_node
ERROR 04-15 16:20:02 [core.py:387]     return node.target(*args, **kwargs)
ERROR 04-15 16:20:02 [core.py:387] TypeError: linear(): argument 'input' (position 1) must be Tensor, not tuple
ERROR 04-15 16:20:02 [core.py:387] 
ERROR 04-15 16:20:02 [core.py:387] The above exception was the direct cause of the following exception:
ERROR 04-15 16:20:02 [core.py:387] 
ERROR 04-15 16:20:02 [core.py:387] Traceback (most recent call last):
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2471, in get_fake_value
ERROR 04-15 16:20:02 [core.py:387]     ret_val = wrap_fake_exception(
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2017, in wrap_fake_exception
ERROR 04-15 16:20:02 [core.py:387]     return fn()
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2472, in <lambda>
ERROR 04-15 16:20:02 [core.py:387]     lambda: run_node(tx.output, node, args, kwargs, nnmodule)
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2604, in run_node
ERROR 04-15 16:20:02 [core.py:387]     raise RuntimeError(make_error_message(e)).with_traceback(
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/torch/_dynamo/utils.py", line 2586, in run_node
ERROR 04-15 16:20:02 [core.py:387]     return node.target(*args, **kwargs)
ERROR 04-15 16:20:02 [core.py:387] RuntimeError: Failed running call_function <built-in function linear>(*((FakeTensor(..., device='cuda:0', size=(s0, 4096), dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s0, 4096), dtype=torch.bfloat16)), Parameter(FakeTensor(..., device='cuda:0', size=(27392, 4096), dtype=torch.bfloat16)), None), **{}):
ERROR 04-15 16:20:02 [core.py:387] linear(): argument 'input' (position 1) must be Tensor, not tuple
ERROR 04-15 16:20:02 [core.py:387] 
ERROR 04-15 16:20:02 [core.py:387] During handling of the above exception, another exception occurred:
...
ERROR 04-15 16:20:02 [core.py:387] from user code:
ERROR 04-15 16:20:02 [core.py:387]    File "/workspace/venv-glm4/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 360, in forward
ERROR 04-15 16:20:02 [core.py:387]     hidden_states, residual = layer(positions, hidden_states, residual)
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/vllm/model_executor/models/glm4.py", line 204, in forward
ERROR 04-15 16:20:02 [core.py:387]     hidden_states = self.mlp(hidden_states)
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 92, in forward
ERROR 04-15 16:20:02 [core.py:387]     x, _ = self.gate_up_proj(x)
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/vllm/model_executor/layers/linear.py", line 474, in forward
ERROR 04-15 16:20:02 [core.py:387]     output_parallel = self.quant_method.apply(self, input_, bias)
ERROR 04-15 16:20:02 [core.py:387]   File "/workspace/venv-glm4/lib/python3.10/site-packages/vllm/model_executor/layers/linear.py", line 191, in apply
ERROR 04-15 16:20:02 [core.py:387]     return F.linear(x, layer.weight, bias)
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
