### PR TITLE
[ci][build] Fix license field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "vllm"
 authors = [{name = "vLLM Team"}]
-license = "Apache-2.0"
-license-files = ["LICENSE"]
+license = {file = "LICENSE"}
 readme = "README.md"
 description = "A high-throughput and memory-efficient inference and serving engine for LLMs"
 classifiers = [


### PR DESCRIPTION
As mentioned in #17360 , we got an installation error that the license field does not match the required format.

Simply replace it with `license = {file = "LICENSE"}`.

