### PR TITLE
Fix noisy warning for uncalibrated q_scale/p_scale

### DIFF
--- a/vllm/model_executor/layers/quantization/kv_cache.py
+++ b/vllm/model_executor/layers/quantization/kv_cache.py
@@ -124,11 +124,12 @@ class BaseKVCacheMethod(QuantizeMethodBase):
         # These are used in the final Attention.forward()
         layer._q_scale.copy_(q_scale)
         layer._prob_scale.copy_(prob_scale)
-        if q_scale == 1.0 or prob_scale == 1.0:
+        if layer.kv_cache_dtype == "fp8" and (q_scale == 1.0
+                                              or prob_scale == 1.0):
             logger.warning_once(
-                f"Using Q scale {q_scale} and prob scale {prob_scale} "
-                "with fp8 attention. This may cause accuracy issues. "
-                "Please make sure Q/prob scaling factors are "
+                f"Using uncalibrated q_scale {q_scale} and/or prob_scale "
+                f"{prob_scale} with fp8 attention. This may cause accuracy "
+                "issues. Please make sure q/prob scaling factors are "
                 "available in the fp8 checkpoint.")
 
         del layer.k_scale


### PR DESCRIPTION
When loading any quantized model that supports quantized kv cache, you see this warning even if quantized kv cache isn't enabled (introduced by https://github.com/vllm-project/vllm/pull/15734)
```
WARNING 04-29 20:32:22 [kv_cache.py:128] Using Q scale 1.0 and prob scale 1.0 with fp8 attention. This may cause accuracy issues. Please make sure Q/prob scaling factors are available in the fp8 checkpoint.
```

This change moves the warning to only happen when the kv cache is quantized. We could further restrict this to ROCm platforms since that is the only consumer of this atm