### PR TITLE
[Feat] Add deprecated=True to CLI args

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -515,7 +515,6 @@ class EngineArgs:
             description=DecodingConfig.__doc__,
         )
         guided_decoding_group.add_argument("--guided-decoding-backend",
-                                           deprecated=True,
                                            **guided_decoding_kwargs["backend"])
         guided_decoding_group.add_argument(
             "--guided-decoding-disable-fallback",
@@ -529,6 +528,7 @@ class EngineArgs:
         guided_decoding_group.add_argument(
             "--enable-reasoning",
             action=argparse.BooleanOptionalAction,
+            deprecated=True,
             help="[DEPRECATED] The `--enable-reasoning` flag is deprecated as "
             "of v0.8.6. Use `--reasoning-parser` to specify the reasoning "
             "parser backend insteadThis flag (`--enable-reasoning`) will be "

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -515,6 +515,7 @@ class EngineArgs:
             description=DecodingConfig.__doc__,
         )
         guided_decoding_group.add_argument("--guided-decoding-backend",
+                                           deprecated=True,
                                            **guided_decoding_kwargs["backend"])
         guided_decoding_group.add_argument(
             "--guided-decoding-disable-fallback",

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1359,6 +1359,7 @@ class FlexibleArgumentParser(ArgumentParser):
         super().__init__(*args, **kwargs)
 
     if sys.version_info < (3, 13):
+
         def parse_known_args(  # type: ignore[override]
             self,
             args: Sequence[str] | None = None,
@@ -1366,10 +1367,12 @@ class FlexibleArgumentParser(ArgumentParser):
         ) -> tuple[Namespace | None, list[str]]:
             namespace, args = super().parse_known_args(args, namespace)
             for action in FlexibleArgumentParser._deprecated:
-                if action.dest not in FlexibleArgumentParser._seen and getattr(namespace, action.dest, None) != action.default:
+                if action.dest not in FlexibleArgumentParser._seen and getattr(
+                        namespace, action.dest,
+                        None) != action.default:  # noqa: E501
                     self._warning(
-                        _gettext("argument '%(argument_name)s' is deprecated") %
-                        {'argument_name': action.dest})
+                        _gettext("argument '%(argument_name)s' is deprecated")
+                        % {'argument_name': action.dest})
                     FlexibleArgumentParser._seen.add(action.dest)
             return namespace, args
 

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1392,7 +1392,7 @@ class FlexibleArgumentParser(ArgumentParser):
 
     def parse_args(  # type: ignore[override]
         self,
-        args: Sequence[str] | None = None,
+        args: list[str] | None = None,
         namespace: Namespace | None = None,
     ):
         if args is None:
@@ -1565,8 +1565,11 @@ class FlexibleArgumentParser(ArgumentParser):
 
         return processed_args
 
-    def add_argument_group(self, *args: Any,
-                           **kwargs: Any) -> _FlexibleArgumentGroup:
+    def add_argument_group(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> _FlexibleArgumentGroup:
         group = _FlexibleArgumentGroup(self, self, *args, **kwargs)
         self._action_groups.append(group)
         return group

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1384,6 +1384,15 @@ class FlexibleArgumentParser(ArgumentParser):
             _gettext('warning: %(message)s\n') % {'message': message},
             sys.stderr)
 
+    def parse_known_args(
+        self,
+        args: list[str],
+        namespace: Namespace,
+    ) -> tuple[Namespace, list[str]]:
+        namespace, args = super().parse_known_args(args, namespace)
+        print(namespace)
+        return namespace, args
+
     def parse_args(  # type: ignore[override]
         self,
         args: Sequence[str] | None = None,

--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -1332,6 +1332,22 @@ class FlexibleArgumentParser(ArgumentParser):
             kwargs['formatter_class'] = SortedHelpFormatter
         super().__init__(*args, **kwargs)
 
+    def add_argument(self, *args: Any, **kwargs: Any):
+        # add a deprecated=True with optional deprecated_reason to signify
+        # reasons for deprecating this args
+        if kwargs.pop("deprecated", False):
+            deprecated_message = kwargs.pop("deprecated_reason", None)
+            if 'help' in kwargs:
+                kwargs['help'] = (
+                    f"[DEPRECATED]{(' ' + deprecated_message) or ''}.\n{kwargs['help']}"  # noqa: E501
+                )
+            else:
+                kwargs['help'] = (
+                    f"[DEPRECATED]{(' ' + deprecated_message) or ''}"  # noqa: E501
+                )
+
+        super().add_argument(*args, **kwargs)
+
     def parse_args(self, args=None, namespace=None):
         if args is None:
             args = sys.argv[1:]


### PR DESCRIPTION
This PR adds a small helper to `FlexibleArgumentParser` to
mark an argument as `deprecated`, aligning with python 3.13 and above logic

This PR also marks `--enable-reasoning` as deprecated.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
