### PR TITLE
Ignore `'<string>'` filepath

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -382,6 +382,10 @@ class VllmBackend:
             hash_content = []
             for filepath in forward_code_files:
                 hash_content.append(filepath)
+                if filepath == "<string>":
+                    # This means the function was dynamically generated, with
+                    # e.g. exec(). We can't actually check these.
+                    continue
                 with open(filepath) as f:
                     hash_content.append(f.read())
             import hashlib


### PR DESCRIPTION
vLLM tries to get a list of files that Dynamo traced through. Some of these files can be equal to `'<string>'`. This may happen if the code object was dynamically generated, which does happen in some dataclasses cases.

This is one of the issues that was blocking the upgrade of vLLM from PyTorch 2.6 to PyTorch 2.7 (#16859). The reason why this happened was because PyTorch 2.7 now traces through more HuggingFace code, including some custom dataclasses.

Test Plan:
- ran `pytest -v tests/models/test_transformers.py -k test_models[meta-llama/Llama-3.2-1B-Instruct-transformers]` with PyTorch >= 2.7



<!--- pyml disable-next-line no-emphasis-as-heading -->
