### PR TITLE
[Misc][AMD] Add query_platform method to interface.py

### DIFF
--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -649,18 +649,8 @@ def get_general_autotune_configs():
     ]
 
 
-def has_cdna_target():
-    ROCM_CDNA_TARGETS = ["gfx940", "gfx941", "gfx942", "gfx90a", "gfx908"]
-    return triton.runtime.driver.active.get_current_target(
-    ).arch in ROCM_CDNA_TARGETS
-
-
-def is_rocm_cdna():
-    return current_platform.is_rocm() and has_cdna_target()
-
-
 def get_autotune_configs():
-    if is_rocm_cdna():
+    if current_platform.query_platform("has_cdna_target"):
         return get_cdna_autotune_configs()
     elif current_platform.is_rocm():
         return get_rdna_autotune_configs()

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -192,6 +192,14 @@ class Platform:
         return current_capability.to_int() >= capability
 
     @classmethod
+    def query_platform(cls, property):
+        if hasattr(cls, property):
+            has_property_fn = getattr(cls, property)
+            if callable(has_property_fn):
+                return has_property_fn()
+        return False
+
+    @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
         """Get the name of a device."""
         raise NotImplementedError

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -344,3 +344,10 @@ class RocmPlatform(Platform):
     def get_cu_count(cls, device_id: int = 0) -> int:
         return torch.cuda.get_device_properties(
             device_id).multi_processor_count
+
+    @classmethod
+    def has_cdna_target(cls):
+        import triton
+        ROCM_CDNA_TARGETS = ["gfx940", "gfx941", "gfx942", "gfx90a", "gfx908"]
+        return triton.runtime.driver.active.get_current_target(
+        ).arch in ROCM_CDNA_TARGETS

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -348,6 +348,6 @@ class RocmPlatform(Platform):
     @classmethod
     def has_cdna_target(cls):
         import triton
-        ROCM_CDNA_TARGETS = ["gfx940", "gfx941", "gfx942", "gfx90a", "gfx908"]
+        ROCM_CDNA_TARGETS = ["gfx942", "gfx90a", "gfx908"]
         return triton.runtime.driver.active.get_current_target(
         ).arch in ROCM_CDNA_TARGETS


### PR DESCRIPTION
This adds query_platform method to interface.py and uses it in triton_flash_attention.py.  

Since it has been undesirable to add specific methods to the Platform class, but it is sometimes necessary to have methods that can query a platform for specific information, such as "Does this platform support CDNA?", this PR adds a query_platform method.

This is similar to how OpenGL / Vulkan applicatons query for certain device capabilities via function pointers.

In order to enable an underlying platform, e.g. ROCm, to answer these queries, a simple method that only returns a boolean can be added to the underlying platform class, e.g. RocmPlatform, which if the boolean method exists can return whether the capability is supported.


<!--- pyml disable-next-line no-emphasis-as-heading -->
