### PR TITLE
[MISC][pre-commit] Add pre-commit check for triton import

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,6 +125,13 @@ repos:
     name: Update Dockerfile dependency graph
     entry: tools/update-dockerfile-graph.sh
     language: script
+  # forbid directly import triton
+  - id: forbid-direct-triton-import
+    name: "Forbid direct 'import triton'"
+    entry: python tools/check_triton_import.py
+    language: python
+    types: [python]
+    pass_filenames: false
   # Keep `suggestion` last
   - id: suggestion
     name: Suggestion

--- a/tools/check_triton_import.py
+++ b/tools/check_triton_import.py
@@ -4,12 +4,19 @@ import subprocess
 import sys
 
 FORBIDDEN_IMPORT_RE = re.compile(r"^(from|import)\s+triton(\s|\.|$)")
-ALLOWED_LINE = "from vllm.triton_utils import triton"
+
+# the way allowed to import triton
+ALLOWED_LINES = {
+    "from vllm.triton_utils import triton",
+    "from vllm.triton_utils import tl",
+    "from vllm.triton_utils import tl, triton",
+}
 
 
 def is_forbidden_import(line: str) -> bool:
-    return bool(FORBIDDEN_IMPORT_RE.match(
-        line.strip())) and ALLOWED_LINE not in line.strip()
+    stripped = line.strip()
+    return bool(
+        FORBIDDEN_IMPORT_RE.match(stripped)) and stripped not in ALLOWED_LINES
 
 
 def parse_diff(diff: str) -> list[str]:

--- a/tools/check_triton_import.py
+++ b/tools/check_triton_import.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+import re
+import subprocess
+import sys
+
+FORBIDDEN_IMPORT_RE = re.compile(r"^(from|import)\s+triton(\s|\.|$)")
+ALLOWED_LINE = "from vllm.triton_utils import triton"
+
+
+def is_forbidden_import(line: str) -> bool:
+    return bool(FORBIDDEN_IMPORT_RE.match(
+        line.strip())) and ALLOWED_LINE not in line.strip()
+
+
+def parse_diff(diff: str) -> list[str]:
+    violations = []
+    current_file = None
+    current_lineno = None
+
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+        elif line.startswith("@@"):
+            match = re.search(r"\+(\d+)", line)
+            if match:
+                current_lineno = int(
+                    match.group(1)) - 1  # next "+ line" is here
+        elif line.startswith("+") and not line.startswith("++"):
+            current_lineno += 1
+            code_line = line[1:]
+            if is_forbidden_import(code_line):
+                violations.append(
+                    f"{current_file}:{current_lineno}: {code_line.strip()}")
+    return violations
+
+
+def get_diff(diff_type: str) -> str:
+    if diff_type == "staged":
+        return subprocess.check_output(
+            ["git", "diff", "--cached", "--unified=0"], text=True)
+    elif diff_type == "unstaged":
+        return subprocess.check_output(["git", "diff", "--unified=0"],
+                                       text=True)
+    else:
+        raise ValueError(f"Unknown diff_type: {diff_type}")
+
+
+def main():
+    all_violations = []
+    for diff_type in ["staged", "unstaged"]:
+        try:
+            diff_output = get_diff(diff_type)
+            violations = parse_diff(diff_output)
+            all_violations.extend(violations)
+        except subprocess.CalledProcessError as e:
+            print(f"[{diff_type}] Git diff failed: {e}", file=sys.stderr)
+
+    if all_violations:
+        print("❌ Forbidden direct `import triton` detected."
+              " ➤ Use `from vllm.triton_utils import triton` instead.\n")
+        for v in all_violations:
+            print(f"❌ {v}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds a pre-commit check for triton import, `from vllm.triton_utils import triton` is allowed, but `import triton` is forbidden.

FIX https://github.com/vllm-project/vllm/pull/17446#issuecomment-2853955293

Test this pr locally, and it works like following:
- the results of `git diff`
```diff
diff --git a/vllm/attention/ops/hpu_paged_attn.py b/vllm/attention/ops/hpu_paged_attn.py
index 1dedd2ffc..890741597 100644
--- a/vllm/attention/ops/hpu_paged_attn.py
+++ b/vllm/attention/ops/hpu_paged_attn.py
@@ -13,6 +13,9 @@ from vllm_hpu_extension import cache_ops, ops
 # Should be the same as PARTITION_SIZE in `paged_attention_v2_launcher`.
 _PARTITION_SIZE = 512
 
+import triton  # noqa
+import triton.language as tl  # noqa
+
 
 @dataclass
 class HPUPagedAttentionMetadata:
diff --git a/vllm/attention/ops/ipex_attn.py b/vllm/attention/ops/ipex_attn.py
index 1702203b1..f907205a2 100644
--- a/vllm/attention/ops/ipex_attn.py
+++ b/vllm/attention/ops/ipex_attn.py
@@ -12,7 +12,7 @@ except (ImportError, AttributeError):
 import torch
 
 from vllm import _custom_ops as ops
-
+from vllm.triton_utils import triton # noqa
 
 class _PagedAttention:
```

- the result of `pre-commit run --all-files`

```bash
codespell................................................................Passed
isort....................................................................Passed
clang-format.............................................................Passed
PyMarkdown...............................................................Passed
Lint GitHub Actions workflow files.......................................Passed
pip-compile..............................................................Failed
- hook id: pip-compile
- exit code: 2

warning: The `--torch-backend` setting is experimental and may change without warning. Pass `--preview` to disable this warning.
⠋ encodec==0.1.1                                                                error: Failed to fetch: `https://pypi.org/simple/lxml/`
  Caused by: request or response body error
  Caused by: operation timed out

Run mypy for local Python installation...................................Passed
Lint shell scripts.......................................................Passed
Lint PNG exports from excalidraw.........................................Passed
Check SPDX headers.......................................................Passed
Check for spaces in all filenames........................................Passed
Update Dockerfile dependency graph.......................................Passed
Forbid direct 'import triton'............................................Failed
- hook id: forbid-direct-triton-import
- exit code: 1

❌ Forbidden direct `import triton` detected. ➤ Use `from vllm.triton_utils import triton` instead.

❌ vllm/attention/ops/hpu_paged_attn.py:16: import triton  # noqa
❌ vllm/attention/ops/hpu_paged_attn.py:17: import triton.language as tl  # noqa

Suggestion...............................................................Passed
- hook id: suggestion
- duration: 0s

To bypass pre-commit hooks, add --no-verify to git commit.
``` 

