### PR TITLE
[Core] Prevent side-channel attacks via cache salting

### DIFF
--- a/docs/source/design/v1/prefix_caching.md
+++ b/docs/source/design/v1/prefix_caching.md
@@ -92,6 +92,8 @@ To improve privacy in shared environments, vLLM supports isolating prefix cache 
 
 With this setup, cache sharing is limited to users or requests that explicitly agree on a common salt, enabling cache reuse within a trust group while isolating others.
 
+> **Note:** Cache isolation is not supported in engine V0.
+
 ## Data Structure
 
 The prefix caching in vLLM v1 is implemented in the KV cache manager. The basic building block is the “Block” data class (simplified):

--- a/docs/source/design/v1/prefix_caching.md
+++ b/docs/source/design/v1/prefix_caching.md
@@ -16,7 +16,7 @@ In the example above, the KV cache in the first block can be uniquely identified
 
 * Parent hash value: The hash value of the parent hash block.
 * Block tokens: A tuple of tokens in this block. The reason to include the exact tokens is to reduce potential hash value collision.
-* Extra hashes: Other values required to make this block unique, such as LoRA IDs and multi-modality input hashes (see the example below).
+* Extra hashes: Other values required to make this block unique, such as LoRA IDs, multi-modality input hashes (see the example below), and cache salts to isolate caches in multi-tenant environments.
 
 > **Note 1:** We only cache full blocks.
 
