### PR TITLE
[CI] Set token permissions for reminder comment CI job

### DIFF
--- a/.github/workflows/reminder_comment.yml
+++ b/.github/workflows/reminder_comment.yml
@@ -1,4 +1,6 @@
 name: PR Reminder Comment Bot
+permissions:
+  issues: write
 on:
   pull_request_target:
     types: [opened]


### PR DESCRIPTION
Potential fix for [https://github.com/vllm-project/vllm/security/code-scanning/22](https://github.com/vllm-project/vllm/security/code-scanning/22)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the permissions required. Since the workflow only needs to create comments on pull requests, we will grant `issues: write` permission. All other permissions will be omitted or set to `read` to minimize access.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
