### PR TITLE
[CORE] Eliminate Occasional Scheduling Delay for Parallel Sampling

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -153,8 +153,9 @@ class EngineCoreRequestType(enum.Enum):
     without separate encoding step.
     """
     ADD = b'\x00'
-    ABORT = b'\x01'
-    START_DP = b'\x02'
-    UTILITY = b'\x03'
+    ADD_BATCHED = b'\x01'
+    ABORT = b'\x02'
+    START_DP = b'\x03'
+    UTILITY = b'\x04'
     # Sentinel used within EngineCoreProc.
-    EXECUTOR_FAILED = b'\x04'
+    EXECUTOR_FAILED = b'\x05'

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -153,9 +153,8 @@ class EngineCoreRequestType(enum.Enum):
     without separate encoding step.
     """
     ADD = b'\x00'
-    ADD_BATCHED = b'\x01'
-    ABORT = b'\x02'
-    START_DP = b'\x03'
-    UTILITY = b'\x04'
+    ABORT = b'\x01'
+    START_DP = b'\x02'
+    UTILITY = b'\x03'
     # Sentinel used within EngineCoreProc.
-    EXECUTOR_FAILED = b'\x05'
+    EXECUTOR_FAILED = b'\x04'

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -217,14 +217,14 @@ class AsyncLLM(EngineClient):
 
         # Fan out child requests (for n>1).
         parent_request = ParentRequest(request_id, params)
-        child_reqs = []
+        child_requests = []
         for idx in range(params.n):
             cid, cparams = parent_request.get_child_info(idx)
             child = request if idx == params.n - 1 else copy(request)
             child.request_id, child.sampling_params = cid, cparams
-            child_reqs.append(child)
+            child_requests.append(child)
 
-        await self._enqueue_requests(child_reqs, parent_request, queue)
+        await self._enqueue_requests(child_requests, parent_request, queue)
         return queue
 
     async def _enqueue_requests(

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -219,10 +219,10 @@ class AsyncLLM(EngineClient):
         parent_request = ParentRequest(request_id, params)
         child_requests = []
         for idx in range(params.n):
-            cid, cparams = parent_request.get_child_info(idx)
+            request_id, params = parent_request.get_child_info(idx)
             child_request = request if idx == params.n - 1 else copy(request)
-            child_request.request_id = cid
-            child_request.sampling_params = cparams
+            child_request.request_id = request_id
+            child_request.sampling_params = params
             child_requests.append(child_request)
 
         await self._enqueue_requests(child_requests, parent_request, queue)

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -220,9 +220,10 @@ class AsyncLLM(EngineClient):
         child_requests = []
         for idx in range(params.n):
             cid, cparams = parent_request.get_child_info(idx)
-            child = request if idx == params.n - 1 else copy(request)
-            child.request_id, child.sampling_params = cid, cparams
-            child_requests.append(child)
+            child_request = request if idx == params.n - 1 else copy(request)
+            child_request.request_id = cid
+            child_request.sampling_params = cparams
+            child_requests.append(child_request)
 
         await self._enqueue_requests(child_requests, parent_request, queue)
         return queue

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -159,11 +159,8 @@ class EngineCore:
                      "warmup model) took %.2f seconds"), elapsed)
         return num_gpu_blocks, num_cpu_blocks, scheduler_kv_cache_config
 
-    def add_request(self, request: Union[EngineCoreRequest,
-                                         list[EngineCoreRequest]]):
+    def add_requests(self, requests: list[EngineCoreRequest]):
         """Add requests to the scheduler."""
-        requests = request if isinstance(request, list) else [request]
-
         for request in requests:
             if request.mm_hashes is not None:
                 # Here, if hash exists for a multimodal input, then it will be
@@ -447,7 +444,7 @@ class EngineCoreProc(EngineCore):
         """Dispatch request from client."""
 
         if request_type == EngineCoreRequestType.ADD:
-            self.add_request(request)
+            self.add_requests(request)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
         elif request_type == EngineCoreRequestType.START_DP:
@@ -503,8 +500,7 @@ class EngineCoreProc(EngineCore):
         """Input socket IO thread."""
 
         # Msgpack serialization decoding.
-        add_request_decoder = MsgpackDecoder(Union[EngineCoreRequest,
-                                                   list[EngineCoreRequest]])
+        add_request_decoder = MsgpackDecoder(list[EngineCoreRequest])
         generic_decoder = MsgpackDecoder()
         identity = engine_index.to_bytes(length=2, byteorder="little")
 

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -82,6 +82,9 @@ class EngineCoreClient(ABC):
     def add_request(self, request: EngineCoreRequest) -> None:
         raise NotImplementedError
 
+    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
+        raise NotImplementedError
+
     def profile(self, is_start: bool = True) -> None:
         raise NotImplementedError
 
