### PR TITLE
[Neuron][Build] Require setuptools >= 77.0.3 for PEP 639

### DIFF
--- a/requirements/neuron.txt
+++ b/requirements/neuron.txt
@@ -2,5 +2,7 @@
 -r common.txt
 
 # Dependencies for Neuron devices
+packaging>=24.2
+setuptools>=77.0.3,<80.0.0
 torch-neuronx >= 2.5.0
 neuronx-cc


### PR DESCRIPTION
Following https://github.com/vllm-project/vllm/pull/17389, added required `setuptools` and `packaging` version for requirements/neuron.txt .

FIX https://github.com/vllm-project/vllm/issues/17464