### PR TITLE
[Fix] Documentation spacing in compilation config help text

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -874,7 +874,7 @@ class EngineArgs:
                             '-O',
                             type=CompilationConfig.from_cli,
                             default=None,
-                            help='torch.compile configuration for the model.'
+                            help='torch.compile configuration for the model. '
                             'When it is a number (0, 1, 2, 3), it will be '
                             'interpreted as the optimization level.\n'
                             'NOTE: level 0 is the default level without '


### PR DESCRIPTION

## Description

This PR addresses a minor spacing issue in the compilation configuration help text.

## Changes

This is a very small, non-functional change that only improves the formatting consistency in the documentation strings. Specifically, it fixes inconsistent spacing in the help text for compilation configuration parameters.