### PR TITLE
Add logging for torch nightly version

### DIFF
--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -310,6 +310,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r requirements/nightly_torch_test.txt
 
 # Logging to confirm the torch versions
-RUN uv pip freeze | grep -E 'torch|xformers|vllm|flashinfer'
+RUN pip freeze | grep -E 'torch|xformers|vllm|flashinfer'
 
 #################### UNITTEST IMAGE #############################

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -309,5 +309,7 @@ ENV HF_HUB_ENABLE_HF_TRANSFER 1
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r requirements/nightly_torch_test.txt
 
-#################### UNITTEST IMAGE #############################
+# Logging to confirm the torch versions
+RUN uv pip freeze | grep -E 'torch|xformers|vllm|flashinfer'
 
+#################### UNITTEST IMAGE #############################

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -38,3 +38,4 @@ matplotlib # required for qwen-vl test
 # required for  Multi-Modal Models Test (Standard)
 num2words # required for smolvlm test
 pqdm
+timm # required for internvl test

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -31,6 +31,6 @@ bitsandbytes>=0.45.3
 vector_quantize_pytorch
 vocos
 
-# basic correctness tests
+# Basic Models Test
 blobfile # required for kimi-vl test
 matplotlib # required for qwen-vl test

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -34,3 +34,7 @@ vocos
 # required for Basic Models Test
 blobfile # required for kimi-vl test
 matplotlib # required for qwen-vl test
+
+# required for  Multi-Modal Models Test (Standard)
+num2words # required for smolvlm test
+pqdm

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -31,6 +31,6 @@ bitsandbytes>=0.45.3
 vector_quantize_pytorch
 vocos
 
-# Basic Models Test
+# required for Basic Models Test
 blobfile # required for kimi-vl test
 matplotlib # required for qwen-vl test

--- a/requirements/nightly_torch_test.txt
+++ b/requirements/nightly_torch_test.txt
@@ -8,7 +8,6 @@ pytest-rerunfailures
 pytest-shard
 pytest-timeout
 
-
 librosa # required by audio tests in entrypoints/openai
 sentence-transformers
 numba == 0.61.2; python_version > '3.9'
@@ -31,3 +30,7 @@ bitsandbytes>=0.45.3
 # required for minicpmo_26 test
 vector_quantize_pytorch
 vocos
+
+# basic correctness tests
+blobfile # required for kimi-vl test
+matplotlib # required for qwen-vl test


### PR DESCRIPTION
print out pip freeze | grep to confirm the torch version

testing build: https://buildkite.com/vllm/ci/builds/19304
https://buildkite.com/vllm/ci/builds/19304#0196a14e-0a7d-4da6-a997-4b37dbb01008


working:
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/f052eaba-90ea-43d3-b660-29fcd09f00e0" />


Also add basic model test dependency:
https://buildkite.com/vllm/ci/builds/19437#0196a741-8743-4539-aaba-acdd2d980381

