### PR TITLE
[BugFix] Revert ROCm Custom Paged Attention Env Flag Check

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -118,6 +118,7 @@ def use_rocm_custom_paged_attention(qtype: torch.dtype, head_size: int,
             and (head_size == 64 or head_size == 128)
             and (block_size == 16 or block_size == 32)
             and (gqa_ratio >= 1 and gqa_ratio <= 16) and max_seq_len <= 32768
+            and (envs.VLLM_ROCM_CUSTOM_PAGED_ATTN)
             and not (envs.VLLM_ROCM_USE_AITER_PAGED_ATTN
                      and envs.VLLM_ROCM_USE_AITER))
 


### PR DESCRIPTION
#15001 Removes `envs.VLLM_ROCM_CUSTOM_PAGED_ATTN` from the `use_rocm_custom_paged_attention` check. This might cause vllm to use rocm custom paged attention even when the flag is not set. This PR reverts the check to maintain correctness.