### PR TITLE
[BugFix][V1] Fix int32 token index overflow when preparing input ids

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -245,7 +245,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                                        self.max_model_len,
                                        self.max_num_tokens),
                                    dtype=np.int32)
-
         # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
         # a faster version of creating a new tensor every time. Thus, we should
         # not make any assumptions about the values in these tensors.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -241,6 +241,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
+        # Keep in int64 to avoid overflow with long context
         self.arange_np = np.arange(max(self.max_num_reqs + 1,
                                        self.max_model_len,
                                        self.max_num_tokens),
@@ -521,7 +522,6 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        # For long context, may need to cast to int64 to avoid overflow
         token_indices = (positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -241,17 +241,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
-
-        # For long context, we may need to store using int64 so max token idx doesn't overflow 
-        # token_indices is calculated by adding (req_idx * max_model_len) to per-request token indices 
-        # e.g. [0, 1, 0, 1, 2, 3, 4, 0, 1, 2] 
+        # For long context, may need to store int64 so max idx doesn't overflow
+        # token_indices are calculated by adding (req_idx * max_model_len)
+        # to per-request indices e.g. [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        max_token_idx = self.max_num_tokens + self.max_num_reqs * self.max_model_len
+        max_token_idx = self.max_num_tokens + self.max_num_reqs * \
+                        self.max_model_len
         self.arange_np = np.arange(max(self.max_num_reqs + 1,
                                        self.max_model_len,
                                        self.max_num_tokens),
-                                   dtype=np.int32 if max_token_idx <= np.iinfo(np.int32).max else np.int64)
+                                   dtype=np.int32 if max_token_idx <= np.iinfo(
+                                       np.int32).max else np.int64)
 
         # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
         # a faster version of creating a new tensor every time. Thus, we should

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -241,10 +241,18 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
+
+        # For long context, we may need to store using int64 so max token idx doesn't overflow 
+        # token_indices calculated as such:
+        # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
+        # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
+        # where M is the max_model_len.
+        max_token_idx = (self.max_num_tokens + (self.max_num_reqs + 1) * self.max_model_len) 
         self.arange_np = np.arange(max(self.max_num_reqs + 1,
                                        self.max_model_len,
                                        self.max_num_tokens),
-                                   dtype=np.int32)
+                                   dtype=np.int32 if max_token_idx <= np.iinfo(np.int32).max else np.int64)
+
         # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
         # a faster version of creating a new tensor every time. Thus, we should
         # not make any assumptions about the values in these tensors.
@@ -527,6 +535,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         # NOTE(woosuk): We use torch.index_select instead of np.take here
         # because torch.index_select is much faster than np.take for large
         # tensors.
+
         torch.index_select(self.input_batch.token_ids_cpu_tensor.flatten(),
                            0,
                            torch.from_numpy(token_indices),

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -216,6 +216,7 @@ class TPUModelRunner:
 
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
+        # Keep in int64 to avoid overflow with long context
         self.arange_np = np.arange(self.max_num_tokens, dtype=np.int64)
         self.num_reqs_paddings = _get_req_paddings(
             min_req_size=MIN_NUM_SEQS, max_req_size=self.max_num_reqs)
@@ -457,7 +458,6 @@ class TPUModelRunner:
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        # For long context, may need to cast to int64 to avoid overflow
         token_indices = (positions_np +
                          req_indices * self.input_batch.token_ids_cpu.shape[1])
 

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -216,14 +216,9 @@ class TPUModelRunner:
 
         # Range tensor with values [0 .. self.max_num_tokens - 1].
         # Used to initialize positions / context_lens / seq_lens
-        self.arange_np = np.arange(self.max_num_tokens, dtype=np.int32)
+        self.arange_np = np.arange(self.max_num_tokens, dtype=np.int64)
         self.num_reqs_paddings = _get_req_paddings(
             min_req_size=MIN_NUM_SEQS, max_req_size=self.max_num_reqs)
-        
-        max_token_idx = self.max_num_reqs * self.max_model_len - 1
-        # if max token idx exceeds int32 max, use int64 to avoid overflow
-        self.token_indices_dtype = np.int32 \
-            if max_token_idx <= np.iinfo(np.int32).max else np.int64
 
     def _update_num_xla_graphs(self, case_str):
         check_comp = self.check_recompilation and not self.enforce_eager
@@ -464,8 +459,7 @@ class TPUModelRunner:
         # where M is the max_model_len.
         # For long context, may need to cast to int64 to avoid overflow
         token_indices = (positions_np +
-                         req_indices.astype(self.token_indices_dtype) * 
-                         self.input_batch.token_ids_cpu.shape[1])
+                         req_indices * self.input_batch.token_ids_cpu.shape[1])
 
         # NOTE(woosuk): We use torch.index_select instead of np.take here
         # because torch.index_select is much faster than np.take for large


### PR DESCRIPTION
Fixes #16414

The issue can be reproduced when setting `max-model-len` to a large value (e.g. 3600000) and sending requests without limiting the max number of requests (e.g. not restricting `--max-num-seqs`, sending requests without `--max-concurrency`) and/or not limiting max. number of tokens to be processed in a single iteration (`--max-num-batched-tokens`).

The error is `IndexError: index out of range in self` which happens in `_prepare_inputs`:
```
        torch.index_select(self.input_batch.token_ids_cpu_tensor.flatten(),
                           0,
                           torch.from_numpy(token_indices),
                           out=self.input_ids_cpu[:total_num_scheduled_tokens])
```

When it fails, the last several items of `token_indices` contains indices that are negative, due to int32 overflow. `token_indices` is given by:

```
        token_indices = (positions_np +
                         req_indices * self.input_batch.token_ids_cpu.shape[1])
``` 

Here, `req_indices` is a `np.int32` array, e.g. `np.array([0,1,2,...598])`, and `self.input_batch.token_ids_cpu.shape[1]` is the max model len, e.g. `3,600,000`. As an example, multiplying 598 * 3,600,000 gives us 2,152,800,000 which is greater `np.int32` max value of 2,147,483,647 so it overflows and gives us a negative number for token index.

To avoid overflow, we can cast to int64 before the multiplication. the max token index can be given by `max_req_index * max_model_len - 1`. 

To verify, I checked that below completes successfully on H200 (previously it would fail with index error after ~1000 requests). Without this fix, the max no. of concurrent requests we can serve with 3.6M context length would be 596. 
```
VLLM_DISABLE_COMPILE_CACHE=1 vllm serve meta-llama/Llama-4-Scout-17B-16E-Instruct --disable-log-requests --gpu-memory-utilization=0.95 --max-model-len=3600000 -tp 8

python3 benchmarks/benchmark_serving.py --port=8000 --dataset-name=sharegpt --dataset-path=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-4-Scout-17B-16E-Instruct --request-rate=64 --backend=vllm --num-prompts=19200 --model=meta-llama/Llama-4-Scout-17B-16E-Instruct --sharegpt-output-len=1024
```
