### PR TITLE
[Fix] Auto-detect XGrammar compiler threads based on CPU cores.

### DIFF
--- a/docs/source/features/structured_outputs.md
+++ b/docs/source/features/structured_outputs.md
@@ -273,3 +273,22 @@ print(outputs[0].outputs[0].text)
 ```
 
 Full example: <gh-file:examples/offline_inference/structured_outputs.py>
+
+## Performance Tuning: XGrammar Compiler Threads
+
+When using the xgrammar backend for structured outputs, the number of threads
+used by the grammar compiler can affect the time to first token, especially for
+complex schemas.
+
+You can control the thread pool size for the xgrammar grammar compiler using the
+environment variable `VLLM_XGRAMMAR_COMPILER_THREADS`. By default, this is set
+to `8`. Increasing this value may help reduce first token latency in some
+environments, particularly when compiling large or complex schemas. For example:
+
+```bash
+export VLLM_XGRAMMAR_COMPILER_THREADS=16
+```
+
+Set this variable before starting vLLM. Note that increasing the thread count
+may increase CPU usage during grammar compilation, and may not always improve
+performance.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -114,6 +114,7 @@ if TYPE_CHECKING:
     VLLM_ALLOW_INSECURE_SERIALIZATION: bool = False
     VLLM_NIXL_SIDE_CHANNEL_HOST: str = "localhost"
     VLLM_NIXL_SIDE_CHANNEL_PORT: int = 5557
+    VLLM_XGRAMMAR_COMPILER_THREADS: int = 8
 
 
 def get_default_cache_root():
@@ -757,6 +758,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Port used for NIXL handshake between remote agents.
     "VLLM_NIXL_SIDE_CHANNEL_PORT":
     lambda: int(os.getenv("VLLM_NIXL_SIDE_CHANNEL_PORT", "5557")),
+
+    # Number of threads to use for the XGrammar grammar compiler.
+    # If not set, defaults to None and the backend will auto-detect.
+    "VLLM_XGRAMMAR_COMPILER_THREADS":
+    lambda: int(os.getenv("VLLM_XGRAMMAR_COMPILER_THREADS", "8")),
 }
 
 # end-env-vars-definition

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -27,8 +26,6 @@ else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
 
 logger = init_logger(__name__)
-
-VLLM_XGRAMMAR_COMPILER_THREADS_ENV_VAR = "VLLM_XGRAMMAR_COMPILER_THREADS"
 
 
 class XgrammarBackend(StructuredOutputBackend):
@@ -90,36 +87,10 @@ class XgrammarBackend(StructuredOutputBackend):
             )
         self.compiler = xgr.GrammarCompiler(
             tokenizer_info,
-            max_threads=self._get_grammar_compiler_threads(),
+            max_threads=vllm.envs.VLLM_XGRAMMAR_COMPILER_THREADS,
             cache_enabled=True,
             cache_limit_bytes=vllm.envs.VLLM_XGRAMMAR_CACHE_MB * 1024 * 1024,
         )
-
-    def _get_grammar_compiler_threads(self) -> int:
-        """Get the number of threads to use for the grammar compiler. If the
-        environment variable VLLM_XGRAMMAR_COMPILER_THREADS is set, it will
-        be used as the number of threads. Otherwise, half of the total thread
-        count is chosen here to avoid occupying all CPU resources. 32 is an
-        estimate of the effective number of compilation threads needed for
-        common schemas, and using more threads may not provide additional
-        benefits.
-
-        Returns:
-            int: The number of threads to use for the grammar compiler.
-        """
-        # check environment variable
-        env_threads = os.environ.get(VLLM_XGRAMMAR_COMPILER_THREADS_ENV_VAR)
-        if env_threads is not None:
-            try:
-                env_threads_int = int(env_threads)
-                if env_threads_int > 0:
-                    return env_threads_int
-            except ValueError:
-                pass
-        num_cpus = os.cpu_count()
-        if num_cpus is None:
-            return 8
-        return min(num_cpus // 2, 32)
 
     def compile_grammar(self, request_type: StructuredOutputOptions,
                         grammar_spec: str) -> StructuredOutputGrammar:


### PR DESCRIPTION
This PR detects the number of threads in XGrammar's GrammarCompiler with the number of CPU cores to achieve best compilation performance.

Thanks to discussion with @russellb 