### PR TITLE
Enabling Tool Calls after Text Chunks

### DIFF
--- a/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
+++ b/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py
@@ -43,6 +43,8 @@ class PythonicToolParser(ToolParser):
         r"\[([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s)?\),\s*)*([a-zA-Z]+\w*\(([a-zA-Z]+\w*=.*,\s*)*([a-zA-Z]+\w*=.*\s*)?\)\s*)+\]",
         re.DOTALL)
 
+    _DELIM_RE = re.compile(r"(?:<\|python_tag\|>|\n)\s*\[")
+
     def __init__(self, tokenizer: PreTrainedTokenizerBase):
         super().__init__(tokenizer)
 
@@ -54,6 +56,24 @@ class PythonicToolParser(ToolParser):
     @current_tool_index.setter
     def current_tool_index(self, value: int) -> None:
         self.current_tool_id = value
+
+    def _split_prefix_and_tools(self, text: str) -> tuple[str, str | None]:
+        """Return (prefix, tools_section).
+
+        tools_section is None when the text does not yet contain a
+        valid list of tool calls starting after one of the supported
+        delimiters or at position 0.
+        """
+        if text.startswith("["):
+            return "", text  # tools start at the very beginning
+
+        m = self._DELIM_RE.search(text)
+        if not m:
+            return text, None  # only regular text so far
+
+        # Locate the first square bracket that belongs to the tool list.
+        start_idx = text.find("[", m.start())
+        return text[:start_idx], text[start_idx:]
 
     def extract_tool_calls(
             self, model_output: str,
@@ -100,11 +120,15 @@ class PythonicToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> Union[DeltaMessage, None]:
 
-        if not current_text.startswith("["):
+        prefix, tools_section = self._split_prefix_and_tools(current_text)
+
+
+        if tools_section is None:
             return DeltaMessage(content=delta_text)
 
         try:
-            valid_and_added_text = _make_valid_python(current_text)
+            valid_and_added_text = _make_valid_python(tools_section)
+
             if valid_and_added_text is None:
                 return None
             valid_text, added_text = valid_and_added_text


### PR DESCRIPTION
Used Llama 4 Maverick (meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8) for testing.

When the model decides to call tool(s) after responding in text chunks it was basically outputting the whole thing without parsing the tool call. (There is a [TODO](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/tool_parsers/pythonic_tool_parser.py#L36) regarding this)

One thing I noticed was (Llama 4 Maverick FP8) the model was starting tool calls with `\n[` rather then `\n\n[`. Hence the delimiter check for `\n` instead of double. 

Currently this has one issue that I'm trying to solve.
```
module = ast.parse(valid_text)
``` 
Throws
```
SyntaxError: invalid syntax
```
when model sends text chunks after tool calls. I'm progressing on solving that part.

Your feedback in general would be specially valuable here @mdepinet.

FIX #[17109](https://github.com/vllm-project/vllm/issues/17109) 





