### PR TITLE
[Bugfix] Disable gptq_bitblas for <SM80 to fix GPTQ on V100/T4

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq_bitblas.py
+++ b/vllm/model_executor/layers/quantization/gptq_bitblas.py
@@ -134,7 +134,7 @@ class GPTQBitBLASConfig(QuantizationConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 70
+        return 80
 
     @classmethod
     def get_config_filenames(cls) -> List[str]:


### PR DESCRIPTION
FIX https://github.com/vllm-project/vllm/issues/17539
FIX https://github.com/vllm-project/vllm/issues/17367

As the attached issue found, `gptq_bitblas` doesn't seem to work at the moment on NVIDIA T4. This causes GPTQ models to fail to run as the override gets triggered without this change. Let's disable this for now

cc @LeiWang1999 