### PR TITLE
Add key latencies to v1 RequestMetrics instance so it can be surfaced…

### DIFF
--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -487,7 +487,10 @@ class _AsyncLLMEngine(LLMEngine):
             raise ValueError(f"Got priority {priority} but "
                              "Priority scheduling is not enabled.")
         if arrival_time is None:
-            arrival_time = time.time()
+            if envs.VLLM_USE_V1:
+                arrival_time = time.monotonic()
+            else:
+                arrival_time = time.time()
 
         if self.tokenizer is not None:
             tokenizer = await self.get_tokenizer_async(lora_request)

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -487,10 +487,7 @@ class _AsyncLLMEngine(LLMEngine):
             raise ValueError(f"Got priority {priority} but "
                              "Priority scheduling is not enabled.")
         if arrival_time is None:
-            if envs.VLLM_USE_V1:
-                arrival_time = time.monotonic()
-            else:
-                arrival_time = time.time()
+            arrival_time = time.time()
 
         if self.tokenizer is not None:
             tokenizer = await self.get_tokenizer_async(lora_request)

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import time
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Optional, Union
 
 from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.sequence import RequestMetrics
 from vllm.sampling_params import RequestOutputKind
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizer_group import BaseTokenizerGroup
@@ -338,6 +340,14 @@ class OutputProcessor:
             # 4) Create and handle RequestOutput objects.
             if request_output := req_state.make_request_output(
                     new_token_ids, finish_reason, stop_reason):
+                request_output.metrics = RequestMetrics(
+                    arrival_time=req_state.stats.arrival_time,
+                    last_token_time=req_state.stats.last_token_ts,
+                    first_scheduled_time=req_state.stats.scheduled_ts,
+                    first_token_time=req_state.stats.first_token_ts,
+                    time_in_queue=req_state.stats.scheduled_ts - req_state.stats.arrival_time,
+                    finished_time=time.monotonic()
+                )
                 if req_state.queue is not None:
                     # AsyncLLM: put into queue for handling by generate().
                     req_state.queue.put(request_output)

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -212,7 +212,7 @@ class Processor:
             raise ValueError("V1 does not support prompt_adapter_request.")
 
         if arrival_time is None:
-            arrival_time = time.time()
+            arrival_time = time.monotonic()
 
         # Process inputs, which includes:
         # 1. Tokenize text prompt, with LoRA request if one exists.


### PR DESCRIPTION
After upgrading to v0.8.1+ where v1 is enabled by default, we encountered metrics not available in generated outputs object as described in https://github.com/vllm-project/vllm/issues/15394

This is to add RequestMetrics instance and key latency attributes back to RequestOutput, so when profiling inference latency metrics, we can still leverage `arrival_time`, `last_token_ts`, `scheduled_ts`, `first_token_ts`, `time_in_queue` and `finished_time`.

Additionally, we aligned `arrival_time` in v1 in monotonic mode (previously wall-clock) as other latency metrics so that they can be used to calculate the latency.


FIX #15394 [Bug]: RequestMetrics object (accessed through output[0].metrics) is None

We have tested this works when calling 

```
async def parse_output(output):
    """Parses the final output after async loop completes."""
    request_id = output.request_id
    prompt_token_ids = output.prompt_token_ids

    output_total_token_len = len(output.outputs[0].token_ids)
    input_total_token_len = len(prompt_token_ids)
    print(f"Input total token length: {input_total_token_len}\n")
    print(f"Output total token length: {output_total_token_len}\n")
    TTFT = (output.metrics.first_token_time - output.metrics.first_scheduled_time) * 1000
    E2E = (output.metrics.finished_time - output.metrics.first_scheduled_time) * 1000
    ...
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