@@ -135,6 +138,10 @@ class EngineCoreClient(ABC):
         raise NotImplementedError
 
     async def add_request_async(self, request: EngineCoreRequest) -> None:
+        raise NotImplementedError
+
+    async def add_request_batched_async(
+            self, requests: list[EngineCoreRequest]) -> None:
         raise NotImplementedError
 
     async def profile_async(self, is_start: bool = True) -> None:
@@ -200,6 +207,10 @@ class InprocClient(EngineCoreClient):
 
     def add_request(self, request: EngineCoreRequest) -> None:
         self.engine_core.add_request(request)
+
+    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
+        for req in requests:
+            self.engine_core.add_request(req)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
@@ -563,6 +574,12 @@ class SyncMPClient(MPClient):
         request.prompt = None
         self._send_input(EngineCoreRequestType.ADD, request)
 
+    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
+        # NOTE: see add_request() above.
+        for request in requests:
+            request.prompt = None
+        self._send_input(EngineCoreRequestType.ADD_BATCHED, requests)
+
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
             self._send_input(EngineCoreRequestType.ABORT, request_ids)
@@ -732,6 +749,14 @@ class AsyncMPClient(MPClient):
         # tokenized.
         request.prompt = None
         await self._send_input(EngineCoreRequestType.ADD, request)
+        self._ensure_output_queue_task()
+
+    async def add_request_batched_async(
+            self, requests: list[EngineCoreRequest]) -> None:
+        # NOTE: see add_request_async() above.
+        for request in requests:
+            request.prompt = None
+        await self._send_input(EngineCoreRequestType.ADD_BATCHED, requests)
         self._ensure_output_queue_task()
 
     async def abort_requests_async(self, request_ids: list[str]) -> None:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -79,10 +79,9 @@ class EngineCoreClient(ABC):
     def get_output(self) -> EngineCoreOutputs:
         raise NotImplementedError
 
