### PR TITLE
add more pytorch related tests for torch nightly

### DIFF
--- a/.buildkite/test-pipeline.yaml
+++ b/.buildkite/test-pipeline.yaml
@@ -293,6 +293,7 @@ steps:
   parallelism: 4
 
 - label: PyTorch Compilation Unit Tests
+  torch_nightly: true
   source_file_dependencies:
     - vllm/
     - tests/compile
@@ -302,6 +303,7 @@ steps:
     - pytest -v -s compile/test_sequence_parallelism.py
 
 - label: PyTorch Fullgraph Smoke Test # 9min
+  torch_nightly: true
   source_file_dependencies:
   - vllm/
   - tests/compile
@@ -312,6 +314,7 @@ steps:
   - pytest -v -s compile/piecewise/test_toy_llama.py
 
 - label: PyTorch Fullgraph Test # 18min
+  torch_nightly: true
   source_file_dependencies:
   - vllm/
   - tests/compile
@@ -436,6 +439,7 @@ steps:
 #####  models test  #####
 
 - label: Basic Models Test # 24min
+  torch_nightly: true
   source_file_dependencies:
   - vllm/
   - tests/models

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -23,5 +23,11 @@ runai-model-streamer-s3==0.11.0
 tensorizer>=2.9.0
 lm-eval==0.4.8
 buildkite-test-collector==0.1.9
-
 lm-eval[api]==0.4.8 # required for model evaluation test
+
+# required for quantization test
+bitsandbytes>=0.45.3
+
+# required for minicpmo_26 test
+vector_quantize_pytorch
+vocos

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-# test
+
 logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-# comment
+
 logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-
+# test
 logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5
@@ -72,6 +72,36 @@ class GuidedDecodingParams:
             whitespace_pattern=whitespace_pattern,
             structural_tag=structural_tag,
         )
+
+    @property
+    def backend_name(self) -> str:
+        """Return the backend name without any options.
+
+        For example if the backend is "xgrammar:no-fallback", returns "xgrammar"
+        """
+        return (self.backend or "").split(":")[0]
+
+    def backend_options(self) -> list[str]:
+        """Return the backend options as a list of strings."""
+        if not self.backend or ":" not in self.backend:
+            return []
+        return self.backend.split(":")[1].split(",")
+
+    def add_option(self, opt_name: str) -> None:
+        """Adds an option to the backend options."""
+        if not self.backend:
+            self.backend = f":{opt_name}"
+        elif ":" not in self.backend:
+            self.backend += f":{opt_name}"
+        else:
+            options = set(self.backend_options())
+            options.add(opt_name)
+            self.backend = f"{self.backend_name}:{','.join(sorted(options))}"
+
+    def no_fallback(self) -> bool:
+        """Returns True if the "no-fallback" option is supplied for the guided
+        decoding backend"""
+        return "no-fallback" in self.backend_options()
 
     def __post_init__(self):
         """Validate that some fields are mutually exclusive."""

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-
+# comment
 logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -188,8 +188,7 @@ class SamplingParams(
             a first argument.
         truncate_prompt_tokens: If set to -1, will use the truncation size
             supported by the model. If set to an integer k, will use only
-            the last k tokens from the prompt (i.e., left truncation).
-            Defaults to None (i.e., no truncation).
+            the last k tokens from the prompt (i.e., left truncation). 
         guided_decoding: If provided, the engine will construct a guided
             decoding logits processor from these parameters. Defaults to None.
         logit_bias: If provided, the engine will construct a logits processor

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -14,7 +14,7 @@ from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
-
+# test
 logger = init_logger(__name__)
 
 _SAMPLING_EPS = 1e-5

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -188,7 +188,8 @@ class SamplingParams(
             a first argument.
         truncate_prompt_tokens: If set to -1, will use the truncation size
             supported by the model. If set to an integer k, will use only
-            the last k tokens from the prompt (i.e., left truncation). 
+            the last k tokens from the prompt (i.e., left truncation).
+            Defaults to None (i.e., no truncation).
         guided_decoding: If provided, the engine will construct a guided
             decoding logits processor from these parameters. Defaults to None.
         logit_bias: If provided, the engine will construct a logits processor

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -73,36 +73,6 @@ class GuidedDecodingParams:
             structural_tag=structural_tag,
         )
 
-    @property
-    def backend_name(self) -> str:
-        """Return the backend name without any options.
-
-        For example if the backend is "xgrammar:no-fallback", returns "xgrammar"
-        """
-        return (self.backend or "").split(":")[0]
-
-    def backend_options(self) -> list[str]:
-        """Return the backend options as a list of strings."""
-        if not self.backend or ":" not in self.backend:
-            return []
-        return self.backend.split(":")[1].split(",")
-
-    def add_option(self, opt_name: str) -> None:
-        """Adds an option to the backend options."""
-        if not self.backend:
-            self.backend = f":{opt_name}"
-        elif ":" not in self.backend:
-            self.backend += f":{opt_name}"
-        else:
-            options = set(self.backend_options())
-            options.add(opt_name)
-            self.backend = f"{self.backend_name}:{','.join(sorted(options))}"
-
-    def no_fallback(self) -> bool:
-        """Returns True if the "no-fallback" option is supplied for the guided
-        decoding backend"""
-        return "no-fallback" in self.backend_options()
-
     def __post_init__(self):
         """Validate that some fields are mutually exclusive."""
         guide_count = sum([
@@ -216,9 +186,9 @@ class SamplingParams(
         logits_processors: list of functions that modify logits based on
             previously generated tokens, and optionally prompt tokens as
             a first argument.
-        truncate_prompt_tokens: If set to -1, will use the truncation size 
-            supported by the model. If set to an integer k, will use only 
-            the last k tokens from the prompt (i.e., left truncation). 
+        truncate_prompt_tokens: If set to -1, will use the truncation size
+            supported by the model. If set to an integer k, will use only
+            the last k tokens from the prompt (i.e., left truncation).
             Defaults to None (i.e., no truncation).
         guided_decoding: If provided, the engine will construct a guided
             decoding logits processor from these parameters. Defaults to None.


### PR DESCRIPTION
Tests needed for vllm against torch nightly:
 - PyTorch compiler tests
 - basic model tests
 - Quantization tests

Testing build with vllm/ change
https://buildkite.com/vllm/ci/builds/18950

Mock tests:
Add some comment in vllm/ path: quantization is blocked, which is expected, the test block `Build torch nightly image` shows in normal nightly

![image](https://github.com/user-attachments/assets/2b6d0ea1-2b09-4d84-988a-b82cb3a981dc)

Testing nightly run:
https://buildkite.com/vllm/ci/builds/18955


No blocking which is expected
![image](https://github.com/user-attachments/assets/0692e380-ed4b-4bf9-9012-8910cd95ab69)
