### PR TITLE
Add `pt_load_map_location` to allow loading to cuda

### DIFF
--- a/tests/quantization/test_torchao.py
+++ b/tests/quantization/test_torchao.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import importlib.util
 
 import pytest
+import torch
 
 DTYPE = ["bfloat16"]
 
@@ -19,6 +20,31 @@ def test_pre_quantized_model(vllm_runner):
                                      max_tokens=32)
     assert output
     print(output)
+
+
+@pytest.mark.skipif(not TORCHAO_AVAILABLE, reason="torchao is not available")
+@pytest.mark.parametrize(
+    "pt_load_map_location",
+    [
+        "cuda:0",
+        # {"": "cuda"},
+    ])
+def test_opt_125m_int4wo_model_loading_with_params(vllm_runner,
+                                                   pt_load_map_location):
+    """
+    Test loading roberta-base model with no lm_head.
+    """
+    torch._dynamo.reset()
+    model_name = "jerryzh168/opt-125m-int4wo"
+    with vllm_runner(model_name=model_name,
+                     quantization="torchao",
+                     dtype="bfloat16",
+                     pt_load_map_location=pt_load_map_location) as llm:
+        output = llm.generate_greedy(["The capital of France is"],
+                                     max_tokens=32)
+
+        assert output
+        print(output)
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -412,13 +412,12 @@ def test_generation_config_loading():
 
     assert model_config.get_diff_sampling_param() == override_generation_config
 
