### PR TITLE
[Bugfix] Fix distributed bug in Qwen2.5-VL & Qwen2.5-Omni

### DIFF
--- a/vllm/model_executor/models/qwen2_5_vl.py
+++ b/vllm/model_executor/models/qwen2_5_vl.py
@@ -198,9 +198,8 @@ class Qwen2_5_VisionMLP(nn.Module):
 
 def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
     """All-gather the input tensor interleavely across model parallel group."""
-    import torch.distributed as dist
     gathered_tensors = [torch.zeros_like(local_tensor) for _ in range(tp_size)]
-    dist.all_gather(gathered_tensors, local_tensor)
+    parallel_state.get_tp_group().all_gather(gathered_tensors, local_tensor)
 
     gathered_tensors_split = [
         torch.split(tensor, hidden_size // tp_size, -1)


### PR DESCRIPTION
This PR fixes the distribution bug in Qwen2.5-VL & Qwen2.5-Omni (introduced in #15130).

When `tp_group != world_size`, current implementation will cause an allgather error.
