### PR TITLE
[Bugfix]Fix index out of range error in api server log

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -881,7 +881,8 @@ def build_app(args: Namespace) -> FastAPI:
                 section async for section in response.body_iterator
             ]
             response.body_iterator = iterate_in_threadpool(iter(response_body))
-            logger.info("response_body={%s}", response_body[0].decode())
+            logger.info("response_body={%s}",
+                        response_body[0].decode() if response_body else None)
             return response
 
     for middleware in args.middleware:


### PR DESCRIPTION
Fix index out of range error in api server log. 
When  using VLLM_DEBUG_LOG_API_SERVER_RESPONSE and curl /health api , it throw error:
vllm/entrypoints/openai/api_server.py", line 884, in log_response
    logger.info("response_body={%s}", response_body[0].decode())
IndexError: list index out of range.