### PR TITLE
[Build][Bugfix] Restrict setuptools version to <80

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -34,7 +34,7 @@ mistral_common[opencv] >= 1.5.4
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
-setuptools>=74.1.1; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+setuptools>=74.1.1,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.9.3 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config


### PR DESCRIPTION
Setuptools appears to have introduced a bug in v80.0.0 resulting in a crash when trying to run `python setup.py develop` with a `--prefix`
Original issue filed at https://github.com/pypa/setuptools/issues/4966
Until it is addressed we should restrict the version
This is a generalization of https://github.com/vllm-project/vllm/pull/17298

Another issue is that v80 will replace `python setup.py develop` with `pip install -e .` which does not work with ROCm, in part due to torch requirement hard coded in pyproject.toml