### PR TITLE
chore: use recommended Python install commands

### DIFF
--- a/benchmarks/kernels/deepgemm/README.md
+++ b/benchmarks/kernels/deepgemm/README.md
@@ -11,7 +11,6 @@ You need to install vLLM in your usual fashion, then install DeepGEMM from sourc
 ```
 git clone --recursive https://github.com/deepseek-ai/DeepGEMM
 cd DeepGEMM
-python setup.py install
 uv pip install -e .
 ```
 

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -97,7 +97,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=bind,source=.git,target=.git \
-    VLLM_TARGET_DEVICE=cpu python3 setup.py develop 
+    VLLM_TARGET_DEVICE=cpu uv pip install --editable .
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -r requirements/dev.txt && \

--- a/docker/Dockerfile.hpu
+++ b/docker/Dockerfile.hpu
@@ -9,7 +9,7 @@ RUN pip install -v -r requirements/hpu.txt
 ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
-RUN VLLM_TARGET_DEVICE=hpu python3 setup.py install
+RUN VLLM_TARGET_DEVICE=hpu pip install .
 
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils

--- a/docker/Dockerfile.ppc64le
+++ b/docker/Dockerfile.ppc64le
@@ -57,7 +57,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
     cd pytorch && \
     uv pip install -r requirements.txt && \
-    python setup.py develop && \
+    uv pip install --editable . && \
     rm -f dist/torch*+git*whl && \
     MAX_JOBS=${MAX_JOBS:-$(nproc)} \
     PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 uv build --wheel --out-dir /torchwheels/

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -96,7 +96,7 @@ RUN if [ ${BUILD_RPD} -eq "1" ]; then \
     && cd rocmProfileData/rpd_tracer \
     && pip install -r requirements.txt && cd ../ \
     && make && make install \
-    && cd hipMarker && python3 setup.py install ; fi
+    && cd hipMarker && python3 -m pip install . ; fi
 
 # Install vLLM
 RUN --mount=type=bind,from=export_vllm,src=/,target=/install \

--- a/docker/Dockerfile.tpu
+++ b/docker/Dockerfile.tpu
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
     python3 -m pip install \
         -r requirements/tpu.txt
-RUN python3 setup.py develop
+RUN python3 -m pip install --editable .
 
 # install development dependencies (for testing)
 RUN python3 -m pip install -e tests/vllm_test_utils

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -38,7 +38,7 @@ ENV VLLM_TARGET_DEVICE=xpu
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=.git,target=.git \
-    python3 setup.py install
+    pip install .
 
 # Please refer xpu doc, we need manually install intel-extension-for-pytorch 2.6.10+xpu due to there are some conflict dependencies with torch 2.6.0+xpu
 # FIXME: This will be fix in ipex 2.7. just leave this here for awareness.

--- a/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
+++ b/docs/source/getting_started/installation/ai_accelerator/hpu-gaudi.inc.md
@@ -64,7 +64,7 @@ To build and install vLLM from source, run:
 git clone https://github.com/vllm-project/vllm.git
 cd vllm
 pip install -r requirements/hpu.txt
-python setup.py develop
+pip install --editable .
 ```
 
 Currently, the latest features and performance optimizations are developed in Gaudi's [vLLM-fork](https://github.com/HabanaAI/vllm-fork) and we periodically upstream them to vLLM main repo. To install latest [HabanaAI/vLLM-fork](https://github.com/HabanaAI/vllm-fork), run the following:
@@ -74,7 +74,7 @@ git clone https://github.com/HabanaAI/vllm-fork.git
 cd vllm-fork
 git checkout habana_main
 pip install -r requirements/hpu.txt
-python setup.py develop
+pip install --editable .
 ```
 
 ## Set up using Docker

--- a/docs/source/getting_started/installation/ai_accelerator/tpu.inc.md
+++ b/docs/source/getting_started/installation/ai_accelerator/tpu.inc.md
@@ -158,7 +158,7 @@ sudo apt-get install libopenblas-base libopenmpi-dev libomp-dev
 Run the setup script:
 
 ```bash
-VLLM_TARGET_DEVICE="tpu" python setup.py develop
+VLLM_TARGET_DEVICE=tpu pip install --editable .
 ```
 
 ## Set up using Docker

--- a/docs/source/getting_started/installation/cpu/build.inc.md
+++ b/docs/source/getting_started/installation/cpu/build.inc.md
@@ -24,5 +24,5 @@ pip install -v -r requirements/cpu.txt --extra-index-url https://download.pytorc
 Finally, build and install vLLM CPU backend:
 
 ```console
-VLLM_TARGET_DEVICE=cpu python setup.py install
+VLLM_TARGET_DEVICE=cpu pip install .
 ```

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -65,7 +65,7 @@ Currently, there are no pre-built ROCm wheels.
     cd flash-attention
     git checkout b7d29fb
     git submodule update --init
-    GPU_ARCHS="gfx90a" python3 setup.py install
+    GPU_ARCHS="gfx90a" pip install .
     cd ..
     ```
 
@@ -88,7 +88,7 @@ Currently, there are no pre-built ROCm wheels.
 
     # Build vLLM for MI210/MI250/MI300.
     $ export PYTORCH_ROCM_ARCH="gfx90a;gfx942"
-    $ python3 setup.py develop
+    $ pip install --editable .
     ```
 
     This may take 5-10 minutes. Currently, `pip install .` does not work for ROCm installation.

--- a/docs/source/getting_started/installation/gpu/xpu.inc.md
+++ b/docs/source/getting_started/installation/gpu/xpu.inc.md
@@ -30,7 +30,7 @@ pip install -v -r requirements/xpu.txt
 - Then, build and install vLLM XPU backend:
 
 ```console
-VLLM_TARGET_DEVICE=xpu python setup.py install
+VLLM_TARGET_DEVICE=xpu pip install .
 ```
 
 - Finally, due to a known issue of conflict dependency(oneapi related) in torch-xpu 2.6 and ipex-xpu 2.6, we install ipex here. This will be fixed in the ipex-xpu 2.7.


### PR DESCRIPTION
[PyPA deprecated][1] `python setup.py install` and `python setup.py develop` and recommends `pip install .` and `pip install --editable .`, respectively.

[1]: https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#should-setup-py-be-deleted