### PR TITLE
[WIP] Initial attempt to add microbatching functionality to RowParallelLinear

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -14,7 +14,6 @@ from vllm.distributed import (divide, get_tensor_model_parallel_rank,
                               split_tensor_along_last_dim,
                               tensor_model_parallel_all_gather,
                               tensor_model_parallel_all_reduce)
-from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
@@ -1109,6 +1108,8 @@ class QKVParallelLinear(ColumnParallelLinear):
 
 
 backup_stream = torch.cuda.Stream()
+
+
 class RowParallelLinear(LinearBase):
     """Linear layer with row parallelism.
 
@@ -1260,30 +1261,30 @@ class RowParallelLinear(LinearBase):
         event = torch.cuda.Event()
         m_over_two = input_parallel.shape[0] // 2
         if m_over_two > 1024:
-            first_output_parallel = self.quant_method.apply(self,
-                                                input_parallel[:m_over_two],
-                                                bias=bias_)
+            first_output_parallel = self.quant_method.apply(
+                self, input_parallel[:m_over_two], bias=bias_)
             event.record()
             if self.reduce_results and self.tp_size > 1:
-                first_output = tensor_model_parallel_all_reduce(first_output_parallel)
+                first_output = tensor_model_parallel_all_reduce(
+                    first_output_parallel)
             else:
                 first_output = first_output_parallel
 
             with torch.cuda.stream(backup_stream):
                 event.wait()
-                second_output_parallel = self.quant_method.apply(self,
-                                                        input_parallel[m_over_two:],
-                                                        bias=bias_)
+                second_output_parallel = self.quant_method.apply(
+                    self, input_parallel[m_over_two:], bias=bias_)
                 if self.reduce_results and self.tp_size > 1:
-                    second_output = tensor_model_parallel_all_reduce(second_output_parallel)
+                    second_output = tensor_model_parallel_all_reduce(
+                        second_output_parallel)
                 else:
                     second_output = second_output_parallel
             torch.cuda.synchronize()
             output = torch.cat((first_output, second_output), dim=0)
         else:
-            output_parallel= self.quant_method.apply(self,
-                                            input_parallel,
-                                            bias=bias_)
+            output_parallel = self.quant_method.apply(self,
+                                                      input_parallel,
+                                                      bias=bias_)
             if self.reduce_results and self.tp_size > 1:
                 output = tensor_model_parallel_all_reduce(output_parallel)
             else:

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1257,6 +1257,7 @@ class RowParallelLinear(LinearBase):
         # bias will not get added more than once in TP>1 case)
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
         event = torch.cuda.Event()
+        event2 = torch.cuda.Event()
         m_over_two = input_parallel.shape[0] // 2
         if m_over_two > 16:
             first_output_parallel = self.quant_method.apply(
@@ -1265,6 +1266,7 @@ class RowParallelLinear(LinearBase):
             if self.reduce_results and self.tp_size > 1:
                 first_output = tensor_model_parallel_all_reduce(
                     first_output_parallel)
+                event2.wait()
             else:
                 first_output = first_output_parallel
 
@@ -1275,9 +1277,10 @@ class RowParallelLinear(LinearBase):
                 if self.reduce_results and self.tp_size > 1:
                     second_output = tensor_model_parallel_all_reduce(
                         second_output_parallel)
+                    event2.record()
                 else:
                     second_output = second_output_parallel
-            torch.cuda.synchronize()
+            # torch.cuda.synchronize()
             output = torch.cat((first_output, second_output), dim=0)
         else:
             output_parallel = self.quant_method.apply(self,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -1256,37 +1256,47 @@ class RowParallelLinear(LinearBase):
         # Only fuse bias add into GEMM for rank 0 (this ensures that
         # bias will not get added more than once in TP>1 case)
         bias_ = None if (self.tp_rank > 0 or self.skip_bias_add) else self.bias
-        event = torch.cuda.Event()
-        event2 = torch.cuda.Event()
+
+        is_ar_required = self.reduce_results and self.tp_size > 1
+        microbatch_threshold = 16
         m_over_two = input_parallel.shape[0] // 2
-        if m_over_two > 16:
+        should_use_microbatching = m_over_two > microbatch_threshold and \
+            is_ar_required
+
+        # If it makes sense to try and overlap the gemm and all
+        # reduce using microbatching
+        if should_use_microbatching:
+            event = torch.cuda.Event()
+            event2 = torch.cuda.Event()
+
+            # Run the first microbatch in the current stream
             first_output_parallel = self.quant_method.apply(
                 self, input_parallel[:m_over_two], bias=bias_)
-            event.record()
-            if self.reduce_results and self.tp_size > 1:
-                first_output = tensor_model_parallel_all_reduce(
-                    first_output_parallel)
-                event2.wait()
-            else:
-                first_output = first_output_parallel
 
+            # Prevent the second microbatch's gemm from starting until the
+            # first microbatch's gemm has finished
+            event.record()
+            first_output = tensor_model_parallel_all_reduce(
+                first_output_parallel)
+            # Block here until the second microbatch's all reduce finishes
+            event2.wait()
+
+            # Run the second microbatch in the backup stream
             with torch.cuda.stream(self.backup_stream):
                 event.wait()
                 second_output_parallel = self.quant_method.apply(
                     self, input_parallel[m_over_two:], bias=bias_)
-                if self.reduce_results and self.tp_size > 1:
-                    second_output = tensor_model_parallel_all_reduce(
-                        second_output_parallel)
-                    event2.record()
-                else:
-                    second_output = second_output_parallel
-            # torch.cuda.synchronize()
+                second_output = tensor_model_parallel_all_reduce(
+                    second_output_parallel)
+                # Notify the main stream that this microbatch has completed
+                event2.wait()
+            # torch.cuda.synchronize(self.backup_stream)
             output = torch.cat((first_output, second_output), dim=0)
         else:
             output_parallel = self.quant_method.apply(self,
                                                       input_parallel,
                                                       bias=bias_)
-            if self.reduce_results and self.tp_size > 1:
+            if is_ar_required:
                 output = tensor_model_parallel_all_reduce(output_parallel)
             else:
                 output = output_parallel


### PR DESCRIPTION
This is a very basic implementation of microbatching that attempts to naively break the GEMM+AR kernels into two microbatches along the M dimension. The goal here is to overlap the GEMM computation with the AR data movement.

This is very much a WIP and I don't have speedups yet. Additionally it would be good to tune the grid sizes of the kernels to account for the fact that we are going to be running GEMM + AR at the same time in two different streams.