-@pytest.mark.parametrize(("model_id", "pt_load_map_location"), [
-    ("facebook/opt-125m", None),
-    ("facebook/opt-125m", "cuda"),
-    ("facebook/opt-125m", "{'': 'cuda'}"),
-    ("jerryzh/opt-125m-int4wo", "cuda")
+@pytest.mark.parametrize("pt_load_map_location", [
+    None,
+    "cuda",
+    '{"": "cuda"}',
 ])
-def test_load_config_pt_load_map_location(model_id, pt_load_map_location):
+def test_load_config_pt_load_map_location(pt_load_map_location):
     load_config = LoadConfig(pt_load_map_location=pt_load_map_location)
     config = VllmConfig(load_config=load_config)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -414,9 +414,10 @@ def test_generation_config_loading():
 
 
 @pytest.mark.parametrize("pt_load_map_location", [
-    None,
     "cuda",
-    '{"": "cuda"}',
+    {
+        "": "cuda"
+    },
 ])
 def test_load_config_pt_load_map_location(pt_load_map_location):
     load_config = LoadConfig(pt_load_map_location=pt_load_map_location)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,9 +4,9 @@ from dataclasses import MISSING, Field, asdict, dataclass, field
 from typing import Literal, Union
 
 import pytest
-import json
 
-from vllm.config import ModelConfig, PoolerConfig, config, get_field, VllmConfig, LoadConfig
+from vllm.config import (LoadConfig, ModelConfig, PoolerConfig, VllmConfig,
+                         config, get_field)
 from vllm.model_executor.layers.pooler import PoolingType
 from vllm.platforms import current_platform
 
@@ -411,6 +411,7 @@ def test_generation_config_loading():
         override_generation_config=override_generation_config)
 
     assert model_config.get_diff_sampling_param() == override_generation_config
+
 
 @pytest.mark.parametrize("pt_load_map_location", [
     None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ from dataclasses import MISSING, Field, asdict, dataclass, field
 from typing import Literal, Union
 
 import pytest
+import json
 
 from vllm.config import ModelConfig, PoolerConfig, config, get_field
 from vllm.model_executor.layers.pooler import PoolingType
@@ -410,3 +411,21 @@ def test_generation_config_loading():
         override_generation_config=override_generation_config)
 
     assert model_config.get_diff_sampling_param() == override_generation_config
+
+@pytest.mark.parametrize(("model_id", "pt_load_map_location"), [
+    ("facebook/opt-125m", None),
+    ("facebook/opt-125m", "cuda"),
+    ("jerryzh/opt-125m-int4wo", "cuda")
+])
+def test_load_config_pt_load_map_location(model_id, pt_load_map_location):
+    config = ModelConfig(
+        model_id,
+        task="auto",
+        tokenizer=model_id,
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+        dtype="float16",
+        seed=0,
+    )
+
+    assert config.is_encoder_decoder == is_encoder_decoder

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from typing import Literal, Union
 import pytest
 import json
 
-from vllm.config import ModelConfig, PoolerConfig, config, get_field
+from vllm.config import ModelConfig, PoolerConfig, config, get_field, VllmConfig, LoadConfig
 from vllm.model_executor.layers.pooler import PoolingType
 from vllm.platforms import current_platform
 
@@ -415,17 +415,12 @@ def test_generation_config_loading():
 @pytest.mark.parametrize(("model_id", "pt_load_map_location"), [
     ("facebook/opt-125m", None),
     ("facebook/opt-125m", "cuda"),
+    ("facebook/opt-125m", "{'': 'cuda'}"),
     ("jerryzh/opt-125m-int4wo", "cuda")
 ])
 def test_load_config_pt_load_map_location(model_id, pt_load_map_location):
-    config = ModelConfig(
-        model_id,
-        task="auto",
-        tokenizer=model_id,
-        tokenizer_mode="auto",
-        trust_remote_code=False,
-        dtype="float16",
-        seed=0,
-    )
+    load_config = LoadConfig(pt_load_map_location=pt_load_map_location)
+    config = VllmConfig(load_config=load_config)
 
-    assert config.is_encoder_decoder == is_encoder_decoder
+    print(config.load_config.pt_load_map_location)
+    assert config.load_config.pt_load_map_location == pt_load_map_location

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -423,5 +423,4 @@ def test_load_config_pt_load_map_location(pt_load_map_location):
     load_config = LoadConfig(pt_load_map_location=pt_load_map_location)
     config = VllmConfig(load_config=load_config)
 
-    print(config.load_config.pt_load_map_location)
     assert config.load_config.pt_load_map_location == pt_load_map_location

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1567,7 +1567,10 @@ class LoadConfig:
     pt_load_map_location: Optional[Union[str, dict[str, str]]] = None
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
-    support loading checkpoints can only be loaded on certain devices like "cuda".
+    support loading checkpoints can only be loaded on certain devices like "cuda", this is equivalent
+    to {"": "cuda"}. Another supported format is mapping from different devices like from GPU 1
+    to GPU 0: {"cuda:1": "cuda:0"}. Note that when passed from command line, the strings in dictionary
+    needs to be double quoted for json parsing.
     For more details,
     see original doc for `map_location` in https://pytorch.org/docs/stable/generated/torch.load.html
     """

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1564,7 +1564,7 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
-    pt_load_map_location: str = "cpu"
+    pt_load_map_location: Union[str, Dict[str, str]] = "cpu"
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
     support loading checkpoints can only be loaded on certain devices like cuda.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1564,11 +1564,13 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
-    pt_load_map_location: Union[str, dict[str, str]] = "cpu"
+    pt_load_map_location: Optional[Union[str, dict[str, str]]] = None
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
-    support loading checkpoints can only be loaded on certain devices like cuda.
-    Default to cpu."""
+    support loading checkpoints can only be loaded on certain devices like "cuda".
+    For more details,
+    see original doc for `map_location` in https://pytorch.org/docs/stable/generated/torch.load.html
+    """
 
     def compute_hash(self) -> str:
         """

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1564,6 +1564,11 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
+    pt_load_map_location: str = "cpu"
+    """
+    pt_load_map_location: the map location for loading pytorch checkpoint, to
+    support loading checkpoints can only be loaded on certain devices like cuda.
+    Default to cpu."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1564,7 +1564,7 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
-    pt_load_map_location: Optional[Union[str, dict[str, str]]] = None
+    pt_load_map_location: Union[str, dict[str, str]] = "cpu"
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
     support loading checkpoints can only be loaded on certain devices like

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1564,7 +1564,7 @@ class LoadConfig:
     use_tqdm_on_load: bool = True
     """Whether to enable tqdm for showing progress bar when loading model
     weights."""
-    pt_load_map_location: Union[str, Dict[str, str]] = "cpu"
+    pt_load_map_location: Union[str, dict[str, str]] = "cpu"
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
     support loading checkpoints can only be loaded on certain devices like cuda.

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -18,7 +18,7 @@ from functools import cached_property
 from importlib.util import find_spec
 from pathlib import Path
 from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Literal, Optional,
-                    Protocol, TypeVar, Union, cast, get_args, get_origin, Dict)
+                    Protocol, TypeVar, Union, cast, get_args, get_origin)
 
 import torch
 from pydantic import BaseModel, Field, PrivateAttr

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1567,11 +1567,11 @@ class LoadConfig:
     pt_load_map_location: Optional[Union[str, dict[str, str]]] = None
     """
     pt_load_map_location: the map location for loading pytorch checkpoint, to
-    support loading checkpoints can only be loaded on certain devices like "cuda", this is equivalent
-    to {"": "cuda"}. Another supported format is mapping from different devices like from GPU 1
-    to GPU 0: {"cuda:1": "cuda:0"}. Note that when passed from command line, the strings in dictionary
-    needs to be double quoted for json parsing.
-    For more details,
+    support loading checkpoints can only be loaded on certain devices like
+    "cuda", this is equivalent to {"": "cuda"}. Another supported format is
+    mapping from different devices like from GPU 1 to GPU 0:
+    {"cuda:1": "cuda:0"}. Note that when passed from command line, the strings
+    in dictionary needs to be double quoted for json parsing. For more details,
     see original doc for `map_location` in https://pytorch.org/docs/stable/generated/torch.load.html
     """
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -18,7 +18,7 @@ from functools import cached_property
 from importlib.util import find_spec
 from pathlib import Path
 from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Literal, Optional,
-                    Protocol, TypeVar, Union, cast, get_args, get_origin)
+                    Protocol, TypeVar, Union, cast, get_args, get_origin, Dict)
 
 import torch
 from pydantic import BaseModel, Field, PrivateAttr

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -64,12 +64,23 @@ def optional_type(
     return _optional_type
 
 
-@deprecated(
-    "Passing a JSON argument as a string containing comma separated key=value "
-    "pairs is deprecated. This will be removed in v0.10.0. Please use a JSON "
-    "string instead.")
-def nullable_kvs(val: str) -> dict[str, int]:
-    """Parses a string containing comma separate key [str] to value [int]
+def optional_str(val: str) -> Optional[str]:
+    return optional_arg(val, str)
+
+
+def optional_int(val: str) -> Optional[int]:
+    return optional_arg(val, int)
+
+
+def optional_float(val: str) -> Optional[float]:
+    return optional_arg(val, float)
+
+
+def nullable_kvs(val: str) -> Optional[dict[str, int]]:
+    """NOTE: This function is deprecated, args should be passed as JSON
+    strings instead.
+
+    Parses a string containing comma separate key [str] to value [int]
     pairs into a dictionary.
 
     Args:
@@ -371,6 +382,7 @@ class EngineArgs:
     reasoning_parser: str = DecodingConfig.reasoning_backend
 
     use_tqdm_on_load: bool = LoadConfig.use_tqdm_on_load
+    pt_load_map_location: str = LoadConfig.pt_load_map_location
 
     def __post_init__(self):
         # support `EngineArgs(compilation_config={...})`
@@ -491,6 +503,8 @@ class EngineArgs:
                                 type=str,
                                 default=None,
                                 help='Name or path of the QLoRA adapter.')
+        load_group.add_argument('--pt-load-map-location',
+                                **load_kwargs["pt_load_map_location"])
 
         # Guided decoding arguments
         guided_decoding_kwargs = get_kwargs(DecodingConfig)
@@ -889,6 +903,7 @@ class EngineArgs:
             model_loader_extra_config=self.model_loader_extra_config,
             ignore_patterns=self.ignore_patterns,
             use_tqdm_on_load=self.use_tqdm_on_load,
+            pt_load_map_location=self.pt_load_map_location,
         )
 
     def create_speculative_config(
@@ -1513,7 +1528,7 @@ def _warn_or_fallback(feature_name: str) -> bool:
 def human_readable_int(value):
     """Parse human-readable integers like '1k', '2M', etc.
     Including decimal values with decimal multipliers.
-    
+
     Examples:
     - '1k' -> 1,000
     - '1K' -> 1,024

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -64,8 +64,7 @@ def optional_type(
     return _optional_type
 
 
-def optional_union_dict_and_str(
-        val: str) -> Optional[Union[str, dict[str, str]]]:
+def union_dict_and_str(val: str) -> Optional[Union[str, dict[str, str]]]:
     if not re.match("^{.*}$", val):
         return str(val)
     else:
@@ -198,7 +197,7 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
         elif contains_type(type_hints,
                            dict) and (contains_type(type_hints, str) or any(
                                is_not_builtin(th) for th in type_hints)):
-            kwargs[name]["type"] = optional_union_dict_and_str
+            kwargs[name]["type"] = union_dict_and_str
         elif contains_type(type_hints, dict):
             # Dict arguments will always be optional
             kwargs[name]["type"] = optional_type(json.loads)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -206,7 +206,6 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
             kwargs[name]["type"] = float
         elif contains_type(type_hints, dict) and (contains_type(type_hints, str)
               or any(is_not_builtin(th) for th in type_hints)):
-            print("option union dict and str type", type_hints)
             kwargs[name]["type"] = optional_union_dict_and_str
         elif contains_type(type_hints, dict):
             # Dict arguments will always be optional

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -64,29 +64,20 @@ def optional_type(
     return _optional_type
 
 
-def optional_str(val: str) -> Optional[str]:
-    return optional_arg(val, str)
-
-
-def optional_int(val: str) -> Optional[int]:
-    return optional_arg(val, int)
-
-
-def optional_float(val: str) -> Optional[float]:
-    return optional_arg(val, float)
-
-def optional_union_dict_and_str(val: str) -> Optional[Union[str, dict[str, str]]]:
+def optional_union_dict_and_str(
+        val: str) -> Optional[Union[str, dict[str, str]]]:
     if not re.match("^{.*}$", val):
         return str(val)
     else:
         return optional_type(json.loads)(val)
 
 
-def nullable_kvs(val: str) -> Optional[dict[str, int]]:
-    """NOTE: This function is deprecated, args should be passed as JSON
-    strings instead.
-
-    Parses a string containing comma separate key [str] to value [int]
+@deprecated(
+    "Passing a JSON argument as a string containing comma separated key=value "
+    "pairs is deprecated. This will be removed in v0.10.0. Please use a JSON "
+    "string instead.")
+def nullable_kvs(val: str) -> dict[str, int]:
+    """Parses a string containing comma separate key [str] to value [int]
     pairs into a dictionary.
 
     Args:
@@ -204,8 +195,9 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
                 kwargs[name]["type"] = human_readable_int
         elif contains_type(type_hints, float):
             kwargs[name]["type"] = float
-        elif contains_type(type_hints, dict) and (contains_type(type_hints, str)
-              or any(is_not_builtin(th) for th in type_hints)):
+        elif contains_type(type_hints,
+                           dict) and (contains_type(type_hints, str) or any(
+                               is_not_builtin(th) for th in type_hints)):
             kwargs[name]["type"] = optional_union_dict_and_str
         elif contains_type(type_hints, dict):
             # Dict arguments will always be optional

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -75,6 +75,12 @@ def optional_int(val: str) -> Optional[int]:
 def optional_float(val: str) -> Optional[float]:
     return optional_arg(val, float)
 
+def optional_union_dict_and_str(val: str) -> Optional[Union[str, dict[str, str]]]:
+    if not re.match("^{.*}$", val):
+        return str(val)
+    else:
+        return optional_type(json.loads)(val)
+
 
 def nullable_kvs(val: str) -> Optional[dict[str, int]]:
     """NOTE: This function is deprecated, args should be passed as JSON
@@ -198,6 +204,10 @@ def get_kwargs(cls: ConfigType) -> dict[str, Any]:
                 kwargs[name]["type"] = human_readable_int
         elif contains_type(type_hints, float):
             kwargs[name]["type"] = float
+        elif contains_type(type_hints, dict) and (contains_type(type_hints, str)
+              or any(is_not_builtin(th) for th in type_hints)):
+            print("option union dict and str type", type_hints)
+            kwargs[name]["type"] = optional_union_dict_and_str
         elif contains_type(type_hints, dict):
             # Dict arguments will always be optional
             kwargs[name]["type"] = optional_type(json.loads)
@@ -897,6 +907,7 @@ class EngineArgs:
 
         if self.quantization == "bitsandbytes":
             self.load_format = "bitsandbytes"
+
         return LoadConfig(
             load_format=self.load_format,
             download_dir=self.download_dir,

--- a/vllm/model_executor/model_loader/loader.py
+++ b/vllm/model_executor/model_loader/loader.py
@@ -384,6 +384,7 @@ class DefaultModelLoader(BaseModelLoader):
             weights_iterator = pt_weights_iterator(
                 hf_weights_files,
                 self.load_config.use_tqdm_on_load,
+                self.load_config.pt_load_map_location,
             )
 
         if current_platform.is_tpu():
@@ -890,6 +891,7 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             iterator = pt_weights_iterator(
                 hf_weights_files,
                 self.load_config.use_tqdm_on_load,
+                self.load_config.pt_load_map_location,
             )
         for org_name, param in iterator:
             # mapping weight names from transformers to vllm while preserving

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -502,7 +502,7 @@ def fastsafetensors_weights_iterator(
 def pt_weights_iterator(
     hf_weights_files: List[str],
     use_tqdm_on_load: bool,
-    pt_load_map_location: Union[str, Dict[str, str]] = "cpu",
+    pt_load_map_location: Union[str, dict[str, str]] = "cpu",
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model bin/pt files."""
     for bin_file in tqdm(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -502,9 +502,12 @@ def fastsafetensors_weights_iterator(
 def pt_weights_iterator(
     hf_weights_files: List[str],
     use_tqdm_on_load: bool,
-    pt_load_map_location: Union[str, dict[str, str]] = "cpu",
+    pt_load_map_location: Optional[Union[str, dict[str, str]]] = None,
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model bin/pt files."""
+    if pt_load_map_location is None:
+        pt_load_map_location = "cpu"
+
     for bin_file in tqdm(
             hf_weights_files,
             desc="Loading pt checkpoint shards",

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -502,6 +502,7 @@ def fastsafetensors_weights_iterator(
 def pt_weights_iterator(
     hf_weights_files: List[str],
     use_tqdm_on_load: bool,
+    pt_load_map_location: str = "cpu",
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model bin/pt files."""
     for bin_file in tqdm(
@@ -510,7 +511,7 @@ def pt_weights_iterator(
             disable=not enable_tqdm(use_tqdm_on_load),
             bar_format=_BAR_FORMAT,
     ):
-        state = torch.load(bin_file, map_location="cpu", weights_only=True)
+        state = torch.load(bin_file, map_location=pt_load_map_location, weights_only=True)
         yield from state.items()
         del state
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -511,7 +511,9 @@ def pt_weights_iterator(
             disable=not enable_tqdm(use_tqdm_on_load),
             bar_format=_BAR_FORMAT,
     ):
-        state = torch.load(bin_file, map_location=pt_load_map_location, weights_only=True)
+        state = torch.load(bin_file,
+                           map_location=pt_load_map_location,
+                           weights_only=True)
         yield from state.items()
         del state
 

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -502,12 +502,9 @@ def fastsafetensors_weights_iterator(
 def pt_weights_iterator(
     hf_weights_files: List[str],
     use_tqdm_on_load: bool,
-    pt_load_map_location: Optional[Union[str, dict[str, str]]] = None,
+    pt_load_map_location: Union[str, dict[str, str]] = "cpu",
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model bin/pt files."""
-    if pt_load_map_location is None:
-        pt_load_map_location = "cpu"
-
     for bin_file in tqdm(
             hf_weights_files,
             desc="Loading pt checkpoint shards",

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -502,7 +502,7 @@ def fastsafetensors_weights_iterator(
 def pt_weights_iterator(
     hf_weights_files: List[str],
     use_tqdm_on_load: bool,
-    pt_load_map_location: str = "cpu",
+    pt_load_map_location: Union[str, Dict[str, str]] = "cpu",
 ) -> Generator[Tuple[str, torch.Tensor], None, None]:
     """Iterate over the weights in the model bin/pt files."""
     for bin_file in tqdm(


### PR DESCRIPTION
Summary:
Right now pytorch checkpoints are always loaded to cpu device, but some checkpoints can only be loaded in cuda or other devices, this PR adds a `pt_load_map_location` flag (defaults to cpu) to LoadConfig

Test Plan:
```
python tests/test_config.py -k test_load_config_pt_load_map_location
```

```
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/phi4-mini-int4wo-hqq --batch-size 1 --pt_load_map_location cuda:0
```

```
# note taht the dict has to use double quote since that's what json expects
python benchmarks/benchmark_latency.py --input-len 256 --output-len 256 --model jerryzh168/phi4-mini-int4wo-hqq --batch-size 1 --pt_load_map_location '{"": "cuda"}'
```

```
Avg latency: 1.0369751011331876 seconds
10% percentile latency: 1.0276115661486984 seconds
25% percentile latency: 1.03127920627594 seconds
50% percentile latency: 1.0362111562862992 seconds
75% percentile latency: 1.0433001522906125 seconds
90% percentile latency: 1.0466034093871712 seconds
99% percentile latency: 1.0539717579446732 seconds
```

Reviewers:

Subscribers:

Tasks:

Tags:
