### PR TITLE
fix typo in logging

### DIFF
--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -140,7 +140,7 @@ class AWQMarlinConfig(QuantizationConfig):
             from vllm.model_executor.layers.quantization.moe_wna16 import (
                 MoeWNA16Config)
             if not check_moe_marlin_supports_layer(layer, self.group_size):
-                logger.warning_one(
+                logger.warning_once(
                     f"Layer '{prefix}' is not supported by AWQMoeMarlin. "
                     "Falling back to Moe WNA16 kernels.")
                 return MoeWNA16Config.from_config(

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -157,7 +157,7 @@ class GPTQMarlinConfig(QuantizationConfig):
             from vllm.model_executor.layers.quantization.moe_wna16 import (
                 MoeWNA16Config)
             if not check_moe_marlin_supports_layer(layer, self.group_size):
-                logger.warning_one(
+                logger.warning_once(
                     f"Layer '{prefix}' is not supported by GPTQMoeMarlin. "
                     "Falling back to Moe WNA16 kernels.")
                 return MoeWNA16Config.from_config(


### PR DESCRIPTION
FIX #17608

- Updated the logging method from `warning_one` to `warning_once` in both:
  - `vllm/model_executor/layers/quantization/awq_marlin.py`
  - `vllm/model_executor/layers/quantization/gptq_marlin.py`

## Rationale
The previous implementation used `logger.warning_one`, which was a syntax error. 

## Impact
logs error properly when this path is hit

<!--- pyml disable-next-line no-emphasis-as-heading -->
