### PR TITLE
[ROCm] fix num_stages for default moe config to avoid triton OutOfResource error

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -747,13 +747,15 @@ def get_default_config(
     if dtype == "fp8_w8a8" and block_shape is not None:
         # Block-wise quant: BLOCK_SIZE_N must be divisible by block_shape[0]
         # BLOCK_SIZE_K must be divisible by block_shape[1]
+        # num_stages=3 can cause triton.runtime.errors.OutOfResources
+        # on ROCm, set it to 2 instead.
         config = {
             "BLOCK_SIZE_M": 64,
             "BLOCK_SIZE_N": block_shape[0],
             "BLOCK_SIZE_K": block_shape[1],
             "GROUP_SIZE_M": 32,
             "num_warps": 4,
-            "num_stages": 3,
+            "num_stages": 3 if not current_platform.is_rocm() else 2,
         }
     elif dtype in ["int4_w4a16", "int8_w8a16"] and block_shape is not None:
         # moe wna16 kernels


### PR DESCRIPTION
When `num_stages=3` is used as default for ROCm, some people might experience below error:
```
[1;36m(VllmWorker rank=7 pid=2605744)[0;0m ERROR 05-05 17:03:35 [multiproc_executor.py:470]     raise OutOfResources(self.metadata.shared, max_shared_mem, "shared memory")

[1;36m(VllmWorker rank=7 pid=2605744)[0;0m ERROR 05-05 17:03:35 [multiproc_executor.py:470] triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 73728, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
```

For ROCm, we set it the default to 2 to avoid such OutOfResources errors.

Check reference (there is no 3 mentioned):
https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference-optimization/workload.html#triton-kernel-performance-optimization
```
Adjusts the number of pipeline stages for different types of kernels. On AMD accelerators, set num_stages according to the following rules:

- For kernels with a single GEMM, set to 2.

- For kernels with two GEMMs fused (Flash Attention, or any other kernel that fuses 2 GEMMs), set to 1.

- For kernels that fuse a single GEMM with another non-GEMM operator (for example ReLU activation), set to 2.

- For kernels that have no GEMMs, set to 1.
```

Test: 
For the person who experienced the error, he manually updated it to 2, and the OutOfResource error went away.




<!--- pyml disable-next-line no-emphasis-as-heading -->
