### PR TITLE
[Bugfix][Benchmarks] Allow benchmark of deepspeed-mii backend to select a model

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -201,6 +201,7 @@ async def async_request_deepspeed_mii(
                                      timeout=AIOHTTP_TIMEOUT) as session:
 
         payload = {
+            "model": request_func_input.model,
             "prompt": request_func_input.prompt,
             "max_tokens": request_func_input.output_len,
             "temperature": 0.01,  # deepspeed-mii does not accept 0.0 temp.


### PR DESCRIPTION
Before applying this patch,  you can't specify the model to do benchmark with deepspeed-mii backend.

This patch allows vllm benchmark of Deepspeed-MII backend to select a model.


FIX #16821 


