### PR TITLE
Add worker metrics and a total prefill tokens metrics

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1759,6 +1759,9 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             model_forward_start.record()
 
         if not bypass_model_exec:
+            if prefill_meta is not None and not self.in_profile_run:
+                self.stats_monitor.on_prefill(model_input.attn_metadata.num_prefill_tokens)
+                logger.debug(f"Running prefill and will prefill {model_input.attn_metadata.num_prefill_tokens} tokens")
             with set_forward_context(model_input.attn_metadata,
                                      self.vllm_config, virtual_engine):
                 hidden_or_intermediate_states = model_executable(

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1759,9 +1759,12 @@ class ModelRunner(GPUModelRunnerBase[ModelInputForGPUWithSamplingMetadata]):
             model_forward_start.record()
 
         if not bypass_model_exec:
-            if prefill_meta is not None and not self.in_profile_run:
-                self.stats_monitor.on_prefill(model_input.attn_metadata.num_prefill_tokens)
-                logger.debug(f"Running prefill and will prefill {model_input.attn_metadata.num_prefill_tokens} tokens")
+            if (model_input.attn_metadata is not None
+                    and prefill_meta is not None and not self.in_profile_run):
+                self.stats_monitor.on_prefill(
+                    model_input.attn_metadata.num_prefill_tokens)
+                logger.debug("Running prefill and will prefill %d tokens",
+                             model_input.attn_metadata.num_prefill_tokens)
             with set_forward_context(model_input.attn_metadata,
                                      self.vllm_config, virtual_engine):
                 hidden_or_intermediate_states = model_executable(

--- a/vllm/worker/model_runner_base.py
+++ b/vllm/worker/model_runner_base.py
@@ -12,6 +12,7 @@ from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import IntermediateTensors, SequenceGroupMetadata
+from vllm.worker.worker_metrics import VllmWorkerStatsMonitor
 
 if TYPE_CHECKING:
     from vllm.attention import AttentionMetadata
@@ -189,6 +190,7 @@ class ModelRunnerBase(ABC, Generic[T]):
         self.speculative_config = vllm_config.speculative_config
         self.prompt_adapter_config = vllm_config.prompt_adapter_config
         self.observability_config = vllm_config.observability_config
+        self.stats_monitor = VllmWorkerStatsMonitor.GetOrCreate()
 
     # Map of request_id -> generator used for seeded random sampling
     generators: Dict[str, torch.Generator] = {}

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -31,6 +31,8 @@ from vllm.worker.model_runner import GPUModelRunnerBase, ModelRunner
 from vllm.worker.pooling_model_runner import PoolingModelRunner
 from vllm.worker.worker_base import (LocalOrDistributedWorkerBase, WorkerBase,
                                      WorkerInput)
+from vllm.worker.worker_metrics import (VllmWorkerMetadata,
+                                        VllmWorkerStatsLogger)
 
 logger = init_logger(__name__)
 
@@ -115,9 +117,10 @@ class Worker(LocalOrDistributedWorkerBase):
         else:
             self.profiler = None
 
-        from vllm.worker.worker_metrics import VllmWorkerMetadata
-        metadata = VllmWorkerMetadata(self.model_config.model, self.parallel_config.world_size, self.parallel_config.rank)
-        from vllm.worker.worker_metrics import VllmWorkerStatsLogger
+        metadata = VllmWorkerMetadata(self.model_config.model,
+                                      self.parallel_config.world_size,
+                                      self.parallel_config.rank)
+        # TODO(maobaolong): Remove this hard-coded value future
         self.stat_logger = VllmWorkerStatsLogger(metadata, log_interval=10)
 
     def start_profile(self):

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -115,6 +115,11 @@ class Worker(LocalOrDistributedWorkerBase):
         else:
             self.profiler = None
 
+        from vllm.worker.worker_metrics import VllmWorkerMetadata
+        metadata = VllmWorkerMetadata(self.model_config.model, self.parallel_config.world_size, self.parallel_config.rank)
+        from vllm.worker.worker_metrics import VllmWorkerStatsLogger
+        self.stat_logger = VllmWorkerStatsLogger(metadata, log_interval=10)
+
     def start_profile(self):
         if self.profiler is None:
             raise RuntimeError("Profiler is not enabled.")

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -21,7 +21,6 @@ from vllm.utils import (enable_trace_function_call_for_thread,
                         resolve_obj_by_qualname, run_method,
                         update_environment_variables,
                         warn_for_unimplemented_methods)
-from vllm.worker.worker_metrics import VllmWorkerStatsLogger, VllmWorkerMetadata
 from vllm.worker.model_runner_base import (BroadcastableModelInput,
                                            ModelRunnerBase,
                                            ModelRunnerInputBase)
@@ -55,8 +54,6 @@ class WorkerBase:
         self.compilation_config = vllm_config.compilation_config
         from vllm.platforms import current_platform
         self.current_platform = current_platform
-        metadata = VllmWorkerMetadata(self.model_config.model, self.parallel_config.world_size, self.parallel_config.rank)
-        self.stat_logger = VllmWorkerStatsLogger(metadata, log_interval=10)
 
     def init_device(self) -> None:
         """Initialize device state, such as loading the model or other on-device

--- a/vllm/worker/worker_base.py
+++ b/vllm/worker/worker_base.py
@@ -21,6 +21,7 @@ from vllm.utils import (enable_trace_function_call_for_thread,
                         resolve_obj_by_qualname, run_method,
                         update_environment_variables,
                         warn_for_unimplemented_methods)
+from vllm.worker.worker_metrics import VllmWorkerStatsLogger, VllmWorkerMetadata
 from vllm.worker.model_runner_base import (BroadcastableModelInput,
                                            ModelRunnerBase,
                                            ModelRunnerInputBase)
@@ -54,6 +55,8 @@ class WorkerBase:
         self.compilation_config = vllm_config.compilation_config
         from vllm.platforms import current_platform
         self.current_platform = current_platform
+        metadata = VllmWorkerMetadata(self.model_config.model, self.parallel_config.world_size, self.parallel_config.rank)
+        self.stat_logger = VllmWorkerStatsLogger(metadata, log_interval=10)
 
     def init_device(self) -> None:
         """Initialize device state, such as loading the model or other on-device

--- a/vllm/worker/worker_metrics.py
+++ b/vllm/worker/worker_metrics.py
@@ -2,8 +2,7 @@
 import threading
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
-from typing import Union
+from typing import TYPE_CHECKING, List, Union
 
 import prometheus_client
 from prometheus_client import Summary
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 prometheus_client.disable_created_metrics()
+
 
 @dataclass
 class VllmWorkerMetadata:
@@ -49,9 +49,7 @@ class VllmWorkerStatsMonitor:
         The function will return the latest states between the current
         call and the previous call.
         """
-        ret = VllmWorkerStats(
-            self.total_prefill_token,
-        )
+        ret = VllmWorkerStats(self.total_prefill_token, )
         self._clear()
         return ret
 
@@ -79,11 +77,10 @@ class PrometheusLogger:
         )
 
     def _log_gauge(self, gauge, data: Union[int, float]) -> None:
-        # Convenience function for logging to gauge.
         gauge.labels(**self.labels).set(data)
 
-    def _log_summary(self, summary: Summary, data:  Union[List[int],
-                                                    List[float]]) -> None:
+    def _log_summary(self, summary: Summary, data: Union[List[int],
+                                                         List[float]]) -> None:
         for value in data:
             summary.labels(**self.labels).observe(value)
 
@@ -104,7 +101,7 @@ class PrometheusLogger:
     def GetOrCreate(metadata: VllmWorkerMetadata) -> "PrometheusLogger":
         if PrometheusLogger._instance is None:
             PrometheusLogger._instance = PrometheusLogger(metadata)
-            logger.info(f"PrometheusLogger created for {metadata}")
+            logger.info("PrometheusLogger created for %s", metadata)
         if PrometheusLogger._instance.metadata != metadata:
             logger.error("PrometheusLogger instance already created with"
                          "different metadata. This should not happen except "
@@ -133,4 +130,3 @@ class VllmWorkerStatsLogger:
     def shutdown(self):
         self.is_running = False
         self.thread.join()
-

--- a/vllm/worker/worker_metrics.py
+++ b/vllm/worker/worker_metrics.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+from typing import Union
+
+import prometheus_client
+from prometheus_client import Summary
+
+from vllm.logger import init_logger
+from vllm.worker.worker_metrics_types import VllmWorkerStats
+
+if TYPE_CHECKING:
+    pass
+
+logger = init_logger(__name__)
+
+prometheus_client.disable_created_metrics()
+
+@dataclass
+class VllmWorkerMetadata:
+    """ name of the LLM model """
+    model_name: str
+    """ world size when running under a distributed setting """
+    world_size: int
+    """ worker id when running under a distributed setting """
+    worker_id: int
+
+
+class VllmWorkerStatsMonitor:
+
+    def __init__(self):
+        self.total_prefill_token = []
+
+    def on_prefill(self, token_count: int):
+        self.total_prefill_token.append(token_count)
+
+    def _clear(self):
+        """
+        Clear all the distribution stats
+        """
+        self.total_prefill_token = []
+
+    def get_stats_and_clear(self) -> VllmWorkerStats:
+        """
+        This function should be called with by prometheus adapter with
+        a specific interval.
+        The function will return the latest states between the current
+        call and the previous call.
+        """
+        ret = VllmWorkerStats(
+            self.total_prefill_token,
+        )
+        self._clear()
+        return ret
+
+    _instance = None
+
+    @staticmethod
+    def GetOrCreate() -> "VllmWorkerStatsMonitor":
+        if VllmWorkerStatsMonitor._instance is None:
+            VllmWorkerStatsMonitor._instance = VllmWorkerStatsMonitor()
+        return VllmWorkerStatsMonitor._instance
+
+
+class PrometheusLogger:
+
+    def __init__(self, metadata: VllmWorkerMetadata):
+        self.metadata = metadata
+
+        self.labels = self._metadata_to_labels(metadata)
+        labelnames = list(self.labels.keys())
+
+        self.summary_total_prefill_token = Summary(
+            name="vllm_worker:total_prefill_token",
+            documentation="Total info of actual prefill token in worker",
+            labelnames=labelnames,
+        )
+
+    def _log_gauge(self, gauge, data: Union[int, float]) -> None:
+        # Convenience function for logging to gauge.
+        gauge.labels(**self.labels).set(data)
+
+    def _log_summary(self, summary: Summary, data:  Union[List[int],
+                                                    List[float]]) -> None:
+        for value in data:
+            summary.labels(**self.labels).observe(value)
+
+    def log_prometheus(self, stats: VllmWorkerStats):
+        self._log_summary(self.summary_total_prefill_token,
+                          stats.summary_total_prefill_token)
+
+    @staticmethod
+    def _metadata_to_labels(metadata: VllmWorkerMetadata):
+        return {
+            "model_name": metadata.model_name,
+            "worker_id": metadata.worker_id
+        }
+
+    _instance = None
+
+    @staticmethod
+    def GetOrCreate(metadata: VllmWorkerMetadata) -> "PrometheusLogger":
+        if PrometheusLogger._instance is None:
+            PrometheusLogger._instance = PrometheusLogger(metadata)
+            logger.info(f"PrometheusLogger created for {metadata}")
+        if PrometheusLogger._instance.metadata != metadata:
+            logger.error("PrometheusLogger instance already created with"
+                         "different metadata. This should not happen except "
+                         "in test")
+        return PrometheusLogger._instance
+
+
+class VllmWorkerStatsLogger:
+
+    def __init__(self, metadata: VllmWorkerMetadata, log_interval: int):
+        self.metadata = metadata
+        self.log_interval = log_interval
+        self.monitor = VllmWorkerStatsMonitor.GetOrCreate()
+        self.prometheus_logger = PrometheusLogger.GetOrCreate(metadata)
+        self.is_running = True
+
+        self.thread = threading.Thread(target=self.log_worker, daemon=True)
+        self.thread.start()
+
+    def log_worker(self):
+        while self.is_running:
+            stats = self.monitor.get_stats_and_clear()
+            self.prometheus_logger.log_prometheus(stats)
+            time.sleep(self.log_interval)
+
+    def shutdown(self):
+        self.is_running = False
+        self.thread.join()
+

--- a/vllm/worker/worker_metrics_types.py
+++ b/vllm/worker/worker_metrics_types.py
@@ -7,4 +7,3 @@ from typing import List
 @dataclass
 class VllmWorkerStats:
     summary_total_prefill_token: List[int]
-

--- a/vllm/worker/worker_metrics_types.py
+++ b/vllm/worker/worker_metrics_types.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class VllmWorkerStats:
+    summary_total_prefill_token: List[int]
+


### PR DESCRIPTION
# Motivation
This PR introduce metrics in worker process leverage the `Prometheus python client multi-process mode`. And we can clear check the prefill token number and prefill count, it is useful for the reuse-purpose kv-store, something like `LMCache`.

# How to test

This can collected all worker metrics into one endpoint tagged by `worker_id`

<img width="1639" alt="image" src="https://github.com/user-attachments/assets/56785c09-21ae-4e67-8d53-f44fa804a605" />

