### PR TITLE
[BugFix] Increase timeout for startup failure test

### DIFF
--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -345,10 +345,12 @@ def test_startup_failure(monkeypatch: pytest.MonkeyPatch):
     with monkeypatch.context() as m, pytest.raises(Exception) as e_info:
         m.setenv("VLLM_USE_V1", "1")
 
+        t = time.time()
         engine_args = EngineArgs(model=MODEL_NAME)
         vllm_config = engine_args.create_engine_config(
             usage_context=UsageContext.UNKNOWN_CONTEXT)
         executor_class = Executor.get_class(vllm_config)
+        print(f"VllmConfig creation took {time.time() - t:.2f} seconds.")
 
         # Start another thread to wait for engine core process to start
         # and kill it - simulate fatal uncaught process exit.
@@ -360,8 +362,9 @@ def test_startup_failure(monkeypatch: pytest.MonkeyPatch):
                 time.sleep(0.5)
                 children = set(this_proc.children()) - children_before
                 if children:
+                    print(f"Found child processes: {children}")
                     child = children.pop()
-                    print("Killing child core process", child.pid)
+                    print(f"Killing child core process {child.pid}")
                     child.kill()
                     break
 

--- a/tests/v1/engine/test_engine_core_client.py
+++ b/tests/v1/engine/test_engine_core_client.py
@@ -337,10 +337,9 @@ def test_kv_cache_events(
                 "Token ids should be the same as the custom tokens")
         finally:
             client.shutdown()
-        return
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_startup_failure(monkeypatch: pytest.MonkeyPatch):
 
     with monkeypatch.context() as m, pytest.raises(Exception) as e_info:


### PR DESCRIPTION
This test is now failing on main most of the time due to the timeout not being large enough.

I'm still confused why this started failing recently. The problem is that just creating `VllmConfig` takes 10 seconds before we even create the `LLM`, which is due to the model class being loaded in a separate process to be able to read some config from it: https://github.com/vllm-project/vllm/blob/2858830c39da0ae153bc1328dbba7680f5fbebe1/vllm/model_executor/models/registry.py#L324-L330

It would be good if we could find a way to retrieve the info in question (like `is_multimodal_model`) without this overhead - I assume it's adding to startup time in all cases, cumulatively contributing to CI times quite a bit, etc.
