### PR TITLE
[Bugfix][ROCm] Using device_type because on ROCm the API is still torch.cuda

### DIFF
--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -406,12 +406,12 @@ class Platform:
         """Raises if this request is unsupported on this platform"""
 
     def __getattr__(self, key: str):
-        device = getattr(torch, self.device_name, None)
+        device = getattr(torch, self.device_type, None)
         if device is not None and hasattr(device, key):
             return getattr(device, key)
         else:
             logger.warning("Current platform %s does not have '%s'" \
-            " attribute.", self.device_name, key)
+            " attribute.", self.device_type, key)
             return None
 
     @classmethod


### PR DESCRIPTION
To fix regression from https://github.com/vllm-project/vllm/pull/17100
On ROCm:
device_name = "rocm"
device_type = "cuda"

The torch API is the same as for CUDA: torch.cuda.Event, etc.