### PR TITLE
Use repeat_interleave in Mamba2 seq_idx computation to reduce cpu-gpu syncs

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -80,13 +80,12 @@ def prepare_mamba2_metadata(
     seq_idx = None
     chunk_indices, chunk_offsets = None, None
     if has_prefill:
-        seq_idx = torch.zeros_like(input_ids, dtype=torch.int32)
-        for i, (srt, end) in enumerate(
-                zip(
-                    attn_metadata.query_start_loc,
-                    attn_metadata.query_start_loc[1:],
-                )):
-            seq_idx[srt:end] = i
+        seq_idx = torch.repeat_interleave(torch.arange(
+            len(attn_metadata.query_start_loc) - 1,
+            dtype=torch.int32,
+            device=attn_metadata.query_start_loc.device),
+                                          attn_metadata.query_start_loc.diff(),
+                                          output_size=len(input_ids))
         seq_idx.unsqueeze_(0)
 
         # compute metadata for chunked prefill.

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -24,21 +24,23 @@ class Mamba2Metadata:
     chunk_offsets: torch.Tensor
 
 
-def _seq_idx_to_chunk_indices_offsets(seq_idx, chunk_size: int):
+def _query_start_loc_to_chunk_indices_offsets(query_start_loc: torch.Tensor,
+                                              chunk_size: int,
+                                              total_seqlens: int):
 
-    # convert seq_idx to chunk indices and offsets
-    # - derive the cu_seqlens
-    _, cu_seqlens = torch.where(seq_idx.diff())
-    cu_seqlens += 1
+    cu_seqlens = query_start_loc[1:]  # remove prepended 0
 
     # outputs will have length expansion of chunks that do not divide
     # chunk_size
-    N = math.ceil(seq_idx.shape[-1] / chunk_size) + (cu_seqlens % chunk_size
-                                                     > 0).sum()
-    chunk_indices = torch.arange(N, dtype=torch.int, device=seq_idx.device)
-    chunk_offsets = torch.zeros((N, ), dtype=torch.int, device=seq_idx.device)
+    N = math.ceil(total_seqlens / chunk_size) + (cu_seqlens[:-1] % chunk_size
+                                                 > 0).sum()
+    chunk_indices = torch.arange(N,
+                                 dtype=torch.int,
+                                 device=query_start_loc.device)
+    chunk_offsets = torch.zeros((N, ),
+                                dtype=torch.int,
+                                device=query_start_loc.device)
 
-    cu_seqlens = cu_seqlens.tolist() + [seq_idx.shape[-1]]
     p = 0  # num of insertions
     for s, e in zip(cu_seqlens[:-1], cu_seqlens[1:]):
 
@@ -80,12 +82,15 @@ def prepare_mamba2_metadata(
     seq_idx = None
     chunk_indices, chunk_offsets = None, None
     if has_prefill:
+        seqlens = attn_metadata.query_start_loc.diff()
+        total_seqlens = len(input_ids)
+
         seq_idx = torch.repeat_interleave(torch.arange(
             len(attn_metadata.query_start_loc) - 1,
             dtype=torch.int32,
             device=attn_metadata.query_start_loc.device),
-                                          attn_metadata.query_start_loc.diff(),
-                                          output_size=len(input_ids))
+                                          seqlens,
+                                          output_size=total_seqlens)
         seq_idx.unsqueeze_(0)
 
         # compute metadata for chunked prefill.
@@ -96,8 +101,11 @@ def prepare_mamba2_metadata(
         # compute them once at the top level model forward and reuse
         # them in mamba layers. If not needed, they will be ignored
         # inside mamba kernels.
-        chunk_indices, chunk_offsets = _seq_idx_to_chunk_indices_offsets(
-            seq_idx, chunk_size)
+        chunk_indices, chunk_offsets = \
+            _query_start_loc_to_chunk_indices_offsets(
+                attn_metadata.query_start_loc,
+                chunk_size=chunk_size,
+                total_seqlens=total_seqlens)
 
     return Mamba2Metadata(has_prefill=has_prefill,
                           has_initial_states=has_initial_states,


### PR DESCRIPTION
This is a small patch to Mamba2 seq_idx metadata computation for prefill path. The original implementation uses a sequential for loop on CPU and the number of cpu-gpu synchronizations can increase with the batch size. With the patch, it avoids using the sequential for loop on host, and makes the code easier to read too. Verified no performance regression and observed a small 1.7% throughput increase with benchmark_serving using ShareGPTV3. 

```
python benchmarks/benchmark_serving.py --model ibm-ai-platform/Bamba-9B \
--dataset-name sharegpt --dataset-path ShareGPT_V3/ShareGPT_V3_unfiltered_cleaned_split.json \
--ignore-eos --port 9999
```

This PR
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  183.30    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              5.46      
Output token throughput (tok/s):         1082.07   
Total Token throughput (tok/s):          2256.11   
---------------Time to First Token----------------
Mean TTFT (ms):                          68477.18  
Median TTFT (ms):                        61241.18  
P99 TTFT (ms):                           169190.08 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          250.29    
Median TPOT (ms):                        262.61    
P99 TPOT (ms):                           387.52    
---------------Inter-token Latency----------------
Mean ITL (ms):                           216.47    
Median ITL (ms):                         332.63    
P99 ITL (ms):                            421.78    
==================================================
```
Main
```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  186.57    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              5.36      
Output token throughput (tok/s):         1063.08   
Total Token throughput (tok/s):          2216.51   
---------------Time to First Token----------------
Mean TTFT (ms):                          69839.75  
Median TTFT (ms):                        62396.53  
P99 TTFT (ms):                           172499.14 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          255.39    
Median TPOT (ms):                        268.28    
P99 TPOT (ms):                           395.79    
---------------Inter-token Latency----------------
Mean ITL (ms):                           220.56    
Median ITL (ms):                         332.56    
P99 ITL (ms):                            429.83    
==================================================
```

lm_eval confirmed no change on quality

```
lm_eval --model vllm     --model_args pretrained=ibm-ai-platform/Bamba-9B,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.9 --batch_size auto --trust_remote_code  --cache_requests true --tasks gsm8k
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.2487|±  |0.0119|
|     |       |strict-match    |     5|exact_match|↑  |0.3563|±  |0.0132|
```
