### PR TITLE
[Bugfix] Fix Qwen2.5-Omni M-RoPE position ids generation

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1229,12 +1229,12 @@ class MRotaryEmbedding(RotaryEmbedding):
             ]:
                 if use_audio_in_video and idx > 0:
                     if src_item[idx] == vision_end_token_id and \
-                        # processing the <|audio_eos|> before <|vision_eos|>
                         src_item[idx - 1] == audio_end_token_id:
+                        # processing the <|audio_eos|> before <|vision_eos|>
                         start_idx -= 1
                     elif src_item[idx] == audio_start_token_id and \
-                        # processing the <|audio_bos|> after <|vision_eos|>
                         src_item[idx - 1] == vision_start_token_id:
+                        # processing the <|audio_bos|> after <|vision_eos|>
                         start_idx -= 1
                 new_src_item.append(src_item[idx])
                 llm_pos_ids = torch.tensor([start_idx],

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -1197,6 +1197,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         video_token_id = thinker_config.video_token_index
         audio_start_token_id = thinker_config.audio_start_token_id
         audio_end_token_id = thinker_config.audio_end_token_id
+        vision_start_token_id = thinker_config.vision_start_token_id
         vision_end_token_id = thinker_config.vision_end_token_id
         seconds_per_chunk = thinker_config.seconds_per_chunk
         spatial_merge_size = thinker_config.vision_config.spatial_merge_size
@@ -1226,8 +1227,15 @@ class MRotaryEmbedding(RotaryEmbedding):
             if src_item[idx] not in [
                     audio_token_id, video_token_id, image_token_id
             ]:
-                if src_item[idx] == vision_end_token_id and use_audio_in_video:
-                    start_idx -= 1
+                if use_audio_in_video and idx > 0:
+                    if src_item[idx] == vision_end_token_id and \
+                        # processing the <|audio_eos|> before <|vision_eos|>
+                        src_item[idx - 1] == audio_end_token_id:
+                        start_idx -= 1
+                    elif src_item[idx] == audio_start_token_id and \
+                        # processing the <|audio_bos|> after <|vision_eos|>
+                        src_item[idx - 1] == vision_start_token_id:
+                        start_idx -= 1
                 new_src_item.append(src_item[idx])
                 llm_pos_ids = torch.tensor([start_idx],
                                            dtype=torch.long).expand(3, -1)
@@ -1285,11 +1293,6 @@ class MRotaryEmbedding(RotaryEmbedding):
                            tokens_per_second).long()
                 t_index_split_chunk = cls._split_list_into_ranges(
                     t_index, t_ntoken_per_chunk)
-                new_src_item.extend([audio_start_token_id])
-                start_idx -= 1
-                llm_pos_ids_list.extend([
-                    torch.tensor([start_idx], dtype=torch.long).expand(3, -1)
-                ] * 1)
                 place_num = (((audio_seqlen - 1) // 2 + 1 - 2) // 2 + 1) + 2
                 pure_audio_len = place_num - 2
                 added_audio_len = 0
@@ -1300,7 +1303,7 @@ class MRotaryEmbedding(RotaryEmbedding):
                     new_src_item.extend([video_token_id] *
                                         vision_ntoken_per_chunk)
                     vision_llm_pos_ids_list = cls._get_llm_pos_ids_for_vision(
-                        start_idx + 1, video_idx, spatial_merge_size, t_chunk,
+                        start_idx, video_idx, spatial_merge_size, t_chunk,
                         grid_hs, grid_ws).split(1, dim=1)
                     llm_pos_ids_list.extend(vision_llm_pos_ids_list)
                     new_src_item.extend(
@@ -1308,13 +1311,13 @@ class MRotaryEmbedding(RotaryEmbedding):
                             added_audio_len) * [audio_token_id])
                     audio_start_idx = start_idx if len(
                         audio_llm_pos_ids_list
-                    ) == 0 else audio_llm_pos_ids_list[-1][0].item()
+                    ) == 0 else audio_llm_pos_ids_list[-1][0].item() + 1
                     if min(t_ntoken_per_chunk,
                            pure_audio_len - added_audio_len) > 0:
                         audio_llm_pos_ids_list = (torch.arange(
                             min(t_ntoken_per_chunk, pure_audio_len -
                                 added_audio_len)).expand(3, -1) +
-                                                  audio_start_idx + 1).split(
+                                                  audio_start_idx).split(
                                                       1, dim=1)
                     else:
                         audio_llm_pos_ids_list = []
@@ -1329,11 +1332,6 @@ class MRotaryEmbedding(RotaryEmbedding):
                             3, -1) + llm_pos_ids_list[-1].max() + 1).split(
                                 1, dim=1)
                     llm_pos_ids_list.extend(audio_llm_pos_ids_list)
-                llm_pos_ids_list.extend([
-                    torch.tensor(
-                        [llm_pos_ids_list[-1].max() + 1] * 3).unsqueeze(1)
-                ] * 1)
-                new_src_item.extend([audio_end_token_id])
                 audio_idx += 1
                 video_idx += 1
             # move to the next token


### PR DESCRIPTION
## What this PR do

This PR fixes the `MRotaryEmbedding::_omni_get_input_positions_tensor` result when `use_audio_in_video=True` and there is an image or a video in the input

