### PR TITLE
[Frontend] Fix tool_call handling in llama3.1 and llama3.2 chat template to allow zero tool_calls

### DIFF
--- a/examples/tool_chat_template_llama3.1_json.jinja
+++ b/examples/tool_chat_template_llama3.1_json.jinja
@@ -91,16 +91,17 @@
         {%- endif %}
         {{- '<|eot_id|>' }}
     {%- elif 'tool_calls' in message %}
-        {%- if not message.tool_calls|length == 1 %}
-            {{- raise_exception("This model only supports single tool-calls at once!") }}
+        {%- if message.tool_calls|length == 1 %}
+            {%- set tool_call = message.tool_calls[0].function %}
+            {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+            {{- '{"name": "' + tool_call.name + '", ' }}
+            {{- '"parameters": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- "}" }}
+            {{- "<|eot_id|>" }}
+        {%- elif message.tool_calls|length > 1 %}
+            {{- raise_exception("This model only supports single tool-call at once!") }}
         {%- endif %}
-        {%- set tool_call = message.tool_calls[0].function %}
-        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
-        {{- '{"name": "' + tool_call.name + '", ' }}
-        {{- '"parameters": ' }}
-        {{- tool_call.arguments | tojson }}
-        {{- "}" }}
-        {{- "<|eot_id|>" }}
     {%- elif message.role == "tool" or message.role == "ipython" %}
         {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
         {%- if message.content is string %}

--- a/examples/tool_chat_template_llama3.2_json.jinja
+++ b/examples/tool_chat_template_llama3.2_json.jinja
@@ -104,16 +104,17 @@
         {%- endif %}
         {{- '<|eot_id|>' }}
     {%- elif 'tool_calls' in message %}
-        {%- if not message.tool_calls|length == 1 %}
-            {{- raise_exception("This model only supports single tool-calls at once!") }}
+        {%- if message.tool_calls|length == 1 %}
+            {%- set tool_call = message.tool_calls[0].function %}
+            {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+            {{- '{"name": "' + tool_call.name + '", ' }}
+            {{- '"parameters": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- "}" }}
+            {{- "<|eot_id|>" }}
+        {%- elif message.tool_calls|length > 1 %}
+            {{- raise_exception("This model only supports single tool-call at once!") }}
         {%- endif %}
-        {%- set tool_call = message.tool_calls[0].function %}
-        {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
-        {{- '{"name": "' + tool_call.name + '", ' }}
-        {{- '"parameters": ' }}
-        {{- tool_call.arguments | tojson }}
-        {{- "}" }}
-        {{- "<|eot_id|>" }}
     {%- elif message.role == "tool" or message.role == "ipython" %}
         {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
         {%- if message.content is string %}


### PR DESCRIPTION
- Corrected the logic to ensure that an exception is raised only when there are multiple tool_calls.
- Now allows zero tool_calls without raising an exception.
- Prevents index errors by only accessing tool_calls[0] when exactly one tool_call is present.



<!--- pyml disable-next-line no-emphasis-as-heading -->
