### PR TITLE
[Misc][ROCm] Exclude `cutlass_mla_decode` for ROCm build

### DIFF
--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -130,12 +130,14 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       ") -> ()");
   ops.impl("advance_step_flashinfer", torch::kCUDA, &advance_step_flashinfer);
 
+#ifndef USE_ROCM
   // Compute MLA decode using cutlass.
   ops.def(
       "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe,"
       "                   Tensor kv_c_and_k_pe_cache, Tensor seq_lens,"
       "                   Tensor page_table, float scale) -> ()");
   ops.impl("cutlass_mla_decode", torch::kCUDA, &cutlass_mla_decode);
+#endif
 
   // Layernorm
   // Apply Root Mean Square (RMS) Normalization to the input tensor.

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -130,15 +130,6 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       ") -> ()");
   ops.impl("advance_step_flashinfer", torch::kCUDA, &advance_step_flashinfer);
 
-#ifndef USE_ROCM
-  // Compute MLA decode using cutlass.
-  ops.def(
-      "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe,"
-      "                   Tensor kv_c_and_k_pe_cache, Tensor seq_lens,"
-      "                   Tensor page_table, float scale) -> ()");
-  ops.impl("cutlass_mla_decode", torch::kCUDA, &cutlass_mla_decode);
-#endif
-
   // Layernorm
   // Apply Root Mean Square (RMS) Normalization to the input tensor.
   ops.def(
@@ -451,6 +442,13 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   // CUTLASS sparse matrix compressor
   ops.def("cutlass_sparse_compress(Tensor a) -> Tensor[]");
   ops.impl("cutlass_sparse_compress", &cutlass_sparse_compress);
+
+  // CUTLASS MLA decode
+  ops.def(
+    "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe,"
+    "                   Tensor kv_c_and_k_pe_cache, Tensor seq_lens,"
+    "                   Tensor page_table, float scale) -> ()");
+  ops.impl("cutlass_mla_decode", torch::kCUDA, &cutlass_mla_decode);
 
   // Mamba selective scan kernel
   ops.def(

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -445,9 +445,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
 
   // CUTLASS MLA decode
   ops.def(
-    "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe,"
-    "                   Tensor kv_c_and_k_pe_cache, Tensor seq_lens,"
-    "                   Tensor page_table, float scale) -> ()");
+      "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe,"
+      "                   Tensor kv_c_and_k_pe_cache, Tensor seq_lens,"
+      "                   Tensor page_table, float scale) -> ()");
   ops.impl("cutlass_mla_decode", torch::kCUDA, &cutlass_mla_decode);
 
   // Mamba selective scan kernel


### PR DESCRIPTION
A small fix for https://github.com/vllm-project/vllm/pull/16032. Do not include the op `cutlass_mla_decode` for ROCm build; otherwise it will cause some import error.