### PR TITLE
[Bugfix] Fix tool call template validation for Mistral models

### DIFF
--- a/examples/tool_chat_template_mistral3.jinja
+++ b/examples/tool_chat_template_mistral3.jinja
@@ -29,8 +29,16 @@
 
 {%- set user_messages = loop_messages | selectattr("role", "equalto", "user") | list %}
 
-{%- for message in loop_messages | rejectattr("role", "equalto", "tool") | rejectattr("role", "equalto", "tool_results") | selectattr("tool_calls", "undefined") %}
-    {%- if (message["role"] == "user") != (loop.index0 % 2 == 0) %}
+{%- set filtered_messages = [] %}
+{%- for message in loop_messages %}
+    {%- if message["role"] not in ["tool", "tool_results"] and not message.get("tool_calls") %}
+        {%- set filtered_messages = filtered_messages + [message] %}
+    {%- endif %}
+{%- endfor %}
+
+{%- for i in range(filtered_messages|length) %}
+    {%- set message = filtered_messages[i] %}
+    {%- if (message["role"] == "user") != (i % 2 == 0) %}
         {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
     {%- endif %}
 {%- endfor %}

--- a/examples/tool_chat_template_mistral3.jinja
+++ b/examples/tool_chat_template_mistral3.jinja
@@ -36,8 +36,7 @@
     {%- endif %}
 {%- endfor %}
 
-{%- for i in range(filtered_messages|length) %}
-    {%- set message = filtered_messages[i] %}
+{%- for message in filtered_messages %}
     {%- if (message["role"] == "user") != (i % 2 == 0) %}
         {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
     {%- endif %}

--- a/examples/tool_chat_template_mistral3.jinja
+++ b/examples/tool_chat_template_mistral3.jinja
@@ -37,7 +37,7 @@
 {%- endfor %}
 
 {%- for message in filtered_messages %}
-    {%- if (message["role"] == "user") != (i % 2 == 0) %}
+    {%- if (message["role"] == "user") != (loop.index0 % 2 == 0) %}
         {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
     {%- endif %}
 {%- endfor %}


### PR DESCRIPTION
This fixes an issue where the template validation fails after function calling due to incorrect message role alternation checking. The fix properly filters tool-related messages before validating the user/assistant alternation pattern.

## Fix tool call template validation for Mistral models

This PR fixes an issue where the template validation fails after function calling due to incorrect message role alternation checking. The fix properly filters tool-related messages before validating the user/assistant alternation pattern.

### Problem
When using Mistral models with function calling (tool calls), the server returns an error:
"After the optional system message, conversation roles must alternate user/assistant/user/assistant/..."
This happens specifically after function calling completes and the conversation attempts to continue.

### Solution
Modified the role alternation validation logic in `tool_chat_template_mistral3.jinja` to properly filter out tool-related messages before validation by:
1. Creating a complete filtered list without tool messages
2. Validating the user/assistant alternation pattern on this clean list

FIX #17643(*link existing issues this PR will resolve*)

<!--- pyml disable-next-line no-emphasis-as-heading -->
