### PR TITLE
[Misc] Modify LRUCache touch

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -316,7 +316,10 @@ class LRUCache(cachetools.LRUCache[_K, _V], Generic[_K, _V]):
         return info
 
     def touch(self, key: _K) -> None:
-        self._LRUCache__update(key)  # type: ignore
+        try:
+            self._LRUCache__order.move_to_end(key)  # type: ignore
+        except KeyError:
+            self._LRUCache__order[key] = None  # type: ignore
 
     @overload
     def get(self, key: _K, /) -> Optional[_V]:


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/16569
`cachetools` may remove `__update` in new versions(see [__touch](https://github.com/tkem/cachetools/blob/master/src/cachetools/__init__.py#L233)),  causing an error in vLLM's LRUCache. Modify vLLM's touch to work around this issue.
