### PR TITLE
[Bugfix] set correct lora mapping when compute prompt logprobs

### DIFF
--- a/vllm/lora/punica_wrapper/punica_base.py
+++ b/vllm/lora/punica_wrapper/punica_base.py
@@ -167,6 +167,7 @@ class PunicaWrapperBase(PunicaWrapperABC):
         self.batch_size: int = -1
         self.is_prefill = False
         self.no_lora = False
+        self.is_prompt_logprobs = False
 
     def _update_base_metadata(
         self,
@@ -338,6 +339,8 @@ class PunicaWrapperBase(PunicaWrapperABC):
             self.is_prefill = True
         else:
             self.is_prefill = False
+
+        self.is_prompt_logprobs = mapping.is_prompt_logprobs
 
     @abstractmethod
     def add_shrink(self, y: Union[Tuple[torch.Tensor, ...], torch.Tensor],

--- a/vllm/lora/punica_wrapper/punica_gpu.py
+++ b/vllm/lora/punica_wrapper/punica_gpu.py
@@ -65,6 +65,7 @@ class PunicaWrapperGPU(PunicaWrapperBase):
             **kwargs):
 
         self.is_prefill = mapping.is_prefill
+        self.is_prompt_logprobs = mapping.is_prompt_logprobs
         self._update_base_metadata(mapping, lora_index_to_id, max_loras,
                                    vocab_size, extra_vocab_size,
                                    long_lora_context)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -635,6 +635,22 @@ class InputBatch:
 
         return prompt_lora_mapping, token_lora_mapping, active_lora_requests
 
+    def make_prompt_logprobs_lora_inputs(
+        self, req_idx: int, num_logits: int
+    ) -> tuple[tuple[int, ...], tuple[int, ...], set[LoRARequest]]:
+        """
+        Given the req_idx and num_logits for a request, return datastructures
+        used to activate the LoRA for prompt logprobs computing.
+        """
+        req_lora_mapping = self.request_lora_mapping[[req_idx]]
+        prompt_lora_mapping = tuple(req_lora_mapping)
+        token_lora_mapping = tuple(
+            req_lora_mapping.repeat(num_logits))
+        active_lora_requests: set[LoRARequest] = set(
+            self.lora_id_to_lora_request.values())
+
+        return prompt_lora_mapping, token_lora_mapping, active_lora_requests
+
     @property
     def num_reqs(self) -> int:
         return len(self.req_id_to_index)

--- a/vllm/v1/worker/gpu_input_batch.py
+++ b/vllm/v1/worker/gpu_input_batch.py
@@ -644,8 +644,7 @@ class InputBatch:
         """
         req_lora_mapping = self.request_lora_mapping[[req_idx]]
         prompt_lora_mapping = tuple(req_lora_mapping)
-        token_lora_mapping = tuple(
-            req_lora_mapping.repeat(num_logits))
+        token_lora_mapping = tuple(req_lora_mapping.repeat(num_logits))
         active_lora_requests: set[LoRARequest] = set(
             self.lora_id_to_lora_request.values())
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1359,7 +1359,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             # Reset the lora mapping for prompt logprobs computing
             if self.lora_config:
-                self.set_active_loras_for_prompt_logprobs(self.input_batch, req_idx, num_logits)
+                self.set_active_loras_for_prompt_logprobs(
+                    self.input_batch, req_idx, num_logits)
 
             logits = self.model.compute_logits(prompt_hidden_states, None)
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1356,6 +1356,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc_np[req_idx].item()
             prompt_hidden_states = hidden_states[offset:offset + num_logits]
+
+            # Reset the lora mapping for prompt logprobs computing
+            if self.lora_config:
+                self.set_active_loras_for_prompt_logprobs(self.input_batch, req_idx, num_logits)
+
             logits = self.model.compute_logits(prompt_hidden_states, None)
 
             # Get the "target" tokens for each index. For prompt at index i,

--- a/vllm/v1/worker/lora_model_runner_mixin.py
+++ b/vllm/v1/worker/lora_model_runner_mixin.py
@@ -83,6 +83,22 @@ class LoRAModelRunnerMixin:
         return self._set_active_loras(prompt_lora_mapping, token_lora_mapping,
                                       lora_requests)
 
+    def set_active_loras_for_prompt_logprobs(self, input_batch: InputBatch,
+                                             req_idx: int,
+                                             num_logits: int) -> None:
+        # set the active loras for prompt logprobs computing
+
+        if not self.lora_manager:
+            raise RuntimeError("LoRA is not enabled.")
+
+        prompt_lora_mapping, token_lora_mapping, lora_requests = \
+            input_batch.make_prompt_logprobs_lora_inputs(req_idx, num_logits)
+        lora_mapping = LoRAMapping(token_lora_mapping,
+                                   prompt_lora_mapping,
+                                   is_prefill=True,
+                                   is_prompt_logprobs=True)
+        self.lora_manager.set_active_adapters(lora_requests, lora_mapping)
+
     @contextmanager
     def maybe_dummy_run_with_lora(self, lora_config: LoRAConfig,
                                   num_scheduled_tokens: np.ndarray):


### PR DESCRIPTION
The current implementation uses the same `get_logits` and `lora_mapping` for both prompt logprob computation and token sampling, which may lead to matrix dimension mismatch or incorrect prompt_logprobs calculation (unexpected implicit broadcasting occurs on [layers.py#L1150-L1152](https://github.com/vllm-project/vllm/blob/54a66e5fee4a1ea62f1e4c79a078b20668e408c6/vllm/lora/layers.py#L1150-L1152) when processing a single request)

FIX #16630, #16576 and #16668 
