### PR TITLE
[ROCm] remove unsupported archs from rocm triton flash-attention supported list

### DIFF
--- a/vllm/attention/ops/triton_flash_attention.py
+++ b/vllm/attention/ops/triton_flash_attention.py
@@ -650,7 +650,7 @@ def get_general_autotune_configs():
 
 
 def has_cdna_target():
-    ROCM_CDNA_TARGETS = ["gfx940", "gfx941", "gfx942", "gfx90a", "gfx908"]
+    ROCM_CDNA_TARGETS = ["gfx942", "gfx90a", "gfx908"]
     return triton.runtime.driver.active.get_current_target(
     ).arch in ROCM_CDNA_TARGETS
 


### PR DESCRIPTION
gfx940 and gfx941 are no longer supported since ROCm 6.3, and also they are not in the PyTorch arch list (env PYTORCH_ROCM_ARCH) . This simple clean up PR is to remove them from the code (here the triton flash-attention supported list).


<!--- pyml disable-next-line no-emphasis-as-heading -->
