### PR TITLE
[CI][Bugfix] Fix failing V1 Test due to missing 'cache_salt' arg

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -306,6 +306,7 @@ def test_kv_cache_events(
                 eos_token_id=None,
                 arrival_time=time.time(),
                 lora_request=None,
+                cache_salt=None,
             )
             client.add_request(request)
 


### PR DESCRIPTION
The CI for V1 Test is broken (https://buildkite.com/vllm/ci/builds/19044/steps?jid=01968804-ba26-4ab6-8efd-afd36c5ed73a#01968804-ba26-4ab6-8efd-afd36c5ed73a/209-2172) due to a forgotten EngineCoreRequest construction without required arg 'cache_salt'. Introduced by https://github.com/vllm-project/vllm/pull/17045