### PR TITLE
 [Kernel] Adding Split-KV Attention Kernel to the triton_attn Backend

### DIFF
--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -422,7 +422,6 @@ def kernel_paged_attention_3d(
     tl.store(segm_max_ptr + segm_offset, M, mask=head_mask)
     tl.store(segm_expsum_ptr + segm_offset, L, mask=head_mask)
 
-
 @triton.jit
 def reduce_segments(
     output_ptr,  # [num_seqs, num_query_heads, head_size]

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -612,9 +612,8 @@ def chunked_prefill_paged_decode(
             k_scale=k_scale,
             v_scale=v_scale,
         )
-    elif (
-        max_seq_len < 256
-    ):  # use 2d kernel to avoid reduction overhead for short sequences
+    elif max_seq_len < 256:
+        # use 2d kernel to avoid reduction overhead for short sequences
         kernel_paged_attention_2d[
             (
                 num_seqs,

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -65,7 +65,8 @@ def kernel_paged_attention_2d(
     if filter_by_query_len:
         cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
         cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
-        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+        cur_batch_query_len = cur_batch_in_all_stop_index \
+            - cur_batch_in_all_start_index
         if cur_batch_query_len > 1:
             return
     else:
@@ -204,7 +205,7 @@ def kernel_paged_attention_2d(
 
 @triton.jit
 def kernel_paged_attention_3d(
-    segm_output_ptr,  # [num_seqs, num_query_heads, num_segments, head_size_padded]
+    segm_output_ptr,  # [num_seqs, num_query_heads, num_segments, head_size]
     segm_max_ptr,  # [num_seqs, num_query_heads, num_segments]
     segm_expsum_ptr,  # [num_seqs, num_query_heads, num_segments]
     query_ptr,  # [num_tokens, num_query_heads, head_size]
@@ -250,7 +251,8 @@ def kernel_paged_attention_3d(
     if filter_by_query_len:
         cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
         cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
-        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+        cur_batch_query_len = cur_batch_in_all_stop_index \
+            - cur_batch_in_all_start_index
         if cur_batch_query_len > 1:
             return
     else:
@@ -407,7 +409,7 @@ def kernel_paged_attention_3d(
 @triton.jit
 def reduce_segments(
     output_ptr,  # [num_seqs, num_query_heads, head_size]
-    segm_output_ptr,  # [num_seqs, num_query_heads, max_num_segments, head_size_padded]
+    segm_output_ptr,  # [num_seqs, num_query_heads, max_num_segments, head_size]
     segm_max_ptr,  # [num_seqs, num_query_heads, max_num_segments]
     segm_expsum_ptr,  # [num_seqs, num_query_heads, max_num_segments]
     seq_lens_ptr,  # [num_seqs]
@@ -430,7 +432,8 @@ def reduce_segments(
     if filter_by_query_len:
         cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
         cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
-        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+        cur_batch_query_len = cur_batch_in_all_stop_index \
+            - cur_batch_in_all_start_index
         if cur_batch_query_len > 1:
             return
     else:

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -409,7 +409,7 @@ def kernel_paged_attention_3d(
 @triton.jit
 def reduce_segments(
     output_ptr,  # [num_seqs, num_query_heads, head_size]
-    segm_output_ptr,  # [num_seqs, num_query_heads, max_num_segments, head_size]
+    segm_output_ptr, # [num_seqs, num_query_heads, max_num_segments, head_size]
     segm_max_ptr,  # [num_seqs, num_query_heads, max_num_segments]
     segm_expsum_ptr,  # [num_seqs, num_query_heads, max_num_segments]
     seq_lens_ptr,  # [num_seqs]

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -23,67 +23,67 @@ def cdiv_fn(x, y):
 
 @triton.jit
 def kernel_paged_attention_2d(
-        output_ptr,  # [num_tokens, num_query_heads, head_size]
-        query_ptr,  # [num_tokens, num_query_heads, head_size]
-        key_cache_ptr,  # [num_blks, num_kv_heads, head_size // x, blk_size, x]
-        value_cache_ptr,  # [num_blks, num_kv_heads, head_size, blk_size]
-        block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
-        seq_lens_ptr,  # [num_seqs]
-        alibi_slopes_ptr,  # [num_query_heads]
-        scale,  # float32
-        k_scale,  # float32
-        v_scale,  # float32
-        num_query_heads: tl.constexpr,  # int
-        num_queries_per_kv: tl.constexpr,  # int
-        num_queries_per_kv_padded: tl.constexpr,  # int
-        block_table_stride: tl.int64,  # int
-        query_stride_0: tl.int64,  # int
-        query_stride_1: tl.int64,  # int, should be equal to head_size
-        output_stride_0: tl.int64,  # int
-        output_stride_1: tl.int64,  # int, should be equal to head_size
-        BLOCK_SIZE: tl.constexpr,  # int
-        HEAD_SIZE: tl.constexpr,  # int
-        HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
-        USE_ALIBI_SLOPES: tl.constexpr,  # bool
-        SLIDING_WINDOW: tl.constexpr,  # int
-        x: tl.constexpr,  # int
-        stride_k_cache_0: tl.int64,  # int
-        stride_k_cache_1: tl.int64,  # int
-        stride_k_cache_2: tl.int64,  # int
-        stride_k_cache_3: tl.int64,  # int
-        stride_k_cache_4: tl.int64,  # int
-        stride_v_cache_0: tl.int64,  # int
-        stride_v_cache_1: tl.int64,  # int
-        stride_v_cache_2: tl.int64,  # int
-        stride_v_cache_3: tl.int64,  # int
-        filter_by_query_len: tl.constexpr,  # bool
-        query_start_len_ptr,  # [num_seqs+1]
+    output_ptr,  # [num_tokens, num_query_heads, head_size]
+    query_ptr,  # [num_tokens, num_query_heads, head_size]
+    key_cache_ptr,  # [num_blks, num_kv_heads, head_size // x, blk_size, x]
+    value_cache_ptr,  # [num_blks, num_kv_heads, head_size, blk_size]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    seq_lens_ptr,  # [num_seqs]
+    alibi_slopes_ptr,  # [num_query_heads]
+    scale,  # float32
+    k_scale,  # float32
+    v_scale,  # float32
+    num_query_heads: tl.constexpr,  # int
+    num_queries_per_kv: tl.constexpr,  # int
+    num_queries_per_kv_padded: tl.constexpr,  # int
+    block_table_stride: tl.int64,  # int
+    query_stride_0: tl.int64,  # int
+    query_stride_1: tl.int64,  # int, should be equal to head_size
+    output_stride_0: tl.int64,  # int
+    output_stride_1: tl.int64,  # int, should be equal to head_size
+    BLOCK_SIZE: tl.constexpr,  # int
+    HEAD_SIZE: tl.constexpr,  # int
+    HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    USE_ALIBI_SLOPES: tl.constexpr,  # bool
+    SLIDING_WINDOW: tl.constexpr,  # int
+    x: tl.constexpr,  # int
+    stride_k_cache_0: tl.int64,  # int
+    stride_k_cache_1: tl.int64,  # int
+    stride_k_cache_2: tl.int64,  # int
+    stride_k_cache_3: tl.int64,  # int
+    stride_k_cache_4: tl.int64,  # int
+    stride_v_cache_0: tl.int64,  # int
+    stride_v_cache_1: tl.int64,  # int
+    stride_v_cache_2: tl.int64,  # int
+    stride_v_cache_3: tl.int64,  # int
+    filter_by_query_len: tl.constexpr,  # bool
+    query_start_len_ptr,  # [num_seqs+1]
 ):
     seq_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
 
     if filter_by_query_len:
         cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
-        cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx +
-                                              1)
-        cur_batch_query_len = cur_batch_in_all_stop_index \
-            - cur_batch_in_all_start_index
+        cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
+        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
         if cur_batch_query_len > 1:
             return
     else:
         cur_batch_in_all_start_index = seq_idx
 
     query_head_idx = kv_head_idx * num_queries_per_kv + tl.arange(
-        0, num_queries_per_kv_padded)
+        0, num_queries_per_kv_padded
+    )
 
-    query_offset = (cur_batch_in_all_start_index * query_stride_0 +
-                    query_head_idx[:, None] * query_stride_1)
+    query_offset = (
+        cur_batch_in_all_start_index * query_stride_0
+        + query_head_idx[:, None] * query_stride_1
+    )
 
     head_mask = query_head_idx < (kv_head_idx + 1) * num_queries_per_kv
     head_mask = head_mask & (query_head_idx < num_query_heads)
 
-    dim_mask = tl.where(tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1,
-                        0).to(tl.int1)
+    dim_mask = tl.where(tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1, 0).to(tl.int1)
 
     # Q : (num_queries_per_kv, HEAD_SIZE,)
     Q = tl.load(
@@ -96,17 +96,16 @@ def kernel_paged_attention_2d(
 
     M = tl.full([num_queries_per_kv_padded], float("-inf"), dtype=tl.float32)
     L = tl.full([num_queries_per_kv_padded], 1.0, dtype=tl.float32)
-    acc = tl.zeros([num_queries_per_kv_padded, HEAD_SIZE_PADDED],
-                   dtype=tl.float32)
+    acc = tl.zeros([num_queries_per_kv_padded, HEAD_SIZE_PADDED], dtype=tl.float32)
 
     # sequence len for this particular sequence
     seq_len = tl.load(seq_lens_ptr + seq_idx)
 
     # alibi slope for this head
     if USE_ALIBI_SLOPES:
-        alibi_slope = tl.load(alibi_slopes_ptr + query_head_idx,
-                              mask=head_mask,
-                              other=0.0)
+        alibi_slope = tl.load(
+            alibi_slopes_ptr + query_head_idx, mask=head_mask, other=0.0
+        )
 
     num_blocks = cdiv_fn(seq_len, BLOCK_SIZE)
 
@@ -118,21 +117,23 @@ def kernel_paged_attention_2d(
         offs_n = tl.arange(0, BLOCK_SIZE)
         offs_d = tl.arange(0, HEAD_SIZE_PADDED)
 
-        v_offset = (physical_block_idx * stride_v_cache_0 +
-                    kv_head_idx * stride_v_cache_1 +
-                    offs_d[None, :] * stride_v_cache_2 +
-                    offs_n[:, None] * stride_v_cache_3)
+        v_offset = (
+            physical_block_idx * stride_v_cache_0
+            + kv_head_idx * stride_v_cache_1
+            + offs_d[None, :] * stride_v_cache_2
+            + offs_n[:, None] * stride_v_cache_3
+        )
 
-        k_offset = (physical_block_idx * stride_k_cache_0 +
-                    kv_head_idx * stride_k_cache_1 +
-                    (offs_d[:, None] // x) * stride_k_cache_2 +
-                    offs_n[None, :] * stride_k_cache_3 +
-                    (offs_d[:, None] % x) * stride_k_cache_4)
+        k_offset = (
+            physical_block_idx * stride_k_cache_0
+            + kv_head_idx * stride_k_cache_1
+            + (offs_d[:, None] // x) * stride_k_cache_2
+            + offs_n[None, :] * stride_k_cache_3
+            + (offs_d[:, None] % x) * stride_k_cache_4
+        )
 
         # K : (HEAD_SIZE, BLOCK_SIZE)
-        K_load = tl.load(key_cache_ptr + k_offset,
-                         mask=dim_mask[:, None],
-                         other=0.0)
+        K_load = tl.load(key_cache_ptr + k_offset, mask=dim_mask[:, None], other=0.0)
 
         if K_load.dtype.is_fp8():
             K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
@@ -140,9 +141,7 @@ def kernel_paged_attention_2d(
             K = K_load
 
         # V : (BLOCK_SIZE, HEAD_SIZE)
-        V_load = tl.load(value_cache_ptr + v_offset,
-                         mask=dim_mask[None, :],
-                         other=0.0)
+        V_load = tl.load(value_cache_ptr + v_offset, mask=dim_mask[None, :], other=0.0)
 
         if V_load.dtype.is_fp8():
             V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
@@ -154,15 +153,13 @@ def kernel_paged_attention_2d(
         seq_mask = seq_offset[None, :] < boundary
 
         # S : (num_queries_per_kv, BLOCK_SIZE,)
-        S = tl.where(head_mask[:, None] & seq_mask, 0.0,
-                     float("-inf")).to(tl.float32)
+        S = tl.where(head_mask[:, None] & seq_mask, 0.0, float("-inf")).to(tl.float32)
         S += scale * tl.dot(Q, K)
 
         context_len = seq_len - 1
 
         if SLIDING_WINDOW > 0:
-            S = tl.where((context_len - seq_offset) < SLIDING_WINDOW, S,
-                         -10000)
+            S = tl.where((context_len - seq_offset) < SLIDING_WINDOW, S, -10000)
 
         if USE_ALIBI_SLOPES:
             S += alibi_slope[:, None] * (seq_offset - context_len)
@@ -193,15 +190,304 @@ def kernel_paged_attention_2d(
     # epilogue
     acc = acc / L[:, None]
 
-    output_offset = (cur_batch_in_all_start_index * output_stride_0 +
-                     query_head_idx * output_stride_1)
+    output_offset = (
+        cur_batch_in_all_start_index * output_stride_0
+        + query_head_idx * output_stride_1
+    )
 
     tl.store(
-        output_ptr + output_offset[:, None] +
-        tl.arange(0, HEAD_SIZE_PADDED)[None, :],
+        output_ptr + output_offset[:, None] + tl.arange(0, HEAD_SIZE_PADDED)[None, :],
         acc,
         mask=dim_mask[None, :] & head_mask[:, None],
     )
+
+
+@triton.jit
+def kernel_paged_attention_3d(
+    segm_output_ptr,  # [num_seqs, num_query_heads, num_segments, head_size_padded]
+    segm_max_ptr,  # [num_seqs, num_query_heads, num_segments]
+    segm_expsum_ptr,  # [num_seqs, num_query_heads, num_segments]
+    query_ptr,  # [num_tokens, num_query_heads, head_size]
+    key_cache_ptr,  # [num_blks, num_kv_heads, head_size // x, blk_size, x]
+    value_cache_ptr,  # [num_blks, num_kv_heads, head_size, blk_size]
+    block_tables_ptr,  # [num_seqs, max_num_blocks_per_seq]
+    seq_lens_ptr,  # [num_seqs]
+    alibi_slopes_ptr,  # [num_query_heads]
+    scale,  # float32
+    k_scale,  # float32
+    v_scale,  # float32
+    num_seqs,  # int
+    num_query_heads: tl.constexpr,  # int
+    num_queries_per_kv: tl.constexpr,  # int
+    num_queries_per_kv_padded: tl.constexpr,  # int
+    block_table_stride: tl.constexpr,
+    query_stride_0: tl.constexpr,
+    query_stride_1: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # int
+    HEAD_SIZE: tl.constexpr,  # int
+    HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    USE_ALIBI_SLOPES: tl.constexpr,  # bool
+    SLIDING_WINDOW: tl.constexpr,  # int
+    x: tl.constexpr,  # int
+    stride_k_cache_0: tl.constexpr,
+    stride_k_cache_1: tl.constexpr,
+    stride_k_cache_2: tl.constexpr,
+    stride_k_cache_3: tl.constexpr,
+    stride_k_cache_4: tl.constexpr,
+    stride_v_cache_0: tl.constexpr,
+    stride_v_cache_1: tl.constexpr,
+    stride_v_cache_2: tl.constexpr,
+    stride_v_cache_3: tl.constexpr,
+    filter_by_query_len: tl.constexpr,  # bool
+    query_start_len_ptr,  # [num_seqs+1]
+    MIN_NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
+    MAX_NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
+):
+    seq_idx = tl.program_id(0)
+    kv_head_idx = tl.program_id(1)
+    segm_idx = tl.program_id(2)
+
+    if filter_by_query_len:
+        cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
+        cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
+        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+        if cur_batch_query_len > 1:
+            return
+    else:
+        cur_batch_in_all_start_index = seq_idx
+
+    # sequence len for this particular sequence
+    seq_len = tl.load(seq_lens_ptr + seq_idx)
+
+    # number of segments and segment size for this particular sequence
+    num_segments = (
+        MAX_NUM_SEGMENTS_PER_SEQ if num_seqs <= 64 else MIN_NUM_SEGMENTS_PER_SEQ
+    )
+    blocks_per_segment = cdiv_fn(seq_len, num_segments * BLOCK_SIZE)
+
+    if segm_idx * blocks_per_segment * BLOCK_SIZE >= seq_len:
+        return
+
+    query_head_idx = kv_head_idx * num_queries_per_kv + tl.arange(
+        0, num_queries_per_kv_padded
+    )
+
+    query_offset = (
+        cur_batch_in_all_start_index * query_stride_0
+        + query_head_idx[:, None] * query_stride_1
+    )
+
+    head_mask = query_head_idx < (kv_head_idx + 1) * num_queries_per_kv
+    head_mask = head_mask & (query_head_idx < num_query_heads)
+
+    dim_mask = tl.where(tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1, 0).to(tl.int1)
+
+    # Q : (num_queries_per_kv, HEAD_SIZE,)
+    Q = tl.load(
+        query_ptr + query_offset + tl.arange(0, HEAD_SIZE_PADDED)[None, :],
+        mask=dim_mask[None, :] & head_mask[:, None],
+        other=0.0,
+    )
+
+    block_table_offset = seq_idx * block_table_stride
+
+    M = tl.full([num_queries_per_kv_padded], float("-inf"), dtype=tl.float32)
+    L = tl.full([num_queries_per_kv_padded], 1.0, dtype=tl.float32)
+    acc = tl.zeros([num_queries_per_kv_padded, HEAD_SIZE_PADDED], dtype=tl.float32)
+
+    # alibi slope for this head
+    if USE_ALIBI_SLOPES:
+        alibi_slope = tl.load(
+            alibi_slopes_ptr + query_head_idx, mask=head_mask, other=0.0
+        )
+
+    num_blocks = cdiv_fn(seq_len, BLOCK_SIZE)
+
+    # iterate through tiles within current segment
+    for j in range(
+        segm_idx * blocks_per_segment,
+        min((segm_idx + 1) * blocks_per_segment, num_blocks),
+    ):
+        physical_block_idx = tl.load(block_tables_ptr + block_table_offset + j)
+
+        offs_n = tl.arange(0, BLOCK_SIZE)
+        offs_d = tl.arange(0, HEAD_SIZE_PADDED)
+
+        v_offset = (
+            physical_block_idx * stride_v_cache_0
+            + kv_head_idx * stride_v_cache_1
+            + offs_d[None, :] * stride_v_cache_2
+            + offs_n[:, None] * stride_v_cache_3
+        )
+
+        k_offset = (
+            physical_block_idx * stride_k_cache_0
+            + kv_head_idx * stride_k_cache_1
+            + (offs_d[:, None] // x) * stride_k_cache_2
+            + offs_n[None, :] * stride_k_cache_3
+            + (offs_d[:, None] % x) * stride_k_cache_4
+        )
+
+        # K : (HEAD_SIZE, BLOCK_SIZE)
+        K_load = tl.load(key_cache_ptr + k_offset, mask=dim_mask[:, None], other=0.0)
+
+        if K_load.dtype.is_fp8():
+            K = (K_load.to(tl.float32) * tl.load(k_scale)).to(Q.dtype)
+        else:
+            K = K_load
+
+        # V : (BLOCK_SIZE, HEAD_SIZE)
+        V_load = tl.load(value_cache_ptr + v_offset, mask=dim_mask[None, :], other=0.0)
+
+        if V_load.dtype.is_fp8():
+            V = (V_load.to(tl.float32) * tl.load(v_scale)).to(Q.dtype)
+        else:
+            V = V_load
+
+        seq_offset = j * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        boundary = tl.full([BLOCK_SIZE], seq_len, dtype=tl.int32)
+        seq_mask = seq_offset[None, :] < boundary
+
+        # S : (num_queries_per_kv, BLOCK_SIZE,)
+        S = tl.where(head_mask[:, None] & seq_mask, 0.0, float("-inf")).to(tl.float32)
+        S += scale * tl.dot(Q, K)
+
+        context_len = seq_len - 1
+
+        if SLIDING_WINDOW > 0:
+            S = tl.where((context_len - seq_offset) < SLIDING_WINDOW, S, -10000)
+
+        if USE_ALIBI_SLOPES:
+            S += alibi_slope[:, None] * (seq_offset - context_len)
+
+        # compute running maximum
+        # m_j : (num_queries_per_kv,)
+        m_j = tl.maximum(M, tl.max(S, axis=1))
+
+        # P : (num_queries_per_kv, BLOCK_SIZE,)
+        P = tl.exp(S - m_j[:, None])
+
+        # l_j : (num_queries_per_kv,)
+        l_j = tl.sum(P, axis=1)
+
+        # alpha : (num_queries_per_kv, )
+        alpha = tl.exp(M - m_j)
+
+        # acc : (num_queries_per_kv, BLOCK_SIZE,)
+        acc = acc * alpha[:, None]
+
+        # update constants
+        L = L * alpha + l_j
+        M = m_j
+
+        # acc : (num_queries_per_kv, BLOCK_SIZE,)
+        acc += tl.dot(P.to(V.dtype), V)
+
+    segm_output_offset = (
+        seq_idx * (num_query_heads * MAX_NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + query_head_idx[:, None] * (MAX_NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + segm_idx * HEAD_SIZE_PADDED
+        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+    )
+    tl.store(
+        segm_output_ptr + segm_output_offset,
+        acc,
+        mask=dim_mask[None, :] & head_mask[:, None],
+    )
+
+    segm_offset = (
+        seq_idx * (num_query_heads * MAX_NUM_SEGMENTS_PER_SEQ)
+        + query_head_idx * MAX_NUM_SEGMENTS_PER_SEQ
+        + segm_idx
+    )
+    tl.store(segm_max_ptr + segm_offset, M, mask=head_mask)
+    tl.store(segm_expsum_ptr + segm_offset, L, mask=head_mask)
+
+
+@triton.jit
+def reduce_segments(
+    output_ptr,  # [num_seqs, num_query_heads, head_size]
+    segm_output_ptr,  # [num_seqs, num_query_heads, max_num_segments, head_size_padded]
+    segm_max_ptr,  # [num_seqs, num_query_heads, max_num_segments]
+    segm_expsum_ptr,  # [num_seqs, num_query_heads, max_num_segments]
+    seq_lens_ptr,  # [num_seqs]
+    num_seqs,  # int
+    num_query_heads: tl.constexpr,  # int
+    output_stride_0: tl.constexpr,
+    output_stride_1: tl.constexpr,
+    block_table_stride: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,  # int
+    HEAD_SIZE: tl.constexpr,  # int, must be power of 2
+    HEAD_SIZE_PADDED: tl.constexpr,  # int, must be power of 2
+    filter_by_query_len: tl.constexpr,  # bool
+    query_start_len_ptr,  # [num_seqs+1]
+    MIN_NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
+    MAX_NUM_SEGMENTS_PER_SEQ: tl.constexpr,  # int
+):
+    seq_idx = tl.program_id(0)
+    query_head_idx = tl.program_id(1)
+
+    if filter_by_query_len:
+        cur_batch_in_all_start_index = tl.load(query_start_len_ptr + seq_idx)
+        cur_batch_in_all_stop_index = tl.load(query_start_len_ptr + seq_idx + 1)
+        cur_batch_query_len = cur_batch_in_all_stop_index - cur_batch_in_all_start_index
+        if cur_batch_query_len > 1:
+            return
+    else:
+        cur_batch_in_all_start_index = seq_idx
+
+    # sequence len for this particular sequence
+    seq_len = tl.load(seq_lens_ptr + seq_idx)
+
+    # number of segments and segment size for this particular sequence
+    num_segments = (
+        MAX_NUM_SEGMENTS_PER_SEQ if num_seqs <= 64 else MIN_NUM_SEGMENTS_PER_SEQ
+    )
+    blocks_per_segment = cdiv_fn(seq_len, num_segments * BLOCK_SIZE)
+
+    # create masks for subsequent loads
+    act_num_segments = cdiv_fn(seq_len, blocks_per_segment * BLOCK_SIZE)
+    segm_mask = tl.arange(0, MAX_NUM_SEGMENTS_PER_SEQ) < tl.full(
+        [MAX_NUM_SEGMENTS_PER_SEQ], act_num_segments, dtype=tl.int32
+    )
+    dim_mask = tl.where(tl.arange(0, HEAD_SIZE_PADDED) < HEAD_SIZE, 1, 0).to(tl.int1)
+
+    # load segment maxima
+    segm_offset = (
+        seq_idx * (num_query_heads * MAX_NUM_SEGMENTS_PER_SEQ)
+        + query_head_idx * MAX_NUM_SEGMENTS_PER_SEQ
+        + tl.arange(0, MAX_NUM_SEGMENTS_PER_SEQ)
+    )
+    segm_max = tl.load(segm_max_ptr + segm_offset, mask=segm_mask, other=float("-inf"))
+    overall_max = tl.max(segm_max)
+
+    # load and rescale segment exp sums
+    segm_expsum = tl.load(segm_expsum_ptr + segm_offset, mask=segm_mask, other=0.0)
+    segm_expsum = segm_expsum * tl.exp(segm_max - overall_max)
+    overall_expsum = tl.sum(segm_expsum)
+
+    # load, rescale, and add segment attention outputs
+    segm_output_offset = (
+        seq_idx * (num_query_heads * MAX_NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + query_head_idx * (MAX_NUM_SEGMENTS_PER_SEQ * HEAD_SIZE_PADDED)
+        + tl.arange(0, MAX_NUM_SEGMENTS_PER_SEQ)[:, None] * HEAD_SIZE_PADDED
+        + tl.arange(0, HEAD_SIZE_PADDED)[None, :]
+    )
+    segm_output = tl.load(
+        segm_output_ptr + segm_output_offset,
+        mask=segm_mask[:, None] & dim_mask[None, :],
+        other=0.0,
+    )
+    segm_output *= tl.exp(segm_max - overall_max)[:, None]
+    acc = tl.sum(segm_output, axis=0) / overall_expsum
+
+    # write result
+    output_offset = (
+        cur_batch_in_all_start_index * output_stride_0
+        + query_head_idx * output_stride_1
+        + tl.arange(0, HEAD_SIZE_PADDED)
+    )
+    tl.store(output_ptr + output_offset, acc, mask=dim_mask)
 
 
 def chunked_prefill_paged_decode(
@@ -225,7 +511,7 @@ def chunked_prefill_paged_decode(
 ):
 
     if sm_scale is None:
-        sm_scale = 1.0 / (query.shape[1]**0.5)
+        sm_scale = 1.0 / (query.shape[1] ** 0.5)
 
     use_alibi_slopes = alibi_slopes is not None
 
@@ -277,22 +563,25 @@ def chunked_prefill_paged_decode(
         key_cache = key_cache.view(target_dtype)
         value_cache = value_cache.view(target_dtype)
 
-    num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv),
-                                    16)
+    num_queries_per_kv_padded = max(triton.next_power_of_2(num_queries_per_kv), 16)
 
-    use_custom = use_rocm_custom_paged_attention(query.dtype, head_size,
-                                                 block_size,
-                                                 num_queries_per_kv,
-                                                 max_seq_len, sliding_window)
+    use_custom = use_rocm_custom_paged_attention(
+        query.dtype,
+        head_size,
+        block_size,
+        num_queries_per_kv,
+        max_seq_len,
+        sliding_window,
+    )
     if use_custom:
         _PARTITION_SIZE_ROCM = 256
-        max_num_partitions = ((max_seq_len + _PARTITION_SIZE_ROCM - 1) //
-                              _PARTITION_SIZE_ROCM)
+        max_num_partitions = (
+            max_seq_len + _PARTITION_SIZE_ROCM - 1
+        ) // _PARTITION_SIZE_ROCM
         assert _PARTITION_SIZE_ROCM % block_size == 0
         total_num_seq = query.shape[0]
         tmp_output = torch.empty(
-            size=(total_num_seq, num_query_heads, max_num_partitions,
-                  head_size),
+            size=(total_num_seq, num_query_heads, max_num_partitions, head_size),
             dtype=output.dtype,
             device=output.device,
         )
@@ -323,11 +612,15 @@ def chunked_prefill_paged_decode(
             k_scale=k_scale,
             v_scale=v_scale,
         )
-    else:
-        kernel_paged_attention_2d[(
-            num_seqs,
-            num_kv_heads,
-        )](
+    elif (
+        max_seq_len < 256
+    ):  # use 2d kernel to avoid reduction overhead for short sequences
+        kernel_paged_attention_2d[
+            (
+                num_seqs,
+                num_kv_heads,
+            )
+        ](
             output_ptr=output,
             query_ptr=query,
             key_cache_ptr=key_cache,
@@ -363,4 +656,93 @@ def chunked_prefill_paged_decode(
             stride_v_cache_3=value_cache.stride(3),
             filter_by_query_len=True,
             query_start_len_ptr=query_start_loc,
+        )
+    else:
+        # minimum and maximum number of segments to be processed in parallel
+        # in the sequence (key/value) length dimension
+        MIN_NUM_SEGMENTS = 4
+        MAX_NUM_SEGMENTS = 16
+
+        segm_output = torch.empty(
+            num_seqs,
+            num_query_heads,
+            MAX_NUM_SEGMENTS,
+            triton.next_power_of_2(head_size),
+            dtype=torch.float32,
+            device=query.device,
+        )
+        segm_max = torch.empty(
+            num_seqs,
+            num_query_heads,
+            MAX_NUM_SEGMENTS,
+            dtype=torch.float32,
+            device=query.device,
+        )
+        segm_expsum = torch.empty(
+            num_seqs,
+            num_query_heads,
+            MAX_NUM_SEGMENTS,
+            dtype=torch.float32,
+            device=query.device,
+        )
+
+        kernel_paged_attention_3d[(num_seqs, num_kv_heads, MAX_NUM_SEGMENTS)](
+            segm_output_ptr=segm_output,
+            segm_max_ptr=segm_max,
+            segm_expsum_ptr=segm_expsum,
+            query_ptr=query,
+            key_cache_ptr=key_cache,
+            value_cache_ptr=value_cache,
+            block_tables_ptr=block_table,
+            seq_lens_ptr=seq_lens,
+            alibi_slopes_ptr=alibi_slopes,
+            scale=sm_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            num_seqs=num_seqs,
+            num_query_heads=num_query_heads,
+            num_queries_per_kv=num_queries_per_kv,
+            num_queries_per_kv_padded=num_queries_per_kv_padded,
+            block_table_stride=block_table.stride(0),
+            query_stride_0=query.stride(0),
+            query_stride_1=query.stride(1),
+            BLOCK_SIZE=block_size,
+            HEAD_SIZE=head_size,
+            HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+            USE_ALIBI_SLOPES=use_alibi_slopes,
+            SLIDING_WINDOW=sliding_window,
+            x=key_cache.shape[4],
+            stride_k_cache_0=key_cache.stride(0),
+            stride_k_cache_1=key_cache.stride(1),
+            stride_k_cache_2=key_cache.stride(2),
+            stride_k_cache_3=key_cache.stride(3),
+            stride_k_cache_4=key_cache.stride(4),
+            stride_v_cache_0=value_cache.stride(0),
+            stride_v_cache_1=value_cache.stride(1),
+            stride_v_cache_2=value_cache.stride(2),
+            stride_v_cache_3=value_cache.stride(3),
+            filter_by_query_len=True,
+            query_start_len_ptr=query_start_loc,
+            MIN_NUM_SEGMENTS_PER_SEQ=MIN_NUM_SEGMENTS,
+            MAX_NUM_SEGMENTS_PER_SEQ=MAX_NUM_SEGMENTS,
+        )
+
+        reduce_segments[(num_seqs, num_query_heads)](
+            output_ptr=output,
+            segm_output_ptr=segm_output,
+            segm_max_ptr=segm_max,
+            segm_expsum_ptr=segm_expsum,
+            seq_lens_ptr=seq_lens,
+            num_seqs=num_seqs,
+            num_query_heads=num_query_heads,
+            output_stride_0=output.stride(0),
+            output_stride_1=output.stride(1),
+            block_table_stride=block_table.stride(0),
+            BLOCK_SIZE=block_size,
+            HEAD_SIZE=head_size,
+            HEAD_SIZE_PADDED=triton.next_power_of_2(head_size),
+            filter_by_query_len=True,
+            query_start_len_ptr=query_start_loc,
+            MIN_NUM_SEGMENTS_PER_SEQ=MIN_NUM_SEGMENTS,
+            MAX_NUM_SEGMENTS_PER_SEQ=MAX_NUM_SEGMENTS,
         )

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -513,6 +513,7 @@ def reduce_segments(
     tl.store(output_ptr + output_offset, acc, mask=dim_mask)
 
 
+
 def chunked_prefill_paged_decode(
     query,
     key,


### PR DESCRIPTION
In this PR we target performance improvements for the V1 `triton_attn` backend by adding a split-kv attention kernel (referred to as 3D kernel in the following) that accelerates the decoding by also parallelizing in the sequence dimension, which offers an advantage, particularly in scenarios with small batch sizes and long sequences.

## Performance
The following results were obtained for `meta-llama/Llama-3.1-8B-Instruct` on an NVIDIA H100 GPU, by running

<pre> $[VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1] VLLM_USE_V1=1 python benchmarks/benchmark_latency.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --input-len 500 --output-len &ltoutput-length&gt \
    --batch-size &ltbatch-size&gt </pre>

for
1. the V1 `FlashAttention` backend (`VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1` is not used in the above command),
2.  the current triton 2D attention kernel, and
3. the new triton 3D attention kernel (this PR).

Results for batch sizes 1 and 128 are shown in the following two graphs. The output length (in tokens) was varied in these experiments across the following values: 10, 100, 200, 400, 800, 1600, 3200, 6400, and 12800 (the latter was only evaluated for batch size 1). The number of warmup iterations and measurement iterations were left at the default values of 10 and 30 respectively.

![batch-size_1](https://github.com/user-attachments/assets/1bff8380-a4dc-4dcd-8e8e-3cd1c10decf5)

![batch-size_128](https://github.com/user-attachments/assets/8303e8a3-3039-4333-92bc-9151edfe23e5)

This PR improves the performance of the V1 `triton_attn` backend by up to a factor of 3 for batch-size 1 as compared to the current 2D-kernel based implementation, while the 3D-kernel based implementation stays also closer in performance to the V1 FlashAttention kernel, even with longer batch sizes.


Further results for `benchmark_serving.py` (which only includes sequence lengths less than 2K tokens):

V1 `FlashAttention`:
<pre> $ python benchmarks/benchmark_serving.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  20.94
Total input tokens:                      215196
Total generated tokens:                  198001
Request throughput (req/s):              47.75
Output token throughput (tok/s):         9453.78
Total Token throughput (tok/s):          19728.54
---------------Time to First Token----------------
Mean TTFT (ms):                          3386.15
Median TTFT (ms):                        3272.63
P99 TTFT (ms):                           6249.82
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          82.82
Median TPOT (ms):                        47.45
P99 TPOT (ms):                           215.18
---------------Inter-token Latency----------------
Mean ITL (ms):                           37.82
Median ITL (ms):                         26.81
P99 ITL (ms):                            218.57 
==================================================</pre>

triton 2D kernel:
<pre> $ python benchmarks/benchmark_serving.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  25.11
Total input tokens:                      215196
Total generated tokens:                  197107
Request throughput (req/s):              39.83
Output token throughput (tok/s):         7850.21
Total Token throughput (tok/s):          16420.85
---------------Time to First Token----------------
Mean TTFT (ms):                          3521.11
Median TTFT (ms):                        3456.28
P99 TTFT (ms):                           6706.20
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          91.82
Median TPOT (ms):                        53.04
P99 TPOT (ms):                           238.21
---------------Inter-token Latency----------------
Mean ITL (ms):                           43.69
Median ITL (ms):                         31.70
P99 ITL (ms):                            242.32
================================================== </pre>

triton 3D kernel (this PR):
<pre> $ python benchmarks/benchmark_serving.py \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --dataset-name sharegpt \
    --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json
============ Serving Benchmark Result ============
Successful requests:                     1000
Benchmark duration (s):                  23.44
Total input tokens:                      215196
Total generated tokens:                  197248
Request throughput (req/s):              42.67
Output token throughput (tok/s):         8416.44
Total Token throughput (tok/s):          17598.70
---------------Time to First Token----------------
Mean TTFT (ms):                          4378.49
Median TTFT (ms):                        4312.11
P99 TTFT (ms):                           7586.13
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          92.06
Median TPOT (ms):                        51.45
P99 TPOT (ms):                           266.57
---------------Inter-token Latency----------------
Mean ITL (ms):                           41.43
Median ITL (ms):                         28.86
P99 ITL (ms):                            245.03
================================================== </pre>

## Correctness

V1 `FlashAttention`:
<pre>VLLM_USE_V1=1 lm_eval --model vllm --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 500

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.788|±  |0.0183|
|     |       |strict-match    |     5|exact_match|↑  |0.766|±  |0.0190| </pre>

This PR:
<pre>VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=TRITON_ATTN_VLLM_V1 lm_eval --model vllm --model_args pretrained=meta-llama/Llama-3.1-8B-Instruct --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 500
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.798|±  |0.0180|
|     |       |strict-match    |     5|exact_match|↑  |0.778|±  |0.0186| </pre>


## How is this performance improvement achieved?

The original triton attention kernel uses a 2D grid to parallelize across batches and heads. To scale this further, we introduced a 3D grid for parallelizing over the sequence length. This is achieved by splitting the attention computation into multiple segments in the sequence dimension, and using online SoftMax to compute partial results in each segment. A reduction kernel is then used to combine the partial results, enabling correct normalization across the segment boundaries.




<!--- pyml disable-next-line no-emphasis-as-heading -->


<!--- pyml disable-next-line no-emphasis-as-heading -->
