### PR TITLE
Fix some speculative decode tests with tl.dot

### DIFF
--- a/tests/spec_decode/e2e/test_multistep_correctness.py
+++ b/tests/spec_decode/e2e/test_multistep_correctness.py
@@ -456,7 +456,7 @@ def test_spec_decode_e2e_greedy_correctness_real_model_large_bs(
 @pytest.mark.parametrize(
     "common_llm_kwargs",
     [{
-        "block_size": 8,
+        "block_size": 16,
         # 2 for small prompt, 256//8 for generated.
         "num_gpu_blocks_override": 2 + 256 // 8,
         "max_model_len": (2 + 256 // 8) * 8,

--- a/tests/spec_decode/e2e/test_multistep_correctness.py
+++ b/tests/spec_decode/e2e/test_multistep_correctness.py
@@ -526,11 +526,8 @@ def test_spec_decode_e2e_greedy_correctness_with_preemption(
 @pytest.mark.parametrize(
     "per_test_common_llm_kwargs",
     [
-        # As of this writing, vLLM only compiles with these 3 block sizes by
-        # default.
-        {
-            "block_size": 8,
-        },
+        # https://github.com/triton-lang/triton/issues/2266 tl.dot
+        # doesn't support embedding < 16
         {
             "block_size": 16,
         },


### PR DESCRIPTION
I'm seeing these failures from my other PR https://github.com/vllm-project/vllm/pull/16859, but they don't seem to be related to PyTorch 2.7.0 release. They seem to come from https://github.com/vllm-project/vllm/pull/13305 with the issue on Triton https://github.com/triton-lang/triton/issues/2266.  I have seen similar a PR from PyTorch about this https://github.com/pytorch/pytorch/pull/147765.

The PR attempts to fix the failed tests accordingly.