### PR TITLE
[Bugfix] Fix Minicpm-O-int4 GPTQ model inference

### DIFF
--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -35,6 +35,9 @@ from transformers.models.whisper.modeling_whisper import (
 
 from vllm.config import VllmConfig
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.gptq import GPTQConfig
+from vllm.model_executor.layers.quantization.gptq_marlin import (
+    GPTQMarlinConfig)
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalKwargs
 from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
                                     NestedTensors)
@@ -512,7 +515,15 @@ class MiniCPMO(MiniCPMV2_6):
                                           prefix=maybe_prefix(prefix, "apm"))
 
         self.audio_token_id = None
-    
+
+    def _maybe_ignore_quant_config(self, quant_config: QuantizationConfig):
+        # GPTQ configs do not have a list of ignored modules, however AutoGPTQ
+        # seems to avoid vision encoder sections for some models.
+        # See: https://huggingface.co/openbmb/MiniCPM-o-2_6-int4
+        if isinstance(quant_config, (GPTQConfig, GPTQMarlinConfig)):
+            return None
+        return quant_config
+
     def init_vision_module(
         self,
         config: PretrainedConfig,
@@ -522,6 +533,18 @@ class MiniCPMO(MiniCPMV2_6):
         # MiniCPMO GPTQ model leave vpm unquantized.
         quant_config = self._maybe_ignore_quant_config(quant_config)
         return super().init_vision_module(config, quant_config, prefix)
+
+    def init_resampler(
+        self,
+        embed_dim: int,
+        vision_dim: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> nn.Module:
+        # MiniCPMO GPTQ model leave resampler unquantized.
+        quant_config = self._maybe_ignore_quant_config(quant_config)
+        return super().init_resampler(embed_dim, vision_dim, quant_config,
+                                      prefix)
 
     def init_audio_module(self, *, vllm_config: VllmConfig, prefix: str = ""):
         # Do not use parameters temporarily

--- a/vllm/model_executor/models/minicpmo.py
+++ b/vllm/model_executor/models/minicpmo.py
@@ -28,12 +28,13 @@ from typing import (Any, Callable, Literal, Optional, Set, Tuple, TypedDict,
 
 import torch
 from torch import nn
-from transformers import BatchFeature
+from transformers import BatchFeature, PretrainedConfig
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.models.whisper.modeling_whisper import (
     ACT2FN, WHISPER_ATTENTION_CLASSES, WhisperConfig, WhisperEncoder)
 
 from vllm.config import VllmConfig
+from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalKwargs
 from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
                                     NestedTensors)
@@ -511,6 +512,16 @@ class MiniCPMO(MiniCPMV2_6):
                                           prefix=maybe_prefix(prefix, "apm"))
 
         self.audio_token_id = None
+    
+    def init_vision_module(
+        self,
+        config: PretrainedConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> nn.Module:
+        # MiniCPMO GPTQ model leave vpm unquantized.
+        quant_config = self._maybe_ignore_quant_config(quant_config)
+        return super().init_vision_module(config, quant_config, prefix)
 
     def init_audio_module(self, *, vllm_config: VllmConfig, prefix: str = ""):
         # Do not use parameters temporarily

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -47,9 +47,6 @@ from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM
 from vllm.model_executor.sampling_metadata import SamplingMetadata
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalKwargs
-from vllm.model_executor.layers.quantization.gptq import GPTQConfig
-from vllm.model_executor.layers.quantization.gptq_marlin import (
-    GPTQMarlinConfig)
 from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
                                     NestedTensors)
 from vllm.multimodal.parse import (DictEmbeddingItems, ImageItem,
@@ -1205,20 +1202,11 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
                                      embed_dim=embed_dim,
                                      num_heads=embed_dim // 128,
                                      kv_dim=vision_dim,
-                                     quant_config=self._maybe_ignore_quant_config(quant_config),
+                                     quant_config=quant_config,
                                      prefix=prefix)
 
         return resampler.to(device=current_platform.device_type,
                             dtype=torch.get_default_dtype())
-
-    def _maybe_ignore_quant_config(self, quant_config: QuantizationConfig):
-        # GPTQ configs do not have a list of ignored modules, however AutoGPTQ
-        # seems to avoid vision encoder sections for some models.
-        # See: https://huggingface.co/openbmb/MiniCPM-V-2_6-int4
-        # and https://huggingface.co/openbmb/MiniCPM-o-2_6-int4
-        if isinstance(quant_config, (GPTQConfig, GPTQMarlinConfig)):
-            return None
-        return quant_config
 
     def get_vision_hidden_states(
             self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:


### PR DESCRIPTION

FIX #17358 
- Similar to Qwen2-VL, MiniCPM-O skip quantization in its ViT and Resampler for gptq quantization.
- This PR added same `_maybe_ignore_quant_config` from Qwen2-VL to MiniCPM-O to make the int4 gptq model work.

<!--- pyml disable-next-line no-emphasis-as-heading -->
