### PR TITLE
feat: engine v1 post process sampled logprobs

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -314,6 +314,10 @@ class ModelConfig:
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the
     OpenAI Chat Completions API."""
+    post_process_logprobs: bool = False
+    """Whether to calculate the log probabilities after applying temperature,
+    min-p, top-k, top-p, etc to the logits. By default (False), the log
+    probabilities are calculated before any of these are applied."""
     disable_sliding_window: bool = False
     """Whether to disable sliding window. If True, we will disable the sliding
     window functionality of the model, capping to sliding window size. If the

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -314,7 +314,7 @@ class ModelConfig:
     """Maximum number of log probabilities to return when `logprobs` is
     specified in `SamplingParams`. The default value comes the default for the
     OpenAI Chat Completions API."""
-    post_process_logprobs: bool = False
+    return_logprobs_post_logits_processing: bool = False
     """Whether to calculate the log probabilities after applying temperature,
     min-p, top-k, top-p, etc to the logits. By default (False), the log
     probabilities are calculated before any of these are applied."""

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -311,7 +311,8 @@ class EngineArgs:
         SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: Optional[int] = SchedulerConfig.max_num_seqs
     max_logprobs: int = ModelConfig.max_logprobs
-    post_process_logprobs: bool = ModelConfig.post_process_logprobs
+    return_logprobs_post_logits_processing: bool = \
+        ModelConfig.return_logprobs_post_logits_processing
     disable_log_stats: bool = False
     revision: Optional[str] = ModelConfig.revision
     code_revision: Optional[str] = ModelConfig.code_revision
@@ -481,8 +482,9 @@ class EngineArgs:
                                  **model_kwargs["max_seq_len_to_capture"])
         model_group.add_argument("--max-logprobs",
                                  **model_kwargs["max_logprobs"])
-        model_group.add_argument("--post_process_logprobs",
-                                 **model_kwargs["post_process_logprobs"])
+        model_group.add_argument(
+            "--return_logprobs_post_logits_processing",
+            **model_kwargs["return_logprobs_post_logits_processing"])
         model_group.add_argument("--disable-sliding-window",
                                  **model_kwargs["disable_sliding_window"])
         model_group.add_argument("--disable-cascade-attn",
@@ -897,7 +899,8 @@ class EngineArgs:
             enforce_eager=self.enforce_eager,
             max_seq_len_to_capture=self.max_seq_len_to_capture,
             max_logprobs=self.max_logprobs,
-            post_process_logprobs=self.post_process_logprobs,
+            return_logprobs_post_logits_processing=self.
+            return_logprobs_post_logits_processing,
             disable_sliding_window=self.disable_sliding_window,
             disable_cascade_attn=self.disable_cascade_attn,
             skip_tokenizer_init=self.skip_tokenizer_init,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -311,6 +311,7 @@ class EngineArgs:
         SchedulerConfig.long_prefill_token_threshold
     max_num_seqs: Optional[int] = SchedulerConfig.max_num_seqs
     max_logprobs: int = ModelConfig.max_logprobs
+    post_process_logprobs: bool = ModelConfig.post_process_logprobs
     disable_log_stats: bool = False
     revision: Optional[str] = ModelConfig.revision
     code_revision: Optional[str] = ModelConfig.code_revision
@@ -480,6 +481,8 @@ class EngineArgs:
                                  **model_kwargs["max_seq_len_to_capture"])
         model_group.add_argument("--max-logprobs",
                                  **model_kwargs["max_logprobs"])
+        model_group.add_argument("--post_process_logprobs",
+                                 **model_kwargs["post_process_logprobs"])
         model_group.add_argument("--disable-sliding-window",
                                  **model_kwargs["disable_sliding_window"])
         model_group.add_argument("--disable-cascade-attn",
@@ -894,6 +897,7 @@ class EngineArgs:
             enforce_eager=self.enforce_eager,
             max_seq_len_to_capture=self.max_seq_len_to_capture,
             max_logprobs=self.max_logprobs,
+            post_process_logprobs=self.post_process_logprobs,
             disable_sliding_window=self.disable_sliding_window,
             disable_cascade_attn=self.disable_cascade_attn,
             skip_tokenizer_init=self.skip_tokenizer_init,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -206,10 +206,10 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         " as strings of the form 'token_id:{token_id}' so that tokens "
         "that are not JSON-encodable can be identified.")
     parser.add_argument(
-        "--post-process-logprobs",
+        "--return-logprobs-post-logits-processing",
         action="store_true",
-        help="When ``--post-process-logprobs`` is specified, the sampled"
-        " logprobs will be calculated after applying temperature,"
+        help="When ``--return-logprobs-post-logits-processing`` is specified,"
+        " the sampled logprobs will be calculated after applying temperature,"
         " top-k, top-p, etc rather than before (default).")
     parser.add_argument(
         "--disable-frontend-multiprocessing",

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -206,6 +206,12 @@ def make_arg_parser(parser: FlexibleArgumentParser) -> FlexibleArgumentParser:
         " as strings of the form 'token_id:{token_id}' so that tokens "
         "that are not JSON-encodable can be identified.")
     parser.add_argument(
+        "--post-process-logprobs",
+        action="store_true",
+        help="When ``--post-process-logprobs`` is specified, the sampled"
+        " logprobs will be calculated after applying temperature,"
+        " top-k, top-p, etc rather than before (default).")
+    parser.add_argument(
         "--disable-frontend-multiprocessing",
         action="store_true",
         help="If specified, will run the OpenAI frontend server in the same "

--- a/vllm/v1/sample/ops/topk_topp_sampler.py
+++ b/vllm/v1/sample/ops/topk_topp_sampler.py
@@ -107,8 +107,7 @@ class TopKTopPSampler(nn.Module):
                            "PyTorch-native implementation.")
             return self.forward_native(logits, generators, k, p)
         else:
