### PR TITLE
[Feature][Refactor][CLI] Rename guided to structured outputs, and `--structured-outputs-config`

### DIFF
--- a/examples/offline_inference/structured_outputs.py
+++ b/examples/offline_inference/structured_outputs.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-This file demonstrates the example usage of guided decoding
-to generate structured outputs using vLLM. It shows how to apply
-different guided decoding techniques such as Choice, Regex, JSON schema,
-and Grammar to produce structured and formatted results
+This file demonstrates the example usage to generate structured
+outputs using vLLM. It shows how to apply different techniques
+such as Choice, Regex, JSON schema, and Grammar to produce
+structured and formatted results
 based on specific prompts.
 """
 
@@ -13,17 +13,21 @@ from enum import Enum
 from pydantic import BaseModel
 
 from vllm import LLM, SamplingParams
-from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import StructuredOuputsParams
 
-# Guided decoding by Choice (list of possible options)
-guided_decoding_params_choice = GuidedDecodingParams(choice=["Positive", "Negative"])
-sampling_params_choice = SamplingParams(guided_decoding=guided_decoding_params_choice)
+# Structured outputs by Choice (list of possible options)
+structured_outputs_params_choice = StructuredOuputsParams(
+    choice=["Positive", "Negative"]
+)
+sampling_params_choice = SamplingParams(
+    structured_outputs=structured_outputs_params_choice
+)
 prompt_choice = "Classify this sentiment: vLLM is wonderful!"
 
-# Guided decoding by Regex
-guided_decoding_params_regex = GuidedDecodingParams(regex=r"\w+@\w+\.com\n")
+# Structured outputs by Regex
+structured_outputs_params_regex = StructuredOuputsParams(regex=r"\w+@\w+\.com\n")
 sampling_params_regex = SamplingParams(
-    guided_decoding=guided_decoding_params_regex, stop=["\n"]
+    structured_outputs=structured_outputs_params_regex, stop=["\n"]
 )
 prompt_regex = (
     "Generate an email address for Alan Turing, who works in Enigma."
@@ -32,7 +36,7 @@ prompt_regex = (
 )
 
 
-# Guided decoding by JSON using Pydantic schema
+# Structured outputs by JSON using Pydantic schema
 class CarType(str, Enum):
     sedan = "sedan"
     suv = "SUV"
@@ -47,14 +51,14 @@ class CarDescription(BaseModel):
 
 
 json_schema = CarDescription.model_json_schema()
-guided_decoding_params_json = GuidedDecodingParams(json=json_schema)
-sampling_params_json = SamplingParams(guided_decoding=guided_decoding_params_json)
+structured_outputs_params_json = StructuredOuputsParams(json=json_schema)
+sampling_params_json = SamplingParams(structured_outputs=structured_outputs_params_json)
 prompt_json = (
     "Generate a JSON with the brand, model and car_type of"
     "the most iconic car from the 90's"
 )
 
-# Guided decoding by Grammar
+# Structured outputs by Grammar
 simplified_sql_grammar = """
 root ::= select_statement
 select_statement ::= "SELECT " column " from " table " where " condition
