### PR TITLE
[Bugfix] Fix AttributeError: 'State' object has no attribute 'engine_client'

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -111,7 +111,7 @@ async def init_app(
     engine = (llm_engine
               if llm_engine is not None else AsyncLLMEngine.from_engine_args(
                   engine_args, usage_context=UsageContext.API_SERVER))
-
+    app.state.engine_client = engine
     return app
 
 


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/17395

test
```
# python3 -m vllm.entrypoints.api_server --model Qwen/Qwen2.5-0.5B-Instruct --gpu-memory-utilization 0.95 --port 21131 --trust-remote-code
.....
INFO 04-30 03:08:01 [loader.py:458] Loading weights took 0.20 seconds
INFO 04-30 03:08:01 [gpu_model_runner.py:1353] Model loading took 0.9264 GiB and 1.655264 seconds
INFO 04-30 03:08:07 [backends.py:433] Using cache directory: /root/.cache/vllm/torch_compile_cache/0140516392/rank_0_0 for vLLM's torch.compile
INFO 04-30 03:08:07 [backends.py:443] Dynamo bytecode transform time: 5.92 s
INFO 04-30 03:08:11 [backends.py:118] Directly load the compiled graph(s) for shape None from the cache, took 3.840 s
INFO 04-30 03:08:12 [monitor.py:33] torch.compile takes 5.92 s in total
INFO 04-30 03:08:13 [kv_cache_utils.py:634] GPU KV cache size: 4,504,128 tokens
INFO 04-30 03:08:13 [kv_cache_utils.py:637] Maximum concurrency for 32,768 tokens per request: 137.46x
INFO 04-30 03:08:36 [gpu_model_runner.py:1697] Graph capturing finished in 22 secs, took 0.07 GiB
INFO 04-30 03:08:36 [core.py:159] init engine (profile, create kv cache, warmup model) took 34.43 seconds
INFO 04-30 03:08:36 [core_client.py:439] Core engine process 0 ready.
INFO 04-30 03:08:36 [launcher.py:28] Available routes are:
INFO 04-30 03:08:36 [launcher.py:36] Route: /openapi.json, Methods: HEAD, GET
INFO 04-30 03:08:36 [launcher.py:36] Route: /docs, Methods: HEAD, GET
INFO 04-30 03:08:36 [launcher.py:36] Route: /docs/oauth2-redirect, Methods: HEAD, GET
INFO 04-30 03:08:36 [launcher.py:36] Route: /redoc, Methods: HEAD, GET
INFO 04-30 03:08:36 [launcher.py:36] Route: /health, Methods: GET
INFO 04-30 03:08:36 [launcher.py:36] Route: /generate, Methods: POST
INFO:     Started server process [3311606]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:21131 (Press CTRL+C to quit)
```