### PR TITLE
[Bugfix] add health check for ray workers

### DIFF
--- a/tests/distributed/test_error_handling.py
+++ b/tests/distributed/test_error_handling.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Test that various errors are handled properly."""
+
+import pytest
+import ray
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.v1.engine.core import EngineCore
+from vllm.v1.executor.ray_distributed_executor import RayDistributedExecutor
+
+
+def test_failed_ray_worker(monkeypatch: pytest.MonkeyPatch):
+    # even for TP=1 and PP=1,
+    # if users specify ray, we will use ray.
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_V1", "1")
+        m.setenv("VLLM_USE_RAY_SPMD_WORKER", "1")
+
+        engine_args = EngineArgs(model="distilbert/distilgpt2",
+                                 enforce_eager=True)
+        vllm_config = engine_args.create_engine_config()
+
+        engine_core = EngineCore(vllm_config=vllm_config,
+                                 executor_class=RayDistributedExecutor,
+                                 log_stats=False)
+
+        assert engine_core.model_executor.uses_ray
+
+        engine_core.model_executor.check_health()
+
+        for worker in engine_core.model_executor.workers:
+            ray.kill(worker)
+
+        with pytest.raises(RuntimeError):
+            engine_core.model_executor.check_health()

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -400,8 +400,12 @@ def engine_client(request: Request) -> EngineClient:
 @router.get("/health")
 async def health(raw_request: Request) -> JSONResponse:
     """Health check."""
-    await engine_client(raw_request).check_health()
-    return JSONResponse(content={}, status_code=200)
+    try:
+        await engine_client(raw_request).check_health()
+    except Exception as e:
+        logger.error(f"Health check failed: {e}")
+        return JSONResponse(content={'status': 'unhealthy'}, status_code=500)
+    return JSONResponse(content={'status': 'healthy'}, status_code=200)
 
 
 @router.get("/load")

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -403,7 +403,7 @@ async def health(raw_request: Request) -> JSONResponse:
     try:
         await engine_client(raw_request).check_health()
     except Exception as e:
-        logger.error(f"Health check failed: {e}")
+        logger.error("Health check failed: %s", str(e))
         return JSONResponse(content={'status': 'unhealthy'}, status_code=500)
     return JSONResponse(content={'status': 'healthy'}, status_code=200)
 

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -703,7 +703,8 @@ class RayDistributedExecutor(DistributedExecutorBase):
         current_job_id = ray.get_runtime_context().get_job_id()
 
         workers = self.workers[:]
-        if not self.use_ray_spmd_worker:
+        if (not self.use_ray_spmd_worker
+                and self.driver_dummy_worker is not None):
             workers.append(self.driver_dummy_worker)
 
         dead_actors = []


### PR DESCRIPTION
In current implementation, if a ray worker
goes down, the health endpoint is still reports
as healthy, and the server continues to run.

We have to check the health status of ray
worker and expose error in the health endpoint.

<!--- pyml disable-next-line no-emphasis-as-heading -->
