### PR TITLE
[Bugfix] LoRA - Retire unused maxnreg LoRA kernel argument

### DIFF
--- a/vllm/lora/ops/triton_ops/lora_expand_op.py
+++ b/vllm/lora/ops/triton_ops/lora_expand_op.py
@@ -204,7 +204,6 @@ def _lora_expand(
     NUM_WARPS = 4
     NUM_CTAS = 1
     NUM_STAGES = 2
-    MAX_NREG = None
 
     EVEN_K = K % BLOCK_K == 0  # type: ignore
 
@@ -258,7 +257,6 @@ def _lora_expand(
         num_warps=NUM_WARPS,
         num_ctas=NUM_CTAS,
         num_stages=NUM_STAGES,
-        maxnreg=MAX_NREG,
     )
 
     return

--- a/vllm/lora/ops/triton_ops/lora_shrink_op.py
+++ b/vllm/lora/ops/triton_ops/lora_shrink_op.py
@@ -168,7 +168,6 @@ def _lora_shrink(
     NUM_WARPS = 4
     NUM_CTAS = 1
     NUM_STAGES = 2
-    MAX_NREG = None
 
     EVEN_K = K % (BLOCK_K * SPLIT_K) == 0  # type: ignore
 
@@ -213,7 +212,6 @@ def _lora_shrink(
         num_warps=NUM_WARPS,
         num_ctas=NUM_CTAS,
         num_stages=NUM_STAGES,
-        maxnreg=MAX_NREG,
     )
 
     return


### PR DESCRIPTION
LoRA triton kernels fail to compile on non-CUDA gpus because the `maxnreg` argument is recognized only on CUDA platforms. 

Fix: The `maxnreg` argument isn't used and it is safe to retire completely. 

FIX #16676