@@ -63,8 +67,12 @@ table ::= "table_1 " | "table_2 "
 condition ::= column "= " number
 number ::= "1 " | "2 "
 """
-guided_decoding_params_grammar = GuidedDecodingParams(grammar=simplified_sql_grammar)
-sampling_params_grammar = SamplingParams(guided_decoding=guided_decoding_params_grammar)
+structured_outputs_params_grammar = StructuredOuputsParams(
+    grammar=simplified_sql_grammar
+)
+sampling_params_grammar = SamplingParams(
+    structured_outputs=structured_outputs_params_grammar
+)
 prompt_grammar = (
     "Generate an SQL query to show the 'username' and 'email'from the 'users' table."
 )
@@ -83,16 +91,16 @@ def main():
     llm = LLM(model="Qwen/Qwen2.5-3B-Instruct", max_model_len=100)
 
     choice_output = generate_output(prompt_choice, sampling_params_choice, llm)
-    format_output("Guided decoding by Choice", choice_output)
+    format_output("Structured outputs by Choice", choice_output)
 
     regex_output = generate_output(prompt_regex, sampling_params_regex, llm)
-    format_output("Guided decoding by Regex", regex_output)
+    format_output("Structured outputs by Regex", regex_output)
 
     json_output = generate_output(prompt_json, sampling_params_json, llm)
-    format_output("Guided decoding by JSON", json_output)
+    format_output("Structured outputs by JSON", json_output)
 
     grammar_output = generate_output(prompt_grammar, sampling_params_grammar, llm)
-    format_output("Guided decoding by Grammar", grammar_output)
+    format_output("Structured outputs by Grammar", grammar_output)
 
 
 if __name__ == "__main__":

--- a/examples/online_serving/openai_chat_completion_client_with_tools_required.py
+++ b/examples/online_serving/openai_chat_completion_client_with_tools_required.py
@@ -5,8 +5,8 @@ To run this example, you can start the vLLM server
 without any specific flags:
 
 ```bash
-VLLM_USE_V1=0 vllm serve unsloth/Llama-3.2-1B-Instruct \
-    --guided-decoding-backend outlines
+vllm serve unsloth/Llama-3.2-1B-Instruct \
+    --structured-output-config '{"backend": "xgrammar"}'
 ```
 
 This example demonstrates how to generate chat completions

--- a/tests/async_engine/test_async_llm_engine.py
+++ b/tests/async_engine/test_async_llm_engine.py
@@ -128,7 +128,6 @@ async def test_new_requests_event():
     engine = MockAsyncLLMEngine()
     assert engine.get_model_config() is not None
     assert engine.get_tokenizer() is not None
-    assert engine.get_decoding_config() is not None
 
 
 def start_engine():

--- a/tests/entrypoints/conftest.py
+++ b/tests/entrypoints/conftest.py
@@ -184,7 +184,7 @@ def sample_enum_json_schema():
 
 
 @pytest.fixture
-def sample_guided_choice():
+def sample_choice():
     return [
         "Python", "Java", "JavaScript", "C++", "C#", "PHP", "TypeScript",
         "Ruby", "Swift", "Kotlin"

--- a/tests/entrypoints/llm/test_guided_generate.py
+++ b/tests/entrypoints/llm/test_guided_generate.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from vllm.distributed import cleanup_dist_env_and_memory
 from vllm.entrypoints.llm import LLM
 from vllm.outputs import RequestOutput
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOuputsParams
 
 MODEL_NAME = "Qwen/Qwen2.5-1.5B-Instruct"
 
@@ -49,7 +49,7 @@ def test_guided_regex(sample_regex, llm, guided_decoding_backend: str,
     sampling_params = SamplingParams(
         temperature=0.8,
         top_p=0.95,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             regex=sample_regex,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -81,7 +81,7 @@ def test_guided_json_completion(sample_json_schema, llm,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=sample_json_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -115,7 +115,7 @@ def test_guided_complex_json_completion(sample_complex_json_schema, llm,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=sample_complex_json_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -150,7 +150,7 @@ def test_guided_definition_json_completion(sample_definition_json_schema, llm,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=sample_definition_json_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -185,7 +185,7 @@ def test_guided_enum_json_completion(sample_enum_json_schema, llm,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=sample_enum_json_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -224,14 +224,14 @@ def test_guided_enum_json_completion(sample_enum_json_schema, llm,
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize("guided_decoding_backend,disable_any_whitespace",
                          ALL_DECODING_BACKENDS)
-def test_guided_choice_completion(sample_guided_choice, llm,
+def test_guided_choice_completion(sample_choice, llm,
                                   guided_decoding_backend: str,
                                   disable_any_whitespace: bool):
     sampling_params = SamplingParams(
         temperature=0.8,
         top_p=0.95,
-        guided_decoding=GuidedDecodingParams(
-            choice=sample_guided_choice,
+        structured_outputs=StructuredOuputsParams(
+            choice=sample_choice,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
     outputs = llm.generate(
@@ -247,7 +247,7 @@ def test_guided_choice_completion(sample_guided_choice, llm,
         generated_text = output.outputs[0].text
         print(generated_text)
         assert generated_text is not None
-        assert generated_text in sample_guided_choice
+        assert generated_text in sample_choice
         print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
 
 
@@ -261,7 +261,7 @@ def test_guided_grammar(sample_sql_statements, llm,
         temperature=0.8,
         top_p=0.95,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             grammar=sample_sql_statements,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -310,7 +310,7 @@ def test_validation_against_both_guided_decoding_options(sample_regex, llm):
     sampling_params = SamplingParams(
         temperature=0.8,
         top_p=0.95,
-        guided_decoding=GuidedDecodingParams(regex=sample_regex))
+        structured_outputs=StructuredOuputsParams(regex=sample_regex))
 
     with pytest.raises(ValueError, match="Cannot set both"):
         llm.generate(prompts="This should fail",
@@ -333,7 +333,7 @@ def test_disable_guided_decoding_fallback(sample_regex, llm):
     }
     sampling_params = SamplingParams(temperature=0.8,
                                      top_p=0.95,
-                                     guided_decoding=GuidedDecodingParams(
+                                     structured_outputs=StructuredOuputsParams(
                                          json=unsupported_json,
                                          backend="xgrammar",
                                          disable_fallback=True))
@@ -356,7 +356,7 @@ def test_guided_json_object(llm, guided_decoding_backend: str,
         temperature=1.0,
         max_tokens=100,
         n=2,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json_object=True,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -409,7 +409,7 @@ def test_guided_json_completion_with_enum(llm, guided_decoding_backend: str,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=json_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace))
@@ -460,7 +460,7 @@ def test_guided_number_range_json_completion(llm, guided_decoding_backend: str,
     sampling_params = SamplingParams(
         temperature=1.0,
         max_tokens=1000,
-        guided_decoding=GuidedDecodingParams(
+        structured_outputs=StructuredOuputsParams(
             json=sample_output_schema,
             backend=guided_decoding_backend,
             disable_any_whitespace=disable_any_whitespace),
@@ -516,14 +516,14 @@ def test_guidance_no_additional_properties(llm):
         "<|im_end|>\n<|im_start|>assistant\n")
 
     def generate_with_backend(backend, disable_additional_properties):
-        guided_params = GuidedDecodingParams(
+        guided_params = StructuredOuputsParams(
             json=schema,
             backend=backend,
             disable_any_whitespace=True,
             disable_additional_properties=disable_additional_properties)
         sampling_params = SamplingParams(temperature=0,
                                          max_tokens=256,
-                                         guided_decoding=guided_params)
+                                         structured_outputs=guided_params)
 
         outputs = llm.generate(prompts=prompt, sampling_params=sampling_params)
         assert outputs is not None

--- a/tests/entrypoints/openai/test_chat.py
+++ b/tests/entrypoints/openai/test_chat.py
@@ -487,8 +487,7 @@ async def test_chat_completion_stream_options(client: openai.AsyncOpenAI,
 
 
 @pytest.mark.asyncio
-async def test_guided_choice_chat(client: openai.AsyncOpenAI,
-                                  sample_guided_choice):
+async def test_guided_choice_chat(client: openai.AsyncOpenAI, sample_choice):
     messages = [{
         "role": "system",
         "content": "you are a helpful assistant"
@@ -503,9 +502,9 @@ async def test_guided_choice_chat(client: openai.AsyncOpenAI,
         messages=messages,
         max_completion_tokens=10,
         temperature=0.7,
-        extra_body=dict(guided_choice=sample_guided_choice))
+        extra_body=dict(guided_choice=sample_choice))
     choice1 = chat_completion.choices[0].message.content
-    assert choice1 in sample_guided_choice
+    assert choice1 in sample_choice
 
     messages.append({"role": "assistant", "content": choice1})
     messages.append({
@@ -517,9 +516,9 @@ async def test_guided_choice_chat(client: openai.AsyncOpenAI,
         messages=messages,
         max_completion_tokens=10,
         temperature=0.7,
-        extra_body=dict(guided_choice=sample_guided_choice))
+        extra_body=dict(guided_choice=sample_choice))
     choice2 = chat_completion.choices[0].message.content
-    assert choice2 in sample_guided_choice
+    assert choice2 in sample_choice
     assert choice1 != choice2
 
 
@@ -624,7 +623,7 @@ async def test_guided_decoding_type_error(client: openai.AsyncOpenAI):
 
 @pytest.mark.asyncio
 async def test_guided_choice_chat_logprobs(client: openai.AsyncOpenAI,
-                                           sample_guided_choice):
+                                           sample_choice):
 
     messages = [{
         "role": "system",
@@ -641,7 +640,7 @@ async def test_guided_choice_chat_logprobs(client: openai.AsyncOpenAI,
         max_completion_tokens=10,
         logprobs=True,
         top_logprobs=5,
-        extra_body=dict(guided_choice=sample_guided_choice))
+        extra_body=dict(guided_choice=sample_choice))
 
     assert chat_completion.choices[0].logprobs is not None
     assert chat_completion.choices[0].logprobs.content is not None

--- a/tests/entrypoints/openai/test_completion.py
+++ b/tests/entrypoints/openai/test_completion.py
@@ -686,20 +686,20 @@ async def test_guided_regex_completion(client: openai.AsyncOpenAI,
 @pytest.mark.parametrize("guided_decoding_backend", GUIDED_DECODING_BACKENDS)
 async def test_guided_choice_completion(client: openai.AsyncOpenAI,
                                         guided_decoding_backend: str,
-                                        sample_guided_choice):
+                                        sample_choice):
     completion = await client.completions.create(
         model=MODEL_NAME,
         prompt="The best language for type-safe systems programming is ",
         n=2,
         temperature=1.0,
         max_tokens=10,
-        extra_body=dict(guided_choice=sample_guided_choice,
+        extra_body=dict(guided_choice=sample_choice,
                         guided_decoding_backend=guided_decoding_backend))
 
     assert completion.id is not None
     assert len(completion.choices) == 2
     for i in range(2):
-        assert completion.choices[i].text in sample_guided_choice
+        assert completion.choices[i].text in sample_choice
 
 
 @pytest.mark.asyncio

--- a/tests/model_executor/test_guided_processors.py
+++ b/tests/model_executor/test_guided_processors.py
@@ -14,7 +14,7 @@ from vllm.model_executor.guided_decoding import (
     get_local_guided_decoding_logits_processor)
 from vllm.model_executor.guided_decoding.outlines_logits_processors import (
     JSONLogitsProcessor, RegexLogitsProcessor)
-from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import StructuredOuputsParams
 
 MODEL_NAME = 'HuggingFaceH4/zephyr-7b-beta'
 GUIDED_DECODING_BACKENDS = [
@@ -76,7 +76,7 @@ async def test_guided_logits_processor_black_box(backend: str, is_local: bool,
         seed=0,
         dtype="bfloat16",
     )
-    regex_request = GuidedDecodingParams(regex=sample_regex, backend=backend)
+    regex_request = StructuredOuputsParams(regex=sample_regex, backend=backend)
 
     regex_lp = get_local_guided_decoding_logits_processor(
             regex_request, zephyr_7B_tokenzer, config) if is_local else \
@@ -90,8 +90,8 @@ async def test_guided_logits_processor_black_box(backend: str, is_local: bool,
     assert tensor.shape == original_tensor.shape
     assert not torch.allclose(tensor, original_tensor)
 
-    json_request = GuidedDecodingParams(json=sample_json_schema,
-                                        backend=backend)
+    json_request = StructuredOuputsParams(json=sample_json_schema,
+                                          backend=backend)
     json_lp = await get_guided_decoding_logits_processor(
         json_request, zephyr_7B_tokenzer, config)
     assert json_lp is not None
@@ -122,7 +122,7 @@ async def test_guided_logits_processor_with_reasoning(
     )
     token_ids = deepseek_r1_qwen_tokenizer.encode(
         "<think>here is the thinking process")
-    regex_request = GuidedDecodingParams(regex=sample_regex, backend=backend)
+    regex_request = StructuredOuputsParams(regex=sample_regex, backend=backend)
 
     regex_lp = get_local_guided_decoding_logits_processor(regex_request,
                     deepseek_r1_qwen_tokenizer, config,
@@ -139,8 +139,8 @@ async def test_guided_logits_processor_with_reasoning(
 
     token_ids = deepseek_r1_qwen_tokenizer.encode(
         "<think>here is the thinking process")
-    json_request = GuidedDecodingParams(json=sample_json_schema,
-                                        backend=backend)
+    json_request = StructuredOuputsParams(json=sample_json_schema,
+                                          backend=backend)
     json_lp = get_local_guided_decoding_logits_processor(
         json_request, deepseek_r1_qwen_tokenizer, config,
         reasoning_backend) if is_local else \
@@ -156,8 +156,8 @@ async def test_guided_logits_processor_with_reasoning(
     # Thinking is over, so the tensor should change.
     token_ids = deepseek_r1_qwen_tokenizer.encode(
         "<think>here is the thinking process</think>")
-    json_request = GuidedDecodingParams(json=sample_json_schema,
-                                        backend=backend)
+    json_request = StructuredOuputsParams(json=sample_json_schema,
+                                          backend=backend)
     json_lp = get_local_guided_decoding_logits_processor(
         json_request, deepseek_r1_qwen_tokenizer, config,
         reasoning_backend) if is_local else \
@@ -174,25 +174,25 @@ async def test_guided_logits_processor_with_reasoning(
 def test_multiple_guided_options_not_allowed(sample_json_schema, sample_regex):
     with pytest.raises(ValueError,
                        match="You can only use one kind of guided"):
-        GuidedDecodingParams(json=sample_json_schema, regex=sample_regex)
+        StructuredOuputsParams(json=sample_json_schema, regex=sample_regex)
 
     with pytest.raises(ValueError,
                        match="You can only use one kind of guided"):
-        GuidedDecodingParams(json=sample_json_schema, json_object=True)
+        StructuredOuputsParams(json=sample_json_schema, json_object=True)
 
     with pytest.raises(ValueError,
                        match="You can only use one kind of guided"):
-        GuidedDecodingParams(json=sample_json_schema, choice=["a", "b"])
+        StructuredOuputsParams(json=sample_json_schema, choice=["a", "b"])
 
     with pytest.raises(ValueError,
                        match="You can only use one kind of guided"):
-        GuidedDecodingParams(json=sample_json_schema, grammar="test grammar")
+        StructuredOuputsParams(json=sample_json_schema, grammar="test grammar")
 
 
 def test_guided_decoding_backend_options():
     """Test backend-specific options"""
     with pytest.warns(DeprecationWarning):
-        guided_decoding_params = GuidedDecodingParams(
+        guided_decoding_params = StructuredOuputsParams(
             backend=
             "xgrammar:no-fallback,disable-any-whitespace,no-additional-properties"
         )

--- a/tests/models/language/generation/test_mistral.py
+++ b/tests/models/language/generation/test_mistral.py
@@ -9,7 +9,7 @@ import pytest
 
 from vllm.entrypoints.openai.tool_parsers.mistral_tool_parser import (
     MistralToolCall, MistralToolParser)
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOuputsParams
 from vllm.transformers_utils.tokenizer import MistralTokenizer
 
 from ...utils import check_logprobs_close
@@ -293,10 +293,10 @@ def test_mistral_guided_decoding(
                 tokenizer_mode="mistral",
                 guided_decoding_backend=guided_backend,
         ) as vllm_model:
-            guided_decoding = GuidedDecodingParams(json=SAMPLE_JSON_SCHEMA)
+            guided_decoding = StructuredOuputsParams(json=SAMPLE_JSON_SCHEMA)
             params = SamplingParams(max_tokens=512,
                                     temperature=0.7,
-                                    guided_decoding=guided_decoding)
+                                    structured_outputs=guided_decoding)
 
             messages = [{
                 "role": "system",

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -9,7 +9,7 @@ import torch
 from vllm.config import (CacheConfig, KVTransferConfig, ModelConfig,
                          SchedulerConfig, SpeculativeConfig, VllmConfig)
 from vllm.multimodal.inputs import MultiModalKwargs, PlaceholderRange
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOuputsParams
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -1874,11 +1874,11 @@ def test_schedule_skip_tokenizer_init():
 
 def test_schedule_skip_tokenizer_init_structured_output_request():
     scheduler = create_scheduler(skip_tokenizer_init=True)
-    guided_params = GuidedDecodingParams(regex="[0-9]+")
+    guided_params = StructuredOuputsParams(regex="[0-9]+")
     sampling_params = SamplingParams(
         ignore_eos=False,
         max_tokens=16,
-        guided_decoding=guided_params,
+        structured_outputs=guided_params,
     )
     request = Request(
         request_id="0",

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional
 import pytest
 
 from vllm import LLM
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+from vllm.sampling_params import SamplingParams, StructuredOuputsParams
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ def _get_test_sampling_params(
             top_p=0.95,
             n=n,
             seed=seed,
-            guided_decoding=GuidedDecodingParams(
+            structured_outputs=StructuredOuputsParams(
                 regex="[0-9]+") if structured_outputs else None,
         ) for n in n_list
     ], n_list

--- a/tests/v1/entrypoints/conftest.py
+++ b/tests/v1/entrypoints/conftest.py
@@ -151,7 +151,7 @@ def sample_definition_json_schema():
 
 
 @pytest.fixture
-def sample_guided_choice():
+def sample_choice():
     return [
         "Python", "Java", "JavaScript", "C++", "C#", "PHP", "TypeScript",
         "Ruby", "Swift", "Kotlin"

--- a/tests/v1/entrypoints/llm/test_struct_output_generate.py
+++ b/tests/v1/entrypoints/llm/test_struct_output_generate.py
@@ -14,6 +14,7 @@ import regex as re
 from pydantic import BaseModel
 
 from tests.reasoning.utils import run_reasoning_extraction
+from vllm.config import StructuredOutputsConfig
 from vllm.entrypoints.llm import LLM
 from vllm.outputs import RequestOutput
 from vllm.platforms import current_platform
@@ -21,7 +22,7 @@ from vllm.reasoning.abs_reasoning_parsers import ReasoningParserManager
 from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 
 if TYPE_CHECKING:
-    from vllm.config import TokenizerMode
+    from vllm.config import StructuredOutputsBackend, TokenizerMode
 
 NGRAM_SPEC_CONFIG = {
     "model": "[ngram]",
@@ -85,7 +86,7 @@ def _load_json(s: str, backend: str) -> str:
 
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
-    "model_name, guided_decoding_backend, tokenizer_mode, speculative_config",
+    "model_name, structured_outputs_backend, tokenizer_mode, speculative_config",
     PARAMS_MODELS_BACKENDS_TOKENIZER_MODE)
 def test_structured_output(
     monkeypatch: pytest.MonkeyPatch,
@@ -95,8 +96,8 @@ def test_structured_output(
     sample_sql_lark: str,
     sample_regex: str,
     sample_guided_choice: str,
-    guided_decoding_backend: str,
-    tokenizer_mode: str,
+    structured_outputs_backend: StructuredOutputsBackend,
+    tokenizer_mode: TokenizerMode,
     model_name: str,
     speculative_config: dict[str, Any],
 ):
@@ -114,9 +115,10 @@ def test_structured_output(
         model=model_name,
         enforce_eager=enforce_eager,
         max_model_len=1024,
-        guided_decoding_backend=guided_decoding_backend,
-        guided_decoding_disable_any_whitespace=(guided_decoding_backend
-                                                in {"xgrammar", "guidance"}),
+        structured_outputs_config=StructuredOutputsConfig(
+            backend=structured_outputs_backend,
+            disable_any_whitespace=guided_decoding_backend in {"xgrammar", "guidance"},
+        ),
         tokenizer_mode=tokenizer_mode,
         speculative_config=speculative_config)
 
@@ -187,7 +189,7 @@ def test_structured_output(
         temperature=1.0,
         max_tokens=4096,
         guided_decoding=GuidedDecodingParams(json=unsupported_json_schema))
-    if guided_decoding_backend.startswith("xgrammar"):
+    if structured_outputs_backend.startswith("xgrammar"):
         with pytest.raises(ValueError,
                            match="The provided JSON schema contains features "
                            "not supported by xgrammar."):
@@ -532,7 +534,7 @@ Make the response as short as possible.
 
 @pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
-    "model_name, guided_decoding_backend, tokenizer_mode, reasoning_parser, speculative_config",  # noqa: E501
+    "model_name, structured_outputs_backend, tokenizer_mode, reasoning_parser, speculative_config",  # noqa: E501
     [
         ("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B", "xgrammar", "auto",
          "deepseek_r1", NGRAM_SPEC_CONFIG),
@@ -541,7 +543,7 @@ Make the response as short as possible.
 )
 def test_structured_output_with_reasoning_matrices(
     monkeypatch: pytest.MonkeyPatch,
-    guided_decoding_backend: str,
+    structured_outputs_backend: StructuredOutputsBackend,
     tokenizer_mode: TokenizerMode,
     reasoning_parser: str,
     model_name: str,
@@ -561,10 +563,12 @@ def test_structured_output_with_reasoning_matrices(
         enforce_eager=bool(not current_platform.is_tpu()),
         max_model_len=1024,
         max_num_seqs=16,
-        guided_decoding_backend=guided_decoding_backend,
-        guided_decoding_disable_any_whitespace=True,
+        structured_outputs_config=StructuredOutputsConfig(
+            backend=structured_outputs_backend,
+            disable_any_whitespace=True,
+            reasoning_parser=reasoning_parser,
+        ),
         tokenizer_mode=tokenizer_mode,
-        reasoning_parser=reasoning_parser,
         speculative_config=speculative_config,
     )
     tokenizer = llm.get_tokenizer(None)
@@ -619,14 +623,16 @@ def test_structured_output_auto_mode(
     monkeypatch: pytest.MonkeyPatch,
     unsupported_json_schema: dict[str, Any],
     model_name: str,
-    tokenizer_mode: str,
+    tokenizer_mode: TokenizerMode,
 ):
     monkeypatch.setenv("VLLM_USE_V1", "1")
 
-    llm = LLM(model=model_name,
-              max_model_len=1024,
-              guided_decoding_backend="auto",
-              tokenizer_mode=tokenizer_mode)
+    llm = LLM(
+        model=model_name,
+        max_model_len=1024,
+        structured_outputs_config=StructuredOutputsConfig(backend="auto"),
+        tokenizer_mode=tokenizer_mode,
+    )
 
     sampling_params = SamplingParams(
         temperature=1.0,
@@ -668,9 +674,11 @@ def test_guidance_no_additional_properties(monkeypatch: pytest.MonkeyPatch):
 
     llm = LLM(model="Qwen/Qwen2.5-1.5B-Instruct",
               max_model_len=1024,
-              guided_decoding_backend="guidance",
-              guided_decoding_disable_any_whitespace=True,
-              guided_decoding_disable_additional_properties=True)
+              structured_outputs_config=StructuredOutputsConfig(
+                  backend='guidance',
+                  disable_any_whitespace=True,
+                  disable_additional_properties=True,
+              ))
 
     schema = {
         'type': 'object',

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -10,7 +10,7 @@ import json
 import sys
 import threading
 import warnings
-from dataclasses import MISSING, dataclass, fields, is_dataclass
+from dataclasses import MISSING, asdict, dataclass, fields, is_dataclass
 from itertools import permutations
 from typing import (TYPE_CHECKING, Annotated, Any, Callable, Dict, List,
                     Literal, Optional, Type, TypeVar, Union, cast, get_args,
@@ -23,17 +23,18 @@ from typing_extensions import TypeIs, deprecated
 
 import vllm.envs as envs
 from vllm.config import (BlockSize, CacheConfig, CacheDType, CompilationConfig,
-                         ConfigFormat, ConfigType, DecodingConfig,
-                         DetailedTraceModules, Device, DeviceConfig,
-                         DistributedExecutorBackend, GuidedDecodingBackend,
-                         GuidedDecodingBackendV1, HfOverrides, KVEventsConfig,
-                         KVTransferConfig, LoadConfig, LoadFormat, LoRAConfig,
-                         ModelConfig, ModelDType, ModelImpl, MultiModalConfig,
+                         ConfigFormat, ConfigType, DetailedTraceModules,
+                         Device, DeviceConfig, DistributedExecutorBackend,
+                         HfOverrides, KVEventsConfig, KVTransferConfig,
+                         LoadConfig, LoadFormat, LoRAConfig, ModelConfig,
+                         ModelDType, ModelImpl, MultiModalConfig,
                          ObservabilityConfig, ParallelConfig, PoolerConfig,
                          PrefixCachingHashAlgo, PromptAdapterConfig,
                          SchedulerConfig, SchedulerPolicy, SpeculativeConfig,
-                         TaskOption, TokenizerMode, TokenizerPoolConfig,
-                         VllmConfig, get_attr_docs, get_field)
+                         StructuredOutputsBackend, StructuredOutputsBackendV1,
+                         StructuredOutputsConfig, TaskOption, TokenizerMode,
+                         TokenizerPoolConfig, VllmConfig, get_attr_docs,
+                         get_field)
 from vllm.logger import init_logger
 from vllm.platforms import CpuArchEnum, current_platform
 from vllm.plugins import load_general_plugins
@@ -429,13 +430,8 @@ class EngineArgs:
 
     disable_hybrid_kv_cache_manager: bool = (
         SchedulerConfig.disable_hybrid_kv_cache_manager)
-
-    guided_decoding_backend: GuidedDecodingBackend = DecodingConfig.backend
-    guided_decoding_disable_fallback: bool = DecodingConfig.disable_fallback
-    guided_decoding_disable_any_whitespace: bool = \
-        DecodingConfig.disable_any_whitespace
-    guided_decoding_disable_additional_properties: bool = \
-        DecodingConfig.disable_additional_properties
+    structured_outputs_config: StructuredOutputsConfig = get_field(
+        VllmConfig, "structured_outputs_config")
     logits_processor_pattern: Optional[
         str] = ModelConfig.logits_processor_pattern
 
@@ -475,8 +471,6 @@ class EngineArgs:
 
     additional_config: dict[str, Any] = \
         get_field(VllmConfig, "additional_config")
-    enable_reasoning: Optional[bool] = None  # DEPRECATED
-    reasoning_parser: str = DecodingConfig.reasoning_backend
 
     use_tqdm_on_load: bool = LoadConfig.use_tqdm_on_load
     pt_load_map_location: str = LoadConfig.pt_load_map_location
@@ -621,24 +615,29 @@ class EngineArgs:
         load_group.add_argument('--pt-load-map-location',
                                 **load_kwargs["pt_load_map_location"])
 
-        # Guided decoding arguments
-        guided_decoding_kwargs = get_kwargs(DecodingConfig)
-        guided_decoding_group = parser.add_argument_group(
-            title="DecodingConfig",
-            description=DecodingConfig.__doc__,
+        # Structured outputs arguments
+        structured_outputs_kwargs = get_kwargs(StructuredOutputsConfig)
+        structured_outputs_group = parser.add_argument_group(
+            title="StructuredOutputsConfig",
+            description=f"[DEPRECATED] {StructuredOutputsConfig.__doc__}",
         )
-        guided_decoding_group.add_argument("--guided-decoding-backend",
-                                           **guided_decoding_kwargs["backend"])
-        guided_decoding_group.add_argument(
+        structured_outputs_group.add_argument(
+            "--guided-decoding-backend",
+            deprecated=True,
+            **structured_outputs_kwargs["backend"])
+        structured_outputs_group.add_argument(
             "--guided-decoding-disable-fallback",
-            **guided_decoding_kwargs["disable_fallback"])
-        guided_decoding_group.add_argument(
+            deprecated=True,
+            **structured_outputs_kwargs["disable_fallback"])
+        structured_outputs_group.add_argument(
             "--guided-decoding-disable-any-whitespace",
-            **guided_decoding_kwargs["disable_any_whitespace"])
-        guided_decoding_group.add_argument(
+            deprecated=True,
+            **structured_outputs_kwargs["disable_any_whitespace"])
+        structured_outputs_group.add_argument(
             "--guided-decoding-disable-additional-properties",
-            **guided_decoding_kwargs["disable_additional_properties"])
-        guided_decoding_group.add_argument(
+            deprecated=True,
+            **structured_outputs_kwargs["disable_additional_properties"])
+        structured_outputs_group.add_argument(
             "--enable-reasoning",
             action=argparse.BooleanOptionalAction,
             deprecated=True,
@@ -647,11 +646,12 @@ class EngineArgs:
             "parser backend instead. This flag (`--enable-reasoning`) will be "
             "removed in v0.10.0. When `--reasoning-parser` is specified, "
             "reasoning mode is automatically enabled.")
-        guided_decoding_group.add_argument(
+        structured_outputs_group.add_argument(
             "--reasoning-parser",
+            deprecated=True,
             # This choices is a special case because it's not static
             choices=list(ReasoningParserManager.reasoning_parsers),
-            **guided_decoding_kwargs["reasoning_backend"])
+            **structured_outputs_kwargs["reasoning_backend"])
 
         # Parallel arguments
         parallel_kwargs = get_kwargs(ParallelConfig)
@@ -936,6 +936,8 @@ class EngineArgs:
                                 **vllm_kwargs["compilation_config"])
         vllm_group.add_argument("--additional-config",
                                 **vllm_kwargs["additional_config"])
+        vllm_group.add_argument('--structured-outputs-config',
+                                **vllm_kwargs["structured_outputs_config"])
 
         # Other arguments
         parser.add_argument('--use-v2-block-manager',
@@ -1079,6 +1081,35 @@ class EngineArgs:
             self.speculative_config)
 
         return speculative_config
+
+    def create_structured_outputs_config(
+        self,
+        backend: str,
+        disable_fallback: bool,
+        disable_any_whitespace: bool,
+        disable_additional_properties: bool,
+        reasoning_parser: str,
+    ) -> StructuredOutputsConfig:
+        default_value = asdict(self.structured_outputs_config)
+
+        updates: dict[str, Any] = {}
+        if backend != default_value["backend"]:
+            updates["backend"] = backend
+        if disable_fallback != default_value["disable_fallback"]:
+            updates["disable_fallback"] = disable_fallback
+        if disable_any_whitespace != default_value["disable_any_whitespace"]:
+            updates["disable_any_whitespace"] = disable_any_whitespace
+        if disable_additional_properties != \
+                default_value["disable_additional_properties"]:
+            updates["disable_additional_properties"] = \
+                    disable_additional_properties
+        if reasoning_parser != default_value["reasoning_backend"]:
+            updates["reasoning_backend"] = reasoning_parser
+
+        if updates:
+            default_value.update(updates)
+
+        return StructuredOutputsConfig(**default_value)
 
     def create_engine_config(
         self,
@@ -1316,20 +1347,19 @@ class EngineArgs:
             max_prompt_adapter_token=self.max_prompt_adapter_token) \
                                         if self.enable_prompt_adapter else None
 
-        decoding_config = DecodingConfig(
-            backend=self.guided_decoding_backend,
-            disable_fallback=self.guided_decoding_disable_fallback,
-            disable_any_whitespace=self.guided_decoding_disable_any_whitespace,
-            disable_additional_properties=\
-                self.guided_decoding_disable_additional_properties,
-            reasoning_backend=self.reasoning_parser
-        )
-
         observability_config = ObservabilityConfig(
             show_hidden_metrics_for_version=self.
             show_hidden_metrics_for_version,
             otlp_traces_endpoint=self.otlp_traces_endpoint,
             collect_detailed_traces=self.collect_detailed_traces,
+        )
+        structured_outputs_config = self.create_structured_outputs_config(
+            backend=self.guided_decoding_backend,
+            disable_fallback=self.guided_decoding_disable_fallback,
+            disable_any_whitespace=self.guided_decoding_disable_any_whitespace,
+            disable_additional_properties=self.
+            guided_decoding_disable_additional_properties,
+            reasoning_parser=self.reasoning_parser,
         )
 
         config = VllmConfig(
@@ -1341,7 +1371,7 @@ class EngineArgs:
             lora_config=lora_config,
             speculative_config=speculative_config,
             load_config=load_config,
-            decoding_config=decoding_config,
+            structured_outputs_config=structured_outputs_config,
             observability_config=observability_config,
             prompt_adapter_config=prompt_adapter_config,
             compilation_config=self.compilation_config,
@@ -1391,12 +1421,13 @@ class EngineArgs:
                                recommend_to_remove=True)
             return False
 
-        if self.guided_decoding_backend not in get_args(
-                GuidedDecodingBackendV1):
+        if self.structured_outputs_config.backend \
+                not in get_args(StructuredOutputsBackendV1):
             _raise_or_fallback(
                 feature_name=
-                f"--guided-decoding-backend={self.guided_decoding_backend}",
-                recommend_to_remove=False)
+                f"""--structured_outputs_config '{{"backend": "{self.structured_outputs_config.backend}"}}'""",  # noqa: E501
+                recommend_to_remove=False,
+            )
             return False
 
         # Need at least Ampere for now (FA support required).
@@ -1748,6 +1779,72 @@ class EngineArgs:
 
             logger.debug("Setting max_num_seqs to %d for %s usage context.",
                          self.max_num_seqs, use_context_value)
+
+    @property
+    @deprecated(
+        "`guided_decoding_backend` is deprecated and has been renamed to `structured_output_config.backend`. This will be removed in v0.10.0. Please use the `backend` argument in `structured_output_config` instead."  # noqa: E501
+    )
+    def guided_decoding_backend(self) -> StructuredOutputsBackend:
+        return self.structured_outputs_config.backend
+
+    @guided_decoding_backend.setter
+    def guided_decoding_backend(self, value: StructuredOutputsBackend):
+        self.structured_outputs_config.backend = value
+
+    @property
+    @deprecated(
+        "`guided_decoding_disable_fallback` is deprecated and has been renamed to `structured_output_config.disable_fallback`. This will be removed in v0.10.0. Please use the `disable_fallback` argument in `structured_output_config` instead."  # noqa: E501
+    )
+    def guided_decoding_disable_fallback(self) -> bool:
+        return self.structured_outputs_config.disable_fallback
+
+    @guided_decoding_disable_fallback.setter
+    def guided_decoding_disable_fallback(self, value: bool):
+        self.structured_outputs_config.disable_fallback = value
+
+    @property
+    @deprecated(
+        "`guided_decoding_disable_any_whitespace` is deprecated and has been renamed to `structured_output_config.disable_any_whitespace`. This will be removed in v0.10.0. Please use the `disable_any_whitespace` argument in `structured_output_config` instead."  # noqa: E501
+    )
+    def guided_decoding_disable_any_whitespace(self) -> bool:
+        return self.structured_outputs_config.disable_any_whitespace
+
+    @guided_decoding_disable_any_whitespace.setter
+    def guided_decoding_disable_any_whitespace(self, value: bool):
+        self.structured_outputs_config.disable_any_whitespace = value
+
+    @property
+    @deprecated(
+        "`guided_decoding_disable_additional_properties` is deprecated and has been renamed to `structured_output_config.disable_additional_properties`. This will be removed in v0.10.0. Please use the `disable_additional_properties` argument in `structured_output_config` instead."  # noqa: E501
+    )
+    def guided_decoding_disable_additional_properties(self) -> bool:
+        return self.structured_outputs_config.disable_additional_properties
+
+    @guided_decoding_disable_additional_properties.setter
+    def guided_decoding_disable_additional_properties(self, value: bool):
+        self.structured_outputs_config.disable_additional_properties = value
+
+    @property
+    @deprecated(
+        "`enable_reasoning` is deprecated and not being used. This will be removed in v0.10.0. Please check based on `reasoning_parser` instead."  # noqa: E501
+    )
+    def enable_reasoning(self) -> Optional[bool]:
+        return None
+
+    @enable_reasoning.setter
+    def enable_reasoning(self, value: Optional[bool]):
+        self.enable_reasoning = value
+
+    @property
+    @deprecated(
+        "`reasoning_parser` is deprecated and has been renamed to `structured_output_config.reasoning_backend`. This will be removed in v0.10.0. Please use the `reasoning_backend` argument in `structured_output_config` instead."  # noqa: E501
+    )
+    def reasoning_parser(self) -> str:
+        return self.structured_outputs_config.reasoning_backend
+
+    @reasoning_parser.setter
+    def reasoning_parser(self, value: str):
+        self.structured_outputs_config.reasoning_backend = value
 
 
 @dataclass

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -11,8 +11,8 @@ from typing import (Any, AsyncGenerator, Callable, Dict, Iterable, List,
 from weakref import ReferenceType
 
 import vllm.envs as envs
-from vllm.config import (DecodingConfig, LoRAConfig, ModelConfig,
-                         ParallelConfig, SchedulerConfig, VllmConfig)
+from vllm.config import (LoRAConfig, ModelConfig, ParallelConfig,
+                         SchedulerConfig, StructuredOutputsConfig, VllmConfig)
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_timeout import asyncio_timeout
@@ -479,8 +479,9 @@ class _AsyncLLMEngine(LLMEngine):
             params = await build_guided_decoding_logits_processor_async(
                 sampling_params=params,
                 tokenizer=await self.get_tokenizer_async(lora_request),
-                default_guided_backend=self.decoding_config.backend,
-                reasoning_backend=self.decoding_config.reasoning_backend,
+                default_guided_backend=self.structured_outputs_config.backend,
+                reasoning_backend=self.structured_outputs_config.
+                reasoning_backend,
                 model_config=self.model_config)
 
         self._add_processed_request(
@@ -1033,7 +1034,7 @@ class AsyncLLMEngine(EngineClient):
         ```
         # Please refer to entrypoints/api_server.py for
         # the complete example.
-    
+
         # initialize the engine and the example input
         # note that engine_args here is AsyncEngineArgs instance
         engine = AsyncLLMEngine.from_engine_args(engine_args)
@@ -1041,13 +1042,13 @@ class AsyncLLMEngine(EngineClient):
             "input": "What is LLM?",
             "request_id": 0,
         }
-    
+
         # start the generation
         results_generator = engine.encode(
         example_input["input"],
         PoolingParams(),
         example_input["request_id"])
-    
+
         # get the results
         final_output = None
         async for request_output in results_generator:
@@ -1057,7 +1058,7 @@ class AsyncLLMEngine(EngineClient):
                 # Return or raise an error
                 ...
             final_output = request_output
-    
+
         # Process and return the final output
         ...
         ```
@@ -1119,7 +1120,7 @@ class AsyncLLMEngine(EngineClient):
         """Get the parallel configuration of the vLLM engine."""
         return self.engine.get_parallel_config()
 
-    async def get_decoding_config(self) -> DecodingConfig:
+    async def get_decoding_config(self) -> StructuredOutputsConfig:
         """Get the decoding configuration of the vLLM engine."""
         return self.engine.get_decoding_config()
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -17,9 +17,9 @@ import torch
 from typing_extensions import TypeVar
 
 import vllm.envs as envs
-from vllm.config import (DecodingConfig, LoRAConfig, ModelConfig,
-                         ObservabilityConfig, ParallelConfig, SchedulerConfig,
-                         VllmConfig)
+from vllm.config import (LoRAConfig, ModelConfig, ObservabilityConfig,
+                         ParallelConfig, SchedulerConfig,
+                         StructuredOutputsConfig, VllmConfig)
 from vllm.core.scheduler import ScheduledSequenceGroup, SchedulerOutputs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.metrics_types import StatLoggerBase, Stats
@@ -221,8 +221,8 @@ class LLMEngine:
         self.device_config = vllm_config.device_config
         self.speculative_config = vllm_config.speculative_config  # noqa
         self.load_config = vllm_config.load_config
-        self.decoding_config = vllm_config.decoding_config or DecodingConfig(  # noqa
-        )
+        self.structured_outputs_config = vllm_config.structured_outputs_config \
+                or StructuredOutputsConfig()
         self.prompt_adapter_config = vllm_config.prompt_adapter_config  # noqa
         self.observability_config = vllm_config.observability_config or ObservabilityConfig(  # noqa
         )
@@ -840,9 +840,9 @@ class LLMEngine:
         """Gets the parallel configuration."""
         return self.parallel_config
 
-    def get_decoding_config(self) -> DecodingConfig:
+    def get_decoding_config(self) -> StructuredOutputsConfig:
         """Gets the decoding configuration."""
-        return self.decoding_config
+        return self.structured_outputs_config
 
     def get_scheduler_config(self) -> SchedulerConfig:
         """Gets the scheduler configuration."""
@@ -1248,7 +1248,7 @@ class LLMEngine:
         engine = LLMEngine.from_engine_args(engine_args)
         example_inputs = [(0, "What is LLM?",
         SamplingParams(temperature=0.0))]
-    
+
         # Start the engine with an event loop
         while True:
             if example_inputs:
@@ -2042,17 +2042,18 @@ class LLMEngine:
 
             tokenizer = self.get_tokenizer(lora_request=lora_request)
             guided_decoding.backend = guided_decoding.backend or \
-                self.decoding_config.backend
+                self.structured_outputs_config.backend
 
-            if self.decoding_config.reasoning_backend:
+            if self.structured_outputs_config.reasoning_backend:
                 logger.debug("Building with reasoning backend %s",
-                             self.decoding_config.reasoning_backend)
+                             self.structured_outputs_config.reasoning_backend)
 
             processor = get_local_guided_decoding_logits_processor(
                 guided_params=guided_decoding,
                 tokenizer=tokenizer,
                 model_config=self.model_config,
-                reasoning_backend=self.decoding_config.reasoning_backend,
+                reasoning_backend=self.structured_outputs_config.
+                reasoning_backend,
             )
             if processor:
                 logits_processors.append(processor)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -700,7 +700,7 @@ class LLMEngine:
                              "Priority scheduling is not enabled.")
 
         if isinstance(params, SamplingParams) \
-            and (params.guided_decoding or params.logits_processors) \
+            and (params.structured_outputs or params.logits_processors) \
             and self.scheduler_config.num_scheduler_steps > 1:
             raise ValueError(
                 "Guided decoding and logits processors are not supported "
@@ -839,10 +839,6 @@ class LLMEngine:
     def get_parallel_config(self) -> ParallelConfig:
         """Gets the parallel configuration."""
         return self.parallel_config
-
-    def get_decoding_config(self) -> StructuredOutputsConfig:
-        """Gets the decoding configuration."""
-        return self.structured_outputs_config
 
     def get_scheduler_config(self) -> SchedulerConfig:
         """Gets the scheduler configuration."""
@@ -2030,11 +2026,11 @@ class LLMEngine:
 
         logits_processors = []
 
-        if sampling_params.guided_decoding is not None:
+        if sampling_params.structured_outputs is not None:
             # Defensively copy sampling params since guided decoding logits
             # processors can have different state for each request
             sampling_params = copy.copy(sampling_params)
-            guided_decoding = sampling_params.guided_decoding
+            guided_decoding = sampling_params.structured_outputs
 
             logger.debug(
                 "Building guided decoding logits processor in "
@@ -2059,7 +2055,7 @@ class LLMEngine:
                 logits_processors.append(processor)
 
             # Unset so this doesn't get passed down to the model
-            sampling_params.guided_decoding = None
+            sampling_params.structured_outputs = None
 
         if (sampling_params.logit_bias or sampling_params.allowed_token_ids):
             tokenizer = self.get_tokenizer(lora_request=lora_request)

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -16,7 +16,7 @@ from zmq import Frame  # type: ignore[attr-defined]
 from zmq.asyncio import Socket
 
 from vllm import PoolingParams
-from vllm.config import DecodingConfig, ModelConfig, VllmConfig
+from vllm.config import ModelConfig, StructuredOutputsConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -96,7 +96,7 @@ class MQLLMEngineClient(EngineClient):
         # Get the configs.
         self.vllm_config = engine_config
         self.model_config = engine_config.model_config
-        self.decoding_config = engine_config.decoding_config
+        self.structured_outputs_config = engine_config.structured_outputs_config
 
         # Create the tokenizer group.
         self.tokenizer = init_tokenizer_from_configs(
@@ -381,8 +381,8 @@ class MQLLMEngineClient(EngineClient):
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config
 
-    async def get_decoding_config(self) -> DecodingConfig:
-        return self.decoding_config
+    async def get_decoding_config(self) -> StructuredOutputsConfig:
+        return self.structured_outputs_config
 
     async def get_model_config(self) -> ModelConfig:
         return self.model_config
@@ -544,11 +544,11 @@ class MQLLMEngineClient(EngineClient):
                 build_guided_decoding_logits_processor_async(
                     sampling_params=params,
                     tokenizer=await self.get_tokenizer(lora_request),
-                    default_guided_backend=(self.decoding_config.backend
-                        if self.decoding_config
-                        else DecodingConfig.backend),
+                    default_guided_backend=(self.structured_outputs_config.backend
+                        if self.structured_outputs_config
+                        else StructuredOutputsConfig.backend),
                     model_config=self.model_config,
-                    reasoning_backend=self.decoding_config.reasoning_backend,
+                    reasoning_backend=self.structured_outputs_config.reasoning_backend,
                 )
 
         # 1) Create output queue for this requests.

--- a/vllm/engine/multiprocessing/client.py
+++ b/vllm/engine/multiprocessing/client.py
@@ -381,9 +381,6 @@ class MQLLMEngineClient(EngineClient):
     async def get_vllm_config(self) -> VllmConfig:
         return self.vllm_config
 
-    async def get_decoding_config(self) -> StructuredOutputsConfig:
-        return self.structured_outputs_config
-
     async def get_model_config(self) -> ModelConfig:
         return self.model_config
 
@@ -539,7 +536,7 @@ class MQLLMEngineClient(EngineClient):
         # it here to avoid contending with cpu resources and the GIL on the
         # backend process.
         if isinstance(params, SamplingParams) and \
-            params.guided_decoding is not None:
+            params.structured_outputs is not None:
             params = await \
                 build_guided_decoding_logits_processor_async(
                     sampling_params=params,

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Mapping, Optional
 
 from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
-from vllm.config import DecodingConfig, ModelConfig, VllmConfig
+from vllm.config import ModelConfig, StructuredOutputsConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.inputs.data import PromptType, TokensPrompt
 from vllm.inputs.parse import is_explicit_encoder_decoder_prompt
@@ -250,7 +250,7 @@ class EngineClient(ABC):
         ...
 
     @abstractmethod
-    async def get_decoding_config(self) -> DecodingConfig:
+    async def get_decoding_config(self) -> StructuredOutputsConfig:
         """Get the decoding configuration of the vLLM engine."""
         ...
 

--- a/vllm/engine/protocol.py
+++ b/vllm/engine/protocol.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Mapping, Optional
 
 from vllm.beam_search import BeamSearchSequence, create_sort_beams_key_function
-from vllm.config import ModelConfig, StructuredOutputsConfig, VllmConfig
+from vllm.config import ModelConfig, VllmConfig
 from vllm.core.scheduler import SchedulerOutputs
 from vllm.inputs.data import PromptType, TokensPrompt
 from vllm.inputs.parse import is_explicit_encoder_decoder_prompt
@@ -247,11 +247,6 @@ class EngineClient(ABC):
     @abstractmethod
     async def get_model_config(self) -> ModelConfig:
         """Get the model configuration of the vLLM engine."""
-        ...
-
-    @abstractmethod
-    async def get_decoding_config(self) -> StructuredOutputsConfig:
-        """Get the decoding configuration of the vLLM engine."""
         ...
 
     @abstractmethod

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -17,7 +17,8 @@ from typing_extensions import TypeVar, deprecated
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence,
                               create_sort_beams_key_function)
-from vllm.config import (CompilationConfig, ModelDType, StructuredOutputsConfig, TokenizerMode, is_init_field)
+from vllm.config import (CompilationConfig, ModelDType,
+                         StructuredOutputsConfig, TokenizerMode, is_init_field)
 from vllm.engine.arg_utils import (EngineArgs, HfOverrides, PoolerConfig,
                                    TaskOption)
 from vllm.engine.llm_engine import LLMEngine
@@ -45,8 +46,8 @@ from vllm.outputs import (ClassificationRequestOutput, EmbeddingRequestOutput,
                           ScoringRequestOutput)
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
-from vllm.sampling_params import (BeamSearchParams, GuidedDecodingParams,
-                                  RequestOutputKind, SamplingParams)
+from vllm.sampling_params import (BeamSearchParams, RequestOutputKind,
+                                  SamplingParams, StructuredOuputsParams)
 from vllm.transformers_utils.tokenizer import (AnyTokenizer, MistralTokenizer,
                                                get_cached_tokenizer)
 from vllm.usage.usage_lib import UsageContext
@@ -1680,11 +1681,11 @@ class LLM:
         if guided_options is None:
             return params
 
-        if params.guided_decoding is not None:
+        if params.structured_outputs is not None:
             raise ValueError("Cannot set both guided_options_request and "
                              "params.guided_decoding.")
 
-        params.guided_decoding = GuidedDecodingParams(
+        params.structured_outputs = StructuredOuputsParams(
             json=guided_options.guided_json,
             regex=guided_options.guided_regex,
             choice=guided_options.guided_choice,

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -17,8 +17,7 @@ from typing_extensions import TypeVar, deprecated
 from vllm.beam_search import (BeamSearchInstance, BeamSearchOutput,
                               BeamSearchSequence,
                               create_sort_beams_key_function)
-from vllm.config import (CompilationConfig, ModelDType, TokenizerMode,
-                         is_init_field)
+from vllm.config import (CompilationConfig, ModelDType, StructuredOutputsConfig, TokenizerMode, is_init_field)
 from vllm.engine.arg_utils import (EngineArgs, HfOverrides, PoolerConfig,
                                    TaskOption)
 from vllm.engine.llm_engine import LLMEngine
@@ -194,6 +193,7 @@ class LLM:
         override_pooler_config: Optional[PoolerConfig] = None,
         compilation_config: Optional[Union[int, dict[str, Any],
                                            CompilationConfig]] = None,
+        structured_outputs_config: Optional[StructuredOutputsConfig] = None,
         **kwargs,
     ) -> None:
         """LLM constructor."""
@@ -241,6 +241,10 @@ class LLM:
         else:
             compilation_config_instance = CompilationConfig()
 
+        structured_outputs = StructuredOutputsConfig() \
+                if structured_outputs_config is None \
+                else structured_outputs_config
+
         engine_args = EngineArgs(
             model=model,
             task=task,
@@ -267,6 +271,7 @@ class LLM:
             mm_processor_kwargs=mm_processor_kwargs,
             override_pooler_config=override_pooler_config,
             compilation_config=compilation_config_instance,
+            structured_outputs_config=structured_outputs,
             **kwargs,
         )
 
@@ -1368,17 +1373,17 @@ class LLM:
         of your inputs into a single list and pass it to this method.
 
         Supports both text and multi-modal data (images, etc.) when used with
-        appropriate multi-modal models. For multi-modal inputs, ensure the 
+        appropriate multi-modal models. For multi-modal inputs, ensure the
         prompt structure matches the model's expected input format.
 
         Args:
-            data_1: Can be a single prompt, a list of prompts or 
-                `ScoreMultiModalParam`, which can contain either text or 
-                multi-modal data. When a list, it must have the same length as 
+            data_1: Can be a single prompt, a list of prompts or
+                `ScoreMultiModalParam`, which can contain either text or
+                multi-modal data. When a list, it must have the same length as
                 the `data_2` list.
-            data_2: The data to pair with the query to form the input to 
+            data_2: The data to pair with the query to form the input to
                 the LLM. Can be text or multi-modal data. See [PromptType]
-                [vllm.inputs.PromptType] for more details about the format of 
+                [vllm.inputs.PromptType] for more details about the format of
                 each prompt.
             use_tqdm: If `True`, shows a tqdm progress bar.
                 If a callable (e.g., `functools.partial(tqdm, leave=False)`),

--- a/vllm/model_executor/guided_decoding/__init__.py
+++ b/vllm/model_executor/guided_decoding/__init__.py
@@ -16,15 +16,15 @@ if TYPE_CHECKING:
 
     from vllm.config import ModelConfig
     from vllm.logits_process import LogitsProcessor
-    from vllm.sampling_params import GuidedDecodingParams
+    from vllm.sampling_params import StructuredOuputsParams
 
 logger = init_logger(__name__)
 
 
 def maybe_backend_fallback(
-        guided_params: GuidedDecodingParams) -> GuidedDecodingParams:
+        guided_params: StructuredOuputsParams) -> StructuredOuputsParams:
 
-    def fallback_or_error(guided_params: GuidedDecodingParams, message: str,
+    def fallback_or_error(guided_params: StructuredOuputsParams, message: str,
                           fallback: str) -> None:
         """Change the backend to the specified fallback with a warning log,
         or raise a ValueError if the `disable_fallback` option is specified."""
@@ -111,7 +111,7 @@ def maybe_backend_fallback(
 
 
 async def get_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
+        guided_params: StructuredOuputsParams,
         tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig,
         reasoning_backend: str | None = None) -> LogitsProcessor | None:
@@ -152,7 +152,7 @@ async def get_guided_decoding_logits_processor(
 
 
 def get_local_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
+        guided_params: StructuredOuputsParams,
         tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig,
         reasoning_backend: str | None = None) -> LogitsProcessor | None:

--- a/vllm/model_executor/guided_decoding/guidance_decoding.py
+++ b/vllm/model_executor/guided_decoding/guidance_decoding.py
@@ -8,13 +8,13 @@ from transformers import PreTrainedTokenizerBase
 
 from vllm.model_executor.guided_decoding.guidance_logits_processors import (
     GuidanceLogitsProcessor)
-from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import StructuredOuputsParams
 from vllm.v1.structured_output.backend_guidance import (
     process_for_additional_properties)
 
 
 def get_local_guidance_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
+        guided_params: StructuredOuputsParams,
         tokenizer: PreTrainedTokenizerBase) -> GuidanceLogitsProcessor:
     """
     Given an OpenAI-compatible request, check for guided decoding parameters

