### PR TITLE
[ROCm] Effort to reduce the number of environment variables in command line

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -114,6 +114,12 @@ COPY --from=export_vllm /examples ${COMMON_WORKDIR}/vllm/examples
 ENV RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
 ENV TOKENIZERS_PARALLELISM=false
 
+# ENV that can improve safe tensor loading, and end-to-end time
+ENV SAFETENSORS_FAST_GPU=1
+# ENV that needed for multi-process on cuda-like platform
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+
 # Performance environment variable.
 ENV HIP_FORCE_DEV_KERNARG=1
 

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -119,7 +119,8 @@ ENV SAFETENSORS_FAST_GPU=1
 
 # User-friendly environment setting for multi-processing to avoid below RuntimeError.
 # RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing,
-# you must use the 'spawn' start method
+# you must use the 'spawn' start method 
+# See https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing
 ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 
 # Performance environment variable.

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -116,9 +116,11 @@ ENV TOKENIZERS_PARALLELISM=false
 
 # ENV that can improve safe tensor loading, and end-to-end time
 ENV SAFETENSORS_FAST_GPU=1
-# ENV that needed for multi-process on cuda-like platform
-ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 
+# User-friendly environment setting for multi-processing to avoid below RuntimeError.
+# RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing,
+# you must use the 'spawn' start method
+ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
 
 # Performance environment variable.
 ENV HIP_FORCE_DEV_KERNARG=1


### PR DESCRIPTION
This is to set two environment variables in the Docker file so that users can reduce the number of environment variables when running scripts.

ENV that can improve safe tensor loading, and end-to-end time
```
ENV SAFETENSORS_FAST_GPU=1
```
ENV that needed for multi-process on cuda-like platform
```
ENV VLLM_WORKER_MULTIPROC_METHOD=spawn
```

Test:
1. build the docker image
```
DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.rocm -t vllm-rocm .
```
3. run the docker container and check the env are set in the container
```
docker run --rm vllm-rocm env | grep spawn
VLLM_WORKER_MULTIPROC_METHOD=spawn

docker run --rm vllm-rocm env | grep FAST
SAFETENSORS_FAST_GPU=1
```



<!--- pyml disable-next-line no-emphasis-as-heading -->
