### PR TITLE
Raise error for data-parallel with benchmark_throughput

### DIFF
--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -520,6 +520,10 @@ def validate_args(args):
         raise ValueError(
             "Tokenizer must be the same as the model for MII backend.")
 
+    # --data-parallel is not supported currently.
+    # https://github.com/vllm-project/vllm/issues/16222
+    if args.data_parallel_size > 1:
+        raise ValueError("Data parallel is not supported currently.")
 
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark the throughput.")

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -523,7 +523,10 @@ def validate_args(args):
     # --data-parallel is not supported currently.
     # https://github.com/vllm-project/vllm/issues/16222
     if args.data_parallel_size > 1:
-        raise ValueError("Data parallel is not supported in offline benchmark, please use benchmark serving instead")
+        raise ValueError(
+            "Data parallel is not supported in offline benchmark, \
+            please use benchmark serving instead")
+
 
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark the throughput.")

--- a/benchmarks/benchmark_throughput.py
+++ b/benchmarks/benchmark_throughput.py
@@ -523,7 +523,7 @@ def validate_args(args):
     # --data-parallel is not supported currently.
     # https://github.com/vllm-project/vllm/issues/16222
     if args.data_parallel_size > 1:
-        raise ValueError("Data parallel is not supported currently.")
+        raise ValueError("Data parallel is not supported in offline benchmark, please use benchmark serving instead")
 
 if __name__ == "__main__":
     parser = FlexibleArgumentParser(description="Benchmark the throughput.")


### PR DESCRIPTION
Running [benchmark_throughput](https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_throughput.py) with data parallel results in a hang. This PR raises an error if `--data-parallel-size` is passed in.

Based on discussions in #16222 

This is my first PR to vLLM so please let me know if I should add any tests. Thanks!

<!--- pyml disable-next-line no-emphasis-as-heading -->
