### PR TITLE
fix gemma3 results all zero

### DIFF
--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -241,7 +241,10 @@ class GemmaRMSNorm(CustomOp):
         """PyTorch-native implementation equivalent to forward()."""
         orig_dtype = x.dtype
         if residual is not None:
-            x = x + residual
+            if orig_dtype == torch.float16:
+                x = x + residual.float()
+            else:
+                x = x + residual
             residual = x
 
         x = x.float()


### PR DESCRIPTION
X+residual will be bigger than max value of float16 (65504) when I try to run Gemma3 with param --dtype float16.
Then the token_ids of model result will be all zero.
Therefore, residual should be float if orig_dtype is float16.
