### PR TITLE
[Misc] Add S3 environment variables for better support of MinIO.

### DIFF
--- a/vllm/transformers_utils/s3_utils.py
+++ b/vllm/transformers_utils/s3_utils.py
@@ -45,7 +45,12 @@ def glob(s3=None,
         list[str]: List of full S3 paths allowed by the pattern
     """
     if s3 is None:
-        s3 = boto3.client("s3")
+        s3 = boto3.client(
+            's3',
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
+            region_name=os.getenv("AWS_REGION_NAME"))
     if not path.endswith("/"):
         path = path + "/"
     bucket_name, _, paths = list_files(s3,
@@ -107,7 +112,12 @@ class S3Model:
     """
 
     def __init__(self) -> None:
-        self.s3 = boto3.client('s3')
+        self.s3 = boto3.client(
+            's3',
+            aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+            endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
+            region_name=os.getenv("AWS_REGION_NAME"))
         for sig in (signal.SIGINT, signal.SIGTERM):
             existing_handler = signal.getsignal(sig)
             signal.signal(sig, self._close_by_signal(existing_handler))


### PR DESCRIPTION


MinIO is an object storage service compatible with the S3 protocol.  
It is commonly used by setting the environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ENDPOINT_URL`.

For example: https://github.com/run-ai/runai-model-streamer/blob/master/cpp/s3/s3.h#L31


Add S3 environment variables for better support of MinIO.