### PR TITLE
[Bugfix] Fix bad words for Mistral models

### DIFF
--- a/vllm/logits_process.py
+++ b/vllm/logits_process.py
@@ -4,11 +4,12 @@ from typing import Callable, Union
 
 import torch
 
-from vllm.transformers_utils.tokenizer import AnyTokenizer, MistralTokenizer
+from vllm.transformers_utils.tokenizer import AnyTokenizer
 
-LogitsProcessor = Union[Callable[[list[int], torch.Tensor], torch.Tensor],
-                        Callable[[list[int], list[int], torch.Tensor],
-                                 torch.Tensor]]
+LogitsProcessor = Union[
+    Callable[[list[int], torch.Tensor], torch.Tensor],
+    Callable[[list[int], list[int], torch.Tensor], torch.Tensor],
+]
 """LogitsProcessor is a function that takes a list
 of previously generated tokens, the logits tensor
 for the next token and, optionally, prompt tokens as a
@@ -29,12 +30,8 @@ def get_bad_words_logits_processors(
             prefix = " " if add_prefix_space else ""
             prompt = prefix + bad_word.lstrip()
 
-            if isinstance(tokenizer, MistralTokenizer):
-                # Mistral tokenizers should not add special tokens
-                prompt_token_ids = tokenizer.encode(text=prompt)
-            else:
-                prompt_token_ids = tokenizer.encode(text=prompt,
-                                                    add_special_tokens=False)
+            prompt_token_ids = tokenizer.encode(text=prompt,
+                                                add_special_tokens=False)
 
             # If no space at the beginning
             # or if prefix space produces a new word token

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -13,7 +13,6 @@ from typing_extensions import deprecated
 from vllm.logger import init_logger
 from vllm.logits_process import LogitsProcessor
 from vllm.transformers_utils.tokenizer import AnyTokenizer
-from vllm.transformers_utils.tokenizers.mistral import MistralTokenizer
 
 logger = init_logger(__name__)
 
@@ -491,13 +490,8 @@ class SamplingParams(
             for add_prefix_space in [False, True]:
                 prefix = " " if add_prefix_space else ""
                 prompt = prefix + bad_word.lstrip()
-
-                if isinstance(tokenizer, MistralTokenizer):
-                    # Mistral tokenizers should not add special tokens
-                    prompt_token_ids = tokenizer.encode(text=prompt)
-                else:
-                    prompt_token_ids = tokenizer.encode(
-                        text=prompt, add_special_tokens=False)
+                prompt_token_ids = tokenizer.encode(text=prompt,
+                                                    add_special_tokens=False)
 
                 # If no space at the beginning
                 # or if prefix space produces a new word token


### PR DESCRIPTION
When using the `bad_words` SamplingParam with Mistral models with V1, `bad_words` compiles incorrectly.
For example, when `bad_words=["the"]` `_bad_words_token_ids` is `[[1, 3265]]` when it should be `[[3265]]`, so the word "the" is never matched. 

We fix this by setting `add_special_tokens=False` for all tokenizers when we generate `_bad_words_token_ids`

It seems that for non-Mistral models too, we don't want to add the special tokens either, so it's a little unclear why this logic was included, as other models like Llama also include start of sequence tokens. 
<img width="629" alt="image" src="https://github.com/user-attachments/assets/8b170a79-4c92-497b-8ba9-eedaf5802f98" />

We can replicate this bug with any Mistral model using the original e2e testing code from https://github.com/vllm-project/vllm/pull/13376
