### PR TITLE
Fix doc build performance

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,9 +60,6 @@ autodoc2_packages = [
 autodoc2_output_dir = "api"
 autodoc2_render_plugin = "myst"
 autodoc2_hidden_objects = ["dunder", "private", "inherited"]
-autodoc2_docstring_parser_regexes = [
-    (".*", "docs.source.autodoc2_docstring_parser"),
-]
 autodoc2_sort_names = True
 autodoc2_index_template = None
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,5 @@
 sphinx==7.4.7
 sphinx-argparse==0.5.2
-sphinx-autodoc2==0.5.0
 sphinx-book-theme==1.1.4
 sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
@@ -8,6 +7,10 @@ sphinx-togglebutton==0.3.2
 myst-parser==3.0.1  # `myst-parser==4.0.1` breaks inline code in titles
 msgspec
 commonmark # Required by sphinx-argparse when using :markdownhelp:
+
+# Custom autodoc2 is necessary for faster docstring processing
+# see: https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/33#issuecomment-2856386035
+git+https://github.com/hmellor/sphinx-autodoc2.git # sphinx-autodoc2==0.5.0
 
 # packages to install to build the documentation
 cachetools


### PR DESCRIPTION
When using `sphinx-autodoc2` with a custom parser that can parse Google style docstrings (as we are):

- the build speed is very slow
- the build directory grows to about 35GB

This was causing problems with docs builds:

- queing up for so long they get cancelled
- timing out while building
- running out of storage

With the [workaround in my fork](https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/33#issuecomment-2856386035) of `sphinx-autodoc2`, both of these problems are resolved.