### PR TITLE
[Doc][Typo] Fixing label in new model requests link in overview.md

### DIFF
--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -17,7 +17,7 @@ Unsure on where to start? Check out the following links for tasks to work on:
 
 - [Good first issues](https://github.com/vllm-project/vllm/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
   - [Selected onboarding tasks](gh-project:6)
-- [New model requests](https://github.com/vllm-project/vllm/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22new%20model%22)
+- [New model requests](https://github.com/vllm-project/vllm/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22new-model%22)
   - [Models with multi-modal capabilities](gh-project:10)
 
 ## License


### PR DESCRIPTION
Job Board's new model requests link had a wrong label for `new model` instead of `new-model` which was giving a filter issue for people who want to contribute:
![image](https://github.com/user-attachments/assets/084a21d5-fa33-47f0-87d0-2a17c2b42c20)


<!--- pyml disable-next-line no-emphasis-as-heading -->
