### PR TITLE
[Bugfix][Easy] Fix whitespace in shm_broadcast.py logging

### DIFF
--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -429,7 +429,7 @@ class MessageQueue:
                             > VLLM_RINGBUFFER_WARNING_INTERVAL * n_warning):
                         logger.debug(
                             ("No available shared memory broadcast block found"
-                             "in %s second."),
+                             " in %s second."),
                             VLLM_RINGBUFFER_WARNING_INTERVAL,
                         )
                         n_warning += 1


### PR DESCRIPTION
Ran into the following:
```
DEBUG 05-04 16:11:41 [shm_broadcast.py:430] No available shared memory broadcast block foundin 60 second.
```