### PR TITLE
[ROCM] Bind triton version to 3.2 in requirements-built.txt 

### DIFF
--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -6,6 +6,7 @@ torch==2.6.0
 torchvision==0.21.0
 torchaudio==2.6.0
 
+triton==3.2
 cmake>=3.26,<4
 packaging
 setuptools>=61


### PR DESCRIPTION
See above. This should fix the baremetal rocm build. Another package is pulling in triton version 3.3 which doesn't match with the version that torch comes with (3.2). This is causing various exceptions to be thrown.