### PR TITLE
[TPU][V1] Add support for top-logprobs

### DIFF
--- a/tests/v1/tpu/test_sampler.py
+++ b/tests/v1/tpu/test_sampler.py
@@ -61,3 +61,30 @@ def test_sampler_different(model_name: str):
         # to have deterministic results over many tokens, tests the first ~20
         # tokens match.
         assert output[0].outputs[0].text[:20] == output[1].outputs[0].text[:20]
+
+@pytest.mark.parametrize("model_name", ["Qwen/Qwen2.5-1.5B-Instruct"])
+@pytest.mark.skipif(not current_platform.is_tpu(),
+                    reason="This test needs a TPU")
+def test_logprobs(model_name: str):
+    """
+    """
+    llm = LLM(model_name,
+              enforce_eager=False,
+              max_num_seqs=1,
+              max_model_len=512,
+              max_num_batched_tokens=512)
+    prompts = [
+        "Write a short story about a robot that dreams for the first time."
+    ]
+    # Greedy sampling
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=64, logprobs=4)
+    output = llm.generate(prompts, sampling_params)
+    print(output)
+
+    sampling_params = SamplingParams(temperature=0.4, min_p=0.2, max_tokens=64, logprobs=4)
+    output = llm.generate(prompts, sampling_params)
+    print(output)
+
+    sampling_params = SamplingParams(temperature=0.4, min_p=0.2, max_tokens=64, logprobs=None)
+    output = llm.generate(prompts, sampling_params)
+    print(output)

--- a/tests/v1/tpu/test_sampler.py
+++ b/tests/v1/tpu/test_sampler.py
@@ -62,29 +62,50 @@ def test_sampler_different(model_name: str):
         # tokens match.
         assert output[0].outputs[0].text[:20] == output[1].outputs[0].text[:20]
 
+
 @pytest.mark.parametrize("model_name", ["Qwen/Qwen2.5-1.5B-Instruct"])
+# TODO TPU will appear busy if we fan-out test params here
+@pytest.mark.parametrize("n_prompts", [1])
 @pytest.mark.skipif(not current_platform.is_tpu(),
                     reason="This test needs a TPU")
-def test_logprobs(model_name: str):
+def test_logprobs(model_name: str, n_prompts: int):
     """
+    Request top logprobs with different sampling settings and check
+    that results contains the requested number, ordered ascendingly.  
     """
+
+    def check_num_logprobs(logprobs, expected_num: int):
+        for step in logprobs:
+            prev_logp = 1.0
+            # order by rank
+            sorted_step = dict(
+                sorted(step.items(), key=lambda item: item[1].rank))
+
+            # Can contain the sampled token
+            assert len(step) == expected_num or len(step) == expected_num + 1
+            # Check results are ordered by prob value
+            for rankno, (tid, logp) in enumerate(sorted_step.items()):
+                assert logp.logprob <= prev_logp
+                prev_logp = logp.logprob
+                assert logp.rank == rankno + 1
+
     llm = LLM(model_name,
               enforce_eager=False,
               max_num_seqs=1,
-              max_model_len=512,
-              max_num_batched_tokens=512)
+              max_model_len=128,
+              max_num_batched_tokens=128)
     prompts = [
         "Write a short story about a robot that dreams for the first time."
-    ]
-    # Greedy sampling
-    sampling_params = SamplingParams(temperature=0.0, max_tokens=64, logprobs=4)
-    output = llm.generate(prompts, sampling_params)
-    print(output)
+    ] * n_prompts
+    greedy_sampling_params = SamplingParams(temperature=0.0, max_tokens=64,\
+         logprobs=4)
+    regular_sampling_params = SamplingParams(temperature=0.4, max_tokens=64,\
+         logprobs=4)
+    topkp_sampling_params = SamplingParams(temperature=0.4, max_tokens=64,\
+         logprobs=4, top_k=12, top_p=0.5)
 
-    sampling_params = SamplingParams(temperature=0.4, min_p=0.2, max_tokens=64, logprobs=4)
-    output = llm.generate(prompts, sampling_params)
-    print(output)
-
-    sampling_params = SamplingParams(temperature=0.4, min_p=0.2, max_tokens=64, logprobs=None)
-    output = llm.generate(prompts, sampling_params)
-    print(output)
+    for sp in [greedy_sampling_params, regular_sampling_params, \
+               topkp_sampling_params]:
+        output = llm.generate(prompts, sp)
+        for o in output:
+            check_num_logprobs(o.outputs[0].logprobs, 4)

--- a/vllm/v1/sample/tpu/metadata.py
+++ b/vllm/v1/sample/tpu/metadata.py
@@ -32,8 +32,8 @@ class TPUSupportedSamplingMetadata:
     all_greedy: bool = True
 
     # Maximum number of top logprobs requested in current batch.
