### PR TITLE
[Frontend] Show progress bar for adding requests

### DIFF
--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -462,10 +462,12 @@ class LLM:
         self._validate_and_add_requests(
             prompts=parsed_prompts,
             params=sampling_params,
+            use_tqdm=use_tqdm,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
             guided_options=guided_options_request,
-            priority=priority)
+            priority=priority,
+        )
 
         outputs = self._run_engine(use_tqdm=use_tqdm)
         return self.engine_class.validate_outputs(outputs, RequestOutput)
@@ -957,6 +959,7 @@ class LLM:
         self._validate_and_add_requests(
             prompts=parsed_prompts,
             params=pooling_params,
+            use_tqdm=use_tqdm,
             lora_request=lora_request,
             tokenization_kwargs=tokenization_kwargs,
             prompt_adapter_request=prompt_adapter_request,
@@ -1127,6 +1130,7 @@ class LLM:
         self._validate_and_add_requests(
             prompts=parsed_prompts,
             params=pooling_params,
+            use_tqdm=use_tqdm,
             lora_request=lora_request,
             prompt_adapter_request=prompt_adapter_request,
         )
@@ -1332,6 +1336,8 @@ class LLM:
         prompts: Union[PromptType, Sequence[PromptType]],
         params: Union[SamplingParams, Sequence[SamplingParams], PoolingParams,
                       Sequence[PoolingParams]],
+        *,
+        use_tqdm: bool,
         lora_request: Optional[Union[Sequence[LoRARequest], LoRARequest]],
         prompt_adapter_request: Optional[PromptAdapterRequest],
         tokenization_kwargs: Optional[dict[str, Any]] = None,
@@ -1367,7 +1373,11 @@ class LLM:
                 sp.output_kind = RequestOutputKind.FINAL_ONLY
 
         # Add requests to the engine.
-        for i, prompt in enumerate(prompts):
+        it = prompts
+        if use_tqdm:
+            it = tqdm(it, desc="Adding requests")
+
+        for i, prompt in enumerate(it):
             self._add_request(
                 prompt,
                 params[i] if isinstance(params, Sequence) else params,


### PR DESCRIPTION
When performing offline batched inference over a large number of images, vLLM appears to hang because it takes a long time to preprocess all of the images before the model is run. This PR adds a progress bar to eliminate this confusion.

## Example with long preprocessing time

```python
import numpy as np
from PIL import Image
from vllm import LLM, SamplingParams
from vllm.multimodal.utils import encode_image_base64


def main(num_images: int = 100):
    images_arr = np.random.randint(
        0,
        255,
        size=(num_images, 128, 128, 3),
        dtype=np.uint8,
    )
    images_base64 = [
        encode_image_base64(Image.fromarray(image))
        for image in images_arr
    ]

    llm = LLM("HuggingFaceTB/SmolVLM-256M-Instruct", enforce_eager=True)
    llm.chat(
        messages=[
            [
                {
                    "role": "user",
                    "content": [
                        {
                            "type": "image_url",
                            "image_url": {
                                "url": f"data:image/jpeg;base64,{image_base64}",
                            },
                        },
                        {"type": "text", "text": "What is in this image?"},
                    ]
                },
            ]
            for image_base64 in images_base64
        ],
        sampling_params=SamplingParams(max_tokens=1),
    )


if __name__ == "__main__":
    main()

```