### PR TITLE
enable multiple platform device in DP init

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -592,11 +592,28 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         from vllm.platforms import current_platform
-        if current_platform.is_cuda_alike():
-            from vllm.platforms.cuda import device_id_to_physical_device_id
-            tp_size = vllm_config.parallel_config.tensor_parallel_size
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(
-                str(device_id_to_physical_device_id(i))
+        visible_device_var = current_platform.device_control_env_var
+        
+        def platform_device_id_to_physical_device_id(device_id: int) -> int:
+            if visible_device_var in os.environ:
+                device_ids = os.environ[visible_device_var].split(",")
+                if device_ids == [""]:
+                    msg = ( "Empty <PLATFORM>_VISIBLE_DEVICE var due to"
+                        " set error. If you are using CUDA and ray, please"
+                        " unset the environment variable"
+                        " `CUDA_VISIBLE_DEVICES` inside the worker/actor."
+                        " Check"
+                        " https://github.com/vllm-project/vllm/issues/8402"
+                        " for more information.")
+                    raise RuntimeError(msg)
+                physical_device_id = device_ids[device_id]
+                return int(physical_device_id)
+            else:
+                return device_id
+
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        os.environ[visible_device_var] = ",".join(
+                str(platform_device_id_to_physical_device_id(i))
                 for i in range(local_dp_rank * tp_size, (local_dp_rank + 1) *
                                tp_size))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

This PR fixed 1 bugs that occurs while using different platforms from CUDA, such as ASCEND.

[BUG] When using non-CUDA platform such as ASCEND NPU, class DPEngineCoreProc cannot set VISIBLE_DEVICE env param successfully due to "`if current_platform.is_cuda_alike()`" branch. Thus we need a general init method that adapts multiple platforms. We fix this bug by using `current_platform.device_control_env_var` to automaticly determine platform type. Also, we rewrite the `device_id_to_physical_device_id()` method so as to adapt multiple platforms.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

Yes, as a bug-fix PR, it introduces a new feature.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
 This patch can be tested by both offline and online instructions. Remember to set `--dp-size` to 2 as least.

Co-authored-by: HanlinDu ftdl21@pku.edu.cn
Co-authored-by: ZhengWG zwg0606@gmail.com
Co-authored-by: realliujiaxu realliujiaxu@163.com