### PR TITLE
[V1] Remove additional_config check

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1410,11 +1410,6 @@ class EngineArgs:
                                recommend_to_remove=True)
             return False
 
-        if self.additional_config != EngineArgs.additional_config:
-            _raise_or_fallback(feature_name="--additional-config",
-                               recommend_to_remove=False)
-            return False
-
         # Xgrammar and Guidance are supported.
         SUPPORTED_GUIDED_DECODING = [
             "xgrammar", "xgrammar:disable-any-whitespace", "guidance",


### PR DESCRIPTION
additional_config is contained in vllm_config and can be used by custom platform. It doesn't affect any V1 feature or function and can be used by V1 correctly. This PR drop the related check for V1 engine.