### PR TITLE
[CI/Build] Update version of setuptools to fix broken installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26",
     "ninja",
     "packaging",
-    "setuptools>=61",
+    "setuptools>=77.0.3",
     "setuptools-scm>=8.0",
     "torch == 2.6.0",
     "wheel",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 cmake>=3.26
 ninja
 packaging
-setuptools>=61
+setuptools>=77.0.3
 setuptools-scm>=8
 torch==2.6.0
 wheel


### PR DESCRIPTION
PR #17259 updates new format of license, which requires setuptools>=77.0.3 according to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license. This breaks installation with older version of setuptools #17360. This PR fix it.