### PR TITLE
[PERF] Speed up of prepare_inputs / mrope

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -22,6 +22,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Rotary Positional Embeddings."""
+import functools
 import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -1404,6 +1405,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         ]
 
     @staticmethod
+    @functools.lru_cache(maxsize=1024)
     def get_next_input_positions_tensor(
         mrope_position_delta: int,
         context_len: int,


### PR DESCRIPTION
Speed up of `_prepare_intups` for models with M-RoPE by caching constant tensor in M-RoPE implementation. 

A huge part of `_prepare_inputs` for Qwen2.5-VL-3B is work for M-RoPE. 1/3 of time is creating small constant CPU tensors in `MRotaryEmbedding.get_next_input_positions_tensor()`. This PR make a cache for these tensors to speed up. 


**Performance results.**   
Tested with Qwen2.5-VL-3B

 - `prepare_intups` itself speeded up by 35%

 - E2E
```
vllm serve Qwen/Qwen2.5-VL-3B-Instruct --disable-log-requests --max-num-seqs 1024  --block-size 16 --max-num-batched-tokens 2048
```

For workload used https://github.com/CentML/flexible-inference-bench
Below command sends 1000 requests, with 50 reqs per second, with one image 512x512 per request.  
```
fib benchmark -rps 50 --input-token-distribution uniform 250 300     --output-token-distribution uniform 150 250 --num-of-imgs-per-req 1     --img-ratios-per-req 512x512 -n 1000 --base-url http://localhost:8000     --endpoint v1/chat/completions --backend openai-chat
```
Before 31.93 reqs/s
After 32.54 reqs/s
**Speed up 1.9%**







