### PR TITLE
[Bugfix] Adding maxnreg to lora expand/shrink kernel definition

### DIFF
--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -46,7 +46,8 @@ def _lora_expand_kernel(
         ADD_INPUTS: tl.constexpr,
         CAST_TYPE: tl.constexpr,
         SLICE_NUM: tl.constexpr,
-        SAME_STRIDE: tl.constexpr):
+        SAME_STRIDE: tl.constexpr,
+        maxnreg: tl.constexpr):
 
     cta_n_num = tl.cdiv(N, BLOCK_N)
     cta_m_num = tl.cdiv(M, BLOCK_M)

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -26,7 +26,8 @@ def _lora_shrink_kernel(input_ptr, lora_ptr, out_ptr, M, N, K,
                         output_d1_stride, output_d2_stride,
                         BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
                         BLOCK_K: tl.constexpr, EVEN_K: tl.constexpr,
-                        SPLIT_K: tl.constexpr, SLICE_NUM: tl.constexpr):
+                        SPLIT_K: tl.constexpr, SLICE_NUM: tl.constexpr,
+                        maxnreg: tl.constexpr):
 
     cta_n_num = tl.cdiv(N, BLOCK_N)
     cta_m_num = tl.cdiv(M, BLOCK_M)


### PR DESCRIPTION
Updating lora_expand and lora_shrink kernel definitions with maxnreg to fix the following error in linked issue
Keyword argument maxnreg was specified but unrecognised

FIX https://github.com/vllm-project/vllm/issues/16676