### PR TITLE
[Hardware] Add processor inputs to platform validation

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, NamedTuple, Optional, Tuple, Union
 import numpy as np
 import torch
 
-from vllm.inputs import PromptType
+from vllm.inputs import ProcessorInputs, PromptType
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -400,6 +400,7 @@ class Platform:
         cls,
         prompt: PromptType,
         params: Union[SamplingParams, PoolingParams],
+        processed_inputs: ProcessorInputs,
     ) -> None:
         """Raises if this request is unsupported on this platform"""
 

--- a/vllm/platforms/tpu.py
+++ b/vllm/platforms/tpu.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import torch
 
 import vllm.envs as envs
-from vllm.inputs import PromptType
+from vllm.inputs import ProcessorInputs, PromptType
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams, SamplingType
 
@@ -150,6 +150,7 @@ class TpuPlatform(Platform):
         cls,
         prompt: PromptType,
         params: Union[SamplingParams, PoolingParams],
+        processed_inputs: ProcessorInputs,
     ) -> None:
         """Raises if this request is unsupported on this platform"""
         if isinstance(params, SamplingParams):

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -202,12 +202,6 @@ class Processor:
 
         # TODO(woosuk): Support pooling models.
         # TODO(woosuk): Support encoder-decoder models.
-
-        from vllm.platforms import current_platform
-        current_platform.validate_request(
-            prompt=prompt,
-            params=params,
-        )
         self._validate_lora(lora_request)
         self._validate_params(params)
         if priority != 0:
@@ -230,6 +224,12 @@ class Processor:
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
             return_mm_hashes=self.use_hash,
+        )
+        from vllm.platforms import current_platform
+        current_platform.validate_request(
+            prompt=prompt,
+            params=params,
+            processed_inputs=processed_inputs,
         )
         eos_token_id = self.input_preprocessor.get_eos_token_id(lora_request)
 


### PR DESCRIPTION
A followup to https://github.com/vllm-project/vllm/pull/16291

This moves the `current_platform.validate_request` call to after input preprocessing happens, so that the `ProcessorInputs` can also be passed to the platform. This will ensure the platform plugins have access to the tokenized prompt and multimodal data for validation as well.

This is a slightly api breaking change since implementations that don't accept the `processed_inputs` kwarg would break, but I've updated the tpu implementation here and [vllm-ascend](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/platform.py) hasn't implemented it yet.

I'll wait for @NickLucche to test this on TPU this time before merging to make sure I didn't break it again

<!--- pyml disable-next-line no-emphasis-as-heading -->
