### PR TITLE
[Model]Remove Dropout Layers

### DIFF
--- a/vllm/model_executor/models/blip.py
+++ b/vllm/model_executor/models/blip.py
@@ -93,7 +93,6 @@ class BlipAttention(nn.Module):
                 f"(got `embed_dim`: {self.embed_dim} and `num_heads`:"
                 f" {self.num_heads}).")
         self.scale = self.head_dim**-0.5
-        self.dropout = config.attention_dropout
 
         self.qkv = QKVParallelLinear(
             self.embed_dim,

--- a/vllm/model_executor/models/blip2.py
+++ b/vllm/model_executor/models/blip2.py
@@ -92,8 +92,6 @@ class Blip2QFormerMultiHeadAttention(nn.Module):
             raise NotImplementedError("Unsupported position_embedding_type: "
                                       f"{self.position_embedding_type}")
 
-        self.dropout = nn.Dropout(config.attention_probs_dropout_prob)
-
     def transpose_for_scores(self, x):
         x = x.view(*x.size()[:-1], self.num_attention_heads,
                    self.attention_head_size)
@@ -124,11 +122,7 @@ class Blip2QFormerMultiHeadAttention(nn.Module):
         attention_probs = torch.softmax(attention_scores * self.scaling,
                                         dim=-1)
 
-        # This is actually dropping out entire tokens to attend to, which might
-        # seem a bit unusual, but is taken from the original Transformer paper.
-        attention_probs_dropped = self.dropout(attention_probs)
-
-        context_layer = torch.matmul(attention_probs_dropped, value_layer)
+        context_layer = torch.matmul(attention_probs, value_layer)
 
         context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
         context_layer = context_layer.view(*context_layer.size()[:-2],
@@ -145,7 +139,6 @@ class Blip2QFormerSelfOutput(nn.Module):
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.LayerNorm = nn.LayerNorm(config.hidden_size,
                                       eps=config.layer_norm_eps)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(
         self,
@@ -153,7 +146,6 @@ class Blip2QFormerSelfOutput(nn.Module):
         input_tensor: torch.Tensor,
     ) -> torch.Tensor:
         hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
         return hidden_states
 
@@ -215,7 +207,6 @@ class Blip2QFormerOutput(nn.Module):
         self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
         self.LayerNorm = nn.LayerNorm(config.hidden_size,
                                       eps=config.layer_norm_eps)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
     def forward(
         self,
@@ -223,7 +214,6 @@ class Blip2QFormerOutput(nn.Module):
         input_tensor: torch.Tensor,
     ) -> torch.Tensor:
         hidden_states = self.dense(hidden_states)
-        hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
         return hidden_states
 
@@ -372,7 +362,6 @@ class Blip2QFormerModel(nn.Module):
 
         self.layernorm = nn.LayerNorm(config.hidden_size,
                                       eps=config.layer_norm_eps)
-        self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
         self.encoder = Blip2QFormerEncoder(config,
                                            quant_config=quant_config,
@@ -386,7 +375,6 @@ class Blip2QFormerModel(nn.Module):
         query_length = query_embeds.shape[1]
 
         embedding_output = self.layernorm(query_embeds)
-        embedding_output = self.dropout(embedding_output)
 
         sequence_output = self.encoder(
             embedding_output,

--- a/vllm/model_executor/models/chameleon.py
+++ b/vllm/model_executor/models/chameleon.py
@@ -551,7 +551,6 @@ class ChameleonVQVAEEncoderResnetBlock(nn.Module):
                                         num_channels=out_channels,
                                         eps=1e-6,
                                         affine=True)
-        self.dropout = torch.nn.Dropout(config.dropout)
         self.conv2 = torch.nn.Conv2d(out_channels,
                                      out_channels,
                                      kernel_size=3,
@@ -579,7 +578,6 @@ class ChameleonVQVAEEncoderResnetBlock(nn.Module):
 
         hidden_states = self.norm2(hidden_states)
         hidden_states *= torch.sigmoid(hidden_states)
-        hidden_states = self.dropout(hidden_states)
         hidden_states = self.conv2(hidden_states)
 
         if self.in_channels != self.out_channels:

--- a/vllm/model_executor/models/chatglm.py
+++ b/vllm/model_executor/models/chatglm.py
@@ -195,7 +195,6 @@ class GLMBlock(nn.Module):
                                            cache_config,
                                            quant_config,
                                            prefix=f"{prefix}.self_attention")
-        self.hidden_dropout = config.hidden_dropout
 
         # Layernorm on the attention output
         self.post_attention_layernorm = layer_norm_func(

--- a/vllm/model_executor/models/clip.py
+++ b/vllm/model_executor/models/clip.py
@@ -105,7 +105,6 @@ class CLIPAttention(nn.Module):
                 f"(got `embed_dim`: {self.embed_dim} and `num_heads`:"
                 f" {self.num_heads}).")
         self.scale = self.head_dim**-0.5
-        self.dropout = config.attention_dropout
 
         self.qkv_proj = QKVParallelLinear(
             hidden_size=self.embed_dim,

--- a/vllm/model_executor/models/commandr.py
+++ b/vllm/model_executor/models/commandr.py
@@ -129,7 +129,6 @@ class CohereAttention(nn.Module):
         super().__init__()
         tp_size = get_tensor_model_parallel_world_size()
         self.config = config
-        self.attention_dropout = config.attention_dropout
         self.hidden_size = config.hidden_size
         self.total_num_heads = config.num_attention_heads
         self.num_heads = self.total_num_heads // tp_size

--- a/vllm/model_executor/models/florence2.py
+++ b/vllm/model_executor/models/florence2.py
@@ -88,7 +88,6 @@ class PositionalEmbeddingCosine1D(nn.Module):
     https://pytorch.org/tutorials/beginner/translation_transformer.html
     Args:
         embed_dim: The dimension of the embeddings.
-        dropout_prob: The dropout probability.
         max_seq_len: The maximum length to precompute the positional encodings.
     """
 

--- a/vllm/model_executor/models/glm4v.py
+++ b/vllm/model_executor/models/glm4v.py
@@ -113,7 +113,6 @@ class EVA2CLIPAttention(nn.Module):
 
         self.attn = MultiHeadAttention(self.num_heads_per_rank, self.head_dim,
                                        self.scale)
-        self.output_dropout = torch.nn.Dropout(config.dropout_prob)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         qkv, _ = self.query_key_value(x)  # B, L, 3 * H * D
@@ -121,7 +120,6 @@ class EVA2CLIPAttention(nn.Module):
 
         out = self.attn(q, k, v)
         output, _ = self.dense(out)
-        output = self.output_dropout(output)
         return output
 
 

--- a/vllm/model_executor/models/idefics2_vision_model.py
+++ b/vllm/model_executor/models/idefics2_vision_model.py
@@ -127,7 +127,6 @@ class Idefics2VisionAttention(nn.Module):
                 f"embed_dim must be divisible by num_heads (got `embed_dim`: {self.embed_dim} and `num_heads`:"  # noqa: E501
                 f" {self.num_heads}).")
         self.scale = self.head_dim**-0.5
-        self.dropout = config.attention_dropout
         self.qkv_proj = QKVParallelLinear(
             self.embed_dim,
             self.head_dim,

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -212,7 +212,6 @@ class Llama4VisionAttention(nn.Module):
         self.num_local_heads = self.num_heads // self.tp_size
         self.q_size = self.num_local_heads * self.head_dim
         self.kv_size = self.num_local_heads * self.head_dim
-        self.attention_dropout = config.attention_dropout
         self.scaling = self.head_dim**-0.5
 
         self.attn = MultiHeadAttention(self.num_local_heads, self.head_dim,

--- a/vllm/model_executor/models/siglip.py
+++ b/vllm/model_executor/models/siglip.py
@@ -157,7 +157,6 @@ class SiglipAttention(nn.Module):
                              f" {self.num_heads}).")
 
         self.scale = self.head_dim**-0.5
-        self.dropout = config.attention_dropout
         self.qkv_proj = QKVParallelLinear(
             hidden_size=self.embed_dim,
             head_size=self.head_dim,

--- a/vllm/model_executor/models/ultravox.py
+++ b/vllm/model_executor/models/ultravox.py
@@ -366,9 +366,6 @@ class ModifiedWhisperEncoder(WhisperEncoder):
         embed_pos = self.embed_positions.weight[:inputs_embeds.size(-2)]
 
         hidden_states = inputs_embeds + embed_pos
-        hidden_states = nn.functional.dropout(hidden_states,
-                                              p=self.dropout,
-                                              training=self.training)
 
         attention_mask = self.get_attention_mask_by_audio_len(
             audio_lens, hidden_states)


### PR DESCRIPTION
Cleanup to remove some dropout layers / references, which shouldn't be needed in vLLM (still need to remove from phi4mm / minicpm o)