### PR TITLE
[Model] Ignore rotary embed load for Cohere model

### DIFF
--- a/vllm/model_executor/models/commandr.py
+++ b/vllm/model_executor/models/commandr.py
@@ -418,6 +418,10 @@ class CohereForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsQuant):
         loaded_params: Set[str] = set()
         for name, loaded_weight in weights:
 
+            # Skip loading rotary embeddings since vLLM has its own
+            if "rotary_emb.inv_freq" in name:
+                continue
+
             if (self.quant_config is not None and
                 (scale_name := self.quant_config.get_cache_scale(name))):
                 # Loading kv cache quantization scales


### PR DESCRIPTION
Skip loading rotary embeddings since vLLM has its own
See: https://github.com/vllm-project/vllm/blob/9dbf7a2/vllm/model_executor/layers/rotary_embedding.py#L99 
Similar to llama: https://github.com/vllm-project/vllm/blob/6d0df0/vllm/model_executor/models/llama.py#L383-L411

cc: @youkaichao 
            