### PR TITLE
[Bugfix] Triton FA function takes no keyword arguments

### DIFF
--- a/vllm/attention/backends/mla/common.py
+++ b/vllm/attention/backends/mla/common.py
@@ -1076,7 +1076,14 @@ class MLACommonImpl(MLAAttentionImpl[T], Generic[T]):
                 q,
                 k,
                 maybe_padded_v,
-                **kwargs,
+                None,  # output
+                kwargs["cu_seqlens_q"],
+                kwargs["cu_seqlens_k"],
+                kwargs["max_seqlen_q"],
+                kwargs["max_seqlen_k"],
+                kwargs["causal"],
+                softmax_scale,
+                None,  # bias
             )
         if is_vllm_fa:
             attn_out = self.flash_attn_varlen_func(


### PR DESCRIPTION
This PR resolves an existing bug in serving Deepseek model using MLA backend with triton flash attention when running the command below:

`VLLM_MLA_DISABLE=0 VLLM_ATTENTION_BACKEND=TRITON_MLA VLLM_USE_TRITON_FLASH_ATTN=1 vllm serve deepseek-ai/DeepSeek-V3 --trust-remote-code --swap-space 16 --disable-log-requests -tp 8`

Throws the error below:

""ERROR 04-21 04:42:55 [engine.py:448]   File "/app/vllm/vllm/attention/backends/mla/common.py", line 1431, in forward
ERROR 04-21 04:42:55 [engine.py:448]     output[:num_prefill_tokens] = self._forward_prefill(
ERROR 04-21 04:42:55 [engine.py:448]                                   ^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-21 04:42:55 [engine.py:448]   File "/app/vllm/vllm/attention/backends/mla/common.py", line 1315, in _forward_prefill
ERROR 04-21 04:42:55 [engine.py:448]     output = self._flash_attn_varlen_diff_headdims(
ERROR 04-21 04:42:55 [engine.py:448]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-21 04:42:55 [engine.py:448]   File "/app/vllm/vllm/attention/backends/mla/common.py", line 1089, in _flash_attn_varlen_diff_headdims
ERROR 04-21 04:42:55 [engine.py:448]     attn_out = self.triton_fa_func(
ERROR 04-21 04:42:55 [engine.py:448]                ^^^^^^^^^^^^^^^^^^^^
ERROR 04-21 04:42:55 [engine.py:448]   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 575, in apply
ERROR 04-21 04:42:55 [engine.py:448]     return super().apply(*args, **kwargs)  # type: ignore[misc]
ERROR 04-21 04:42:55 [engine.py:448]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ERROR 04-21 04:42:55 [engine.py:448] TypeError: apply() takes no keyword arguments
ERROR 04-21 04:42:56 [multiproc_worker_utils.py:120] Worker VllmWorkerProcess pid 38646 died, exit code: -15
INFO 04-21 04:42:56 [multiproc_worker_utils.py:124] Killing local vLLM worker processes
""


<!--- pyml disable-next-line no-emphasis-as-heading -->
