### PR TITLE
[Bugfix] Temporarily disable gptq_bitblas on ROCm

### DIFF
--- a/docs/source/features/quantization/supported_hardware.md
+++ b/docs/source/features/quantization/supported_hardware.md
@@ -80,7 +80,7 @@ The table below shows the compatibility of various quantization implementations 
   * ✅︎
   * ✅︎
   * ✅︎
-  * ✅︎
+  * ❌
   * ❌
   * ❌
   * ❌

--- a/vllm/model_executor/layers/quantization/gptq_bitblas.py
+++ b/vllm/model_executor/layers/quantization/gptq_bitblas.py
@@ -24,6 +24,7 @@ from vllm.model_executor.parameter import (ChannelQuantScaleParameter,
                                            PackedColumnParameter,
                                            PackedvLLMParameter,
                                            RowvLLMParameter)
+from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
 
 logger = init_logger(__name__)
@@ -189,6 +190,10 @@ class GPTQBitBLASConfig(QuantizationConfig):
         group_size = quant_config.get("group_size")
         sym = quant_config.get("sym")
         desc_act = quant_config.get("desc_act")
+
+        # temporarily disable on ROCm platform
+        if not current_platform.is_cuda():
+            return False
 
         # If we cannot find the info needed in the config, cannot convert.
         if (num_bits is None or group_size is None or sym is None


### PR DESCRIPTION
In v0.8.5, those lines of code replaces `gptq` with `gptq_bitblas`: 

https://github.com/vllm-project/vllm/blob/ba41cc90e8ef7f236347b2f1599eec2cbb9e1f0d/vllm/config.py#L795-L810  

After the replacement, a check is introduced to verify whether the current platform supports the specified quantization method: 

https://github.com/vllm-project/vllm/blob/ba41cc90e8ef7f236347b2f1599eec2cbb9e1f0d/vllm/config.py#L828  

However, `gptq_bitblas` is not included in the list of supported methods for ROCm, causing vLLM to throw an exception and exit: 

https://github.com/vllm-project/vllm/blob/ba41cc90e8ef7f236347b2f1599eec2cbb9e1f0d/vllm/platforms/rocm.py#L132-L135  

Due to this check, `gptq_bitblas` should not be functional on the ROCm platform in this version of vLLM. Any user attempting to use `gptq_bitblas` on ROCm should encounter this error and the program will exit. 

In other words, it appears that no one has actually tested or successfully run `gptq_bitblas` on the ROCm platform. In this situation, I believe we should temporarily disable `gptq_bitblas` for ROCm users. The feature can be re-enabled once a developer successfully tests and runs `gptq_bitblas` on ROCm. 

This PR primarily considers users on the ROCm platform who rely on GPTQ quantization. These users will encounter issues where vLLM fails to start after updating from v0.8.4 to v0.8.5. 

FIX #17410 