### PR TITLE
[Doc] Move todo out of beam search docstring

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -520,11 +520,9 @@ class LLM:
             prompts: A list of prompts. Each prompt can be a string or a list
                 of token IDs.
             params: The beam search parameters.
-
-        TODO: how does beam search work together with length penalty, frequency
-        penalty, and stopping criteria, etc.?
         """
-
+        # TODO: how does beam search work together with length penalty,
+        # frequency, penalty, and stopping criteria, etc.?
         beam_width = params.beam_width
         max_tokens = params.max_tokens
         temperature = params.temperature


### PR DESCRIPTION
Moves a TODO out of the docstring for beam search to prevent it from rendering in the docs [here](https://docs.vllm.ai/en/latest/api/offline_inference/llm.html#vllm.LLM.beam_search) 🙂 