### PR TITLE
[Model] Mamba2 causal conv1d Refactor to Split Prefill and Decode Requests for Corresponding Kernels

### DIFF
--- a/tests/kernels/mamba/test_mamba_ssm_ssd.py
+++ b/tests/kernels/mamba/test_mamba_ssm_ssd.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 
 from vllm.model_executor.layers.mamba.mamba2_metadata import (
-    _seq_idx_to_chunk_indices_offsets)
+    _query_start_loc_to_chunk_indices_offsets)
 from vllm.model_executor.layers.mamba.ops.ssd_combined import (
     mamba_chunk_scan_combined)
 from vllm.platforms import current_platform
@@ -274,8 +274,9 @@ def test_mamba_chunk_scan_cont_batch(d_head, n_heads, seq_len_chunk_size_cases,
                                          last_taken, exhausted, n_heads,
                                          d_head, itype):
 
-        chunk_indices, chunk_offsets = _seq_idx_to_chunk_indices_offsets(
-            seq_idx, chunk_size)
+        chunk_indices, chunk_offsets = \
+            _query_start_loc_to_chunk_indices_offsets(
+                cu_seqlens, chunk_size, cu_seqlens[-1])
 
         Y, new_states = mamba_chunk_scan_combined(
             X,

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -71,14 +71,14 @@ def prepare_mamba2_metadata(
 
     # Need flags to indicate if there are initial states
     # currently we really only support the FlashAttention backend
-    # initial states are only relevant for prefills
     has_initial_states = None
     prep_initial_states = False
     if (isinstance(attn_metadata, (FlashAttentionMetadata, XFormersMetadata,
                                    PlaceholderAttentionMetadata))
             and attn_metadata.context_lens_tensor is not None):
+        # keeping flags for both prefill and decode causal_conv1d varlen
         has_initial_states = attn_metadata.context_lens_tensor > 0  # [batch,]
-        # precompute flag to avoid device syncs later in mamba2 forwards
+        # precompute flag to avoid device syncs later in mamba2 layer forwards
         # prep is only needed for mamba2 ssd prefill processing
         prep_initial_states = torch.any(
             has_initial_states[:num_prefills]).item()

--- a/vllm/model_executor/layers/mamba/mamba2_metadata.py
+++ b/vllm/model_executor/layers/mamba/mamba2_metadata.py
@@ -77,7 +77,9 @@ def prepare_mamba2_metadata(
             and attn_metadata.context_lens_tensor is not None):
         has_initial_states = attn_metadata.context_lens_tensor > 0  # [batch,]
         # precompute flag to avoid device syncs later in mamba2 forwards
-        prep_initial_states = torch.any(has_initial_states).item()
+        # prep is only needed for mamba2 ssd prefill processing
+        prep_initial_states = torch.any(
+            has_initial_states[:num_prefills]).item()
 
     # Compute seq_idx, chunk_indices and chunk_offsets for prefill only
     seq_idx = None

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -545,8 +545,8 @@ class MambaMixer2(CustomOp):
             dt_d = dt_d[:, :, None].expand(-1, -1, self.head_dim)
             dt_bias = self.dt_bias[:, None, ...].expand(-1, self.head_dim)
             D_d = self.D[:, None, ...].expand(-1, self.head_dim)
-            B_d = B_d.view(-1, n_groups, B.shape[1] // n_groups)
-            C_d = C_d.view(-1, n_groups, C.shape[1] // n_groups)
+            B_d = B_d.view(-1, n_groups, B_d.shape[1] // n_groups)
+            C_d = C_d.view(-1, n_groups, C_d.shape[1] // n_groups)
             hidden_states_d = hidden_states_d.view(
                 -1, self.num_heads // self.tp_size, self.head_dim)
 

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -468,7 +468,7 @@ class MambaMixer2(CustomOp):
             dim=0,
         )
         C_p, C_d = torch.split(
-            B,
+            C,
             [num_prefill_tokens, num_decodes],
             dim=0,
         )

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -397,7 +397,6 @@ class MambaMixer2(CustomOp):
         has_prefill = num_prefills > 0
         has_decode = num_decodes > 0
 
-        seq_len, _ = hidden_states.shape
         groups_time_state_size = self.n_groups * self.ssm_state_size
 
         # 1. Gated MLP's linear projection

--- a/vllm/model_executor/layers/mamba/mamba_mixer2.py
+++ b/vllm/model_executor/layers/mamba/mamba_mixer2.py
@@ -391,9 +391,9 @@ class MambaMixer2(CustomOp):
         # stay the same and reused for all mamba layers in the same iteration
         attn_metadata: AttentionMetadata = get_forward_context().attn_metadata
 
-        num_prefills = attn_metadata.num_prefills  # #requests
-        num_decodes = attn_metadata.num_decode_tokens  # #tokens==#requests
-        num_prefill_tokens = attn_metadata.num_prefill_tokens  # #tokens
+        num_prefills = attn_metadata.num_prefills  # request count
+        num_decodes = attn_metadata.num_decode_tokens  # token count (=request)
+        num_prefill_tokens = attn_metadata.num_prefill_tokens  # token count
         has_prefill = num_prefills > 0
         has_decode = num_decodes > 0
 

--- a/vllm/model_executor/layers/mamba/ops/ssd_combined.py
+++ b/vllm/model_executor/layers/mamba/ops/ssd_combined.py
@@ -40,7 +40,6 @@ def _mamba_chunk_scan_combined_fwd(x,
     _, _, ngroups, dstate = B.shape
     assert nheads % ngroups == 0
     assert B.shape == (batch, seqlen, ngroups, dstate)
-    assert x.shape == (batch, seqlen, nheads, headdim)
     assert dt.shape == (batch, seqlen, nheads)
     assert A.shape == (nheads, )
     assert C.shape == B.shape

--- a/vllm/model_executor/models/bamba.py
+++ b/vllm/model_executor/models/bamba.py
@@ -313,7 +313,6 @@ class BambaModel(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.mamba_chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/granitemoehybrid.py
+++ b/vllm/model_executor/models/granitemoehybrid.py
@@ -338,7 +338,6 @@ class GraniteMoeHybridModel(nn.Module):
         attn_metadata = get_forward_context().attn_metadata
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.mamba_chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/mamba2.py
+++ b/vllm/model_executor/models/mamba2.py
@@ -142,7 +142,6 @@ class Mamba2Model(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 

--- a/vllm/model_executor/models/zamba2.py
+++ b/vllm/model_executor/models/zamba2.py
@@ -751,7 +751,6 @@ class Zamba2Model(nn.Module):
 
         mamba2_metadata = prepare_mamba2_metadata(
             chunk_size=self.config.chunk_size,
-            input_ids=input_ids,
             attn_metadata=attn_metadata,
         )
 


### PR DESCRIPTION
As a follow up to PR #16942 

The CUDA Causal Conv1d kernel has a similar problem to the mamba2 ssd prefill kernels. It doesn't perform well when chunked prefill is turned ON resulting in the input batch to have mixed prefill and decode requests. This PR splits the requests, and we observe a big total throughput improvement for benchmark_serving.py with SharedGPT v3 workload.

### This PR chunked prefill ON
```
vllm serve ibm-ai-platform/Bamba-9B --port 9999 
```

```
python benchmarks/benchmark_serving.py --model ibm-ai-platform/Bamba-9B  --dataset-name sharegpt     --dataset-path /net/storage149/mnt/md0/ccyang/github.com/ShareGPT_V3/ShareGPT_V3_unfiltered_cleaned_split.json --ignore-eos --port 9999 
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  47.63     
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              21.00     
Output token throughput (tok/s):         4164.34   
Total Token throughput (tok/s):          8682.61   
---------------Time to First Token----------------
Mean TTFT (ms):                          15089.14  
Median TTFT (ms):                        13729.31  
P99 TTFT (ms):                           35227.37  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          56.06     
Median TPOT (ms):                        53.62     
P99 TPOT (ms):                           116.86    
---------------Inter-token Latency----------------
Mean ITL (ms):                           48.57     
Median ITL (ms):                         48.07     
P99 ITL (ms):                            118.30    
==================================================
```
### This PR chunked prefill OFF

```
vllm serve ibm-ai-platform/Bamba-9B --port 9999 --no-enable-chunked-prefill --max_model_len=4096
```

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  52.72     
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              18.97     
Output token throughput (tok/s):         3761.94   
Total Token throughput (tok/s):          7843.62   
---------------Time to First Token----------------
Mean TTFT (ms):                          16965.86  
Median TTFT (ms):                        15540.24  
P99 TTFT (ms):                           40363.40  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          68.57     
Median TPOT (ms):                        63.19     
P99 TPOT (ms):                           259.66    
---------------Inter-token Latency----------------
Mean ITL (ms):                           56.02     
Median ITL (ms):                         58.01     
P99 ITL (ms):                            121.75    
==================================================
```


### Main (d9ac9e3) chunked prefill on
```
vllm serve ibm-ai-platform/Bamba-9B --port 9999 
```

```
python benchmarks/benchmark_serving.py --model ibm-ai-platform/Bamba-9B  --dataset-name sharegpt     --dataset-path /net/storage149/mnt/md0/ccyang/github.com/ShareGPT_V3/ShareGPT_V3_unfiltered_cleaned_split.json --ignore-eos --port 9999 
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  183.82    
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              5.44      
Output token throughput (tok/s):         1079.03   
Total Token throughput (tok/s):          2249.77   
---------------Time to First Token----------------
Mean TTFT (ms):                          66936.01  
Median TTFT (ms):                        59901.93  
P99 TTFT (ms):                           169459.47 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          255.65    
Median TPOT (ms):                        269.80    
P99 TPOT (ms):                           395.92    
---------------Inter-token Latency----------------
Mean ITL (ms):                           220.89    
Median ITL (ms):                         333.07    
P99 ITL (ms):                            427.35    
==================================================
```

### Main (d9ac9e3) chunked prefill off

```
vllm serve ibm-ai-platform/Bamba-9B --port 9999 --no-enable-chunked-prefill --max_model_len=4096
```

```
============ Serving Benchmark Result ============
Successful requests:                     1000      
Benchmark duration (s):                  52.14     
Total input tokens:                      215201    
Total generated tokens:                  198343    
Request throughput (req/s):              19.18     
Output token throughput (tok/s):         3803.80   
Total Token throughput (tok/s):          7930.91   
---------------Time to First Token----------------
Mean TTFT (ms):                          16630.70  
Median TTFT (ms):                        15313.57  
P99 TTFT (ms):                           39832.65  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          67.94     
Median TPOT (ms):                        62.02     
P99 TPOT (ms):                           257.02    
---------------Inter-token Latency----------------
Mean ITL (ms):                           55.36     
Median ITL (ms):                         56.91     
P99 ITL (ms):                            121.58    
==================================================

## Output Quality

### Bamba-9B

```
vllm (pretrained=ibm-ai-platform/Bamba-9B,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.9,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.2623|±  |0.0121|
|     |       |strict-match    |     5|exact_match|↑  |0.3700|±  |0.0133|
```

### Zamba2-2.7B

```
vllm (pretrained=Zyphra/Zamba2-2.7B,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.9,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.5299|±  |0.0137|
|     |       |strict-match    |     5|exact_match|↑  |0.5436|±  |0.0137|
```

### Mamba-Codestral-7B

```
vllm (pretrained=mistralai/Mamba-Codestral-7B-v0.1,tensor_parallel_size=1,dtype=auto,gpu_memory_utilization=0.9,trust_remote_code=True), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: auto
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.4761|±  |0.0138|
|     |       |strict-match    |     5|exact_match|↑  |0.4632|±  |0.0137|
```