### PR TITLE
Add missing content type headers to /ping and /health (#17036)

### DIFF
--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -44,6 +44,6 @@ schema = schemathesis.from_pytest_fixture("get_schema")
 
 @schema.parametrize()
 @schema.override(headers={"Content-Type": "application/json"})
-async def test_openapi_stateless(case):
+def test_openapi_stateless(case):
     #No need to verify SSL certificate for localhost
-    await case.call_and_validate(verify=False)
+    case.call_and_validate(verify=False)

--- a/tests/entrypoints/openai/test_openai_schema.py
+++ b/tests/entrypoints/openai/test_openai_schema.py
@@ -44,6 +44,6 @@ schema = schemathesis.from_pytest_fixture("get_schema")
 
 @schema.parametrize()
 @schema.override(headers={"Content-Type": "application/json"})
-def test_openapi_stateless(case):
+def test_openapi_stateless(case: schemathesis.Case):
     #No need to verify SSL certificate for localhost
     case.call_and_validate(verify=False)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -393,7 +393,7 @@ def engine_client(request: Request) -> EngineClient:
 async def health(raw_request: Request) -> Response:
     """Health check."""
     await engine_client(raw_request).check_health()
-    return Response(status_code=200)
+    return JSONResponse(content={}, status_code=200)
 
 
 @router.get("/load")

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -390,7 +390,7 @@ def engine_client(request: Request) -> EngineClient:
 
 
 @router.get("/health")
-async def health(raw_request: Request) -> Response:
+async def health(raw_request: Request) -> JSONResponse:
     """Health check."""
     await engine_client(raw_request).check_health()
     return JSONResponse(content={}, status_code=200)
@@ -415,7 +415,7 @@ async def get_server_load_metrics(request: Request):
 
 
 @router.api_route("/ping", methods=["GET", "POST"])
-async def ping(raw_request: Request) -> Response:
+async def ping(raw_request: Request) -> JSONResponse:
     """Ping check. Endpoint required for SageMaker"""
     return await health(raw_request)
 


### PR DESCRIPTION
This change adds a `Content-Type: application/json` header to `/ping` and `/health` as per #17036. I've also changed the `test_openai_schema.py` to remove an await that caused the following failure:

```
    @schema.parametrize()
    @schema.override(headers={"Content-Type": "application/json"})
    async def test_openapi_stateless(case):
        #No need to verify SSL certificate for localhost
>       await case.call_and_validate(verify=False)
E       TypeError: object Response can't be used in 'await' expression
E       Falsifying example: async_run(
E           case=,
E       )

tests/entrypoints/openai/test_openai_schema.py:49: TypeError
``` 

FIX #17036

<!--- pyml disable-next-line no-emphasis-as-heading -->
