### PR TITLE
[Bugifx] Remove TritonPlaceholder from sys.modules

### DIFF
--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -48,7 +48,7 @@ if not HAS_TRITON:
             self.constexpr = None
             self.dtype = None
 
-    def init_torch_inductor():
+    def init_torch_inductor_runtime():
         name = "torch._inductor.runtime"
         torch_runtime = importlib.import_module(name)
         path = torch_runtime.__path__
@@ -63,7 +63,7 @@ if not HAS_TRITON:
                     continue
 
     # initialize torch inductor without triton placeholder
-    init_torch_inductor()
+    init_torch_inductor_runtime()
     # Replace the triton module in sys.modules with the placeholder
     sys.modules['triton'] = TritonPlaceholder()
     sys.modules['triton.language'] = TritonLanguagePlaceholder()

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -63,6 +63,8 @@ if not HAS_TRITON:
                     continue
 
     # initialize torch inductor without triton placeholder
+    # FIXME(Isotr0py): See if we can remove this after bumping torch version 
+    # to 2.7.0, because torch 2.7.0 has a better triton check.
     init_torch_inductor_runtime()
     # Replace the triton module in sys.modules with the placeholder
     sys.modules['triton'] = TritonPlaceholder()

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-import importlib
-import sys
+
 import types
 from importlib.util import find_spec
-from typing import Optional
 
 from vllm.logger import init_logger
 
@@ -18,37 +16,17 @@ if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"
                 " functions will not be available.")
 
-    class TritonModulePlaceholder(types.ModuleType):
-
-        def __init__(
-            self,
-            name: str,
-            dummy_objects: Optional[list[str]] = None,
-        ):
-            super().__init__(name)
-
-            if dummy_objects is not None:
-                for obj_name in dummy_objects:
-                    setattr(self, obj_name, object)
-
-    class TritonLanguagePlaceholder(TritonModulePlaceholder):
+    class TritonPlaceholder(types.ModuleType):
 
         def __init__(self):
-            super().__init__("triton.language")
-            self.constexpr = None
-            self.dtype = None
-
-    class TritonPlaceholder(TritonModulePlaceholder):
-
-        def __init__(self):
-            super().__init__("triton", dummy_objects=["Config"])
+            super().__init__("triton")
             self.jit = self._dummy_decorator("jit")
             self.autotune = self._dummy_decorator("autotune")
             self.heuristics = self._dummy_decorator("heuristics")
             self.language = TritonLanguagePlaceholder()
             logger.warning_once(
                 "Triton is not installed. Using dummy decorators. "
-                "Install it via `pip install triton` to enable kernel "
+                "Install it via `pip install triton` to enable kernel"
                 "compilation.")
 
         def _dummy_decorator(self, name):
@@ -60,27 +38,10 @@ if not HAS_TRITON:
 
             return decorator
 
-    # Hack `_is_triton_available` in torch to return False
-    torch_hints = importlib.import_module("torch._inductor.runtime.hints")
-    torch_hints._is_triton_available = lambda: False  # type: ignore[attr-defined]
+    class TritonLanguagePlaceholder(types.ModuleType):
 
-    # Replace the triton module and torch triton helpers in sys.modules
-    # with the placeholder
-    sys.modules['triton'] = TritonPlaceholder()
-    sys.modules['triton.language'] = TritonLanguagePlaceholder()
-    sys.modules['torch._inductor.runtime.triton_helpers'] = types.ModuleType(
-        "triton_helpers")
-
-    # Replace triton submodules with dummy objects to keep compatibility with
-    # torch triton check
-    triton_modules_with_objects = {
-        "triton.compiler": ["CompiledKernel"],
-        "triton.runtime.autotuner": ["OutOfResources"],
-        "triton.runtime.jit": ["KernelInterface"],
-    }
-    for module_name, dummy_objects in triton_modules_with_objects.items():
-        sys.modules[module_name] = TritonModulePlaceholder(
-            module_name, dummy_objects=dummy_objects)
-
-if 'triton' in sys.modules:
-    logger.info("Triton module has been replaced with a placeholder.")
+        def __init__(self):
+            super().__init__("triton.language")
+            self.constexpr = None
+            self.dtype = None
+            self.int64 = None

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-
 import importlib
