### PR TITLE
Avoid overwriting vllm_compile_cache.py

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -66,11 +66,16 @@ class CompilerManager:
                                        disable_cache=disable_cache)
 
     def save_to_file(self):
-        if self.disable_cache or os.path.exists(self.cache_file_path):
+        if self.disable_cache:
             return
+        printer = pprint.PrettyPrinter(indent=4)
+        data = printer.pformat(self.cache)
+        if os.path.exists(self.cache_file_path):
+            with open(self.cache_file_path) as f:
+                file_content = f.read()
+            if data == file_content:
+                return
         with open(self.cache_file_path, "w") as f:
-            printer = pprint.PrettyPrinter(indent=4)
-            data = printer.pformat(self.cache)
             f.write(data)
 
     def load(self,

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -66,7 +66,7 @@ class CompilerManager:
                                        disable_cache=disable_cache)
 
     def save_to_file(self):
-        if self.disable_cache:
+        if self.disable_cache or os.path.exists(self.cache_file_path):
             return
         with open(self.cache_file_path, "w") as f:
             printer = pprint.PrettyPrinter(indent=4)


### PR DESCRIPTION
When vLLM is reusing a previously compile torch.compile cache files, it should not modify/overwrite it, since nothing is expected to be changed under the same hash.

After the change, verified the cache dir is no longer modified when existing cache file is found.
