### PR TITLE
[Bugfix] Fix Lora Name Parsing

### DIFF
--- a/tests/lora/test_utils.py
+++ b/tests/lora/test_utils.py
@@ -39,6 +39,18 @@ def test_parse_fine_tuned_lora_name_valid():
             False,
             False,
         ),
+        (
+            "language_model.layers.9.mlp.down_proj.lora_A.weight",
+            "language_model.layers.9.mlp.down_proj",
+            True,
+            False,
+        ),
+        (
+            "language_model.layers.9.mlp.down_proj.lora_B.weight",
+            "language_model.layers.9.mlp.down_proj",
+            False,
+            False,
+        ),
     }
     for name, module_name, is_lora_a, is_bias in fixture:
         assert (module_name, is_lora_a,

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -124,7 +124,7 @@ def parse_fine_tuned_lora_name(
         name = "base_model.model." + name
 
     # In some situations, we may not start with `base_model.model.`.
-    # If we don't, we should keep the prefix intact.
+    # If we don't (e.g., ibm-granite/granite-speech-3.3-8b), we should keep the prefix intact.
     start_index = 2 if "base_model.model." in name else 0
 
     parts = name.split(".")

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -124,7 +124,8 @@ def parse_fine_tuned_lora_name(
         name = "base_model.model." + name
 
     # In some situations, we may not start with `base_model.model.`.
-    # If we don't (e.g., ibm-granite/granite-speech-3.3-8b), we should keep the prefix intact.
+    # If we don't (e.g., ibm-granite/granite-speech-3.3-8b),
+    # we should keep the prefix intact.
     start_index = 2 if "base_model.model." in name else 0
 
     parts = name.split(".")

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -114,7 +114,7 @@ def parse_fine_tuned_lora_name(
             is_bias whether the tensor is lora bias.
     """
 
-    # LoRA weight qualified name usually start with `base_model.model.`,
+    # LoRA weight qualified name usually starts with `base_model.model.`,
     # so we remove the prefix `base_model.model.` to make the following
     # mapping correctly.
     if "base_model.model." in name:
@@ -123,9 +123,8 @@ def parse_fine_tuned_lora_name(
         # recover the prefix `base_model.model.`
         name = "base_model.model." + name
 
-    # In some situations, we may not start with `base_model.model.`, depending
-    # on if the model is intended to be loaded through the transformers peft
-    # integration; if it's the latter, we should take the whole prefix.
+    # In some situations, we may not start with `base_model.model.`.
+    # If we don't, we should keep the prefix intact.
     start_index = 2 if "base_model.model." in name else 0
 
     parts = name.split(".")

--- a/vllm/lora/utils.py
+++ b/vllm/lora/utils.py
@@ -114,7 +114,7 @@ def parse_fine_tuned_lora_name(
             is_bias whether the tensor is lora bias.
     """
 
-    # LoRA weight qualified name always starts with `base_model.model.`,
+    # LoRA weight qualified name usually start with `base_model.model.`,
     # so we remove the prefix `base_model.model.` to make the following
     # mapping correctly.
     if "base_model.model." in name:
@@ -123,18 +123,23 @@ def parse_fine_tuned_lora_name(
         # recover the prefix `base_model.model.`
         name = "base_model.model." + name
 
+    # In some situations, we may not start with `base_model.model.`, depending
+    # on if the model is intended to be loaded through the transformers peft
+    # integration; if it's the latter, we should take the whole prefix.
+    start_index = 2 if "base_model.model." in name else 0
+
     parts = name.split(".")
     if parts[-1] == "weight" and (parts[-2] == "lora_A"
                                   or parts[-2] == "lora_B"):
-        new_name = ".".join(parts[2:-2])
+        new_name = ".".join(parts[start_index:-2])
         return new_name, parts[-2] == "lora_A", False
 
     if parts[-1] == "lora_embedding_A" or parts[-1] == "lora_embedding_B":
-        new_name = ".".join(parts[2:-1])
+        new_name = ".".join(parts[start_index:-1])
         return new_name, parts[-1] == "lora_embedding_A", False
 
     if parts[-1] == "bias":
-        new_name = ".".join(parts[2:-2])
+        new_name = ".".join(parts[start_index:-2])
         return new_name, False, True
 
     raise ValueError(f"{name} is unsupported LoRA weight")


### PR DESCRIPTION
Currently, we assume lora weights start with `base_model.model.` and split the prefix of lora weights accordingly. This is usually true, but in some situations, there may be lora adapters that don't have this prefix. An example of such a model is [granite speech 3.3](https://huggingface.co/ibm-granite/granite-speech-3.3-8b), where the audio specific lora weights are bundled directly with the model so that they can be automatically loaded together with `from_pretrained` using the transformers peft mixin, and the weight names align with the transformers (not peft) model tensor names.

This fix keeps the full prefix if the lora tensors don't start with `base_model.model.`. This is needed for https://github.com/vllm-project/vllm/pull/16246 to work correctly, since the lora is currently not applied due to erroneous slicing (e.g., `language_model.model.layers.1.self_attn_q_proj` vs `layers.1.self_attn_q_proj`)

<!--- pyml disable-next-line no-emphasis-as-heading -->
