### PR TITLE
[Core] Use platform-agnostic device control for DP engine core

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import enum
+import os
 import platform
 import random
 from platform import uname
@@ -160,6 +161,24 @@ class Platform:
 
     def is_sleep_mode_available(self) -> bool:
         return self._enum == PlatformEnum.CUDA
+
+    @classmethod
+    def device_id_to_physical_device_id(cls, device_id: int):
+        if cls.device_control_env_var in os.environ:
+            device_ids = os.environ[cls.device_control_env_var].split(",")
+            if device_ids == [""]:
+                msg = (
+                    f"{cls.device_control_env_var} is set to empty string, which means"
+                    " current platform support is disabled. If you are using ray,"
+                    f" please unset the environment variable"
+                    f" `{cls.device_control_env_var}` inside the worker/actor. "
+                    "Check https://github.com/vllm-project/vllm/issues/8402 for"
+                    " more information.")
+                raise RuntimeError(msg)
+            physical_device_id = device_ids[device_id]
+            return int(physical_device_id)
+        else:
+            return device_id
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend: _Backend, head_size: int,

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -167,13 +167,13 @@ class Platform:
         if cls.device_control_env_var in os.environ:
             device_ids = os.environ[cls.device_control_env_var].split(",")
             if device_ids == [""]:
-                msg = (
-                    f"{cls.device_control_env_var} is set to empty string, which means"
-                    " current platform support is disabled. If you are using ray,"
-                    f" please unset the environment variable"
-                    f" `{cls.device_control_env_var}` inside the worker/actor. "
-                    "Check https://github.com/vllm-project/vllm/issues/8402 for"
-                    " more information.")
+                msg = (f"{cls.device_control_env_var} is set to empty string, "
+                       "which means current platform support is disabled. If "
+                       "you are using ray, please unset the environment "
+                       f"variable `{cls.device_control_env_var}` inside the "
+                       "worker/actor. Check "
+                       "https://github.com/vllm-project/vllm/issues/8402 for "
+                       "more information.")
                 raise RuntimeError(msg)
             physical_device_id = device_ids[device_id]
             return int(physical_device_id)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -95,15 +95,6 @@ def with_amdsmi_context(fn):
     return wrapper
 
 
-def device_id_to_physical_device_id(device_id: int) -> int:
-    if "CUDA_VISIBLE_DEVICES" in os.environ:
-        device_ids = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
-        physical_device_id = device_ids[device_id]
-        return int(physical_device_id)
-    else:
-        return device_id
-
-
 @cache
 def on_mi250_mi300() -> bool:
     GPU_ARCH = torch.cuda.get_device_properties("cuda").gcnArchName
@@ -238,7 +229,7 @@ class RocmPlatform(Platform):
     @with_amdsmi_context
     @lru_cache(maxsize=8)
     def get_device_name(cls, device_id: int = 0) -> str:
-        physical_device_id = device_id_to_physical_device_id(device_id)
+        physical_device_id = cls.device_id_to_physical_device_id(device_id)
         handle = amdsmi_get_processor_handles()[physical_device_id]
         asic_info = amdsmi_get_gpu_asic_info(handle)
         device_name: str = asic_info["device_id"]

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -613,13 +613,12 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         from vllm.platforms import current_platform
-        if current_platform.is_cuda_alike():
-            from vllm.platforms.cuda import device_id_to_physical_device_id
-            tp_size = vllm_config.parallel_config.tensor_parallel_size
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
-                str(device_id_to_physical_device_id(i))
-                for i in range(local_dp_rank * tp_size, (local_dp_rank + 1) *
-                               tp_size))
+        device_control_env_var = current_platform.device_control_env_var
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        os.environ[device_control_env_var] = ",".join(
+            str(current_platform.device_id_to_physical_device_id(i))
+            for i in range(local_dp_rank * tp_size, (local_dp_rank + 1) *
+                           tp_size))
 
         self.local_dp_rank = local_dp_rank
         self.dp_group = vllm_config.parallel_config.stateless_init_dp_group()


### PR DESCRIPTION
Refactor the DP engine core to use the platform-specific `device_control_env_var` attribute instead of hardcoding CUDA_VISIBLE_DEVICES. This change improves platform compatibility and code maintainability.

The update includes:
1. Moving the `device_id_to_physical_device_id` function to a shared utils file
2. Updating imports in CUDA and ROCm platform files
3. Replacing CUDA-specific environment variable setting with a platform-agnostic approach in the DPEngineCoreProc class

This refactoring enhances the flexibility of the codebase to support different platforms more seamlessly.