### PR TITLE
[Bugfix] Fix `numel()` downcast in fused_layernorm_dynamic_per_token_quant.cu

### DIFF
--- a/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -96,7 +96,7 @@ void rms_norm_dynamic_per_token_quant_dispatch(
     std::optional<at::Tensor> const& scale_ub,
     std::optional<at::Tensor>& residual) {
   int32_t hidden_size = input.size(-1);
-  int32_t num_tokens = input.numel() / hidden_size;
+  auto num_tokens = input.numel() / hidden_size;
 
   dim3 grid(num_tokens);
   dim3 block(std::min(hidden_size, 1024));


### PR DESCRIPTION
Summary: `numel()` has type `int64_t`. The implicit downcasts fix in this change artificially truncate data ranges which can lead to hard-to-debug errors and SEVs. Using `auto` ensures that the correct data type is used.

Reviewed By: dtolnay

Differential Revision: D73608869


