### PR TITLE
[V1] Update default max_num_batched_tokens for V1 openai server

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1961,7 +1961,6 @@ class SchedulerConfig:
                 self.max_num_batched_tokens,
                 _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS,
             )
-
         if self.is_multimodal_model:
             # The value needs to be at least the number of multimodal tokens
             self.max_num_batched_tokens = max(

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1961,12 +1961,13 @@ class SchedulerConfig:
                     self.max_num_batched_tokens,
                     _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS,
                 )
-            if self.is_multimodal_model:
-                # The value needs to be at least the number of multimodal tokens
-                self.max_num_batched_tokens = max(
-                    self.max_num_batched_tokens,
-                    _MULTIMODAL_MODEL_MAX_NUM_BATCHED_TOKENS,
-                )
+
+        if self.is_multimodal_model:
+            # The value needs to be at least the number of multimodal tokens
+            self.max_num_batched_tokens = max(
+                self.max_num_batched_tokens,
+                _MULTIMODAL_MODEL_MAX_NUM_BATCHED_TOKENS,
+            )
 
         self.max_num_encoder_input_tokens = self.max_num_batched_tokens
         self.encoder_cache_size = self.max_num_batched_tokens

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1955,12 +1955,12 @@ class SchedulerConfig:
                 self.max_num_batched_tokens = max(
                     self.max_model_len, _DEFAULT_MAX_NUM_BATCHED_TOKENS)
 
-            if self.runner_type == "pooling":
-                # Choose specific value for higher throughput
-                self.max_num_batched_tokens = max(
-                    self.max_num_batched_tokens,
-                    _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS,
-                )
+        if self.runner_type == "pooling":
+            # Choose specific value for higher throughput
+            self.max_num_batched_tokens = max(
+                self.max_num_batched_tokens,
+                _POOLING_MODEL_MAX_NUM_BATCHED_TOKENS,
+            )
 
         if self.is_multimodal_model:
             # The value needs to be at least the number of multimodal tokens

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1684,7 +1684,6 @@ class EngineArgs:
             # This is only used to set default_max_num_batched_tokens
             device_name = "no-device"
 
-        default_max_num_batched_tokens: dict[UsageContext, Optional[int]]
         if "h100" in device_name or "h200" in device_name:
             # For H100 and H200, we use larger default values.
             default_max_num_batched_tokens = {
@@ -1696,7 +1695,7 @@ class EngineArgs:
             # TODO(woosuk): Tune the default values for other hardware.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 8192,
-                UsageContext.OPENAI_API_SERVER: None,
+                UsageContext.OPENAI_API_SERVER: 2048,
             }
             default_max_num_seqs = 256
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1684,6 +1684,7 @@ class EngineArgs:
             # This is only used to set default_max_num_batched_tokens
             device_name = "no-device"
 
+        default_max_num_batched_tokens: dict[UsageContext, Optional[int]]
         if "h100" in device_name or "h200" in device_name:
             # For H100 and H200, we use larger default values.
             default_max_num_batched_tokens = {
@@ -1695,7 +1696,7 @@ class EngineArgs:
             # TODO(woosuk): Tune the default values for other hardware.
             default_max_num_batched_tokens = {
                 UsageContext.LLM_CLASS: 8192,
-                UsageContext.OPENAI_API_SERVER: 2048,
+                UsageContext.OPENAI_API_SERVER: None,
             }
             default_max_num_seqs = 256
 


### PR DESCRIPTION
- The default `max_num_batched_tokens` for `OPENAI_API_SERVER` in v1 is always set to 2048 even if for multimodal models on non H100/H200 devices, causing `mm_embeds` for large images isn't scheduled properly in some cases.
- This PR updates the `max_num_batched_tokens` to None for default behavior so that it can be updated to 5120 in `SchedulerConfig`'s `__post_init__` method for multimodal models.

<!--- pyml disable-next-line no-emphasis-as-heading -->
