### PR TITLE
[Bugfix][Benchmark] Fix --save-detailed flag being applied when not specified

### DIFF
--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -741,8 +741,8 @@ def main(args: argparse.Namespace):
                     "input_lens", "output_lens", "ttfts", "itls",
                     "generated_texts", "errors"
             ]:
-                if field in result_json:
-                    del result_json[field]
+                if field in benchmark_result:
+                    del benchmark_result[field]
 
         # Traffic
         result_json["request_rate"] = (args.request_rate if args.request_rate


### PR DESCRIPTION
In benchmark_serving.py, the `--save-detailed` flag is always applied, even when not specified, because the code attempts to remove detail keys from an incorrect dictionary.

This PR corrects the logic to ensure that detailed output is only saved when the flag is explicitly enabled.