--- a/vllm/model_executor/guided_decoding/lm_format_enforcer_decoding.py
+++ b/vllm/model_executor/guided_decoding/lm_format_enforcer_decoding.py
@@ -13,11 +13,11 @@ from lmformatenforcer.integrations.vllm import (
 from transformers import PreTrainedTokenizerBase
 
 from vllm.logits_process import LogitsProcessor
-from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import StructuredOuputsParams
 
 
 def get_local_lm_format_enforcer_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
+        guided_params: StructuredOuputsParams,
         tokenizer) -> Optional[LogitsProcessor]:
     """
     Given an OpenAI-compatible request, check for guided decoding parameters

--- a/vllm/model_executor/guided_decoding/outlines_decoding.py
+++ b/vllm/model_executor/guided_decoding/outlines_decoding.py
@@ -14,7 +14,7 @@ from transformers import PreTrainedTokenizerBase
 from vllm.model_executor.guided_decoding.outlines_logits_processors import (
     JSONLogitsProcessor, RegexLogitsProcessor)
 from vllm.reasoning import ReasoningParser
-from vllm.sampling_params import GuidedDecodingParams
+from vllm.sampling_params import StructuredOuputsParams
 
 
 class GuidedDecodingMode(Enum):
@@ -32,7 +32,7 @@ _MAX_THREADPOOL_WORKERS = 16
 
 
 async def get_outlines_guided_decoding_logits_processor(
-    guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizerBase,
+    guided_params: StructuredOuputsParams, tokenizer: PreTrainedTokenizerBase,
     reasoner: Optional[ReasoningParser]
 ) -> Union[JSONLogitsProcessor, RegexLogitsProcessor, None]:
     """