-    # TODO use constant from sampler.py OR a bool
-    max_num_logprobs: Optional[int] = 24
+    # TODO specify why bool
+    logprobs: bool = False
 
     # TODO No penalties for now
     no_penalties: bool = True
@@ -85,10 +85,12 @@ class TPUSupportedSamplingMetadata:
                 we want to pre-compile a graph with sampling parameters, even if
                 they are not strictly needed for greedy decoding.
         """
+        needs_logprobs = input_batch.max_num_logprobs>0 if \
+            input_batch.max_num_logprobs else False
         # Early return to avoid unnecessary cpu to tpu copy
         if (input_batch.all_greedy is True
                 and generate_params_if_all_greedy is False):
-            return cls(all_greedy=True)
+            return cls(all_greedy=True, logprobs=needs_logprobs)
 
         num_reqs = input_batch.num_reqs
 
@@ -117,4 +119,4 @@ class TPUSupportedSamplingMetadata:
                 xla_device),
             min_p=input_batch.min_p_cpu_tensor[:padded_num_reqs].to(
                 xla_device),
-            max_num_logprobs=input_batch.max_num_logprobs)
+            logprobs=needs_logprobs)

--- a/vllm/v1/sample/tpu/metadata.py
+++ b/vllm/v1/sample/tpu/metadata.py
@@ -31,8 +31,9 @@ class TPUSupportedSamplingMetadata:
 
     all_greedy: bool = True
 
-    # Maximum number of top logprobs requested in current batch.
-    # TODO specify why bool
+    # Whether logprobs are to be gathered in this batch of request. To balance
+    # out compile time and runtime, a fixed `max_number_logprobs` value is used
+    # when gathering logprobs, regardless of the values specified in the batch.
     logprobs: bool = False
 
     # TODO No penalties for now

--- a/vllm/v1/sample/tpu/metadata.py
+++ b/vllm/v1/sample/tpu/metadata.py
@@ -31,8 +31,9 @@ class TPUSupportedSamplingMetadata:
 
     all_greedy: bool = True
 
-    # unsupported, you need to return an extra tensor of static size BxV
-    max_num_logprobs = None
+    # Maximum number of top logprobs requested in current batch.
+    # TODO use constant from sampler.py OR a bool
+    max_num_logprobs: Optional[int] = 24
 
     # TODO No penalties for now
     no_penalties: bool = True
@@ -115,4 +116,5 @@ class TPUSupportedSamplingMetadata:
             top_k=input_batch.top_k_cpu_tensor[:padded_num_reqs].to(
                 xla_device),
             min_p=input_batch.min_p_cpu_tensor[:padded_num_reqs].to(
-                xla_device))
+                xla_device),
+            max_num_logprobs=input_batch.max_num_logprobs)

--- a/vllm/v1/sample/tpu/sampler.py
+++ b/vllm/v1/sample/tpu/sampler.py
@@ -28,7 +28,8 @@ class Sampler(nn.Module):
         # temperature scaling) for the top-k logprobs.
         # This is different from the V0 sampler, which uses the logits that
         # is used for sampling (after penalties and temperature scaling).
-        raw_logprobs = self.compute_logprobs(logits)
+        if sampling_metadata.logprobs:
+            raw_logprobs = self.compute_logprobs(logits)
 
         # Use float32 for the logits.
         logits = logits.to(torch.float32)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -789,7 +789,8 @@ class TPUModelRunner:
             logits = self.structured_decode(require_struct_decoding,
                                             grammar_bitmask_padded, logits,
                                             arange)
-        selected_token_ids, logprobs = self.sample_from_logits(logits, tpu_sampling_metadata)
+        selected_token_ids, logprobs = self.sample_from_logits(
+            logits, tpu_sampling_metadata)
         # Remove padding on cpu and keep dynamic op outside of xla graph.
         selected_token_ids = selected_token_ids.cpu()[:num_reqs]
         logprobs_lists = logprobs.tolists() \
@@ -1256,7 +1257,8 @@ class TPUModelRunner:
     @torch.compile(backend="openxla", fullgraph=True, dynamic=False)
     def sample_from_logits(
             self, logits: torch.Tensor,
-            sampling_metadata: TPUSupportedSamplingMetadata) -> torch.Tensor:
+            sampling_metadata: TPUSupportedSamplingMetadata) -> \
+                tuple[torch.Tensor, Optional[LogprobsTensors]]:
         """
         Sample with xla-friendly function. This function is to be traced 
         separately from `forward` for lighter compilation overhead.

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -1288,8 +1288,8 @@ class TPUModelRunner:
         if sampling_metadata.all_greedy:
             out_tokens = torch.argmax(logits, dim=-1, keepdim=True)
         else:
