### PR TITLE
prototype for adding gpu side timings to data structures

### DIFF
--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -43,6 +43,7 @@ class CompletionOutput:
     finish_reason: Optional[str] = None
     stop_reason: Union[int, str, None] = None
     lora_request: Optional[LoRARequest] = None
+    gpu_execution_time_ms: Optional[float] = None
 
     def finished(self) -> bool:
         return self.finish_reason is not None
@@ -54,7 +55,8 @@ class CompletionOutput:
                 f"cumulative_logprob={self.cumulative_logprob}, "
                 f"logprobs={self.logprobs}, "
                 f"finish_reason={self.finish_reason}, "
-                f"stop_reason={self.stop_reason})")
+                f"stop_reason={self.stop_reason}, "
+                f"gpu_execution_time_ms={self.gpu_execution_time_ms})")
 
 
 @dataclass
@@ -103,6 +105,7 @@ class RequestOutput:
         encoder_prompt_token_ids: The token IDs of the encoder prompt.
                                   None if decoder-only.
         num_cached_tokens: The number of tokens with prefix cache hit.
+        gpu_execution_time_ms: The time taken by the GPU to execute the request.
     """
 
     def __init__(
@@ -118,6 +121,7 @@ class RequestOutput:
         encoder_prompt: Optional[str] = None,
         encoder_prompt_token_ids: Optional[list[int]] = None,
         num_cached_tokens: Optional[int] = None,
+        gpu_execution_time_ms: Optional[float] = None,
         *,
         multi_modal_placeholders: Optional[MultiModalPlaceholderDict] = None,
     ) -> None:
@@ -133,6 +137,7 @@ class RequestOutput:
         self.encoder_prompt = encoder_prompt
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
+        self.gpu_execution_time_ms = gpu_execution_time_ms
 
     def add(self, next_output: "RequestOutput") -> None:
         """Merge subsequent RequestOutput into this one"""

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -68,7 +68,7 @@ class GuidedDecodingParams:
     @property
     def backend_name(self) -> str:
         """Return the backend name without any options.
-        
+
         For example if the backend is "xgrammar:no-fallback", returns "xgrammar"
         """
         return (self.backend or "").split(":")[0]

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -121,3 +121,5 @@ class SchedulerOutput:
     structured_output_request_ids: dict[str, int]
     # the bitmask for the whole batch
     grammar_bitmask: Optional[npt.NDArray[np.int32]]
+
+    num_sms: int

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -135,6 +135,7 @@ class EngineCoreOutputs(
     outputs: list[EngineCoreOutput] = []
     scheduler_stats: Optional[SchedulerStats] = None
     timestamp: float = 0.0
+    gpu_execution_time_ms: float = 0.0
 
     utility_output: Optional[UtilityOutput] = None
     finished_requests: Optional[set[str]] = None

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -319,8 +319,10 @@ class AsyncLLM(EngineClient):
 
                 for i, outputs_slice in enumerate(slices):
                     # 2) Process EngineCoreOutputs.
+                    assert outputs.gpu_execution_time_ms is not None
                     processed_outputs = self.output_processor.process_outputs(
-                        outputs_slice, outputs.timestamp, iteration_stats)
+                        outputs_slice, outputs.timestamp, iteration_stats,
+                        outputs.gpu_execution_time_ms)
                     # NOTE: RequestOutputs are pushed to their queues.
                     assert not processed_outputs.request_outputs
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -223,7 +223,8 @@ class LLMEngine:
 
         # 2) Process EngineCoreOutputs.
         processed_outputs = self.output_processor.process_outputs(
-            outputs.outputs)
+            outputs.outputs,
+            gpu_execution_time_ms=outputs.gpu_execution_time_ms)
 
         # 3) Abort any reqs that finished due to stop strings.
         self.engine_core.abort_requests(processed_outputs.reqs_to_abort)

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -100,6 +100,8 @@ class ModelRunnerOutput:
     # [prompt_len]
     prompt_logprobs_dict: dict[str, Optional[LogprobsTensors]]
 
+    gpu_execution_time_ms: float
+
 
 EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(
     req_ids=[],
@@ -108,4 +110,5 @@ EMPTY_MODEL_RUNNER_OUTPUT = ModelRunnerOutput(
     spec_token_ids=None,
     logprobs=None,
     prompt_logprobs_dict={},
+    gpu_execution_time_ms=0.0,
 )


### PR DESCRIPTION
```python
from vllm import LLM, SamplingParams
from time import perf_counter

PREFILL_TOKENS = [128, 512, 2048, 8192]

llm = LLM(
    model="RedHatAI/Meta-Llama-3-8B-Instruct-FP8",
    load_format="dummy",
    max_model_len=max(PREFILL_TOKENS),
    enable_prefix_caching=False,
)

# warmup
# llm.generate([{
#     "prompt_token_ids": [1] * (max(PREFILL_TOKENS) - 1)
# }],
#              sampling_params,
#              use_tqdm=False)


def make_input(prefill_tokens: int):
    return [{"prompt_token_ids": [1] * (prefill_tokens - 1)}]


data = []

for _ in range(3):
    for prefill_tokens in PREFILL_TOKENS:
        start = perf_counter()
        out = llm.generate(make_input(prefill_tokens),
                           SamplingParams(detokenize=False,
                                          max_tokens=1,)
                           use_tqdm=False)
        end = perf_counter()

        data.append({
            "prefill_tokens": prefill_tokens,
            "gpu_execution_time_ms": out[0].gpu_execution_time_ms,
            "wall_time_ms": (end - start) * 1000,
        })

        print(
            f"Prefilling {prefill_tokens} tokens: {(end - start) * 1000:.2f} ms, {out[0].gpu_execution_time_ms=}"
        )

import pandas as pd

df = pd.DataFrame(data)
df.to_csv("prefill-data.csv", index=False)

```