### PR TITLE
Add `:markdownhelp:` to `EngineArgs` docs so markdown docstrings render properly

### DIFF
--- a/docs/source/serving/engine_args.md
+++ b/docs/source/serving/engine_args.md
@@ -16,6 +16,7 @@ Below, you can find an explanation of every engine argument:
     :func: _engine_args_parser
     :prog: vllm serve
     :nodefaultconst:
+    :markdownhelp:
 ```
 
 ## Async Engine Arguments
@@ -29,4 +30,5 @@ Additional arguments are available to the asynchronous engine which is used for 
     :func: _async_engine_args_parser
     :prog: vllm serve
     :nodefaultconst:
+    :markdownhelp:
 ```

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,6 +7,7 @@ sphinx-togglebutton==0.3.2
 myst-parser==3.0.1
 msgspec
 cloudpickle
+commonmark # Required by sphinx-argparse when using :markdownhelp:
 
 # packages to install to build the documentation
 cachetools


### PR DESCRIPTION
Before this change, the help strings would have to be written in `rst` to render properly.