### PR TITLE
[Bugfix] Fix Gemma3 multimodal placeholder replacement

### DIFF
--- a/vllm/model_executor/models/gemma3_mm.py
+++ b/vllm/model_executor/models/gemma3_mm.py
@@ -377,14 +377,18 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
         # We need to detect "\n\n" inside "\n\n\n" and "\n\n\n\n"
         tokenizer = self.info.get_tokenizer()
         vocab = tokenizer.get_vocab()
+        eoi_token = vocab[tokenizer.eoi_token]
         newline_1 = vocab["\n"]
         newline_2 = vocab["\n\n"]
         newline_3 = vocab["\n\n\n"]
         newline_4 = vocab["\n\n\n\n"]
 
-        def get_repl_toks(tok: int) -> list[int]:
+        def get_repl_toks(tok: int, previous_tok: int) -> list[int]:
             if tok == newline_3:
-                return [newline_1, newline_2]
+                if previous_tok == eoi_token:
+                    return [newline_2, newline_1]
+                else:
+                    return [newline_1, newline_2]
             if tok == newline_4:
                 return [newline_2, newline_2]
 
@@ -392,10 +396,12 @@ class Gemma3MultiModalProcessor(BaseMultiModalProcessor[Gemma3ProcessingInfo]):
 
         repl_token_ids = list[int]()
         repl_orig_idxs = list[int]()
+        orig_previous_token = None
         for orig_idx, orig_tok in enumerate(new_token_ids):
-            repl_toks = get_repl_toks(orig_tok)
+            repl_toks = get_repl_toks(orig_tok, orig_previous_token)
             repl_token_ids.extend(repl_toks)
             repl_orig_idxs.extend(orig_idx for _ in range(len(repl_toks)))
+            orig_previous_token = orig_tok
 
         repls = find_mm_placeholders(mm_prompt_updates, repl_token_ids,
                                      mm_item_counts)


### PR DESCRIPTION
`google/gemma-3-4b-it` fails when run via the openai server with multimodal input and `chat_template_content_format="string"` with the following error:

````
RuntimeError: Expected there to be 1 prompt updates corresponding to 1 image items, but instead found 0 prompt updates! Either the prompt text has missing/incorrect tokens for multi-modal inputs, or there is a problem with your implementation of merged multi-modal processor for this model (usually arising from an inconsistency between `_call_hf_processor` and `_get_prompt_updates`).
````

I observed the issue with engine V0, I didn't try with engine V1.

The issue  can be observed for messages of this form:

```
[
  {
    'role': 'system',
    'content': [{'text': 'Describe the image in a short sentence.', 'type': 'text'}]
  }, 
  {
    'role': 'user',
    'content': [
      {'text': 'random text', 'type': 'text'},
      {'image_url': , {'url': my_image_url}, 'type': 'image_url'}
    ]
  }
]
```

The issue comes from the fact that if the input message containing the image also has text parts (the `user` message in the example above), then the `chat_utils._get_full_multimodal_text_prompt` method will put the image placeholder at the front like so `'<start_of_image>\nrandom text`. Then the `Gemma3MultiModalProcessor._get_prompt_updates => get_replacement_gemma3 => get_image_repl` will replace the placeholder with `Gemma3Processor.full_image_sequence = f"\n\n{tokenizer.boi_token}{image_tokens_expanded}{tokenizer.eoi_token}\n\n"`, which will result in 3 consecutive `\n` characters after the `eoi_token`. The `\n\n\n` which will be tokenized as the 109 token, and when passed to `_find_mm_placeholders`, the 109 token will be replaced by [107, 108], instead of [108, 107], which won't allow the [matching condition](https://github.com/vllm-project/vllm/blob/bdb366031252cd8d99270a3f81dfe76021a760c1/vllm/multimodal/processing.py#L841) in `_iter_placeholders` to ever evaluate to `True`.

The same issue would probably occur as well with `chat_template_content_format="openai"` if the image message part is followed by a text part that starts with `\n` for instance.

<!--- pyml disable-next-line no-emphasis-as-heading -->
