### PR TITLE
fix: do not install triton on cpu mac m

### DIFF
--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -17,4 +17,4 @@ torchvision==0.21.0; platform_machine == "ppc64le"
 datasets # for benchmark scripts
 
 # cpu cannot use triton 3.3.0
-triton==3.2.0; platform_machine != "ppc64le"
+triton==3.2.0; platform_machine != "ppc64le" and platform_system != "Darwin"


### PR DESCRIPTION


This patch follow https://github.com/vllm-project/vllm/pull/16470

that mac can not install triton too

error:

```
  × No solution found when resolving dependencies:
  ╰─▶ Because triton{platform_machine != 'ppc64le'}==3.2.0 has no wheels with a matching platform tag (e.g., `macosx_15_0_arm64`) and you require
      triton{platform_machine != 'ppc64le'}==3.2.0, we can conclude that your requirements are unsatisfiable.

      hint: Wheels are available for `triton` (v3.2.0) on the following platforms: `manylinux_2_17_x86_64`, `manylinux2014_x86_64`
```
