### PR TITLE
[Bugfix] Fix cached token compute only once in prefix caching

### DIFF
--- a/vllm/core/block_manager.py
+++ b/vllm/core/block_manager.py
@@ -518,3 +518,7 @@ class SelfAttnBlockSpaceManager(BlockSpaceManager):
         cached in the block manager for the sequence.
         """
         return self._computed_blocks_tracker.get_num_cached_tokens(seq)
+    
+    def clear_computed_blocks_tracker(self, seq_group: SequenceGroup):
+        for seq in seq_group.get_seqs():
+            self._computed_blocks_tracker.remove_seq(seq.seq_id)

--- a/vllm/core/scheduler.py
+++ b/vllm/core/scheduler.py
@@ -900,6 +900,7 @@ class Scheduler:
                     num_new_tokens=num_new_tokens_uncached,
                     num_new_seqs=num_new_seqs,
             ):
+                self.block_manager.clear_computed_blocks_tracker(seq_group)
                 break
 
             if lora_int_id > 0 and curr_loras is not None:
@@ -1021,6 +1022,7 @@ class Scheduler:
                 waiting_queue.appendleft(vseq_group)
                 force_preemption_count += 1
             # Put the sequence back into the waiting queue
+            self.block_manager.clear_computed_blocks_tracker(seq_group)
             waiting_queue.appendleft(seq_group)
 
         waiting_queue = deque(sorted(waiting_queue, key=self._get_priority))
@@ -1124,6 +1126,7 @@ class Scheduler:
             can_allocate = self.block_manager.can_allocate(
                 seq_group, num_lookahead_slots=num_lookahead_slots)
             if can_allocate == AllocStatus.LATER:
+                self.block_manager.clear_computed_blocks_tracker(seq_group)
                 break
             elif can_allocate == AllocStatus.NEVER:
                 logger.warning(
@@ -1148,6 +1151,7 @@ class Scheduler:
                         and len(curr_loras) >= self.lora_config.max_loras):
                     # We don't have a space for another LoRA, so
                     # we ignore this request for now.
+                    self.block_manager.clear_computed_blocks_tracker(seq_group)
                     leftover_waiting_sequences.appendleft(seq_group)
                     waiting_queue.popleft()
                     continue
@@ -1157,6 +1161,7 @@ class Scheduler:
                 # We've reached the budget limit - since there might be
                 # continuous prefills in the running queue, we should break
                 # to avoid scheduling any new prefills.
+                self.block_manager.clear_computed_blocks_tracker(seq_group)
                 break
 
             num_new_seqs = seq_group.get_max_num_running_seqs()
@@ -1164,6 +1169,7 @@ class Scheduler:
                     num_new_tokens=num_new_tokens_uncached,
                     num_new_seqs=num_new_seqs,
             ):
+                self.block_manager.clear_computed_blocks_tracker(seq_group)
                 break
 
             # Can schedule this request.


### PR DESCRIPTION
In Prefix Caching, the scheduler determines if a sequence group can run by considering its cached and uncached token counts. The number of cached tokens is often stored persistently (e.g., in a compute_block_tracker), even if the group isn't scheduled immediately. This creates a problem: when the group is finally run, the underlying KV cache might have been altered. However, the system might still operate based on the stale cached token count from the tracker. This discrepancy means the KV cache used is inconsistent with the actual prefix tokens, leading to incorrect computation results for that sequence group.
