### PR TITLE
[TPU][V1] Fix padding recompilation when `max-num-batched-tokens` is not even

### DIFF
--- a/tests/v1/tpu/worker/test_tpu_model_runner.py
+++ b/tests/v1/tpu/worker/test_tpu_model_runner.py
@@ -305,7 +305,6 @@ def test_get_paddings():
     expected_paddings = [16, 32, 64, 128, 192, 256, 320]
     actual_paddings = _get_token_paddings(min_token_size, max_token_size,
                                           padding_gap)
-    print(actual_paddings, expected_paddings)
     assert actual_paddings == expected_paddings
 
     # Exponential padding.

--- a/tests/v1/tpu/worker/test_tpu_model_runner.py
+++ b/tests/v1/tpu/worker/test_tpu_model_runner.py
@@ -294,11 +294,20 @@ def test_update_states_request_unscheduled(model_runner):
 
 
 def test_get_paddings():
+    # Bucketed padding
     min_token_size, max_token_size, padding_gap = 16, 512, 64
     expected_paddings = [16, 32, 64, 128, 192, 256, 320, 384, 448, 512]
     actual_paddings = _get_token_paddings(min_token_size, max_token_size,
                                           padding_gap)
+
+    # Bucketed padding with max_token_size not a power of two.
+    max_token_size = 317
+    expected_paddings = [16, 32, 64, 128, 192, 256, 320]
+    actual_paddings = _get_token_paddings(min_token_size, max_token_size,
+                                          padding_gap)
+    print(actual_paddings, expected_paddings)
     assert actual_paddings == expected_paddings
+
     # Exponential padding.
     max_token_size, padding_gap = 1024, 0
     expected_paddings = [16, 32, 64, 128, 256, 512, 1024]

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -128,10 +128,16 @@ class TPUModelRunner:
         self.block_size = cache_config.block_size
         self.max_model_len = model_config.max_model_len
         self.max_num_blocks_per_req = cdiv(self.max_model_len, self.block_size)
-        self.max_num_tokens = scheduler_config.max_num_batched_tokens
         # InputBatch needs to work with sampling tensors greater than padding
         # to avoid dynamic shapes. Also, avoid suboptimal alignment.
         self.max_num_reqs = max(scheduler_config.max_num_seqs, MIN_NUM_SEQS)
+        self.num_tokens_paddings = _get_token_paddings(
+            min_token_size=16,
+            max_token_size=scheduler_config.max_num_batched_tokens,
+            padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP)
+        # In case `max_num_tokens < max(num_tokens_paddings)` use the actual
+        # padded max value to pre-allocate data structures and pre-compile.
+        self.max_num_tokens = self.num_tokens_paddings[-1]
 
         # Model-related.
         self.num_attn_layers = model_config.get_num_layers_by_block_type(
@@ -211,10 +217,6 @@ class TPUModelRunner:
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
         self.arange_np = np.arange(self.max_num_tokens, dtype=np.int32)
-        self.num_tokens_paddings = _get_token_paddings(
-            min_token_size=16,
-            max_token_size=self.max_num_tokens,
-            padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP)
         self.num_reqs_paddings = _get_req_paddings(
             min_req_size=MIN_NUM_SEQS, max_req_size=self.max_num_reqs)
 

--- a/vllm/v1/worker/tpu_worker.py
+++ b/vllm/v1/worker/tpu_worker.py
@@ -156,8 +156,8 @@ class TPUWorker:
             self.vllm_config.compilation_config.static_forward_context,
             runner_kv_caches)
 
-        self.model_runner._dummy_run(
-            self.scheduler_config.max_num_batched_tokens)
+        # `max_num_tokens >= max_num_batched_tokens` due to padding.
+        self.model_runner._dummy_run(self.model_runner.max_num_tokens)
 
         # Synchronize before measuring the memory usage.
         xm.wait_device_ops()


### PR DESCRIPTION
`max-num-batched-tokens` values that are not power of 2s (or simply not even when using bucketing) can silently cause recompiliations. 
This is due to the fact in such cases both bucketed and exponential padding will return a maximal padding value that will be > `max-num-batched-tokens`.
Assume:
```
# 317
self.max_num_tokens = scheduler_config.max_num_batched_tokens
self.num_tokens_paddings = _get_token_paddings(..)
print(self.num_tokens_paddings[-1]) # 512 for exponential, 320 for bucketed
```
In turn, auxiliary data structures will be instantiated with the original uneven value (say 317)
```
self.input_ids_cpu = torch.zeros(self.max_num_tokens, # 317
                                 dtype=torch.int32,
                                 device="cpu")
```
Causing the following 
```
# Padded value=512, which is > 317
padded_total_num_scheduled_tokens = _get_padded_token_len(
    self.num_tokens_paddings, total_num_scheduled_tokens)
...
# Select 512 positions in 317 position array will yield the full 317 positions
self.input_ids = self.input_ids_cpu[:
                                    padded_total_num_scheduled_tokens].to(
                                        self.device)
# Causing `input_ids` to run with a potentially uncompiled size of 317
```

To verify:
```
VLLM_XLA_CACHE_PATH= VLLM_XLA_CHECK_RECOMPILATION=1 VLLM_USE_V1=1 vllm serve Qwen/Qwen2.5-1.5B-Instruct \
 --port 8004 \
 --gpu-memory-utilization 0.95 \
 --max-num-seqs 8 \
 --max-num-batched-tokens 93 \
 --tensor-parallel-size 1 \
 --max-model-len 256
 
 
 # Some long request
 curl http://localhost:8004/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2.5-1.5B-Instruct",
    "messages": [
      {
        "role": "system",
        "content": "You are a helpful assistant."
      },
      {
        "role": "user",
        "content": "Imagine a lone samurai wandering across feudal Japan, passing through misty mountains, quiet villages, and fields touched by the morning dew. He reflects on the impermanence of life, the fleeting nature of honor, and the silent strength required to walk a solitary path. His sword is sheathed not just in steel, but in wisdom. His heart carries both the burden of war and the beauty of cherry blossoms falling in the spring breeze. He meets no one, yet learns from every shadow, every whisper of wind, and every broken piece of pottery he finds along the way. Please write a short poem that captures the spirit of this samurai journey and his internal reflections. The tone should be serene, slightly melancholic, yet filled with a sense of dignity and resolve."
      }
    ],
    "temperature": 0.4,
    "min_p": 0.8,
    "max_tokens": 48,
    "stream": false
  }'
```
 
 
We can either have the last padding element be always exactly equal to `max-num-batched-tokens` or adjust for its "actual" padded value computed by `_get_token_paddings` (a power of 2 or "bucketed" power of 2). 

This PR implements the latter because I ultimately think having these sizes be aligned can help with memory accesses here and there. 
I am open to discuss better approaches if you have suggestions.