### PR TITLE
Fix for divide by 0 exception when there is no interleave-moe-layer-step for llama4

### DIFF
--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -273,7 +273,7 @@ class Llama4DecoderLayer(nn.Module):
             cache_config=cache_config,
             prefix=f"{prefix}.self_attn",
         )
-        is_moe_layer = (self.layer_idx +
+        is_moe_layer = config.interleave_moe_layer_step > 0 and (self.layer_idx +
                         1) % config.interleave_moe_layer_step == 0
         if is_moe_layer:
             self.feed_forward = Llama4MoE(

--- a/vllm/model_executor/models/llama4.py
+++ b/vllm/model_executor/models/llama4.py
@@ -273,8 +273,8 @@ class Llama4DecoderLayer(nn.Module):
             cache_config=cache_config,
             prefix=f"{prefix}.self_attn",
         )
-        is_moe_layer = config.interleave_moe_layer_step > 0 and (self.layer_idx +
-                        1) % config.interleave_moe_layer_step == 0
+        is_moe_layer = config.interleave_moe_layer_step > 0 and (
+            self.layer_idx + 1) % config.interleave_moe_layer_step == 0
         if is_moe_layer:
             self.feed_forward = Llama4MoE(
                 config=config,


### PR DESCRIPTION
Fix the case where if interleave-moe-layer-step is 0, the code will throw div by 0 error.

<!--- pyml disable-next-line no-emphasis-as-heading -->