-    def add_request(self, request: EngineCoreRequest) -> None:
-        raise NotImplementedError
-
-    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
+    def add_request(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
         raise NotImplementedError
 
     def profile(self, is_start: bool = True) -> None:
@@ -137,11 +136,9 @@ class EngineCoreClient(ABC):
     async def get_output_async(self) -> EngineCoreOutputs:
         raise NotImplementedError
 
-    async def add_request_async(self, request: EngineCoreRequest) -> None:
-        raise NotImplementedError
-
-    async def add_request_batched_async(
-            self, requests: list[EngineCoreRequest]) -> None:
+    async def add_request_async(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
         raise NotImplementedError
 
     async def profile_async(self, is_start: bool = True) -> None:
@@ -205,12 +202,12 @@ class InprocClient(EngineCoreClient):
     def get_output(self) -> EngineCoreOutputs:
         return self.engine_core.step()
 
-    def add_request(self, request: EngineCoreRequest) -> None:
-        self.engine_core.add_request(request)
-
-    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
-        for req in requests:
-            self.engine_core.add_request(req)
+    def add_request(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
+        requests = request if isinstance(request, list) else [request]
+        for request in requests:
+            self.engine_core.add_request(request)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
@@ -568,17 +565,15 @@ class SyncMPClient(MPClient):
 
         return future.result()
 
-    def add_request(self, request: EngineCoreRequest) -> None:
+    def add_request(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
         # NOTE: text prompt is not needed in the core engine as it has been
         # tokenized.
-        request.prompt = None
-        self._send_input(EngineCoreRequestType.ADD, request)
-
-    def add_request_batched(self, requests: list[EngineCoreRequest]) -> None:
-        # NOTE: see add_request() above.
+        requests = request if isinstance(request, list) else [request]
         for request in requests:
             request.prompt = None
-        self._send_input(EngineCoreRequestType.ADD_BATCHED, requests)
+        self._send_input(EngineCoreRequestType.ADD, requests)
 
     def abort_requests(self, request_ids: list[str]) -> None:
         if len(request_ids) > 0:
@@ -744,19 +739,15 @@ class AsyncMPClient(MPClient):
         self._ensure_output_queue_task()
         return await future
 
-    async def add_request_async(self, request: EngineCoreRequest) -> None:
+    async def add_request_async(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
         # NOTE: text prompt is not needed in the core engine as it has been
         # tokenized.
-        request.prompt = None
-        await self._send_input(EngineCoreRequestType.ADD, request)
-        self._ensure_output_queue_task()
-
-    async def add_request_batched_async(
-            self, requests: list[EngineCoreRequest]) -> None:
-        # NOTE: see add_request_async() above.
-        for request in requests:
-            request.prompt = None
-        await self._send_input(EngineCoreRequestType.ADD_BATCHED, requests)
+        requests = request if isinstance(request, list) else [request]
+        for req in requests:
+            req.prompt = None
+        await self._send_input(EngineCoreRequestType.ADD, requests)
         self._ensure_output_queue_task()
 
     async def abort_requests_async(self, request_ids: list[str]) -> None:
@@ -850,12 +841,16 @@ class DPAsyncMPClient(AsyncMPClient):
             for engine in self.core_engines
         ]))[0]
 
-    async def add_request_async(self, request: EngineCoreRequest) -> None:
+    async def add_request_async(
+            self, request: Union[EngineCoreRequest,
+                                 list[EngineCoreRequest]]) -> None:
         # NOTE: text prompt is not needed in the core engine as it has been
         # tokenized.
-        request.prompt = None
+        requests = request if isinstance(request, list) else [request]
+        for request in requests:
+            request.prompt = None
 
-        msg = (EngineCoreRequestType.ADD.value, *self.encoder.encode(request))
+        msg = (EngineCoreRequestType.ADD.value, *self.encoder.encode(requests))
 
         chosen_engine = self.get_core_engine_for_request()
         self.reqs_in_flight[request.request_id] = chosen_engine

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -203,12 +203,13 @@ class LLMEngine:
         child_requests = []
         for idx in range(n):
             request_id, params = parent_req.get_child_info(idx)
-            child = request if idx == n - 1 else copy(request)
-            child.request_id, child.sampling_params = request_id, params
-            child_requests.append(child)
+            child_request = request if idx == n - 1 else copy(request)
+            child_request.request_id = request_id
+            child_request.sampling_params = params
+            child_requests.append(child_request)
 
             # Make a new RequestState and queue.
-            self.output_processor.add_request(child, parent_req, idx)
+            self.output_processor.add_request(child_request, parent_req, idx)
 
         # Add the batch of child requests to EngineCore.
         self.engine_core.add_request_batched(child_requests)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -200,19 +200,18 @@ class LLMEngine:
 
         # Fan out child requests (for n>1).
         parent_req = ParentRequest(request_id, params)
-        child_reqs = []
+        child_requests = []
         for idx in range(n):
             request_id, params = parent_req.get_child_info(idx)
-            child_req = request if idx == n - 1 else copy(request)
-            child_req.request_id = request_id
-            child_req.sampling_params = params
+            child = request if idx == n - 1 else copy(request)
+            child.request_id, child.sampling_params = request_id, params
+            child_requests.append(child)
 
             # Make a new RequestState and queue.
-            self.output_processor.add_request(child_req, parent_req, idx)
-            child_reqs.append(child_req)
+            self.output_processor.add_request(child, parent_req, idx)
 
         # Add the batch of child requests to EngineCore.
-        self.engine_core.add_request_batched(child_reqs)
+        self.engine_core.add_request_batched(child_requests)
 
     def step(self) -> list[RequestOutput]:
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -195,7 +195,7 @@ class LLMEngine:
             # Make a new RequestState and queue.
             self.output_processor.add_request(request, None, 0)
             # Add the request to EngineCore.
-            self.engine_core.add_request(request)
+            self.engine_core.add_requests([request])
             return
 
         # Fan out child requests (for n>1).
@@ -212,7 +212,7 @@ class LLMEngine:
             self.output_processor.add_request(child_request, parent_req, idx)
 
         # Add the batch of child requests to EngineCore.
-        self.engine_core.add_request(child_requests)
+        self.engine_core.add_requests(child_requests)
 
     def step(self) -> list[RequestOutput]:
 

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -212,7 +212,7 @@ class LLMEngine:
             self.output_processor.add_request(child_request, parent_req, idx)
 
         # Add the batch of child requests to EngineCore.
-        self.engine_core.add_request_batched(child_requests)
+        self.engine_core.add_request(child_requests)
 
     def step(self) -> list[RequestOutput]:
 


### PR DESCRIPTION
FIX #[16373](https://github.com/vllm-project/vllm/issues/16373): Eliminate Scheduling Lag in Parallel Sampling

# Summary
This PR reduces scheduling latency when using n > 1 for parallel sampling in AsyncLLM.

# Problem
Previously, each of the n child requests was sent individually to EngineCore via add_request_async. This caused:
- The first request to be scheduled immediately (if the engine was idle)
- Subsequent requests to be picked up in the next scheduling cycle

This resulted in a consistent one-cycle scheduling delay for all but the first request. This latency gap is most prominent in low to medium throughput scenarios, particularly when batch sizes are 1, where the engine is idle and able to schedule immediately.

# Solution
This PR introduces batched_add_request, which sends all n requests in a single ZMQ message. This enables EngineCore to prefill and schedule all parallel samples at once, eliminating the latency introduced by staggered request submission.

# Result
All parallel samples now begin decoding simultaneously, improving latency consistency and overall responsiveness for parallel sampling workloads.

TODO: Add benchmark latencies
