### PR TITLE
[Frontend] Expand tools even if tool_choice="none"

### DIFF
--- a/docs/features/tool_calling.md
+++ b/docs/features/tool_calling.md
@@ -97,6 +97,14 @@ vLLM supports the `tool_choice='required'` option in the chat completion API. Si
 
 When tool_choice='required' is set, the model is guaranteed to generate one or more tool calls based on the specified tool list in the `tools` parameter. The number of tool calls depends on the user's query. The output format strictly follows the schema defined in the `tools` parameter.
 
+## None Function Calling
+
+vLLM supports the `tool_choice='none'` option in the chat completion API. When this option is set, the model will not generate any tool calls and will respond with regular text content only, even if tools are defined in the request.
+
+By default, when `tool_choice='none'` is specified, vLLM excludes tool definitions from the prompt to optimize context usage. To include tool definitions even with `tool_choice='none'`, use the `--expand-tools-even-if-tool-choice-none` option.
+
+Note: This behavior will change in v0.10.0, where tool definitions will be included by default even with `tool_choice='none'`.
+
 ## Automatic Function Calling
 
 To enable this feature, you should set the following flags:

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1187,8 +1187,6 @@ async def init_app_state(
         chat_template_content_format=args.chat_template_content_format,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
-        expand_tools_even_if_tool_choice_none=args.
-        expand_tools_even_if_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1187,6 +1187,7 @@ async def init_app_state(
         chat_template_content_format=args.chat_template_content_format,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
+        expand_tools_even_if_tool_choice_none=args.expand_tools_even_if_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1187,7 +1187,8 @@ async def init_app_state(
         chat_template_content_format=args.chat_template_content_format,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
-        expand_tools_even_if_tool_choice_none=args.expand_tools_even_if_tool_choice_none,
+        expand_tools_even_if_tool_choice_none=args.
+        expand_tools_even_if_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -1187,6 +1187,8 @@ async def init_app_state(
         chat_template_content_format=args.chat_template_content_format,
         return_tokens_as_token_ids=args.return_tokens_as_token_ids,
         enable_auto_tools=args.enable_auto_tool_choice,
+        expand_tools_even_if_tool_choice_none=args.
+        expand_tools_even_if_tool_choice_none,
         tool_parser=args.tool_call_parser,
         reasoning_parser=args.reasoning_parser,
         enable_prompt_tokens_details=args.enable_prompt_tokens_details,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -223,6 +223,11 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         default=False,
         help="Enable auto tool choice for supported models. Use "
         "``--tool-call-parser`` to specify which parser to use.")
+    parser.add_argument(
+        "--expand-tools-even-if-tool-choice-none",
+        action="store_true",
+        default=False,
+        help="Include tool definitions in prompt when tool_choice='none'")
 
     valid_tool_parsers = ToolParserManager.tool_parsers.keys()
     parser.add_argument(

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -223,11 +223,6 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         default=False,
         help="Enable auto tool choice for supported models. Use "
         "``--tool-call-parser`` to specify which parser to use.")
-    parser.add_argument(
-        "--expand-tools-even-if-tool-choice-none",
-        action="store_true",
-        default=False,
-        help="Include tool definitions in prompt when tool_choice='none'")
 
     valid_tool_parsers = ToolParserManager.tool_parsers.keys()
     parser.add_argument(

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -227,7 +227,8 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         "--expand-tools-even-if-tool-choice-none",
         action="store_true",
         default=False,
-        help="[DEPRECATED] Include tool definitions in prompts "
+        deprecated=True,
+        help="Include tool definitions in prompts "
         "even when tool_choice='none'. "
         "This is a transitional option that will be removed in v0.10.0. "
         "In v0.10.0, tool definitions will always be included regardless of "

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -227,7 +227,11 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         "--expand-tools-even-if-tool-choice-none",
         action="store_true",
         default=False,
-        help="Include tool definitions in prompt when tool_choice='none'")
+        help="[DEPRECATED] Include tool definitions in prompts even when tool_choice='none'. "
+        "This is a transitional option that will be removed in v0.10.0. "
+        "In v0.10.0, tool definitions will always be included regardless of "
+        "tool_choice setting. Use this flag now to test the new behavior "
+        "before the breaking change.")
 
     valid_tool_parsers = ToolParserManager.tool_parsers.keys()
     parser.add_argument(

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -227,7 +227,8 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         "--expand-tools-even-if-tool-choice-none",
         action="store_true",
         default=False,
-        help="[DEPRECATED] Include tool definitions in prompts even when tool_choice='none'. "
+        help="[DEPRECATED] Include tool definitions in prompts "
+        "even when tool_choice='none'. "
         "This is a transitional option that will be removed in v0.10.0. "
         "In v0.10.0, tool definitions will always be included regardless of "
         "tool_choice setting. Use this flag now to test the new behavior "

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -686,10 +686,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if "tool_choice" not in data and data.get("tools"):
             data["tool_choice"] = "auto"
 
-        # if "tool_choice" is "none" -- ignore tools if present
+        # if "tool_choice" is "none" -- no validation is needed for tools
         if "tool_choice" in data and data["tool_choice"] == "none":
-            # ensure that no tools are present
-            data.pop("tools", None)
             return data
 
         # if "tool_choice" is specified -- validation

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -109,7 +109,8 @@ class OpenAIServingChat(OpenAIServing):
                 raise TypeError("Error: --enable-auto-tool-choice requires "
                                 f"tool_parser:'{tool_parser}' which has not "
                                 "been registered") from e
-        self.expand_tools_even_if_tool_choice_none = expand_tools_even_if_tool_choice_none
+        self.expand_tools_even_if_tool_choice_none = (
+            expand_tools_even_if_tool_choice_none)
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.default_sampling_params = (

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -174,14 +174,12 @@ class OpenAIServingChat(OpenAIServing):
                     "--enable-auto-tool-choice and --tool-call-parser to be set"
                 )
 
-            if (request.tools is None or
-                    (request.tool_choice == "none" and
-                     not self.expand_tools_even_if_tool_choice_none)):
+            if (request.tools is None
+                    or (request.tool_choice == "none"
+                        and not self.expand_tools_even_if_tool_choice_none)):
                 tool_dicts = None
             else:
-                tool_dicts = [
-                    tool.model_dump() for tool in request.tools
-                ]
+                tool_dicts = [tool.model_dump() for tool in request.tools]
 
             (
                 conversation,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -62,7 +62,6 @@ class OpenAIServingChat(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         reasoning_parser: str = "",
         enable_auto_tools: bool = False,
-        expand_tools_even_if_tool_choice_none: bool = False,
         tool_parser: Optional[str] = None,
         enable_prompt_tokens_details: bool = False,
     ) -> None:
@@ -109,8 +108,6 @@ class OpenAIServingChat(OpenAIServing):
                 raise TypeError("Error: --enable-auto-tool-choice requires "
                                 f"tool_parser:'{tool_parser}' which has not "
                                 "been registered") from e
-        self.expand_tools_even_if_tool_choice_none = (
-            expand_tools_even_if_tool_choice_none)
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.default_sampling_params = (
@@ -175,12 +172,9 @@ class OpenAIServingChat(OpenAIServing):
                     "--enable-auto-tool-choice and --tool-call-parser to be set"
                 )
 
-            if (request.tools is None
-                    or (request.tool_choice == "none"
-                        and not self.expand_tools_even_if_tool_choice_none)):
-                tool_dicts = None
-            else:
-                tool_dicts = [tool.model_dump() for tool in request.tools]
+            tool_dicts = None if request.tools is None else [
+                tool.model_dump() for tool in request.tools
+            ]
 
             (
                 conversation,

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -190,8 +190,7 @@ class OpenAIServingChat(OpenAIServing):
                         "with tool_choice='none'. To adopt the new behavior "
                         "now, use --expand-tools-even-if-tool-choice-none. "
                         "To suppress this warning, either remove tools from "
-                        "the request or set tool_choice to a different value."
-                    )
+                        "the request or set tool_choice to a different value.")
                 tool_dicts = None
             else:
                 tool_dicts = [tool.model_dump() for tool in request.tools]

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -182,15 +182,15 @@ class OpenAIServingChat(OpenAIServing):
                 assert request.tools is not None
                 if len(request.tools) > 0:
                     logger.warning(
-                        "Tools are specified but tool_choice is set to 'none' and "
-                        "--expand-tools-even-if-tool-choice-none is not enabled. "
-                        "Tool definitions will be excluded from the prompt. "
-                        "This behavior will change in vLLM v0.10 where tool definitions "
-                        "will be included by default even with tool_choice='none'. "
-                        "To adopt the new behavior now, "
-                        "use --expand-tools-even-if-tool-choice-none. "
-                        "To suppress this warning, either remove tools from the request "
-                        "or set tool_choice to a different value."
+                        "Tools are specified but tool_choice is set to 'none' "
+                        "and --expand-tools-even-if-tool-choice-none is not "
+                        "enabled. Tool definitions will be excluded from the "
+                        "prompt. This behavior will change in vLLM v0.10 where "
+                        "tool definitions will be included by default even "
+                        "with tool_choice='none'. To adopt the new behavior "
+                        "now, use --expand-tools-even-if-tool-choice-none. "
+                        "To suppress this warning, either remove tools from "
+                        "the request or set tool_choice to a different value."
                     )
                 tool_dicts = None
             else:

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -179,7 +179,6 @@ class OpenAIServingChat(OpenAIServing):
                 tool_dicts = None
             elif (request.tool_choice == "none"
                   and not self.expand_tools_even_if_tool_choice_none):
-                assert request.tools is not None
                 if len(request.tools) > 0:
                     logger.warning_once(
                         "Tools are specified but tool_choice is set to 'none' "

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -181,7 +181,7 @@ class OpenAIServingChat(OpenAIServing):
                   and not self.expand_tools_even_if_tool_choice_none):
                 assert request.tools is not None
                 if len(request.tools) > 0:
-                    logger.warning(
+                    logger.warning_once(
                         "Tools are specified but tool_choice is set to 'none' "
                         "and --expand-tools-even-if-tool-choice-none is not "
                         "enabled. Tool definitions will be excluded from the "

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -175,9 +175,23 @@ class OpenAIServingChat(OpenAIServing):
                     "--enable-auto-tool-choice and --tool-call-parser to be set"
                 )
 
-            if (request.tools is None
-                    or (request.tool_choice == "none"
-                        and not self.expand_tools_even_if_tool_choice_none)):
+            if request.tools is None:
+                tool_dicts = None
+            elif (request.tool_choice == "none"
+                  and not self.expand_tools_even_if_tool_choice_none):
+                assert request.tools is not None
+                if len(request.tools) > 0:
+                    logger.warning(
+                        "Tools are specified but tool_choice is set to 'none' and "
+                        "--expand-tools-even-if-tool-choice-none is not enabled. "
+                        "Tool definitions will be excluded from the prompt. "
+                        "This behavior will change in vLLM v0.10 where tool definitions "
+                        "will be included by default even with tool_choice='none'. "
+                        "To adopt the new behavior now, "
+                        "use --expand-tools-even-if-tool-choice-none. "
+                        "To suppress this warning, either remove tools from the request "
+                        "or set tool_choice to a different value."
+                    )
                 tool_dicts = None
             else:
                 tool_dicts = [tool.model_dump() for tool in request.tools]

--- a/vllm/entrypoints/openai/serving_chat.py
+++ b/vllm/entrypoints/openai/serving_chat.py
@@ -62,6 +62,7 @@ class OpenAIServingChat(OpenAIServing):
         return_tokens_as_token_ids: bool = False,
         reasoning_parser: str = "",
         enable_auto_tools: bool = False,
+        expand_tools_even_if_tool_choice_none: bool = False,
         tool_parser: Optional[str] = None,
         enable_prompt_tokens_details: bool = False,
     ) -> None:
@@ -108,6 +109,8 @@ class OpenAIServingChat(OpenAIServing):
                 raise TypeError("Error: --enable-auto-tool-choice requires "
                                 f"tool_parser:'{tool_parser}' which has not "
                                 "been registered") from e
+        self.expand_tools_even_if_tool_choice_none = (
+            expand_tools_even_if_tool_choice_none)
 
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
         self.default_sampling_params = (
@@ -172,9 +175,12 @@ class OpenAIServingChat(OpenAIServing):
                     "--enable-auto-tool-choice and --tool-call-parser to be set"
                 )
 
-            tool_dicts = None if request.tools is None else [
-                tool.model_dump() for tool in request.tools
-            ]
+            if (request.tools is None
+                    or (request.tool_choice == "none"
+                        and not self.expand_tools_even_if_tool_choice_none)):
+                tool_dicts = None
+            else:
+                tool_dicts = [tool.model_dump() for tool in request.tools]
 
             (
                 conversation,


### PR DESCRIPTION
# Add option to include tool definitions even when tool_choice is 'none'

## Summary
This PR adds a new command-line option `--expand-tools-even-if-tool-choice-none` which allows including tool definitions in prompts even when `tool_choice='none'`.

## Motivation
In the current implementation, when `tool_choice` is set to `'none'`, all tool definitions are removed from the request, preventing the model from seeing the tool schemas. This change enables a workflow where:

1. The model can be aware of available tools (via their definitions in the prompt)
2. But is not expected to use them automatically (since `tool_choice='none'`)

This is useful for:
- Models that need to "plan" about available tools before using them in subsequent requests
- Cases where tool descriptions provide useful context even if the tools aren't used
- Situations where you want the model to reference tool capabilities in its response without actually calling them

## Implementation
- Added a new CLI flag `--expand-tools-even-if-tool-choice-none` (default: False)
- Modified the request validation in `protocol.py` to no longer remove tools when `tool_choice='none'`
- Added the new parameter to `OpenAIServingChat` and passed it through from the API server
