### PR TITLE
[misc] ignore marlin_moe_wna16 local gen codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ benchmarks/**/*.json
 # Linting
 actionlint
 shellcheck*/
+
+# Ingore moe/marlin_moe gen code
+csrc/moe/marlin_moe_wna16/kernel_*


### PR DESCRIPTION

It would be better if we ignored the marlin_moe_wna16 local gen codes. This can avoid wrongly committing the locally generated code.

<!--- pyml disable-next-line no-emphasis-as-heading -->
