### PR TITLE
[Bugfix] Prioritize dtype in root config before checking text config

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -2954,10 +2954,12 @@ def _get_and_verify_dtype(
 ) -> torch.dtype:
     # NOTE: getattr(config, "torch_dtype", torch.float32) is not correct
     # because config.torch_dtype can be None.
-    config_dtype = getattr(config.get_text_config(), "torch_dtype", None)
+    config_dtype = getattr(config, "torch_dtype", None)
 
-    # Fallback for multi-modal models if the root config
+    # Fallbacks for multi-modal models if the root config
     # does not define torch_dtype
+    if config_dtype is None:
+        config_dtype = getattr(config.get_text_config(), "torch_dtype", None)
     if config_dtype is None and hasattr(config, "vision_config"):
         config_dtype = getattr(config.vision_config, "torch_dtype", None)
 


### PR DESCRIPTION
We should still prioritze the dtype defined in the root config before checking text_config or vision_config. Sorry I missed this when reviewing #17105!

FIX https://github.com/vllm-project/vllm/issues/17622