### PR TITLE
[API_SERVER] Add maximum concurrency limit for API interface

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -704,6 +704,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # It can be changed with this variable if needed for some reason.
     "VLLM_XGRAMMAR_CACHE_MB":
     lambda: int(os.getenv("VLLM_XGRAMMAR_CACHE_MB", "512")),
+
+    # Maximum number of concurrent requests to the API server
+    "VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS":
+    lambda: int(os.getenv("VLLM_API_SERVICE_MAX_CONCURRENT_REQUESTS", "0")),
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
The larger the concurrent API requests, the longer the response time. In order to improve user experience, the maximum concurrent request limit is increased to ensure that the response time of the service is within a controllable range

https://github.com/vllm-project/vllm/pull/11997