### PR TITLE
Move V1 into regular `mypy` call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ files = [
     "vllm/transformers_utils",
     "vllm/triton_utils",
     "vllm/usage",
+    "vllm/v1",
 ]
 # TODO(woosuk): Include the code from Megatron and HuggingFace.
 exclude = [

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -34,4 +34,3 @@ run_mypy vllm/plugins
 run_mypy vllm/prompt_adapter
 run_mypy vllm/spec_decode
 run_mypy vllm/worker
-run_mypy vllm/v1


### PR DESCRIPTION
Once all code inside `vllm/v1` is `mypy` compliant, this PR should be mergeable.

Relevant PRs that udpate typing in `vllm/v1`:
- [x] #17051
- [x] #17053
- [x] #17104
- [x] #17105
- [ ] #17113