### PR TITLE
[easy] Fix logspam on PiecewiseBackend errors

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -239,6 +239,8 @@ class PiecewiseCompileInterpreter(torch.fx.Interpreter):
         self.graph_pool = graph_pool
         self.vllm_config = vllm_config
         self.vllm_backend = vllm_backend
+        # When True, it annoyingly dumps the torch.fx.Graph on errors.
+        self.extra_traceback = False
 
     def run(self, *args):
         fake_args = [


### PR DESCRIPTION
Sometimes when there is an error, we get spammed with a dump of the current torch.fx.Graph that is being compiled. That is due to this code here:
https://github.com/pytorch/pytorch/blob/fc6e37ceb23f99808265c11a37368078d5f982b8/torch/fx/interpreter.py#L173-L183

We turn off this flag so we don't get logspams. The spam is not helpful, also vLLM has other ways of dumping the graphs to file.