### PR TITLE
[easy] Print number of needed GPUs in skip message

### DIFF
--- a/tests/compile/test_basic_correctness.py
+++ b/tests/compile/test_basic_correctness.py
@@ -103,7 +103,8 @@ def test_compile_correctness(
     method = test_setting.method
     fullgraph = test_setting.fullgraph
     if cuda_device_count_stateless() != pp_size * tp_size:
-        pytest.skip("Not correct CUDA devices for the test.")
+        pytest.skip(f"Need exactly {pp_size}*{tp_size} CUDA gpus but got "
+                    f"{cuda_device_count_stateless()}")
 
     with monkeypatch.context() as m:
         m.setenv("VLLM_ATTENTION_BACKEND", attn_backend)


### PR DESCRIPTION
tests/compile/test_basic_correctness requires a specific number of GPUs to run. I changed the skip message to print it.

Separately I'm looking into if there's another way to run this test, because I have an 8 GPU machine and I would like to run these without setting CUDA_VISIBLE_DEVICES all the time.
