### PR TITLE
[CI] set token permissions for pre-commit CI job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vllm-project/vllm/security/code-scanning/21](https://github.com/vllm-project/vllm/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow only runs pre-commit checks and does not modify repository contents or interact with pull requests, it only requires `contents: read` permissions. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
