### PR TITLE
[frontend] enhance tool_calls type check

### DIFF
--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1095,7 +1095,7 @@ def _parse_chat_message_content(
         if role == 'assistant':
             parsed_msg = _AssistantParser(message)
 
-            if "tool_calls" in parsed_msg:
+            if "tool_calls" in parsed_msg and parsed_msg["tool_calls"] is not None: # noqa: E501
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
         elif role == "tool":
             parsed_msg = _ToolParser(message)

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1095,6 +1095,9 @@ def _parse_chat_message_content(
         if role == 'assistant':
             parsed_msg = _AssistantParser(message)
 
+            # The 'tool_calls' is not None check ensures compatibility.
+            # It's needed only if downstream code doesn't strictly
+            # follow the OpenAI spec.
             if ("tool_calls" in parsed_msg
                 and parsed_msg["tool_calls"] is not None):
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1095,7 +1095,8 @@ def _parse_chat_message_content(
         if role == 'assistant':
             parsed_msg = _AssistantParser(message)
 
-            if "tool_calls" in parsed_msg and parsed_msg["tool_calls"] is not None: # noqa: E501
+            if ("tool_calls" in parsed_msg
+                and parsed_msg["tool_calls"] is not None):
                 result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
         elif role == "tool":
             parsed_msg = _ToolParser(message)


### PR DESCRIPTION

FIX #16678 (*link existing issues this PR will resolve*)

Based on the description with tool_calls is None, it can reproduce:

```
client:
python examples/online_serving/openai_chat_completion_client_with_tools.py

    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'object': 'error', 'message': "'NoneType' object is not iterable", 'type': 'BadRequestError', 'param': None, 'code': 400}


server:
INFO 04-20 07:58:28 [async_llm.py:239] Added request chatcmpl-c45e0e16c6694176a2ca86df9926de39.
ERROR 04-20 07:58:29 [serving_chat.py:200] Error in preprocessing prompt inputs
ERROR 04-20 07:58:29 [serving_chat.py:200] Traceback (most recent call last):
ERROR 04-20 07:58:29 [serving_chat.py:200]   File "/home/user/vllm/vllm/entrypoints/openai/serving_chat.py", line 183, in create_chat_completion
ERROR 04-20 07:58:29 [serving_chat.py:200]     ) = await self._preprocess_chat(
ERROR 04-20 07:58:29 [serving_chat.py:200]         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-20 07:58:29 [serving_chat.py:200]   File "/home/user/vllm/vllm/entrypoints/openai/serving_engine.py", line 403, in _preprocess_chat
ERROR 04-20 07:58:29 [serving_chat.py:200]     conversation, mm_data_future = parse_chat_messages_futures(
ERROR 04-20 07:58:29 [serving_chat.py:200]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-20 07:58:29 [serving_chat.py:200]   File "/home/user/vllm/vllm/entrypoints/chat_utils.py", line 1158, in parse_chat_messages_futures
ERROR 04-20 07:58:29 [serving_chat.py:200]     sub_messages = _parse_chat_message_content(
ERROR 04-20 07:58:29 [serving_chat.py:200]                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-20 07:58:29 [serving_chat.py:200]   File "/home/user/vllm/vllm/entrypoints/chat_utils.py", line 1098, in _parse_chat_message_content
ERROR 04-20 07:58:29 [serving_chat.py:200]     result_msg["tool_calls"] = list(parsed_msg["tool_calls"])
ERROR 04-20 07:58:29 [serving_chat.py:200]                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-20 07:58:29 [serving_chat.py:200] TypeError: 'NoneType' object is not iterable

```

<!--- pyml disable-next-line no-emphasis-as-heading -->
