### PR TITLE
Add ability to use CUDAGraphs with use_inductor=False

### DIFF
--- a/tests/compile/piecewise/test_simple.py
+++ b/tests/compile/piecewise/test_simple.py
@@ -74,11 +74,12 @@ class SillyModel(nn.Module):
         return x
 
 
-def test_simple_piecewise_compile():
+def _test_simple_piecewise_compile(*, use_inductor):
 
     vllm_config = VllmConfig(compilation_config=CompilationConfig(
         level=CompilationLevel.PIECEWISE,
         use_cudagraph=True,
+        use_inductor=use_inductor,
         splitting_ops=["silly.attention"],
         cudagraph_copy_inputs=True,
         cudagraph_capture_sizes=[1, 2],
@@ -108,3 +109,11 @@ def test_simple_piecewise_compile():
         output = model(input)
         assert global_counter == 2
         assert torch.allclose(output.cpu(), torch.tensor([3., 1.]))
+
+
+def test_simple_piecewise_compile_inductor():
+    _test_simple_piecewise_compile(use_inductor=True)
+
+
+def test_simple_piecewise_compile_no_inductor():
+    _test_simple_piecewise_compile(use_inductor=False)

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -12,6 +12,7 @@ import torch._inductor.compile_fx
 import torch.fx as fx
 
 import vllm.envs as envs
+from vllm.compilation.counter import compilation_counter
 from vllm.config import VllmConfig
 from vllm.utils import is_torch_equal_or_newer
 
@@ -175,6 +176,7 @@ class InductorStandaloneAdaptor(CompilerInterface):
         runtime_shape: Optional[int] = None,
         key: Optional[str] = None,
     ) -> tuple[Optional[Callable], Optional[Any]]:
+        compilation_counter.num_inductor_compiles += 1
         current_config = {}
         if compiler_config is not None:
             current_config.update(compiler_config)
@@ -262,6 +264,7 @@ class InductorAdaptor(CompilerInterface):
         runtime_shape: Optional[int] = None,
         key: Optional[str] = None,
     ) -> tuple[Optional[Callable], Optional[Any]]:
+        compilation_counter.num_inductor_compiles += 1
         from torch._inductor.compile_fx import compile_fx
         current_config = {}
         if compiler_config is not None:
@@ -528,6 +531,7 @@ class EagerAdaptor(CompilerInterface):
         runtime_shape: Optional[int] = None,
         key: Optional[str] = None,
     ) -> tuple[Optional[Callable], Optional[Any]]:
+        compilation_counter.num_eager_compiles += 1
         # we don't need to compile the graph, just return the graph itself.
         # It does not support caching, return None for the handle.
         return graph, None

--- a/vllm/compilation/counter.py
+++ b/vllm/compilation/counter.py
@@ -15,6 +15,10 @@ class CompilationCounter:
     num_piecewise_capturable_graphs_seen: int = 0
     num_backend_compilations: int = 0
     num_cudagraph_caputured: int = 0
+    # InductorAdapter.compile calls
+    num_inductor_compiles: int = 0
+    # EagerAdapter.compile calls
+    num_eager_compiles: int = 0
 
     def clone(self) -> "CompilationCounter":
         return copy.deepcopy(self)

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -4318,15 +4318,10 @@ class VllmConfig:
             self.compilation_config.custom_ops.append("+rms_norm")
         if envs.VLLM_USE_V1 and self.model_config is not None and \
             not self.model_config.enforce_eager:
-            # NOTE(woosuk): Currently, we use inductor because the piecewise
-            # CUDA graphs do not work properly with the custom CUDA kernels.
-            # FIXME(woosuk): Disable inductor to reduce the compilation time
-            # and avoid any potential issues with the inductor.
             # FIXME(rob): Add function to set all of these.
             if not self.compilation_config.custom_ops:
                 self.compilation_config.custom_ops = ["none"]
             self.compilation_config.use_cudagraph = True
-            self.compilation_config.use_inductor = True
             self.compilation_config.cudagraph_num_of_warmups = 1
             self.compilation_config.pass_config.enable_fusion = False
             self.compilation_config.pass_config.enable_noop = False


### PR DESCRIPTION
Should fix #15896, unless users actually want to turn off TorchDynamo too (keep reading for context)

This PR adds the ability to specify `use_inductor=False` in a CompilationConfig. The main use case for this is the ability to use CUDAGraphs without actually using Inductor. However, we still need torch.compile's graph capture (e.g. TorchDynamo) to use CUDAGraphs because we need to capture a graph in order to split it for piecewise CUDAGraphs.

We recommend combining `use_inductor=False`  with `custom_ops=['all']`. By default, all of the torch.compile configs do not use custom operators (with the exception of attention ops); this allows them to generate better kernels. With `use_inductor=False`, there is no backend compiler, so we recommend allowing all custom operators.

Here is how to use this in serving and offline inference:

Serving
```
vllm serve meta-llama/Llama-3.2-1B --compilation-config="{'use_inductor': False, 'custom_ops': ['all']}"
```

Offline
```py
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
model = args.model

compilation_config = {
    'use_inductor': False,
    'custom_ops': ["all"],
}
llm = LLM(model=model, compilation_config=compilation_config)
outputs = llm.generate(prompts, sampling_params)
```

I also removed some old comments, Woosuk mentioned that they may be outdated.

Test Plan:
- ran the above commands
- `pytest tests/compile/piecewise/test_simple.py && pytest tests/compile/piecewise/test_toy_llama.py`

Benchmarks:

I used benchmark_latency.py to benchmark some models with:
1. the default settings
2. "eager+CUDAGraphs" `--compilation-config="{'use_inductor': False, 'custom_ops': ['all']}"`
3. "eager" `--enforce-eager`

Performance numbers below:


| Model | eager | eager with CUDAGraphs | torch.compile and CUDAGraphs |
| :---- | :---- | :---- | :---- |
| meta-llama/Meta-Llama-3.1-8B on 1xH100 | 1.28s | 1.23s | 1.16s |
| meta-llama/Meta-Llama-3.1-70B on 8xH100 | 3.32s |  1.96s | 1.87s |
| google/gemma-3-4b-it on 1xH100 | 2.97s | 1.37s | 0.78s |
| Qwen/Qwen3-8B on 1xH100 | 1.79s | 1.41s | 1.23s |

