### PR TITLE
[Bugfix][Model] vllm-v0 engine run eagle algo with qwen2.5 model, KeyError: 'norm.weight' bugfix

### DIFF
--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -388,6 +388,8 @@ class Qwen2Model(nn.Module):
                     continue
                 if is_pp_missing_parameter(name, self):
                     continue
+                if name not in params_dict:
+                    continue
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -401,6 +403,8 @@ class Qwen2Model(nn.Module):
                 if name is None:
                     continue
                 if is_pp_missing_parameter(name, self):
+                    continue
+                if name not in params_dict:
                     continue
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader",


### PR DESCRIPTION

FIX #17517  

<!--- pyml disable-next-line no-emphasis-as-heading -->
