### PR TITLE
[Model][Frontend] Adding timeseries modality support and Qwen2.5-ChatTS model support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -693,6 +693,7 @@ setup(
         "fastsafetensors": ["fastsafetensors >= 0.1.10"],
         "runai": ["runai-model-streamer", "runai-model-streamer-s3", "boto3"],
         "audio": ["librosa", "soundfile"],  # Required for audio processing
+        "timeseries": ["pyarrow", "pandas"],  # For time series processing
         "video": []  # Kept for backwards compatibility
     },
     cmdclass=cmdclass,

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -20,7 +20,8 @@ from vllm.transformers_utils.tokenizer import (AnyTokenizer, MistralTokenizer,
                                                cached_tokenizer_from_config,
                                                encode_tokens)
 
-from ....multimodal.utils import random_audio, random_image, random_video
+from ....multimodal.utils import (random_audio, random_image,
+                                  random_timeseries, random_video)
 from ...registry import HF_EXAMPLE_MODELS
 
 
@@ -75,6 +76,7 @@ def _test_processing_correctness(
         "image": Image.new("RGB", size=(128, 128)),
         "video": np.zeros((4, 128, 128, 3), dtype=np.uint8),
         "audio": (np.zeros((512, )), 16000),
+        "timeseries": np.zeros(256),
     }
     input_factory = {
         "image":
@@ -88,6 +90,8 @@ def _test_processing_correctness(
                 max_wh=256),
         "audio":
         partial(random_audio, rng, min_len=512, max_len=1024, sr=16000),
+        "timeseries":
+        partial(random_timeseries, rng, min_len=10, max_len=100),
     }
 
     for batch_idx in range(num_batches):
@@ -240,6 +244,7 @@ def _test_processing_correctness_one(
     "CohereForAI/aya-vision-8b",
     "Salesforce/blip2-opt-2.7b",
     "facebook/chameleon-7b",
+    "bytedance-research/ChatTS-14B",
     "deepseek-ai/deepseek-vl2-tiny",
     "microsoft/Florence-2-base",
     "adept/fuyu-8b",

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -382,6 +382,8 @@ _MULTIMODAL_EXAMPLE_MODELS = {
                                                       trust_remote_code=True,
                                                       hf_overrides={"architectures": ["QwenVLForConditionalGeneration"]}),  # noqa: E501
     "Qwen2AudioForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2-Audio-7B-Instruct"),  # noqa: E501
+    "Qwen2TSForCausalLM": _HfExamplesInfo("bytedance-research/ChatTS-14B",
+                                          trust_remote_code=True),
     "Qwen2VLForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2-VL-2B-Instruct"),  # noqa: E501
     "Qwen2_5_VLForConditionalGeneration": _HfExamplesInfo("Qwen/Qwen2.5-VL-3B-Instruct"),  # noqa: E501
     "Qwen2_5OmniModel": _HfExamplesInfo("Qwen/Qwen2.5-Omni-3B"),

--- a/tests/multimodal/utils.py
+++ b/tests/multimodal/utils.py
@@ -31,3 +31,12 @@ def random_audio(
 ):
     audio_len = rng.randint(min_len, max_len)
     return rng.rand(audio_len), sr
+
+
+def random_timeseries(
+    rng: np.random.RandomState,
+    min_len: int,
+    max_len: int,
+):
+    length = rng.randint(min_len, max_len)
+    return rng.rand(length)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -123,6 +123,35 @@ class CustomChatCompletionContentSimpleVideoParam(TypedDict, total=False):
     video_url: Required[str]
 
 
+TimeSeriesDataType: TypeAlias = Union[str, list[list[float]], list[float]]
+
+
+class TimeSeriesData(TypedDict, total=False):
+    data: Required[TimeSeriesDataType]
+    """
+    The time series data, which can be:
+    - A URL pointing to CSV, Parquet, or Arrow File data
+    - A data URI with base64 encoded data
+    - A simple array (list) for univariate time series
+    """
+
+
+class ChatCompletionContentPartTimeSeriesParam(TypedDict, total=False):
+    timeseries: Required[TimeSeriesData]
+    type: Required[Literal["timeseries"]]
+    """The type of the content part."""
+
+
+class CustomChatCompletionContentSimpleTimeSeriesParam(TypedDict, total=False):
+    """A simpler version of the param that accepts time series data directly.
+    Example:
+    {
+        "timeseries": [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    }
+    """
+    timeseries: Required[TimeSeriesDataType]
+
+
 ChatCompletionContentPartParam: TypeAlias = Union[
     OpenAIChatCompletionContentPartParam, ChatCompletionContentPartAudioParam,
     ChatCompletionContentPartInputAudioParam,
@@ -130,7 +159,9 @@ ChatCompletionContentPartParam: TypeAlias = Union[
     CustomChatCompletionContentSimpleImageParam,
     ChatCompletionContentPartImageEmbedsParam,
     CustomChatCompletionContentSimpleAudioParam,
-    CustomChatCompletionContentSimpleVideoParam, str]
+    CustomChatCompletionContentSimpleVideoParam,
+    ChatCompletionContentPartTimeSeriesParam,
+    CustomChatCompletionContentSimpleTimeSeriesParam, str]
 
 
 class CustomChatCompletionMessageParam(TypedDict, total=False):
