### PR TITLE
[Bugfix] Fix Mistral3 spatial merge error

### DIFF
--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -272,6 +272,9 @@ class Mistral3MultiModalProcessor(
 
         vision_config = hf_config.vision_config
         assert isinstance(vision_config, PixtralVisionConfig)
+        # Need to sneak in spatial_merge_size for Mistral3
+        vision_config.spatial_merge_size = getattr(hf_config,
+                                                   "spatial_merge_size", 1)
         encoder_info = PixtralHFEncoderInfo(vision_config)
 
         def get_replacement(item_idx: int):

--- a/vllm/model_executor/models/pixtral.py
+++ b/vllm/model_executor/models/pixtral.py
@@ -911,9 +911,8 @@ class PixtralHFEncoderInfo(VisionEncoderInfo[PixtralVisionConfig]):
         return self.vision_config.image_size
 
     def get_patch_size(self) -> int:
-        spatial_merge_size = getattr(self.vision_config, "spatial_merge_size",
-                                     1)
-        return (self.vision_config.patch_size * spatial_merge_size)
+        return (self.vision_config.patch_size *
+                self.vision_config.spatial_merge_size)
 
     def get_patch_grid_length(self) -> int:
         image_size, patch_size = self.get_image_size(), self.get_patch_size()


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/16675

We just were not patching spatial_merge_size into the vision config in both of the places needed. This results in the dummy inputs having the right spatial_merge_size being applied but actual inferences were missing it, causing the shapes to mismatch during inference.

Here is where is it being applied already in vision.py https://github.com/vllm-project/vllm/blob/20e489eaa1d1de7ca05297e6d46797432e0f7c3d/vllm/model_executor/models/vision.py#L63-L67

With this PR, the example passes:
```
python ~/code/vllm/examples/offline_inference/vision_language.py -m mistral3 

Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:03<00:00,  1.23it/s, est. speed input: 2559.91 toks/s, output: 78.61 toks/s]
--------------------------------------------------
The image depicts a vibrant and picturesque scene featuring the iconic Tokyo Skytree, a tall broadcasting and observation tower located in Tokyo, Japan. The Skytree is framed by cherry blossom trees in full bloom, creating a beautiful, natural archway of pink flowers. The sky is clear and bright blue, enhancing
--------------------------------------------------
The image depicts a picturesque scene featuring cherry blossom trees in full bloom. The blossoms are predominantly pink and create a beautiful, almost tunnel-like effect with their branches framing the image. In the background, the iconic Tokyo Skytree, a tall broadcasting and observation tower located in Tokyo, Japan, is visible.
--------------------------------------------------
The image depicts a picturesque scene featuring the iconic Tokyo Skytree, a tall broadcasting and observation tower located in Tokyo, Japan. The tower is framed by a beautiful canopy of cherry blossom (sakura) trees in full bloom. The cherry blossoms are in various shades of pink, creating a vibrant and colorful
--------------------------------------------------
This image features a picturesque scene of cherry blossom trees in full bloom with their vibrant pink flowers. The trees frame the image, creating a natural archway that leads the viewer's eye towards the central focus of the image: the iconic Tokyo Skytree, a tall broadcasting and observation tower located in Tokyo, Japan
--------------------------------------------------
```