### PR TITLE
[V1][Structured Output] Clear xgrammar compiler object when engine core shut down to avoid nanobind leaked warning

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -252,6 +252,10 @@ class EngineCore:
         if self.model_executor:
             self.model_executor.shutdown()
 
+        so_backend = self.structured_output_manager.backend
+        if so_backend is not None:
+            so_backend.destroy()
+
     def profile(self, is_start: bool = True):
         self.model_executor.profile(is_start)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -249,12 +249,9 @@ class EngineCore:
         return engine_core_outputs
 
     def shutdown(self):
+        self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()
-
-        so_backend = self.structured_output_manager.backend
-        if so_backend is not None:
-            so_backend.destroy()
 
     def profile(self, is_start: bool = True):
         self.model_executor.profile(is_start)

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -107,3 +107,7 @@ class StructuredOutputManager:
         # np.ndarray, because that is much more efficient for serialization
         # and deserialization when sending this to the GPU workers.
         return bitmask_tensor.numpy()
+
+    def clear_backend(self) -> None:
+        if self.backend is not None:
+            self.backend.destroy()

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -110,6 +110,9 @@ class GuidanceBackend(StructuredOutputBackend):
         return llguidance_torch.allocate_token_bitmask(
             max_num_seqs, self.ll_tokenizer.vocab_size)
 
+    def destroy(self):
+        pass
+
 
 @dataclass
 class GuidanceGrammar(StructuredOutputGrammar):

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -91,5 +91,5 @@ class StructuredOutputBackend(ABC):
     @abstractmethod
     def destroy(self):
         """
-        Clear objects in the backend to avoid nanobind leaked.
+        Backend-specific cleanup.
         """

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -87,3 +87,9 @@ class StructuredOutputBackend(ABC):
             max_num_seqs (int): The maximum number of sequences for which
               to allocate the bitmask.
         """
+
+    @abstractmethod
+    def destroy(self):
+        """
+        Clear objects in the backend to avoid nanobind leaked.
+        """

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -126,6 +126,9 @@ class XgrammarBackend(StructuredOutputBackend):
     def allocate_token_bitmask(self, max_num_seqs: int):
         return xgr.allocate_token_bitmask(max_num_seqs, self.vocab_size)
 
+    def destroy(self):
+        del self.compiler
+
 
 @dataclass
 class XgrammarGrammar(StructuredOutputGrammar):


### PR DESCRIPTION
Clear `xgrammar` compiler object when engine core shut down to avoid nanobind leaked warning.

Find more details about the bug here: https://github.com/vllm-project/vllm/issues/16951.

**How to fix?**

1. Add a `destroy()` method to `StructuredOutputBackend` and implement it in `xgrammar` backend.
2. call this `destroy()` method when engine core shut down to delete the `xgrammar` compiler.

After apply this change, structured output worked well with `xgrammar` without leaked warning.

The test logs are shown below:

```bash
Processed prompts: 100%|████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.94s/it, est. speed input: 3.74 toks/s, output: 1.02 toks/s]
--------------------------------------------------
Guided decoding by Choice: Negative
--------------------------------------------------
Processed prompts: 100%|█████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.67it/s, est. speed input: 117.71 toks/s, output: 29.42 toks/s]
--------------------------------------------------
Guided decoding by Regex: alan_turing@enigma.com
--------------------------------------------------
Processed prompts: 100%|██████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.27it/s, est. speed input: 27.89 toks/s, output: 27.89 toks/s]
--------------------------------------------------
Guided decoding by JSON: {"brand": "Ford", "model": "Mustang", "car_type": "Coupe"}
--------------------------------------------------
Processed prompts: 100%|██████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.18it/s, est. speed input: 24.83 toks/s, output: 24.82 toks/s]
--------------------------------------------------
Guided decoding by Grammar: SELECT col_1  from table_1  where col_2 = 1 
--------------------------------------------------
```

