### PR TITLE
fix float16 support for kimi-vl

### DIFF
--- a/vllm/model_executor/models/kimi_vl.py
+++ b/vllm/model_executor/models/kimi_vl.py
@@ -340,8 +340,7 @@ class KimiVLForConditionalGeneration(nn.Module, SupportsMultiModal):
         else:
             pixel_values = pixel_values.reshape(-1, num_channels, patch_size,
                                                 patch_size)
-        # fp32 -> bf16
-        pixel_values = pixel_values.to(torch.bfloat16)
+        pixel_values = pixel_values.to(self.vision_tower.dtype)
         # image_grid_hws.shape = (N, 2)
         assert image_grid_hws.ndim == 2, f"unexpected shape for image_grid_hws: {image_grid_hws.shape}"
 


### PR DESCRIPTION
FIX https://github.com/MoonshotAI/Kimi-VL/issues/41

inference with float16:

```python
from PIL import Image
from transformers import AutoProcessor
from vllm import LLM, SamplingParams

model_path = "moonshotai/Kimi-VL-A3B-Instruct"
llm = LLM(
    model_path,
    trust_remote_code=True,
    dtype="float16",
)

processor = AutoProcessor.from_pretrained(model_path, trust_remote_code=True)

image_path = "./figures/demo.png"  # from https://github.com/MoonshotAI/Kimi-VL/blob/main/figures/demo.png
image = Image.open(image_path)
messages = [
    {"role": "user", "content": [{"type": "image", "image": image_path}, {"type": "text", "text": "What is the dome building in the picture? Think step by step."}]}
]
text = processor.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt")
outputs = llm.generate([{"prompt": text, "multi_modal_data": {"image": image}}], sampling_params = SamplingParams(max_tokens=512))

print("-" * 50)
for o in outputs:
    generated_text = o.outputs[0].text
    print(generated_text)
    print("-" * 50)
```

output:

```
INFO 04-25 10:52:36 [__init__.py:239] Automatically detected platform cuda.
WARNING 04-25 10:52:46 [config.py:2926] Casting torch.bfloat16 to torch.float16.
...
--------------------------------------------------
To identify the dome building in the picture, we can follow these steps:

1. **Recognize the Building**: The building with a distinctive dome structure is Rogers Centre, a multi-purpose stadium.

2. **Signage and Design**: The prominent signage on the building reads "Rogers Centre," which is a key identifier.

3. **Geographical Context**: Rogers Centre is located in Toronto, which matches the cityscape in the image.

By combining these observations, we can conclude that the dome building in the picture is Rogers Centre.
```
