### PR TITLE
[ROCm] update installation guide to include build aiter from source instructions

### DIFF
--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -115,7 +115,6 @@ Currently, there are no pre-built ROCm wheels.
    - The ROCm version of PyTorch, ideally, should match the ROCm driver version.
     :::
 
-
 :::{tip}
 - For MI300x (gfx942) users, to achieve optimal performance, please refer to [MI300x tuning guide](https://rocm.docs.amd.com/en/latest/how-to/tuning-guides/mi300x/index.html) for performance optimization and tuning tips on system and workflow level.
   For vLLM, please refer to [vLLM performance optimization](https://rocm.docs.amd.com/en/latest/how-to/tuning-guides/mi300x/workload.html#vllm-performance-optimization).

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -73,7 +73,22 @@ Currently, there are no pre-built ROCm wheels.
     You might need to downgrade the "ninja" version to 1.10 it is not used when compiling flash-attention-2 (e.g. `pip install ninja==1.10.2.4`)
     :::
 
-3. Build vLLM. For example, vLLM on ROCM 6.3 can be built with the following steps:
+3. If you choose to build AITER yourself to use a certain branch or commit, you can build AITER using the following steps:
+
+    ```console
+    python3 -m pip uninstall -y aiter
+    git clone --recursive https://github.com/ROCm/aiter.git
+    cd aiter
+    git checkout $AITER_BRANCH_OR_COMMIT
+    git submodule sync; git submodule update --init --recursive
+    python3 setup.py develop
+    ```
+
+    :::{note}
+    You will need to config the $AITER_BRANCH_OR_COMMIT for your purpose.
+    :::
+
+4. Build vLLM. For example, vLLM on ROCM 6.3 can be built with the following steps:
 
     ```bash
     $ pip install --upgrade pip
@@ -99,6 +114,7 @@ Currently, there are no pre-built ROCm wheels.
    - To use CK flash-attention or PyTorch naive attention, please use this flag `export VLLM_USE_TRITON_FLASH_ATTN=0` to turn off triton flash attention.
    - The ROCm version of PyTorch, ideally, should match the ROCm driver version.
     :::
+
 
 :::{tip}
 - For MI300x (gfx942) users, to achieve optimal performance, please refer to [MI300x tuning guide](https://rocm.docs.amd.com/en/latest/how-to/tuning-guides/mi300x/index.html) for performance optimization and tuning tips on system and workflow level.

--- a/docs/source/getting_started/installation/gpu/rocm.inc.md
+++ b/docs/source/getting_started/installation/gpu/rocm.inc.md
@@ -85,7 +85,7 @@ Currently, there are no pre-built ROCm wheels.
     ```
 
     :::{note}
-    You will need to config the $AITER_BRANCH_OR_COMMIT for your purpose.
+    You will need to config the `$AITER_BRANCH_OR_COMMIT` for your purpose.
     :::
 
 4. Build vLLM. For example, vLLM on ROCM 6.3 can be built with the following steps:


### PR DESCRIPTION
As AITER integration is more common these days, this PR is to update the installation guide to include the steps for build AITER from source.

Test:
build the docs, and check the html page:
![image](https://github.com/user-attachments/assets/bbe6b516-da89-4305-8958-3b4f0a8edfb3)





<!--- pyml disable-next-line no-emphasis-as-heading -->
