### PR TITLE
[Doc] Split dummy_processor_inputs() in Multimodal Docs

### DIFF
--- a/docs/source/design/mm_processing.md
+++ b/docs/source/design/mm_processing.md
@@ -47,7 +47,7 @@ Moreover, since the tokenized text has not passed through the HF processor, we h
 
 ### Dummy text
 
-We work around the first issue by requiring each model to define how to generate dummy text based on the number of multi-modal inputs, via {meth}`~vllm.multimodal.profiling.BaseDummyInputsBuilder.get_dummy_processor_inputs`. This lets us generate dummy text corresponding to the multi-modal inputs and input them together to obtain the processed multi-modal data.
+We work around the first issue by requiring each model to define how to generate dummy text based on the number of multi-modal inputs, via {meth}`~vllm.multimodal.profiling.BaseDummyInputsBuilder.get_dummy_text`. This lets us generate dummy text corresponding to the multi-modal inputs and input them together to obtain the processed multi-modal data.
 
 (mm-automatic-prompt-updating)=
 


### PR DESCRIPTION
This PR follows https://github.com/vllm-project/vllm/pull/16416 with some doc changes for implementing `get_dummy_mm_data` & `get_dummy_text` instead of `get_dummy_processor_inputs`, since multimodal models should now implement these directly! @DarkLight1337