### PR TITLE
[Bugfix] Revert max_prompt_len validation for decoder-only models.

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2062,7 +2062,7 @@ class LLMEngine:
                 raise ValueError(f"The {prompt_type} prompt cannot be empty")
 
         max_prompt_len = self.model_config.max_model_len
-        if len(prompt_ids) >= max_prompt_len:
+        if len(prompt_ids) > max_prompt_len:
             if prompt_type == "encoder" and model_config.is_multimodal_model:
                 mm_registry = self.input_preprocessor.mm_registry
                 mm_processor = mm_registry.create_processor(

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -351,7 +351,7 @@ class Processor:
             raise ValueError(f"Token id {max_input_id} is out of vocabulary")
 
         max_prompt_len = self.model_config.max_model_len
-        if len(prompt_ids) >= max_prompt_len:
+        if len(prompt_ids) > max_prompt_len:
             if prompt_type == "encoder" and model_config.is_multimodal_model:
                 mm_registry = self.input_preprocessor.mm_registry
                 mm_processor = mm_registry.create_processor(


### PR DESCRIPTION
A bugfix (https://github.com/vllm-project/vllm/pull/16156) improved input validation for multi-modal models.

However for decoder-only models it changed:

```python
if len(prompt_ids) > max_prompt_len:
```

to 

```python
if len(prompt_ids) >= max_prompt_len:
```

This change breaks inputs for decoder-only models that provide inputs equal to `max_prompt_len`, which is valid behavior. This breaks LLM eval frameworks like OLMES and the LM Eval harness. See:

FIX #16445

This will revert this change to the original behavior (`len(prompt_ids) > max_prompt_len`). This fixes the v1 engine as well.
