### PR TITLE
[Misc] not show --model in vllm serve --help

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -5,6 +5,7 @@ import argparse
 import dataclasses
 import json
 import re
+import sys
 import threading
 import warnings
 from dataclasses import MISSING, dataclass, fields, is_dataclass
@@ -440,7 +441,8 @@ class EngineArgs:
             title="ModelConfig",
             description=ModelConfig.__doc__,
         )
-        model_group.add_argument("--model", **model_kwargs["model"])
+        if 'serve' not in sys.argv[1:] and '--help' not in sys.argv[1:]:
+            model_group.add_argument("--model", **model_kwargs["model"])
         model_group.add_argument("--task", **model_kwargs["task"])
         model_group.add_argument("--tokenizer", **model_kwargs["tokenizer"])
         model_group.add_argument("--tokenizer-mode",


### PR DESCRIPTION


`serve` is use model as a positional argument, but still show in --help, so try to hide it.
```
 vllm serve --model mistralai/Mistral-7B-Instruct-v0.3
INFO 04-16 10:14:00 [__init__.py:239] Automatically detected platform cuda.
Traceback (most recent call last):
  File "/home/ccc/vllm/bin/vllm", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ccc/github/vllm/vllm/entrypoints/cli/main.py", line 46, in main
    args = parser.parse_args()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ccc/github/vllm/vllm/utils.py", line 1312, in parse_args
    raise ValueError(
ValueError: With `vllm serve`, you should provide the model as a positional argument or in a config file instead of via the `--model` option.

$ vllm serve --help|grep '\-\-model'
  --model MODEL         Name or path of the huggingface model to use.
  --model-impl {auto,vllm,transformers}
                        ``--model`` argument. Noted that this name(s) will
  --model-loader-extra-config MODEL_LOADER_EXTRA_CONFIG
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
