### PR TITLE
Only depend on importlib-metadata for Python < 3.10

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -29,7 +29,7 @@ partial-json-parser # used for parsing partial JSON outputs
 pyzmq >= 25.0.0
 msgspec
 gguf >= 0.13.0
-importlib_metadata
+importlib_metadata; python_version < '3.10'
 mistral_common[opencv] >= 1.5.4
 opencv-python-headless >= 4.11.0    # required for video IO
 pyyaml


### PR DESCRIPTION
The stdlib module `importlib.metadata` replaces the PyPI package `importlib-metadata` since Python 3.10. The function `vllm.plugins.load_plugins_by_group()` is the only place that imports `importlib_metadata`. The import is conditional for `sys.version_info < (3, 10)`.
