### PR TITLE
[Misc] add get kv cache token capacity

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2147,6 +2147,15 @@ class LLMEngine:
         return self.model_executor.collective_rpc(method, timeout, args,
                                                   kwargs)
 
+    def get_kv_cache_token_capacity(self) -> int:
+        """Get the total token capacity of the KV cache.
+
+        Returns:
+            int: The total number of tokens that can be stored in the KV cache.
+        """
+        return self.vllm_config.cache_config.num_gpu_blocks \
+            * self.vllm_config.cache_config.block_size
+
 
 if envs.is_set("VLLM_USE_V1") and envs.VLLM_USE_V1:
     from vllm.v1.engine.llm_engine import LLMEngine as V1LLMEngine

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1478,3 +1478,6 @@ class LLM:
         # This is necessary because some requests may be finished earlier than
         # its previous requests.
         return sorted(outputs, key=lambda x: int(x.request_id))
+
+    def get_kv_cache_token_capacity(self) -> int:
+        return self.llm_engine.get_kv_cache_token_capacity()

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -285,3 +285,11 @@ class LLMEngine:
     def __del__(self):
         if dp_group := getattr(self, "dp_group", None):
             stateless_destroy_torch_distributed_process_group(dp_group)
+
+    def get_kv_cache_token_capacity(self) -> int:
+        """Get the total token capacity of the KV cache.
+
+        Returns:
+            int: The total number of tokens that can be stored in the KV cache.
+        """
+        return self.engine_core.get_kv_cache_token_capacity()


### PR DESCRIPTION

FIX https://github.com/vllm-project/vllm/issues/15538#issuecomment-2844655155

```
llm = LLM(**args)
print(f'get_kv_cache_token_capacity: {llm.get_kv_cache_token_capacity()}')
```

<!--- pyml disable-next-line no-emphasis-as-heading -->
