### PR TITLE
[Docs] Add command for running mypy tests from CI

### DIFF
--- a/docs/source/contributing/overview.md
+++ b/docs/source/contributing/overview.md
@@ -40,6 +40,10 @@ pre-commit install --hook-type pre-commit --hook-type commit-msg
 # You can manually run pre-commit with
 pre-commit run --all-files
 
+# To manually run something from CI that does not run
+# locally by default, you can run:
+pre-commit run mypy-3.9 --hook-stage manual --all-files
+
 # Unit tests
 pytest tests/
 ```


### PR DESCRIPTION
Whenever one of the `mypy` jobs that only runs in CI fails, I'm doing
`history | grep mypy` to remember what command I used to run the mypy
tests from CI. This adds the command to the docs to help others (and
myself) find it when needed.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
