### PR TITLE
[doc] add install tips

### DIFF
--- a/docs/source/features/quantization/fp8.md
+++ b/docs/source/features/quantization/fp8.md
@@ -86,7 +86,7 @@ recipe = QuantizationModifier(
 # Apply the quantization algorithm.
 oneshot(model=model, recipe=recipe)
 
-# Save the model.
+# Save the model: Meta-Llama-3-8B-Instruct-FP8-Dynamic
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-Dynamic"
 model.save_pretrained(SAVE_DIR)
 tokenizer.save_pretrained(SAVE_DIR)

--- a/docs/source/features/quantization/fp8.md
+++ b/docs/source/features/quantization/fp8.md
@@ -44,6 +44,12 @@ To produce performant FP8 quantized models with vLLM, you'll need to install the
 pip install llmcompressor
 ```
 
+Additionally, install `vllm` and `lm-evaluation-harness` for evaluation:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
+
 ## Quantization Process
 
 The quantization process involves three main steps:
@@ -93,12 +99,6 @@ tokenizer.save_pretrained(SAVE_DIR)
 ```
 
 ### 3. Evaluating Accuracy
-
-Install `vllm` and `lm-evaluation-harness`:
-
-```console
-pip install vllm lm-eval==0.4.4
-```
 
 Load and run the model in `vllm`:
 

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -18,6 +18,12 @@ To use INT4 quantization with vLLM, you'll need to install the [llm-compressor](
 pip install llmcompressor
 ```
 
+Additionally, install `vllm` and `lm-evaluation-harness` for evaluation:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
+
 ## Quantization Process
 
 The quantization process involves four main steps:
@@ -96,12 +102,6 @@ tokenizer.save_pretrained(SAVE_DIR)
 This process creates a W4A16 model with weights quantized to 4-bit integers.
 
 ### 4. Evaluating Accuracy
-
-Install `vllm` and `lm-evaluation-harness`:
-
-```console
-pip install vllm lm-eval==0.4.4
-```
 
 After quantization, you can load and run the model in vLLM:
 

--- a/docs/source/features/quantization/int4.md
+++ b/docs/source/features/quantization/int4.md
@@ -87,7 +87,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
 )
 
-# Save the compressed model
+# Save the compressed model: Meta-Llama-3-8B-Instruct-W4A16-G128
 SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16-G128"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)
@@ -96,6 +96,12 @@ tokenizer.save_pretrained(SAVE_DIR)
 This process creates a W4A16 model with weights quantized to 4-bit integers.
 
 ### 4. Evaluating Accuracy
+
+Install `vllm` and `lm-evaluation-harness`:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
 
 After quantization, you can load and run the model in vLLM:
 

--- a/docs/source/features/quantization/int8.md
+++ b/docs/source/features/quantization/int8.md
@@ -19,6 +19,12 @@ To use INT8 quantization with vLLM, you'll need to install the [llm-compressor](
 pip install llmcompressor
 ```
 
+Additionally, install `vllm` and `lm-evaluation-harness` for evaluation:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
+
 ## Quantization Process
 
 The quantization process involves four main steps:
@@ -100,12 +106,6 @@ tokenizer.save_pretrained(SAVE_DIR)
 This process creates a W8A8 model with weights and activations quantized to 8-bit integers.
 
 ### 4. Evaluating Accuracy
-
-Install `vllm` and `lm-evaluation-harness`:
-
-```console
-pip install vllm lm-eval==0.4.4
-```
 
 After quantization, you can load and run the model in vLLM:
 

--- a/docs/source/features/quantization/int8.md
+++ b/docs/source/features/quantization/int8.md
@@ -91,7 +91,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
 )
 
-# Save the compressed model
+# Save the compressed model: Meta-Llama-3-8B-Instruct-W8A8-Dynamic-Per-Token
 SAVE_DIR = MODEL_ID.split("/")[1] + "-W8A8-Dynamic-Per-Token"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)
@@ -100,6 +100,12 @@ tokenizer.save_pretrained(SAVE_DIR)
 This process creates a W8A8 model with weights and activations quantized to 8-bit integers.
 
 ### 4. Evaluating Accuracy
+
+Install `vllm` and `lm-evaluation-harness`:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
 
 After quantization, you can load and run the model in vLLM:
 

--- a/docs/source/features/quantization/quantized_kvcache.md
+++ b/docs/source/features/quantization/quantized_kvcache.md
@@ -126,7 +126,7 @@ oneshot(
     num_calibration_samples=NUM_CALIBRATION_SAMPLES,
 )
 
-# Save quantized model
+# Save quantized model: Llama-3.1-8B-Instruct-FP8-KV
 SAVE_DIR = MODEL_ID.split("/")[1] + "-FP8-KV"
 model.save_pretrained(SAVE_DIR, save_compressed=True)
 tokenizer.save_pretrained(SAVE_DIR)

--- a/docs/source/features/quantization/quark.md
+++ b/docs/source/features/quantization/quark.md
@@ -19,6 +19,12 @@ pip install amd-quark
 You can refer to [Quark installation guide](https://quark.docs.amd.com/latest/install.html)
 for more installation details.
 
+Additionally, install `vllm` and `lm-evaluation-harness` for evaluation:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
+
 ## Quantization Process
 
 After installing Quark, we will use an example to illustrate how to use Quark.  
@@ -150,6 +156,7 @@ LLAMA_KV_CACHE_GROUP = ["*k_proj", "*v_proj"]
 export_config = ExporterConfig(json_export_config=JsonExporterConfig())
 export_config.json_export_config.kv_cache_group = LLAMA_KV_CACHE_GROUP
 
+# Model: Llama-2-70b-chat-hf-w-fp8-a-fp8-kvcache-fp8-pertensor-autosmoothquant
 EXPORT_DIR = MODEL_ID.split("/")[1] + "-w-fp8-a-fp8-kvcache-fp8-pertensor-autosmoothquant"
 exporter = ModelExporter(config=export_config, export_dir=EXPORT_DIR)
 with torch.no_grad():
@@ -158,12 +165,6 @@ with torch.no_grad():
 ```
 
 ### 5. Evaluation in vLLM
-
-Install `vllm` and `lm-evaluation-harness`:
-
-```console
-pip install vllm lm-eval==0.4.4
-```
 
 Now, you can load and run the Quark quantized model directly through the LLM entrypoint:
 

--- a/docs/source/features/quantization/quark.md
+++ b/docs/source/features/quantization/quark.md
@@ -159,6 +159,12 @@ with torch.no_grad():
 
 ### 5. Evaluation in vLLM
 
+Install `vllm` and `lm-evaluation-harness`:
+
+```console
+pip install vllm lm-eval==0.4.4
+```
+
 Now, you can load and run the Quark quantized model directly through the LLM entrypoint:
 
 ```python


### PR DESCRIPTION


- `lm-evaluation-harness` is not installed by default and fp8 mention it , not for others:
https://github.com/vllm-project/vllm/blob/97cc8729f0bc351a5536380fd897607f4ecdeef1/docs/source/features/quantization/fp8.md?plain=1#L97
- and add the model name to save that connect to the next operation

<!--- pyml disable-next-line no-emphasis-as-heading -->
