### PR TITLE
[Model] Refactor Mamba2 SSD to improve chunked prefill performance

### DIFF
--- a/tests/kernels/mamba/test_mamba_ssm_ssd.py
+++ b/tests/kernels/mamba/test_mamba_ssm_ssd.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 
 from vllm.model_executor.layers.mamba.mamba2_metadata import (
-    _seq_idx_to_chunk_indices_offsets)
+    _query_start_loc_to_chunk_indices_offsets)
 from vllm.model_executor.layers.mamba.ops.ssd_combined import (
     mamba_chunk_scan_combined)
 from vllm.platforms import current_platform
@@ -274,8 +274,9 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases,
                                          last_taken, exhausted, n_heads,
                                          d_head, itype):
 
-        chunk_indices, chunk_offsets = _seq_idx_to_chunk_indices_offsets(
-            seq_idx, chunk_size)
+        chunk_indices, chunk_offsets = \
+            _query_start_loc_to_chunk_indices_offsets(
+                cu_seqlens, chunk_size, cu_seqlens[-1])
 
         Y, new_states = mamba_chunk_scan_combined(
             X,

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -71,14 +71,14 @@ def prepare_mamba2_metadata(
 
     # Need flags to indicate if there are initial states
     # currently we really only support the FlashAttention backend
-    # initial states are only relevant for prefills
     has_initial_states = None
     prep_initial_states = False
     if (isinstance(attn_metadata, (FlashAttentionMetadata, XFormersMetadata,
                                    PlaceholderAttentionMetadata))
             and attn_metadata.context_lens_tensor is not None):
+        # keeping flags for both prefill and decode causal_conv1d varlen
         has_initial_states = attn_metadata.context_lens_tensor > 0  # [batch,]
-        # precompute flag to avoid device syncs later in mamba2 forwards
+        # precompute flag to avoid device syncs later in mamba2 layer forwards
         # prep is only needed for mamba2 ssd prefill processing
         prep_initial_states = torch.any(
             has_initial_states[:num_prefills]).item()

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -77,7 +77,9 @@ def prepare_mamba2_metadata(
             and attn_metadata.context_lens_tensor is not None):
         has_initial_states = attn_metadata.context_lens_tensor > 0  # [batch,]
         # precompute flag to avoid device syncs later in mamba2 forwards
-        prep_initial_states = torch.any(has_initial_states).item()
+        # prep is only needed for mamba2 ssd prefill processing
+        prep_initial_states = torch.any(
+            has_initial_states[:num_prefills]).item()
 
     # Compute seq_idx, chunk_indices and chunk_offsets for prefill only
     seq_idx = None

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -545,8 +545,8 @@ class MambaMixer2(CustomOp):
             dt_d = dt_d[:, :, None].expand(-1, -1, self.head_dim)
             dt_bias = self.dt_bias[:, None, ...].expand(-1, self.head_dim)
             D_d = self.D[:, None, ...].expand(-1, self.head_dim)
-            B_d = B_d.view(-1, n_groups, B.shape[1] // n_groups)
-            C_d = C_d.view(-1, n_groups, C.shape[1] // n_groups)
+            B_d = B_d.view(-1, n_groups, B_d.shape[1] // n_groups)
+            C_d = C_d.view(-1, n_groups, C_d.shape[1] // n_groups)
             hidden_states_d = hidden_states_d.view(
                 -1, self.num_heads // self.tp_size, self.head_dim)
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -468,7 +468,7 @@ class MambaMixer2(CustomOp):
             dim=0,
         )
         C_p, C_d = torch.split(
-            B,
+            C,
             [num_prefill_tokens, num_decodes],
             dim=0,
         )

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -391,9 +391,9 @@ class MambaMixer2(CustomOp):
         # stay the same and reused for all mamba layers in the same iteration
         attn_metadata: AttentionMetadata = get_forward_context().attn_metadata
 
-        num_prefills = attn_metadata.num_prefills  # #requests
-        num_decodes = attn_metadata.num_decode_tokens  # #tokens==#requests
-        num_prefill_tokens = attn_metadata.num_prefill_tokens  # #tokens
+        num_prefills = attn_metadata.num_prefills  # request count
+        num_decodes = attn_metadata.num_decode_tokens  # token count (=request)
+        num_prefill_tokens = attn_metadata.num_prefill_tokens  # token count
         has_prefill = num_prefills > 0
         has_decode = num_decodes > 0
 

--- a/vllm/model_executor/layers/mamba/ops/ssd_combined.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_combined.py
@@ -40,7 +40,6 @@ def _mamba_chunk_scan_combined_fwd(x,
     _, _, ngroups, dstate = B.shape
     assert nheads % ngroups == 0
     assert B.shape == (batch, seqlen, ngroups, dstate)
-    assert x.shape == (batch, seqlen, nheads, headdim)
     assert dt.shape == (batch, seqlen, nheads)
     assert A.shape == (nheads, )
     assert C.shape == B.shape

--- a/vllm/model_executor/models/bamba.py
+++ b/vllm/model_executor/models/bamba.py
@@ -313,7 +313,6 @@ class BambaModel(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.mamba_chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -338,7 +338,6 @@ class GraniteMoeHybridModel(nn.Module):
         attn_metadata = get_forward_context().attn_metadata
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.mamba_chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -142,7 +142,6 @@ class Mamba2Model(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/zamba2.py
+++ b/vllm/model_executor/models/zamba2.py
@@ -751,7 +751,6 @@ class Zamba2Model(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 


### PR DESCRIPTION
We found that when chunked prefill is enabled, the performance is bad for benchmark_serving.py with ShareGPTv3. After some analysis, we identified that `chunk_scan_fwd_kernel` latency increases linearly with the number of "chunks", and while this can process prefill chunks efficiently, each decode request in the mixed batch will give the kernel one full chunk of work to process, despite that the decode request has only a single token. 

In this PR, we modify the mamba2 ssd control flow assuming vLLM v0, where the mixed input batch has prefill chunks that come before decode requests. When processing the input, we split the input tensors at the prefill-decode boundary, and invoke SSD processing functions to apply to them separately. In this way, the prefill kernels don't deal with decode requests and can run more efficiently. 

For V1 Mamba2 SSD will likely require reordering of the batch for the logic to work and will need some rewriting.

Known issue:
- This PR doesn't split prefill and decode for causal_conv1d, and from profile results, conv1d is still a huge bottleneck for  benchmark_serving with chunked prefill ON. I built another draft PR #17146  that builds on top of this by splitting conv1d inputs, which show very promising performance improvement. We will address conv1d soon with a follow up PR.