### PR TITLE
[Chore] Ignore Ruff warning on E501

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 100
-line-length = 100
+# Allow lines to be as long as 80.
+line-length = 80
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 80.
-line-length = 80
+# Allow lines to be as long as 119
+line-length = 119
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py",
@@ -115,6 +115,8 @@ ignore = [
     "UP032",
     # Can remove once 3.10+ is the minimum Python version
     "UP007",
+    # Line too long
+    "E501",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 119
-line-length = 119
+# Allow lines to be as long as 100
+line-length = 100
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py",


### PR DESCRIPTION
This PR disable E501 checks for line too long. This warning is annoying when writing logs and we should just let
yapf handle breakpoint if needed to

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
