### PR TITLE
[CI] Add workflow permissions for helm CI job

### DIFF
--- a/.github/workflows/lint-and-deploy.yaml
+++ b/.github/workflows/lint-and-deploy.yaml
@@ -2,6 +2,9 @@ name: Lint and Deploy Charts
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vllm-project/vllm/security/code-scanning/24](https://github.com/vllm-project/vllm/security/code-scanning/24)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimum permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily reads repository contents and does not appear to require write permissions. Therefore, we will set `contents: read` as the default permission. If any specific steps require additional permissions, they can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
