### PR TITLE
[Benchmark] Add single turn MTBench to Serving Bench

### DIFF
--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -783,8 +783,8 @@ class MTBenchDataset(HuggingFaceDataset):
 
     We create a single turn dataset for MT-Bench. 
     This is similar to Spec decoding benchmark setup in vLLM
-    https://github.com/vllm-project/vllm/blob/9d98ab5ec/examples/offline_inference/eagle.py#L14-L18  # noqa: E501
-    """
+    https://github.com/vllm-project/vllm/blob/9d98ab5ec/examples/offline_inference/eagle.py#L14-L18
+    """ # noqa: E501
 
     DEFAULT_OUTPUT_LEN = 256  # avg len used in SD bench in vLLM
     SUPPORTED_DATASET_PATHS = {

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -783,7 +783,7 @@ class MTBenchDataset(HuggingFaceDataset):
 
     We create a single turn dataset for MT-Bench. 
     This is similar to Spec decoding benchmark setup in vLLM
-    https://github.com/vllm-project/vllm/blob/9d98ab5ec/examples/offline_inference/eagle.py#L14-L18 # noqa: E501
+    https://github.com/vllm-project/vllm/blob/9d98ab5ec/examples/offline_inference/eagle.py#L14-L18  # noqa: E501
     """
 
     DEFAULT_OUTPUT_LEN = 256  # avg len used in SD bench in vLLM

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -805,6 +805,13 @@ class MTBenchDataset(HuggingFaceDataset):
             if len(sampled_requests) >= num_requests:
                 break
             prompt = item['turns'][0]
+            
+            # apply template
+            prompt=tokenizer.apply_chat_template([{
+                "role": "user",
+                "content": prompt
+            }], tokenize=False)
+
             prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(
                 SampleRequest(

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -772,6 +772,51 @@ class InstructCoderDataset(HuggingFaceDataset):
 
 
 # -----------------------------------------------------------------------------
+# MT-Bench Dataset Implementation
+# -----------------------------------------------------------------------------
+
+
+class MTBenchDataset(HuggingFaceDataset):
+    """
+    MT-Bench Dataset.
+    https://huggingface.co/datasets/philschmid/mt-bench
+
+    We create a single turn dataset for MT-Bench. 
+    This is similar to Spec decoding benchmark setup in vLLM
+    https://github.com/vllm-project/vllm/blob/9d98ab5ec/examples/offline_inference/eagle.py#L14-L18 # noqa: E501
+    """
+
+    DEFAULT_OUTPUT_LEN = 256  # avg len used in SD bench in vLLM
+    SUPPORTED_DATASET_PATHS = {
+        "philschmid/mt-bench",
+    }
+
+    def sample(self,
+               tokenizer: PreTrainedTokenizerBase,
+               num_requests: int,
+               output_len: Optional[int] = None,
+               enable_multimodal_chat: bool = False,
+               **kwargs) -> list:
+        output_len = (output_len
+                      if output_len is not None else self.DEFAULT_OUTPUT_LEN)
+        sampled_requests = []
+
+        for item in self.data:
+            if len(sampled_requests) >= num_requests:
+                break
+            prompt = item['turns'][0]
+            prompt_len = len(tokenizer(prompt).input_ids)
+            sampled_requests.append(
+                SampleRequest(
+                    prompt=prompt,
+                    prompt_len=prompt_len,
+                    expected_output_len=output_len,
+                ))
+        self.maybe_oversample_requests(sampled_requests, num_requests)
+        return sampled_requests
+
+
+# -----------------------------------------------------------------------------
 # AIMO Dataset Implementation
 # -----------------------------------------------------------------------------
 

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -810,7 +810,7 @@ class MTBenchDataset(HuggingFaceDataset):
             prompt=tokenizer.apply_chat_template([{
                 "role": "user",
                 "content": prompt
-            }], tokenize=False)
+            }], add_generation_prompt=True, tokenize=False)
 
             prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(

--- a/benchmarks/benchmark_dataset.py
+++ b/benchmarks/benchmark_dataset.py
@@ -805,12 +805,14 @@ class MTBenchDataset(HuggingFaceDataset):
             if len(sampled_requests) >= num_requests:
                 break
             prompt = item['turns'][0]
-            
+
             # apply template
-            prompt=tokenizer.apply_chat_template([{
+            prompt = tokenizer.apply_chat_template([{
                 "role": "user",
                 "content": prompt
-            }], add_generation_prompt=True, tokenize=False)
+            }],
+                                                   add_generation_prompt=True,
+                                                   tokenize=False)
 
             prompt_len = len(tokenizer(prompt).input_ids)
             sampled_requests.append(

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -52,7 +52,8 @@ except ImportError:
 
 from benchmark_dataset import (AIMODataset, ASRDataset, BurstGPTDataset,
                                ConversationDataset, HuggingFaceDataset,
-                               InstructCoderDataset, RandomDataset,
+                               InstructCoderDataset, MTBenchDataset, 
+                               RandomDataset,
                                SampleRequest, ShareGPTDataset, SonnetDataset,
                                VisionArenaDataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
@@ -594,6 +595,9 @@ def main(args: argparse.Namespace):
             args.hf_subset = None
         elif args.dataset_path in InstructCoderDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = InstructCoderDataset
+            args.hf_split = "train"
+        elif args.dataset_path in MTBenchDataset.SUPPORTED_DATASET_PATHS:
+            dataset_class = MTBenchDataset
             args.hf_split = "train"
         elif args.dataset_path in ConversationDataset.SUPPORTED_DATASET_PATHS:
             dataset_class = ConversationDataset

--- a/benchmarks/benchmark_serving.py
+++ b/benchmarks/benchmark_serving.py
@@ -52,10 +52,9 @@ except ImportError:
 
 from benchmark_dataset import (AIMODataset, ASRDataset, BurstGPTDataset,
                                ConversationDataset, HuggingFaceDataset,
-                               InstructCoderDataset, MTBenchDataset, 
-                               RandomDataset,
-                               SampleRequest, ShareGPTDataset, SonnetDataset,
-                               VisionArenaDataset)
+                               InstructCoderDataset, MTBenchDataset,
+                               RandomDataset, SampleRequest, ShareGPTDataset,
+                               SonnetDataset, VisionArenaDataset)
 from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000


### PR DESCRIPTION
This PR adds single turn MTBench to benchmark datasets. 
We have been using [single turn MTBench](https://github.com/vllm-project/vllm/blob/a5450f11c95847cf51a17207af9a3ca5ab569b2c/examples/offline_inference/eagle.py#L15-L20) for EAGLE bench using`/offline_inference/eagle.py`. However, it outputs output/s which does not ignore the TTFT. To measure TPOT we have to use `benchmark_serving.py`. We already have a lot of results on MTBench for different EAGLE settings so this PR adds MTBench to serving benchmark to measure TPOT. 

bench cmd
```
python3 benchmarks/benchmark_serving.py --port 9001 --save-result \
  --backend vllm \
  --model meta-llama/Llama-3.1-8B-Instruct \
  --endpoint /v1/completions \
  --dataset-name hf \
  --dataset-path philschmid/mt-bench \
  --num-prompts 80 \
  --max-concurrency 1
```

VANILLA 
serve cmd
```
vllm serve meta-llama/Llama-3.1-8B-Instruct  --disable-log-requests --port 9001
```



Result
```
Starting initial single prompt test run...                         
Initial test run completed. Starting main benchmark run...
Traffic request rate: inf                                                                                                              
Burstiness factor: 1.0 (Poisson process)                                                                                               
Maximum request concurrency: 1                                     
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 80/80 [02:26<00:00,  1.83s/it]
============ Serving Benchmark Result ============ 
Successful requests:                     80        
Benchmark duration (s):                  146.25    
Total input tokens:                      5333      
Total generated tokens:                  19450     
Request throughput (req/s):              0.55      
Output token throughput (tok/s):         132.99    
Total Token throughput (tok/s):          169.45    
---------------Time to First Token----------------
Mean TTFT (ms):                          12.24     
Median TTFT (ms):                        12.22     
P99 TTFT (ms):                           13.79     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.50      
Median TPOT (ms):                        7.49      
P99 TPOT (ms):                           7.61      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.50      
Median ITL (ms):                         7.49      
P99 ITL (ms):                            7.99      
==================================================
```

EAGLE-1

serve cmd
```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --disable-log-requests --port 9001 \
  --speculative_config '{"model": "yuhuili/EAGLE-LLaMA3.1-Instruct-8B", "num_speculative_tokens": 2}'
```

Result
```
Starting initial single prompt test run...
Initial test run completed. Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 1
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 80/80 [01:28<00:00,  1.10s/it]
============ Serving Benchmark Result ============
Successful requests:                     80        
Benchmark duration (s):                  88.03     
Total input tokens:                      8133      
Total generated tokens:                  16943     
Request throughput (req/s):              0.91      
Output token throughput (tok/s):         192.46    
Total Token throughput (tok/s):          284.85    
---------------Time to First Token----------------
Mean TTFT (ms):                          14.77     
Median TTFT (ms):                        14.74     
P99 TTFT (ms):                           15.98     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          5.11      
Median TPOT (ms):                        5.05      
P99 TPOT (ms):                           6.59      
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.46     
Median ITL (ms):                         10.57     
P99 ITL (ms):                            11.46     
==================================================
```

EAGLE-3

serve cmd
```
VLLM_USE_V1=1 vllm serve meta-llama/Llama-3.1-8B-Instruct \
  --disable-log-requests --port 9001 \
  --speculative_config '{"method": "eagle3", "model": "yuhuili/EAGLE3-LLaMA3.1-Instruct-8B", "num_speculative_tokens": 2}'
```

Result
```
Initial test run completed. Starting main benchmark run...
Traffic request rate: inf
Burstiness factor: 1.0 (Poisson process)
Maximum request concurrency: 1
100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 80/80 [01:32<00:00,  1.15s/it]
============ Serving Benchmark Result ============
Successful requests:                     80        
Benchmark duration (s):                  92.35     
Total input tokens:                      8133      
Total generated tokens:                  16908     
Request throughput (req/s):              0.87      
Output token throughput (tok/s):         183.09    
Total Token throughput (tok/s):          271.16    
---------------Time to First Token----------------
Mean TTFT (ms):                          15.87     
Median TTFT (ms):                        15.15     
P99 TTFT (ms):                           21.82     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          5.37      
Median TPOT (ms):                        5.38      
P99 TPOT (ms):                           6.92      
---------------Inter-token Latency----------------
Mean ITL (ms):                           10.64     
Median ITL (ms):                         10.76     
P99 ITL (ms):                            11.71     
==================================================
```


cc: @LiuXiaoxuanPKU 