### PR TITLE
fix setuptools-scm was unable to detect version for workspace 

### DIFF
--- a/docker/Dockerfile.arm
+++ b/docker/Dockerfile.arm
@@ -25,19 +25,23 @@ WORKDIR /workspace
 
 ARG PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
 ENV PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+
+COPY requirements/build.txt /tmp/requirements.txt
+
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,src=requirements/build.txt,target=requirements/build.txt \
     pip install --upgrade pip && \
-    pip install -r requirements/build.txt
+    pip install --no-cache-dir -r /tmp/requirements.txt
 
 FROM cpu-test-arm AS build
 
 WORKDIR /workspace/vllm
 
+COPY requirements/common.txt /workspace/requirements/common.txt
+
+COPY requirements/cpu.txt /workspace/requirements/cpu.txt
+
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=bind,src=requirements/common.txt,target=requirements/common.txt \
-    --mount=type=bind,src=requirements/cpu.txt,target=requirements/cpu.txt \
-    pip install -v -r requirements/cpu.txt
+    pip install -v -r /workspace/requirements/cpu.txt
 
 COPY . .
 ARG GIT_REPO_CHECK=0

--- a/setup.py
+++ b/setup.py
@@ -540,8 +540,8 @@ def get_gaudi_sw_version():
 def get_vllm_version() -> str:
     try:
         version = get_version(write_to="vllm/_version.py")
-    except:
-        version = "0.8.4" # fall back version
+    except LookupError:
+        version = "0.8.4"  # fall back version
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
     if _no_device():

--- a/setup.py
+++ b/setup.py
@@ -538,7 +538,10 @@ def get_gaudi_sw_version():
 
 
 def get_vllm_version() -> str:
-    version = get_version(write_to="vllm/_version.py")
+    try:
+        version = get_version(write_to="vllm/_version.py")
+    except:
+        version = "0.8.4" # fall back version
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
     if _no_device():


### PR DESCRIPTION

Fix issues with Docker.arm

```
raise LookupError(
LookupError: setuptools-scm was unable to detect version for /workspace.
```
and

```
[1/2] STEP 11/11: RUN --mount=type=cache,target=/root/.cache/pip     --mount=type=bind,src=requirements/build.txt,target=requirements/build.txt     pip install --upgrade pip &&     pip install -r requirements/build.txt
Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
Requirement already satisfied: pip in /usr/lib/python3/dist-packages (22.0.2)
Collecting pip
  Using cached pip-25.0.1-py3-none-any.whl (1.8 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 22.0.2
    Not uninstalling pip at /usr/lib/python3/dist-packages, outside environment /usr
    Can't uninstall 'pip'. No files were found to uninstall.
Successfully installed pip-25.0.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
ERROR: Could not open requirements file: [Errno 13] Permission denied: 'requirements/build.txt'
Error: building at STEP "RUN --mount=type=cache,target=/root/.cache/pip --mount=type=bind,src=requirements/build.txt,target=requirements/build.txt pip install --upgrade pip &&     pip install -r requirements/build.txt": while running runtime: exit status 1
```


FIX #13130 

<!--- pyml disable-next-line no-emphasis-as-heading -->