## Root cause

The main branch code incorrectly handles the position shift among `vision_bos`, `audio_bos`, `audio_eos` and `vision_eos`, causing a `1` position delta between the hf output and the vLLM output

1. Main branch vLLM incorrectly applies **position id shift (-1) for image** when `use_audio_in_video=True`, the position id shift should only apply to video
   - Line 1229: didn't check whether `vision_end` belongs to an image or a video
     https://github.com/vllm-project/vllm/blob/205d84aaa974d6c7752705bb2835bac6809794cc/vllm/model_executor/layers/rotary_embedding.py#L1226-L1234
3. Main branch vLLM incorrectly do `audio_bos` & `audio_eos` handling **twice** when `use_audio_in_video=True`
   - first time: Line 1229
     https://github.com/vllm-project/vllm/blob/205d84aaa974d6c7752705bb2835bac6809794cc/vllm/model_executor/layers/rotary_embedding.py#L1226-L1234
   - second time: Line 1288
     https://github.com/vllm-project/vllm/blob/205d84aaa974d6c7752705bb2835bac6809794cc/vllm/model_executor/layers/rotary_embedding.py#L1271-L1296

## Compare to the groundtruth

Current vLLM impl is producing different result from the huggingface transformers impl, the following snippet do these tests.

https://gist.github.com/imkero/0377d5cc175bf068af237465a861dc3d

### Case 1

`use_audio_in_video=True` and an image

```
[input_ids]
tensor([
           100,    101,  # text
           151652, # vision_bos
           151655, 151655, 151655, 151655,  # image tokens
           151653, # vision_eos
           102,    103   # text
])

[image_grid_thw]
tensor([[1, 4, 4]])

[hf] mrope_position_ids
tensor([[0, 1, 2, 3, 3, 3, 3, 5, 6, 7],
        [0, 1, 2, 3, 3, 4, 4, 5, 6, 7],
        [0, 1, 2, 3, 4, 3, 4, 5, 6, 7]])

[vllm] mrope_position_ids
tensor([[0, 1, 2, 3, 3, 3, 3, 4, 5, 6],
        [0, 1, 2, 3, 3, 4, 4, 4, 5, 6],
        [0, 1, 2, 3, 4, 3, 4, 4, 5, 6]])
```

### Case 2

`use_audio_in_video=True` and an video

NOTE: currently the HuggingFace transformers main branch code has another bug in it, and won't produce reliable groundtruth now, see https://github.com/huggingface/transformers/pull/37631

the following result is generated by the transformers code in https://github.com/huggingface/transformers/pull/37631

for detailed explanation about the input and output, please refer to https://github.com/huggingface/transformers/blob/b16b93d6857cc1a3d318d3f9ae9957413a6e976c/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py#L384-L510

```
t_ntoken_per_chunk 50

video_chunk_indexes [(0, 8), (8, 16), (16, 20)]
audio_chunk_indexes [(0, 50), (50, 100), (100, 125)]

[input_ids]
# for readability, i replace the token_id with the token_name
tensor([
    100,    101,

vision_bos, audio_bos,

video, video, video, video, 
video, video, video, video, 

audio, audio, audio, audio, audio, audio, audio, audio, audio, 
audio, audio, audio, audio, audio, audio, audio, audio, audio, 
audio, audio, audio, audio, audio, audio, audio, audio, audio, 
audio, audio, audio, audio, audio, audio, audio, audio, audio, 
audio, audio, audio, audio, audio, audio, audio, audio, audio, 
audio, audio, audio, audio, audio, 

video, video, video, video, 

audio, audio, audio, audio, audio, audio, audio, audio, audio,
audio, audio, audio, audio, audio, audio, audio, audio, audio,
audio, audio, audio, audio, audio, audio, audio,

audio_eos, vision_eos,

    102,    103
])

[video_grid_thw]
tensor([[5, 4, 4]])

[https://github.com/huggingface/transformers/pull/37631] mrope_position_ids
tensor([[ 0,  1,  2,  2,  3,  3,  3,  3, 28, 28, 28, 28,  3,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52, 53, 53, 53, 53, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 78, 79, 80],
        [ 0,  1,  2,  2,  3,  3,  4,  4,  3,  3,  4,  4,  3,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52,  3,  3,  4,  4, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 78, 79, 80],
        [ 0,  1,  2,  2,  3,  4,  3,  4,  3,  4,  3,  4,  3,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52,  3,  4,  3,  4, 53, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 78, 79, 80]])
[vllm] mrope_position_ids
tensor([[ 0,  1,  2,  3,  3,  4,  4,  4,  4, 29, 29, 29, 29,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 54, 54, 54, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 79, 80, 81],
        [ 0,  1,  2,  3,  3,  4,  4,  5,  5,  4,  4,  5,  5,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52, 53,  4,  4,  5,  5, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 79, 80, 81],
        [ 0,  1,  2,  3,  3,  4,  5,  4,  5,  4,  5,  4,  5,  4,  5,  6,  7,  8,
          9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
         45, 46, 47, 48, 49, 50, 51, 52, 53,  4,  5,  4,  5, 54, 55, 56, 57, 58,
         59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
         77, 78, 79, 80, 81]])
```

cc @ywang96 @fyabc 