### PR TITLE
docs: fix name for Qwen MoE supported models

### DIFF
--- a/docs/source/models/supported_models.md
+++ b/docs/source/models/supported_models.md
@@ -542,7 +542,7 @@ See [this page](#generative-models) for more information on how to use generativ
   * ✅︎
 - * `Qwen3MoeForCausalLM`
   * Qwen3MoE
-  * `Qwen/Qwen3-MoE-15B-A2B`, etc.
+  * `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-235B-A22B`, etc.
   * ✅︎
   * ✅︎
 - * `StableLmForCausalLM`


### PR DESCRIPTION
Despite the fact that transformers library report that Qwen MoE is `Qwen3-MoE-15B-A2B` (https://github.com/huggingface/transformers/blob/755b0fa2fe85d13726585609efeac593d394783e/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py#L29), to the best of my knowledge, Qwen releases two MoE: Qwen3-235B-A22B and Qwen3-30B-A3B.
