### PR TITLE
[Bugfix][ROCm] Fix import error on ROCm

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -32,7 +32,7 @@ from transformers import PretrainedConfig
 from vllm.model_executor.custom_op import CustomOp
 from vllm.platforms import current_platform
 
-if current_platform.is_cuda_alike():
+if current_platform.is_cuda():
     from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
 
 


### PR DESCRIPTION
Fix regression added in https://github.com/vllm-project/vllm/pull/17435
`from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb` does not apply to ROCm, it results in
```
ModuleNotFoundError: No module named 'vllm.vllm_flash_attn.layers'
```