### PR TITLE
[Bugfix] fix tmp_out and exp_sums dimensions

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -1780,9 +1780,9 @@ void paged_attention_custom_launcher(
 // clang-format off
 void paged_attention(
     torch::Tensor& out,         // [num_seqs, num_heads, head_size]
-    torch::Tensor& exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& exp_sums,    // [block_tables.size(0), num_heads, max_num_partitions]
     torch::Tensor& max_logits,  // [num_seqs, num_heads, max_num_partitions]
-    torch::Tensor& tmp_out,     // [num_seqs, num_heads, max_num_partitions, head_size]
+    torch::Tensor& tmp_out,     // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
     torch::Tensor& key_cache,   // [num_blocks, num_heads, head_size/x, block_size, x]
     torch::Tensor& value_cache, // [num_blocks, num_heads, head_size, block_size]

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -278,9 +278,9 @@ __launch_bounds__(NUM_THREADS, 5) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
-    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,           // [block_tables.size(0), num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [block_tables.size(0), num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   // clang-format on
@@ -792,9 +792,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
-    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,           // [block_tables.size(0), num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [block_tables.size(0), num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   // clang-format on
@@ -1501,9 +1501,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,             // [num_seqs, num_heads, max_num_partitions]
-    float* __restrict__ max_logits,           // [num_seqs, num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,               // [num_seqs, num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,             // [block_tables.size(0), num_heads, max_num_partitions]
+    float* __restrict__ max_logits,           // [block_tables.size(0), num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,               // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,             // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   UNREACHABLE_CODE
@@ -1528,9 +1528,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,            // [num_seqs, num_heads, max_num_partitions]
-    float* __restrict__ max_logits,          // [num_seqs, num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,              // [num_seqs, num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,            // [block_tables.size(0), num_heads, max_num_partitions]
+    float* __restrict__ max_logits,          // [block_tables.size(0), num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,              // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,            // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   UNREACHABLE_CODE
@@ -1781,7 +1781,7 @@ void paged_attention_custom_launcher(
 void paged_attention(
     torch::Tensor& out,         // [num_seqs, num_heads, head_size]
     torch::Tensor& exp_sums,    // [block_tables.size(0), num_heads, max_num_partitions]
-    torch::Tensor& max_logits,  // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& max_logits,  // [block_tables.size(0), num_heads, max_num_partitions]
     torch::Tensor& tmp_out,     // [block_tables.size(0), num_heads, max_num_partitions, head_size]
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
     torch::Tensor& key_cache,   // [num_blocks, num_heads, head_size/x, block_size, x]

--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -278,9 +278,9 @@ __launch_bounds__(NUM_THREADS, 5) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,           // [block_tables.size(0), num_heads, max_num_partitions]
-    float* __restrict__ max_logits,         // [block_tables.size(0), num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,             // [block_tables.size(0), num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   // clang-format on
@@ -792,9 +792,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,           // [block_tables.size(0), num_heads, max_num_partitions]
-    float* __restrict__ max_logits,         // [block_tables.size(0), num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,             // [block_tables.size(0), num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,           // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,         // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,             // [num_seqs, num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,           // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   // clang-format on
@@ -1501,9 +1501,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma16_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,             // [block_tables.size(0), num_heads, max_num_partitions]
-    float* __restrict__ max_logits,           // [block_tables.size(0), num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,               // [block_tables.size(0), num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,             // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,           // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,               // [num_seqs, num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,             // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   UNREACHABLE_CODE
@@ -1528,9 +1528,9 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
     const int q_stride,
     const int kv_block_stride,
     const int kv_head_stride,
-    float* __restrict__ exp_sums,            // [block_tables.size(0), num_heads, max_num_partitions]
-    float* __restrict__ max_logits,          // [block_tables.size(0), num_heads, max_num_partitions]
-    scalar_t* __restrict__ out,              // [block_tables.size(0), num_heads, max_num_partitions, head_size]
+    float* __restrict__ exp_sums,            // [num_seqs, num_heads, max_num_partitions]
+    float* __restrict__ max_logits,          // [num_seqs, num_heads, max_num_partitions]
+    scalar_t* __restrict__ out,              // [num_seqs, num_heads, max_num_partitions, head_size]
     OUTT* __restrict__ final_out,            // [num_seqs, num_heads, head_size]
     int max_ctx_blocks, const float* k_scale, const float* v_scale) {
   UNREACHABLE_CODE
@@ -1780,9 +1780,9 @@ void paged_attention_custom_launcher(
 // clang-format off
 void paged_attention(
     torch::Tensor& out,         // [num_seqs, num_heads, head_size]
-    torch::Tensor& exp_sums,    // [block_tables.size(0), num_heads, max_num_partitions]
-    torch::Tensor& max_logits,  // [block_tables.size(0), num_heads, max_num_partitions]
-    torch::Tensor& tmp_out,     // [block_tables.size(0), num_heads, max_num_partitions, head_size]
+    torch::Tensor& exp_sums,    // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& max_logits,  // [num_seqs, num_heads, max_num_partitions]
+    torch::Tensor& tmp_out,     // [num_seqs, num_heads, max_num_partitions, head_size]
     torch::Tensor& query,       // [num_seqs, num_heads, head_size]
     torch::Tensor& key_cache,   // [num_blocks, num_heads, head_size/x, block_size, x]
     torch::Tensor& value_cache, // [num_blocks, num_heads, head_size, block_size]

--- a/vllm/attention/ops/chunked_prefill_paged_decode.py
+++ b/vllm/attention/ops/chunked_prefill_paged_decode.py
@@ -289,7 +289,7 @@ def chunked_prefill_paged_decode(
         max_num_partitions = ((max_seq_len + _PARTITION_SIZE_ROCM - 1) //
                               _PARTITION_SIZE_ROCM)
         assert _PARTITION_SIZE_ROCM % block_size == 0
-        total_num_seq = query.shape[0]
+        total_num_seq = block_table.shape[0]
         tmp_output = torch.empty(
             size=(total_num_seq, num_query_heads, max_num_partitions,
                   head_size),


### PR DESCRIPTION
The first dimension of tmp_out and exp_sums is inferred from block_tables.size(0), which may be different from query.shape(0). The later can be much larger than block_tables.size(0), which may cause OOM.

This PR fix the total_num_seq and the comments.