### PR TITLE
[Bugfix][Disaggregated] Set min_tokens in disagg_proxy_demo.py

### DIFF
--- a/examples/online_serving/disagg_examples/disagg_proxy_demo.py
+++ b/examples/online_serving/disagg_examples/disagg_proxy_demo.py
@@ -254,6 +254,7 @@ class Proxy:
 
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            kv_prepare_request["min_tokens"] = 0
 
             prefill_instance = self.schedule(self.prefill_cycler)
             try:
@@ -290,6 +291,7 @@ class Proxy:
             # add params to request
             kv_prepare_request = request.copy()
             kv_prepare_request["max_tokens"] = 1
+            kv_prepare_request["min_tokens"] = 0
 
             # prefill stage
             prefill_instance = self.schedule(self.prefill_cycler)


### PR DESCRIPTION
When the `min_tokens` parameter is set in a test request, , referring to https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/vllm-integration-v1.md
```
curl -s http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
  "model": "/workspace/models/Qwen2.5-3B-Instruct",
  "prompt": "San Francisco is a",
  "max_tokens": 1000,
  "min_tokens": 100
}'
```
The prefill vllm will encounter the following error
```
"POST /v1/completions HTTP/1.1" 400 Bad Request
```

We should set `min_tokens` to 0 in `disagg_proxy_demo.py` to ensure that it is not greater than `max_tokens`.

CC: @ShangmingCai 