-import pkgutil
 import sys
 import types
 from importlib.util import find_spec
+from typing import Optional
 
 from vllm.logger import init_logger
 
@@ -19,17 +18,37 @@ if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"
                 " functions will not be available.")
 
-    class TritonPlaceholder(types.ModuleType):
+    class TritonModulePlaceholder(types.ModuleType):
+
+        def __init__(
+            self,
+            name: str,
+            dummy_objects: Optional[list[str]] = None,
+        ):
+            super().__init__(name)
+
+            if dummy_objects is not None:
+                for obj_name in dummy_objects:
+                    setattr(self, obj_name, object)
+
+    class TritonLanguagePlaceholder(TritonModulePlaceholder):
 
         def __init__(self):
-            super().__init__("triton")
+            super().__init__("triton.language")
+            self.constexpr = None
+            self.dtype = None
+
+    class TritonPlaceholder(TritonModulePlaceholder):
+
+        def __init__(self):
+            super().__init__("triton", dummy_objects=["Config"])
             self.jit = self._dummy_decorator("jit")
             self.autotune = self._dummy_decorator("autotune")
             self.heuristics = self._dummy_decorator("heuristics")
             self.language = TritonLanguagePlaceholder()
             logger.warning_once(
                 "Triton is not installed. Using dummy decorators. "
-                "Install it via `pip install triton` to enable kernel"
+                "Install it via `pip install triton` to enable kernel "
                 "compilation.")
 
         def _dummy_decorator(self, name):
@@ -41,34 +60,27 @@ if not HAS_TRITON:
 
             return decorator
 
-    class TritonLanguagePlaceholder(types.ModuleType):
+    # Hack `_is_triton_available` in torch to return False
+    torch_hints = importlib.import_module("torch._inductor.runtime.hints")
+    torch_hints._is_triton_available = lambda: False  # type: ignore[attr-defined]
 
-        def __init__(self):
-            super().__init__("triton.language")
-            self.constexpr = None
-            self.dtype = None
-
-    def init_torch_inductor_runtime():
-        name = "torch._inductor.runtime"
-        torch_runtime = importlib.import_module(name)
-        path = torch_runtime.__path__
-        for module_info in pkgutil.iter_modules(path, name + "."):
-            if not module_info.ispkg:
-                try:
-                    importlib.import_module(module_info.name)
-                except Exception as e:
-                    logger.warning(
-                        "Ignore import error when loading " \
-                        "%s: %s", module_info.name, e)
-                    continue
-
-    # initialize torch inductor without triton placeholder
-    # FIXME(Isotr0py): See if we can remove this after bumping torch version
-    # to 2.7.0, because torch 2.7.0 has a better triton check.
-    init_torch_inductor_runtime()
-    # Replace the triton module in sys.modules with the placeholder
+    # Replace the triton module and torch triton helpers in sys.modules
+    # with the placeholder
     sys.modules['triton'] = TritonPlaceholder()
     sys.modules['triton.language'] = TritonLanguagePlaceholder()
+    sys.modules['torch._inductor.runtime.triton_helpers'] = types.ModuleType(
+        "triton_helpers")
+
+    # Replace triton submodules with dummy objects to keep compatibility with
+    # torch triton check
+    triton_modules_with_objects = {
+        "triton.compiler": ["CompiledKernel"],
+        "triton.runtime.autotuner": ["OutOfResources"],
+        "triton.runtime.jit": ["KernelInterface"],
+    }
+    for module_name, dummy_objects in triton_modules_with_objects.items():
+        sys.modules[module_name] = TritonModulePlaceholder(
+            module_name, dummy_objects=dummy_objects)
 
 if 'triton' in sys.modules:
     logger.info("Triton module has been replaced with a placeholder.")

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -59,11 +59,11 @@ if not HAS_TRITON:
                 except Exception as e:
                     logger.warning(
                         "Ignore import error when loading " \
-                        "torch._inductor.runtime module: %s", e)
+                        "%s: %s", module_info.name, e)
                     continue
 
     # initialize torch inductor without triton placeholder
