### PR TITLE
[Bugfix] Fix missing ARG in Dockerfile for arm64 platforms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -297,6 +297,7 @@ RUN mv vllm test_docs/
 #################### OPENAI API SERVER ####################
 # base openai image with additional requirements, for any subsequent openai-style images
 FROM vllm-base AS vllm-openai-base
+ARG TARGETPLATFORM
 
 # This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
 # Reference: https://github.com/astral-sh/uv/pull/1694


### PR DESCRIPTION
The target `vllm-openai-base` uses the `$TARGETPLATFORM` variable to modify which version of `bitsandbytes` is installed based on the platform. However, the Dockerfile does not specify `ARG TARGETPLATFORM` for this target. When using Podman, the environment variable is thus not set and the build fails for `linux/arm64` targets (e.g., GH200).

I believe Docker does not exhibit the same issue as `ARG TARGETPLATFORM` is declared for the base target.

<!--- pyml disable-next-line no-emphasis-as-heading -->