@@ -465,7 +496,7 @@ def resolve_chat_template_content_format(
 
 
 
-ModalityStr = Literal["image", "audio", "video", "image_embeds"]
+ModalityStr = Literal["image", "audio", "video", "image_embeds", "timeseries"]
 _T = TypeVar("_T")
 
 
@@ -569,6 +600,11 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                 return self._cached_token_str(self._tokenizer,
                                               hf_config.video_token_index)
             raise TypeError(f"Unknown {modality} model type: {model_type}")
+        elif modality == "timeseries":
+            if model_type == "chatts":
+                return "<ts><ts/>"
+            else:
+                raise TypeError(f"Unknown {modality} model type: {model_type}")
         else:
             raise TypeError(f"Unknown modality: {modality}")
 
@@ -633,6 +669,9 @@ class MultiModalItemTracker(BaseMultiModalItemTracker[object]):
             mm_inputs["audio"] = items_by_modality["audio"] # A list of audios
         if "video" in items_by_modality:
             mm_inputs["video"] = items_by_modality["video"] # A list of videos
+        if "timeseries" in items_by_modality:
+            # A list of timeseries
+            mm_inputs["timeseries"] = items_by_modality["timeseries"]
         return mm_inputs
 
     def create_parser(self) -> "BaseMultiModalContentParser":
@@ -666,6 +705,9 @@ class AsyncMultiModalItemTracker(BaseMultiModalItemTracker[Awaitable[object]]):
             mm_inputs["audio"] = items_by_modality["audio"] # A list of audios
         if "video" in items_by_modality:
             mm_inputs["video"] = items_by_modality["video"] # A list of videos
+        if "timeseries" in items_by_modality:
+            # A list of timeseries
+            mm_inputs["timeseries"] = items_by_modality["timeseries"]
         return mm_inputs
 
     def create_parser(self) -> "BaseMultiModalContentParser":
@@ -706,6 +748,10 @@ class BaseMultiModalContentParser(ABC):
 
     @abstractmethod
     def parse_video(self, video_url: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def parse_timeseries(self, timeseries_data: TimeSeriesDataType) -> None:
         raise NotImplementedError
 
 
@@ -758,6 +804,20 @@ class MultiModalContentParser(BaseMultiModalContentParser):
         video = self._connector.fetch_video(video_url)
 
         placeholder = self._tracker.add("video", video)
+        self._add_placeholder(placeholder)
+
+    def parse_timeseries(self, timeseries_data: TimeSeriesDataType) -> None:
+        # Check if the data is a URL string
+        if isinstance(timeseries_data, str):
+            # Fetch time series data from URL
+            timeseries = self._connector.fetch_timeseries(timeseries_data)
+        elif isinstance(timeseries_data, list):
+            # For non-URL data (lists/arrays), use it directly
+            timeseries = timeseries_data
+        else:
+            raise ValueError("Invalid timeseries data format")
+
+        placeholder = self._tracker.add("timeseries", timeseries)
         self._add_placeholder(placeholder)
 
 
@@ -813,6 +873,22 @@ class AsyncMultiModalContentParser(BaseMultiModalContentParser):
         video = self._connector.fetch_video_async(video_url)
 
         placeholder = self._tracker.add("video", video)
+        self._add_placeholder(placeholder)
+
+    def parse_timeseries(self, timeseries: TimeSeriesDataType) -> None:
+        # Check if the data is a URL string
+        if isinstance(timeseries, str):
+            # Fetch time series data from URL asynchronously
+            coroutine = self._connector.fetch_timeseries_async(timeseries)
+            placeholder = self._tracker.add("timeseries", coroutine)
+        elif isinstance(timeseries, list):
+            # For non-URL data (lists/arrays), create a future with the data
+            future: asyncio.Future = asyncio.Future()
+            future.set_result(timeseries)
+            placeholder = self._tracker.add("timeseries", future)
+        else:
+            raise ValueError("Invalid timeseries data format")
+
         self._add_placeholder(placeholder)
 
 
@@ -918,6 +994,7 @@ _RefusalParser = partial(cast, ChatCompletionContentPartRefusalParam)
 _ImageParser = TypeAdapter(ChatCompletionContentPartImageParam).validate_python
 _AudioParser = TypeAdapter(ChatCompletionContentPartAudioParam).validate_python
 _VideoParser = TypeAdapter(ChatCompletionContentPartVideoParam).validate_python
+_TimeSeriesParser = TypeAdapter(ChatCompletionContentPartTimeSeriesParam).validate_python # noqa: E501
 
 _ContentPart: TypeAlias = Union[str, dict[str, str], InputAudio]
 
@@ -940,6 +1017,9 @@ MM_PARSER_MAP: dict[
     lambda part: _RefusalParser(part).get("refusal", None),
     "video_url":
     lambda part: _VideoParser(part).get("video_url", {}).get("url", None),
+    "timeseries":
+    lambda part: _TimeSeriesParser(part).get("timeseries", {}).get(
+        "data", None),
 }
 
 
@@ -992,6 +1072,10 @@ def _parse_chat_message_content_mm_part(
             video_params = cast(CustomChatCompletionContentSimpleVideoParam,
                                 part)
             return "video_url", video_params.get("video_url", "")
+        if part.get("timeseries") is not None:
+            timeseries_params = cast(
+                CustomChatCompletionContentSimpleTimeSeriesParam, part)
+            return "timeseries", timeseries_params.get("timeseries", "")
         # Raise an error if no 'type' or direct URL is found.
         raise ValueError("Missing 'type' field in multimodal part.")
 
@@ -1001,8 +1085,8 @@ def _parse_chat_message_content_mm_part(
 
 
 VALID_MESSAGE_CONTENT_MM_PART_TYPES = ("text", "refusal", "image_url",
-                                       "image_embeds",
-                                       "audio_url", "input_audio", "video_url")
+                                       "image_embeds", "audio_url",
+                                       "input_audio", "video_url", "timeseries")
 
 
 def _parse_chat_message_content_parts(
@@ -1094,6 +1178,11 @@ def _parse_chat_message_content_part(
         str_content = cast(str, content)
         mm_parser.parse_video(str_content)
         return {'type': 'video'} if wrap_dicts else None
+
+    if part_type == "timeseries":
+        dict_content = cast(TimeSeriesDataType, content)
+        mm_parser.parse_timeseries(dict_content)
+        return {'type': 'timeseries'} if wrap_dicts else None
 
     raise NotImplementedError(f"Unknown part type: {part_type}")
 

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -601,7 +601,7 @@ class BaseMultiModalItemTracker(ABC, Generic[_T]):
                                               hf_config.video_token_index)
             raise TypeError(f"Unknown {modality} model type: {model_type}")
         elif modality == "timeseries":
-            if model_type == "chatts":
+            if model_type == "chatts" or model_type == "qwen3ts":
                 return "<ts><ts/>"
             else:
                 raise TypeError(f"Unknown {modality} model type: {model_type}")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
     VLLM_VIDEO_FETCH_TIMEOUT: int = 30
     VLLM_AUDIO_FETCH_TIMEOUT: int = 10
     VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
+    VLLM_TIMESERIES_FETCH_TIMEOUT: int = 30
     VLLM_MM_INPUT_CACHE_GIB: int = 8
     VLLM_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: Optional[str] = None
@@ -498,6 +499,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If a non-existing backend is used, an AssertionError will be thrown.
     "VLLM_VIDEO_LOADER_BACKEND":
     lambda: os.getenv("VLLM_VIDEO_LOADER_BACKEND", "opencv"),
+
+    # Timeout for fetching time series when serving multimodal models
+    # Default is 30 seconds
+    "VLLM_TIMESERIES_FETCH_TIMEOUT":
+    lambda: int(os.getenv("VLLM_TIMESERIES_FETCH_TIMEOUT", "30")),
 
     # Cache size (in GiB) for multimodal input cache
     # Default is 4 GiB

--- a/vllm/model_executor/models/chatts.py
+++ b/vllm/model_executor/models/chatts.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Tsinghua University and ByteDance.
+# Copyright 2025 Alexander Chemeris <Alexander.Chemeris@gmail.com>
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/license/mit
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Reference: vLLM (https://github.com/vllm-project/vllm)
+"""Inference-only Qwen2-ChatTS model compatible with HuggingFace weights."""
+from collections.abc import Iterable, Mapping
+from typing import Optional, TypedDict, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.models.interfaces import (SupportsLoRA,
+                                                   SupportsMultiModal,
+                                                   SupportsPP)
+from vllm.model_executor.models.utils import (AutoWeightsLoader, WeightsMapper,
+                                              init_vllm_registered_model,
+                                              maybe_prefix,
+                                              merge_multimodal_embeddings)
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import NestedTensors
+from vllm.multimodal.processing import (BaseMultiModalProcessor,
+                                        BaseProcessingInfo, MultiModalDataDict,
+                                        MultiModalDataItems,
+                                        MultiModalFieldConfig,
+                                        MultiModalKwargs, PromptReplacement,
+                                        PromptUpdateDetails)
+from vllm.multimodal.profiling import BaseDummyInputsBuilder
+from vllm.sequence import IntermediateTensors
+
+# === Time Series Inputs === #
+
+
+class Qwen2TSTimeSeriesInput(TypedDict):
+    timeseries: torch.Tensor
+    """Shape: `(num_time_series, max_length, num_features)`
+    
+    Concatenated time series data from all time series in the batch.
+    Each time series may have different lengths, padded to max_length.
+    The last feature dimension contains mask information.
+    """
+
+
+# === TimeSeriesEmbedding ===
+class TimeSeriesEmbedding(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.patch_size = config['patch_size']
+        self.num_layers = config['num_layers']
+        self.hidden_size = config['hidden_size']
+        self.num_features = config['num_features']
+
+        layers = []
+        input_size = 1 * self.patch_size
+
+        for _ in range(self.num_layers - 1):
+            layers.append(
+                ReplicatedLinear(input_size,
+                                 self.hidden_size,
+                                 return_bias=False))
+            layers.append(nn.GELU())
+            input_size = self.hidden_size
+        layers.append(
+            ReplicatedLinear(input_size, self.hidden_size, return_bias=False))
+
+        self.mlp = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor):
+        batch_size = x.size(0)
+        x = x.reshape(batch_size, -1, self.num_features)
+
+        mask = x[:, :, -1]
+        valid_lengths = mask.sum(dim=1).long()  # Shape: (batch_size)
+
+        patch_cnt = (valid_lengths + self.patch_size -
+                     1) // self.patch_size  # 向上取整
+
+        patches_list = []
+        for i in range(batch_size):
+            vl = valid_lengths[i].item()
+            pc = patch_cnt[i].item()
+            if pc == 0:
+                continue
+            xi = x[i, :vl, :1]
+            total_padded_length = pc * self.patch_size
+            padding_length = total_padded_length - vl
+            if padding_length > 0:
+                padding = torch.zeros(padding_length,
+                                      1,
+                                      device=x.device,
+                                      dtype=x.dtype)
+                xi = torch.cat([xi, padding], dim=0)
+            xi = xi.reshape(pc, self.patch_size * 1)
+            patches_list.append(xi)
+
+        if patches_list:
+            x_patches = torch.cat(
+                patches_list,
+                dim=0)  # Shape: (total_patch_cnt, patch_size * num_features)
+            x = self.mlp(x_patches)
+        else:
+            x = torch.empty(0, self.hidden_size, device=x.device)
+
+        return x, patch_cnt
+
+
+# === TS Encoder === #
+# get_patch_cnt: From Time Series Embedding
+def get_patch_cnt(x: torch.Tensor, ts_config: PretrainedConfig):
+    batch_size = x.shape[0]
+    x = x.reshape(batch_size, -1, ts_config['num_features'])
+
+    mask = x[:, :, -1]
+    valid_lengths = mask.sum(1).long()  # Shape: (batch_size)
+
+    patch_cnt = (valid_lengths + int(ts_config['patch_size']) - 1) // int(
+        ts_config['patch_size'])
+    return patch_cnt
+
+
+class Qwen2TSProcessingInfo(BaseProcessingInfo):
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(PretrainedConfig)
+
+    def get_hf_processor(self, **kwargs: object):
+        return self.ctx.get_hf_processor(ProcessorMixin, **kwargs)
+
+    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+        return {"timeseries": 50}  # Allow up to 50 time series per prompt
+
+
+class Qwen2TSDummyInputsBuilder(BaseDummyInputsBuilder[Qwen2TSProcessingInfo]):
+
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return "<ts><ts/>" * mm_counts.get("timeseries", 0)
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> MultiModalDataDict:
+        hf_config = self.info.get_hf_config()
+        max_ts_length = hf_config.ts['max_length']
+        ts_count = mm_counts.get("timeseries", 0)
+        return {
+            "timeseries":
+            self._get_dummy_timeseries(length=max_ts_length,
+                                       num_timeseries=ts_count)
+        }
+
+
+class Qwen2TSMultiModalProcessor(BaseMultiModalProcessor[Qwen2TSProcessingInfo]
+                                 ):
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        mm_data = dict(mm_data)
+        ts = mm_data.pop("timeseries", [])
+
+        if ts:
+            mm_data["timeseries"] = ts
+
+        mm_kwargs = dict(mm_kwargs)
+        mm_kwargs['vllm_flag'] = True
+        result = super()._call_hf_processor(
+            prompt=prompt,
+            mm_data=mm_data,
+            mm_kwargs=mm_kwargs,
+        )
+
+        return result
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        # Define the field name and configuration for time series data
+        return {
+            "timeseries": MultiModalFieldConfig.batched("timeseries"),
+        }
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> bool:
+        return False
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> list[PromptReplacement]:
+        hf_config = self.info.get_hf_config()
+        placeholder = hf_config.ts_token_start_index
+
+        if 'timeseries' not in mm_items:
+            return []
+
+        if 'timeseries' not in out_mm_kwargs:
+            return []
+
+        # ChatTS processor returns a list of tuples
+        # (ts_tokens, encoded_ts_arrays)
+        ts_tokens, encoded_ts_arrays = zip(*out_mm_kwargs["timeseries"])
+
+        # patch_cnt = get_patch_cnt(concatenated_ts, hf_config.ts)
+        patch_size = hf_config.ts['patch_size']
+        # encoded_ts_arrays: list[torch.Tensor]
+        # encoded_ts_arrays[i].shape: (num_rows, num_elements*2, num_features)
+        # num_elements*2 is used because each element is a pair of (value, mask)
+        patch_cnt = [
+            (encoded_ts_arrays[i].shape[1] // 2 + patch_size - 1) // patch_size
+            for i in range(len(encoded_ts_arrays))
+        ]
+
+        def get_replacement_qwen2_ts(item_idx: int):
+            # Use the pre-tokenized replacements
+            tokens = ts_tokens[item_idx].copy()
+            # Extend the tokens with placeholders to match the patch_cnt
+            num_placeholders = sum(1 for t in tokens if t == placeholder)
+            if num_placeholders < patch_cnt[item_idx]:
+                tokens.extend([placeholder] *
+                              (patch_cnt[item_idx] - num_placeholders))
+            # return tokens
+            return PromptUpdateDetails.select_token_id(
+                tokens,
+                embed_token_id=placeholder,
+            )
+
+        return [
+            PromptReplacement(
+                modality="timeseries",
+                target=[placeholder, placeholder + 1],
+                replacement=get_replacement_qwen2_ts,
+            )
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen2TSMultiModalProcessor,
+    info=Qwen2TSProcessingInfo,
+    dummy_inputs=Qwen2TSDummyInputsBuilder,
+)
+class Qwen2TSForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
+                         SupportsLoRA):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
+
+    # To ensure correct weight loading and mapping.
+    hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={
+        "lm_head.": "language_model.lm_head.",
+        "model.": "language_model.model.",
+    })
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: PretrainedConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        self.config = config
+        self.multimodal_config = multimodal_config
+        self.model_dtype = vllm_config.model_config.dtype
+
+        self.ts_encoder = TimeSeriesEmbedding(config.ts)
+        self.quant_config = quant_config
+
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            hf_config=config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            architectures=["Qwen2ForCausalLM"],
+        )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    def _parse_and_validate_ts_input(
+            self, **kwargs: object) -> Optional[Qwen2TSTimeSeriesInput]:
+        timeseries = kwargs.pop('timeseries', None)
+        if timeseries is None:
+            return None
+
+        # ChatTS processor returns a list of tuples
+        # (ts_tokens, encoded_ts_arrays)
+        encoded_ts_arrays = [ts[0][1] for ts in timeseries]
+        # ts_tokens, encoded_ts_arrays = zip(*timeseries)
+
+        device = encoded_ts_arrays[0].device
+
+        max_length = max(ts.shape[1] for ts in encoded_ts_arrays)
+        total_rows = sum(ts.shape[0] for ts in encoded_ts_arrays)
+        feature_dim = encoded_ts_arrays[0].shape[2] if encoded_ts_arrays else 0
+
+        # Pre-allocate the tensor with the right size
+        concatenated_ts = torch.zeros((total_rows, max_length, feature_dim),
+                                      dtype=self.model_dtype,
+                                      device=device)
+
+        # Copy each array to the right position
+        row_offset = 0
+        for ts in encoded_ts_arrays:
+            ts_tensor = torch.tensor(ts, dtype=self.model_dtype,
+                                     device=device) if isinstance(
+                                         ts, np.ndarray) else ts
+            concatenated_ts[row_offset:row_offset +
+                            ts.shape[0], :ts.shape[1], :] = ts_tensor
+            row_offset += ts.shape[0]
+
+        input_features = concatenated_ts
+
+        if not isinstance(input_features, (torch.Tensor, list)):
+            raise ValueError("Incorrect type of ts input features. "
+                             f"Got type: {type(input_features)}")
+
+        return Qwen2TSTimeSeriesInput(timeseries=input_features)
+
+    def _process_ts_input(
+            self, ts_input: Qwen2TSTimeSeriesInput) -> list[torch.Tensor]:
+        """Process time series input and return a list of 2D tensors."""
+        ts_features, patch_cnt = self.ts_encoder(ts_input["timeseries"])
+
+        # Reshape ts_features into a list of 2D tensors
+        if ts_features.size(0) > 0:
+            features_list = []
+            start_idx = 0
+            for count in patch_cnt:
+                if count > 0:
+                    end_idx = start_idx + count
+                    features_list.append(ts_features[start_idx:end_idx])
+                    start_idx = end_idx
+                else:
+                    # Add empty tensor for consistency when count is 0
+                    # This ensures consistent behavior with prefix caching
+                    features_list.append(
+                        torch.zeros((0, ts_features.size(1)),
+                                    device=ts_features.device,
+                                    dtype=ts_features.dtype))
+            return features_list
+        else:
+            return []
+
+    def get_multimodal_embeddings(self, **kwargs) -> Optional[NestedTensors]:
+        ts_input = self._parse_and_validate_ts_input(**kwargs)
+        if ts_input is None:
+            return None
+
+        return self._process_ts_input(ts_input)
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: Optional[NestedTensors] = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+        if multimodal_embeddings is not None:
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids, inputs_embeds, multimodal_embeddings,
+                self.config.ts_token_start_index)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+
+        # NOTE: In v1, inputs_embeds is always generated at model runner, this
+        # condition is for v0 compatibility.
+        elif inputs_embeds is None:
+            ts_features = self.get_multimodal_embeddings(**kwargs)
+            inputs_embeds = self.get_input_embeddings(input_ids, ts_features)
+            input_ids = None
+
+        hidden_states = self.language_model.model(input_ids,
+                                                  positions,
+                                                  intermediate_tensors,
+                                                  inputs_embeds=inputs_embeds)
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states,
+                                                  sampling_metadata)
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+
+        autoloaded_weights = loader.load_weights(weights,
+                                                 mapper=self.hf_to_vllm_mapper)
+
+        # The HF config doesn't specify whether these are tied,
+        # so we detect it this way
+        if "embed_tokens.weight" not in autoloaded_weights:
+            self.embed_tokens = self.language_model.model.embed_tokens
+            autoloaded_weights.add("embed_tokens.weight")
+
+        return autoloaded_weights