-    # FIXME(Isotr0py): See if we can remove this after bumping torch version 
+    # FIXME(Isotr0py): See if we can remove this after bumping torch version
     # to 2.7.0, because torch 2.7.0 has a better triton check.
     init_torch_inductor_runtime()
     # Replace the triton module in sys.modules with the placeholder


### PR DESCRIPTION
FIX #17309 (*link existing issues this PR will resolve*)
- This PR tries to fix the triton placeholder conflicts by importing all modules under `torch._inductor.runtime` to trigger all torch triton check before placeholder introduction intentionally.
- I tried to hack `_is_triton_available` but torch2.6 also used a bad triton check in `triton_heuristics.py`, which will always be affected by placeholder 😢: https://github.com/pytorch/pytorch/blob/1eba9b3aa3c43f86f4a2c807ac8e12c4a7767340/torch/_inductor/runtime/triton_heuristics.py#L52-L58

Tested on x86 CPU environment by uninstalling triton intentionally:
```
$ python examples/offline_inference/basic/basic.py 
INFO 04-29 01:23:25 [importing.py:19] Triton not installed or not compatible; certain GPU-related functions will not be available.
WARNING 04-29 01:23:27 [importing.py:60] Ignore import error when loading torch._inductor.runtime.triton_helpers: No module named 'triton'
WARNING 04-29 01:23:27 [importing.py:30] Triton is not installed. Using dummy decorators. Install it via `pip install triton` to enable kernelcompilation.
INFO 04-29 01:23:27 [importing.py:74] Triton module has been replaced with a placeholder.
INFO 04-29 01:23:30 [__init__.py:239] Automatically detected platform cpu.
INFO 04-29 01:23:41 [config.py:716] This model supports multiple tasks: {'embed', 'generate', 'reward', 'score', 'classify'}. Defaulting to 'generate'.
WARNING 04-29 01:23:41 [_logger.py:72] device type=cpu is not supported by the V1 Engine. Falling back to V0. 
INFO 04-29 01:23:41 [config.py:1772] Disabled the custom all-reduce kernel because it is not supported on current platform.
WARNING 04-29 01:23:41 [_logger.py:72] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
WARNING 04-29 01:23:41 [_logger.py:72] uni is not supported on CPU, fallback to mp distributed executor backend.
INFO 04-29 01:23:41 [llm_engine.py:240] Initializing a V0 LLM engine (v0.8.5.dev277+gb90093e42) with config: model='/data/LLM-model/opt-125m', speculative_config=None, tokenizer='/data/LLM-model/opt-125m', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=2048, download_dir=None, load_format=LoadFormat.AUTO, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cpu, decoding_config=DecodingConfig(guided_decoding_backend='auto', reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=/data/LLM-model/opt-125m, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=None, chunked_prefill_enabled=False, use_async_output_proc=False, disable_mm_preprocessor_cache=False, mm_processor_kwargs=None, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=False, 
INFO 04-29 01:23:41 [cpu.py:45] Using Torch SDPA backend.
INFO 04-29 01:23:41 [parallel_state.py:1004] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.47it/s]
Loading pt checkpoint shards: 100% Completed | 1/1 [00:00<00:00,  3.47it/s]

INFO 04-29 01:23:42 [loader.py:458] Loading weights took 0.30 seconds
INFO 04-29 01:23:42 [executor_base.py:112] # cpu blocks: 910, # CPU blocks: 0
INFO 04-29 01:23:42 [executor_base.py:117] Maximum concurrency for 2048 tokens per request: 56.88x
INFO 04-29 01:23:42 [llm_engine.py:437] init engine (profile, create kv cache, warmup model) took 0.45 seconds
Processed prompts:   0%|                                                                                                            | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]WARNING 04-29 01:23:42 [_logger.py:72] Pin memory is not supported on CPU.
Processed prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:01<00:00,  3.45it/s, est. speed input: 22.42 toks/s, output: 55.19 toks/s]
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
