### PR TITLE
[Bugfix] Fix the missing '}' issue for nested object parameters in stream function call.

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/hermes_tool_parser.py
@@ -41,6 +41,7 @@ class Hermes2ProToolParser(ToolParser):
 
         self.tool_call_start_token: str = "<tool_call>"
         self.tool_call_end_token: str = "</tool_call>"
+        self.right_brace_processed = set()
 
         self.tool_call_regex = re.compile(
             r"<tool_call>(.*?)</tool_call>|<tool_call>(.*)", re.DOTALL)
@@ -342,7 +343,9 @@ class Hermes2ProToolParser(ToolParser):
             elif cur_arguments and prev_arguments:
                 if isinstance(delta_text, str) and len(delta_text.rstrip(
                 )) >= 1 and delta_text.rstrip()[-1] == '}':
-                    delta_text = delta_text.rstrip()[:-1]
+                    if self.current_tool_id not in self.right_brace_processed:
+                        delta_text = delta_text.rstrip()[:-1]
+                        self.right_brace_processed.add(self.current_tool_id)
 
                 logger.debug("got diff %s", delta_text)
 


### PR DESCRIPTION
This PR fixes the problem of an illegal JSON format being returned when using a nested object parameter under a streaming function call. The test cases are as follows
```python
    client = OpenAI(base_url=VLLM_SERVER_API, api_key="not-needed")
    tools = [{
        "type": "function",
        "function": {
            "name": "search_knowledge_base",
            "description": "Query a knowledge base to retrieve relevant info on a topic.",
            "parameters": {
                "type": "object",
                "properties": {
                    "query": {
                        "type": "string",
                        "description": "The user question or search query."
                    },
                    "options": {
                        "type": "object",
                        "properties": {
                            "num_results": {
                                "type": "number",
                                "description": "Number of top results to return."
                            },
                            "domain_filter": {
                                "type": [
                                    "string",
                                    "null"
                                ],
                                "description": "Optional domain to narrow the search (e.g. 'finance', 'medical'). Pass null if not needed."
                            },
                            "sort_by": {
                                "type": [
                                    "string",
                                    "null"
                                ],
                                "enum": [
                                    "relevance",
                                    "date",
                                    "popularity",
                                    "alphabetical"
                                ],
                                "description": "How to sort results. Pass null if not needed."
                            }
                        },
                        "required": [
                            "num_results",
                            "domain_filter",
                            "sort_by"
                        ],
                        "additionalProperties": False
                    }
                },
                "required": [
                    "query",
                    "options"
                ],
                "additionalProperties": False
            },
            "strict": True
        }
    }]

    stream = client.chat.completions.create(
        model=MODEL_NAME,
        messages=[{"role": "user", "content": "Can you find information about ChatGPT in the AI knowledge base?"}],
        tools=tools,
        stream=True,
        temperature=0.0
    )

    final_tool_calls = {}
    for chunk in stream:
        print(f"chunk {chunk}")
        for tool_call in chunk.choices[0].delta.tool_calls or []:
            index = tool_call.index
            if index not in final_tool_calls:
                final_tool_calls[index] = tool_call
            if final_tool_calls[index].function.arguments is None:
                final_tool_calls[index].function.arguments = ""
            if tool_call.function.arguments is None:
                continue
            final_tool_calls[index].function.arguments += tool_call.function.arguments
    print(f"final_tool_calls {final_tool_calls}")
````

The returned result is as follows. The last chunk parameter is '' which is missing }, resulting in a JSON parsing failure.

> ChatCompletionChunk(id='chatcmpl-8c9fd015bfb94ea6af80183d04c5a9ae', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, refusal=None, role=None, tool_calls=[ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(**arguments='"}',** name=None), type=None)]), finish_reason=None, index=0, logprobs=None)], created=1745236648, model='/root/ai-models/qwen2.5-7b', object='chat.completion.chunk', service_tier=None, system_fingerprint=None, usage=None)
> 
> ChatCompletionChunk(id='chatcmpl-8c9fd015bfb94ea6af80183d04c5a9ae', choices=[Choice(delta=ChoiceDelta(content=None, function_call=None, refusal=None, role=None, tool_calls=[ChoiceDeltaToolCall(index=0, id=None, function=ChoiceDeltaToolCallFunction(**arguments=''**, name=None), type=None)]), finish_reason=None, index=0, logprobs=None)], created=1745236648, model='/root/ai-models/qwen2.5-7b', object='chat.completion.chunk', service_tier=None, system_fingerprint=None, usage=None)