--- a/vllm/model_executor/models/qwen3ts.py
+++ b/vllm/model_executor/models/qwen3ts.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Tsinghua University and ByteDance.
+# Copyright 2025 Alexander Chemeris <Alexander.Chemeris@gmail.com>
+#
+# Licensed under the MIT License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/license/mit
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Reference: vLLM (https://github.com/vllm-project/vllm)
+"""Inference-only Qwen3TS model compatible with HuggingFace weights."""
+from collections.abc import Iterable, Mapping
+from typing import Optional, TypedDict, Union
+
+import numpy as np
+import torch
+import torch.nn as nn
+from transformers import BatchFeature, PretrainedConfig, ProcessorMixin
+
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.models.interfaces import (SupportsLoRA,
+                                                   SupportsMultiModal,
+                                                   SupportsPP)
+from vllm.model_executor.models.utils import (AutoWeightsLoader, WeightsMapper,
+                                              init_vllm_registered_model,
+                                              maybe_prefix,
+                                              merge_multimodal_embeddings)
+from vllm.model_executor.sampling_metadata import SamplingMetadata
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import NestedTensors
+from vllm.multimodal.processing import (BaseMultiModalProcessor,
+                                        BaseProcessingInfo, MultiModalDataDict,
+                                        MultiModalDataItems,
+                                        MultiModalFieldConfig,
+                                        MultiModalKwargs, PromptReplacement,
+                                        PromptUpdateDetails)
+from vllm.multimodal.profiling import BaseDummyInputsBuilder
+from vllm.sequence import IntermediateTensors
+
+# === Time Series Inputs === #
+
+
+class Qwen3TSTimeSeriesInput(TypedDict):
+    timeseries: torch.Tensor
+    """Shape: `(num_time_series, max_length, num_features)`
+    
+    Concatenated time series data from all time series in the batch.
+    Each time series may have different lengths, padded to max_length.
+    The last feature dimension contains mask information.
+    """
+
+
+# === TimeSeriesEmbedding ===
+class TimeSeriesEmbedding(nn.Module):
+
+    def __init__(self, config):
+        super().__init__()
+        self.patch_size = config['patch_size']
+        self.num_layers = config['num_layers']
+        self.hidden_size = config['hidden_size']
+        self.num_features = config['num_features']
+
+        layers = []
+        input_size = 1 * self.patch_size
+
+        for _ in range(self.num_layers - 1):
+            layers.append(
+                ReplicatedLinear(input_size,
+                                 self.hidden_size,
+                                 return_bias=False))
+            layers.append(nn.GELU())
+            input_size = self.hidden_size
+        layers.append(
+            ReplicatedLinear(input_size, self.hidden_size, return_bias=False))
+
+        self.mlp = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor):
+        batch_size = x.size(0)
+        x = x.reshape(batch_size, -1, self.num_features)
+
+        mask = x[:, :, -1]
+        valid_lengths = mask.sum(dim=1).long()  # Shape: (batch_size)
+
+        patch_cnt = (valid_lengths + self.patch_size -
+                     1) // self.patch_size  # 向上取整
+
+        patches_list = []
+        for i in range(batch_size):
+            vl = valid_lengths[i].item()
+            pc = patch_cnt[i].item()
+            if pc == 0:
+                continue
+            xi = x[i, :vl, :1]
+            total_padded_length = pc * self.patch_size
+            padding_length = total_padded_length - vl
+            if padding_length > 0:
+                padding = torch.zeros(padding_length,
+                                      1,
+                                      device=x.device,
+                                      dtype=x.dtype)
+                xi = torch.cat([xi, padding], dim=0)
+            xi = xi.reshape(pc, self.patch_size * 1)
+            patches_list.append(xi)
+
+        if patches_list:
+            x_patches = torch.cat(
+                patches_list,
+                dim=0)  # Shape: (total_patch_cnt, patch_size * num_features)
+            x = self.mlp(x_patches)
+        else:
+            x = torch.empty(0, self.hidden_size, device=x.device)
+
+        return x, patch_cnt
+
+
+# === TS Encoder === #
+# get_patch_cnt: From Time Series Embedding
+def get_patch_cnt(x: torch.Tensor, ts_config: PretrainedConfig):
+    batch_size = x.shape[0]
+    x = x.reshape(batch_size, -1, ts_config['num_features'])
+
+    mask = x[:, :, -1]
+    valid_lengths = mask.sum(1).long()  # Shape: (batch_size)
+
+    patch_cnt = (valid_lengths + int(ts_config['patch_size']) - 1) // int(
+        ts_config['patch_size'])
+    return patch_cnt
+
+
+class Qwen3TSProcessingInfo(BaseProcessingInfo):
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(PretrainedConfig)
+
+    def get_hf_processor(self, **kwargs: object):
+        return self.ctx.get_hf_processor(ProcessorMixin, **kwargs)
+
+    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+        return {"timeseries": 50}  # Allow up to 50 time series per prompt
+
+
+class Qwen3TSDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3TSProcessingInfo]):
+
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return "<ts><ts/>" * mm_counts.get("timeseries", 0)
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+    ) -> MultiModalDataDict:
+        hf_config = self.info.get_hf_config()
+        max_ts_length = hf_config.ts['max_length']
+        ts_count = mm_counts.get("timeseries", 0)
+        return {
+            "timeseries":
+            self._get_dummy_timeseries(length=max_ts_length,
+                                       num_timeseries=ts_count)
+        }
+
+
+class Qwen3TSMultiModalProcessor(BaseMultiModalProcessor[Qwen3TSProcessingInfo]
+                                 ):
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        mm_data = dict(mm_data)
+        ts = mm_data.pop("timeseries", [])
+
+        if ts:
+            mm_data["timeseries"] = ts
+
+        mm_kwargs = dict(mm_kwargs)
+        mm_kwargs['vllm_flag'] = True
+        result = super()._call_hf_processor(
+            prompt=prompt,
+            mm_data=mm_data,
+            mm_kwargs=mm_kwargs,
+        )
+
+        return result
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        # Define the field name and configuration for time series data
+        return {
+            "timeseries": MultiModalFieldConfig.batched("timeseries"),
+        }
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> bool:
+        return False
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> list[PromptReplacement]:
+        hf_config = self.info.get_hf_config()
+        placeholder = hf_config.ts_token_start_index
+
+        if 'timeseries' not in mm_items:
+            return []
+
+        if 'timeseries' not in out_mm_kwargs:
+            return []
+
+        # ChatTS processor returns a list of tuples
+        # (ts_tokens, encoded_ts_arrays)
+        ts_tokens, encoded_ts_arrays = zip(*out_mm_kwargs["timeseries"])
+
+        # patch_cnt = get_patch_cnt(concatenated_ts, hf_config.ts)
+        patch_size = hf_config.ts['patch_size']
+        # encoded_ts_arrays: list[torch.Tensor]
+        # encoded_ts_arrays[i].shape: (num_rows, num_elements*2, num_features)
+        # num_elements*2 is used because each element is a pair of (value, mask)
+        patch_cnt = [
+            (encoded_ts_arrays[i].shape[1] // 2 + patch_size - 1) // patch_size
+            for i in range(len(encoded_ts_arrays))
+        ]
+
+        def get_replacement_qwen3_ts(item_idx: int):
+            # Use the pre-tokenized replacements
+            tokens = ts_tokens[item_idx].copy()
+            # Extend the tokens with placeholders to match the patch_cnt
+            num_placeholders = sum(1 for t in tokens if t == placeholder)
+            if num_placeholders < patch_cnt[item_idx]:
+                tokens.extend([placeholder] *
+                              (patch_cnt[item_idx] - num_placeholders))
+            # return tokens
+            return PromptUpdateDetails.select_token_id(
+                tokens,
+                embed_token_id=placeholder,
+            )
+
+        return [
+            PromptReplacement(
+                modality="timeseries",
+                target=[placeholder, placeholder + 1],
+                replacement=get_replacement_qwen3_ts,
+            )
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3TSMultiModalProcessor,
+    info=Qwen3TSProcessingInfo,
+    dummy_inputs=Qwen3TSDummyInputsBuilder,
+)
+class Qwen3TSForCausalLM(nn.Module, SupportsMultiModal, SupportsPP,
+                         SupportsLoRA):
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
+
+    # To ensure correct weight loading and mapping.
+    hf_to_vllm_mapper = WeightsMapper(orig_to_new_prefix={
+        "lm_head.": "language_model.lm_head.",
+        "model.": "language_model.model.",
+    })
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: PretrainedConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        self.config = config
+        self.multimodal_config = multimodal_config
+        self.model_dtype = vllm_config.model_config.dtype
+
+        self.ts_encoder = TimeSeriesEmbedding(config.ts)
+        self.quant_config = quant_config
+
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            hf_config=config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            architectures=["Qwen3ForCausalLM"],
+        )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    def _parse_and_validate_ts_input(
+            self, **kwargs: object) -> Optional[Qwen3TSTimeSeriesInput]:
+        timeseries = kwargs.pop('timeseries', None)
+        if timeseries is None:
+            return None
+
+        # ChatTS processor returns a list of tuples
+        # (ts_tokens, encoded_ts_arrays)
+        encoded_ts_arrays = [ts[0][1] for ts in timeseries]
+        # ts_tokens, encoded_ts_arrays = zip(*timeseries)
+
+        device = encoded_ts_arrays[0].device
+
+        max_length = max(ts.shape[1] for ts in encoded_ts_arrays)
+        total_rows = sum(ts.shape[0] for ts in encoded_ts_arrays)
+        feature_dim = encoded_ts_arrays[0].shape[2] if encoded_ts_arrays else 0
+
+        # Pre-allocate the tensor with the right size
+        concatenated_ts = torch.zeros((total_rows, max_length, feature_dim),
+                                      dtype=self.model_dtype,
+                                      device=device)
+
+        # Copy each array to the right position
+        row_offset = 0
+        for ts in encoded_ts_arrays:
+            ts_tensor = torch.tensor(ts, dtype=self.model_dtype,
+                                     device=device) if isinstance(
+                                         ts, np.ndarray) else ts
+            concatenated_ts[row_offset:row_offset +
+                            ts.shape[0], :ts.shape[1], :] = ts_tensor
+            row_offset += ts.shape[0]
+
+        input_features = concatenated_ts
+
+        if not isinstance(input_features, (torch.Tensor, list)):
+            raise ValueError("Incorrect type of ts input features. "
+                             f"Got type: {type(input_features)}")
+
+        return Qwen3TSTimeSeriesInput(timeseries=input_features)
+
+    def _process_ts_input(
+            self, ts_input: Qwen3TSTimeSeriesInput) -> list[torch.Tensor]:
+        """Process time series input and return a list of 2D tensors."""
+        ts_features, patch_cnt = self.ts_encoder(ts_input["timeseries"])
+
+        # Reshape ts_features into a list of 2D tensors
+        if ts_features.size(0) > 0:
+            features_list = []
+            start_idx = 0
+            for count in patch_cnt:
+                if count > 0:
+                    end_idx = start_idx + count
+                    features_list.append(ts_features[start_idx:end_idx])
+                    start_idx = end_idx
+                else:
+                    # Add empty tensor for consistency when count is 0
+                    # This ensures consistent behavior with prefix caching
+                    features_list.append(
+                        torch.zeros((0, ts_features.size(1)),
+                                    device=ts_features.device,
+                                    dtype=ts_features.dtype))
+            return features_list
+        else:
+            return []
+
+    def get_multimodal_embeddings(self, **kwargs) -> Optional[NestedTensors]:
+        ts_input = self._parse_and_validate_ts_input(**kwargs)
+        if ts_input is None:
+            return None
+
+        return self._process_ts_input(ts_input)
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: Optional[NestedTensors] = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+        if multimodal_embeddings is not None:
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids, inputs_embeds, multimodal_embeddings,
+                self.config.ts_token_start_index)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+
+        # NOTE: In v1, inputs_embeds is always generated at model runner, this
+        # condition is for v0 compatibility.
+        elif inputs_embeds is None:
+            ts_features = self.get_multimodal_embeddings(**kwargs)
+            inputs_embeds = self.get_input_embeddings(input_ids, ts_features)
+            input_ids = None
+
+        hidden_states = self.language_model.model(input_ids,
+                                                  positions,
+                                                  intermediate_tensors,
+                                                  inputs_embeds=inputs_embeds)
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states,
+                                                  sampling_metadata)
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+
+        autoloaded_weights = loader.load_weights(weights,
+                                                 mapper=self.hf_to_vllm_mapper)
+
+        # The HF config doesn't specify whether these are tied,
+        # so we detect it this way
+        if "embed_tokens.weight" not in autoloaded_weights:
+            self.embed_tokens = self.language_model.model.embed_tokens
+            autoloaded_weights.add("embed_tokens.weight")
+
+        return autoloaded_weights

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -210,6 +210,7 @@ _MULTIMODAL_MODELS = {
     "Qwen2AudioForConditionalGeneration": ("qwen2_audio", "Qwen2AudioForConditionalGeneration"),  # noqa: E501
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "Qwen2_5OmniForConditionalGeneration": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
+    "Qwen2TSForCausalLM": ("chatts", "Qwen2TSForCausalLM"),
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
     "TarsierForConditionalGeneration": ("tarsier", "TarsierForConditionalGeneration"),  # noqa: E501

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -211,6 +211,7 @@ _MULTIMODAL_MODELS = {
     "Qwen2_5OmniModel": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "Qwen2_5OmniForConditionalGeneration": ("qwen2_5_omni_thinker", "Qwen2_5OmniThinkerForConditionalGeneration"),  # noqa: E501
     "Qwen2TSForCausalLM": ("chatts", "Qwen2TSForCausalLM"),
+    "Qwen3TSForCausalLM": ("qwen3ts", "Qwen3TSForCausalLM"),
     "UltravoxModel": ("ultravox", "UltravoxModel"),
     "Phi4MMForCausalLM": ("phi4mm", "Phi4MMForCausalLM"),
     "TarsierForConditionalGeneration": ("tarsier", "TarsierForConditionalGeneration"),  # noqa: E501

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -198,7 +198,8 @@ Uses a list instead of a tensor if the dimensions of each element do not match.
 """
 
 
-def nested_tensors_equal(a: NestedTensors, b: NestedTensors) -> bool:
+def nested_tensors_equal(a: Union[NestedTensors, int, float, bool],
+                         b: Union[NestedTensors, int, float, bool]) -> bool:
     """Equality check between
     [`NestedTensors`][vllm.multimodal.inputs.NestedTensors] objects."""
     if isinstance(a, torch.Tensor):
@@ -206,11 +207,23 @@ def nested_tensors_equal(a: NestedTensors, b: NestedTensors) -> bool:
     elif isinstance(b, torch.Tensor):
         return isinstance(a, torch.Tensor) and torch.equal(b, a)
 
+    if isinstance(a, np.ndarray):
+        return isinstance(b, np.ndarray) and np.array_equal(a, b)
+    elif isinstance(b, np.ndarray):
+        return isinstance(a, np.ndarray) and np.array_equal(b, a)
+
     if isinstance(a, list):
         return (isinstance(b, list)
                 and all(nested_tensors_equal(a_, b_) for a_, b_ in zip(a, b)))
     if isinstance(b, list):
         return (isinstance(a, list)
+                and all(nested_tensors_equal(b_, a_) for b_, a_ in zip(b, a)))
+
+    if isinstance(a, tuple):
+        return (isinstance(b, tuple)
+                and all(nested_tensors_equal(a_, b_) for a_, b_ in zip(a, b)))
+    if isinstance(b, tuple):
+        return (isinstance(a, tuple)
                 and all(nested_tensors_equal(b_, a_) for b_, a_ in zip(b, a)))
 
     # Both a and b are scalars

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -47,6 +47,19 @@ Represents a single audio
 item, which can be passed to a HuggingFace `AudioProcessor`.
 """
 
+HfTimeSeriesItem: TypeAlias = Union[list[float], list[list[float]], np.ndarray,
+                                    "torch.Tensor"]
+"""
+Represents a single time series
+item, which can be passed to a time series processor.
+
+Can be a list of values (univariate time series), list of lists 
+(multivariate time series), or numpy array.
+
+Alternatively, a tensor that is treated as time series embeddings;
+these are directly passed to the model without preprocessing.
+"""
+
 ImageItem: TypeAlias = Union[HfImageItem, "torch.Tensor"]
 """
 A `transformers.image_utils.ImageInput` representing a single image
@@ -82,6 +95,18 @@ which are treated as audio embeddings;
 these are directly passed to the model without HF processing.
 """
 
+TimeSeriesItem: TypeAlias = Union[HfTimeSeriesItem, torch.Tensor]
+"""
+Represents a single time series
+item, which can be passed to a time series processor.
+
+Can be a list of values (univariate time series), list of lists
+(multivariate time series), or numpy array.
+
+Alternatively, a tensor that is treated as time series embeddings;
+these are directly passed to the model without preprocessing.
+"""
+
 ModalityData: TypeAlias = Union[_T, list[_T]]
 """
 Either a single data item, or a list of data items.
@@ -103,6 +128,9 @@ class MultiModalDataBuiltins(TypedDict, total=False):
 
     audio: ModalityData[AudioItem]
     """The input audio(s)."""
+
+    timeseries: ModalityData[TimeSeriesItem]
+    """The input time series data."""
 
 
 MultiModalDataDict: TypeAlias = Mapping[str, ModalityData[Any]]

--- a/vllm/multimodal/profiling.py
+++ b/vllm/multimodal/profiling.py
@@ -129,6 +129,17 @@ class BaseDummyInputsBuilder(ABC, Generic[_I]):
         video = np.full((num_frames, width, height, 3), 255)
         return [video] * num_videos
 
+    def _get_dummy_timeseries(
+        self,
+        *,
+        length: int,
+        num_timeseries: int,
+    ) -> list[npt.NDArray]:
+        if num_timeseries == 0:
+            return []
+        timeseries = np.zeros(length)
+        return [timeseries] * num_timeseries
+
 
 class MultiModalProfiler(Generic[_I]):
     """

--- a/vllm/multimodal/time_series.py
+++ b/vllm/multimodal/time_series.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import io
+from pathlib import Path
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.utils import PlaceholderModule
+
+from .base import MediaIO
+
+try:
+    import pandas as pd
+    import pyarrow as pa
+    import pyarrow.csv as pac
+    import pyarrow.ipc as ipc
+    import pyarrow.parquet as pq
+except ImportError:
+    pd = PlaceholderModule("pandas")  # type: ignore[assignment]
+    pa = PlaceholderModule("pyarrow")  # type: ignore[assignment]
+    pq = PlaceholderModule("pyarrow.parquet")  # type: ignore[assignment]
+    ipc = PlaceholderModule("pyarrow.ipc")  # type: ignore[assignment]
+    pac = PlaceholderModule("pyarrow.csv")  # type: ignore[assignment]
+
+logger = init_logger(__name__)
+
+
+class TimeSeriesMediaIO(MediaIO[torch.Tensor]):
+    """Media I/O operations for time series data."""
+
+    def load_bytes(self, data: bytes) -> torch.Tensor:
+        """Load time series data from bytes by detecting format.
+        
+        Supports Parquet, Arrow File, and CSV formats.
+        Format is detected by the first 8 bytes of the bytes.
+        """
+        buffer = io.BytesIO(data)
+
+        # Read first 8 bytes to identify file format
+        magic_bytes = buffer.read(8)
+        buffer.seek(0)  # Reset position after reading
+
+        # Check for Parquet (starts with 'PAR1')
+        if magic_bytes.startswith(b'PAR1'):
+            try:
+                table = pq.read_table(buffer)
+                return table.to_pandas().values.flatten()
+            except Exception as e:
+                raise ValueError(f"Invalid Parquet file: {str(e)}") from e
+
+        # Check for Arrow IPC (starts with 'ARROW1')
+        elif magic_bytes.startswith(b'ARROW1'):
+            try:
+                reader = pa.ipc.open_file(buffer)
+                table = reader.read_all()
+                return table.to_pandas().values.flatten()
+            except pa.lib.ArrowInvalid as e:
+                raise ValueError(f"Invalid Arrow file: {str(e)}") from e
+
+        # Default to CSV (no reliable magic bytes)
+        else:
+            try:
+                table = pac.read_csv(buffer)
+                return table.to_pandas().values.flatten()
+            except Exception as e:
+                raise ValueError(
+                    f"Invalid CSV file or unknown format: {str(e)}") from e
+
+    def load_base64(self, media_type: str, data: str) -> torch.Tensor:
+        """Load time series data from base64 encoded string."""
+        return self.load_bytes(base64.b64decode(data))
+
+    def load_file(self, filepath: Path) -> torch.Tensor:
+        """Load time series data from a file."""
+        suffix = filepath.suffix.lower()
+
+        if suffix == '.parquet':
+            try:
+                table = pq.read_table(filepath)
+                return table.to_pandas().values.flatten()
+            except Exception as e:
+                raise ValueError(f"Invalid Parquet file: {str(e)}") from e
+        elif suffix in ['.arrow', '.ipc']:
+            try:
+                reader = ipc.open_file(filepath)
+                table = reader.read_all()
+                return table.to_pandas().values.flatten()
+            except Exception as e:
+                raise ValueError(f"Invalid Arrow file: {str(e)}") from e
+        elif suffix == '.csv':
+            try:
+                table = pac.read_csv(filepath)
+                return table.to_pandas().values.flatten()
+            except Exception as e:
+                raise ValueError(f"Invalid CSV file: {str(e)}") from e
+        else:
+            raise ValueError(f"Unsupported file extension: {suffix}")
+
+    def encode_base64(self,
+                      media: list[list[float]],
+                      format: str = "csv") -> str:
+        """Encode time series data to base64 string."""
+        with io.BytesIO() as buffer:
+            if format == "csv":
+                df = pd.DataFrame(media)
+                df.to_csv(buffer, index=False)
+            elif format == "parquet":
+                df = pd.DataFrame(media)
+                df.to_parquet(buffer)
+            elif format == "arrow":
+                df = pd.DataFrame(media)
+                df.to_parquet(buffer, engine="pyarrow")
+            else:
+                raise ValueError(f"Unsupported format: {format}")
+            data = buffer.getvalue()
+        return base64.b64encode(data).decode('utf-8')


### PR DESCRIPTION
This pull request has two parts:
1. Adds generic infrastructure for handling time series as a modality, including an OpenAI API server.
2. Adds support for [ChatTS](https://github.com/NetManAIOps/ChatTS/) model inference that relies on the above change for both offline inference and online serving using the OpenAI API server.

Please refer to the official ChatTS documentation for details about the model architecture: https://github.com/NetManAIOps/ChatTS/
This code is based on the original ChatTS code, but works with the latest vllm code, and adds support for V1 vLLM engine and OpenAI API serving.

To use the current version of ChatTS requires `--trust-remote-code` and `--hf-overrides` in order to load config and processing classes from the ChatTS HF repo, but use the vllm implementation of the model itself.

Example script to serve ChatTS via an OpenAI API server with vLLM:
```bash
vllm serve ../ChatTS-model \
    --served-model-name chatts \
    --trust-remote-code \
    --hf-overrides '{"model_type":"chatts"}' \
    --max-model-len 6000 \
    --gpu-memory-utilization 0.8 \
    --limit-mm-per-prompt timeseries=50 \
    --allowed-local-media-path $(pwd) \
    --host 0.0.0.0 \
    --port 8090 
```