### PR TITLE
[V1] Disable pickle by default for new serial_utils usage

### DIFF
--- a/tests/v1/test_serial_utils.py
+++ b/tests/v1/test_serial_utils.py
@@ -63,8 +63,8 @@ def test_encode_decode():
         empty_tensor=torch.empty(0),
     )
 
-    encoder = MsgpackEncoder(size_threshold=256)
-    decoder = MsgpackDecoder(MyType)
+    encoder = MsgpackEncoder(size_threshold=256, allow_pickle=True)
+    decoder = MsgpackDecoder(MyType, allow_pickle=True)
 
     encoded = encoder.encode(obj)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -501,8 +501,9 @@ class EngineCoreProc(EngineCore):
         """Input socket IO thread."""
 
         # Msgpack serialization decoding.
-        add_request_decoder = MsgpackDecoder(EngineCoreRequest)
-        generic_decoder = MsgpackDecoder()
+        add_request_decoder = MsgpackDecoder(EngineCoreRequest,
+                                             allow_pickle=True)
+        generic_decoder = MsgpackDecoder(allow_pickle=True)
         identity = engine_index.to_bytes(length=2, byteorder="little")
 
         with zmq_socket_ctx(input_path,
@@ -536,7 +537,7 @@ class EngineCoreProc(EngineCore):
         """Output socket IO thread."""
 
         # Msgpack serialization encoding.
-        encoder = MsgpackEncoder()
+        encoder = MsgpackEncoder(allow_pickle=True)
         # Send buffers to reuse.
         reuse_buffers: list[bytearray] = []
         # Keep references to outputs and buffers until zmq is finished

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -365,8 +365,8 @@ class MPClient(EngineCoreClient):
     ):
         self.vllm_config = vllm_config
         # Serialization setup.
-        self.encoder = MsgpackEncoder()
-        self.decoder = MsgpackDecoder(EngineCoreOutputs)
+        self.encoder = MsgpackEncoder(allow_pickle=True)
+        self.decoder = MsgpackDecoder(EngineCoreOutputs, allow_pickle=True)
 
         # ZMQ setup.
         sync_ctx = zmq.Context(io_threads=2)

--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -49,7 +49,7 @@ class MsgpackEncoder:
 
     def __init__(self,
                  size_threshold: Optional[int] = None,
-                 allow_pickle: bool = True):
+                 allow_pickle: bool = False):
         if size_threshold is None:
             size_threshold = envs.VLLM_MSGPACK_ZERO_COPY_THRESHOLD
         self.encoder = msgpack.Encoder(enc_hook=self.enc_hook)
@@ -185,7 +185,7 @@ class MsgpackDecoder:
     not thread-safe when encoding tensors / numpy arrays.
     """
 
-    def __init__(self, t: Optional[Any] = None, allow_pickle: bool = True):
+    def __init__(self, t: Optional[Any] = None, allow_pickle: bool = False):
         args = () if t is None else (t, )
         self.decoder = msgpack.Decoder(*args,
                                        ext_hook=self.ext_hook,


### PR DESCRIPTION
This changes vllm.v1.serial_utils to disable the pickle fallback
behavior by default for new code using these interfaces. All existing
usage has been updated to use `allow_pickle=True` so that nothing
breaks.

This is a better default, as it requires code authors to explicitly
acknowledge and declare that `pickle` is in use, which must be analyzed
for security risk before turned on.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
