### PR TITLE
[BugFix] Accuracy fix for llama4 int4 - improperly casted scales

### DIFF
--- a/csrc/moe/moe_wna16.cu
+++ b/csrc/moe/moe_wna16.cu
@@ -16,7 +16,7 @@ __global__ void moe_wna16_gemm_kernel(
     const uint32_t* __restrict__ qweight, const scalar_t* __restrict__ scales,
     const uint32_t* __restrict__ qzeros,
 
-    const scalar_t* __restrict__ topk_weights,
+    const float* __restrict__ topk_weights,
     const int32_t* __restrict__ sorted_token_ids,
     const int32_t* __restrict__ expert_ids,
     const int32_t* __restrict__ num_tokens_post_pad,
@@ -211,7 +211,7 @@ __global__ void moe_wna16_gemm_kernel(
       const int32_t token_index =
           sorted_token_ids[blockIdx.x * BLOCK_SIZE_M + m];
       if (mul_topk_weight) {
-        res[m] *= Dtype::num2float(topk_weights[token_index]);
+        res[m] *= topk_weights[token_index];
       }
       atomicAdd(&output[token_index * size_n + offset_n],
                 Dtype::float2num(res[m]));
@@ -225,7 +225,7 @@ __global__ void moe_wna16_gemm_kernel(
 template <typename scalar_t>
 void run_moe_wna16_gemm(const scalar_t* input, scalar_t* output,
                         const uint32_t* b_qweight, const scalar_t* b_scales,
-                        const uint32_t* b_qzeros, const scalar_t* topk_weights,
+                        const uint32_t* b_qzeros, const float* topk_weights,
                         const int32_t* sorted_token_ids,
                         const int32_t* expert_ids,
                         const int32_t* num_tokens_post_pad, int num_experts,
@@ -298,9 +298,9 @@ torch::Tensor moe_wna16_gemm(torch::Tensor input, torch::Tensor output,
   const uint32_t* b_qzeros_ptr;
   if (b_qzeros.has_value())
     b_qzeros_ptr = (const uint32_t*)b_qzeros.value().data_ptr<uint8_t>();
-  const float* topk_weights_ptr;
+  const float* topk_weights_ptr = nullptr;
   if (topk_weights.has_value())
-    topk_weights_ptr = (const float*)topk_weights.value().data_ptr();
+    topk_weights_ptr = (const float*)topk_weights.value().data_ptr<float>();
 
   int groups_per_block_row = BLOCK_SIZE_K / group_size;
   TORCH_CHECK(bit == 4 || bit == 8, "bit must be 4 or 8");
@@ -314,36 +314,27 @@ torch::Tensor moe_wna16_gemm(torch::Tensor input, torch::Tensor output,
               "BLOCK_SIZE_K // group_size must be one of [1, 2, 4, 8]");
 
   if (input.scalar_type() == at::ScalarType::Half) {
-    const at::Half* topk_weights_ptr = nullptr;
-    if (topk_weights.has_value())
-      topk_weights_ptr = topk_weights.value().data_ptr<at::Half>();
-
     run_moe_wna16_gemm<half>(
         (const half*)input.data_ptr<at::Half>(),
         (half*)output.data_ptr<at::Half>(),
         (const uint32_t*)b_qweight.data_ptr<uint8_t>(),
         (const half*)b_scales.data_ptr<at::Half>(), b_qzeros_ptr,
-        (const half*)topk_weights_ptr, sorted_token_ids.data_ptr<int32_t>(),
+        topk_weights_ptr, sorted_token_ids.data_ptr<int32_t>(),
         expert_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
         num_experts, group_size, num_token_blocks, top_k, size_m, size_n,
         size_k, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, bit,
         b_qzeros.has_value(), topk_weights.has_value());
   } else if (input.scalar_type() == at::ScalarType::BFloat16) {
-    const at::BFloat16* topk_weights_ptr = nullptr;
-    if (topk_weights.has_value())
-      topk_weights_ptr = topk_weights.value().data_ptr<at::BFloat16>();
-
     run_moe_wna16_gemm<nv_bfloat16>(
         (const nv_bfloat16*)input.data_ptr<at::BFloat16>(),
         (nv_bfloat16*)output.data_ptr<at::BFloat16>(),
         (const uint32_t*)b_qweight.data_ptr<uint8_t>(),
         (const nv_bfloat16*)b_scales.data_ptr<at::BFloat16>(), b_qzeros_ptr,
-        (const nv_bfloat16*)topk_weights_ptr,
-        sorted_token_ids.data_ptr<int32_t>(), expert_ids.data_ptr<int32_t>(),
-        num_tokens_post_pad.data_ptr<int32_t>(), num_experts, group_size,
-        num_token_blocks, top_k, size_m, size_n, size_k, BLOCK_SIZE_M,
-        BLOCK_SIZE_N, BLOCK_SIZE_K, bit, b_qzeros.has_value(),
-        topk_weights.has_value());
+        topk_weights_ptr, sorted_token_ids.data_ptr<int32_t>(),
+        expert_ids.data_ptr<int32_t>(), num_tokens_post_pad.data_ptr<int32_t>(),
+        num_experts, group_size, num_token_blocks, top_k, size_m, size_n,
+        size_k, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, bit,
+        b_qzeros.has_value(), topk_weights.has_value());
   } else {
     TORCH_CHECK(false, "moe_wna16_gemm only supports bfloat16 and float16");
   }

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -422,6 +422,7 @@ class FusedMoE(torch.nn.Module):
 
         if params_dtype is None:
             params_dtype = torch.get_default_dtype()
+        self.params_dtype = params_dtype
 
         # Note: here we guard against accessing the TP and DP groups when
         # uninitialized (this happens when testing)

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -51,8 +51,8 @@ class Llama4MoE(nn.Module):
         renormalize: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         router_scores, router_indices = fast_topk(gating_output, topk, dim=-1)
-        router_scores = torch.sigmoid(router_scores.float()).to(
-            hidden_states.dtype)
+        # psuedo-standard is that the router scores are floats
+        router_scores = torch.sigmoid(router_scores.float())
         return (router_scores, router_indices.to(torch.int32))
 
     def __init__(self,


### PR DESCRIPTION
A few MoE fixes:
1) Scales where fp16/bf16 but were being casted to float unsafely. Add a check by using `.data_ptr<float>()`
2) Fix `AttributeError: 'FusedMoE' object has no attribute 'params_dtype'`
3) Make sure Llama4 returns float router weights to ensure compatibility with kernels (namely `moe_wna16_gemm `)