### PR TITLE
[CI] Actually run tests/kv_transfer/test_disagg.py in CI

### DIFF
--- a/tests/kv_transfer/test_disagg.py
+++ b/tests/kv_transfer/test_disagg.py
@@ -14,7 +14,7 @@ import torch
 # Fixture to set up environment variables and teardown servers after tests
 @pytest.fixture(scope="module", autouse=True)
 def setup_servers():
-    if torch.cuda.device_count() < 4:
+    if torch.cuda.device_count() < 2:
         pytest.skip("Skipping test: fewer than 4 GPUs available")
 
     # Set up environment variables

--- a/tests/kv_transfer/test_disagg.py
+++ b/tests/kv_transfer/test_disagg.py
@@ -15,7 +15,7 @@ import torch
 @pytest.fixture(scope="module", autouse=True)
 def setup_servers():
     if torch.cuda.device_count() < 2:
-        pytest.skip("Skipping test: fewer than 4 GPUs available")
+        pytest.skip("Skipping test: fewer than 2 GPUs available")
 
     # Set up environment variables
     VLLM_HOST_IP = subprocess.check_output("hostname -I | awk '{print $1}'",


### PR DESCRIPTION
This test never actually ran because it was run in CI with only 2 GPUs
https://github.com/vllm-project/vllm/blob/173daac19dbf00180f1eb0752ce33fd97f48649d/.buildkite/test-pipeline.yaml#L594
https://buildkite.com/vllm/ci/builds/19124/summary/annotations?sid=01968bca-6920-43bd-a320-ee4f66de15c3#01968bca-69b1-45d1-a999-f887bf68fb68/6-9562

The test requires 4 GPUs for no reason, it only uses 2.