### PR TITLE
[Bugfix] Fix for the condition to accept empty encoder inputs for mllama

### DIFF
--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -2021,7 +2021,7 @@ class LLMEngine:
         if not prompt_ids:
             if prompt_type == "encoder" and model_config.is_multimodal_model:
                 pass  # Mllama may have empty encoder inputs for text-only data
-            if prompt_inputs["type"] == "embeds":
+            elif prompt_inputs["type"] == "embeds":
                 pass
             else:
                 raise ValueError(f"The {prompt_type} prompt cannot be empty")


### PR DESCRIPTION
Fix for the regression from https://github.com/vllm-project/vllm/pull/15428
Currently an exception will be raised when encoder part of the prompt (image) for mllama is empty