### PR TITLE
Ensure that `pid` passed to `kill_process_tree` is `int` for `mypy`

### DIFF
--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -134,8 +134,8 @@ def shutdown(proc: Process, input_path: str, output_path: str):
         proc.terminate()
         proc.join(5)
 
-        if proc.is_alive():
-            kill_process_tree(proc.pid)
+        if proc.is_alive() and (pid := proc.pid):
+            kill_process_tree(pid)
 
     # Remove zmq ipc socket files.
     ipc_sockets = [output_path, input_path]

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -134,7 +134,7 @@ def shutdown(proc: Process, input_path: str, output_path: str):
         proc.terminate()
         proc.join(5)
 
-        if proc.is_alive() and (pid := proc.pid):
+        if proc.is_alive() and (pid := proc.pid) is not None:
             kill_process_tree(pid)
 
     # Remove zmq ipc socket files.


### PR DESCRIPTION
Makes V1 code more `mypy` compliant.