@@ -58,7 +58,7 @@ async def get_outlines_guided_decoding_logits_processor(
 
 
 def get_local_outlines_guided_decoding_logits_processor(
-    guided_params: GuidedDecodingParams, tokenizer: PreTrainedTokenizerBase,
+    guided_params: StructuredOuputsParams, tokenizer: PreTrainedTokenizerBase,
     reasoner: Optional[ReasoningParser]
 ) -> Union[JSONLogitsProcessor, RegexLogitsProcessor, None]:
     """
@@ -74,7 +74,7 @@ def get_local_outlines_guided_decoding_logits_processor(
 
 
 def _get_guide_and_mode(
-    guided_params: GuidedDecodingParams
+    guided_params: StructuredOuputsParams
 ) -> Union[tuple[str, GuidedDecodingMode], tuple[None, None]]:
     if guided_params.json:
         if isinstance(guided_params.json, dict):

--- a/vllm/model_executor/guided_decoding/xgrammar_decoding.py
+++ b/vllm/model_executor/guided_decoding/xgrammar_decoding.py
@@ -30,13 +30,13 @@ if TYPE_CHECKING:
 
     from vllm.config import ModelConfig
     from vllm.reasoning import ReasoningParser
-    from vllm.sampling_params import GuidedDecodingParams
+    from vllm.sampling_params import StructuredOuputsParams
 
 logger = init_logger(__name__)
 
 
 def get_local_xgrammar_guided_decoding_logits_processor(
-        guided_params: GuidedDecodingParams,
+        guided_params: StructuredOuputsParams,
         tokenizer: PreTrainedTokenizer,
         model_config: ModelConfig,
         reasoner: ReasoningParser | None,
@@ -158,7 +158,7 @@ class GrammarConfig:
 
     @classmethod
     def from_guided_params(cls,
-                           guided_params: GuidedDecodingParams,
+                           guided_params: StructuredOuputsParams,
                            model_config: ModelConfig,
                            tokenizer: PreTrainedTokenizer,
                            max_threads: int = 8) -> GrammarConfig:

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -526,9 +526,6 @@ class AsyncLLM(EngineClient):
     async def get_model_config(self) -> ModelConfig:
         return self.model_config
 
-    async def get_decoding_config(self):
-        raise ValueError("Not Supported on V1 yet.")
-
     async def get_input_preprocessor(self) -> InputPreprocessor:
         return self.processor.input_preprocessor
 

--- a/vllm/v1/engine/processor.py
+++ b/vllm/v1/engine/processor.py
@@ -42,7 +42,7 @@ class Processor:
         self.model_config = vllm_config.model_config
         self.cache_config = vllm_config.cache_config
         self.lora_config = vllm_config.lora_config
-        self.decoding_config = vllm_config.decoding_config
+        self.structured_outputs_config = vllm_config.structured_outputs_config
         self.tokenizer = tokenizer
 
         self.generation_config_fields = (
@@ -151,7 +151,7 @@ class Processor:
                              "not enabled!")
 
     def _validate_structured_output(self, params: SamplingParams) -> None:
-        if not params.guided_decoding or not self.decoding_config:
+        if not params.guided_decoding or not self.structured_outputs_config:
             return
 
         if self.model_config.skip_tokenizer_init and params.guided_decoding:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -50,7 +50,7 @@ class Request:
             time.time()
 
         self.status = RequestStatus.WAITING
-        if sampling_params and sampling_params.guided_decoding is not None:
+        if sampling_params and sampling_params.structured_outputs is not None:
             self.status = RequestStatus.WAITING_FOR_FSM
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: Union[int, str, None] = None
@@ -63,7 +63,7 @@ class Request:
         elif sampling_params is not None:
             assert sampling_params.max_tokens is not None
             self.max_tokens = sampling_params.max_tokens
-            if sampling_params.guided_decoding is not None:
+            if sampling_params.structured_outputs is not None:
                 self.status = RequestStatus.WAITING_FOR_FSM
 
             if sampling_params.extra_args is not None:
@@ -174,7 +174,7 @@ class Request:
     @property
     def use_structured_output(self) -> bool:
         return self.sampling_params is not None and \
-            self.sampling_params.guided_decoding is not None
+            self.sampling_params.structured_outputs is not None
 
     def record_event(
         self,

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -54,7 +54,7 @@ class StructuredOutputManager:
                 lora_config=self.vllm_config.lora_config,
             ).get_lora_tokenizer(None)
             reasoning_backend = \
-                    self.vllm_config.decoding_config.reasoning_backend
+                    self.vllm_config.structured_outputs_config.reasoning_backend
             if reasoning_backend:
                 reasoner_cls = ReasoningParserManager.get_reasoning_parser(
                     reasoning_backend)
@@ -66,7 +66,7 @@ class StructuredOutputManager:
 
         if TYPE_CHECKING:
             assert request.sampling_params is not None and \
-                request.sampling_params.guided_decoding is not None
+                request.sampling_params.structured_outputs is not None
 
         # Initialize the backend the first time it is needed.
         #
@@ -74,7 +74,7 @@ class StructuredOutputManager:
         # backends on a per-request basis in V1 (for now, anyway...).
         if self.backend is None:
             assert request.sampling_params is not None
-            backend = request.sampling_params.guided_decoding.backend
+            backend = request.sampling_params.structured_outputs.backend
             vocab_size = self.vllm_config.model_config.get_vocab_size()
             if backend == "xgrammar":
                 self.backend = XgrammarBackend(

--- a/vllm/v1/structured_output/backend_guidance.py
+++ b/vllm/v1/structured_output/backend_guidance.py
@@ -60,9 +60,9 @@ class GuidanceBackend(StructuredOutputBackend):
 
     def __post_init__(self):
         self.disable_any_whitespace = \
-            self.vllm_config.decoding_config.disable_any_whitespace
+            self.vllm_config.structured_outputs_config.disable_any_whitespace
         self.disable_additional_properties = \
-            self.vllm_config.decoding_config.disable_additional_properties
+            self.vllm_config.structured_outputs_config.disable_additional_properties
 
         self.ll_tokenizer = llguidance_hf.from_tokenizer(
             self.tokenizer, self.vocab_size)

--- a/vllm/v1/structured_output/backend_outlines.py
+++ b/vllm/v1/structured_output/backend_outlines.py
@@ -157,10 +157,10 @@ class OutlinesGrammar(StructuredOutputGrammar):
 
 
 def validate_structured_output_request_outlines(params: SamplingParams):
-    if params.guided_decoding is None:
+    if params.structured_outputs is None:
         return
 
-    gd_params = params.guided_decoding
+    gd_params = params.structured_outputs
 
     if gd_params.regex:
         validate_regex_is_buildable(gd_params.regex)

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -34,7 +34,7 @@ class XgrammarBackend(StructuredOutputBackend):
 
     def __post_init__(self):
         self.disable_any_whitespace = \
-            self.vllm_config.decoding_config.disable_any_whitespace
+            self.vllm_config.structured_outputs_config.disable_any_whitespace
 
         if isinstance(self.tokenizer, MistralTokenizer):
             # NOTE: ideally, xgrammar should handle this accordingly.

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -243,10 +243,10 @@ def validate_xgrammar_grammar(sampling_params: SamplingParams) -> None:
 
     Raises ValueError if the request is not supported.
     """
-    if sampling_params.guided_decoding is None:
+    if sampling_params.structured_outputs is None:
         return
 
-    gd_params = sampling_params.guided_decoding
+    gd_params = sampling_params.structured_outputs
 
     if gd_params.regex:
         try:

--- a/vllm/v1/structured_output/request.py
+++ b/vllm/v1/structured_output/request.py
@@ -60,7 +60,7 @@ class StructuredOutputRequest:
 
 def get_structured_output_key(
         sampling_params: SamplingParams) -> StructuredOutputKey:
-    params = sampling_params.guided_decoding
+    params = sampling_params.structured_outputs
     assert params is not None, "params can't be None."
     if params.json is not None:
         if not isinstance(params.json, str):


### PR DESCRIPTION
This PR introduces the args `--structured-output-config` as a way to unify all related structured outputs config in one CLI field.
This would help simplify general UX for specifying custom options with backends.

I also remove all previous guided_decoding options in preparation for v0.10.0

This is the first of many to move all `guided_decoding` -> `structured_output` namespace. 

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
Co-authored-by: Nick Hill <nhill@redhat.com>