@@ -75,6 +75,22 @@ Block 3
 ```
 
 In the rest of this document, we first introduce the data structure used for prefix caching in vLLM v1, followed by the prefix caching workflow of major KV cache operators (e.g., allocate, append, free, eviction). Finally, we use an example to illustrate the end to end prefix caching workflow.
+
+**Cache Isolation for Security**
+To improve privacy in shared environments, vLLM supports isolating prefix cache reuse through optional per-request salting. By including a `cache_salt` in the request, this value is injected into the hash of the first block, ensuring that only requests with the same salt can reuse cached KV blocks. This prevents timing-based attacks where an adversary could infer cached content by observing latency differences. This offers protection without compromising performance.
+
+```json
+{
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Here is a document with details about the world series: ..."},
+    {"role": "user", "content": "Who won the world series in 2020?"}
+  ],
+  "cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ=="
+}
+```
+
+With this setup, cache sharing is limited to users or requests that explicitly agree on a common salt, enabling cache reuse within a trust group while isolating others.
 
 ## Data Structure
 

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -273,6 +273,26 @@ def test_serving_chat_could_load_correct_generation_config():
     assert mock_engine.generate.call_args.args[1].temperature == 0.0
     assert mock_engine.generate.call_args.args[1].repetition_penalty == 1.05
 
+
+def test_serving_chat_did_set_correct_cache_salt():
+    mock_model_config = MockModelConfig()
+
+    mock_engine = MagicMock(spec=MQLLMEngineClient)
+    mock_engine.get_tokenizer.return_value = get_tokenizer(MODEL_NAME)
+    mock_engine.errored = False
+
+    # Initialize the serving chat
+    models = OpenAIServingModels(engine_client=mock_engine,
+                                 base_model_paths=BASE_MODEL_PATHS,
+                                 model_config=mock_model_config)
+    serving_chat = OpenAIServingChat(mock_engine,
+                                     mock_model_config,
+                                     models,
+                                     response_role="assistant",
+                                     chat_template=CHAT_TEMPLATE,
+                                     chat_template_content_format="auto",
+                                     request_logger=None)
+
     # Test cache_salt
     req = ChatCompletionRequest(
         model=MODEL_NAME,

--- a/tests/entrypoints/openai/test_serving_chat.py
+++ b/tests/entrypoints/openai/test_serving_chat.py
@@ -272,3 +272,23 @@ def test_serving_chat_could_load_correct_generation_config():
 
     assert mock_engine.generate.call_args.args[1].temperature == 0.0
     assert mock_engine.generate.call_args.args[1].repetition_penalty == 1.05
+
+    # Test cache_salt
+    req = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{
+            "role": "user",
+            "content": "what is 1+1?"
+        }],
+    )
+
+    # By default cache_salt in the engine prompt is not set
+    with suppress(Exception):
+        asyncio.run(serving_chat.create_chat_completion(req))
+    assert "cache_salt" not in mock_engine.generate.call_args.args[0]
+
+    # Test with certain cache_salt
+    req.cache_salt = "test_salt"
+    with suppress(Exception):
+        asyncio.run(serving_chat.create_chat_completion(req))
+    assert mock_engine.generate.call_args.args[0]["cache_salt"] == "test_salt"

--- a/tests/tokenization/test_detokenize.py
+++ b/tests/tokenization/test_detokenize.py
@@ -60,8 +60,16 @@ def _run_incremental_decode(tokenizer,
         skip_special_tokens=skip_special_tokens,
         spaces_between_special_tokens=spaces_between_special_tokens,
     )
-    request = EngineCoreRequest("", prompt_token_ids, None, None, None, params,
-                                None, 0.0, None)
+    request = EngineCoreRequest("",
+                                prompt_token_ids,
+                                None,
+                                None,
+                                None,
+                                params,
+                                None,
+                                0.0,
+                                None,
+                                cache_salt=None)
 
     if fast is None:
         detokenizer = IncrementalDetokenizer.from_new_request(

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -29,7 +29,8 @@ from vllm.v1.request import Request
 def make_request(request_id,
                  prompt_token_ids,
                  mm_positions=None,
-                 mm_hashes=None):
+                 mm_hashes=None,
+                 cache_salt=None):
     if mm_positions is None:
         multi_modal_inputs = None
     else:
@@ -45,6 +46,7 @@ def make_request(request_id,
         eos_token_id=100,
         arrival_time=0,
         lora_request=None,
+        cache_salt=cache_salt,
     )
 
 
@@ -211,6 +213,45 @@ def test_generate_block_hash_extra_keys_no_mm_inputs():
     extra_keys, next_mm_idx = generate_block_hash_extra_keys(request, 0, 5, 0)
     assert extra_keys is None
     assert next_mm_idx == 0
+
+
+def test_generate_block_hash_extra_keys_cache_salt():
+    request = make_request(
+        request_id=0,
+        prompt_token_ids=[_ for _ in range(6)],
+        mm_positions=None,
+        mm_hashes=None,
+        cache_salt="salt",
+    )
+
+    # salt is added for the first token
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 1, 0)
+    assert extra_keys == ('salt', )
+    extra_keys, _ = generate_block_hash_extra_keys(request, 0, 10, 0)
+    assert extra_keys == ('salt', )
+
+    # no salt added for other tokens
+    extra_keys, _ = generate_block_hash_extra_keys(request, 1, 2, 0)
+    assert extra_keys is None
+    extra_keys, _ = generate_block_hash_extra_keys(request, 6, 10, 0)
+    assert extra_keys is None
+
+    # works together with other extra keys
+    request_mm = make_request(
+        request_id=0,
+        prompt_token_ids=[_ for _ in range(20)],
+        mm_positions=[
+            PlaceholderRange(offset=0, length=5),
+        ],
+        mm_hashes=["hash1"],
+        cache_salt="salt",
+    )
+
+    # Test with no extra keys
+    extra_keys, next_mm_idx = generate_block_hash_extra_keys(
+        request_mm, 0, 5, 0)
+    assert extra_keys == ("hash1", "salt")
+    assert next_mm_idx == 1
 
 
 @pytest.mark.parametrize("hash_fn", [sha256, hash])

--- a/tests/v1/engine/test_engine_core.py
+++ b/tests/v1/engine/test_engine_core.py
@@ -40,6 +40,7 @@ def make_request() -> EngineCoreRequest:
         eos_token_id=None,
         arrival_time=time.time(),
         lora_request=None,
+        cache_salt=None,
     )
 
 

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -43,6 +43,7 @@ def make_request(params: SamplingParams) -> EngineCoreRequest:
         eos_token_id=None,
         arrival_time=time.time(),
         lora_request=None,
+        cache_salt=None,
     )
 
 

--- a/tests/v1/engine/test_output_processor.py
+++ b/tests/v1/engine/test_output_processor.py
@@ -57,6 +57,7 @@ def test_incremental_detokenization(request_output_kind: RequestOutputKind,
                           mm_placeholders=None,
                           eos_token_id=None,
                           lora_request=None,
+                          cache_salt=None,
                           sampling_params=SamplingParams(
                               skip_special_tokens=False,
                               spaces_between_special_tokens=False,
@@ -403,6 +404,7 @@ def test_logprobs_processor(request_output_kind: RequestOutputKind,
                           mm_placeholders=None,
                           eos_token_id=None,
                           lora_request=None,
+                          cache_salt=None,
                           sampling_params=SamplingParams(
                               skip_special_tokens=False,
                               spaces_between_special_tokens=False,
@@ -503,7 +505,7 @@ def test_stop_token(include_stop_str_in_output: bool,
       reason should be "stop" (i.e. first control token causes stop
       and is represented in output text)
 
-    * else, the detokenized string should be 
+    * else, the detokenized string should be
       <token><token>...<token> and the finish reason should be "stop"
       (i.e. first control token causes stop but is not represented
       in output text.)
@@ -565,6 +567,7 @@ def test_stop_token(include_stop_str_in_output: bool,
         mm_placeholders=None,
         eos_token_id=eos_token_id,
         lora_request=None,
+        cache_salt=None,
         sampling_params=SamplingParams(
             skip_special_tokens=False,
             spaces_between_special_tokens=False,
@@ -661,6 +664,7 @@ def test_stop_string(include_stop_str_in_output: bool,
             mm_placeholders=None,
             eos_token_id=None,
             lora_request=None,
+            cache_salt=None,
             sampling_params=SamplingParams(
                 skip_special_tokens=False,
                 spaces_between_special_tokens=False,
@@ -774,6 +778,7 @@ def test_iteration_stats(dummy_test_vectors):
             mm_placeholders=None,
             eos_token_id=None,
             lora_request=None,
+            cache_salt=None,
             sampling_params=SamplingParams(),
         ) for idx, prompt_tokens in enumerate(dummy_test_vectors.prompt_tokens)
     ]

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -408,6 +408,15 @@ class ChatCompletionRequest(OpenAIBaseModel):
             "If specified with 'logprobs', tokens are represented "
             " as strings of the form 'token_id:{token_id}' so that tokens "
             "that are not JSON-encodable can be identified."))
+    cache_salt: Optional[str] = Field(
+        default=None,
+        description=(
+            "If specified, the prefix cache will be salted with the provided "
+            "string to prevent an attacker to guess prompts in multi-user "
+            "environments. The salt should be random, protected from "
+            "access by 3rd parties, and long enough to be "
+            "unpredictable (e.g., 43 characters base64-encoded, corresponding "
+            "to 256 bit)."))
 
     # doc: end-chat-completion-extra-params
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -744,8 +744,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 raise ValueError(
                     "Parameter 'cache_salt' is not supported with "
                     "this instance of vLLM, which uses engine V0.")
-            if not isinstance(data["cache_salt"], str) or len(
-                    data["cache_salt"]) == 0:
+            if not isinstance(data["cache_salt"],
+                              str) or not data["cache_salt"]:
                 raise ValueError("Parameter 'cache_salt' must be a "
                                  "non-empty string if provided.")
         return data

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -470,7 +470,7 @@ class OpenAIServing:
         if request.mm_processor_kwargs is not None:
             engine_prompt["mm_processor_kwargs"] = request.mm_processor_kwargs
 
-        if request.cache_salt is not None:
+        if hasattr(request, "cache_salt") and request.cache_salt is not None:
             engine_prompt["cache_salt"] = request.cache_salt
 
         return conversation, [request_prompt], [engine_prompt]

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -470,6 +470,9 @@ class OpenAIServing:
         if request.mm_processor_kwargs is not None:
             engine_prompt["mm_processor_kwargs"] = request.mm_processor_kwargs
 
+        if request.cache_salt is not None:
+            engine_prompt["cache_salt"] = request.cache_salt
+
         return conversation, [request_prompt], [engine_prompt]
 
     def _log_inputs(

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -141,11 +141,17 @@ class TokenInputs(TypedDict):
     The original prompt text corresponding to the token IDs, if available.
     """
 
+    cache_salt: NotRequired[str]
+    """
+    Optional cache salt to be used for prefix caching.
+    """
+
 
 def token_inputs(
     prompt_token_ids: list[int],
     token_type_ids: Optional[list[int]] = None,
     prompt: Optional[str] = None,
+    cache_salt: Optional[str] = None,
 ) -> TokenInputs:
     """Construct :class:`TokenInputs` from optional values."""
     inputs = TokenInputs(type="token", prompt_token_ids=prompt_token_ids)
@@ -154,6 +160,8 @@ def token_inputs(
         inputs["prompt"] = prompt
     if token_type_ids is not None:
         inputs["token_type_ids"] = token_type_ids
+    if cache_salt is not None:
+        inputs["cache_salt"] = cache_salt
 
     return inputs
 
@@ -217,7 +225,7 @@ def zip_enc_dec_prompts(
     """
     Zip encoder and decoder prompts together into a list of
     :class:`ExplicitEncoderDecoderPrompt` instances.
-    
+
     ``mm_processor_kwargs`` may also be provided; if a dict is passed, the same
     dictionary will be used for every encoder/decoder prompt. If an iterable is
     provided, it will be zipped with the encoder/decoder prompts.

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -28,6 +28,11 @@ class TextPrompt(TypedDict):
     to pass the mm_processor_kwargs to each of them.
     """
 
+    cache_salt: NotRequired[str]
+    """
+    Optional cache salt to be used for prefix caching.
+    """
+
 
 class TokensPrompt(TypedDict):
     """Schema for a tokenized prompt."""
@@ -50,6 +55,11 @@ class TokensPrompt(TypedDict):
     multimodal input mapper & processor. Note that if multiple modalities
     have registered mappers etc for the model being considered, we attempt
     to pass the mm_processor_kwargs to each of them.
+    """
+
+    cache_salt: NotRequired[str]
+    """
+    Optional cache salt to be used for prefix caching.
     """
 
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -256,11 +256,10 @@ class InputPreprocessor:
         if mm_processor_kwargs is None:
             mm_processor_kwargs = {}
 
-        return mm_processor.apply(prompt,
-                                  mm_data,
-                                  mm_processor_kwargs,
-                                  return_mm_hashes,
-                                  cache_salt=cache_salt)
+        inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
+                                    return_mm_hashes)
+        inputs["cache_salt"] = cache_salt
+        return inputs
 
     async def _process_multimodal_async(
         self,
@@ -286,11 +285,10 @@ class InputPreprocessor:
         if mm_processor_kwargs is None:
             mm_processor_kwargs = {}
 
-        return mm_processor.apply(prompt,
-                                  mm_data,
-                                  mm_processor_kwargs,
-                                  return_mm_hashes,
-                                  cache_salt=cache_salt)
+        inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
+                                    return_mm_hashes)
+        inputs["cache_salt"] = cache_salt
+        return inputs
 
     def _get_prompt_data(self, parsed_prompt: Union[ParsedStrPrompt,
                                                     ParsedTextPrompt,
@@ -303,13 +301,13 @@ class InputPreprocessor:
         if parsed_prompt["type"] == "str":
             prompt_text = parsed_prompt["content"]
         else:
-            content = parsed_prompt["content"]
-            cache_salt = content.get("cache_salt")
+            cache_salt = parsed_prompt["content"].get("cache_salt")
             if parsed_prompt["type"] == "text":
-                prompt_text = content["prompt"]
+                prompt_text = parsed_prompt["content"]["prompt"]
             elif parsed_prompt["type"] == "tokens":
-                prompt_token_ids = content.get("prompt_token_ids")
-                token_type_ids = content.get("token_type_ids")
+                prompt_token_ids = parsed_prompt["content"].get(
+                    "prompt_token_ids")
+                token_type_ids = parsed_prompt["content"].get("token_type_ids")
             else:
                 assert_never(parsed_prompt)
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -483,7 +483,6 @@ class InputPreprocessor:
                     mm_kwargs=inputs["mm_kwargs"],
                     mm_hashes=inputs["mm_hashes"],
                     mm_placeholders=inputs["mm_placeholders"],
-                    cache_salt=inputs["cache_salt"],
                 )
             else:
                 decoder_inputs = MultiModalInputs(
@@ -493,8 +492,12 @@ class InputPreprocessor:
                     mm_kwargs=inputs["mm_kwargs"],
                     mm_hashes=inputs["mm_hashes"],
                     mm_placeholders=inputs["mm_placeholders"],
-                    cache_salt=inputs["cache_salt"],
                 )
+
+            cache_salt = inputs.get("cache_salt")
+            if cache_salt is not None:
+                decoder_inputs["cache_salt"] = cache_salt
+
         elif inputs["type"] == "token":
             # Text-only inputs
             encoder_inputs = token_inputs(prompt="", prompt_token_ids=[])

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -375,21 +375,8 @@ class InputPreprocessor:
         """Async version of :meth:`_extract_prompt_components`."""
         parsed = parse_singleton_prompt(prompt)
 
-        if parsed["type"] == "str":
-            prompt_text = parsed["content"]
-            prompt_token_ids = await self._tokenize_prompt_async(
-                prompt=prompt_text,
-                lora_request=lora_request,
-                tokenization_kwargs=tokenization_kwargs,
-            )
-
-            return token_inputs(
-                prompt=prompt_text,
-                prompt_token_ids=prompt_token_ids,
-            )
-
-        prompt_text, prompt_token_ids, token_type_ids = self._get_prompt_data(
-            parsed)
+        prompt_text, prompt_token_ids, token_type_ids, cache_salt = \
+            self._get_prompt_data(parsed)
 
         if parsed["type"] != "str" and parsed["content"].get(
                 "multi_modal_data") is not None:
@@ -406,6 +393,7 @@ class InputPreprocessor:
             prompt_token_ids = await self._tokenize_prompt_async(
                 prompt_text,
                 lora_request=lora_request,
+                tokenization_kwargs=tokenization_kwargs,
             )
 
         return token_inputs(

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -258,7 +258,8 @@ class InputPreprocessor:
 
         inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
                                     return_mm_hashes)
-        inputs["cache_salt"] = cache_salt
+        if inputs is not None:
+            inputs["cache_salt"] = cache_salt
         return inputs
 
     async def _process_multimodal_async(
@@ -287,7 +288,8 @@ class InputPreprocessor:
 
         inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
                                     return_mm_hashes)
-        inputs["cache_salt"] = cache_salt
+        if inputs is not None:
+            inputs["cache_salt"] = cache_salt
         return inputs
 
     def _get_prompt_data(self, parsed_prompt: Union[ParsedStrPrompt,

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -362,22 +362,7 @@ class InputPreprocessor:
                 cache_salt=cache_salt,
             )
 
-        if parsed["type"] == "text":
-            text_content = parsed["content"]
-
-            prompt_text = text_content["prompt"]
-            multi_modal_data = text_content.get("multi_modal_data")
-            mm_processor_kwargs = text_content.get("mm_processor_kwargs")
-
-            if multi_modal_data is not None:
-                return self._process_multimodal(
-                    prompt_text,
-                    multi_modal_data,
-                    mm_processor_kwargs,
-                    lora_request=lora_request,
-                    return_mm_hashes=return_mm_hashes,
-                )
-
+        if prompt_token_ids is None:
             prompt_token_ids = self._tokenize_prompt(
                 prompt_text,
                 lora_request=lora_request,

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -336,29 +336,12 @@ class InputPreprocessor:
         * :class:`SingletonInputs` instance
         """
         parsed = parse_singleton_prompt(prompt)
+        prompt_text, prompt_token_ids, token_type_ids, cache_salt = \
+            self._get_prompt_data(parsed)
 
-        if parsed["type"] == "str":
-            prompt_text = parsed["content"]
-            prompt_token_ids = self._tokenize_prompt(
-                prompt_text,
-                lora_request=lora_request,
-                tokenization_kwargs=tokenization_kwargs,
-            )
-
-            return token_inputs(
-                prompt=prompt_text,
-                prompt_token_ids=prompt_token_ids,
-            )
-
-        prompt_text, prompt_token_ids, token_type_ids = self._get_prompt_data(
-            parsed)
-
-        content = parsed["content"]
-        multi_modal_data = content.get("multi_modal_data")
-        mm_processor_kwargs = content.get("mm_processor_kwargs")
-        cache_salt = content.get("cache_salt")
-
-        if multi_modal_data is not None:
+        # If multimodal data is present, process and return immediately
+        if parsed["type"] != "str" and parsed["content"].get(
+                "multi_modal_data") is not None:
             return self._process_multimodal(
                 prompt_text if prompt_text is not None else prompt_token_ids,
                 parsed["content"]["multi_modal_data"],
@@ -408,8 +391,8 @@ class InputPreprocessor:
         prompt_text, prompt_token_ids, token_type_ids = self._get_prompt_data(
             parsed)
 
-        if parsed["type"] != "str" and "multi_modal_data" in parsed[
-                "content"] is not None:
+        if parsed["type"] != "str" and parsed["content"].get(
+                "multi_modal_data") is not None:
             return await self._process_multimodal_async(
                 prompt_token_ids if prompt_text is None else prompt_text,
                 parsed["content"]["multi_modal_data"],

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -403,7 +403,7 @@ class InputPreprocessor:
             )
 
         if prompt_token_ids is None:
-            prompt_token_ids = self._tokenize_prompt_async(
+            prompt_token_ids = await self._tokenize_prompt_async(
                 prompt_text,
                 lora_request=lora_request,
             )

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -258,7 +258,7 @@ class InputPreprocessor:
 
         inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
                                     return_mm_hashes)
-        if inputs is not None:
+        if cache_salt is not None:
             inputs["cache_salt"] = cache_salt
         return inputs
 
@@ -288,7 +288,7 @@ class InputPreprocessor:
 
         inputs = mm_processor.apply(prompt, mm_data, mm_processor_kwargs,
                                     return_mm_hashes)
-        if inputs is not None:
+        if cache_salt is not None:
             inputs["cache_salt"] = cache_salt
         return inputs
 
@@ -361,7 +361,7 @@ class InputPreprocessor:
         if multi_modal_data is not None:
             return self._process_multimodal(
                 prompt_text if prompt_text is not None else prompt_token_ids,
-                parsed["content"].get("multi_modal_data"),
+                parsed["content"]["multi_modal_data"],
                 parsed["content"].get("mm_processor_kwargs"),
                 lora_request=lora_request,
                 return_mm_hashes=return_mm_hashes,
@@ -412,7 +412,7 @@ class InputPreprocessor:
                 "content"] is not None:
             return await self._process_multimodal_async(
                 prompt_token_ids if prompt_text is None else prompt_text,
-                parsed["content"].get("multi_modal_data"),
+                parsed["content"]["multi_modal_data"],
                 parsed["content"].get("mm_processor_kwargs"),
                 lora_request=lora_request,
                 return_mm_hashes=return_mm_hashes,

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -826,7 +826,7 @@ class MultiModalInputs(TypedDict):
     :code:`prompt_token_ids`.
     """
 
-    cache_salt: Optional[str]
+    cache_salt: NotRequired[str]
     """
     Optional cache salt to be used for prefix caching.
     """

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -826,6 +826,11 @@ class MultiModalInputs(TypedDict):
     :code:`prompt_token_ids`.
     """
 
+    cache_salt: Optional[str]
+    """
+    Optional cache salt to be used for prefix caching.
+    """
+
 
 class MultiModalEncDecInputs(MultiModalInputs):
     """

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1777,7 +1777,6 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_kwargs=mm_kwargs,
             mm_hashes=mm_hashes,
             mm_placeholders=mm_placeholder_ranges,
-            cache_salt=cache_salt,
         )
 
 

--- a/vllm/multimodal/processing.py
+++ b/vllm/multimodal/processing.py
@@ -1777,6 +1777,7 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_kwargs=mm_kwargs,
             mm_hashes=mm_hashes,
             mm_placeholders=mm_placeholder_ranges,
+            cache_salt=cache_salt,
         )
 
 
@@ -1789,7 +1790,7 @@ class EncDecMultiModalProcessor(BaseMultiModalProcessor[_I]):
         mm_data: MultiModalDataDict,
     ) -> Union[str, list[int]]:
         """
-        Create input prompt for the encoder. HF processor will be applied on 
+        Create input prompt for the encoder. HF processor will be applied on
         this prompt during profiling and generation.
         """
         raise NotImplementedError

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -57,6 +57,7 @@ class EngineCoreRequest(
     eos_token_id: Optional[int]
     arrival_time: float
     lora_request: Optional[LoRARequest]
+    cache_salt: Optional[str]
 
     # Used in DP case to indicate which wave of requests this is expected to
     # belong to, to cover a race condition where the request is sent before

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -317,6 +317,7 @@ class Processor:
             eos_token_id=eos_token_id,
             arrival_time=arrival_time,
             lora_request=lora_request,
+            cache_salt=processed_inputs.get("cache_salt"),
         )
 
     def _validate_model_inputs(self,

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -317,7 +317,7 @@ class Processor:
             eos_token_id=eos_token_id,
             arrival_time=arrival_time,
             lora_request=lora_request,
-            cache_salt=processed_inputs.get("cache_salt"),
+            cache_salt=decoder_inputs.get("cache_salt"),
         )
 
     def _validate_model_inputs(self,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -29,6 +29,7 @@ class Request:
         arrival_time: float,
         lora_request: Optional["LoRARequest"] = None,
         structured_output_request: Optional["StructuredOutputRequest"] = None,
+        cache_salt: Optional[str] = None,
     ) -> None:
         self.request_id = request_id
         self.sampling_params = sampling_params
@@ -51,6 +52,7 @@ class Request:
         self._all_token_ids: list[int] = self.prompt_token_ids.copy()
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
+        self.cache_salt: Optional[str] = cache_salt
 
         # Multi-modal related
         self.mm_positions = multi_modal_placeholders or []
@@ -89,6 +91,7 @@ class Request:
             lora_request=request.lora_request,
             structured_output_request=StructuredOutputRequest(
                 sampling_params=request.sampling_params),
+            cache_salt=request.cache_salt,
         )
 
     def append_output_token_ids(


### PR DESCRIPTION
# Context
Prefix caching in vLLM improves inference performance by reusing KV blocks across requests. However, this reuse introduces a potential privacy risk in shared environments, where an attacker could infer prompt reuse via timing side channels as demonstrated in [Leaking Secrets from Prefix Caches](https://arxiv.org/html/2411.18191v1). 

To address this, we propose to isolate caches as described in an RFC: https://github.com/vllm-project/vllm/issues/16016

# Suggested change
This PR implements the single barrier approach from the RFC by adding support for an optional `cache_salt` field in the request schema. When present, the salt is injected into the hash of the first block, ensuring that only requests with the same salt can share cached blocks. This effectively segments cache reuse by salt and protects against timing-based attacks.

```json
{
  "messages": [
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Here is a document with details about the world series: ..."},
    {"role": "user", "content": "Who won the world series in 2020?"}
  ],
  "cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ=="
}
```

The change is compatible with OpenAI requests as only an additional optional field is added. Users can still use the OpenAI client:
```python
response = client.chat.completions.create(
    model=model,
    messages=messages,
    extra_body={
        "cache_salt": "Z3V2bmV3aGxza3ZubGFoZ3Zud3V3ZWZ2bmd0b3V2bnZmc2xpZ3RoZ2x2aQ==",
    },
)
```

The scope of cache sharing can be configured per request as needed, e.g., full single user protection or cache sharing within a group of users.

The change is in line with cache protection applied by other providers such as OpenAI and provides a solution that allows for higher flexibility allowing for more fine-grained configuration.

<!--- pyml disable-next-line no-emphasis-as-heading -->
