### PR TITLE
Use git-path commit in hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,8 +101,8 @@ repos:
     args:
       - -c
       - |
-        if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" .git/COMMIT_EDITMSG; then
-          printf "\nSigned-off-by: $(git config user.name) <$(git config user.email)>\n" >> .git/COMMIT_EDITMSG
+        if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$(git rev-parse --git-path COMMIT_EDITMSG)"; then
+          printf "\nSigned-off-by: $(git config user.name) <$(git config user.email)>\n" >> "$(git rev-parse --git-path COMMIT_EDITMSG)"
         fi
     language: system
     verbose: true


### PR DESCRIPTION
This PR updates the pre-commit hook to use `git rev-parse --git-path COMMIT_EDITMSG` to find the commit message.

Within a worktree the commit path is:

```bash
$ git rev-parse --git-path COMMIT_EDITMSG
/Users/.../Repos/vllm/.git/worktrees/vllm2/COMMIT_EDITMSG
```

Within a non-worktree:

```bash
$ git rev-parse --git-path COMMIT_EDITMSG
.git/COMMIT_EDITMSG
```

FIX https://github.com/vllm-project/vllm/issues/17592