### PR TITLE
[benchmark][structured output] Add offline benchmark script for structured output

### DIFF
--- a/benchmarks/benchmark_offline_structured_output.py
+++ b/benchmarks/benchmark_offline_structured_output.py
@@ -55,9 +55,17 @@ def _to_request_output(
 def _to_vllm_guided_decoding_params(
         args: argparse.Namespace,
         request: SampleRequest) -> GuidedDecodingParams:
+    if args.dataset in ["grammar", "regex", "json", "choice"]:
+        field_name = args.dataset
+    elif "grammar" in args.dataset:
+        field_name = "grammar"
+    elif "json" in args.dataset:
+        field_name = "json"
+    else:
+        raise ValueError(f"Unsupported dataset: {args.dataset}")
     kwargs = {
         "backend": args.structured_output_backend,
-        args.dataset: request.schema
+        field_name: request.schema
     }
     return GuidedDecodingParams(**kwargs)
 

--- a/benchmarks/benchmark_offline_structured_output.py
+++ b/benchmarks/benchmark_offline_structured_output.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+r"""Benchmark offline throughput with structured outputs.
+
+Usage:
+    python benchmarks/benchmark_offline_structured_output.py \
+        --model <your_model> \
+        --dataset json \
+        --structured-output-ratio 1.0 \
+        --structured-output-backend auto \
+        --request-rate 10 \
+        --num-prompts 1000
+
+"""
+import argparse
+import random
+
+import numpy as np
+from benchmark_serving_structured_output import (
+    SampleRequest, fill_structure_type, get_structured_output_argparser,
+    get_tokenizer_from_args, sample_requests)
+from transformers import PreTrainedTokenizerBase
+
+from vllm import LLM
+from vllm.sampling_params import GuidedDecodingParams, SamplingParams
+
+
+def benchmark_sync(args: argparse.Namespace,
+                   tokenizer: PreTrainedTokenizerBase,
+                   input_requests: list[SampleRequest]) -> list[str]:
+    llm = LLM(
+        model=args.model,
+        tokenizer=args.tokenizer if args.tokenizer is not None else args.model,
+        tokenizer_mode=args.tokenizer_mode,
+        trust_remote_code=args.trust_remote_code,
+    )
+
+    def _to_vllm_guided_decoding_params(
+            args: argparse.Namespace,
+            request: SampleRequest) -> GuidedDecodingParams:
+        kwargs = {
+            "backend": args.structured_output_backend,
+            args.dataset: request.schema
+        }
+        return GuidedDecodingParams(**kwargs)
+
+    outputs = llm.generate(
+        prompts=[req.prompt for req in input_requests],
+        sampling_params=[
+            SamplingParams(guided_decoding=_to_vllm_guided_decoding_params(
+                args, req), ) for req in input_requests
+        ],
+        use_tqdm=not args.disable_tqdm)
+    return [output.outputs[0].text for output in outputs]
+
+
+def benchmark_async(backend: str, api_url: str, base_url: str, model_id: str):
+    pass
+
+
+def main(args: argparse.Namespace):
+    print(args)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+
+    tokenizer = get_tokenizer_from_args(args)
+    fill_structure_type(args)
+
+    input_requests = sample_requests(tokenizer, args)
+
+    benchmark_sync(args=args,
+                   tokenizer=tokenizer,
+                   input_requests=input_requests)
+
+
+if __name__ == "__main__":
+    parser = get_structured_output_argparser()
+    parser.add_argument("--async",
+                        action="store_true",
+                        help="Run the benchmark in async mode.")
+    args = parser.parse_args()
+    main(args)

--- a/benchmarks/benchmark_offline_structured_output.py
+++ b/benchmarks/benchmark_offline_structured_output.py
@@ -13,20 +13,46 @@ Usage:
 """
 import argparse
 import random
+from time import perf_counter
 
 import numpy as np
+from backend_request_func import RequestFuncOutput
 from benchmark_serving_structured_output import (
-    SampleRequest, fill_structure_type, get_structured_output_argparser,
-    get_tokenizer_from_args, sample_requests)
+    SampleRequest, calculate_metrics, evaluate, fill_structure_type,
+    get_structured_output_argparser, get_tokenizer_from_args,
+    print_metrics_to_console, sample_requests)
 from transformers import PreTrainedTokenizerBase
 
 from vllm import LLM
+from vllm.outputs import RequestOutput
 from vllm.sampling_params import GuidedDecodingParams, SamplingParams
 
 
-def benchmark_sync(args: argparse.Namespace,
-                   tokenizer: PreTrainedTokenizerBase,
-                   input_requests: list[SampleRequest]) -> list[str]:
+def _to_request_output(
+        vllm_outputs: list[RequestOutput]) -> list[RequestFuncOutput]:
+    return [
+        RequestFuncOutput(
+            generated_text=output.outputs[0].text,
+            success=output.finished,
+            latency=(output.metrics.finished_time -
+                     output.metrics.arrival_time) if output.metrics else 0.0,
+            output_tokens=len(output.outputs[0].token_ids),
+            ttft=(output.metrics.first_token_time -
+                  output.metrics.arrival_time) if output.metrics else 0.0,
+        ) for output in vllm_outputs
+    ]
+
+
+def benchmark_sync(
+    args: argparse.Namespace, tokenizer: PreTrainedTokenizerBase,
+    input_requests: list[SampleRequest]
+) -> tuple[list[RequestFuncOutput], float]:
+    """
+    Benchmark synchronous offline vLLM with structured outputs.
+
+    Returns:
+        A tuple of (output texts, benchmark duration in seconds).
+    """
     llm = LLM(
         model=args.model,
         tokenizer=args.tokenizer if args.tokenizer is not None else args.model,
@@ -43,14 +69,18 @@ def benchmark_sync(args: argparse.Namespace,
         }
         return GuidedDecodingParams(**kwargs)
 
+    start = perf_counter()
     outputs = llm.generate(
         prompts=[req.prompt for req in input_requests],
         sampling_params=[
-            SamplingParams(guided_decoding=_to_vllm_guided_decoding_params(
-                args, req), ) for req in input_requests
+            SamplingParams(
+                ignore_eos=args.ignore_eos,
+                guided_decoding=_to_vllm_guided_decoding_params(args, req),
+            ) for req in input_requests
         ],
         use_tqdm=not args.disable_tqdm)
-    return [output.outputs[0].text for output in outputs]
+    end = perf_counter()
+    return outputs, end - start
 
 
 def benchmark_async(backend: str, api_url: str, base_url: str, model_id: str):
@@ -66,10 +96,30 @@ def main(args: argparse.Namespace):
     fill_structure_type(args)
 
     input_requests = sample_requests(tokenizer, args)
+    selected_percentile_metrics = []
 
-    benchmark_sync(args=args,
-                   tokenizer=tokenizer,
-                   input_requests=input_requests)
+    outputs, benchmark_duration = benchmark_sync(args=args,
+                                                 tokenizer=tokenizer,
+                                                 input_requests=input_requests)
+
+    metrics, actual_output_lens = calculate_metrics(
+        input_requests=input_requests,
+        outputs=_to_request_output(outputs),
+        dur_s=benchmark_duration,
+        tokenizer=tokenizer,
+        selected_percentile_metrics=selected_percentile_metrics,
+        selected_percentiles=[],
+        goodput_config_dict=None,
+    )
+
+    print_metrics_to_console(metrics, benchmark_duration,
+                             selected_percentile_metrics)
+
+    score = evaluate([{
+        'generated': output.outputs[0].text,
+        'expected': None
+    } for output in outputs], args)
+    print("correct_rate(%)", score, '\n')
 
 
 if __name__ == "__main__":

--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -644,7 +644,7 @@ async def benchmark(
     result = print_metrics_to_console(metrics, benchmark_duration,
                                       selected_percentile_metrics,
                                       goodput_config_dict)
-    result.merge({
+    result.update({
         "ttft_description":
         pd.Series([output.ttft for output in outputs]).describe().to_dict(),
         "tpot_description":

--- a/benchmarks/run_structured_output_benchmark.sh
+++ b/benchmarks/run_structured_output_benchmark.sh
@@ -17,11 +17,12 @@ OUTPUT_DIR=${5:-"$SCRIPT_DIR/structured_output_benchmark_results"}
 
 GUIDED_RATIO=${6:-0.5}
 
+# Define QPS values to test
+QPS_VALUES=${7:-"70,60,50,25,20,15,10"}
+QPS_VALUES=(${QPS_VALUES//,/ })
+
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
-
-# Define QPS values to test
-QPS_VALUES=(70 60 50 25 20 15 10)
 
 # Common parameters
 COMMON_PARAMS="--backend $BACKEND \


### PR DESCRIPTION
* Reuse some flags from serving version
* Tested that serving benchmark still work in V0
  - V1 serving benchmark is broken, but it was already broken on main branch
* Tested that offline benchmark work in V0/V1
* updated `run_structured_ouput_benchmark.sh` to allow config `QPS_VALUES`