### PR TITLE
[CI] Add token permissions for add-ready-label CI job

### DIFF
--- a/.github/workflows/add_label_automerge.yml
+++ b/.github/workflows/add_label_automerge.yml
@@ -1,4 +1,6 @@
 name: Add label on auto-merge enabled
+permissions:
+    issues: write
 on:
     pull_request_target:
         types:


### PR DESCRIPTION
Potential fix for [https://github.com/vllm-project/vllm/security/code-scanning/20](https://github.com/vllm-project/vllm/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required for the workflow. Since the workflow uses the `issues.addLabels` API, it requires `issues: write` permission. All other permissions will be set to `read` or omitted entirely.

The `permissions` block will be added at the root level of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