-            sampler_out = self.sampler(logits, sampling_metadata)
-            out_tokens = sampler_out.sampled_token_ids
+            out_tokens = self.sampler(logits,
+                                      sampling_metadata).sampled_token_ids
         return out_tokens
 
     @torch.compile(backend="openxla", fullgraph=True, dynamic=False)

--- a/vllm/v1/worker/tpu_model_runner.py
+++ b/vllm/v1/worker/tpu_model_runner.py
@@ -1256,6 +1256,10 @@ class TPUModelRunner:
     def sample_from_logits(
             self, logits: torch.Tensor,
             sampling_metadata: TPUSupportedSamplingMetadata) -> torch.Tensor:
+        """
+        Sample with xla-friendly function. This function is to be traced 
+        separately from `forward` for lighter compilation overhead.
+        """
         if sampling_metadata.all_greedy:
             out_tokens = torch.argmax(logits, dim=-1, keepdim=True)
             # TODO skip if not needed and compile for it


### PR DESCRIPTION
This PR implements top-logprobs support for TPU V1.

The main design decisions I've taken in this first version are:
 - Returning logprobs is optional, so it has a separate graph that is executed only when needed. 
   Akin to what is happening on GPU, when a single request in the batch requires logprobs, the prob tensor is gathered for all requests in the batch (but only streamed back to those that need it).
 - To mitigate compilation issue and strike a balance between long compilation times and minimal computational waste at runtime, "logprobs" is a binary flag. Therefore
   a graph is generated for when the flag is off (no change from current) and another one when it's on. 
 - The value for which logprobs are gathered is static and fixed at startup with `model_config.max_logprobs`. Default is 20 as specified by the OpenAI API. Hence (when needed) this impl will gather the top 20 logprobs values, move the batched tensor to host and then slice off the needed ones with the same logic as in GPU. 


Benchmark+Compile time highlight:
```
pre:
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  133.86    
Total input tokens:                      1638796   
Total generated tokens:                  128000    
Request throughput (req/s):              7.47      
Output token throughput (tok/s):         956.22    
Total Token throughput (tok/s):          13198.78  
---------------Time to First Token----------------
Mean TTFT (ms):                          63739.75  
Median TTFT (ms):                        64401.80  
P99 TTFT (ms):                           129335.27 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          79.05     
Median TPOT (ms):                        81.04     
P99 TPOT (ms):                           94.23     
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.05     
Median ITL (ms):                         41.94     
P99 ITL (ms):                            125.57    
==================================================

INFO 04-23 18:02:40 [tpu_model_runner.py:1033] Compiling sampling with different num_reqs.
INFO 04-23 18:02:48 [tpu_model_runner.py:1053]   -- num_seqs: 8
INFO 04-23 18:02:57 [tpu_model_runner.py:1053]   -- num_seqs: 16
INFO 04-23 18:03:07 [tpu_model_runner.py:1053]   -- num_seqs: 32
INFO 04-23 18:03:16 [tpu_model_runner.py:1053]   -- num_seqs: 64
INFO 04-23 18:03:24 [tpu_model_runner.py:1053]   -- num_seqs: 128
INFO 04-23 18:03:24 [tpu_model_runner.py:1056] Compilation finished in in 44.63 [secs].


post (I assume no logprobs on sonnet benchmark):
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  133.84    
Total input tokens:                      1638796   
Total generated tokens:                  128000    
Request throughput (req/s):              7.47      
Output token throughput (tok/s):         956.38    
Total Token throughput (tok/s):          13201.06  
---------------Time to First Token----------------
Mean TTFT (ms):                          63713.64  
Median TTFT (ms):                        64372.12  
P99 TTFT (ms):                           129280.69 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          79.16     
Median TPOT (ms):                        81.05     
P99 TPOT (ms):                           93.32     
---------------Inter-token Latency----------------
Mean ITL (ms):                           79.16     
Median ITL (ms):                         41.98     
P99 ITL (ms):                            125.63    
==================================================

INFO 04-23 17:53:50 [tpu_model_runner.py:1097] Compiling sample_from_logits with different input shapes.
INFO 04-23 17:54:09 [tpu_model_runner.py:1119]   -- num_seqs: 8
INFO 04-23 17:54:29 [tpu_model_runner.py:1119]   -- num_seqs: 16
INFO 04-23 17:54:52 [tpu_model_runner.py:1119]   -- num_seqs: 32
INFO 04-23 17:55:15 [tpu_model_runner.py:1119]   -- num_seqs: 64
INFO 04-23 17:55:38 [tpu_model_runner.py:1119]   -- num_seqs: 128
INFO 04-23 17:55:38 [tpu_model_runner.py:1122] Compilation finished in 107.82 [secs].

```