### PR TITLE
house keeping - fixing docker build warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -153,7 +153,7 @@ RUN if [ "$RUN_WHEEL_CHECK" = "true" ]; then \
 #################### EXTENSION Build IMAGE ####################
 
 #################### DEV IMAGE ####################
-FROM base as dev
+FROM base AS dev
 
 # This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
 # Reference: https://github.com/astral-sh/uv/pull/1694


### PR DESCRIPTION
Fixing silly docker build warning:

```
[+] Building 1452.0s (30/41)                                                                                                                                                                                                   docker:default
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 156)                                                                                                                                                         0.1s
 => => sha256:da6791294b0b04d7e65d87b7451d6f2390b4d36225ab0701ee7dfec5769829f5 743B / 743B  
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
