### PR TITLE
[Bugfix] Fix missing int type for `-n` in multi-image example

### DIFF
--- a/examples/offline_inference/vision_language_multi_image.py
+++ b/examples/offline_inference/vision_language_multi_image.py
@@ -791,7 +791,8 @@ def parse_args():
     parser.add_argument(
         "--num-images",
         "-n",
-        choices=list(range(1, 13)),  # 12 is the max number of images
+        type=int,
+        choices=list(range(1, len(IMAGE_URLS))),  # the max number of images
         default=2,
         help="Number of images to use for the demo.")
     return parser.parse_args()

--- a/examples/offline_inference/vision_language_multi_image.py
+++ b/examples/offline_inference/vision_language_multi_image.py
@@ -792,7 +792,8 @@ def parse_args():
         "--num-images",
         "-n",
         type=int,
-        choices=list(range(1, len(IMAGE_URLS))),  # the max number of images
+        choices=list(range(1,
+                           len(IMAGE_URLS) + 1)),  # the max number of images
         default=2,
         help="Number of images to use for the demo.")
     return parser.parse_args()


### PR DESCRIPTION
- Fix missing `type=int` for `-n` in `vision_language_multi_image.py`:
```
vision_language_multi_image.py: error: argument --num-images/-n: invalid choice: '3' (choose from 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
```

