### PR TITLE
[CI/Build] Fix docker command casing warning

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -156,7 +156,7 @@ RUN if [ "$RUN_WHEEL_CHECK" = "true" ]; then \
 #################### EXTENSION Build IMAGE ####################
 
 #################### DEV IMAGE ####################
-FROM base as dev
+FROM base AS dev
 
 # This timeout (in seconds) is necessary when installing some dependencies via uv since it's likely to time out
 # Reference: https://github.com/astral-sh/uv/pull/1694


### PR DESCRIPTION
Just turn the `as` to upper case to get rid of docker's warning of casing mismatch.