### PR TITLE
[Bug fix] ROCm FlashAttention: add missing `full_scales` argument to Triton wrapper

### DIFF
--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -711,6 +711,7 @@ class _attention(torch.autograd.Function):
         causal=False,
         sm_scale=1.0,
         bias=None,
+        full_scales=None,
     ):
         if o is None:
             o = torch.empty_like(q, dtype=v.dtype)


### PR DESCRIPTION
The recent change in PR #15734 adds a full_scales tensor to the call site in rocm_flash_attn.py.
However, _attention.forward in attention/ops/triton_flash_attention.py still accepts only 12 positional arguments. This mismatch causes:
```
TypeError: _attention.forward() takes from 9 to 12 positional arguments but 13 were given
```
cc: @houseroad @luccafong  @rasmith 