-            sample, probs = flashinfer_sample(logits, k, p, generators,
-                                              return_logits)
+            sample, probs = flashinfer_sample(logits, k, p, return_logits)
             if return_logits:
                 assert probs is not None
                 # Set logits to -inf where probs were set to 0.0.
@@ -279,7 +278,6 @@ def flashinfer_sample(
     logits: torch.Tensor,
     k: Optional[torch.Tensor],
     p: Optional[torch.Tensor],
-    generators: dict[int, torch.Generator],
     return_probs: bool,
 ) -> tuple[torch.Tensor, Union[torch.Tensor, None]]:
     """Sample from the logits using FlashInfer.

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -100,12 +100,12 @@ class Sampler(nn.Module):
         may update the logits tensor in-place.
         """
         # Perform greedy sampling before applying temperature, top-k, etc
+        assert not (sampling_metadata.all_greedy
+                    and sampling_metadata.all_random)
         if sampling_metadata.all_random:
             greedy_sampled = None
         else:
             greedy_sampled = self.greedy_sample(logits)
-        assert not (sampling_metadata.all_greedy
-                    and sampling_metadata.all_random)
         if sampling_metadata.all_greedy:
             if return_logits:
                 return greedy_sampled, logits

--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -18,10 +18,11 @@ _SAMPLING_EPS = 1e-5
 
 class Sampler(nn.Module):
 
-    def __init__(self, post_process_logprobs: bool = False):
+    def __init__(self, return_logprobs_post_logits_processing: bool = False):
         super().__init__()
         self.topk_topp_sampler = TopKTopPSampler()
-        self.post_process_logprobs = post_process_logprobs
+        self.return_logprobs_post_logits_processing =\
+            return_logprobs_post_logits_processing
 
     def forward(
         self,
@@ -35,10 +36,12 @@ class Sampler(nn.Module):
         # TODO(rob): provide option for logprobs post sampling.
         # See https://vllm-dev.slack.com/archives/C07UUL8E61Z/p1735907856007919 # noqa: E501
         num_logprobs = sampling_metadata.max_num_logprobs
-        if num_logprobs is not None and not self.post_process_logprobs:
+        if (num_logprobs is not None
+                and not self.return_logprobs_post_logits_processing):
             raw_logprobs = self.compute_logprobs(logits)
         # Return logits to get logprobs at the end.
-        return_logits = num_logprobs is not None and self.post_process_logprobs
+        return_logits = (num_logprobs is not None
+                         and self.return_logprobs_post_logits_processing)
 
         # Use float32 for the logits.
         logits = logits.to(torch.float32)

--- a/vllm/v1/sample/tpu/sampler.py
+++ b/vllm/v1/sample/tpu/sampler.py
@@ -63,7 +63,7 @@ class Sampler(nn.Module):
             logits = self.apply_min_p(logits, sampling_metadata.min_p)
 
         # Apply top_k and/or top_p.
-        random_sampled = self.topk_topp_sampler(
+        random_sampled, _ = self.topk_topp_sampler(
             logits,
             sampling_metadata.generators,
             sampling_metadata.top_k,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -132,7 +132,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.encoder_cache_size = encoder_cache_size
 
         # Sampler
-        self.sampler = Sampler()
+        self.sampler = Sampler(
+            post_process_logprobs=self.model_config.post_process_logprobs)
 
         # Lazy initializations
         # self.model: nn.Module  # Set after load_model

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -133,7 +133,8 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
         # Sampler
         self.sampler = Sampler(
-            post_process_logprobs=self.model_config.post_process_logprobs)
+            return_logprobs_post_logits_processing=self.model_config.
+            return_logprobs_post_logits_processing)
 
         # Lazy initializations
         # self.model: nn.Module  # Set after load_model


### PR DESCRIPTION
vLLM v1 Engines only support calculating logprobs before any post-processing (temperature, top-k, top-p, etc) is applied. This PR adds the capability to calculate sampled logprobs after the post-processing has run.

Edit: I did an initial test on CPU which seemed to work fine. I'll do more thorough tests tomorrow, opening for review already in the meantime.