### PR TITLE
[Bugfix][Benchmarks] Fix a benchmark of deepspeed-mii backend to use api_key

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -194,6 +194,11 @@ async def async_request_deepspeed_mii(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm] = None,
 ) -> RequestFuncOutput:
+    api_url = request_func_input.api_url
+    assert api_url.endswith(("completions", "profile")), (
+        "OpenAI Completions API URL must end with 'completions' or 'profile'."
+    )
+
     async with aiohttp.ClientSession(
         trust_env=True, timeout=AIOHTTP_TIMEOUT
     ) as session:
@@ -204,6 +209,8 @@ async def async_request_deepspeed_mii(
             "temperature": 0.01,  # deepspeed-mii does not accept 0.0 temp.
             "top_p": 1.0,
         }
+        headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+
         output = RequestFuncOutput()
         output.prompt_len = request_func_input.prompt_len
 
@@ -215,7 +222,7 @@ async def async_request_deepspeed_mii(
         st = time.perf_counter()
         try:
             async with session.post(
-                url=request_func_input.api_url, json=payload
+                url=api_url, json=payload, headers=headers
             ) as response:
                 if response.status == 200:
                     parsed_resp = await response.json()


### PR DESCRIPTION
Previously, a benchmark can't run to a deepspeed-mii server with using api_key.

This patch is ported the implementation from
async_request_openai_completions() so that api_key can be specified.

<details>
<summary>Bug reproduction</summary>

server command:
```text
$ python -m mii.entrypoints.openai_api_server --tensor-parallel 1 --model meta-llama/Meta-Llama-3-8B --port 8000 --api-keys testabc
```

client command:
```text
$ export OPENAI_API_KEY=testabc
$ python vllm/benchmarks/benchmark_serving.py --dataset-name sharegpt --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json --model meta-llama/Meta-Llama-3-8B --num_prompts 500 --request-rate 4 --port 8000 --backend deepspeed-mii
```

</details>