### PR TITLE
[torch.compile][ROCm] Fuse quantization onto attention using a torch.compile pass

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -305,6 +305,7 @@ steps:
   commands:
     - pytest -v -s compile/test_pass_manager.py
     - pytest -v -s compile/test_fusion.py
+    - pytest -v -s compile/test_fusion_attn.py
     - pytest -v -s compile/test_silu_mul_quant_fusion.py
     - pytest -v -s compile/test_sequence_parallelism.py
     - pytest -v -s compile/test_async_tp.py

--- a/tests/compile/test_async_tp.py
+++ b/tests/compile/test_async_tp.py
@@ -169,8 +169,7 @@ def async_tp_pass_on_test_model(local_rank: int, world_size: int,
 
     # In pre-nodes, all gather or reduce scatter should exist,
     # fused_matmul_reduce_scatter or fused_all_gather_matmul should not
-    backend.check_before_ops(model.ops_in_model_before(),
-                             ops_fully_replaced=False)
+    backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
 
     # In post-nodes, fused_matmul_reduce_scatter or \
     # fused_all_gather_matmul should exist

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -8,7 +8,6 @@ import vllm.envs as envs
 import vllm.plugins
 from vllm.compilation.fusion import (FUSED_OPS, QUANT_OPS, FusedRMSQuantKey,
                                      FusionPass, QuantKey)
-from vllm.compilation.fx_utils import find_auto_fn, find_auto_fn_maybe
 from vllm.compilation.noop_elimination import NoOpEliminationPass
 from vllm.config import (CompilationConfig, CompilationLevel, PassConfig,
                          VllmConfig)
@@ -122,9 +121,7 @@ def test_fusion_rmsnorm_quant(dtype, hidden_size, num_tokens, eps, static,
         torch.testing.assert_close(result, result2, atol=ATOL, rtol=RTOL)
 
         # In pre-nodes, fp8 quant should be there and fused kernels should not
-        backend.check_before_ops(model.ops_in_model_before(), find_auto_fn,
-                                 find_auto_fn_maybe)
+        backend.check_before_ops(model.ops_in_model_before())
 
         # In post-nodes, fused kernels should be there and fp8 quant should not
-        backend.check_after_ops(model.ops_in_model_after(), find_auto_fn,
-                                find_auto_fn_maybe)
+        backend.check_after_ops(model.ops_in_model_after())

--- a/tests/compile/test_fusion.py
+++ b/tests/compile/test_fusion.py
@@ -7,7 +7,7 @@ import torch
 import vllm.envs as envs
 import vllm.plugins
 from vllm.compilation.fusion import (FUSED_OPS, QUANT_OPS, FusedRMSQuantKey,
-                                     FusionPass, QuantKey)
+                                     FusionPass, GroupShape, QuantKey)
 from vllm.compilation.noop_elimination import NoOpEliminationPass
 from vllm.config import (CompilationConfig, CompilationLevel, PassConfig,
                          VllmConfig)
@@ -29,9 +29,10 @@ class TestModel(torch.nn.Module):
         self.cutlass_fp8_enabled = cutlass_fp8_enabled
         self.norm = [RMSNorm(hidden_size, eps) for _ in range(3)]
         self.wscale = [torch.rand(1, dtype=torch.float32) for _ in range(2)]
+        group_shape = GroupShape.PER_TENSOR if static else GroupShape.PER_TOKEN
         self.key = QuantKey(dtype=FP8_DTYPE,
                             static=static,
-                            per_tensor=static,
+                            group_shape=group_shape,
                             symmetric=True)
         if static:
             self.scale = [torch.rand(1, dtype=torch.float32) for _ in range(2)]

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+import torch.nn
+
+from vllm.attention import Attention
+from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.linear import (QKVParallelLinear,
+                                               RowParallelLinear)
+
+
+class TestLayer(torch.nn.Module):
+
+    def __init__(self,
+                 head_size=32,
+                 hidden_dim=4096,
+                 num_heads=128,
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.qkv_size = self.num_heads * self.head_size
+        self.hidden_dim = hidden_dim
+        self.attn = Attention(self.num_heads, self.head_size, 0.5)
+        self.qkv_proj = QKVParallelLinear(self.hidden_dim,
+                                          self.head_size,
+                                          self.num_heads,
+                                          bias=False,
+                                          return_bias=False)
+        self.o_proj = RowParallelLinear(self.num_heads * self.head_size,
+                                        self.hidden_dim,
+                                        bias=False,
+                                        return_bias=False)
+
+    def forward(self, input_: torch.Tensor):
+        qkv = self.qkv_proj(input_)
+        q, k, v = qkv.split([self.qkv_size] * 3, dim=-1)
+        out = self.attn(q, k, v)
+        return self.o_proj(out)
+
+
+class TestModel(torch.nn.Module):
+
+    def __init__(self,
+                 num_layers: int,
+                 head_size=32,
+                 hidden_dim=4096,
+                 num_heads=128,
+                 *args,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.layers = torch.nn.Sequential(
+            *(TestLayer(head_size, hidden_dim, num_heads)
+              for _ in range(num_layers)))
+
+    def forward(self, input: torch.Tensor):
+        return self.layers(input)
+
+
+def test_attention_fusion(dist_init):
+    torch.set_default_device("cuda")
+
+    model = TestModel(1)
+    input = torch.rand(5, 4096)
+
+    with set_forward_context():
+        out = model(input)
+        out2 = torch.compile(model)(input)
+
+        torch.testing.assert_close(out, out2)

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,10 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch.nn
 
-from vllm.attention import Attention
+# yapf: disable
+from tests.compile.backend import TestBackend
+from vllm.attention import Attention, AttentionMetadata, get_attn_backend
+from vllm.compilation.fusion_attn import AttnFusionPass
+from vllm.compilation.fx_utils import find_auto_fn
+from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.linear import (QKVParallelLinear,
                                                RowParallelLinear)
+from vllm.platforms import current_platform
+
+# yapf: enable
 
 
 class TestLayer(torch.nn.Module):
@@ -56,14 +64,72 @@ class TestModel(torch.nn.Module):
         return self.layers(input)
 
 
+PassConfig = CompilationConfig.PassConfig
+
+
 def test_attention_fusion(dist_init):
     torch.set_default_device("cuda")
 
-    model = TestModel(1)
-    input = torch.rand(5, 4096)
+    input = torch.rand(9, 4096)
 
-    with set_forward_context():
+    enable_attn_fusion = True
+    pass_config = PassConfig(enable_attn_fusion=enable_attn_fusion,
+                             enable_noop=True)
+    compile_config = CompilationConfig(pass_config=pass_config)
+    vllm_config = VllmConfig(compilation_config=compile_config)
+
+    head_size = 32
+    dtype = torch.bfloat16
+    block_size = 16
+
+    attn_backend = get_attn_backend(
+        head_size,
+        dtype,
+        None,
+        block_size,
+        False,
+    )
+    impl = attn_backend.get_impl_cls()(0, 0, 0.0)
+    assert impl.fused_output_quant_supported(current_platform.fp8_dtype(),
+                                             True, False)
+    # TODO use layerwise impls from layers instead
+
+    # attn_meta_builder = attn_backend.get_builder_cls()()
+
+    attn_metadata = AttentionMetadata(
+        num_prefills=2,
+        num_prefill_tokens=5,
+        num_decode_tokens=4,
+        slot_mapping=torch.arange(0, 9),
+        multi_modal_placeholder_index_maps=None,
+        enable_kv_scales_calculation=False,
+    )
+    with set_current_vllm_config(vllm_config), set_forward_context(
+            attn_metadata, vllm_config, num_tokens=9):
+        # attention layers set the forward context on config
+        model = TestModel(1)
         out = model(input)
-        out2 = torch.compile(model)(input)
 
-        torch.testing.assert_close(out, out2)
+        cc = vllm_config.compilation_config
+        passes = []
+        if enable_attn_fusion:
+            # passes += [NoOpEliminationPass(cc.pass_config)] # TODO
+            passes += [
+                AttnFusionPass(cc.pass_config, cc.static_forward_context)
+            ]
+        inductor_backend = TestBackend(*passes)
+        out2 = torch.compile(model, backend=inductor_backend)(input)
+
+    torch.testing.assert_close(out, out2)
+
+    if enable_attn_fusion:
+        # TODO check fusion
+        # TODO check if the backend supports it
+        #  - need to make sure this always works so we can turn on by default
+        # TODO use graph.find_nodes
+        # TODO quant method for linear
+        # TODO check that quant is gone
+        # TODO fullgraph test
+        node = find_auto_fn(inductor_backend.graph_post_pass.nodes,
+                            torch.ops.vllm.unified_attention_with_output)
+        assert node is not None

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,227 +1,81 @@
 # SPDX-License-Identifier: Apache-2.0
-from copy import deepcopy
-from typing import Any, Dict, List, Optional, Type
 
-import numpy as np
-import torch.nn
+import pytest
 
-from vllm.attention import Attention, AttentionBackend, get_attn_backend
-from vllm.compilation.fx_utils import find_auto_fn
-from vllm.config import (CompilationConfig, ModelConfig, PassConfig,
-                         VllmConfig, get_current_vllm_config,
-                         set_current_vllm_config)
-from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.linear import (QKVParallelLinear,
-                                               RowParallelLinear)
-from vllm.platforms import current_platform
-from vllm.sequence import SequenceGroupMetadata
-from vllm.utils import bind_kv_cache
-from vllm.worker.model_runner import GPUModelRunnerBase
-from vllm.worker.model_runner_base import T
+from tests.compile.backend import TestBackend
+from tests.models.utils import check_outputs_equal
+from vllm import LLM, SamplingParams
+from vllm.compilation.fusion import QUANT_OPS, kFp8StaticTensorSym
+from vllm.compilation.fusion_attn import ATTN_OP, AttnFusionPass
+from vllm.compilation.fx_utils import find_op_nodes
+from vllm.compilation.noop_elimination import NoOpEliminationPass
+from vllm.config import CompilationConfig, CompilationLevel, VllmConfig
 
-# yapf: disable
-
-# yapf: enable
+MODEL = "amd/Llama-3.1-8B-Instruct-FP8-KV"
+test_backend = TestBackend()
 
 
-class TestLayer(torch.nn.Module):
+@pytest.mark.parametrize("num_prompts", [4])
+def test_attention_fusion2(example_prompts, num_prompts):
+    # TODO(luka): use all prompts if possible (after recompilation resolved)
+    # https://github.com/vllm-project/vllm/issues/19391
+    prompts = example_prompts[:num_prompts]
 
-    def __init__(self,
-                 head_size=32,
-                 hidden_dim=4096,
-                 num_heads=128,
-                 prefix="",
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self.num_heads = num_heads
-        self.head_size = head_size
-        self.qkv_size = self.num_heads * self.head_size
-        self.hidden_dim = hidden_dim
-        self.attn = Attention(self.num_heads,
-                              self.head_size,
-                              0.5,
-                              prefix=f"{prefix}.attn")
-        self.qkv_proj = QKVParallelLinear(self.hidden_dim,
-                                          self.head_size,
-                                          self.num_heads,
-                                          bias=False,
-                                          return_bias=False)
-        self.o_proj = RowParallelLinear(self.num_heads * self.head_size,
-                                        self.hidden_dim,
-                                        bias=False,
-                                        return_bias=False)
+    # For some reason, if we compile the first LLM with Dynamo,
+    # the second time the compiler is not invoked.
+    # Hence, we use eager mode as the baseline.
+    llm = LLM(MODEL,
+              enforce_eager=True,
+              compilation_config=CompilationConfig(
+                  level=CompilationLevel.NO_COMPILATION),
+              gpu_memory_utilization=0.9)
 
-        def load_randn_weight(l):
-            l.weight.data = torch.randn_like(l.weight)
+    sampling_params = SamplingParams(temperature=0.0,
+                                     max_tokens=10,
+                                     top_p=0.95)
 
-        load_randn_weight(self.qkv_proj)
-        # load_randn_weight(self.attn)
-        load_randn_weight(self.o_proj)
+    unfused_output = llm.generate(prompts, sampling_params)
+    del llm
 
-    def forward(self, input_: torch.Tensor):
-        # qkv = self.qkv_proj(input_)
-        # q, k, v = qkv.split([self.qkv_size] * 3, dim=-1)
-        # out = self.attn(q, k, v)
-        # return self.o_proj(out)
-
-        q, k, v = input_.split([self.qkv_size] * 3, dim=-1)
-        return self.attn(q, k, v)
-
-
-class TestModel(torch.nn.Module):
-
-    def __init__(self,
-                 num_layers: int,
-                 head_size=32,
-                 hidden_dim=4096,
-                 num_heads=128,
-                 *args,
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self.layers = torch.nn.Sequential(*(
-            TestLayer(head_size, hidden_dim, num_heads, prefix=f"layer.{idx}")
-            for idx in range(num_layers)))
-
-    def forward(self, input: torch.Tensor):
-        return self.layers(input)
-
-
-def test_attention_fusion(dist_init):
-    torch.manual_seed(0)
-    torch.set_default_device("cuda")
-
-    input = torch.rand(9, 4096 * 3)
-
-    enable_attn_fusion = False
-    pass_config = PassConfig(enable_attn_fusion=enable_attn_fusion,
-                             enable_noop=True)
-    compile_config = CompilationConfig(pass_config=pass_config)
-    model_config = ModelConfig()
-    vllm_config = VllmConfig(compilation_config=compile_config,
-                             model_config=model_config)
-
-    dtype = torch.bfloat16
-    quant_dtype = current_platform.fp8_dtype()
-
-    head_size = 32  # TODO model config?
-    block_size = 16
-    kvcache_dtype = torch.bfloat16
-    attn_backend = get_attn_backend(
-        head_size,
-        dtype,
-        None,
-        block_size,
-        False,
+    compile_config = CompilationConfig(
+        # DYNAMO_AS_IS triggers custom backend & does full Dynamo compilation
+        level=CompilationLevel.DYNAMO_AS_IS,
+        backend="tests.compile.test_fusion_attn.test_backend",
+        use_cudagraph=False,
     )
+    vllm_config = VllmConfig(compilation_config=compile_config)
 
-    # impl = attn_backend.get_impl_cls()(0, 0, 0.0, kvcache_dtype)
-    # assert impl.fused_output_quant_supported(quant_dtype,
-    #                                          True, False)
-    # TODO use layerwise impls from layers instead
+    # AttnFusionPass needs attention layers to be registered in config upon init
+    # so we initialize it during compilation.
+    attn_pass = lambda *args, **kw: AttnFusionPass(vllm_config)(*args, **kw)
+    test_backend.custom_passes += [NoOpEliminationPass(vllm_config), attn_pass]
+    llm2 = LLM(MODEL,
+               compilation_config=compile_config,
+               gpu_memory_utilization=0.9)
 
-    # attn_meta_builder = attn_backend.get_builder_cls()()
+    # Check quant ops
+    test_backend.check_before_ops([QUANT_OPS[kFp8StaticTensorSym]],
+                                  fully_replaced=False)
 
-    class MockRunner:
+    # attention ops present in both, just output_scale param changes
+    attn_nodes_pre = list(find_op_nodes(ATTN_OP, test_backend.graph_pre_pass))
+    attn_nodes_post = list(find_op_nodes(ATTN_OP,
+                                         test_backend.graph_post_pass))
+    assert len(attn_nodes_pre) == len(attn_nodes_post)
 
-        def __init__(self, attention_backend: Type[AttentionBackend],
-                     max_seq_len_to_capture: int):
-            self.attention_backend = attention_backend
-            self.max_seq_len_to_capture = max_seq_len_to_capture
-            self.device = "cuda"
-            self.graph_block_tables = np.zeros(
-                (self.max_batchsize_to_capture,
-                 self.get_max_block_per_batch()),
-                dtype=np.int32)
+    for pre_node, post_node in zip(attn_nodes_pre, attn_nodes_post):
+        assert pre_node.kwargs["output_scale"] is None
+        assert post_node.kwargs["output_scale"] is not None
 
-    class GPUMockRunner(GPUModelRunnerBase):
+    # check outputs
+    fused_output = llm2.generate(prompts, sampling_params)
 
-        def make_model_input_from_broadcasted_tensor_dict(
-                self, tensor_dict: Dict[str, Any]) -> T:
-            raise NotImplementedError
+    req_outs = lambda ro: [(list(s.token_ids), s.text) for s in ro.outputs]
+    outs_lst = lambda ros: [tuple(zip(*req_outs(ro))) for ro in ros]
 
-        def prepare_model_input(
-                self,
-                seq_group_metadata_list: List[SequenceGroupMetadata],
-                virtual_engine: int = 0,
-                finished_requests_ids: Optional[List[str]] = None) -> T:
-            raise NotImplementedError
-
-    #
-    # attn_metadata = AttentionMetadata(
-    #     num_prefills=2,
-    #     num_prefill_tokens=5,
-    #     num_decode_tokens=4,
-    #     slot_mapping=torch.arange(0, 9),
-    #     multi_modal_placeholder_index_maps=None,
-    #     enable_kv_scales_calculation=False,
-    # )
-
-    NUM_LAYERS = 1
-    vllm_config0 = deepcopy(vllm_config)
-
-    # set new config so new attn backends (and kv-caches) are created
-    with set_current_vllm_config(deepcopy(vllm_config)):
-        vllm_cfg = get_current_vllm_config()
-        runner = GPUMockRunner(vllm_cfg)
-        state = attn_backend.get_state_cls()(runner)
-        # TODO dtype and larger last dim
-        kv_cache = [[
-            torch.zeros(2, 1024, 16 * 4096, device="cuda")
-            for _ in range(NUM_LAYERS)
-        ]]
-
-        # attention layers set the forward context on config
-        model = TestModel(NUM_LAYERS)
-
-        bind_kv_cache(vllm_cfg.compilation_config.static_forward_context,
-                      kv_cache)
-        with state.graph_capture(128):
-            metadata = state.graph_capture_get_metadata_for_batch(128)
-            with set_forward_context(metadata, vllm_cfg):
-                out = model(input.clone())
-
-    # set new config so new attn backends (and kv-caches) are created
-    with set_current_vllm_config(deepcopy(vllm_config)):
-        vllm_cfg = get_current_vllm_config()
-        runner = GPUMockRunner(vllm_cfg)
-        state = attn_backend.get_state_cls()(runner)
-        # TODO dtype and larger last dim
-        kv_cache = [[
-            torch.zeros(2, 1024, 16 * 4096, device="cuda")
-            for _ in range(NUM_LAYERS)
-        ]]
-
-        # attention layers set the forward context on config
-        model = TestModel(NUM_LAYERS)
-
-        bind_kv_cache(vllm_cfg.compilation_config.static_forward_context,
-                      kv_cache)
-        with state.graph_capture(128):
-            metadata = state.graph_capture_get_metadata_for_batch(128)
-            with set_forward_context(metadata, vllm_cfg):
-                out2 = model(input.clone())
-        #
-        # passes = []
-        # if enable_attn_fusion:
-        #     passes += [NoOpEliminationPass(vllm_config)] # TODO
-        #     passes += [AttnFusionPass(vllm_config)]
-        # inductor_backend = TestBackend(*passes)
-        # out2 = torch.compile(model2, backend=inductor_backend)(input)
-        # out2 = model2(input)
-
-    # print(out2)
-    # print(out)
-    torch.testing.assert_close(out, out2)
-
-    if enable_attn_fusion:
-        # TODO check fusion
-        # TODO check if the backend supports it
-        #  - need to make sure this always works so we can turn on by default
-        # TODO use graph.find_nodes
-        # TODO quant method for linear
-        # TODO check that quant is gone
-        # TODO fullgraph test
-        node = find_auto_fn(inductor_backend.graph_post_pass.nodes,
-                            torch.ops.vllm.unified_attention_with_output)
-        assert node is not None
+    check_outputs_equal(
+        outputs_0_lst=outs_lst(unfused_output),
+        outputs_1_lst=outs_lst(fused_output),
+        name_0="unfused",
+        name_1="fused",
+    )

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from typing import Optional
 
 import pytest
 import torch._dynamo
@@ -14,8 +15,8 @@ from vllm.config import CompilationConfig, CompilationLevel, VllmConfig
 from vllm.platforms import current_platform
 
 # globals needed for string-import custom Dynamo backend field
-backend: TestBackend
-backend_unfused: TestBackend
+backend: Optional[TestBackend] = None
+backend_unfused: Optional[TestBackend] = None
 
 
 @pytest.mark.parametrize(

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,19 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 from copy import deepcopy
+from typing import Any, Dict, List, Optional, Type
 
+import numpy as np
 import torch.nn
 
-# yapf: disable
-from tests.compile.backend import TestBackend
-from vllm.attention import Attention, AttentionMetadata, get_attn_backend
-from vllm.compilation.fusion_attn import AttnFusionPass
+from vllm.attention import Attention, AttentionBackend, get_attn_backend
 from vllm.compilation.fx_utils import find_auto_fn
-from vllm.compilation.noop_elimination import NoOpEliminationPass
-from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
+from vllm.config import (CompilationConfig, ModelConfig, PassConfig,
+                         VllmConfig, get_current_vllm_config,
+                         set_current_vllm_config)
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.linear import (QKVParallelLinear,
                                                RowParallelLinear)
 from vllm.platforms import current_platform
+from vllm.sequence import SequenceGroupMetadata
+from vllm.utils import bind_kv_cache
+from vllm.worker.model_runner import GPUModelRunnerBase
+from vllm.worker.model_runner_base import T
+
+# yapf: disable
 
 # yapf: enable
 
@@ -24,6 +30,7 @@ class TestLayer(torch.nn.Module):
                  head_size=32,
                  hidden_dim=4096,
                  num_heads=128,
+                 prefix="",
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
@@ -31,7 +38,10 @@ class TestLayer(torch.nn.Module):
         self.head_size = head_size
         self.qkv_size = self.num_heads * self.head_size
         self.hidden_dim = hidden_dim
-        self.attn = Attention(self.num_heads, self.head_size, 0.5)
+        self.attn = Attention(self.num_heads,
+                              self.head_size,
+                              0.5,
+                              prefix=f"{prefix}.attn")
         self.qkv_proj = QKVParallelLinear(self.hidden_dim,
                                           self.head_size,
                                           self.num_heads,
@@ -69,42 +79,42 @@ class TestModel(torch.nn.Module):
                  *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
-        self.layers = torch.nn.Sequential(
-            *(TestLayer(head_size, hidden_dim, num_heads)
-              for _ in range(num_layers)))
+        self.layers = torch.nn.Sequential(*(
+            TestLayer(head_size, hidden_dim, num_heads, prefix=f"layer.{idx}")
+            for idx in range(num_layers)))
 
     def forward(self, input: torch.Tensor):
         return self.layers(input)
-
-
-PassConfig = CompilationConfig.PassConfig
 
 
 def test_attention_fusion(dist_init):
     torch.manual_seed(0)
     torch.set_default_device("cuda")
 
-    input = torch.rand(9, 4096*3)
+    input = torch.rand(9, 4096 * 3)
 
     enable_attn_fusion = False
     pass_config = PassConfig(enable_attn_fusion=enable_attn_fusion,
                              enable_noop=True)
     compile_config = CompilationConfig(pass_config=pass_config)
-    vllm_config = VllmConfig(compilation_config=compile_config)
+    model_config = ModelConfig()
+    vllm_config = VllmConfig(compilation_config=compile_config,
+                             model_config=model_config)
 
     dtype = torch.bfloat16
     quant_dtype = current_platform.fp8_dtype()
 
-    # head_size = 32
-    # block_size = 16
-    # kvcache_dtype = torch.bfloat16
-    # attn_backend = get_attn_backend(
-    #     head_size,
-    #     dtype,
-    #     None,
-    #     block_size,
-    #     False,
-    # )
+    head_size = 32  # TODO model config?
+    block_size = 16
+    kvcache_dtype = torch.bfloat16
+    attn_backend = get_attn_backend(
+        head_size,
+        dtype,
+        None,
+        block_size,
+        False,
+    )
+
     # impl = attn_backend.get_impl_cls()(0, 0, 0.0, kvcache_dtype)
     # assert impl.fused_output_quant_supported(quant_dtype,
     #                                          True, False)
@@ -112,29 +122,85 @@ def test_attention_fusion(dist_init):
 
     # attn_meta_builder = attn_backend.get_builder_cls()()
 
-    attn_metadata = AttentionMetadata(
-        num_prefills=2,
-        num_prefill_tokens=5,
-        num_decode_tokens=4,
-        slot_mapping=torch.arange(0, 9),
-        multi_modal_placeholder_index_maps=None,
-        enable_kv_scales_calculation=False,
-    )
+    class MockRunner:
 
+        def __init__(self, attention_backend: Type[AttentionBackend],
+                     max_seq_len_to_capture: int):
+            self.attention_backend = attention_backend
+            self.max_seq_len_to_capture = max_seq_len_to_capture
+            self.device = "cuda"
+            self.graph_block_tables = np.zeros(
+                (self.max_batchsize_to_capture,
+                 self.get_max_block_per_batch()),
+                dtype=np.int32)
+
+    class GPUMockRunner(GPUModelRunnerBase):
+
+        def make_model_input_from_broadcasted_tensor_dict(
+                self, tensor_dict: Dict[str, Any]) -> T:
+            raise NotImplementedError
+
+        def prepare_model_input(
+                self,
+                seq_group_metadata_list: List[SequenceGroupMetadata],
+                virtual_engine: int = 0,
+                finished_requests_ids: Optional[List[str]] = None) -> T:
+            raise NotImplementedError
+
+    #
+    # attn_metadata = AttentionMetadata(
+    #     num_prefills=2,
+    #     num_prefill_tokens=5,
+    #     num_decode_tokens=4,
+    #     slot_mapping=torch.arange(0, 9),
+    #     multi_modal_placeholder_index_maps=None,
+    #     enable_kv_scales_calculation=False,
+    # )
+
+    NUM_LAYERS = 1
     vllm_config0 = deepcopy(vllm_config)
-    with set_current_vllm_config(vllm_config0), set_forward_context(
-            attn_metadata, vllm_config0, num_tokens=9):
-        # attention layers set the forward context on config
-        model = TestModel(1)
-        out = model(input.clone())
 
     # set new config so new attn backends (and kv-caches) are created
-    with set_current_vllm_config(vllm_config), set_forward_context(
-            attn_metadata, vllm_config, num_tokens=9):
-        model2 = TestModel(1)
+    with set_current_vllm_config(deepcopy(vllm_config)):
+        vllm_cfg = get_current_vllm_config()
+        runner = GPUMockRunner(vllm_cfg)
+        state = attn_backend.get_state_cls()(runner)
+        # TODO dtype and larger last dim
+        kv_cache = [[
+            torch.zeros(2, 1024, 16 * 4096, device="cuda")
+            for _ in range(NUM_LAYERS)
+        ]]
 
-        attn_dict: dict[str, Attention] = vllm_config.compilation_config.static_forward_context
-        assert all(attn_dict[k].impl.fused_output_quant_supported(quant_dtype, True, False) for k in attn_dict)
+        # attention layers set the forward context on config
+        model = TestModel(NUM_LAYERS)
+
+        bind_kv_cache(vllm_cfg.compilation_config.static_forward_context,
+                      kv_cache)
+        with state.graph_capture(128):
+            metadata = state.graph_capture_get_metadata_for_batch(128)
+            with set_forward_context(metadata, vllm_cfg):
+                out = model(input.clone())
+
+    # set new config so new attn backends (and kv-caches) are created
+    with set_current_vllm_config(deepcopy(vllm_config)):
+        vllm_cfg = get_current_vllm_config()
+        runner = GPUMockRunner(vllm_cfg)
+        state = attn_backend.get_state_cls()(runner)
+        # TODO dtype and larger last dim
+        kv_cache = [[
+            torch.zeros(2, 1024, 16 * 4096, device="cuda")
+            for _ in range(NUM_LAYERS)
+        ]]
+
+        # attention layers set the forward context on config
+        model = TestModel(NUM_LAYERS)
+
+        bind_kv_cache(vllm_cfg.compilation_config.static_forward_context,
+                      kv_cache)
+        with state.graph_capture(128):
+            metadata = state.graph_capture_get_metadata_for_batch(128)
+            with set_forward_context(metadata, vllm_cfg):
+                out2 = model(input.clone())
         #
         # passes = []
         # if enable_attn_fusion:
@@ -142,8 +208,10 @@ def test_attention_fusion(dist_init):
         #     passes += [AttnFusionPass(vllm_config)]
         # inductor_backend = TestBackend(*passes)
         # out2 = torch.compile(model2, backend=inductor_backend)(input)
-        out2 = model2(input)
+        # out2 = model2(input)
 
+    # print(out2)
+    # print(out)
     torch.testing.assert_close(out, out2)
 
     if enable_attn_fusion:

--- a/tests/compile/test_fusion_attn.py
+++ b/tests/compile/test_fusion_attn.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+from copy import deepcopy
+
 import torch.nn
 
 # yapf: disable
@@ -6,6 +8,7 @@ from tests.compile.backend import TestBackend
 from vllm.attention import Attention, AttentionMetadata, get_attn_backend
 from vllm.compilation.fusion_attn import AttnFusionPass
 from vllm.compilation.fx_utils import find_auto_fn
+from vllm.compilation.noop_elimination import NoOpEliminationPass
 from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.linear import (QKVParallelLinear,
@@ -39,11 +42,21 @@ class TestLayer(torch.nn.Module):
                                         bias=False,
                                         return_bias=False)
 
+        def load_randn_weight(l):
+            l.weight.data = torch.randn_like(l.weight)
+
+        load_randn_weight(self.qkv_proj)
+        # load_randn_weight(self.attn)
+        load_randn_weight(self.o_proj)
+
     def forward(self, input_: torch.Tensor):
-        qkv = self.qkv_proj(input_)
-        q, k, v = qkv.split([self.qkv_size] * 3, dim=-1)
-        out = self.attn(q, k, v)
-        return self.o_proj(out)
+        # qkv = self.qkv_proj(input_)
+        # q, k, v = qkv.split([self.qkv_size] * 3, dim=-1)
+        # out = self.attn(q, k, v)
+        # return self.o_proj(out)
+
+        q, k, v = input_.split([self.qkv_size] * 3, dim=-1)
+        return self.attn(q, k, v)
 
 
 class TestModel(torch.nn.Module):
@@ -68,30 +81,33 @@ PassConfig = CompilationConfig.PassConfig
 
 
 def test_attention_fusion(dist_init):
+    torch.manual_seed(0)
     torch.set_default_device("cuda")
 
-    input = torch.rand(9, 4096)
+    input = torch.rand(9, 4096*3)
 
-    enable_attn_fusion = True
+    enable_attn_fusion = False
     pass_config = PassConfig(enable_attn_fusion=enable_attn_fusion,
                              enable_noop=True)
     compile_config = CompilationConfig(pass_config=pass_config)
     vllm_config = VllmConfig(compilation_config=compile_config)
 
-    head_size = 32
     dtype = torch.bfloat16
-    block_size = 16
+    quant_dtype = current_platform.fp8_dtype()
 
-    attn_backend = get_attn_backend(
-        head_size,
-        dtype,
-        None,
-        block_size,
-        False,
-    )
-    impl = attn_backend.get_impl_cls()(0, 0, 0.0)
-    assert impl.fused_output_quant_supported(current_platform.fp8_dtype(),
-                                             True, False)
+    # head_size = 32
+    # block_size = 16
+    # kvcache_dtype = torch.bfloat16
+    # attn_backend = get_attn_backend(
+    #     head_size,
+    #     dtype,
+    #     None,
+    #     block_size,
+    #     False,
+    # )
+    # impl = attn_backend.get_impl_cls()(0, 0, 0.0, kvcache_dtype)
+    # assert impl.fused_output_quant_supported(quant_dtype,
+    #                                          True, False)
     # TODO use layerwise impls from layers instead
 
     # attn_meta_builder = attn_backend.get_builder_cls()()
@@ -104,21 +120,29 @@ def test_attention_fusion(dist_init):
         multi_modal_placeholder_index_maps=None,
         enable_kv_scales_calculation=False,
     )
-    with set_current_vllm_config(vllm_config), set_forward_context(
-            attn_metadata, vllm_config, num_tokens=9):
+
+    vllm_config0 = deepcopy(vllm_config)
+    with set_current_vllm_config(vllm_config0), set_forward_context(
+            attn_metadata, vllm_config0, num_tokens=9):
         # attention layers set the forward context on config
         model = TestModel(1)
-        out = model(input)
+        out = model(input.clone())
 
-        cc = vllm_config.compilation_config
-        passes = []
-        if enable_attn_fusion:
-            # passes += [NoOpEliminationPass(cc.pass_config)] # TODO
-            passes += [
-                AttnFusionPass(cc.pass_config, cc.static_forward_context)
-            ]
-        inductor_backend = TestBackend(*passes)
-        out2 = torch.compile(model, backend=inductor_backend)(input)
+    # set new config so new attn backends (and kv-caches) are created
+    with set_current_vllm_config(vllm_config), set_forward_context(
+            attn_metadata, vllm_config, num_tokens=9):
+        model2 = TestModel(1)
+
+        attn_dict: dict[str, Attention] = vllm_config.compilation_config.static_forward_context
+        assert all(attn_dict[k].impl.fused_output_quant_supported(quant_dtype, True, False) for k in attn_dict)
+        #
+        # passes = []
+        # if enable_attn_fusion:
+        #     passes += [NoOpEliminationPass(vllm_config)] # TODO
+        #     passes += [AttnFusionPass(vllm_config)]
+        # inductor_backend = TestBackend(*passes)
+        # out2 = torch.compile(model2, backend=inductor_backend)(input)
+        out2 = model2(input)
 
     torch.testing.assert_close(out, out2)
 

--- a/tests/kernels/test_triton_flash_attention.py
+++ b/tests/kernels/test_triton_flash_attention.py
@@ -7,6 +7,7 @@ Run `pytest tests/kernels/test_triton_flash_attention.py`.
 import pytest
 import torch
 
+import vllm._custom_ops as ops
 # yapf: disable
 from vllm.attention.ops.triton_flash_attention import (SUPPORTED_LAYOUTS,
                                                        MetaData,
@@ -382,17 +383,20 @@ def test_op_fwd_fp8(Z,
 
 # TODO(luka): this test is supposed to replicate the arguments
 #  as they occur after the attention fusion pass.
+#  But sadly it fails with a maxdiff.
 @pytest.mark.parametrize("fp8_kvcache", [True])
-@pytest.mark.parametrize("fused_o_quant", [True])
-def test_fused_fwd(fp8_kvcache: bool, fused_o_quant: bool):
+@pytest.mark.parametrize("N", [
+    1,
+])  # [256] for CUDAGraph
+@pytest.mark.skip()
+def test_fused_fwd(fp8_kvcache: bool, N: int):
     current_platform.seed_everything(0)
     torch.set_default_device("cuda")
 
-    MAX_SEQLENS = 512
-    N = 256
-    q = torch.empty(MAX_SEQLENS * N, 8, 128, dtype=torch.bfloat16)
-    k = torch.empty(MAX_SEQLENS * N, 8, 128, dtype=torch.bfloat16)
-    v = torch.empty(MAX_SEQLENS * N, 8, 128, dtype=torch.bfloat16)
+    MAX_SEQLENS = 64
+    q = torch.rand(MAX_SEQLENS * N, 32, 128, dtype=torch.bfloat16)
+    k = torch.rand(MAX_SEQLENS * N, 8, 128, dtype=torch.bfloat16)
+    v = torch.rand(MAX_SEQLENS * N, 8, 128, dtype=torch.bfloat16)
 
     cu_seqlens = torch.arange(0, N + 1, dtype=torch.int32) * MAX_SEQLENS
 
@@ -400,25 +404,36 @@ def test_fused_fwd(fp8_kvcache: bool, fused_o_quant: bool):
     fp8_scales = (torch.tensor([1.0]), torch.tensor([0.0508]),
                   torch.tensor([0.0508]),
                   torch.tensor([1.0])) if fp8_kvcache else None
-    input_scale = torch.tensor([0.0019]) if fused_o_quant else None
+    # input_scale = torch.tensor([0.0019])
+    input_scale = torch.tensor([0.0019])
 
-    out_dtype = current_platform.fp8_dtype(
-    ) if fused_o_quant else torch.bfloat16
-    o = torch.empty(MAX_SEQLENS * N, 8, 128, dtype=out_dtype)
+    FP8_DTYPE = current_platform.fp8_dtype()
+    oq_fused = torch.empty(MAX_SEQLENS * N, 32, 128, dtype=FP8_DTYPE)
+    o_unfused = torch.empty(MAX_SEQLENS * N, 32, 128, dtype=torch.bfloat16)
 
-    triton_attention(q,
-                     k,
-                     v,
-                     o,
-                     cu_seqlens,
-                     cu_seqlens,
-                     MAX_SEQLENS,
-                     MAX_SEQLENS,
-                     causal=True,
-                     sm_scale=0.08838,
-                     bias=None,
-                     fp8_scales=fp8_scales,
-                     input_scale=input_scale)
+    call_attn = lambda o, scale: triton_attention(q,
+                                                  k,
+                                                  v,
+                                                  o,
+                                                  cu_seqlens,
+                                                  cu_seqlens,
+                                                  MAX_SEQLENS,
+                                                  MAX_SEQLENS,
+                                                  causal=True,
+                                                  sm_scale=0.08838,
+                                                  bias=None,
+                                                  fp8_scales=fp8_scales,
+                                                  input_scale=scale)
+
+    call_attn(oq_fused, input_scale)
+
+    call_attn(o_unfused, None)
+    oq_unfused, _ = ops.scaled_fp8_quant(o_unfused.view(-1, 4096), input_scale)
+
+    out_fused = oq_fused.view(-1, 4096).to(torch.float32)
+    out_unfused = oq_unfused.to(torch.float32)
+
+    torch.testing.assert_close(out_fused, out_unfused, atol=1e-2, rtol=2e-2)
 
 
 @pytest.mark.parametrize('Z, H, N_CTX_Q, N_CTX_K, D_HEAD', [

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1228,6 +1228,7 @@ def scaled_fp8_quant(
     num_token_padding: Optional[int] = None,
     scale_ub: Optional[torch.Tensor] = None,
     use_per_token_if_dynamic: bool = False,
+    output: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize input tensor to FP8 and return quantized tensor and scale.
@@ -1259,7 +1260,12 @@ def scaled_fp8_quant(
     out_dtype: torch.dtype = current_platform.fp8_dtype()
     if num_token_padding:
         shape = (max(num_token_padding, input.shape[0]), shape[1])
-    output = torch.empty(shape, device=input.device, dtype=out_dtype)
+    if output is None:
+        output = torch.empty(shape, device=input.device, dtype=out_dtype)
+    else:
+        assert num_token_padding is None, \
+            "padding not supported if output passed in"
+        assert output.dtype == out_dtype
 
     if scale is None:
         if use_per_token_if_dynamic:

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -284,6 +284,7 @@ class AttentionImpl(ABC, Generic[T]):
         kv_cache: torch.Tensor,
         attn_metadata: T,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         raise NotImplementedError
 
@@ -315,6 +316,7 @@ class MLAAttentionImpl(AttentionImpl[T], Generic[T]):
         kv_cache: torch.Tensor,
         attn_metadata: T,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         raise NotImplementedError
 

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -287,6 +287,21 @@ class AttentionImpl(ABC, Generic[T]):
     ) -> torch.Tensor:
         raise NotImplementedError
 
+    def fused_output_quant_supported(self, dtype: torch.dtype, static: bool,
+                                     per_token: bool):
+        """
+        Does this attention implementation support fused output quantization.
+        This is used by the AttnFusionPass to only fuse output quantization
+        onto implementations that support it.
+
+        TODO(luka) merge parameters into QuantDescriptor
+        :param dtype: quantized dtype
+        :param static: static or dynamic quantization
+        :param per_token: per-token or per-tensor quantization
+        :return: is fusion supported for this type of quantization
+        """
+        return False
+
 
 class MLAAttentionImpl(AttentionImpl[T], Generic[T]):
 

--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -289,7 +289,7 @@ class AttentionImpl(ABC, Generic[T]):
         raise NotImplementedError
 
     def fused_output_quant_supported(self, dtype: torch.dtype, static: bool,
-                                     per_token: bool):
+                                     group_shape: tuple[int, int]):
         """
         Does this attention implementation support fused output quantization.
         This is used by the AttnFusionPass to only fuse output quantization
@@ -298,7 +298,7 @@ class AttentionImpl(ABC, Generic[T]):
         TODO(luka) merge parameters into QuantDescriptor
         :param dtype: quantized dtype
         :param static: static or dynamic quantization
-        :param per_token: per-token or per-tensor quantization
+        :param group_shape: quant group shape. (-1, -1) for per-tensor.
         :return: is fusion supported for this type of quantization
         """
         return False

--- a/vllm/attention/backends/blocksparse_attn.py
+++ b/vllm/attention/backends/blocksparse_attn.py
@@ -374,6 +374,7 @@ class BlocksparseFlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: BlocksparseFlashAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention and PagedAttention.
 
@@ -388,6 +389,11 @@ class BlocksparseFlashAttentionImpl(AttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for BlocksparseFlashAttentionImpl")
+
         num_tokens, hidden_size = query.shape
         # Reshape the query, key, and value tensors.
         query = query.view(-1, self.num_heads, self.head_size)

--- a/vllm/attention/backends/dual_chunk_flash_attn.py
+++ b/vllm/attention/backends/dual_chunk_flash_attn.py
@@ -370,6 +370,8 @@ class DualChunkFlashAttentionImpl(FlashAttentionImpl):
         value: torch.Tensor,
         kv_cache: torch.Tensor,
         attn_metadata: DualChunkFlashAttentionMetadata,
+        output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with DualChunkFlashAttention.
         Args:
@@ -383,6 +385,13 @@ class DualChunkFlashAttentionImpl(FlashAttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        assert output is None, "Output tensor not supported for DualChunk"
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlashAttentionImpl")
+
         (
             query,
             query_succ,

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -673,6 +673,7 @@ class FlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention.
 
@@ -691,6 +692,11 @@ class FlashAttentionImpl(AttentionImpl):
               We use torch's .expand() to avoid duplicating values
         """
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlashAttentionImpl")
 
         # NOTE(woosuk): FlashAttention2 does not support FP8 KV cache.
         if not flash_attn_supports_fp8() or output.dtype != torch.bfloat16:

--- a/vllm/attention/backends/flashinfer.py
+++ b/vllm/attention/backends/flashinfer.py
@@ -975,7 +975,13 @@ class FlashInferImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashInferMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlashInferImpl")
 
         # TODO: directly write to output tensor
         num_heads: int = self.num_heads

--- a/vllm/attention/backends/hpu_attn.py
+++ b/vllm/attention/backends/hpu_attn.py
@@ -181,6 +181,7 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         kv_cache: torch.Tensor,
         attn_metadata: HPUAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with xFormers and PagedAttention.
 
@@ -193,6 +194,11 @@ class HPUAttentionImpl(AttentionImpl, torch.nn.Module):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for HPUAttentionImpl")
+
         batch_size, seq_len, hidden_size = query.shape
         _, seq_len_kv, _ = key.shape
 

--- a/vllm/attention/backends/ipex_attn.py
+++ b/vllm/attention/backends/ipex_attn.py
@@ -192,6 +192,7 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
         kv_cache: torch.Tensor,
         attn_metadata: IpexAttnMetadata,  # type: ignore
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with IPEX varlen_attention and PagedAttention.
 
@@ -206,6 +207,11 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for IpexAttentionImpl")
+
         assert layer._k_scale_float == 1.0 and layer._v_scale_float == 1.0
         num_tokens, hidden_size = query.shape
         # Reshape the query, key, and value tensors.

--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1319,10 +1319,16 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
         kv_cache: torch.Tensor,
         attn_metadata: T,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         if output is not None:
             raise NotImplementedError(
                 "output is not yet supported for MLAImplBase")
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for MLAImplBase")
 
         if attn_metadata.is_profile_run and \
             attn_metadata.context_chunk_workspace is not None:

--- a/vllm/attention/backends/pallas.py
+++ b/vllm/attention/backends/pallas.py
@@ -172,6 +172,7 @@ class PallasAttentionBackendImpl(AttentionImpl):
         kv_cache: Tuple[torch.Tensor, torch.Tensor],
         attn_metadata: PallasMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with Pallas attention.
 
@@ -187,6 +188,11 @@ class PallasAttentionBackendImpl(AttentionImpl):
         Returns:
             shape = [batch_size, seq_len, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for PallasAttentionImpl")
+
         assert layer._k_scale_float == 1.0 and layer._v_scale_float == 1.0
         batch_size, seq_len, hidden_size = query.shape
         query = query.view(batch_size, seq_len, self.num_heads, self.head_size)

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -909,13 +909,13 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                 assert _PARTITION_SIZE_ROCM % block_size == 0
                 tmp_output = torch.empty(
                     size=(num_seqs, num_heads, max_num_partitions, head_size),
-                    dtype=output.dtype,
-                    device=output.device,
+                    dtype=out_pa.dtype,
+                    device=out_pa.device,
                 )
                 exp_sums = torch.empty(
                     size=(num_seqs, num_heads, max_num_partitions),
                     dtype=torch.float32,
-                    device=output.device,
+                    device=out_pa.device,
                 )
                 max_logits = torch.empty_like(exp_sums)
 

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -594,10 +594,10 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                                                     head_dim))
 
     def fused_output_quant_supported(self, dtype: torch.dtype, static: bool,
-                                     per_token: bool):
+                                     group_shape: tuple[int, int]):
         if self.use_triton_flash_attn:
             return dtype == current_platform.fp8_dtype(
-            ) and static and not per_token
+            ) and static and group_shape == (-1, -1)  # per-tensor
 
         # Only supported in the Triton backend
         return False

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -663,11 +663,6 @@ class ROCmFlashAttentionImpl(AttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
-        if output_scale is not None and not self.use_triton_flash_attn:
-            raise NotImplementedError(
-                "fused output quantization only supported for Triton"
-                " implementation in ROCMFlashAttentionImpl for now")
-
         assert output is not None, "Output tensor must be provided."
 
         if output_scale is not None and not self.use_triton_flash_attn:

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -37,11 +37,11 @@ def is_rocm_aiter_paged_attn_enabled() -> bool:
 @cache
 def _get_paged_attn_module() -> PagedAttention:
     """
-    Initializes the appropriate PagedAttention module from `attention/ops`, 
+    Initializes the appropriate PagedAttention module from `attention/ops`,
     which is used as helper function
     by `ROCmFlashAttentionImpl` and `ROCmFlashAttentionBackend`.
 
-    The choice of attention module depends on whether 
+    The choice of attention module depends on whether
     AITER paged attention is enabled:
     - If enabled, `ROCmFlashAttentionImpl` uses `AITERPagedAttention`.
     - Otherwise, it defaults to using the original `PagedAttention`.
@@ -889,6 +889,15 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                 decode_query.dtype, head_size, block_size, gqa_ratio,
                 decode_meta.max_decode_seq_len, self.sliding_window,
                 self.kv_cache_dtype, self.alibi_slopes)
+
+            # PagedAttention does not support fused quant, manually quantize
+            if output_scale is None:
+                out_pa = output[num_prefill_tokens:]
+            else:
+                # TODO(luka) fix dtype
+                out_pa = torch.empty_like(output[num_prefill_tokens:],
+                                          dtype=torch.bfloat16)
+
             if use_custom:
                 max_seq_len = (decode_meta.max_decode_seq_len if self.attn_type
                                != AttentionType.ENCODER_DECODER else
@@ -912,7 +921,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
 
                 query_start_loc = None
                 ops.paged_attention_rocm(
-                    output[num_prefill_tokens:],
+                    out_pa,
                     exp_sums,
                     max_logits,
                     tmp_output,
@@ -936,7 +945,7 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     layer._v_scale,
                 )
             else:
-                output[num_prefill_tokens:] = paged_attn.forward_decode(
+                out_pa[:] = paged_attn.forward_decode(
                     decode_query,
                     key_cache,
                     value_cache,
@@ -956,6 +965,13 @@ class ROCmFlashAttentionImpl(AttentionImpl):
                     layer._k_scale,
                     layer._v_scale,
                 )
+
+            # Manually perform quantization
+            if output_scale is not None:
+                out_uq = out_pa.view(-1, self.num_heads * self.head_size)
+                out_q = output.view(-1, self.num_heads * self.head_size)
+                out_q[num_prefill_tokens:] = ops.scaled_fp8_quant(
+                    out_uq, output_scale)[0]
 
         # Reshape the output tensor.
         return output.view(-1, self.num_heads * self.head_size)

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -459,6 +459,7 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
         kv_cache: torch.Tensor,
         attn_metadata: TorchSDPAMetadata,  # type: ignore
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with torch SDPA and PagedAttention.
 
@@ -473,6 +474,10 @@ class TorchSDPABackendImpl(AttentionImpl[TorchSDPAMetadata]):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for TorchSDPABackendImpl")
 
         # For warming-up
         if attn_metadata is None:

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -435,6 +435,7 @@ class XFormersImpl(AttentionImpl[XFormersMetadata]):
         kv_cache: torch.Tensor,
         attn_metadata: "XFormersMetadata",
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with xFormers and PagedAttention.
 
@@ -487,6 +488,11 @@ class XFormersImpl(AttentionImpl[XFormersMetadata]):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for XFormersImpl")
+
         attn_type = self.attn_type
         # Check that appropriate attention metadata attributes are
         # selected for the desired attention type

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -430,6 +430,7 @@ def unified_attention_with_output(
     value: torch.Tensor,
     output: torch.Tensor,
     layer_name: str,
+    output_scale: torch.Tensor = None,
 ) -> None:
     wait_for_kv_layer_from_connector(layer_name)
     forward_context: ForwardContext = get_forward_context()
@@ -444,7 +445,8 @@ def unified_attention_with_output(
                       value,
                       kv_cache,
                       attn_metadata,
-                      output=output)
+                      output=output,
+                      output_scale=output_scale)
 
     maybe_save_kv_layer_to_connector(layer_name, kv_cache)
 
@@ -455,6 +457,7 @@ def unified_attention_with_output_fake(
     value: torch.Tensor,
     output: torch.Tensor,
     layer_name: str,
+    output_scale: Optional[torch.Tensor] = None,
 ) -> None:
     return
 

--- a/vllm/attention/layer.py
+++ b/vllm/attention/layer.py
@@ -430,7 +430,7 @@ def unified_attention_with_output(
     value: torch.Tensor,
     output: torch.Tensor,
     layer_name: str,
-    output_scale: torch.Tensor = None,
+    output_scale: Optional[torch.Tensor] = None,
 ) -> None:
     wait_for_kv_layer_from_connector(layer_name)
     forward_context: ForwardContext = get_forward_context()

--- a/vllm/compilation/fusion.py
+++ b/vllm/compilation/fusion.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, ClassVar, NamedTuple, Optional
 
 import torch
 import torch._inductor.pattern_matcher as pm
@@ -34,36 +33,66 @@ RMS_OP = torch.ops._C.rms_norm.default
 RMS_ADD_OP = torch.ops._C.fused_add_rms_norm.default
 
 
+# Use proxy as NamedTuple direct subclasses cannot have static members
+class _GroupShape(NamedTuple):
+    row: int
+    col: int
+
+
+class GroupShape(_GroupShape):
+    """
+    This class describes the quantization group shape.
+    It includes static members for common shapes (per-tensor, per-token).
+    """
+
+    # Aliases for common quantization group shapes
+    PER_TENSOR: ClassVar['GroupShape']
+    PER_TOKEN: ClassVar['GroupShape']
+
+
+GroupShape.PER_TENSOR = GroupShape(-1, -1)
+GroupShape.PER_TOKEN = GroupShape(1, -1)
+
+
 class QuantKey(NamedTuple):
     """
     Named tuple for identifying the type of quantization.
     dtype: quantized data type
     static: static quantization if True, dynamic if False
-    per_tensor: per-tensor quantization if True, per-token if False
+    group_shape: quantization group shape
     symmetric: symmetric if True, asymmetric if False
+
+    TODO(luka) use QuantDescriptor once standardized:
+    https://github.com/vllm-project/vllm/issues/8913
+
     """
     dtype: torch.dtype
     static: bool
-    per_tensor: bool = True
+    group_shape: GroupShape
     symmetric: bool = True
 
     def __str__(self):
+        group_shape = ('per_tensor'
+                       if self.group_shape == GroupShape.PER_TENSOR else
+                       ('per_token' if self.group_shape == GroupShape.PER_TOKEN
+                        else str(self.group_shape)))
+
         return (f"QuantKey({'static' if self.static else 'dynamic'},"
-                f"{fx.graph.dtype_abbrs[self.dtype]},"
-                f"{'per_tensor' if self.per_tensor else 'per_token'},"
+                f"{fx.graph.dtype_abbrs[self.dtype]},{group_shape},"
                 f"{'a' if not self.symmetric else ''}symmetric)")
 
 
-kFp8StaticTensorSym = QuantKey(FP8_DTYPE, True, True, True)
-kFp8DynamicTensorSym = QuantKey(FP8_DTYPE, False, True, True)
-kFp8DynamicTokenSym = QuantKey(FP8_DTYPE, False, False, True)
+kFp8StaticTensorSym = QuantKey(FP8_DTYPE, True, GroupShape.PER_TENSOR, True)
+kFp8DynamicTensorSym = QuantKey(FP8_DTYPE, False, GroupShape.PER_TENSOR, True)
+kFp8DynamicTokenSym = QuantKey(FP8_DTYPE, False, GroupShape.PER_TOKEN, True)
 
 QUANT_OPS: dict[QuantKey, OpOverload] = {
-    kFp8StaticTensorSym: torch.ops._C.static_scaled_fp8_quant.default,  # noqa
+    kFp8StaticTensorSym:
+    torch.ops._C.static_scaled_fp8_quant.default,  # noqa: E501
     kFp8DynamicTensorSym:
-    torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa
+    torch.ops._C.dynamic_scaled_fp8_quant.default,  # noqa: E501
     kFp8DynamicTokenSym:
-    torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa
+    torch.ops._C.dynamic_per_token_scaled_fp8_quant.default,  # noqa: E501
 }
 
 
@@ -83,13 +112,13 @@ class FusedRMSQuantKey(NamedTuple):
 
 FUSED_OPS: dict[FusedRMSQuantKey, OpOverload] = {
     FusedRMSQuantKey(kFp8StaticTensorSym, False):
-    torch.ops._C.rms_norm_static_fp8_quant.default,  # noqa
+    torch.ops._C.rms_norm_static_fp8_quant.default,  # noqa: E501
     FusedRMSQuantKey(kFp8StaticTensorSym, True):
-    torch.ops._C.fused_add_rms_norm_static_fp8_quant.default,  # noqa
+    torch.ops._C.fused_add_rms_norm_static_fp8_quant.default,  # noqa: E501
     FusedRMSQuantKey(kFp8DynamicTokenSym, False):
-    torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa
+    torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa: E501
     FusedRMSQuantKey(kFp8DynamicTokenSym, True):
-    torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa
+    torch.ops._C.rms_norm_dynamic_per_token_quant.default,  # noqa: E501
 }
 
 
@@ -177,10 +206,11 @@ class RMSNormStaticQuantPattern(RMSNormQuantPattern):
                  quant_dtype: torch.dtype,
                  symmetric=True):
         fused_key = FusedRMSQuantKey(fused_add=False,
-                                     quant=QuantKey(dtype=quant_dtype,
-                                                    static=True,
-                                                    per_tensor=True,
-                                                    symmetric=symmetric))
+                                     quant=QuantKey(
+                                         dtype=quant_dtype,
+                                         static=True,
+                                         group_shape=GroupShape.PER_TENSOR,
+                                         symmetric=symmetric))
         super().__init__(epsilon, fused_key)
 
     def register(self, pm_pass: PatternMatcherPass):
@@ -233,10 +263,11 @@ class FusedAddRMSNormStaticQuantPattern(RMSNormQuantPattern):
                  quant_dtype: torch.dtype,
                  symmetric=True):
         key = FusedRMSQuantKey(fused_add=True,
-                               quant=QuantKey(dtype=quant_dtype,
-                                              static=True,
-                                              per_tensor=True,
-                                              symmetric=symmetric))
+                               quant=QuantKey(
+                                   dtype=quant_dtype,
+                                   static=True,
+                                   group_shape=GroupShape.PER_TENSOR,
+                                   symmetric=symmetric))
         super().__init__(epsilon, key)
 
     def register(self, pm_pass: PatternMatcherPass,
@@ -323,12 +354,12 @@ class RMSNormDynamicQuantPattern(RMSNormQuantPattern):
     def __init__(self,
                  epsilon: float,
                  quant_dtype: torch.dtype,
-                 per_tensor: bool,
+                 group_shape: GroupShape = GroupShape.PER_TOKEN,
                  symmetric=True):
         key = FusedRMSQuantKey(fused_add=False,
                                quant=QuantKey(dtype=quant_dtype,
                                               static=False,
-                                              per_tensor=per_tensor,
+                                              group_shape=group_shape,
                                               symmetric=symmetric))
         super().__init__(epsilon, key)
 
@@ -421,12 +452,12 @@ class FusedAddRMSNormDynamicQuantPattern(RMSNormQuantPattern):
     def __init__(self,
                  epsilon: float,
                  quant_dtype: torch.dtype,
-                 per_tensor: bool = True,
+                 group_shape: GroupShape = GroupShape.PER_TOKEN,
                  symmetric=True):
         key = FusedRMSQuantKey(fused_add=True,
                                quant=QuantKey(dtype=quant_dtype,
                                               static=False,
-                                              per_tensor=per_tensor,
+                                              group_shape=group_shape,
                                               symmetric=symmetric))
         super().__init__(epsilon, key)
 
@@ -566,16 +597,12 @@ class FusionPass(VllmInductorPass):
                 self.patterns, self.record_match)
 
             # Fuse rms_norm + dynamic per-token fp8 quant
-            RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE,
-                                       per_tensor=False).register(
-                                           self.patterns, self.record_match)
+            RMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+                self.patterns, self.record_match)
 
             # Fuse fused_add_rms_norm + dynamic per-token fp8 quant
-            FusedAddRMSNormDynamicQuantPattern(epsilon,
-                                               FP8_DTYPE,
-                                               per_tensor=False).register(
-                                                   self.patterns,
-                                                   self.record_match)
+            FusedAddRMSNormDynamicQuantPattern(epsilon, FP8_DTYPE).register(
+                self.patterns, self.record_match)
 
             # WARNING: This is a hack to clear the pattern matcher cache
             # and allow multiple values of epsilon.

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torch import fx
+
+from vllm.attention import Attention
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+from .fx_utils import find_getitem, get_only_user, is_auto_func, is_func
+from .vllm_inductor_pass import VllmInductorPass
+
+logger = init_logger(__name__)
+
+
+class AttnFusionPass(VllmInductorPass):
+    """
+    - check if output is quantized
+    - set the scale on the attention backend
+      - lookup via layer name and config (need config)
+    - remap the out from scaled_fp8_quant to attention directly
+    - remap the meta vals
+
+    TODO with pattern_matcher:
+     - hope the attention layers are available so we can extract dims
+     - otherwise wildcard the sizes?
+    """
+
+    def __init__(self, config: VllmConfig):
+        super().__init__(config)
+        self.static_fwd_ctx = config.compilation_config.static_forward_context
+
+    def __call__(self, graph: torch.fx.graph.Graph) -> None:
+        RESHAPE_OP = torch.ops.aten.reshape.default
+        ATTN_OP = torch.ops.vllm.unified_attention_with_output.default
+        QUANT_OP = torch.ops._C.static_scaled_fp8_quant.default
+        EMPTY_OP = torch.ops.aten.empty.memory_format
+
+        self.dump_graph(graph, "before_attn_fusion")
+        count = 0
+        for node in graph.nodes:
+            # Find the unified attention nodes
+            if not is_auto_func(node, ATTN_OP):
+                continue
+
+            attn_getitem = find_getitem(node, 1)
+
+            # Output view might be reshaped, skip reshapes until the real use
+            output_view = attn_getitem
+
+            while is_func(get_only_user(output_view), RESHAPE_OP):
+                output_view = get_only_user(output_view)
+
+            # If this is not a quant node, exit
+            if not is_auto_func(get_only_user(output_view), QUANT_OP):
+                continue
+
+            quant_node: fx.Node = get_only_user(output_view)
+            quant_output: fx.Node = quant_node.kwargs["result"]
+            assert is_func(quant_output, EMPTY_OP)
+            quant_output_shape = quant_output.args[0]
+
+            # Extract pertinent attention information,
+            # assuming the output is allocated 2d and reshaped
+            layer_name = node.kwargs["layer_name"]
+            attn_output_view = node.kwargs["output"]
+            assert is_func(attn_output_view, RESHAPE_OP)
+            attn_output_buf = attn_output_view.args[0]
+            assert is_func(attn_output_buf, EMPTY_OP)
+
+            # Check that the attention layer impl supports quant fusion
+            attn_layer: Attention = self.static_fwd_ctx[layer_name]
+            quant_dtype = quant_output.kwargs['dtype']
+            # hardcoded because we only match the op for static/per-tensor
+            # (static_scaled_fp8_quant) for now
+            static, per_token = True, False
+            if not attn_layer.impl.fused_output_quant_supported(
+                    quant_dtype, static=static, per_token=per_token):
+                continue
+
+            # The output shapes and dtypes are:
+            # - attn_view: bf16[s0, n_heads, head_size]
+            # - attn_buf: bf16[s0, n_heads * head_size]
+            # - quant: fp8[s0, n_heads * head_size]
+
+            # START REWRITE
+            # After this point, all operations must succeed for the graph to
+            # remain valid. That includes modifications to attention layers.
+
+            # 1. Set scale on Attention layer object
+            # TODO
+            attn_layer._o_scale = quant_node.kwargs['scale']
+            print(attn_layer)
+
+            # 2. Rewrite the graph
+            # 2.a Rewrite the initial buf alloc dtype
+            attn_output_buf.update_kwarg('dtype', quant_output.kwargs['dtype'])
+            assert attn_output_buf.args == quant_output.args
+            assert attn_output_buf.kwargs == quant_output.kwargs
+            assert quant_output.meta['val'].dtype == quant_dtype
+            attn_output_buf.meta['val'] = quant_output.meta['val']
+
+            # 2.b Propagate the dtype TODO
+            # attn_output_view.meta['val'].dtype = quant_dtype
+            # node.meta['val'][1].dtype = quant_dtype
+            # attn_getitem.meta['val'].dtype = quant_dtype
+
+            # 2.d Reshape output buffer back to 2d for scaled mm input
+            with graph.inserting_after(attn_getitem):
+                reshape_args = (attn_getitem, quant_output_shape)
+                attn_new_output = graph.call_function(RESHAPE_OP, reshape_args)
+
+            # 2.e Rebind users of quant to use output of attention directly:
+            find_getitem(quant_node, 1).replace_all_uses_with(attn_new_output)
+
+            count += 1
+
+        logger.debug("fused quantization onto %s attention nodes", count)
+        self.dump_graph(graph, "after_attn_fusion")
+
+    def error_out(self, message: str):
+        # TODO(luka) this could be an error?
+        logger.warning(
+            "Unexpected fx.Graph state while fusing quant onto attention. "
+            "If you expect this to work, please submit a bug report to "
+            "https://github.com/vllm-project/vllm/issues/new/choose. "
+            "Reason: %s.", message)

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -42,6 +42,7 @@ class AttnFusionPass(VllmInductorPass):
         fake_tensor_updater = FakeTensorUpdater(graph)
         nodes_to_process = []
 
+        self.begin()
         self.dump_graph(graph, "before_attn_fusion")
         count = 0
         for node in graph.nodes:
@@ -140,11 +141,4 @@ class AttnFusionPass(VllmInductorPass):
 
         logger.debug("fused quantization onto %s attention nodes", count)
         self.dump_graph(graph, "after_attn_fusion")
-
-    def error_out(self, message: str):
-        # TODO(luka) this could be an error?
-        logger.warning(
-            "Unexpected fx.Graph state while fusing quant onto attention. "
-            "If you expect this to work, please submit a bug report to "
-            "https://github.com/vllm-project/vllm/issues/new/choose. "
-            "Reason: %s.", message)
+        self.end_and_log()

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -1,17 +1,118 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
+import torch._inductor.pattern_matcher as pm
 from torch import fx
+from torch._higher_order_ops.auto_functionalize import auto_functionalized
+from torch._inductor.pattern_matcher import PatternMatcherPass
+from torch._subclasses.fake_tensor import (FakeTensorMode,
+                                           unset_fake_temporarily)
 
 from vllm.attention import Attention
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
+# TODO(luka) move this around
+from .fusion import QUANT_OPS, QuantKey, empty_bf16, empty_fp32
 from .fx_utils import find_getitem, get_only_user, is_auto_func, is_func
 from .vllm_inductor_pass import VllmInductorPass
 
 logger = init_logger(__name__)
+
+ATTN_OP = torch.ops.vllm.unified_attention_with_output.default
+RESHAPE_OP = torch.ops.aten.reshape.default
+
+
+class AttentionStaticQuantPattern:
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        quant_dtype: torch.dtype,
+        symmetric=True,
+    ):
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.quant_dtype = quant_dtype
+        self.quant_key = QuantKey(dtype=quant_dtype,
+                                  static=True,
+                                  per_tensor=True,
+                                  symmetric=symmetric)
+        assert self.quant_key in QUANT_OPS, \
+            f"unsupported quantization scheme {self.quant_key}"
+        self.QUANT_OP = QUANT_OPS[self.quant_key]
+
+    def empty_quant(self, *args, **kwargs):
+        kwargs = {'dtype': self.quant_dtype, 'device': "cuda", **kwargs}
+        return torch.empty(*args, **kwargs)
+
+    def register(self, pm_pass: PatternMatcherPass):
+
+        def pattern(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                    output_attn: torch.Tensor, output_quant: torch.Tensor,
+                    scale: torch.Tensor):
+            view_7 = RESHAPE_OP(output_attn,
+                                [-1, self.num_heads, self.head_size])
+
+            at1 = auto_functionalized(
+                ATTN_OP,
+                query=q,
+                key=k,
+                value=v,
+                output=view_7,
+                layer_name='model.layers.0.self_attn.attn',
+                output_scale=None)
+            attn_out_view = RESHAPE_OP(at1[1],
+                                       [-1, self.num_heads * self.head_size])
+
+            at2 = auto_functionalized(self.QUANT_OP,
+                                      result=output_quant,
+                                      input=attn_out_view,
+                                      scale=scale)
+            return at2[1]
+
+        def replacement(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                        output_attn: torch.Tensor, output_quant: torch.Tensor,
+                        scale: torch.Tensor):
+            view_7 = RESHAPE_OP(output_quant,
+                                [-1, self.num_heads, self.head_size])
+
+            at1 = auto_functionalized(
+                ATTN_OP,
+                query=q,
+                key=k,
+                value=v,
+                output=view_7,
+                layer_name='model.layers.0.self_attn.attn',
+                output_scale=scale)
+
+            return RESHAPE_OP(at1[1], [-1, self.num_heads * self.head_size])
+
+        # custom fake mode, not tracing yet?
+        with unset_fake_temporarily(), FakeTensorMode():
+            inputs = [
+                empty_bf16(5, self.num_heads, self.head_size),  # q
+                empty_bf16(5, self.num_heads, self.head_size),  # k
+                empty_bf16(5, self.num_heads, self.head_size),  # v
+                empty_bf16(5, self.num_heads * self.head_size),  # attn_output
+                self.empty_quant(5, self.num_heads *
+                                 self.head_size),  # quant_output
+                empty_fp32(1, 1)  # scale
+            ]
+
+            def extra_check(match):
+                print(match)
+                return False
+
+            pm.register_replacement(pattern,
+                                    replacement,
+                                    inputs,
+                                    pm.fwd_only,
+                                    pm_pass,
+                                    extra_check=extra_check)
+            # extra_check=lambda m: record_match())
 
 
 class AttnFusionPass(VllmInductorPass):
@@ -31,6 +132,13 @@ class AttnFusionPass(VllmInductorPass):
         super().__init__(config)
         self.static_fwd_ctx = config.compilation_config.static_forward_context
 
+        self.patterns = PatternMatcherPass(pass_name="attn_fusion_pass")
+
+        key, layer = list(self.static_fwd_ctx.items())[0]
+        AttentionStaticQuantPattern(layer.num_heads, layer.head_size,
+                                    current_platform.fp8_dtype()).register(
+                                        self.patterns)
+
     def __call__(self, graph: torch.fx.graph.Graph) -> None:
         RESHAPE_OP = torch.ops.aten.reshape.default
         ATTN_OP = torch.ops.vllm.unified_attention_with_output.default
@@ -44,6 +152,11 @@ class AttnFusionPass(VllmInductorPass):
 
         self.begin()
         self.dump_graph(graph, "before_attn_fusion")
+
+        count2 = self.patterns.apply(graph)
+        logger.debug("Matched %s patterns", count2)
+        self.dump_graph(graph, "after_pattern_match")
+
         count = 0
         for node in graph.nodes:
             # Find the unified attention nodes

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -104,12 +104,25 @@ class AttentionStaticQuantPattern:
 
             def extra_check(match):
                 print(match)
+                # TODO copy custom check from current code
                 return False
+
+            def wrap_trace_fn(process_fx, trace_fn):
+
+                def wrapped(*args, **kwargs):
+                    return process_fx(trace_fn(*args, **kwargs))
+
+                return wrapped
+
+            def process(gm: torch.fx.GraphModule):
+                from torch._inductor.fx_passes.post_grad import view_to_reshape
+                view_to_reshape(gm)
+                return gm
 
             pm.register_replacement(pattern,
                                     replacement,
                                     inputs,
-                                    pm.fwd_only,
+                                    wrap_trace_fn(process, pm.fwd_only),
                                     pm_pass,
                                     extra_check=extra_check)
             # extra_check=lambda m: record_match())

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -154,6 +154,6 @@ class AttnFusionPass(VllmInductorPass):
         self.dump_graph(graph, "before_attn_fusion")
 
         count = self.patterns.apply(graph)
-        logger.debug("fused quantization onto %s attention nodes", count)
+        logger.debug("Fused quantization onto %s attention nodes", count)
         self.dump_graph(graph, "after_attn_fusion")
         self.end_and_log()

--- a/vllm/compilation/fusion_attn.py
+++ b/vllm/compilation/fusion_attn.py
@@ -148,6 +148,12 @@ class AttnFusionPass(VllmInductorPass):
                                                   layer.head_size,
                                                   current_platform.fp8_dtype())
             pattern.register_if_supported(self.patterns, layer)
+        if len(self.static_fwd_ctx) == 0:
+            logger.warning(
+                "Attention + quant fusion is enabled, but "
+                "CompilationConfig.static_forward_context is empty. "
+                "Cannot access attention layers so no fusion "
+                "patterns were registered.")
 
     def __call__(self, graph: torch.fx.graph.Graph) -> None:
         self.begin()

--- a/vllm/compilation/fx_utils.py
+++ b/vllm/compilation/fx_utils.py
@@ -14,6 +14,10 @@ def is_func(node: fx.Node, target) -> bool:
     return node.op == "call_function" and node.target == target
 
 
+def is_auto_func(node: fx.Node, op: OpOverload) -> bool:
+    return is_func(node, auto_functionalized) and node.args[0] == op
+
+
 # Returns the first specified node with the given op (if it exists)
 def find_specified_fn_maybe(nodes: Iterable[fx.Node],
                             op: OpOverload) -> Optional[fx.Node]:
@@ -60,3 +64,9 @@ def find_getitem(node: fx.Node, idx: int) -> fx.Node:
     ret = find_getitem_maybe(node, idx)
     assert ret is not None, f"Could not find getitem {idx} in node {node}"
     return ret
+
+
+# Asserts that the node only has one user and returns it
+def get_only_user(node: fx.Node) -> fx.Node:
+    assert len(node.users) == 1
+    return next(iter(node.users))

--- a/vllm/compilation/fx_utils.py
+++ b/vllm/compilation/fx_utils.py
@@ -67,6 +67,8 @@ def find_getitem(node: fx.Node, idx: int) -> fx.Node:
 
 
 # Asserts that the node only has one user and returns it
+# Even if a node has only 1 user, it might share storage with another node,
+# which might need to be taken into account.
 def get_only_user(node: fx.Node) -> fx.Node:
     assert len(node.users) == 1
     return next(iter(node.users))

--- a/vllm/compilation/noop_elimination.py
+++ b/vllm/compilation/noop_elimination.py
@@ -25,7 +25,7 @@ class NoOpEliminationPass(VllmInductorPass):
 
     Cases handled:
       1. A chain of reshapes is equivalent to the last reshape called on the
-      input of the first reshape.
+      base tensor (input of the first reshape).
       2. A reshape that produces the shape of the input is redundant
       3. A slice that produces the shape of the input is redundant
 
@@ -74,7 +74,7 @@ class NoOpEliminationPass(VllmInductorPass):
         # Remove no-op reshapes/views:
         for node in graph.nodes:
             if is_func(node, torch.ops.aten.reshape.default):
-                # Case 1: rewrite a series of reshapes to just the last one
+                # Case 1: rewrite reshape chains to reshapes on the base tensor
                 input = node.args[0]
                 # If the input is a reshape, rebind to that node
                 if is_func(input, torch.ops.aten.reshape.default):

--- a/vllm/compilation/noop_elimination.py
+++ b/vllm/compilation/noop_elimination.py
@@ -23,7 +23,23 @@ class NoOpEliminationPass(VllmInductorPass):
     in the 2D-case. Additionally, torch internal no-op elimination pass does
     not handle certain slice variants.
 
+    Cases handled:
+      1. A chain of reshapes is equivalent to the last reshape called on the
+      input of the first reshape.
+      2. A reshape that produces the shape of the input is redundant
+      3. A slice that produces the shape of the input is redundant
+
     Example graph 1:
+    mul_1: "f16[s0, 4096]" = ...
+    view_1: "f16[s0, 128, 32]" = torch.reshape(mul_1, [-1, 128, 32])
+    view_2: "f16[s0, 4096]" = torch.reshape(view_2, [-1, 4096])
+    view_3: "f16[s0, 128, 32]" = torch.reshape(view_3, [-1, 128, 32])
+
+    Can be replaced with:
+    mul_1: "f16[s0, 4096]" = ...
+    view_3: "f16[s0, 128, 32]" = ...
+
+    Example graph 2:
     getitem_1: "f16[s0, 4096]" = ...
     view_1: "f16[s0, 4096]" = torch.reshape(getitem_1, [-1, 4096])
     at = auto_functionalized(static_scaled_fp8_quant, input = view_1, ...)
@@ -34,7 +50,7 @@ class NoOpEliminationPass(VllmInductorPass):
     at = auto_functionalized(static_scaled_fp8_quant, input = getitem_1, ...)
     out: "f8e4m3fn[s0, 4096]" = at[1]
 
-    Example graph 2:
+    Example graph 3:
     arg0: "s0" = SymInt(s0)
     scaled_mm: "f16[s0, 4096]" = ...
     slice_1: "f16[s0, 4096]" = torch.slice(scaled_mm, -1, 0, arg0)
@@ -58,6 +74,18 @@ class NoOpEliminationPass(VllmInductorPass):
         # Remove no-op reshapes/views:
         for node in graph.nodes:
             if is_func(node, torch.ops.aten.reshape.default):
+                # Case 1: rewrite a series of reshapes to just the last one
+                input = node.args[0]
+                # If the input is a reshape, rebind to that node
+                if is_func(input, torch.ops.aten.reshape.default):
+                    # The new input is guaranteed not to be a reshape,
+                    # because we process nodes in order
+                    node.update_arg(0, input.args[0])
+                    if len(input.users) == 0:
+                        graph.erase_node(input)
+                        count += 1
+
+                # Case 2: remove this reshape if it produces the original shape
                 input, shape = node.args[:2]
                 input_shape = input.meta["val"].shape
                 if len(shape) != len(input_shape):

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -10,6 +10,7 @@ from .activation_quant_fusion import ActivationQuantFusionPass
 from .collective_fusion import AsyncTPPass
 from .fix_functionalization import FixFunctionalizationPass
 from .fusion import FusionPass
+from .fusion_attn import AttnFusionPass
 from .inductor_pass import CustomGraphPass, InductorPass, get_pass_context
 from .noop_elimination import NoOpEliminationPass
 from .sequence_parallelism import SequenceParallelismPass
@@ -59,6 +60,8 @@ class PostGradPassManager(CustomGraphPass):
             if self.pass_config.enable_async_tp:
                 self.passes += [AsyncTPPass(config)]
 
+        # TODO enable flag
+        self.passes += [AttnFusionPass(config)]
         self.fix_functionalization = FixFunctionalizationPass(config)
 
     def add(self, pass_: InductorPass):

--- a/vllm/compilation/pass_manager.py
+++ b/vllm/compilation/pass_manager.py
@@ -60,8 +60,9 @@ class PostGradPassManager(CustomGraphPass):
             if self.pass_config.enable_async_tp:
                 self.passes += [AsyncTPPass(config)]
 
-        # TODO enable flag
-        self.passes += [AttnFusionPass(config)]
+        if self.pass_config.enable_attn_fusion:
+            self.passes += [AttnFusionPass(config)]
+
         self.fix_functionalization = FixFunctionalizationPass(config)
 
     def add(self, pass_: InductorPass):

--- a/vllm/compilation/vllm_inductor_pass.py
+++ b/vllm/compilation/vllm_inductor_pass.py
@@ -4,6 +4,7 @@
 import time
 
 import torch
+from torch._dynamo.utils import lazy_format_graph_code
 
 from vllm.config import PassConfig, VllmConfig
 # yapf: disable
@@ -34,6 +35,8 @@ class VllmInductorPass(InductorPass):
         self.pass_name = self.__class__.__name__
 
     def dump_graph(self, graph: torch.fx.Graph, stage: str, always=False):
+        lazy_format_graph_code(stage, graph.owning_module)
+
         if stage in self.pass_config.dump_graph_stages or always:
             # Make sure filename includes rank in the distributed setting
             parallel = p_is_init() and get_tp_world_size() > 1

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3796,15 +3796,17 @@ class PassConfig:
     its own stages (before, after, maybe in-between)."""
     dump_graph_dir: Path = Path(".")
     """Directory to dump the graphs."""
-    # TODO(luka) better pass enabling system.
     enable_fusion: bool = True
-    """Whether to enable the custom fusion pass."""
+    """Whether to enable the custom fusion (RMSNorm/SiluMul+quant) pass."""
+    enable_attn_fusion: bool = False
+    """Whether to enable the custom attention+quant fusion pass."""
     enable_noop: bool = True
     """Whether to enable the custom no-op elimination pass."""
     enable_sequence_parallelism: bool = False
     """Whether to enable sequence parallelism."""
     enable_async_tp: bool = False
     """Whether to enable async TP."""
+    # TODO(luka) better pass enabling system.
 
     def uuid(self):
         """
@@ -3813,19 +3815,20 @@ class PassConfig:
         Do not include dump_graph_* in the hash - they don't affect
         compilation.
         """
-        include = {
-            "enable_fusion", "enable_noop", "enable_sequence_parallelism",
-            "enable_async_tp"
-        }
-        dict_ = {k: v for k, v in asdict(self).items() if k in include}
+        exclude = {"dump_graph_stages", "dump_graph_dir"}
+        dict_ = {k: v for k, v in asdict(self).items() if k not in exclude}
         return InductorPass.hash_dict(dict_)
 
     def __post_init__(self) -> None:
-        if not self.enable_noop and self.enable_fusion:
-            logger.warning_once(
-                "Fusion enabled but reshape elimination disabled. "
-                "RMSNorm + quant (fp8) fusion might not work")
-
+        if not self.enable_noop:
+            if self.enable_fusion:
+                logger.warning_once(
+                    "Fusion enabled but reshape elimination disabled. "
+                    "RMSNorm/SiluMul + quant (fp8) fusion might not work")
+            if self.enable_attn_fusion:
+                logger.warning_once(
+                    "Fusion enabled but reshape elimination disabled. "
+                    "Attention + quant (fp8) fusion might not work")
 
 @config
 @dataclass

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3806,6 +3806,7 @@ class PassConfig:
     """Whether to enable sequence parallelism."""
     enable_async_tp: bool = False
     """Whether to enable async TP."""
+
     # TODO(luka) better pass enabling system.
 
     def uuid(self):
@@ -3829,6 +3830,7 @@ class PassConfig:
                 logger.warning_once(
                     "Fusion enabled but reshape elimination disabled. "
                     "Attention + quant (fp8) fusion might not work")
+
 
 @config
 @dataclass

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
     VLLM_NCCL_SO_PATH: Optional[str] = None
     LD_LIBRARY_PATH: Optional[str] = None
-    VLLM_USE_TRITON_FLASH_ATTN: bool = False
+    VLLM_USE_TRITON_FLASH_ATTN: bool = True
     VLLM_V1_USE_PREFILL_DECODE_ATTENTION: bool = False
     VLLM_FLASH_ATTN_VERSION: Optional[int] = None
     LOCAL_RANK: int = 0

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -569,6 +569,7 @@ class FlashAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention.
 
@@ -585,6 +586,11 @@ class FlashAttentionImpl(AttentionImpl):
               We use torch's .expand() to avoid duplicating values
         """
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlashAttentionImpl")
 
         if attn_metadata is None:
             # Profiling run.

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -547,6 +547,7 @@ class FlashInferImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashInferMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashInfer.
 
@@ -560,6 +561,11 @@ class FlashInferImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlashInferImpl")
 
         if attn_metadata is None:
             # Profiling run.

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -414,6 +414,7 @@ class FlexAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlexAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FLexAttention.
 
@@ -427,6 +428,12 @@ class FlexAttentionImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for FlexAttentionImpl")
+
         enable_gqa = self.num_kv_heads != self.num_heads
 
         if attn_metadata is None:

--- a/vllm/v1/attention/backends/mla/common.py
+++ b/vllm/v1/attention/backends/mla/common.py
@@ -865,9 +865,15 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         kv_cache: torch.Tensor,
         attn_metadata: M,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for MLACommonImpl")
 
         if attn_metadata is None:
             # The zero fill is required when used with DP + EP

--- a/vllm/v1/attention/backends/pallas.py
+++ b/vllm/v1/attention/backends/pallas.py
@@ -161,6 +161,7 @@ class PallasAttentionBackendImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: PallasMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with Pallas attention.
 
@@ -173,6 +174,11 @@ class PallasAttentionBackendImpl(AttentionImpl):
         Returns:
             shape = [num_tokens, num_heads * head_size]
         """
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for PallasAttentionBackendImpl")
+
         # For determine_available_memory case.
         if kv_cache.numel() == 0:
             if output is None:

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -142,6 +142,7 @@ class TritonAttentionImpl(AttentionImpl):
         kv_cache: torch.Tensor,
         attn_metadata: FlashAttentionMetadata,
         output: Optional[torch.Tensor] = None,
+        output_scale: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with FlashAttention.
 
@@ -155,6 +156,11 @@ class TritonAttentionImpl(AttentionImpl):
             shape = [num_tokens, num_heads * head_size]
         """
         assert output is not None, "Output tensor must be provided."
+
+        if output_scale is not None:
+            raise NotImplementedError(
+                "fused output quantization is not yet supported"
+                " for TritonAttentionImpl")
 
         if attn_metadata is None:
             # Profiling run.


### PR DESCRIPTION
This PR implements the fusion of fp8 quantization onto attention, described in #16220. It performs this fusion using a new `AttnFusionPass`, which uses the pattern matcher and only performs the fusion if the backend supports it. It is currently off by default, pending more robust V1 support and performance measurement.

This PR also makes the following changes:
- `output_scale` added as a parameter to `unified_attention_with_output`. During the `torch.compile` fusion pass, we do not have access to the scale, just the graph node corresponding to it. Hence, we cannot just set the scale on the layer object.
- A new method `fused_output_quant_supported` on the `AttentionImpl`. This method tells the fusion pass that it is safe to fuse the output quantization onto attention. It is opt-in, so fusion will only be performed if the backend impl supports it.
- Support for attention + quant fusion to the `ROCmFlashAttentionImpl` attention backend. This is the motivating case for this pass, as AMD is adding support for fused attention quantization to the Triton kernel in #12591.
- ~~`PostGradPassManager` now accepts the forward context as a parameter, so it can be passed to passes that need it (like `AttnFusionPass`). We cannot currently pass the whole compilation config as that would create a cycle when the manager adds itself to `CompilationConfig.inductor_config`.~~ (since #16155 we pass vllm_config to passes anyway)
- Additional case to `NoOpEliminationPass`. We now also replace a chain of reshapes with the last one: `t.view(*args1).view(*args2).view(*args3)` -> `t.view(*args3)`. This is needed for correct pattern matching. Either way it's always good to simplify the graph.
- Calling `lazy_format_graph_pass` inside `VllmInductorPass` makes sure the graph gets printed when debugging with `depyf`.
- Test for `AttnFusionPass`. Using LLM instances instead of silly models to avoid redoing metadata setup in test code.

While this PR only adds fusion support on ROCm, it makes it easy to add support for other backends once their attention kernels add support for fused quantization of output. This includes V1, although we'll either need to use full cudagraphs or address the piecewise problem as described in #16220. Additionally, support for other quantization schemes can be added as well with minor additions to the pass (matching appropriate quant ops and saving quant metadata into the attention layer).

This PR depends on #12591, #15734, #16431 and #17139. All of them have been merged to main.

Pewrf numbers below, improvement on decode (ITL) and reduction on prefill (TTFT), but not going to invest as it's using a deprecated V0 prefill triton kernel. Will revisit performance with support for other backends.

`VLLM_USE_V1=0 vllm serve amd/Llama-3.1-8B-Instruct-FP8-KV -O '{"pass_config":{"enable_attn_fusion": false}}'`:

```console
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.74|±  |0.0441|
|     |       |strict-match    |     5|exact_match|↑  | 0.70|±  |0.0461|
```

`VLLM_USE_V1=0 vllm serve serve amd/Llama-3.1-8B-Instruct-FP8-KV -O '{"pass_config":{"enable_attn_fusion": true}}'`:

```console
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.74|±  |0.0441|
|     |       |strict-match    |     5|exact_match|↑  | 0.68|±  |0.0469|
```
<!--- pyml disable-next-line no-emphasis-as-heading -->
