### PR TITLE
added stream_n to v1/async_llm, created streaming_params

### DIFF
--- a/vllm/streaming_params.py
+++ b/vllm/streaming_params.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Streaming parameters for token streaming during text generation."""
+from dataclasses import dataclass
+from typing import Annotated
+
+import msgspec
+
+
+class StreamValidationError(ValueError):
+    pass
+
+
+class StreamDefaults:
+    STREAM_N_DEFAULT = 1
+
+
+class StreamLimits:
+    STREAM_N_MIN = 1
+    STREAM_N_MAX = 1024
+
+
+class StreamingParams(
+        msgspec.Struct,
+        omit_defaults=True,  # type: ignore[call-arg]
+        dict=True):  # type: ignore[call-arg]
+    """Streaming parameters for token streaming during text generation.
+
+    Args:
+        stream_n: Number of tokens to stream at a time. Must be an integer >= 1.
+            Defaults to 1.
+    """
+
+    stream_n: Annotated[int, msgspec.Meta(ge=StreamLimits.STREAM_N_MIN)] = (
+        StreamDefaults.STREAM_N_DEFAULT)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.stream_n, int):
+            raise StreamValidationError(
+                f"stream_n must be an integer, got {type(self.stream_n)}.")
+        if not (StreamLimits.STREAM_N_MIN <= self.stream_n <= StreamLimits.STREAM_N_MAX):
+            raise StreamValidationError(
+                f"stream_n must be between {StreamLimits.STREAM_N_MIN} and "
+                f"{StreamLimits.STREAM_N_MAX}, got {self.stream_n}.")
+
+    def __repr__(self) -> str:
+        return f"StreamingParams(stream_n={self.stream_n})"

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -20,6 +20,7 @@ from vllm.outputs import RequestOutput
 from vllm.pooling_params import PoolingParams
 from vllm.prompt_adapter.request import PromptAdapterRequest
 from vllm.sampling_params import SamplingParams
+from vllm.streaming_params import StreamingParams
 from vllm.transformers_utils.tokenizer import AnyTokenizer
 from vllm.transformers_utils.tokenizer_group import init_tokenizer_from_configs
 from vllm.usage.usage_lib import UsageContext
@@ -260,6 +261,7 @@ class AsyncLLM(EngineClient):
         self,
         prompt: PromptType,
         sampling_params: SamplingParams,
+        streaming_params: StreamingParams,
         request_id: str,
         lora_request: Optional[LoRARequest] = None,
         trace_headers: Optional[Mapping[str, str]] = None,
@@ -300,6 +302,8 @@ class AsyncLLM(EngineClient):
             # The output_handler task pushes items into the queue.
             # This task pulls from the queue and yields to caller.
             finished = False
+            buffer: Optional[RequestOutput] = None # buffer of output tokens
+            buffer_token_count = 0
             while not finished:
                 # Note: drain queue without await if possible (avoids
                 # task switching under load which helps performance).
@@ -308,7 +312,18 @@ class AsyncLLM(EngineClient):
                 # Note: both OutputProcessor and EngineCore handle their
                 # own request cleanup based on finished.
                 finished = out.finished
-                yield out
+
+                if buffer is None:
+                    buffer = out
+                else:
+                    buffer.add(out, aggregate = True)
+                
+                buffer_token_count += sum(len(o.token_ids) for o in out.outputs)
+                if buffer_token_count >= streaming_params.stream_n or finished:
+                    yield buffer
+                    buffer = None
+                    buffer_token_count = 0
+
 
         # If the request is disconnected by the client, generate()
         # is cancelled. So, we abort the request if we end up here.


### PR DESCRIPTION
Added `stream_n` as an option to async_llm in v1, where it streams `stream_n` tokens at a time reducing network bandwidth issues. Created a new streaming_params class to hold this parameter (and future related ones).
