### PR TITLE
Add OpenAI-compatible Whisper client example for audio transcription

### DIFF
--- a/examples/online_serving/openai_whisper_client.py
+++ b/examples/online_serving/openai_whisper_client.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Example client for using OpenAI-compatible Whisper transcription via vLLM.
+"""
+
+import openai
+
+# === User configuration ===
+VLLM_SERVER_URL = (
+    "http://your-vllm-server:port/v1/"  # Replace with your vLLM server URL
+)
+WHISPER_MODEL_NAME = (
+    "your-whisper-model-name"  # Replace with the name of your Whisper model
+)
+AUDIO_FILE_PATH = (
+    "path/to/your-audio-file.mp3"  # Replace with the path to your audio file
+)
+
+# Set the custom vLLM endpoint
+openai.base_url = VLLM_SERVER_URL
+openai.api_key = "no-key"  # Dummy key for compatibility
+
+# Load and send the audio file for transcription
+with open(AUDIO_FILE_PATH, "rb") as audio_file:
+    transcript = openai.audio.transcriptions.create(
+        model=WHISPER_MODEL_NAME,
+        file=audio_file,
+        response_format="text",  # Use "json" if you want full metadata
+    )
+
+print("Transcription result:")
+print(transcript)


### PR DESCRIPTION
Add OpenAI-compatible Whisper client example

This PR adds a new example script under `examples/online_serving/` that demonstrates how to use a vLLM server with an OpenAI-compatible endpoint for Whisper-based audio transcription.

The script shows how to:
- Set the custom base URL and model name
- Use the `openai` Python SDK to send audio files
- Get transcription results in plain text

All sensitive values (server URL, model name, file path) are left as clear placeholders for the user to fill in.

No related issues — this is an example contribution.

<!--- pyml disable-next-line no-emphasis-as-heading -->
