### PR TITLE
Support loading transformers models with named parameters

### DIFF
--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -317,7 +317,7 @@ class TransformersModel(nn.Module):
         """
         for name, param in module.named_parameters(recurse=False):
             if param.device == torch.device("meta"):
-                new_param = getattr(type(module)(self.config), name)
+                new_param = nn.Parameter(torch.empty_like(param.data, device=self.device_config.device))
                 setattr(module, name, new_param)
         for child in module.children():
             self.init_parameters(child)

--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -300,7 +300,7 @@ class TransformersModel(nn.Module):
                 setattr(module, name, new_buffer)
         for child in module.children():
             self.init_buffers(child)
-            
+
     def init_parameters(self, module: nn.Module):
         """
         If a `parameter` is on the `meta` device, then its parent
@@ -317,7 +317,9 @@ class TransformersModel(nn.Module):
         """
         for name, param in module.named_parameters(recurse=False):
             if param.device == torch.device("meta"):
-                new_param = nn.Parameter(torch.empty_like(param.data, device=self.device_config.device))
+                new_param = nn.Parameter(
+                    torch.empty_like(param.data,
+                                     device=self.device_config.device))
                 setattr(module, name, new_param)
         for child in module.children():
             self.init_parameters(child)

--- a/vllm/model_executor/models/transformers.py
+++ b/vllm/model_executor/models/transformers.py
@@ -310,10 +310,6 @@ class TransformersModel(nn.Module):
         with torch.device("meta"):
             self.model: PreTrainedModel = AutoModel.from_config(...)
         ```
-
-        This means that:
-        - `type(module)` is a class from `transformers`
-        - This class is constructed using a `PretrainedConfig`
         """
         for name, param in module.named_parameters(recurse=False):
             if param.device == torch.device("meta"):

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -186,7 +186,6 @@ class AutoWeightsLoader:
     ) -> Iterable[str]:
         if isinstance(module, PPMissingLayer):
             return
-        
 
         # Avoid infinite recursion since this function is typically
         # called inside load_weights of the module itself
@@ -206,15 +205,6 @@ class AutoWeightsLoader:
 
         child_modules = dict(module.named_children())
         child_params = dict(module.named_parameters(recurse=False))
-        # print("===============================================")
-        # print(f"In base_prefix: {base_prefix}")
-        # if base_prefix == "model":
-        #     print(module)
-        # for module in child_modules.keys():
-        #     print(f"\tchild module: {module}")
-        # for param in child_params.keys():
-        #     print(f"\tchild param: {param}")
-        # print("===============================================")
 
         # Add missing tensors the weight loader needs to be able to load
         # that aren't registered as params, e.g., batchnorm statistics.
@@ -268,7 +258,6 @@ class AutoWeightsLoader:
         if mapper is not None:
             weights = mapper.apply(weights)
 
-        weights = list(weights)
         autoloaded_weights = set(self._load_module("", self.module, weights))
         return autoloaded_weights
 

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -186,6 +186,7 @@ class AutoWeightsLoader:
     ) -> Iterable[str]:
         if isinstance(module, PPMissingLayer):
             return
+        
 
         # Avoid infinite recursion since this function is typically
         # called inside load_weights of the module itself
@@ -205,6 +206,15 @@ class AutoWeightsLoader:
 
         child_modules = dict(module.named_children())
         child_params = dict(module.named_parameters(recurse=False))
+        # print("===============================================")
+        # print(f"In base_prefix: {base_prefix}")
+        # if base_prefix == "model":
+        #     print(module)
+        # for module in child_modules.keys():
+        #     print(f"\tchild module: {module}")
+        # for param in child_params.keys():
+        #     print(f"\tchild param: {param}")
+        # print("===============================================")
 
         # Add missing tensors the weight loader needs to be able to load
         # that aren't registered as params, e.g., batchnorm statistics.
@@ -258,6 +268,7 @@ class AutoWeightsLoader:
         if mapper is not None:
             weights = mapper.apply(weights)
 
+        weights = list(weights)
         autoloaded_weights = set(self._load_module("", self.module, weights))
         return autoloaded_weights
 


### PR DESCRIPTION
This PR adds support for loading custom transformers models with NamedParameters.

This is generally helpful for models which have something of the form

```
class Model(nn.Module):
  def __init__(self):
    self.my_scalar_hyperparam = nn.Parameter([0])

  def forward(self, x):
    x = x * self.my_scalar_hyperparam
```