### PR TITLE
[BugFix] Fix mla cpu - missing 3 required positional arguments

### DIFF
--- a/vllm/_ipex_ops.py
+++ b/vllm/_ipex_ops.py
@@ -177,7 +177,7 @@ class ipex_ops:
         out: torch.Tensor,
         seqlen_q: torch.Tensor,
         seqlen_k: torch.Tensor,
-        alibi_slopes: torch.Tensor,
+        alibi_slopes: Optional[torch.Tensor],
         max_seqlen_q: int,
         max_seqlen_k: int,
         pdropout: float,
@@ -193,6 +193,8 @@ class ipex_ops:
         if ipex.__version__.endswith("cpu"):
             if logits_soft_cap != 0.0:
                 raise ValueError("IPEX CPU does not support logits_soft_cap")
+            assert alibi_slopes is None
+            assert window_size_left < 0 and window_size_right < 0
             ipex.llm.functional.varlen_attention(query.contiguous(),
                                                  key.contiguous(),
                                                  value.contiguous(), out,

--- a/vllm/attention/backends/cpu_mla.py
+++ b/vllm/attention/backends/cpu_mla.py
@@ -273,6 +273,9 @@ class CPUMLAImpl(MLACommonImpl[CPUMLAMetadata]):
             return_softmax=False,
             gen_=None,
             logits_soft_cap=0.0,
+            window_size_left=-1,
+            window_size_right=-1,
+            alibi_slopes=None,
         )
 
         # remove padding


### PR DESCRIPTION
Fix 
```
[rank0]: TypeError: ipex_ops.varlen_attention() missing 3 required positional arguments: 'alibi_slopes', 'window_size_left', and 'window_size_right'
```
caused by 
https://github.com/vllm-project/vllm/pull/17444


cc @gau-nernst @jikunshang

```
(vllm-cpu) lwilkinson@beaker:~/code/vllm$ python3 examples/offline_inference/basic/generate.py --model deepseek-ai/DeepSeek-V2-Lite-Chat --trust-remote-code --max-model-len 1024 --block-size 16
[W430 19:37:52.878519098 OperatorEntry.cpp:154] Warning: Warning only once for all operators,  other operators may also be overridden.
  Overriding a previously registered kernel for the same operator and the same dispatch key
  operator: aten::_addmm_activation(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1, bool use_gelu=False) -> Tensor
    registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
  dispatch key: AutocastCPU
  previous kernel: registered at /pytorch/aten/src/ATen/autocast_mode.cpp:327
       new kernel: registered at /opt/workspace/ipex-cpu-dev/csrc/cpu/autocast/autocast_mode.cpp:112 (function operator())
INFO 04-30 19:37:53 [__init__.py:239] Automatically detected platform cpu.
INFO 04-30 19:37:55 [config.py:214] Replacing legacy 'type' key with 'rope_type'
INFO 04-30 19:38:00 [config.py:749] This model supports multiple tasks: {'generate', 'classify', 'score', 'embed', 'reward'}. Defaulting to 'generate'.
WARNING 04-30 19:38:00 [_logger.py:72] device type=cpu is not supported by the V1 Engine. Falling back to V0. 
INFO 04-30 19:38:00 [config.py:1835] Disabled the custom all-reduce kernel because it is not supported on current platform.
INFO 04-30 19:38:00 [config.py:4029] MLA is enabled on a non-GPU platform; forcing chunked prefill and prefix caching to be disabled.
WARNING 04-30 19:38:00 [_logger.py:72] Environment variable VLLM_CPU_KVCACHE_SPACE (GiB) for CPU backend is not set, using 4 by default.
WARNING 04-30 19:38:00 [_logger.py:72] uni is not supported on CPU, fallback to mp distributed executor backend.
INFO 04-30 19:38:00 [llm_engine.py:240] Initializing a V0 LLM engine (v0.8.5.dev369+ga55a4093c.d20250430) with config: model='deepseek-ai/DeepSeek-V2-Lite-Chat', speculative_config=None, tokenizer='deepseek-ai/DeepSeek-V2-Lite-Chat', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, override_neuron_config={}, tokenizer_revision=None, trust_remote_code=True, dtype=torch.bfloat16, max_seq_len=1024, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=True, quantization=None, enforce_eager=True, kv_cache_dtype=auto,  device_config=cpu, decoding_config=DecodingConfig(backend='auto', disable_fallback=False, disable_any_whitespace=False, disable_additional_properties=False, reasoning_backend=None), observability_config=ObservabilityConfig(show_hidden_metrics=False, otlp_traces_endpoint=None, collect_model_forward_time=False, collect_model_execute_time=False), seed=None, served_model_name=deepseek-ai/DeepSeek-V2-Lite-Chat, num_scheduler_steps=1, multi_step_stream_outputs=True, enable_prefix_caching=False, chunked_prefill_enabled=False, use_async_output_proc=False, pooler_config=None, compilation_config={"splitting_ops":[],"compile_sizes":[],"cudagraph_capture_sizes":[256,248,240,232,224,216,208,200,192,184,176,168,160,152,144,136,128,120,112,104,96,88,80,72,64,56,48,40,32,24,16,8,4,2,1],"max_capture_size":256}, use_cached_outputs=False, 
INFO 04-30 19:38:01 [cpu.py:43] Using CPU MLA backend.
INFO 04-30 19:38:01 [parallel_state.py:1004] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, TP rank 0
INFO 04-30 19:38:01 [weight_utils.py:265] Using model weights format ['*.safetensors']
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:00,  3.33it/s]
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:00<00:00,  2.37it/s]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:01<00:00,  2.16it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.04it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  2.16it/s]

INFO 04-30 19:38:03 [loader.py:458] Loading weights took 1.96 seconds
INFO 04-30 19:38:03 [executor_base.py:112] # cpu blocks: 8630, # CPU blocks: 0
INFO 04-30 19:38:03 [executor_base.py:117] Maximum concurrency for 1024 tokens per request: 134.84x
INFO 04-30 19:38:03 [llm_engine.py:437] init engine (profile, create kv cache, warmup model) took 0.12 seconds
WARNING 04-30 19:38:04 [logger.py:63] Default sampling parameters have been overridden by the model's Hugging Face generation config recommended from the model creator. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
Processed prompts:   0%|                                                                                                                                    | 0/4 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s]WARNING 04-30 19:38:08 [_logger.py:72] Pin memory is not supported on CPU.
INFO 04-30 19:38:09 [metrics.py:486] Avg prompt throughput: 5.1 tokens/s, Avg generation throughput: 3.1 tokens/s, Running: 4 reqs, Swapped: 0 reqs, Pending: 0 reqs, GPU KV cache usage: 0.0%, CPU KV cache usage: 0.0%.
Processed prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:08<00:00,  2.20s/it, est. speed input: 2.95 toks/s, output: 7.26 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Maria and I am a aui (adult undergraduate intern) at the Counseling Center'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' the head of state and head of government of the United States, by virtue of'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: ' Paris. Paris is known for its beautiful architecture, art, and history. It'
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' a hot topic right now, and it’s easy to get lost in the'
--------------------------------------------------
```
