### PR TITLE
doc: fix bug report Github template formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/400-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/400-bug-report.yml
@@ -21,12 +21,12 @@ body:
       It is suggested to download and execute the latest script, as vllm might frequently update the diagnosis information needed for accurately and quickly responding to issues.
     value: |
       <details>
-      <summary>The output of `python collect_env.py`</summary>
+      <summary>The output of <code>python collect_env.py</code></summary>
 
       ```text
       Your output of `python collect_env.py` here
       ```
-      
+
       </details>
   validations:
     required: true


### PR DESCRIPTION
Backticks don't render monospace font correctly inside of HTML tags. Use the `<code>` HTML tag instead.

## before

<img width="654" alt="image" src="https://github.com/user-attachments/assets/3e1ea295-4338-4232-a485-499c0fbf8e3e" />

## after

<img width="657" alt="image" src="https://github.com/user-attachments/assets/110c568f-b127-414a-92c9-e7e2d17dc1c4" />
