### PR TITLE
[Bugfix][ROCm] Restrict ray version due to a breaking release

### DIFF
--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -9,7 +9,7 @@ awscli
 boto3
 botocore
 datasets
-ray >= 2.10.0
+ray>=2.10.0,<2.45.0
 peft
 pytest-asyncio
 tensorizer>=2.9.0


### PR DESCRIPTION
Restrict ray version due to https://github.com/ray-project/ray/issues/52701

The 2.45.0 release on ROCm would lead to an assertion on `import ray` if CUDA_VISIBLE_DEVICES is set