### PR TITLE
[V1] Avoid socket errors during shutdown when requests are in in-flight

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -384,7 +384,7 @@ class EngineCoreProc(EngineCore):
 
         except SystemExit:
             logger.debug("EngineCore exiting.")
-
+            raise
         except Exception as e:
             if engine_core is None:
                 logger.exception("EngineCore failed to start.")

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -312,6 +312,7 @@ class BackgroundResources:
     def __call__(self):
         """Clean up background resources."""
 
+        self.engine_dead = True
         for core_engine in self.core_engines:
             core_engine.close()
 
@@ -564,7 +565,7 @@ class SyncMPClient(MPClient):
         self._send_input(EngineCoreRequestType.ADD, request)
 
     def abort_requests(self, request_ids: list[str]) -> None:
-        if len(request_ids) > 0:
+        if request_ids and not self.resources.engine_dead:
             self._send_input(EngineCoreRequestType.ABORT, request_ids)
 
     def profile(self, is_start: bool = True) -> None:
@@ -735,7 +736,7 @@ class AsyncMPClient(MPClient):
         self._ensure_output_queue_task()
 
     async def abort_requests_async(self, request_ids: list[str]) -> None:
-        if len(request_ids) > 0:
+        if request_ids and not self.resources.engine_dead:
             await self._send_input(EngineCoreRequestType.ABORT, request_ids)
 
     async def profile_async(self, is_start: bool = True) -> None:
@@ -895,5 +896,6 @@ class DPAsyncMPClient(AsyncMPClient):
 
     async def _abort_requests(self, request_ids: list[str],
                               engine: CoreEngine) -> None:
-        await self._send_input(EngineCoreRequestType.ABORT, request_ids,
-                               engine)
+        if not self.resources.engine_dead:
+            await self._send_input(EngineCoreRequestType.ABORT, request_ids,
+                                   engine)


### PR DESCRIPTION
Currently if there are requests in flight when the API server is shutdown via a SIGINT, there can be exception stacktraces in the log because there's an attempt to send an abort to the engine for the cancelled request using a socket that's already closed. We should ignore aborts when the engine is already dead / shutting down.

```
[2025-04-18 00:06:57] ERROR runners.py:118: Task exception was never retrieved
future: <Task finished name='Task-10' coro=<create_chat_completion() done, defined at /workspace/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/utils.py:75> exception=ZMQError('Socket operation on non-socket')>
Traceback (most recent call last):
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 296, in generate
    out = q.get_nowait() or await q.get()
                            ^^^^^^^^^^^^^
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/v1/engine/output_processor.py", line 50, in get
    await self.ready.wait()
  File "/usr/lib64/python3.12/asyncio/locks.py", line 212, in wait
    await fut
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/utils.py", line 85, in wrapper
    return await func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/openai/api_server.py", line 477, in create_chat_completion
    generator = await handler.create_chat_completion(request, raw_request)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py", line 267, in create_chat_completion
    return await self.chat_completion_full_generator(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/entrypoints/openai/serving_chat.py", line 906, in chat_completion_full_generator
    async for res in result_generator:
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 306, in generate
    await self.abort(request_id)
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/v1/engine/async_llm.py", line 398, in abort
    await self.engine_core.abort_requests_async(request_ids)
  File "/workspace/my-vllm/lib64/python3.12/site-packages/vllm/v1/engine/core_client.py", line 739, in abort_requests_async
    await self._send_input(EngineCoreRequestType.ABORT, request_ids)
  File "/workspace/my-vllm/lib64/python3.12/site-packages/zmq/_future.py", line 552, in _add_send_event
    r = send(msg, **nowait_kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/my-vllm/lib64/python3.12/site-packages/zmq/sugar/socket.py", line 752, in send_multipart
    self.send(msg, zmq.SNDMORE | flags, copy=copy, track=track)
  File "/workspace/my-vllm/lib64/python3.12/site-packages/zmq/sugar/socket.py", line 701, in send
    return super().send(data, flags=flags, copy=copy, track=track)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "_zmq.py", line 1092, in zmq.backend.cython._zmq.Socket.send
  File "_zmq.py", line 1151, in zmq.backend.cython._zmq.Socket.send
  File "_zmq.py", line 1344, in zmq.backend.cython._zmq._send_copy
  File "_zmq.py", line 1339, in zmq.backend.cython._zmq._send_copy
  File "_zmq.py", line 179, in zmq.backend.cython._zmq._check_rc
zmq.error.ZMQError: Socket operation on non-socket
```
