### PR TITLE
[Bugfix][V1][Spec Dec] Add generator to request even when no seed is provided.

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -338,11 +338,11 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         for new_req_data in scheduler_output.scheduled_new_reqs:
             req_id = new_req_data.req_id
             sampling_params = new_req_data.sampling_params
+            generator = torch.Generator(device=self.device)
             if sampling_params.sampling_type == SamplingType.RANDOM_SEED:
-                generator = torch.Generator(device=self.device)
                 generator.manual_seed(sampling_params.seed)
             else:
-                generator = None
+                generator.initial_seed()
 
             self.requests[req_id] = CachedRequestState(
                 req_id=req_id,


### PR DESCRIPTION
Fix for https://github.com/vllm-project/vllm/issues/17498.

Currently, when no seed is provided to sampling parameters, the request state will have no generator. This leads to a problem in speculative decoding, where different workers will accept different number of tokens when temp > 0 since the sampling process has not been seeded. 

cc @WoosukKwon @LiuXiaoxuanPKU 