### PR TITLE
[Build] Require setuptools >= 77.0.3 for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@
 requires = [
     "cmake>=3.26",
     "ninja",
-    "packaging",
-    "setuptools>=77.0.3",
+    "packaging>=24.2",
+    "setuptools>=77.0.3,<80.0.0",
     "setuptools-scm>=8.0",
     "torch == 2.7.0",
     "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "cmake>=3.26",
     "ninja",
     "packaging",
-    "setuptools>=61",
+    "setuptools>=77.0.3",
     "setuptools-scm>=8.0",
     "torch == 2.7.0",
     "wheel",

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 cmake>=3.26
 ninja
 packaging
-setuptools>=61
+setuptools>=77.0.3
 setuptools-scm>=8
 torch==2.7.0
 wheel

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -2,7 +2,7 @@
 cmake>=3.26
 ninja
 packaging
-setuptools>=77.0.3
+setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 torch==2.7.0
 wheel

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,7 +1,7 @@
 # Should be mirrored in pyproject.toml
 cmake>=3.26
 ninja
-packaging
+packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 torch==2.7.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -34,7 +34,7 @@ mistral_common[opencv] >= 1.5.4
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
-setuptools>=74.1.1,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
+setuptools>=77.0.3,<80; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
 compressed-tensors == 0.9.3 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,6 +7,6 @@ triton==3.1.0
 pandas
 numpy==1.26.4
 tabulate
-setuptools>=77.0.3
+setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@f1f6624

--- a/requirements/hpu.txt
+++ b/requirements/hpu.txt
@@ -7,6 +7,6 @@ triton==3.1.0
 pandas
 numpy==1.26.4
 tabulate
-setuptools>=61
+setuptools>=77.0.3
 setuptools-scm>=8
 vllm-hpu-extension @ git+https://github.com/HabanaAI/vllm-hpu-extension.git@f1f6624

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -9,7 +9,7 @@ torchaudio==2.7.0
 triton==3.2
 cmake>=3.26,<4
 packaging
-setuptools>=77.0.3
+setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -8,7 +8,7 @@ torchaudio==2.7.0
 
 triton==3.2
 cmake>=3.26,<4
-packaging
+packaging>=24.2
 setuptools>=77.0.3,<80.0.0
 setuptools-scm>=8
 wheel

--- a/requirements/rocm-build.txt
+++ b/requirements/rocm-build.txt
@@ -9,7 +9,7 @@ torchaudio==2.7.0
 triton==3.2
 cmake>=3.26,<4
 packaging
-setuptools>=61
+setuptools>=77.0.3
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -396,7 +396,7 @@ opencv-python-headless==4.11.0.86
     # via
     #   -r requirements/test.in
     #   mistral-common
-packaging==24.1
+packaging==24.2
     # via
     #   accelerate
     #   black

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -632,7 +632,7 @@ sentence-transformers==3.2.1
     # via -r requirements/test.in
 sentencepiece==0.2.0
     # via mistral-common
-setuptools==75.8.0
+setuptools==77.0.3
     # via
     #   mamba-ssm
     #   pytablewriter

--- a/requirements/tpu.txt
+++ b/requirements/tpu.txt
@@ -3,7 +3,7 @@
 
 # Dependencies for TPU
 cmake>=3.26
-packaging
+packaging>=24.2
 setuptools-scm>=8
 wheel
 jinja2>=3.1.6

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -5,7 +5,7 @@ ray>=2.9
 cmake>=3.26
 packaging
 setuptools-scm>=8
-setuptools>=75.8.0,<80.0.0
+setuptools>=77.0.3,<80.0.0
 wheel
 jinja2>=3.1.6
 datasets # for benchmark scripts

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -3,7 +3,7 @@
 
 ray>=2.9
 cmake>=3.26
-packaging
+packaging>=24.2
 setuptools-scm>=8
 setuptools>=77.0.3,<80.0.0
 wheel


### PR DESCRIPTION
In PR #17259, the license specification in `pyproject.toml` was updated
to use the new format specified by PEP 639. The previous format has been
deprecated. Support for this new format requires `setuptools>=77.0.3`.
Update the requirements accordingly.

For more details on the format, see:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

Signed-off-by: Russell Bryant <rbryant@redhat.com>

FIX #17464
