### PR TITLE
Addendum Fix to support FIPS enabled machines with MD5 hashing

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/shared_storage_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/shared_storage_connector.py
@@ -357,7 +357,8 @@ class SharedStorageConnector(KVConnectorBase_V1):
         ids.
         """
         input_ids_bytes = input_ids.numpy().tobytes()
-        input_ids_hash = hashlib.md5(input_ids_bytes).hexdigest()
+        input_ids_hash = hashlib.md5(input_ids_bytes,
+                                     usedforsecurity=False).hexdigest()
         foldername = os.path.join(self._storage_path, input_ids_hash)
         if create_folder:
             os.makedirs(foldername, exist_ok=True)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -794,6 +794,7 @@ def compute_hash() -> str:
         if key in environment_variables:
             factorize(key)
 
-    hash_str = hashlib.md5(str(factors).encode()).hexdigest()
+    hash_str = hashlib.md5(str(factors).encode(),
+                           usedforsecurity=False).hexdigest()
 
     return hash_str


### PR DESCRIPTION
Complete FIPS compliance fixes for MD5 hashing

This PR completes the work started in the previous merge (#15299), which addressed the issue of FIPS-enabled machines prohibiting MD5 hashing. The previous PR used the `usedforsecurity=False` flag with hashlib.md5() to resolve the issue, but it missed applying this change in a few locations within the codebase. The following changes ensure full compliance with FIPS requirements across the entire library.

FIX #17031


<!--- pyml disable-next-line no-emphasis-as-heading -->
